### PR TITLE
Use threading instead of gevent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ FROM python:3.8.5-buster AS build
 
 WORKDIR /rhizo-server
 
-# Install expensive dependencies as a separate build step so we don't have to repeat it if
-# cheaper dependencies are added/removed.
-COPY requirements-prebuild.txt ./
-RUN pip install -r requirements-prebuild.txt
 RUN pip install psycopg2-binary
 
 # Install remaining dependencies

--- a/README.md
+++ b/README.md
@@ -98,15 +98,6 @@ controller and controller). Some messages are handled specifically by the server
 *   send_email: sends an email message from the server
 *   send_text_message: sends a text message from the server
 
-### WebSocket connections
-
-A WebSocket connection is opened by via `/api/v1/websocket`. Authentication is similar to the REST
-authentication described below.
-
-Websocket messages are sent as JSON strings with the following minimum format:
-`{ “type”: <type>, “parameters”: { <parameters> }`.
-Here `<parameters>` is a dictionary of parameter names and values.
-
 ## Permissions
 
 Permissions specify which users can access which resources. We're currently reworking the permission

--- a/main/messages/message_queue_basic.py
+++ b/main/messages/message_queue_basic.py
@@ -1,6 +1,6 @@
 import json
 import datetime
-import gevent
+import time
 from .message_queue import MessageQueue
 
 
@@ -35,7 +35,7 @@ class MessageQueueBasic(MessageQueue):
         while True:
 
             # sleep for a bit; don't want to overload the database
-            gevent.sleep(0.5)
+            time.sleep(0.5)
 
             # fix(soon): is there a good way to avoid losing messages while server is restarting? could go back 5 minutes, but then we'd get
             # duplicates. it would be nice if each web/worker process could remember where it was across restarts

--- a/main/workers/controller_watchdog.py
+++ b/main/workers/controller_watchdog.py
@@ -5,7 +5,6 @@ import datetime
 
 
 # external imports
-import gevent
 from sqlalchemy import not_
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -81,4 +80,4 @@ def controller_watchdog():
             last_log_time = time.time()
 
         # wait one minute
-        gevent.sleep(60)
+        time.sleep(60)

--- a/main/workers/message_deleter.py
+++ b/main/workers/message_deleter.py
@@ -1,5 +1,4 @@
 import time
-import gevent
 import datetime
 from main.app import db
 from main.workers.util import worker_log
@@ -25,7 +24,7 @@ def message_deleter():
         worker_log('message_deleter', 'deleted %d messages in %.3f seconds' % (delete_count, delete_time))
 
         # sleep for 6 hours
-        gevent.sleep(6 * 60 * 60)
+        time.sleep(6 * 60 * 60)
 
 
 # if run as top-level script

--- a/main/workers/message_monitor.py
+++ b/main/workers/message_monitor.py
@@ -4,7 +4,6 @@ import datetime
 
 
 # external imports
-import gevent
 import paho.mqtt.client as mqtt
 
 
@@ -110,9 +109,7 @@ def message_monitor():
     if mqtt_tls:
         mqtt_client.tls_set()  # enable SSL
     mqtt_client.connect(mqtt_host, mqtt_port)
-    mqtt_client.loop_start()
-    while True:
-        gevent.sleep(60)
+    mqtt_client.loop_forever(retry_first_connection=True)
 
 
 # if run as top-level script

--- a/main/workers/sequence_truncator.py
+++ b/main/workers/sequence_truncator.py
@@ -1,5 +1,5 @@
 import json
-import gevent
+import time
 from sqlalchemy import func
 from main.app import db
 from main.resources.models import Resource, ResourceRevision
@@ -59,7 +59,7 @@ def sequence_truncator():
             worker_log('sequence_truncator', 'done with truncation pass; truncated %d sequences' % truncate_count)
 
         # sleep for an hour
-        gevent.sleep(60 * 60)
+        time.sleep(60 * 60)
 
 
 # if run as top-level script

--- a/requirements-prebuild.txt
+++ b/requirements-prebuild.txt
@@ -1,6 +1,0 @@
-# This file should have requirements that are especially expensive to build. They will be
-# installed in a separate step in the Docker build so that they're cached as a separate
-# layer. That way when we add ordinary plain-Python packages to requirements.txt, it won't
-# force a time-consuming rebuild of the expensive stuff.
-
-gevent==20.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,6 @@ Flask
 Flask-Login
 Flask-RESTful
 Flask-SQLAlchemy
-gevent
-gevent-websocket  # remove this after switch to MQTT
-greenlet
 gunicorn  # make this optional
 Markdown
 paho-mqtt

--- a/run_worker.py
+++ b/run_worker.py
@@ -1,9 +1,7 @@
 # standard python imports
 import json
-
-
-# external imports
-import gevent
+from threading import Thread
+import time
 
 
 # internal imports
@@ -28,16 +26,16 @@ def worker():
     worker_log('system', 'starting worker process')
 
     # start various worker threads
-    gevent.spawn(controller_watchdog)
-    gevent.spawn(sequence_truncator)
-    gevent.spawn(message_deleter)
-    gevent.spawn(message_monitor)
+    Thread(target=controller_watchdog).start()
+    Thread(target=sequence_truncator).start()
+    Thread(target=message_deleter).start()
+    Thread(target=message_monitor).start()
 
     # loop forever
     while True:
 
         # sleep for one second each loop
-        gevent.sleep(1)
+        time.sleep(1)
 
         # check for messages
         if False:
@@ -48,7 +46,7 @@ def worker():
                     params = json.loads(message.parameters)
                     if params['name'] == 'add_resource_revisions':
                         print('#### starting add_resource_revisions')
-                        gevent.spawn(add_resource_revisions)
+                        # Thread(add_resource_revisions).start()
 
 
 # if run as top-level script


### PR DESCRIPTION
Switch to native Python threads to reduce the dependency footprint and speed up
aarch64 builds.

This removes WebSocket support from the server! The `-s` command-line option is no
longer recognized. However, it doesn't remove all the WebSocket code from most of
the code base; that can happen in a future change.
