### PR TITLE
Type-safe wrapper for URL columns in database

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -119,7 +119,11 @@ class TerrawareGenerator : KotlinGenerator() {
             ForcedType()
                 .withBinding("com.terraformation.backend.db.GeometryBinding")
                 .withIncludeTypes("GEOMETRY")
-                .withUserType("net.postgis.jdbc.geometry.Geometry"))
+                .withUserType("net.postgis.jdbc.geometry.Geometry"),
+            ForcedType()
+                .withIncludeExpression("(?i:.*_ur[li])")
+                .withConverter("com.terraformation.backend.db.UriConverter")
+                .withUserType("java.net.URI"))
 
     ENUM_TABLES.forEach { types.add(it.forcedType(targetPackage)) }
     ID_WRAPPERS.forEach { types.add(it.forcedType(targetPackage)) }

--- a/src/main/kotlin/com/terraformation/backend/db/UriConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/UriConverter.kt
@@ -1,0 +1,15 @@
+package com.terraformation.backend.db
+
+import java.net.URI
+import org.jooq.impl.AbstractConverter
+
+/**
+ * Converts text values from the database to and from URI objects. This is for type safety, so we
+ * don't treat arbitrary string values as URIs.
+ *
+ * This is referenced in generated database classes.
+ */
+class UriConverter : AbstractConverter<String, URI>(String::class.java, URI::class.java) {
+  override fun from(databaseObject: String?): URI? = databaseObject?.let { URI(it) }
+  override fun to(userObject: URI?): String? = userObject?.let { "$it" }
+}

--- a/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
@@ -23,7 +23,6 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.gis.model.FeatureModel
 import com.terraformation.backend.log.perClassLogger
 import java.io.InputStream
-import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.time.Clock
@@ -237,7 +236,7 @@ class FeatureStore(
                 createdTime = createdTime,
                 id = null,
                 modifiedTime = createdTime,
-                storageUrl = "$photoUrl")
+                storageUrl = photoUrl)
 
         photosDao.insert(sanitizedRow)
 
@@ -294,7 +293,7 @@ class FeatureStore(
   fun getPhotoData(featureId: FeatureId, photoId: PhotoId): SizedInputStream {
     val photosRow = getPhotoMetadata(featureId, photoId)
 
-    return fileStore.read(URI(photosRow.storageUrl!!))
+    return fileStore.read(photosRow.storageUrl!!)
   }
 
   fun deletePhoto(featureId: FeatureId, photoId: PhotoId) {
@@ -305,7 +304,7 @@ class FeatureStore(
     }
 
     val thumbnails = thumbnailDao.fetchByPhotoId(photoId)
-    val url = URI(photosRow.storageUrl!!)
+    val url = photosRow.storageUrl!!
 
     dslContext.transaction { _ ->
       if (thumbnails.isNotEmpty()) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -80,7 +80,7 @@ class PhotoRepository(
                 location = metadata.location,
                 modifiedTime = clock.instant(),
                 size = size,
-                storageUrl = "$photoUrl",
+                storageUrl = photoUrl,
             )
 
         photosDao.insert(photosRow)
@@ -187,7 +187,6 @@ class PhotoRepository(
         .and(ACCESSIONS.NUMBER.eq(accessionNumber))
         .and(PHOTOS.FILE_NAME.eq(filename))
         .fetchOne(PHOTOS.STORAGE_URL)
-        ?.let { URI(it) }
         ?: throw NoSuchFileException(filename)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -293,7 +293,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
             id = photoId,
             capturedTime = time1,
             fileName = "myphoto",
-            storageUrl = "$storageUrl",
+            storageUrl = storageUrl,
             contentType = "jpeg",
             size = 1000,
             createdTime = time1,
@@ -338,7 +338,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
             id = photoId,
             capturedTime = time1,
             fileName = "myphoto",
-            storageUrl = "$storageUrl",
+            storageUrl = storageUrl,
             contentType = "jpeg",
             size = 1000,
             createdTime = time1,
@@ -431,7 +431,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         photosRow.copy(
-            id = photoId, createdTime = null, modifiedTime = null, storageUrl = "$storageUrl"),
+            id = photoId, createdTime = null, modifiedTime = null, storageUrl = storageUrl),
         actualPhotosRow?.copy(createdTime = null, modifiedTime = null))
   }
 
@@ -455,7 +455,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     val feature = store.createFeature(validCreateRequest)
     val featureId = feature.id!!
     val photosRow = insertFeaturePhoto(featureId)
-    val storageUrl = URI(photosRow.storageUrl!!)
+    val storageUrl = photosRow.storageUrl!!
 
     justRun { fileStore.delete(any()) }
 
@@ -487,7 +487,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     val photosRow = insertFeaturePhoto(featureId)
 
     val sizedInputStream = SizedInputStream(inputStream, data.size.toLong())
-    every { fileStore.read(URI(photosRow.storageUrl!!)) } returns sizedInputStream
+    every { fileStore.read(photosRow.storageUrl!!) } returns sizedInputStream
 
     val actualStream = store.getPhotoData(featureId, photosRow.id!!)
 
@@ -581,7 +581,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
             fileName = "foo",
             modifiedTime = Instant.EPOCH,
             size = 1,
-            storageUrl = "file:///${Random.nextLong()}",
+            storageUrl = URI("file:///${Random.nextLong()}"),
         )
 
     photosDao.insert(photosRow)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -74,6 +74,7 @@ import com.terraformation.backend.species.db.SpeciesStore
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
+import java.net.URI
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -736,7 +737,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             contentType = MediaType.IMAGE_JPEG_VALUE,
             modifiedTime = Instant.now(),
             size = 123,
-            storageUrl = "file:///photo.jpg",
+            storageUrl = URI("file:///photo.jpg"),
         )
     photosDao.insert(photosRow)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -25,6 +25,7 @@ import io.mockk.mockk
 import java.io.IOException
 import java.io.InputStream
 import java.net.SocketTimeoutException
+import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
@@ -65,7 +66,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   override val user: UserModel = mockk()
 
   private lateinit var photoPath: Path
-  private lateinit var photoStorageUrl: String
+  private lateinit var photoStorageUrl: URI
   private lateinit var tempDir: Path
 
   private val accessionId = AccessionId(12345)
@@ -113,7 +114,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     val relativePath = Path("2021", "02", "03", "accession", "040506-0123456789ABCDEF.jpg")
 
     photoPath = tempDir.resolve(relativePath)
-    photoStorageUrl = "file:///${relativePath.invariantSeparatorsPathString}"
+    photoStorageUrl = URI("file:///${relativePath.invariantSeparatorsPathString}")
 
     every { user.canReadAccession(any(), any()) } returns true
     every { user.canUpdateAccession(any(), any()) } returns true
@@ -187,7 +188,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             capturedTime = capturedTime,
             contentType = contentType,
             fileName = filename,
-            storageUrl = "file:///$filename",
+            storageUrl = URI("file:///$filename"),
             location = mercatorPoint(1.0, 2.0, 3.0),
             size = 1,
             createdTime = uploadedTime,


### PR DESCRIPTION
Use Java standard library `URI` objects to represent URLs in the database.
The application code was mostly already doing that, but was converting URIs to
strings and vice versa explicitly at each call site.
