### PR TITLE
Move seed bank photo code to seedbank package

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
@@ -17,9 +17,9 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.photo.PhotoMetadata
-import com.terraformation.backend.photo.PhotoRepository
 import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.db.PhotoRepository
+import com.terraformation.backend.seedbank.model.PhotoMetadata
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Encoding

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -1,11 +1,11 @@
-package com.terraformation.backend.photo
+package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
-import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.model.PhotoMetadata
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.FileAlreadyExistsException

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/PhotoMetadata.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/PhotoMetadata.kt
@@ -1,4 +1,4 @@
-package com.terraformation.backend.photo
+package com.terraformation.backend.seedbank.model
 
 import java.math.BigDecimal
 import java.time.Instant

--- a/src/test/kotlin/com/terraformation/backend/photo/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/photo/PhotoRepositoryTest.kt
@@ -7,6 +7,8 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.db.PhotoRepository
+import com.terraformation.backend.seedbank.model.PhotoMetadata
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk


### PR DESCRIPTION
Since it's all very seed-bank-specific and is unlikely to be too useful as a
starting point for a more general-purpose photo storage system, the code for
reading and writing accession photos should really live in the `seedbank`
package. Once we add a more generic photo storage system, this code can be
removed or turned into a facade for the new code.
