### PR TITLE
Use URLs for file storage locations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.file
 
 import java.io.IOException
 import java.io.InputStream
+import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -24,8 +25,10 @@ interface FileStore {
    * @throws NoSuchFileException The file did not exist.
    * @throws IOException An error occurred while deleting the file. The file may or may not have
    * actually been removed.
+   * @throws InvalidStorageLocationException The URL referred to a file that isn't managed by this
+   * file store.
    */
-  fun delete(path: Path)
+  fun delete(url: URI)
 
   /**
    * Reads a file from the storage system. The returned stream is not guaranteed to be non-blocking.
@@ -33,8 +36,10 @@ interface FileStore {
    * @return An input stream that includes the file size. The caller is responsible for closing it.
    * @throws NoSuchFileException The file does not exist.
    * @throws IOException An error occurred while opening the file.
+   * @throws InvalidStorageLocationException The URL referred to a file that isn't managed by this
+   * file store.
    */
-  fun read(path: Path): SizedInputStream
+  fun read(url: URI): SizedInputStream
 
   /**
    * Returns the size of a file. Note that [read] returns the size alongside the file contents, so
@@ -42,8 +47,10 @@ interface FileStore {
    *
    * @throws NoSuchFileException The file does not exist.
    * @throws IOException An error occurred while fetching the file's size.
+   * @throws InvalidStorageLocationException The URL referred to a file that isn't managed by this
+   * file store.
    */
-  fun size(path: Path): Long
+  fun size(url: URI): Long
 
   /**
    * Writes a file to the storage system. Does not overwrite existing data. If you need to overwrite
@@ -58,6 +65,14 @@ interface FileStore {
    * @throws IOException An error occurred while writing the file or while reading [contents].
    * Implementations should attempt to delete files that weren't written successfully, though
    * depending on the nature of the error, it may be impossible to do so.
+   * @throws InvalidStorageLocationException The URL referred to a file that isn't managed by this
+   * file store.
    */
-  fun write(path: Path, contents: InputStream, size: Long)
+  fun write(url: URI, contents: InputStream, size: Long)
+
+  /** Returns true if this file store can accept a URI. */
+  fun canAccept(url: URI): Boolean
+
+  /** Returns the URL of a file with a given relative path on this file store. */
+  fun getUrl(path: Path): URI
 }

--- a/src/main/kotlin/com/terraformation/backend/file/UriNotSupportedException.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UriNotSupportedException.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.file
+
+import java.io.IOException
+import java.net.URI
+
+/** A file store was asked to accept a URL that refers to some other storage location. */
+class InvalidStorageLocationException(private val uri: URI, message: String? = null) :
+    IOException(message)

--- a/src/test/kotlin/com/terraformation/backend/file/LocalFileStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/LocalFileStoreTest.kt
@@ -3,12 +3,18 @@ package com.terraformation.backend.file
 import com.terraformation.backend.config.TerrawareServerConfig
 import io.mockk.every
 import io.mockk.mockk
+import java.net.URI
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.outputStream
+import kotlin.random.Random
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 
 class LocalFileStoreTest : FileStoreTest() {
@@ -25,18 +31,37 @@ class LocalFileStoreTest : FileStoreTest() {
     store = LocalFileStore(config)
   }
 
-  override fun createFile(path: Path, content: ByteArray) {
-    val fullPath = tempDir.resolve(path)
+  @Test
+  fun `cannot escape storage directory with relative paths in URLs`() {
+    tempDir.resolve("fileInParentDir").outputStream().use { stream -> stream.write(0) }
+    tempDir.resolve("subdir").createDirectories()
+
+    every { config.photoDir } returns tempDir.resolve("subdir")
+    store = LocalFileStore(config)
+
+    assertThrows<NoSuchFileException> { store.read(URI("file:///../fileInParentDir")) }
+  }
+
+  override fun createFile(url: URI, content: ByteArray) {
+    val fullPath = tempDir.resolve(relativePath(url))
     fullPath.parent?.createDirectories()
     fullPath.outputStream().use { stream -> stream.write(content) }
   }
 
-  override fun fileExists(path: Path): Boolean {
-    return tempDir.resolve(path).exists()
+  override fun fileExists(url: URI): Boolean {
+    return tempDir.resolve(relativePath(url)).exists()
   }
 
-  override fun readFile(path: Path): ByteArray {
-    val fullPath = tempDir.resolve(path)
+  override fun readFile(url: URI): ByteArray {
+    val fullPath = tempDir.resolve(relativePath(url))
     return fullPath.inputStream().readAllBytes()
+  }
+
+  override fun makeUrl(): URI {
+    return URI("file:///${Random.nextInt()}")
+  }
+
+  private fun relativePath(url: URI): Path {
+    return Path(url.path.substring(1))
   }
 }


### PR DESCRIPTION
Down the road, we may want to support multiple file storage locations, e.g.,
different S3 buckets for different photo types. In anticipation of that, and
also in anticipation of an upcoming change to store photo file locations in
the `photos` table, change the `FileStore` API so it accepts URLs rather than
paths.

This doesn't actually support multiple active `FileStore`s, but will make it
easier to do so in the future since we'll be able to look at the URL to route
calls to the correct one.
