### PR TITLE
SW-216 Prevent concurrent runs of daily tasks

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.daily
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.tables.pojos.TaskProcessedTimesRow
+import com.terraformation.backend.db.tables.references.TASK_PROCESSED_TIMES
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
 import java.time.Instant
@@ -9,10 +11,12 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.annotation.ManagedBean
 import javax.annotation.PreDestroy
+import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
+import org.springframework.dao.DuplicateKeyException
 
 /**
  * Executes all the tasks that need to run on a daily basis. Handles the clock jumping forward by a
@@ -28,6 +32,7 @@ import org.springframework.context.event.EventListener
 class DailyTaskRunner(
     private val clock: Clock,
     private val config: TerrawareServerConfig,
+    private val dslContext: DSLContext,
     private val publisher: ApplicationEventPublisher
 ) : Runnable {
   private var thread = Thread(this, "DailyTasksThread")
@@ -66,6 +71,106 @@ class DailyTaskRunner(
     }
 
     log.trace("Daily task worker thread stopped")
+  }
+
+  /**
+   * Determines what time period should be scanned for new work and invokes a function to do it.
+   * Records the most recently processed time period so that the next invocation won't overlap with
+   * times that have already been covered.
+   */
+  fun runTask(task: TimePeriodTask, taskName: String = task.javaClass.simpleName) {
+    val now = clock.instant()
+
+    val since =
+        dslContext.transactionResult { _ ->
+
+          // Hold a row lock on the task_processed_times table while we check to see if we should
+          // run the task. This prevents two terraware-server instances from running the same task
+          // at the same time. The second one will block waiting for the row lock here, and when
+          // the first one releases the lock, it will have already updated started_time.
+          //
+          // If this is the first time the task has ever run, there won't be an existing row for it;
+          // in that case, we rely on the unique constraint on the name column to ensure that only
+          // one terraware-server instance succeeds in inserting the row for the task.
+
+          val row =
+              dslContext
+                  .selectFrom(TASK_PROCESSED_TIMES)
+                  .where(TASK_PROCESSED_TIMES.NAME.eq(taskName))
+                  .forUpdate()
+                  .fetchOneInto(TaskProcessedTimesRow::class.java)
+
+          val startedTime = row?.startedTime
+          val processedUpTo = row?.processedUpTo ?: task.startTimeForFirstRun(now)
+
+          val since: Instant? =
+              if (row == null) {
+                log.info("Task $taskName running for the first time")
+
+                try {
+                  dslContext
+                      .insertInto(TASK_PROCESSED_TIMES)
+                      .set(TASK_PROCESSED_TIMES.NAME, taskName)
+                      .set(TASK_PROCESSED_TIMES.PROCESSED_UP_TO, processedUpTo)
+                      .set(TASK_PROCESSED_TIMES.STARTED_TIME, now)
+                      .execute()
+                  processedUpTo
+                } catch (e: DuplicateKeyException) {
+                  log.warn(
+                      "Failed to insert row for task $taskName; most likely another instance " +
+                          "inserted it at the same time",
+                      e)
+                  null
+                }
+              } else if (startedTime == null) {
+                processedUpTo
+              } else if (startedTime.plus(task.timeoutPeriod) < now) {
+                log.warn(
+                    "Task $taskName running since $startedTime; assuming it bombed out so retrying")
+                processedUpTo
+              } else {
+                log.debug("Skipping task $taskName because it is already in progress")
+                null
+              }
+
+          if (since != null) {
+            dslContext
+                .update(TASK_PROCESSED_TIMES)
+                .set(TASK_PROCESSED_TIMES.STARTED_TIME, now)
+                .where(TASK_PROCESSED_TIMES.NAME.eq(taskName))
+                .execute()
+          }
+
+          since
+        }
+
+    if (since != null) {
+      val until = (since + task.maximumPeriod).coerceAtMost(now)
+
+      try {
+        task.processPeriod(since, until)
+
+        try {
+          dslContext
+              .update(TASK_PROCESSED_TIMES)
+              .set(TASK_PROCESSED_TIMES.PROCESSED_UP_TO, until)
+              .setNull(TASK_PROCESSED_TIMES.STARTED_TIME)
+              .where(TASK_PROCESSED_TIMES.NAME.eq(taskName))
+              .execute()
+        } catch (e: Exception) {
+          log.error("Unable to mark task $taskName as finished", e)
+        }
+      } catch (e: Exception) {
+        log.error(
+            "Task $taskName failed for period $since - $until. Will retry on the next run.", e)
+
+        dslContext
+            .update(TASK_PROCESSED_TIMES)
+            .setNull(TASK_PROCESSED_TIMES.STARTED_TIME)
+            .where(TASK_PROCESSED_TIMES.NAME.eq(taskName))
+            .execute()
+      }
+    }
   }
 
   private fun computeNextRunTime(): Instant {

--- a/src/main/kotlin/com/terraformation/backend/daily/TimePeriodTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/TimePeriodTask.kt
@@ -1,57 +1,34 @@
 package com.terraformation.backend.daily
 
-import com.terraformation.backend.db.tables.daos.TaskProcessedTimesDao
-import com.terraformation.backend.db.tables.pojos.TaskProcessedTimesRow
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 
 /**
- * Scaffolding for periodic tasks that scan for work in specific time periods. Records the most
- * recently processed time period in the database if it was handled successfully, such that the next
- * time the task is invoked, it will only look for new work rather than overlapping with the
- * previous invocation.
+ * A periodic task that scans for work spanning a specific time period.
+ *
+ * @see DailyTaskRunner
  */
 interface TimePeriodTask {
-  val clock: Clock
-  val taskProcessedTimesDao: TaskProcessedTimesDao
-
   /** The maximum amount of time that can be covered by a single run. */
   val maximumPeriod: Duration
     get() = Duration.ofDays(30)
+
+  /**
+   * The maximum amount of time a task can be marked as in progress before we decide the original
+   * run must have bombed out without marking itself as finished.
+   */
+  val timeoutPeriod: Duration
+    get() = Duration.ofHours(4)
 
   /** How far back to start searching the first time a task is run. */
   fun startTimeForFirstRun(now: Instant): Instant = now - maximumPeriod
 
   /**
-   * Determines what time period should be scanned for new work and invokes a function to do it.
-   * Records the most recently processed time period so that the next invocation won't overlap with
-   * times that have already been covered.
+   * Scans a time period for work and runs whatever processes need to happen for anything it finds.
+   * Invoked by [DailyTaskRunner.runTask].
+   *
+   * @param since Start of the time period, exclusive.
+   * @param until End of the time period, inclusive.
    */
-  fun processNewWork(taskName: String = javaClass.simpleName, processor: TimePeriodProcessor) {
-    val now = clock.instant()
-    val lastRun = taskProcessedTimesDao.fetchOneByName(taskName)
-    val since = lastRun?.processedUpTo ?: startTimeForFirstRun(now)
-    val until = (since + maximumPeriod).coerceAtMost(now)
-
-    processor.processPeriod(since, until)
-
-    val newRun = TaskProcessedTimesRow(name = javaClass.simpleName, processedUpTo = until)
-    if (lastRun == null) {
-      taskProcessedTimesDao.insert(newRun)
-    } else {
-      taskProcessedTimesDao.update(newRun)
-    }
-  }
-
-  /** @see [processPeriod] */
-  fun interface TimePeriodProcessor {
-    /**
-     * Scans a time period for work and runs whatever processes need to happen for anything it
-     * finds.
-     * @param since Start of the time period, exclusive.
-     * @param until End of the time period, inclusive.
-     */
-    fun processPeriod(since: Instant, until: Instant)
-  }
+  fun processPeriod(since: Instant, until: Instant)
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/daily/AccessionScheduledStateTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/daily/AccessionScheduledStateTask.kt
@@ -1,11 +1,14 @@
 package com.terraformation.backend.seedbank.daily
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.daily.DailyTaskRunner
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
+import com.terraformation.backend.daily.TimePeriodTask
 import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.db.AccessionStore
 import java.time.Clock
+import java.time.Instant
 import javax.annotation.ManagedBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.event.EventListener
@@ -13,10 +16,11 @@ import org.springframework.context.event.EventListener
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
 @ManagedBean
 class AccessionScheduledStateTask(
-    private val store: AccessionStore,
+    private val accessionStore: AccessionStore,
     private val clock: Clock,
+    private val dailyTaskRunner: DailyTaskRunner,
     private val facilitiesDao: FacilitiesDao
-) {
+) : TimePeriodTask {
   private val log = perClassLogger()
 
   /** Updates the states of any accessions that are scheduled for a time-based state transition. */
@@ -24,20 +28,23 @@ class AccessionScheduledStateTask(
   fun updateScheduledStates(
       @Suppress("UNUSED_PARAMETER") event: DailyTaskTimeArrivedEvent
   ): FinishedEvent {
+    dailyTaskRunner.runTask(this)
+    return FinishedEvent()
+  }
+
+  override fun processPeriod(since: Instant, until: Instant) {
     log.info("Scanning for scheduled accession state updates")
 
     facilitiesDao.findAll().mapNotNull { it.id }.forEach { facilityId ->
-      store
+      accessionStore
           .fetchTimedStateTransitionCandidates(facilityId)
           .filter { it.getStateTransition(it, clock) != null }
           .forEach { model ->
             if (model.accessionNumber != null) {
-              store.update(facilityId, model.accessionNumber, model)
+              accessionStore.update(facilityId, model.accessionNumber, model)
             }
           }
     }
-
-    return FinishedEvent()
   }
 
   /**

--- a/src/main/resources/db/migration/common/V51__TaskStarted.sql
+++ b/src/main/resources/db/migration/common/V51__TaskStarted.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task_processed_times ADD COLUMN started_time TIMESTAMP WITH TIME ZONE;

--- a/src/test/kotlin/com/terraformation/backend/daily/DailyTaskRunnerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/DailyTaskRunnerTest.kt
@@ -1,0 +1,113 @@
+package com.terraformation.backend.daily
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.tables.daos.TaskProcessedTimesDao
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+
+internal class DailyTaskRunnerTest : DatabaseTest() {
+  private val clock: Clock = mockk()
+  private val config: TerrawareServerConfig = mockk()
+  private val publisher: ApplicationEventPublisher = mockk()
+
+  private lateinit var dailyTaskRunner: DailyTaskRunner
+  private lateinit var taskProcessedTimesDao: TaskProcessedTimesDao
+
+  private lateinit var task: TimePeriodTask
+
+  private val now = Instant.parse("2021-01-01T00:00:00Z")
+  private val startTimeForFirstRun = Instant.parse("2020-01-01T00:00:00Z")
+  private val maximumPeriod = Duration.ofDays(7)
+  private val timeoutPeriod = Duration.ofHours(4)
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns now
+    every { clock.zone } returns ZoneOffset.UTC
+
+    task = makeMockTask()
+
+    dailyTaskRunner = DailyTaskRunner(clock, config, dslContext, publisher)
+    taskProcessedTimesDao = TaskProcessedTimesDao(dslContext.configuration())
+  }
+
+  private fun makeMockTask(name: String? = "task"): TimePeriodTask {
+    val task: TimePeriodTask = mockk(name = name)
+
+    every { task.maximumPeriod } returns maximumPeriod
+    justRun { task.processPeriod(any(), any()) }
+    every { task.startTimeForFirstRun(any()) } returns startTimeForFirstRun
+    every { task.timeoutPeriod } returns timeoutPeriod
+
+    return task
+  }
+
+  @Test
+  fun `runs task that hasn't been run before with correct initial time period`() {
+    val sinceSlot: CapturingSlot<Instant> = slot()
+    val untilSlot: CapturingSlot<Instant> = slot()
+    justRun { task.processPeriod(capture(sinceSlot), capture(untilSlot)) }
+
+    dailyTaskRunner.runTask(task)
+
+    verify { task.processPeriod(any(), any()) }
+    assertEquals(startTimeForFirstRun, sinceSlot.captured, "Since")
+    assertEquals(startTimeForFirstRun + maximumPeriod, untilSlot.captured, "Until")
+  }
+
+  @Test
+  fun `skips task that is already in progress`() {
+    every { task.processPeriod(any(), any()) } answers
+        {
+          // The task should already be marked as in progress, so this shouldn't try running it
+          // again.
+          dailyTaskRunner.runTask(task)
+        }
+
+    dailyTaskRunner.runTask(task)
+
+    verify(exactly = 1) { task.processPeriod(any(), any()) }
+  }
+
+  @Test
+  fun `runs task that has been in progress too long`() {
+    every { task.processPeriod(any(), any()) } answers
+        {
+          every { clock.instant() } returns now + timeoutPeriod + Duration.ofSeconds(1)
+          justRun { task.processPeriod(any(), any()) }
+          dailyTaskRunner.runTask(task)
+        }
+
+    dailyTaskRunner.runTask(task)
+
+    verify(exactly = 2) { task.processPeriod(any(), any()) }
+  }
+
+  @Test
+  fun `different tasks can run concurrently`() {
+    val otherTask = makeMockTask("other")
+
+    every { task.processPeriod(any(), any()) } answers
+        {
+          dailyTaskRunner.runTask(otherTask, "other")
+        }
+
+    dailyTaskRunner.runTask(task)
+
+    verify(exactly = 1) { task.processPeriod(any(), any()) }
+    verify(exactly = 1) { otherTask.processPeriod(any(), any()) }
+  }
+}


### PR DESCRIPTION
When we start running multiple terraware-server instances for redundancy, it will
become possible for two or more of them to decide to execute the daily seed bank
tasks at the same time. This could result in duplicate notifications or other bad
side effects.

Add logic to ensure that only one server instance can run a given daily task.

As part of this, move the code that updates the tasks table out of
`TimePeriodTask`, where it never really belonged in the first place. That
interface is now much simpler.

Unit-testing row locking logic is a bit tricky to do reliably since there are no
guarantees about consistent timing in a CI environment. So this includes some
basic functional tests, and I tested by hand by adding `Thread.sleep(30000)` to
various places in the code (e.g., right after the `SELECT FOR UPDATE`, or right
before the `INSERT`) and starting two terraware-server instances to make sure
only one of them ran the tasks.
