### PR TITLE
Include logging in app initialization

### DIFF
--- a/main/app.py
+++ b/main/app.py
@@ -9,6 +9,7 @@ from . import config
 from .messages.socket_sender import SocketSender
 from .messages.message_queue_basic import MessageQueueBasic
 from .messages.message_sender import MessageSender
+from .util import prep_logging
 
 # Create and configure the application. Default config values may be overridden by a config file,
 # and then overridden by environment variables.
@@ -21,6 +22,7 @@ app.config.from_pyfile(
     silent=True)
 app.config.update(config.environment())
 
+prep_logging(app.config)
 
 # create database wrapper
 db = SQLAlchemy(app)

--- a/main/messages/socket_receiver.py
+++ b/main/messages/socket_receiver.py
@@ -214,7 +214,8 @@ def process_web_socket_message(message_struct, ws_conn):
     elif message_type == 'debug_messaging':
         parameters = message_struct['parameters']
         enable = bool(parameters['enable'])
-        socket_sender.debug_messaging(enable)
+        level = logging.DEBUG if enable else logging.INFO
+        logging.getLogger().setLevel(level)
 
     # handle other action messages
     elif message_type in ('sendEmail', 'sendTextMessage', 'send_email', 'send_text_message'):

--- a/main/messages/socket_sender.py
+++ b/main/messages/socket_sender.py
@@ -6,40 +6,12 @@ import gevent
 from geventwebsocket.websocket import WebSocketError
 
 
-def prep_logging(log_path):
-    formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.DEBUG)
-    console_handler.setFormatter(formatter)
-    time_str = datetime.datetime.now().strftime('%Y-%m-%d-%H%M%S')
-    file_handler = logging.FileHandler('%s/%d-%s.txt' % (log_path, os.getpid(), time_str))
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(formatter)
-    root = logging.getLogger()
-    root.addHandler(console_handler)
-    root.addHandler(file_handler)
-    root.setLevel(logging.DEBUG)
-
-
 # The SocketSender runs a greenlet that sends messages (temporarily stored in DB) out to websockets.
 class SocketSender(object):
 
     def __init__(self):
         logging.info('init socket sender')
         self.connections = []  # list of WebSocketConnection objects
-        from main.app import app
-        self.logging_prepped = False
-        self.debug_messaging(app.config['DEBUG_MESSAGING'])
-
-    def debug_messaging(self, enable):
-        from main.app import app
-        self._debug_messaging = enable
-        if enable and not self.logging_prepped:
-            prep_logging(app.config['MESSAGING_LOG_PATH'])
-            self.logging_prepped = True
-        if self.logging_prepped and not enable:
-            root = logging.getLogger()
-            root.setLevel(logging.INFO)
 
     # register a client (possible message recipient)
     def register(self, ws_conn):

--- a/main/util.py
+++ b/main/util.py
@@ -1,6 +1,9 @@
+import logging
 import os  # fix(clean): remove?
 import datetime
 from functools import wraps
+from typing import Dict
+
 import flask  # fix(clean): remove?
 from flask import request, redirect, current_app
 
@@ -44,3 +47,36 @@ def load_server_config():
     else:
         server_config.from_object('settings.config')
     return server_config
+
+
+def prep_logging(app_config: Dict[str, str]):
+    """Initialize logging based on the application config.
+
+    The log level is set to DEBUG if the DEBUG_MESSAGING config option is truthy, else INFO.
+
+    If the MESSAGING_LOG_PATH config option is set, logs are written to a file in that
+    directory in addition to the console.
+    """
+    root = logging.getLogger()
+    if root.hasHandlers():
+        # Logging was already initialized.
+        return
+
+    formatter = logging.Formatter('%(asctime)s: %(levelname)s: %(message)s')
+
+    level = logging.DEBUG if app_config['DEBUG_MESSAGING'] else logging.INFO
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(level)
+    console_handler.setFormatter(formatter)
+
+    root.addHandler(console_handler)
+    root.setLevel(level)
+
+    log_path = app_config['MESSAGING_LOG_PATH']
+    if log_path:
+        time_str = datetime.datetime.now().strftime('%Y-%m-%d-%H%M%S')
+        file_handler = logging.FileHandler('%s/%d-%s.txt' % (log_path, os.getpid(), time_str))
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)


### PR DESCRIPTION
Previously, logging was configured as part of WebSockets initialization, and
thus was never configured when not running with WebSockets enabled.

Initialize it early on so we can see log messages generated during startup.
