### PR TITLE
Create and delete API keys from admin UI

### DIFF
--- a/KEYCLOAK.md
+++ b/KEYCLOAK.md
@@ -59,10 +59,62 @@ These steps apply to a local instance of Keycloak, and also to an existing one t
       - view-users
    10. Click the "Credentials" tab.
    11. Copy the value of the "client secret" field; you'll be using it later.
+5. Create a role that will identify the synthetic Keycloak users for API clients.
+   1. Click "Roles" in the left navbar.
+   2. Click "Add Role" in the header bar of the list of roles.
+   3. Enter a role name of `api-client`. (You can use a different name if you prefer, but we'll use that name in these instructions.)
+   4. Click "Save."
+6. Create a group that grants the new role to API clients.
+   1. Click "Groups" in the left navbar.
+   2. Click "New" in the header bar of the list of groups.
+   3. Use a group name of `api-clients`. (If you choose a different name, you will have to override a configuration setting as described later.)
+   4. Click "Save."
+   5. Click the "Role Mappings" tab.
+   6. Select "api-client" in the list of available roles and click "Add selected."
+7. Create an authentication flow that only allows users with the API client role to authenticate.
+   1. Click "Authentication" in the left navbar.
+   2. Click "New" in the header bar of the list of authentication flows.
+   3. Set "Alias" to `API Client Authentication`. (You can use a different name if you prefer.)
+   4. Click "Save."
+   5. Click "Add execution" in the header bar.
+   6. Select "Username Validation".
+   7. Click "Save".
+   8. Click "Add execution" again.
+   9. Select "Password."
+   10. Click "Save."
+   11. Click the "Required" radio button on the "Password" line.
+   12. Click "Add flow" in the header bar.
+   13. Set "Alias" to `Require API Client Role`. (You can use a different name if you prefer.)
+   14. Click "Save."
+   15. Click the "Conditional" radio button on the "Require API Client Role" line.
+   16. From the "Actions" drop-down on the "Require API Client Role" line, click "Add execution."
+   17. Select "Condition - User Role."
+   18. Click "Save."
+   19. Click the "Required" radio button on the "Condition - User Role" line.
+   20. From the "Actions" drop-down on the "Condition - User Role" line, click "Config."
+   21. Set "Alias" to `api-client`.
+   22. Set "User role" to `api-client`.
+   23. Set "Negate output" to "On."
+   24. Click "Save."
+   25. Click "API Client Authentication" in the navigation links at the top of the page.
+   26. From the "Actions" drop-down on the "Require API Client Role" line, click "Add execution."
+   27. Select "Deny Access."
+   28. Click "Save."
+   29. Click the "Required" radio button on the "Deny Access" line.
+8. Create a Keycloak client that terraware-server API clients will use to request access tokens.
+   1. Click "Clients" in the left navbar.
+   2. Click "Create" in the header bar of the list of clients.
+   3. Set the client ID to `api`. Leave the other fields set to their default values.
+   4. Click "Save."
+   5. Set "Standard Flow Enabled" to "Off."
+   6. Click "Authentication Flow Overrides" to expand that section of the page.
+   7. Set "Browser Flow" to "API Client Authentication."
+   8. Set "Direct Grant Flow" to "API Client Authentication."
+   9. Click "Save."
 
 ### Terraware-server environment variables
 
-You'll need to run Keycloak to authenticate to terraware-server, and terraware-server needs to know how to communicate with Keycloak, which requires setting four environment variables. If you work at Terraformation then ask a fellow developer for the values of these environment variables (likely in the Terraformation 1Password Eng Infra Vault).
+You'll need to run Keycloak to authenticate to terraware-server, and terraware-server needs to know how to communicate with Keycloak, which requires setting four environment variables. You can also override some defaults with additional optional environment variables. If you work at Terraformation then ask a fellow developer for the values of these environment variables (likely in the Terraformation 1Password Eng Infra Vault).
 
 | Variable | Description
 | --- | ---
@@ -70,6 +122,9 @@ You'll need to run Keycloak to authenticate to terraware-server, and terraware-s
 |`TERRAWARE_KEYCLOAK_REALM` | The name of the Keycloak realm that contains terraware-server user information. If you followed the instructions to create a local Keycloak instance then this will be `terraware`.
 |`TERRAWARE_KEYCLOAK_CLIENT_ID` | The client ID terraware-server will use to make Keycloak API requests. If you followed the instructions to create a local Keycloak instance, then this will be `dev-terraware-server`.
 |`TERRAWARE_KEYCLOAK_CLIENT_SECRET` | The secret associated with the client ID.
+|`TERRAWARE_KEYCLOAK_API_CLIENT_ID` | The Keycloak client ID that terraware-server API clients will use to generate access tokens. If you followed the instructions to create a local Keycloak instance, then this will be `api`.
+|`TERRAWARE_KEYCLOAK_API_CLIENT_GROUP_NAME` | The name of the Keycloak group to add newly-created API client users to. The default is `/api-clients`. If you chose a different group name when you were setting up Keycloak, you'll need to set this. Note that because Keycloak group names are hierarchical, the value must start with `/`.
+|`TERRAWARE_KEYCLOAK_API_CLIENT_USERNAME_PREFIX` | A prefix to put at the beginning of the Keycloak usernames of API client users. The default is `api-`. This is to make the users easy to identify in the Keycloak admin console.
 
 If you're launching the server from the command line (including using Gradle) you can set these in your shell.
 

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -9,6 +9,7 @@ import javax.validation.constraints.Min
 import javax.validation.constraints.NotNull
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.DefaultValue
 import org.springframework.core.io.Resource
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.validation.annotation.Validated
@@ -128,6 +129,21 @@ class TerrawareServerConfig(
 
       /** Client secret corresponding to clientId. */
       @NotNull val clientSecret: String,
+
+      /**
+       * Client ID that API clients will use to request access tokens given an offline refresh
+       * token. This should be a public client (no client secret) with `offline_access` scope.
+       */
+      @NotNull val apiClientId: String,
+
+      /** Name of Keycloak group to add API clients to on creation. */
+      @DefaultValue("/api-clients") @NotNull val apiClientGroupName: String,
+
+      /**
+       * Prefix to put at the beginning of auto-generated Keycloak usernames for API client users.
+       * The prefix will cause API client users to be grouped together in the Keycloak admin UI.
+       */
+      @DefaultValue("api-") @NotNull val apiClientUsernamePrefix: String,
   )
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -83,6 +83,8 @@ class OrganizationStore(
             USERS.EMAIL,
             USERS.FIRST_NAME,
             USERS.LAST_NAME,
+            USERS.USER_TYPE_ID,
+            USERS.CREATED_TIME,
             ORGANIZATION_USERS.ORGANIZATION_ID,
             ORGANIZATION_USERS.ROLE_ID,
             PROJECT_USERS.PROJECT_ID)
@@ -100,17 +102,27 @@ class OrganizationStore(
           val firstRow = rows.first()
           val userId = firstRow[USERS.ID]
           val authId = firstRow[USERS.AUTH_ID]
+          val userType = firstRow[USERS.USER_TYPE_ID]
+          val createdTime = firstRow[USERS.CREATED_TIME]
           val email = firstRow[USERS.EMAIL]
           val orgId = firstRow[ORGANIZATION_USERS.ORGANIZATION_ID]
           val role = firstRow[ORGANIZATION_USERS.ROLE_ID]?.let { Role.of(it) }
 
-          if (userId != null && authId != null && email != null && orgId != null && role != null) {
+          if (userId != null &&
+              authId != null &&
+              userType != null &&
+              createdTime != null &&
+              email != null &&
+              orgId != null &&
+              role != null) {
             OrganizationUserModel(
                 userId,
                 authId,
                 email,
                 firstRow[USERS.FIRST_NAME],
                 firstRow[USERS.LAST_NAME],
+                userType,
+                createdTime,
                 orgId,
                 role,
                 rows.mapNotNull { it[PROJECT_USERS.PROJECT_ID] })

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -1,18 +1,40 @@
 package com.terraformation.backend.customer.db
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.UserModel
 import com.terraformation.backend.db.KeycloakRequestFailedException
 import com.terraformation.backend.db.KeycloakUserNotFoundException
+import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.UsersRow
+import com.terraformation.backend.log.perClassLogger
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
 import java.time.Clock
+import java.util.Base64
 import javax.annotation.ManagedBean
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import kotlin.random.Random
+import org.apache.commons.codec.binary.Base32
 import org.keycloak.admin.client.resource.RealmResource
+import org.keycloak.representations.idm.CredentialRepresentation
 import org.keycloak.representations.idm.UserRepresentation
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
@@ -27,7 +49,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
  * This class is a little different from some of the other Store classes because of the interaction
  * between terraware-server and Keycloak. When a new user registers with Keycloak and accesses
  * terraware-server for the first time, we automatically insert a row into the users table for them,
- * and prepopulate it with the profile information they gave to Keycloak when they signed up.
+ * and pre-populate it with the profile information they gave to Keycloak when they signed up.
  * Fetching a user's details can thus result in an API call to the Keycloak server.
  *
  * Spring Security calls this class to look up users when it is authenticating requests.
@@ -36,10 +58,24 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException
 class UserStore(
     private val accessionsDao: AccessionsDao,
     private val clock: Clock,
+    private val config: TerrawareServerConfig,
+    private val httpClient: HttpClient,
+    private val objectMapper: ObjectMapper,
+    private val organizationStore: OrganizationStore,
     private val permissionStore: PermissionStore,
-    private val realmResource: RealmResource,
+    realmResource: RealmResource,
     private val usersDao: UsersDao,
 ) : UserDetailsService {
+  private val log = perClassLogger()
+  private val usersResource = realmResource.users()
+
+  /**
+   * Default Keycloak groups for each user type. Currently, we only auto-assign API client users to
+   * a Keycloak group.
+   */
+  private val defaultKeycloakGroups =
+      mapOf(UserType.APIClient to listOf(config.keycloak.apiClientGroupName))
+
   /**
    * Returns the details for the user with a given Keycloak user ID. Pulls the user's information
    * from Keycloak if they don't exist in our users table yet.
@@ -48,7 +84,6 @@ class UserStore(
    * implies that the user didn't exist in the users table.
    * @throws KeycloakUserNotFoundException There is no user with that ID in the Keycloak database.
    */
-  @Suppress("MemberVisibilityCanBePrivate")
   fun fetchByAuthId(authId: String): UserModel {
     val existingUser = usersDao.fetchByAuthId(authId).firstOrNull()
     val user =
@@ -57,7 +92,7 @@ class UserStore(
         } else {
           val keycloakUser =
               try {
-                realmResource.users().get(authId)?.toRepresentation()
+                usersResource.get(authId)?.toRepresentation()
               } catch (e: Exception) {
                 throw KeycloakRequestFailedException("Failed to request user data from Keycloak", e)
               }
@@ -87,7 +122,7 @@ class UserStore(
         } else {
           val keycloakUsers =
               try {
-                realmResource.users().search(email, true)
+                usersResource.search(email, true)
               } catch (e: Exception) {
                 throw KeycloakRequestFailedException(
                     "Failed to search for user data in Keycloak", e)
@@ -110,6 +145,217 @@ class UserStore(
    */
   fun fetchById(userId: UserId): UserModel? {
     return usersDao.fetchOneById(userId)?.let { rowToDetails(it) }
+  }
+
+  /**
+   * Creates a new API client user and registers it with Keycloak.
+   *
+   * We do a few things to make API client users easier to deal with in the Keycloak admin console.
+   *
+   * - The username has a prefix of `api-`
+   * - The last name includes the organization ID
+   * - The first name is the admin-supplied description
+   */
+  fun createApiClient(organizationId: OrganizationId, description: String?): UserModel {
+    if (!currentUser().canCreateApiKey(organizationId)) {
+      throw AccessDeniedException("No permission to create API keys in this organization")
+    }
+
+    // Use base32 instead of base64 so the username doesn't include "/" and "+".
+    val randomString = Base32().encodeToString(Random.nextBytes(15)).lowercase()
+    val username = "${config.keycloak.apiClientUsernamePrefix}$randomString"
+    val lastName = "Organization $organizationId"
+
+    val keycloakUser = registerKeycloakUser(username, description, lastName, UserType.APIClient)
+    val usersRow = insertKeycloakUser(keycloakUser, UserType.APIClient)
+    val user = rowToDetails(usersRow)
+
+    organizationStore.addUser(organizationId, user.userId, Role.CONTRIBUTOR)
+
+    return user
+  }
+
+  /** Deletes an API client user including its Keycloak registration. */
+  fun deleteApiClient(userId: UserId): Boolean {
+    val user = fetchById(userId) ?: return false
+
+    if (user.userType != UserType.APIClient) {
+      throw IllegalArgumentException("User is not an API client")
+    }
+
+    user.organizationRoles.keys.forEach { organizationId ->
+      if (!currentUser().canDeleteApiKey(organizationId)) {
+        throw AccessDeniedException("No permission to delete API keys in this organization")
+      }
+    }
+
+    log.debug("Removing API client user $userId (${user.authId}) from Keycloak")
+
+    val response = usersResource.delete(user.authId)
+
+    if (response.statusInfo.family == Response.Status.Family.SUCCESSFUL) {
+      log.info("Removed API client user $userId (${user.authId}) from Keycloak")
+    } else if (response.status == Response.Status.NOT_FOUND.statusCode) {
+      log.warn("API client user $userId (${user.authId}) in local database but not in Keycloak")
+    } else {
+      log.error(
+          "Got unexpected HTTP status ${response.status} when deleting API client user $userId " +
+              "(${user.authId}) from Keycloak")
+      throw KeycloakRequestFailedException("Failed to delete user from Keycloak")
+    }
+
+    // For now, completely delete the user from our database. We will likely need to revisit this
+    // once we have more objects in the system that are owned by or otherwise associated with
+    // specific users.
+    user.organizationRoles.keys.forEach { organizationId ->
+      organizationStore.removeUser(organizationId, userId)
+    }
+
+    usersDao.deleteById(userId)
+
+    return true
+  }
+
+  /**
+   * Registers a user in Keycloak and returns its representation.
+   *
+   * @throws DuplicateKeyException There was already a user with the requested email address in
+   * Keycloak.
+   * @throws KeycloakRequestFailedException Unable to complete registration request.
+   */
+  private fun registerKeycloakUser(
+      username: String,
+      firstName: String?,
+      lastName: String?,
+      @Suppress("SameParameterValue") // We'll use this method for invitations later
+      type: UserType
+  ): UserRepresentation {
+    val newKeycloakUser = UserRepresentation()
+    newKeycloakUser.isEmailVerified = true
+    newKeycloakUser.isEnabled = true
+    newKeycloakUser.email = username
+    newKeycloakUser.firstName = firstName
+    newKeycloakUser.groups = defaultKeycloakGroups[type]
+    newKeycloakUser.lastName = lastName
+    newKeycloakUser.username = username
+
+    log.debug("Creating user $username in Keycloak")
+
+    val response = usersResource.create(newKeycloakUser)
+
+    if (response.status == HttpStatus.CONFLICT.value()) {
+      throw DuplicateKeyException("User already registered")
+    } else if (response.statusInfo.family != Response.Status.Family.SUCCESSFUL) {
+      val responseBody = response.readEntity(String::class.java)
+      log.error(
+          "Failed to create user $username in Keycloak: HTTP ${response.status} $responseBody")
+      throw KeycloakRequestFailedException("User creation failed")
+    }
+
+    log.info("Created user $username in Keycloak")
+
+    val keycloakUser = usersResource.search(username, true).firstOrNull()
+    if (keycloakUser == null) {
+      log.error("Created Keycloak user $username but failed to find them immediately afterwards")
+      throw KeycloakUserNotFoundException("User creation succeeded but couldn't find user!")
+    }
+
+    return keycloakUser
+  }
+
+  /**
+   * Generates a new offline token for the API client user with a given user ID. This revokes any
+   * previously existing offline tokens.
+   *
+   * Note that this also resets the user's password! API client users can't log in using passwords
+   * so there is no harm done to them, but you can't use this on an individual user.
+   *
+   * This may fail if it is called concurrently for the same user ID; if none of the current calls
+   * succeeds, the user's old offline token will continue to work.
+   */
+  fun generateOfflineToken(userId: UserId): String {
+    val usersRow =
+        usersDao.fetchOneById(userId) ?: throw IllegalArgumentException("User does not exist")
+    val authId = usersRow.authId ?: throw IllegalStateException("User has no authentication ID")
+
+    if (usersRow.userTypeId != UserType.APIClient) {
+      throw IllegalArgumentException("Offline tokens may only be generated for API clients")
+    }
+
+    val user =
+        usersResource.get(authId)
+            ?: throw KeycloakUserNotFoundException("Keycloak could not find user")
+
+    // Reset the user's password, so we can use it to authenticate to Keycloak and request a new
+    // offline token. There is no administrative Keycloak API to do that on behalf of a user.
+    // When we're done, we will remove the password. Use a long random password so that even if
+    // this process bombs out, an attacker won't be able to guess the password.
+    val credentials = randomPasswordCredential()
+
+    user.resetPassword(credentials)
+
+    try {
+      val tokenUrl =
+          config.keycloak.serverUrl.resolve(
+              "/auth/realms/${config.keycloak.realm}/protocol/openid-connect/token")
+
+      val formSubmission =
+          mapOf(
+              "client_id" to config.keycloak.apiClientId,
+              "scope" to "offline_access",
+              "grant_type" to "password",
+              "username" to user.toRepresentation().username,
+              "password" to credentials.value)
+              .map { (name, value) -> name to URLEncoder.encode(value, StandardCharsets.UTF_8) }
+              .joinToString("&") { (name, value) -> "$name=$value" }
+
+      val request =
+          HttpRequest.newBuilder()
+              .uri(tokenUrl)
+              .header("Content-Type", MediaType.APPLICATION_FORM_URLENCODED)
+              .POST(HttpRequest.BodyPublishers.ofString(formSubmission))
+              .build()
+      val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+      if (response.statusCode() != HttpStatus.OK.value()) {
+        log.error("Keycloak returned HTTP ${response.statusCode()} for refresh token request")
+        log.info("Keycloak response: ${response.body()}")
+        throw KeycloakRequestFailedException("Failed to generate refresh token")
+      }
+
+      val tokenResponsePayload =
+          try {
+            objectMapper.readValue<OpenIdConnectTokenResponsePayload>(response.body())
+          } catch (e: JsonProcessingException) {
+            log.error("Keycloak returned malformed response to refresh token request", e)
+            log.info("Keycloak response: ${response.body()}")
+            throw KeycloakRequestFailedException("Failed to generate refresh token")
+          }
+
+      return tokenResponsePayload.refresh_token
+    } finally {
+      user.credentials().filter { it.type == "password" }.forEach { credential ->
+        try {
+          user.removeCredential(credential.id)
+        } catch (e: Exception) {
+          log.error(
+              "Failed to remove temporary password from API client user $userId " +
+                  "(${user.toRepresentation().id}) after generating token",
+              e)
+
+          // But return the token anyway; it should be usable and a long random password sticking
+          // around afterwards should be harmless.
+        }
+      }
+    }
+  }
+
+  private fun randomPasswordCredential(): CredentialRepresentation {
+    return CredentialRepresentation().apply {
+      isTemporary = false
+      type = "password"
+      value = Base64.getEncoder().encodeToString(Random.nextBytes(40))
+    }
   }
 
   /**
@@ -139,14 +385,17 @@ class UserStore(
     )
   }
 
-  private fun insertKeycloakUser(keycloakUser: UserRepresentation): UsersRow {
+  private fun insertKeycloakUser(
+      keycloakUser: UserRepresentation,
+      type: UserType = UserType.Individual
+  ): UsersRow {
     val usersRow =
         UsersRow(
             authId = keycloakUser.id,
             email = keycloakUser.email,
             firstName = keycloakUser.firstName,
             lastName = keycloakUser.lastName,
-            userTypeId = UserType.Individual,
+            userTypeId = type,
             createdTime = clock.instant(),
             modifiedTime = clock.instant(),
         )
@@ -154,6 +403,10 @@ class UserStore(
     usersDao.insert(usersRow)
     return usersRow
   }
+
+  /** Relevant parts of the payload of a valid response to an OpenID Connect token request. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  data class OpenIdConnectTokenResponsePayload(val refresh_token: String)
 
   companion object {
     @Suppress("unused")

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationUserModel.kt
@@ -3,6 +3,8 @@ package com.terraformation.backend.customer.model
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
+import java.time.Instant
 
 data class OrganizationUserModel(
     val userId: UserId,
@@ -10,6 +12,8 @@ data class OrganizationUserModel(
     val email: String,
     val firstName: String?,
     val lastName: String?,
+    val userType: UserType,
+    val createdTime: Instant,
     val organizationId: OrganizationId,
     val role: Role,
     val projectIds: List<ProjectId>

--- a/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
@@ -45,7 +45,7 @@ class UserModel(
     val email: String,
     val firstName: String?,
     val lastName: String?,
-    private val userType: UserType,
+    val userType: UserType,
     private val accessionsDao: AccessionsDao,
     private val permissionStore: PermissionStore,
 ) : UserDetails, Principal {
@@ -199,6 +199,17 @@ class UserModel(
     val role = organizationRoles[organizationId]
     return role == Role.OWNER
   }
+
+  fun canCreateApiKey(organizationId: OrganizationId): Boolean {
+    return when (organizationRoles[organizationId]) {
+      Role.OWNER, Role.ADMIN -> true
+      else -> false
+    }
+  }
+
+  fun canDeleteApiKey(organizationId: OrganizationId): Boolean = canCreateApiKey(organizationId)
+
+  fun canListApiKeys(organizationId: OrganizationId): Boolean = canCreateApiKey(organizationId)
 
   /**
    * Temporary helper to get the user's facility ID.

--- a/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.util
+
+import java.net.http.HttpClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Configures the HTTP client.
+ *
+ * For now, this just uses the default configuration including the default connection and thread
+ * pools. It is published as a Spring bean both so that it can be shared across services and so that
+ * we can change the configuration centrally in the future, e.g., to adjust pool sizes.
+ */
+@Configuration
+class HttpClientConfig {
+  @Bean
+  fun httpClient(): HttpClient {
+    return HttpClient.newHttpClient()
+  }
+}

--- a/src/main/resources/application-apidoc.yaml
+++ b/src/main/resources/application-apidoc.yaml
@@ -26,6 +26,7 @@ terraware:
   mqtt:
     enabled: false
   keycloak:
+    apiClientId: dummy
     clientId: dummy
     clientSecret: dummy
     serverUrl: http://dummy

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -1,4 +1,7 @@
 terraware:
+  keycloak:
+    client-id: "dev-terraware-server"
+
   mqtt:
     enabled: false
     address: "ws://localhost:1883/"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,9 @@
+terraware:
+  keycloak:
+    api-client-id: "api"
+    client-id: "terraware-server"
+    realm: "terraware"
+
 spring:
   datasource:
     url: "${DATABASE_URL:jdbc:postgresql://localhost:5432/terraware}"

--- a/src/main/resources/templates/admin/apiKeyAdded.html
+++ b/src/main/resources/templates/admin/apiKeyAdded.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/admin/header :: head"/>
+<body>
+
+<span th:include="/admin/header :: top"/>
+
+<a th:href="|${prefix}/|">Home</a>
+-
+<a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Organization name</a>
+
+<h2>API Key Created</h2>
+
+<p>
+    A new API key with ID <code th:text="${keyId}">111-222-333</code> has been created:
+</p>
+
+<textarea style="font-family: monospace;" cols="80" rows="10" th:text="${token}">big long key goes here</textarea>
+
+<p>
+    <b>Please record this key now. It will not be available again after you leave this page.</b>
+</p>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -1,6 +1,14 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="/admin/header :: head"/>
+<style>
+    table.bordered, table.bordered tr th, table.bordered tr td {
+        border: 1px solid black;
+    }
+    table.bordered td, table.bordered th {
+        padding: .25em;
+    }
+</style>
 <body>
 
 <span th:include="/admin/header :: top"/>
@@ -13,7 +21,8 @@
 
 <ul>
     <li th:each="user : ${users}">
-        <a th:href="|${prefix}/user/${user.userId}|" th:text="|${user.firstName} ${user.lastName} (${user.email})|">user@domain</a>
+        <a th:href="|${prefix}/user/${user.userId}|"
+           th:text="|${user.firstName} ${user.lastName} (${user.email})|">user@domain</a>
         <span th:text="|(${user.role.displayName})|" th:if="!${canAddUser}">(role)</span>
         <span th:if="${canAddUser}">
             <form method="POST" style="display: inline;"
@@ -70,6 +79,43 @@
     <input type="text" name="name" id="name" required/>
     <input type="submit" value=" Create Project "/>
 </form>
+
+<div th:if="${canListApiKeys}">
+
+    <h3>API Keys</h3>
+
+    <table class="bordered">
+        <tr>
+            <th>ID</th>
+            <th>Description</th>
+            <th>Created</th>
+            <th>Actions</th>
+        </tr>
+
+        <tr th:each="client : ${apiClients}">
+            <td th:text="${client.email}">123-456-789</td>
+            <td th:text="${client.firstName}">Description</td>
+            <td th:text="${apiClientCreatedTimes[client.email]}">2021-11-22 33:44:55Z</td>
+            <td>
+                <form method="POST" th:action="|${prefix}/deleteApiKey|" th:if="${canDeleteApiKey}">
+                    <input type="hidden" name="userId" th:value="${client.userId}"/>
+                    <input type="hidden" name="organizationId" th:value="${organization.id}"/>
+                    <input type="submit" value=" Delete "/>
+                </form>
+            </td>
+        </tr>
+    </table>
+
+    <form method="POST" th:action="|${prefix}/createApiKey|" th:if="${canCreateApiKey}">
+        <h4>Create API Key</h4>
+
+        <input type="hidden" name="organizationId" th:value="${organization.id}"/>
+        <label for="apiKeyDescription">Description (optional)</label>
+        <input type="text" name="description" id="apiKeyDescription"/>
+        <input type="submit" value=" Create API Key "/>
+    </form>
+
+</div>
 
 </body>
 </html>

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -9,6 +9,7 @@ terraware:
   site-config-url: "classpath:config/test.json"
   photo-dir: "/dummy-directory"
   keycloak:
+    apiClientId: "dummyClientForApiClients"
     clientId: "dummyClient"
     clientSecret: "dummySecret"
     realm: "dummyRealm"


### PR DESCRIPTION
The organization view of the placeholder admin UI now includes a list of API keys
and a button to create a new key. Currently, the intended audience for these keys
is people working on the device manager code: the device manager will need to use
these keys to authenticate to terraware-server.

These "API keys" are actually OAuth2 refresh tokens with no expiration date (aka
"offline tokens" in the lingo of OpenID Connect). The device manager will use them
to authenticate to Keycloak and request access tokens. This requires some
additional setup on the Keycloak side, which is documented in detail in
`KEYCLOAK.md`.

Behind the scenes, the code now has the ability to dynamically create and destroy
Keycloak users and to request offline refresh tokens from Keycloak.

CU-185t84y
