### PR TITLE
Allow web clients to construct MQTT server address

### DIFF
--- a/main/api/views.py
+++ b/main/api/views.py
@@ -87,16 +87,21 @@ def generate_csrf_token():
 # provide MQTT host and authentication information
 def generate_mqtt_info():
     if current_user.is_authenticated and app.config['MQTT_HOST']:
-        return {
-            'host': app.config['MQTT_HOST'],
-            'port': app.config.get('MQTT_PORT', 443),
+        info = {
             'token': message_auth_token(current_user.id),
             'clientId': '%d-%d' % (current_user.id, random.randint(0, 10000000)),  # fix: reconsider client IDs
             'enableOld': int(app.config.get('ENABLE_OLD_MESSAGING', False)),
-            'ssl': bool(app.config['MQTT_TLS']),
+            'ssl': app.config['MQTT_TLS'],
         }
+
+        if not app.config['WEB_MQTT_SAME_HOST']:
+            info['host'] = app.config['MQTT_HOST']
+        if not app.config['WEB_MQTT_SAME_PORT']:
+            info['port'] = app.config['MQTT_PORT']
     else:
-        return {}
+        info = {}
+
+    return info
 
 
 # add functions that can be used in templates

--- a/main/config.py
+++ b/main/config.py
@@ -44,6 +44,20 @@ def defaults():
         'THREADS_PER_PAGE': 8,
         'TWILIO_ACCOUNT_SID': '',
         'TWILIO_AUTH_TOKEN': '',
+
+        # By default, the server tells the client to use MQTT_HOST:MQTT_PORT as the address of
+        # the MQTT WebSocket interface. But this isn't always what we need:
+        #
+        # If the server and MQTT server are running in separate Docker containers on the same
+        # host, then MQTT_HOST will point to the MQTT server's hostname on the Docker bridge
+        # network but clients will need to connect to it using the host's external address.
+        # In that case, set WEB_MQTT_SAME_HOST to True.
+        #
+        # If the server and MQTT server are both sitting behind a proxy, e.g., an Nginx instance
+        # that does TLS termination, then the two will look like a single service to the client.
+        # In that case, set both WEB_MQTT_SAME_HOST and WEB_MQTT_SAME_PORT to True.
+        'WEB_MQTT_SAME_HOST': False,
+        'WEB_MQTT_SAME_PORT': False,
     }
 
 

--- a/main/static/js/rhizo/messages.js
+++ b/main/static/js/rhizo/messages.js
@@ -258,13 +258,16 @@ function createWebSocketHolder() {
 			}
 		}
 
-		if (g_mqttInfo && g_mqttInfo.host) {
-			console.log('opening MQTT connection');
+		if (g_mqttInfo && g_mqttInfo.token) {
+			var host = g_mqttInfo.host || new URL(document.location).hostname
+			var port = g_mqttInfo.port || new URL(document.location).port
+			console.log('opening MQTT connection to ' + host + ':' + port);
+
 			var useSSL = g_mqttInfo.ssl;
 			var clientId = g_mqttInfo.clientId;
 			var userName = 'token';
 			var password = g_mqttInfo.token;
-			wsh.client = new Paho.Client(g_mqttInfo.host, Number(g_mqttInfo.port), clientId);
+			wsh.client = new Paho.Client(host, Number(port), '/', clientId);
 
 			// set callback handlers
 			wsh.client.onConnectionLost = onConnectionLost;


### PR DESCRIPTION
When the service is running on the Pi, to web browsers the MQTT server will
look like it is running on the same host as the web server but with a different
port number. But from within the server's Docker container, the MQTT server
looks like it is running on a separate host (since each container has its own
address on the internal bridge network).  Therefore we can't just tell the
client to connect to the same MQTT host the server uses.

Add config options to deal with this situation by letting the client construct
the MQTT server address based on the web UI's URL.
