### PR TITLE
Allow ID wrappers as path variables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
   implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
   implementation("com.opencsv:opencsv:5.3")
-  implementation("io.swagger.core.v3:swagger-annotations:2.1.7")
+  implementation("io.swagger.core.v3:swagger-annotations:2.1.10")
   implementation("javax.inject:javax.inject:1")
   implementation("net.postgis:postgis-jdbc:2021.1.0")
   implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1")

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
@@ -23,6 +23,7 @@ class IdWrapper(
   fun render(out: JavaWriter) {
     out.println("""
       class $className @JsonCreator constructor(@get:JsonValue val value: Long) {
+        constructor(value: String) : this(value.toLong())
         override fun equals(other: Any?): Boolean = other is $className && other.value == value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): String = value.toString()

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ jacksonVersion=2.11.3
 jooqVersion=3.14.7
 kotlinVersion=1.5.10
 postgresJdbcVersion=42.2.19
-springDocVersion=1.5.5
+springDocVersion=1.5.10

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -781,6 +781,9 @@ paths:
         content:
           multipart/form-data:
             schema:
+              required:
+              - file
+              - metadata
               type: object
               properties:
                 file:

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilityController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilityController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.api
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.FacilityStore
+import com.terraformation.backend.db.FacilityId
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -28,13 +29,18 @@ class FacilityController(private val facilityStore: FacilityStore) {
               facilityRoles[facility.id]
                   ?: throw IllegalStateException(
                       "BUG! No role for facility that was selected based on the presence of a role")
-          ListFacilitiesElement(facility.id.value, facility.name, facility.type.id, role.name)
+          ListFacilitiesElement(facility.id, facility.name, facility.type.id, role.name)
         }
 
     return ListFacilitiesResponse(elements)
   }
 }
 
-data class ListFacilitiesElement(val id: Long, val name: String, val type: Int, val role: String)
+data class ListFacilitiesElement(
+    val id: FacilityId,
+    val name: String,
+    val type: Int,
+    val role: String
+)
 
 data class ListFacilitiesResponse(val facilities: List<ListFacilitiesElement>)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationController.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.api
 
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.db.OrganizationId
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -18,13 +19,11 @@ class OrganizationController(private val organizationStore: OrganizationStore) {
   )
   fun listAll(): ListOrganizationsResponse {
     val elements =
-        organizationStore.fetchAll().map { model ->
-          ListOrganizationsElement(model.id.value, model.name)
-        }
+        organizationStore.fetchAll().map { model -> ListOrganizationsElement(model.id, model.name) }
     return ListOrganizationsResponse(elements)
   }
 }
 
-data class ListOrganizationsElement(val id: Long, val name: String)
+data class ListOrganizationsElement(val id: OrganizationId, val name: String)
 
 data class ListOrganizationsResponse(val organizations: List<ListOrganizationsElement>)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
@@ -54,26 +54,26 @@ class SiteController(private val projectsDao: ProjectsDao, private val sitesDao:
       ),
       ApiResponse(responseCode = "404", description = "No site with the requested ID exists."),
   )
-  fun getSite(@PathVariable siteId: Long): GetSiteResponse {
-    if (!currentUser().canReadSite(SiteId(siteId))) {
+  fun getSite(@PathVariable siteId: SiteId): GetSiteResponse {
+    if (!currentUser().canReadSite(siteId)) {
       throw WrongOrganizationException()
     }
 
-    val site = sitesDao.fetchOneById(SiteId(siteId)) ?: throw NotFoundException()
+    val site = sitesDao.fetchOneById(siteId) ?: throw NotFoundException()
 
     return GetSiteResponse(site)
   }
 }
 
-data class ListSitesElement(val id: Long, val name: String) {
-  constructor(site: SitesRow) : this(site.id!!.value, site.name!!)
+data class ListSitesElement(val id: SiteId, val name: String) {
+  constructor(site: SitesRow) : this(site.id!!, site.name!!)
 }
 
 data class ListSitesResponse(val sites: List<ListSitesElement>)
 
 @Schema(requiredProperties = ["id"])
 data class GetSiteResponse(
-    val id: Long,
+    val id: SiteId,
     val name: String,
     val latitude: String,
     val longitude: String,
@@ -83,7 +83,7 @@ data class GetSiteResponse(
   constructor(
       record: SitesRow
   ) : this(
-      record.id!!.value,
+      record.id!!,
       record.name!!,
       record.latitude!!.toPlainString(),
       record.longitude!!.toPlainString(),

--- a/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
@@ -60,17 +60,16 @@ class TimeseriesController(
       decimalPlaces: Int?,
       @RequestParam(required = false)
       @Schema(description = "Alias for facilityId for backward compatibility.")
-      siteModuleId: Long?,
+      siteModuleId: FacilityId?,
       @RequestParam(required = false)
       @Schema(
           description =
               "Which facility the device is in, if it isn't in the seed bank's default facility. " +
                   "Must match the facility ID the device is associated with in the per-site " +
                   "configuration.")
-      facilityId: Long?,
+      facilityId: FacilityId?,
   ): SimpleSuccessResponsePayload {
-    val effectiveFacilityId =
-        (facilityId ?: siteModuleId)?.let { FacilityId(it) } ?: currentUser().defaultFacilityId()
+    val effectiveFacilityId = facilityId ?: siteModuleId ?: currentUser().defaultFacilityId()
     val deviceId =
         deviceStore.getDeviceIdByName(effectiveFacilityId, device)
             ?: throw NotFoundException("Device $device does not exist")

--- a/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
@@ -42,9 +42,9 @@ class FeatureController(private val featureStore: FeatureStore) {
   @ApiResponse(responseCode = "200")
   @ApiResponse404(description = "The specified feature doesn't exist.")
   @GetMapping("/{featureId}")
-  fun read(@PathVariable featureId: Long): GetFeatureResponsePayload {
+  fun read(@PathVariable featureId: FeatureId): GetFeatureResponsePayload {
     val model =
-        featureStore.fetchFeature(FeatureId(featureId))
+        featureStore.fetchFeature(featureId)
             ?: throw NotFoundException("The feature with id $featureId doesn't exist.")
 
     return GetFeatureResponsePayload(FeatureResponse(model))
@@ -55,10 +55,9 @@ class FeatureController(private val featureStore: FeatureStore) {
   @GetMapping("/list/{layerId}")
   fun list(
       @RequestBody payload: ListFeaturesRequestPayload,
-      @PathVariable layerId: Long
+      @PathVariable layerId: LayerId
   ): ListFeaturesResponsePayload {
-    val features =
-        featureStore.listFeatures(LayerId(layerId), skip = payload.skip, limit = payload.limit)
+    val features = featureStore.listFeatures(layerId, skip = payload.skip, limit = payload.limit)
     return ListFeaturesResponsePayload(features.map { FeatureResponse(it) })
   }
 
@@ -71,10 +70,10 @@ class FeatureController(private val featureStore: FeatureStore) {
   @PutMapping("/{featureId}")
   fun update(
       @RequestBody payload: UpdateFeatureRequestPayload,
-      @PathVariable featureId: Long,
+      @PathVariable featureId: FeatureId,
   ): UpdateFeatureResponsePayload {
     try {
-      val updatedModel = featureStore.updateFeature(payload.toModel(FeatureId(featureId)))
+      val updatedModel = featureStore.updateFeature(payload.toModel(featureId))
       return UpdateFeatureResponsePayload(FeatureResponse(updatedModel))
     } catch (e: FeatureNotFoundException) {
       throw NotFoundException(
@@ -90,10 +89,10 @@ class FeatureController(private val featureStore: FeatureStore) {
               "feature. This includes but is not limited to plants, plant observations, photos, " +
               "and thumbnails.")
   @DeleteMapping("/{featureId}")
-  fun delete(@PathVariable featureId: Long): DeleteFeatureResponsePayload {
+  fun delete(@PathVariable featureId: FeatureId): DeleteFeatureResponsePayload {
     try {
-      featureStore.deleteFeature(FeatureId(featureId))
-      return DeleteFeatureResponsePayload(FeatureId(featureId))
+      featureStore.deleteFeature(featureId)
+      return DeleteFeatureResponsePayload(featureId)
     } catch (e: FeatureNotFoundException) {
       throw NotFoundException("The feature with id $featureId doesn't exist.")
     }

--- a/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
@@ -40,9 +40,9 @@ class LayerController(private val layerStore: LayerStore) {
   @ApiResponse(responseCode = "200")
   @ApiResponse404(description = "The specified layer doesn't exist.")
   @GetMapping("/{layerId}")
-  fun read(@PathVariable layerId: Long): GetLayerResponsePayload {
+  fun read(@PathVariable layerId: LayerId): GetLayerResponsePayload {
     val layerModel =
-        layerStore.fetchLayer(LayerId(layerId))
+        layerStore.fetchLayer(layerId)
             ?: throw NotFoundException("The layer with id $layerId doesn't exist.")
 
     return GetLayerResponsePayload(LayerResponse(layerModel))
@@ -50,8 +50,8 @@ class LayerController(private val layerStore: LayerStore) {
 
   @ApiResponse(responseCode = "200")
   @GetMapping("/list/{siteId}")
-  fun list(@PathVariable siteId: Long): ListLayersResponsePayload {
-    val layers = layerStore.listLayers(SiteId(siteId))
+  fun list(@PathVariable siteId: SiteId): ListLayersResponsePayload {
+    val layers = layerStore.listLayers(siteId)
     return ListLayersResponsePayload(layers.map { LayerResponse(it) })
   }
 
@@ -64,10 +64,10 @@ class LayerController(private val layerStore: LayerStore) {
   @PutMapping("/{layerId}")
   fun update(
       @RequestBody payload: UpdateLayerRequestPayload,
-      @PathVariable layerId: Long,
+      @PathVariable layerId: LayerId,
   ): UpdateLayerResponsePayload {
     try {
-      val updatedModel = layerStore.updateLayer(payload.toModel(id = LayerId(layerId)))
+      val updatedModel = layerStore.updateLayer(payload.toModel(id = layerId))
       return UpdateLayerResponsePayload(LayerResponse(updatedModel))
     } catch (e: LayerNotFoundException) {
       throw NotFoundException(
@@ -78,9 +78,9 @@ class LayerController(private val layerStore: LayerStore) {
   @ApiResponse(responseCode = "200")
   @ApiResponse404(description = "The specified layer doesn't exist.")
   @DeleteMapping("/{layerId}")
-  fun delete(@PathVariable layerId: Long): DeleteLayerResponsePayload {
+  fun delete(@PathVariable layerId: LayerId): DeleteLayerResponsePayload {
     try {
-      val layerModel = layerStore.deleteLayer(LayerId(layerId))
+      val layerModel = layerStore.deleteLayer(layerId)
       return DeleteLayerResponsePayload(DeleteLayerResponse(layerModel))
     } catch (e: LayerNotFoundException) {
       throw NotFoundException("The layer with id $layerId doesn't exist.")

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
@@ -43,9 +43,9 @@ class PlantController(private val plantStore: PlantStore) {
   @ApiResponse(responseCode = "200")
   @ApiResponse404(description = "The specified plant doesn't exist.")
   @GetMapping("/{featureId}")
-  fun get(@PathVariable featureId: Long): GetPlantResponsePayload {
+  fun get(@PathVariable featureId: FeatureId): GetPlantResponsePayload {
     val plant =
-        plantStore.fetchPlant(FeatureId(featureId))
+        plantStore.fetchPlant(featureId)
             ?: throw NotFoundException("The plant with id $featureId doesn't exist.")
     return GetPlantResponsePayload(PlantResponse(plant))
   }
@@ -58,11 +58,11 @@ class PlantController(private val plantStore: PlantStore) {
   @GetMapping("/list/{layerId}")
   fun getPlantsList(
       @RequestBody payload: ListPlantsRequestPayload,
-      @PathVariable layerId: Long
+      @PathVariable layerId: LayerId
   ): ListPlantsResponsePayload {
     val plants =
         plantStore.fetchPlantsList(
-            layerId = LayerId(layerId),
+            layerId = layerId,
             speciesName = payload.speciesName,
             minEnteredTime = payload.minEnteredTime,
             maxEnteredTime = payload.maxEnteredTime,
@@ -79,11 +79,11 @@ class PlantController(private val plantStore: PlantStore) {
   @GetMapping("/list/summary/{layerId}")
   fun getPlantSummary(
       @RequestBody payload: GetPlantSummaryPayload,
-      @PathVariable layerId: Long
+      @PathVariable layerId: LayerId
   ): PlantSummaryResponsePayload {
     val summary =
         plantStore.fetchPlantSummary(
-            LayerId(layerId),
+            layerId,
             minEnteredTime = payload.minEnteredTime,
             maxEnteredTime = payload.maxEnteredTime)
     return PlantSummaryResponsePayload(summary)
@@ -95,10 +95,10 @@ class PlantController(private val plantStore: PlantStore) {
   @PutMapping("/{featureId}")
   fun update(
       @RequestBody payload: UpdatePlantRequestPayload,
-      @PathVariable featureId: Long
+      @PathVariable featureId: FeatureId
   ): UpdatePlantResponsePayload {
     try {
-      val updatedPlant = plantStore.updatePlant(payload.toRow(FeatureId(featureId)))
+      val updatedPlant = plantStore.updatePlant(payload.toRow(featureId))
       return UpdatePlantResponsePayload(PlantResponse(updatedPlant))
     } catch (e: PlantNotFoundException) {
       throw NotFoundException("The plant with feature id $featureId doesn't exist.")

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
@@ -43,19 +43,19 @@ class PlantObservationsController(private val observStore: PlantObservationsStor
   @ApiResponse(responseCode = "200")
   @ApiResponse404(description = "The specified plant observation doesn't exist.")
   @GetMapping("/{plantObservationId}")
-  fun get(@PathVariable plantObservationId: Long): GetObservationResponsePayload {
-    val id = PlantObservationId(plantObservationId)
+  fun get(@PathVariable plantObservationId: PlantObservationId): GetObservationResponsePayload {
     val observation =
-        observStore.fetch(id)
-            ?: throw NotFoundException("The plant observation with id $id doesn't exist.")
+        observStore.fetch(plantObservationId)
+            ?: throw NotFoundException(
+                "The plant observation with id $plantObservationId doesn't exist.")
     return GetObservationResponsePayload(ObservationResponse(observation))
   }
 
   @ApiResponse(responseCode = "200")
   @Operation(summary = "Fetch a list of the plant observations associated with a plant.")
   @GetMapping("/list/{featureId}")
-  fun getList(@PathVariable featureId: Long): ListObservationsResponsePayload {
-    val list = observStore.fetchList(FeatureId(featureId))
+  fun getList(@PathVariable featureId: FeatureId): ListObservationsResponsePayload {
+    val list = observStore.fetchList(featureId)
     return ListObservationsResponsePayload(list.map { ObservationResponse(it) })
   }
 
@@ -69,10 +69,10 @@ class PlantObservationsController(private val observStore: PlantObservationsStor
   @PutMapping("/{plantObservationId}")
   fun update(
       @RequestBody payload: UpdateObservationRequestPayload,
-      @PathVariable plantObservationId: Long
+      @PathVariable plantObservationId: PlantObservationId
   ): UpdateObservationResponsePayload {
     try {
-      val updated = observStore.update(payload.toRow(PlantObservationId(plantObservationId)))
+      val updated = observStore.update(payload.toRow(plantObservationId))
       return UpdateObservationResponsePayload(ObservationResponse(updated))
     } catch (e: PlantObservationNotFoundException) {
       throw NotFoundException("The plant observation with id $plantObservationId doesn't exist.")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -42,7 +42,7 @@ class ValuesController(
   @GetMapping("/species")
   fun listSpecies(): ListSpeciesResponsePayload {
     return ListSpeciesResponsePayload(
-        speciesStore.findAllSortedByName().map { SpeciesDetails(it.id!!.value, it.name!!) })
+        speciesStore.findAllSortedByName().map { SpeciesDetails(it.id!!, it.name!!) })
   }
 
   @ApiResponses(
@@ -57,7 +57,7 @@ class ValuesController(
     try {
       val row = SpeciesRow(name = payload.name)
       val speciesId = speciesStore.createSpecies(row)
-      return CreateSpeciesResponsePayload(SpeciesDetails(speciesId.value, payload.name))
+      return CreateSpeciesResponsePayload(SpeciesDetails(speciesId, payload.name))
     } catch (e: DuplicateKeyException) {
       throw DuplicateNameException("A species with that name already exists.")
     }
@@ -75,11 +75,11 @@ class ValuesController(
   @PostMapping("/species/{id}")
   fun updateSpecies(
       @RequestBody payload: CreateSpeciesRequestPayload,
-      @PathVariable id: Long
+      @PathVariable id: SpeciesId
   ): UpdateSpeciesResponsePayload {
     try {
-      val newId = accessionStore.updateSpecies(SpeciesId(id), payload.name)
-      return UpdateSpeciesResponsePayload(newId?.value)
+      val newId = accessionStore.updateSpecies(id, payload.name)
+      return UpdateSpeciesResponsePayload(newId)
     } catch (e: SpeciesNotFoundException) {
       throw NotFoundException("Species not found.")
     }
@@ -132,7 +132,7 @@ class ValuesController(
   }
 }
 
-data class SpeciesDetails(val id: Long, val name: String)
+data class SpeciesDetails(val id: SpeciesId, val name: String)
 
 data class ListSpeciesResponsePayload(val values: List<SpeciesDetails>) : SuccessResponsePayload
 
@@ -146,7 +146,7 @@ data class UpdateSpeciesResponsePayload(
         description =
             "If the requested species name already existed, the ID of the existing species. " +
                 "Will not be present if the requested species name did not already exist.")
-    val mergedWithSpeciesId: Long?
+    val mergedWithSpeciesId: SpeciesId?
 ) : SuccessResponsePayload
 
 data class StorageLocationsResponsePayload(val locations: List<StorageLocationDetails>) :

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -84,9 +84,9 @@ class SpeciesController(
   @ApiResponse404
   @GetMapping("/{speciesId}")
   @Operation(summary = "Gets information about a single species.")
-  fun speciesRead(@PathVariable speciesId: Long): SpeciesGetResponsePayload {
+  fun speciesRead(@PathVariable speciesId: SpeciesId): SpeciesGetResponsePayload {
     val row =
-        speciesDao.fetchOneById(SpeciesId(speciesId))
+        speciesDao.fetchOneById(speciesId)
             ?: throw NotFoundException("Species $speciesId not found.")
     return SpeciesGetResponsePayload(SpeciesResponseElement(row))
   }
@@ -97,10 +97,10 @@ class SpeciesController(
   @Operation(summary = "Updates an existing species.")
   @PutMapping("/{speciesId}")
   fun speciesUpdate(
-      @PathVariable speciesId: Long,
+      @PathVariable speciesId: SpeciesId,
       @RequestBody payload: SpeciesRequestPayload
   ): SimpleSuccessResponsePayload {
-    speciesStore.updateSpecies(payload.toRow(SpeciesId(speciesId)))
+    speciesStore.updateSpecies(payload.toRow(speciesId))
     return SimpleSuccessResponsePayload()
   }
 
@@ -112,9 +112,9 @@ class SpeciesController(
   @ApiResponse404
   @DeleteMapping("/{speciesId}")
   @Operation(summary = "Delete an existing species.")
-  fun speciesDelete(@PathVariable speciesId: Long): SimpleSuccessResponsePayload {
+  fun speciesDelete(@PathVariable speciesId: SpeciesId): SimpleSuccessResponsePayload {
     try {
-      speciesStore.deleteSpecies(SpeciesId(speciesId))
+      speciesStore.deleteSpecies(speciesId)
       return SimpleSuccessResponsePayload()
     } catch (e: DataIntegrityViolationException) {
       throw ResourceInUseException("Species $speciesId is currently in use.")
@@ -151,9 +151,9 @@ class SpeciesController(
   @ApiResponse(responseCode = "200", description = "Species names retrieved.")
   @ApiResponse404("The species does not exist.")
   @GetMapping("/{speciesId}/names")
-  fun speciesNamesList(@PathVariable speciesId: Long): SpeciesNamesListResponsePayload {
+  fun speciesNamesList(@PathVariable speciesId: SpeciesId): SpeciesNamesListResponsePayload {
     try {
-      val names = speciesStore.listAllSpeciesNames(SpeciesId(speciesId))
+      val names = speciesStore.listAllSpeciesNames(speciesId)
       return SpeciesNamesListResponsePayload(names.map { SpeciesNamesResponseElement(it) })
     } catch (e: SpeciesNotFoundException) {
       throw NotFoundException("The species does not exist.")
@@ -164,9 +164,9 @@ class SpeciesController(
   @ApiResponse404
   @GetMapping("/names/{speciesNameId}")
   @Operation(description = "Gets information about a single species name.")
-  fun speciesNameGet(@PathVariable speciesNameId: Long): SpeciesNameGetResponsePayload {
+  fun speciesNameGet(@PathVariable speciesNameId: SpeciesNameId): SpeciesNameGetResponsePayload {
     val row =
-        speciesNamesDao.fetchOneById(SpeciesNameId(speciesNameId))
+        speciesNamesDao.fetchOneById(speciesNameId)
             ?: throw NotFoundException("Species name not found")
     return SpeciesNameGetResponsePayload(SpeciesNamesResponseElement(row))
   }
@@ -178,18 +178,18 @@ class SpeciesController(
   @ApiResponse404
   @DeleteMapping("/names/{speciesNameId}")
   @Operation(description = "Deletes one of the secondary names of a species.")
-  fun speciesNameDelete(@PathVariable speciesNameId: Long): SimpleSuccessResponsePayload {
-    speciesStore.deleteSpeciesName(SpeciesNameId(speciesNameId))
+  fun speciesNameDelete(@PathVariable speciesNameId: SpeciesNameId): SimpleSuccessResponsePayload {
+    speciesStore.deleteSpeciesName(speciesNameId)
     return SimpleSuccessResponsePayload()
   }
 
   @Operation(description = "Updates one of the names of a species.")
   @PutMapping("/names/{speciesNameId}")
   fun speciesNameUpdate(
-      @PathVariable speciesNameId: Long,
+      @PathVariable speciesNameId: SpeciesNameId,
       @RequestBody payload: SpeciesNameRequestPayload
   ): SimpleSuccessResponsePayload {
-    speciesStore.updateSpeciesName(payload.toRow().copy(id = SpeciesNameId(speciesNameId)))
+    speciesStore.updateSpeciesName(payload.toRow().copy(id = speciesNameId))
     return SimpleSuccessResponsePayload()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/api/SiteControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/api/SiteControllerTest.kt
@@ -68,7 +68,9 @@ class SiteControllerTest : RunsAsUser {
 
       val expected =
           ListSitesResponse(
-              listOf(ListSitesElement(1, "First Site"), ListSitesElement(2, "Second Site")))
+              listOf(
+                  ListSitesElement(SiteId(1), "First Site"),
+                  ListSitesElement(SiteId(2), "Second Site")))
 
       assertEquals(expected, siteController.listSites())
     }
@@ -101,7 +103,7 @@ class SiteControllerTest : RunsAsUser {
       every { projectsDao.fetchOneById(projectId) } returns project
       every { siteDao.fetchOneById(siteId) } returns site
 
-      assertDoesNotThrow { siteController.getSite(siteId.value) }
+      assertDoesNotThrow { siteController.getSite(siteId) }
     }
 
     @Test
@@ -109,7 +111,7 @@ class SiteControllerTest : RunsAsUser {
       every { user.canReadSite(siteId) } returns true
       every { siteDao.fetchOneById(siteId) } returns null
 
-      assertThrows<NotFoundException> { siteController.getSite(siteId.value) }
+      assertThrows<NotFoundException> { siteController.getSite(siteId) }
     }
 
     @Test
@@ -120,7 +122,7 @@ class SiteControllerTest : RunsAsUser {
       every { siteDao.fetchOneById(siteId) } returns
           SitesRow(id = siteId, projectId = projectId, name = "site")
 
-      assertThrows<WrongOrganizationException> { siteController.getSite(siteId.value) }
+      assertThrows<WrongOrganizationException> { siteController.getSite(siteId) }
     }
 
     @Test
@@ -131,14 +133,14 @@ class SiteControllerTest : RunsAsUser {
 
       val expected =
           GetSiteResponse(
-              id = siteId.value,
+              id = siteId,
               name = "site",
               latitude = latitudeString,
               longitude = longitudeString,
               locale = locale,
               timezone = timezone)
 
-      assertEquals(expected, siteController.getSite(siteId.value))
+      assertEquals(expected, siteController.getSite(siteId))
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1492,7 +1492,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                     uniqueId = "uniqueId"),
             endangered = SpeciesEndangeredType.Unsure,
             environmentalNotes = "envNotes",
-            facilityId = facilityId.value,
+            facilityId = facilityId,
             family = "family",
             fieldNotes = "fieldNotes",
             founderId = "founderId",


### PR DESCRIPTION
Previously, if we wanted to include an ID value in the URL path, we had to declare
the path variable as `Long` in the controller and then explicitly create an ID
wrapper object.

This was needed because Spring MVC didn't know how to convert a string to an
instance of an ID wrapper class. So the simple fix is to add a constructor to the
wrapper classes that takes a string argument. If the client uses a non-numeric
value, it will fail with HTTP 400 the same way it fails with `Long` parameters.

Update all the controller methods that used to take `Long` arguments to instead
use the appropriate wrapper classes.

This caused us to hit https://github.com/swagger-api/swagger-core/issues/3904 so
upgrade the OpenAPI library to get the fix for that.
