### PR TITLE
Add user types

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -38,6 +38,7 @@ val ENUM_TABLES =
             "storage_conditions",
             listOf("accessions\\.target_storage_condition", "storage_locations\\.condition_id")),
         EnumTable("timeseries_types", "timeseries\\.type_id"),
+        EnumTable("user_types", ".*\\.user_type_id"),
         EnumTable("withdrawal_purposes", "withdrawals\\.purpose_id"))
 
 val ID_WRAPPERS =

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.UserModel
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.UsersRow
@@ -105,7 +106,7 @@ class UserStore(
         usersRow.email ?: throw IllegalStateException("Email should never be null"),
         usersRow.firstName,
         usersRow.lastName,
-        usersRow.superAdmin == true,
+        usersRow.userTypeId ?: throw IllegalStateException("User type should never be null"),
         accessionsDao,
         permissionStore,
     )
@@ -118,7 +119,7 @@ class UserStore(
             email = keycloakUser.email,
             firstName = keycloakUser.firstName,
             lastName = keycloakUser.lastName,
-            superAdmin = false,
+            userTypeId = UserType.Individual,
             createdTime = clock.instant(),
             modifiedTime = clock.instant(),
         )

--- a/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.log.perClassLogger
 import java.security.Principal
@@ -44,7 +45,7 @@ class UserModel(
     val email: String,
     val firstName: String?,
     val lastName: String?,
-    private val superAdmin: Boolean,
+    private val userType: UserType,
     private val accessionsDao: AccessionsDao,
     private val permissionStore: PermissionStore,
 ) : UserDetails, Principal {
@@ -192,7 +193,7 @@ class UserModel(
   }
 
   override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
-    return if (superAdmin) {
+    return if (userType == UserType.SuperAdmin) {
       mutableSetOf(SuperAdminAuthority)
     } else {
       mutableSetOf()

--- a/src/main/resources/db/migration/common/V41__UserTypes.sql
+++ b/src/main/resources/db/migration/common/V41__UserTypes.sql
@@ -1,0 +1,20 @@
+CREATE TABLE user_types (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+INSERT INTO user_types
+VALUES (1, 'Individual');
+INSERT INTO user_types
+VALUES (2, 'Super Admin');
+INSERT INTO user_types
+VALUES (3, 'API Client');
+
+ALTER TABLE users ADD COLUMN user_type_id INTEGER REFERENCES user_types (id);
+
+UPDATE users
+SET user_type_id = CASE WHEN super_admin THEN 2 ELSE 1 END
+WHERE users.user_type_id IS NULL;
+
+ALTER TABLE users ALTER COLUMN user_type_id SET NOT NULL;
+ALTER TABLE users DROP COLUMN super_admin;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.daos.ProjectsDao
@@ -231,7 +232,7 @@ internal class PermissionStoreTest : DatabaseTest() {
             id = userId,
             authId = "auth$id",
             email = "user$id@terraformation.com",
-            superAdmin = false,
+            userTypeId = UserType.Individual,
             createdTime = Instant.EPOCH,
             modifiedTime = Instant.EPOCH))
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
@@ -116,7 +117,7 @@ internal class PermissionTest : DatabaseTest() {
             id = userId,
             authId = "dummyAuthId",
             email = "test@domain.com",
-            superAdmin = false,
+            userTypeId = UserType.Individual,
             createdTime = Instant.EPOCH,
             modifiedTime = Instant.EPOCH))
   }


### PR DESCRIPTION
In preparation for revamping the way API client authentication works, add a
concept of "user type." Most users are of type "Individual." Super admins have
a different type, as will API clients.

In this change, the user type just replaces the old `super_admin` flag. A later
change will update API authentication to use API client users instead of a
dedicated `api_keys` table.

CU-185t84y
