### PR TITLE
Make -w flag run worker as part of server

### DIFF
--- a/main/messages/socket_receiver.py
+++ b/main/messages/socket_receiver.py
@@ -259,6 +259,7 @@ def process_web_socket_message(message_struct, ws_conn):
             # fix(soon): can we move this spawn above access level check (might require request context)
             Thread(
                 target=message_queue.add,
+                daemon=True,
                 args=[folder_id, None, message_type, parameters],
                 kwargs={
                     'sender_controller_id': ws_conn.controller_id,

--- a/main/messages/socket_sender.py
+++ b/main/messages/socket_sender.py
@@ -12,7 +12,7 @@ class SocketSender(Thread):
 
     def __init__(self):
         logger.info('init socket sender')
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         self.connections = []  # list of WebSocketConnection objects
 
     # register a client (possible message recipient)
@@ -71,7 +71,7 @@ class SocketSender(Thread):
                                 'timestamp': message.timestamp.isoformat() + 'Z',
                                 'parameters': json.loads(message.parameters)
                             }
-                            Thread(target=self.send, args=[ws_conn, json.dumps(message_struct)]).start()
+                            Thread(target=self.send, daemon=True, args=[ws_conn, json.dumps(message_struct)]).start()
                             if ws_conn.controller_id:
                                 logger.debug('sending message to controller; type: %s', message.type)
                             else:

--- a/main/workers/util.py
+++ b/main/workers/util.py
@@ -1,10 +1,13 @@
 import datetime
+import logging
+
 from main.resources.resource_util import update_sequence_value, find_resource
 
 
 # add a message to the worker log
 def worker_log(worker_name, message):
-    print(worker_name + ': ' + message)
+    logger = logging.getLogger(f'{__name__}.{worker_name}')
+    logger.info(worker_name + ': ' + message)
     name = '/system/worker/log'
     log_resource = find_resource(name)
     if log_resource:

--- a/run.py
+++ b/run.py
@@ -18,13 +18,15 @@ from main.users import models
 from main.messages import models
 from main.resources import models
 
+from run_worker import worker
+
 
 # if run as top-level script
 if __name__ == '__main__':
 
     # process command arguments
     parser = OptionParser()
-    parser.add_option('-w', '--run-as-worker', dest='run_as_worker', default='')
+    parser.add_option('-w', '--run-as-worker', dest='run_as_worker', action='store_true', default=False)
     parser.add_option('-d', '--init-db', dest='init_db', action='store_true', default=False)
     parser.add_option('-a', '--create-admin', dest='create_admin', default='')
     parser.add_option('-m', '--migrate-db', dest='migrate_db', action='store_true', default=False)
@@ -59,4 +61,6 @@ if __name__ == '__main__':
                 logging.error('Unable to complete Balena setup: %s', ex)
                 sys.exit(1)
 
+        if options.run_as_worker:
+            worker(blocking=False)
         app.run(host=options.listen_address, port=options.port, debug=True)

--- a/run_worker.py
+++ b/run_worker.py
@@ -26,10 +26,10 @@ def worker(blocking=True, debug=False):
     worker_log('system', 'starting worker process')
 
     # start various worker threads
-    Thread(target=controller_watchdog).start()
-    Thread(target=sequence_truncator).start()
-    Thread(target=message_deleter).start()
-    Thread(target=message_monitor).start()
+    Thread(target=controller_watchdog, daemon=True).start()
+    Thread(target=sequence_truncator, daemon=True).start()
+    Thread(target=message_deleter, daemon=True).start()
+    Thread(target=message_monitor, daemon=True).start()
 
     # loop forever
     while blocking:

--- a/run_worker.py
+++ b/run_worker.py
@@ -20,7 +20,7 @@ from main.resources import models
 
 
 # the worker process
-def worker():
+def worker(blocking=True, debug=False):
 
     # log that the worker process is starting
     worker_log('system', 'starting worker process')
@@ -32,13 +32,13 @@ def worker():
     Thread(target=message_monitor).start()
 
     # loop forever
-    while True:
+    while blocking:
 
         # sleep for one second each loop
         time.sleep(1)
 
         # check for messages
-        if False:
+        if debug:
             messages = message_queue.receive()
             for message in messages:
                 if message.type == 'start_worker_task':


### PR DESCRIPTION
The server had an existing flag to run as a worker, but it didn't do anything.
Make it launch the worker in background threads in addition to running the server.
The `run_worker.py` script is still available to run standalone workers.
