### PR TITLE
SW-194 Generate and cache photo thumbnails

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
   implementation("com.opencsv:opencsv:5.3")
   implementation("io.swagger.core.v3:swagger-annotations:2.1.10")
   implementation("javax.inject:javax.inject:1")
+  implementation("net.coobird:thumbnailator:0.4.14")
   implementation("net.postgis:postgis-jdbc:2021.1.0")
   implementation("net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1")
   implementation("org.apache.tika:tika-core:2.1.0")

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -74,7 +74,7 @@ val ID_WRAPPERS =
         IdWrapper("SpeciesNameId", listOf("species_names\\.id")),
         IdWrapper(
             "StorageLocationId", listOf("storage_locations\\.id", ".*\\.storage_location_id")),
-        IdWrapper("ThumbnailId", listOf("thumbnail\\.id")),
+        IdWrapper("ThumbnailId", listOf("thumbnails\\.id")),
         IdWrapper("TimeseriesId", listOf("timeseries\\.id", ".*\\.timeseries_id")),
         IdWrapper("UserId", listOf("users\\.id", ".*\\.user_id")),
         IdWrapper("WithdrawalId", listOf("withdrawals\\.id", ".*\\.withdrawal_id")),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -228,6 +228,13 @@ paths:
       tags:
       - GISApp
       summary: Gets the contents of a photo of a feature.
+      description: "Optional maxWidth and maxHeight parameters may be included to\
+        \ control the dimensions of the image; the server will scale the original\
+        \ down as needed. If neither parameter is specified, the original full-size\
+        \ image will be returned. The aspect ratio of the original image is maintained,\
+        \ so the returned image may be smaller than the requested width and height.\
+        \ If only maxWidth or only maxHeight is supplied, the other dimension will\
+        \ be computed based on the original image's aspect ratio."
       operationId: downloadFeaturePhoto
       parameters:
       - name: featureId
@@ -242,6 +249,28 @@ paths:
         schema:
           type: integer
           format: int64
+      - name: maxWidth
+        in: query
+        required: false
+        schema:
+          type: integer
+          description: "Maximum desired width in pixels. If neither this nor maxHeight\
+            \ is specified, the full-sized original image will be returned. If this\
+            \ is specified, an image no wider than this will be returned. The image\
+            \ may be narrower than this value if needed to preserve the aspect ratio\
+            \ of the original."
+          format: int32
+      - name: maxHeight
+        in: query
+        required: false
+        schema:
+          type: integer
+          description: "Maximum desired height in pixels. If neither this nor maxWidth\
+            \ is specified, the full-sized original image will be returned. If this\
+            \ is specified, an image no taller than this will be returned. The image\
+            \ may be shorter than this value if needed to preserve the aspect ratio\
+            \ of the original."
+          format: int32
       responses:
         "200":
           description: The photo was successfully retrieved.
@@ -886,6 +915,13 @@ paths:
       tags:
       - SeedBankApp
       summary: Retrieve a specific photo from an accession.
+      description: "Optional maxWidth and maxHeight parameters may be included to\
+        \ control the dimensions of the image; the server will scale the original\
+        \ down as needed. If neither parameter is specified, the original full-size\
+        \ image will be returned. The aspect ratio of the original image is maintained,\
+        \ so the returned image may be smaller than the requested width and height.\
+        \ If only maxWidth or only maxHeight is supplied, the other dimension will\
+        \ be computed based on the original image's aspect ratio."
       operationId: getPhoto
       parameters:
       - name: accessionNumber
@@ -898,6 +934,28 @@ paths:
         required: true
         schema:
           type: string
+      - name: maxWidth
+        in: query
+        required: false
+        schema:
+          type: integer
+          description: "Maximum desired width in pixels. If neither this nor maxHeight\
+            \ is specified, the full-sized original image will be returned. If this\
+            \ is specified, an image no wider than this will be returned. The image\
+            \ may be narrower than this value if needed to preserve the aspect ratio\
+            \ of the original."
+          format: int32
+      - name: maxHeight
+        in: query
+        required: false
+        schema:
+          type: integer
+          description: "Maximum desired height in pixels. If neither this nor maxWidth\
+            \ is specified, the full-sized original image will be returned. If this\
+            \ is specified, an image no taller than this will be returned. The image\
+            \ may be shorter than this value if needed to preserve the aspect ratio\
+            \ of the original."
+          format: int32
       responses:
         "200":
           description: The photo was successfully retrieved.

--- a/src/main/kotlin/com/terraformation/backend/api/DocumentationStrings.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/DocumentationStrings.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.api
+
+/**
+ * Description of maxWidth and maxHeight parameters on photo endpoints. This is suitable for use in
+ * the description value of an `@Operation` annotation on a photo endpoint.
+ */
+const val PHOTO_OPERATION_DESCRIPTION =
+    "Optional maxWidth and maxHeight parameters may be included to control the dimensions of the " +
+        "image; the server will scale the original down as needed. If neither parameter is " +
+        "specified, the original full-size image will be returned. The aspect ratio of the " +
+        "original image is maintained, so the returned image may be smaller than the requested " +
+        "width and height. If only maxWidth or only maxHeight is supplied, the other dimension " +
+        "will be computed based on the original image's aspect ratio."
+
+/** Description of the maxWidth parameter on a photo GET endpoint. */
+const val PHOTO_MAXWIDTH_DESCRIPTION =
+    "Maximum desired width in pixels. If neither this nor maxHeight is specified, the full-sized " +
+        "original image will be returned. If this is specified, an image no wider than this will " +
+        "be returned. The image may be narrower than this value if needed to preserve the aspect " +
+        "ratio of the original."
+
+/** Description of the maxHeight parameter on a photo GET endpoint. */
+const val PHOTO_MAXHEIGHT_DESCRIPTION =
+    "Maximum desired height in pixels. If neither this nor maxWidth is specified, the full-sized " +
+        "original image will be returned. If this is specified, an image no taller than this " +
+        "will be returned. The image may be shorter than this value if needed to preserve the " +
+        "aspect ratio of the original."

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -1,0 +1,254 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.db.PhotoId
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.tables.daos.PhotosDao
+import com.terraformation.backend.db.tables.daos.ThumbnailsDao
+import com.terraformation.backend.db.tables.pojos.ThumbnailsRow
+import com.terraformation.backend.db.tables.references.THUMBNAILS
+import com.terraformation.backend.log.debugWithTiming
+import com.terraformation.backend.log.perClassLogger
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.NoSuchFileException
+import java.time.Clock
+import javax.annotation.ManagedBean
+import javax.imageio.ImageIO
+import kotlin.io.path.Path
+import kotlin.io.path.nameWithoutExtension
+import net.coobird.thumbnailator.Thumbnails
+import net.coobird.thumbnailator.resizers.configurations.ScalingMode
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.springframework.http.MediaType
+
+@ManagedBean
+class ThumbnailStore(
+    private val clock: Clock,
+    private val dslContext: DSLContext,
+    private val fileStore: FileStore,
+    private val photosDao: PhotosDao,
+    private val thumbnailsDao: ThumbnailsDao
+) {
+  /**
+   * If an image is scaled to this size or larger (on either axis), use a quality-optimized scaling
+   * algorithm to reduce visible scaling artifacts. Smaller target sizes can use a speed-optimized
+   * algorithm.
+   *
+   * The design assumption here is that we're likely to be asked to generate a bunch of tiny
+   * thumbnails all at once, e.g., the first time someone does a search for a certain set of
+   * entities. So we want to generate those thumbnails pretty quickly, and users won't care if they
+   * have pixel-perfect antialiasing and such. Larger images are likely to be requested one at a
+   * time, so it's both fine to spend longer generating them and more important that they look good.
+   *
+   * With some image scaling algorithms, it is slower to scale to a tiny size than a medium size, so
+   * setting this to a very low value may chew extra CPU cycles for no benefit.
+   */
+  val minSizeForHighQuality = 320
+
+  /** Don't allow scaling to widths or heights larger than this. */
+  private val maxAllowedSize = 2000
+
+  private val log = perClassLogger()
+
+  /**
+   * Returns the contents of a thumbnail image for a photo. This may return a cached copy of a
+   * thumbnail if one exists, or it may scale the original image down on demand.
+   *
+   * At least one of [maxWidth] and [maxHeight] must be non-null. If both of them are non-null, the
+   * resulting thumbnail may be smaller than the limit depending on the aspect ratio of the original
+   * photo.
+   *
+   * @param maxWidth Maximum width of thumbnail in pixels. If null, the width will be computed based
+   * on [maxHeight].
+   * @param maxHeight Maximum height of the thumbnail in pixels. If null, the height will be
+   * computed based on [maxWidth].
+   */
+  fun getThumbnailData(photoId: PhotoId, maxWidth: Int?, maxHeight: Int?): SizedInputStream {
+    if (maxWidth == null && maxHeight == null) {
+      throw IllegalArgumentException("At least one thumbnail dimension must be specified")
+    }
+
+    if (maxWidth != null && (maxWidth < 1 || maxWidth > maxAllowedSize)) {
+      throw IllegalArgumentException("maxWidth is outside of allowed range 1-$maxAllowedSize")
+    }
+
+    if (maxHeight != null && (maxHeight < 1 || maxHeight > maxAllowedSize)) {
+      throw IllegalArgumentException("maxHeight is outside of allowed range 1-$maxAllowedSize")
+    }
+
+    // After the first time a thumbnail is fetched, we can reuse the cached copy.
+    val thumbnailsRow = fetchByMaximumSize(photoId, maxWidth, maxHeight)
+    if (thumbnailsRow != null) {
+      val thumbUrl = thumbnailsRow.storageUrl!!
+
+      try {
+        return fileStore.read(thumbUrl)
+      } catch (e: NoSuchFileException) {
+        log.warn("Found thumbnail $thumbUrl in database but file did not exist; regenerating it")
+        thumbnailsDao.delete(thumbnailsRow)
+      }
+    }
+
+    return generateThumbnail(photoId, maxWidth, maxHeight)
+  }
+
+  /**
+   * Generates a new thumbnail for a photo. Stores it in the file store and inserts a row in the
+   * thumbnails table with its information.
+   */
+  private fun generateThumbnail(
+      photoId: PhotoId,
+      maxWidth: Int?,
+      maxHeight: Int?
+  ): SizedInputStream {
+    val photosRow = photosDao.fetchOneById(photoId) ?: throw PhotoNotFoundException(photoId)
+    val photoUrl = photosRow.storageUrl!!
+
+    val resizedImage = scalePhoto(photoUrl, maxWidth, maxHeight)
+    val buffer = encodeAsJpeg(resizedImage)
+    val size = buffer.size
+
+    val thumbUrl = getThumbnailUrl(photoUrl, resizedImage.width, resizedImage.height)
+
+    try {
+      fileStore.write(thumbUrl, ByteArrayInputStream(buffer), size.toLong())
+    } catch (e: FileAlreadyExistsException) {
+      // This is suspicious if it happens a lot, but we expect to see it if, e.g., two users
+      // run the same search at the same time and there isn't already a thumbnail for one of
+      // the results. The assumption is that that kind of race will be rare enough that it's not
+      // worth trying to coordinate across servers to prevent it.
+      //
+      // We will still attempt to insert the database row in this case, though, to recover from
+      // situations where we'd previously written the file to the file store but failed to insert a
+      // row for it in the thumbnails table.
+      log.warn("Photo $photoId thumbnail $thumbUrl already exists; keeping existing file")
+    }
+
+    val thumbnailId =
+        with(THUMBNAILS) {
+          dslContext
+              .insertInto(THUMBNAILS)
+              .set(CONTENT_TYPE, MediaType.IMAGE_JPEG_VALUE)
+              .set(CREATED_TIME, clock.instant())
+              .set(HEIGHT, resizedImage.height)
+              .set(PHOTO_ID, photoId)
+              .set(SIZE, size)
+              .set(STORAGE_URL, thumbUrl)
+              .set(WIDTH, resizedImage.width)
+              .onConflictDoNothing()
+              .returning(ID)
+              .fetchOne()
+              ?.id
+        }
+
+    log.info(
+        "Created photo $photoId thumbnail $thumbnailId dimensions ${resizedImage.width} x " +
+            "${resizedImage.height} bytes $size",
+    )
+
+    return SizedInputStream(ByteArrayInputStream(buffer), size.toLong())
+  }
+
+  /** Compresses an image to a JPEG file in a memory buffer. */
+  private fun encodeAsJpeg(image: BufferedImage): ByteArray {
+    val outputStream = ByteArrayOutputStream()
+    ImageIO.write(image, "JPEG", outputStream)
+    return outputStream.toByteArray()
+  }
+
+  /** Scales an existing photo to a new set of maximum dimensions. */
+  private fun scalePhoto(photoUrl: URI, maxWidth: Int?, maxHeight: Int?): BufferedImage {
+    val originalImage =
+        log.debugWithTiming("Loaded $photoUrl into image buffer") {
+          fileStore.read(photoUrl).use { stream -> ImageIO.read(stream) }
+        }
+
+    // If the image is large enough for visual quality to matter, use a higher-quality scaling
+    // algorithm.
+    val useHighQuality =
+        (maxWidth ?: 0) >= minSizeForHighQuality || (maxHeight ?: 0) >= minSizeForHighQuality
+    val scalingMode =
+        if (useHighQuality) {
+          ScalingMode.PROGRESSIVE_BILINEAR
+        } else {
+          ScalingMode.BILINEAR
+        }
+
+    return log.debugWithTiming(
+        "Resizing image from ${originalImage.width} x ${originalImage.height} to $maxWidth x $maxHeight") {
+      Thumbnails.of(originalImage)
+          .scalingMode(scalingMode)
+          .size(maxWidth ?: Int.MAX_VALUE, maxHeight ?: Int.MAX_VALUE)
+          .asBufferedImage()
+    }
+  }
+
+  /**
+   * Finds an existing image for a photo that meets the requested size criteria.
+   *
+   * If just one of [width] or [height] is specified, finds a thumbnail whose width or height is the
+   * exact value specified.
+   *
+   * If both [width] and [height] are specified, finds a thumbnail that is the exact width or the
+   * exact height specified, and that isn't larger than the other dimension. For example, if
+   * width=80 and height=60, thumbnails of these dimensions would match:
+   *
+   * - 80x60 (exact match)
+   * - 80x59 (exact width, height not greater than requested height)
+   * - 79x60 (exact height, width not greater than requested width)
+   *
+   * But these wouldn't:
+   *
+   * - 80x61 (exact width, but height too large)
+   * - 81x60 (exact height, but width too large)
+   */
+  private fun fetchByMaximumSize(photoId: PhotoId, width: Int?, height: Int?): ThumbnailsRow? {
+    val sizeCondition =
+        if (width != null) {
+          if (height != null) {
+            // Return an image with either the height or the width requested, whichever one causes
+            // the other dimension to not exceed the requested value.
+            DSL.or(
+                THUMBNAILS.HEIGHT.eq(height).and(THUMBNAILS.WIDTH.le(width)),
+                THUMBNAILS.WIDTH.eq(width).and(THUMBNAILS.HEIGHT.le(height)),
+            )
+          } else {
+            THUMBNAILS.WIDTH.eq(width)
+          }
+        } else {
+          THUMBNAILS.HEIGHT.eq(height)
+        }
+
+    return dslContext
+        .selectFrom(THUMBNAILS)
+        .where(THUMBNAILS.PHOTO_ID.eq(photoId))
+        .and(sizeCondition)
+        .orderBy(THUMBNAILS.WIDTH.desc(), THUMBNAILS.HEIGHT.desc())
+        .limit(1)
+        .fetchOneInto(ThumbnailsRow::class.java)
+  }
+
+  /**
+   * Computes the URL of an image thumbnail with certain dimensions.
+   *
+   * This puts thumbnails in a subdirectory of the original image's directory and appends the
+   * dimensions to the filename. If the original image's URL is `proto://host/a/b/c/d.jpg` and the
+   * thumbnail dimensions are 640x480, the thumbnail URL will be
+   * `proto://host/a/b/c/thumb/d-640x480.jpg`.
+   *
+   * Thumbnails are currently always JPEG images, so the file extension is always `.jpg`.
+   */
+  private fun getThumbnailUrl(photoUrl: URI, width: Int, height: Int): URI {
+    val originalPath = Path(photoUrl.path)
+    val originalFilename = originalPath.fileName
+    val originalBaseName = originalFilename.nameWithoutExtension
+    val thumbPath =
+        originalPath.parent.resolve("thumb").resolve("$originalBaseName-${width}x$height.jpg")
+
+    return fileStore.getUrl(thumbPath)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
@@ -3,6 +3,9 @@ package com.terraformation.backend.gis.api
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.GISAppEndpoint
 import com.terraformation.backend.api.NotFoundException
+import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_OPERATION_DESCRIPTION
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
@@ -20,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
 import javax.ws.rs.BadRequestException
+import javax.ws.rs.QueryParam
 import net.postgis.jdbc.geometry.Geometry
 import net.postgis.jdbc.geometry.Point
 import org.springframework.core.io.InputStreamResource
@@ -161,13 +165,21 @@ class FeatureController(private val featureStore: FeatureStore) {
   @ApiResponse404(
       "The accession does not exist, or does not have a photo with the requested filename.")
   @GetMapping("/{featureId}/photos/{photoId}", produces = [MediaType.IMAGE_JPEG_VALUE])
-  @Operation(summary = "Gets the contents of a photo of a feature.")
+  @Operation(
+      summary = "Gets the contents of a photo of a feature.",
+      description = PHOTO_OPERATION_DESCRIPTION)
   @ResponseBody
   fun downloadFeaturePhoto(
       @PathVariable featureId: FeatureId,
-      @PathVariable photoId: PhotoId
+      @PathVariable photoId: PhotoId,
+      @QueryParam("maxWidth")
+      @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
+      maxWidth: Int? = null,
+      @QueryParam("maxHeight")
+      @Schema(description = PHOTO_MAXHEIGHT_DESCRIPTION)
+      maxHeight: Int? = null,
   ): ResponseEntity<InputStreamResource> {
-    val stream = featureStore.getPhotoData(featureId, photoId)
+    val stream = featureStore.getPhotoData(featureId, photoId, maxWidth, maxHeight)
     val headers = HttpHeaders()
     headers.contentLength = stream.size
 

--- a/src/main/resources/db/migration/common/V52__Thumbnails.sql
+++ b/src/main/resources/db/migration/common/V52__Thumbnails.sql
@@ -1,0 +1,16 @@
+ALTER TABLE thumbnail RENAME TO thumbnails;
+
+ALTER TABLE thumbnails ADD COLUMN content_type TEXT NOT NULL;
+ALTER TABLE thumbnails ADD COLUMN created_time TIMESTAMP WITH TIME ZONE NOT NULL;
+ALTER TABLE thumbnails ADD COLUMN size INTEGER NOT NULL;
+ALTER TABLE thumbnails ADD COLUMN storage_url TEXT NOT NULL;
+
+ALTER TABLE thumbnails DROP COLUMN file_name;
+
+-- Clients may want to specify thumbnail sizes by either width or height depending on their layout
+-- requirements. We only want one thumbnail of a particular size for each photo.
+ALTER TABLE thumbnails ADD CONSTRAINT thumbnails_unique_width UNIQUE (photo_id, width);
+ALTER TABLE thumbnails ADD CONSTRAINT thumbnails_unique_height UNIQUE (photo_id, height);
+
+-- A file in the file store should never be described by multiple rows in the thumbnails table.
+ALTER TABLE thumbnails ADD CONSTRAINT thumbnails_unique_storage_url UNIQUE (storage_url);

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -1,0 +1,301 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.PhotoId
+import com.terraformation.backend.db.ThumbnailId
+import com.terraformation.backend.db.tables.daos.PhotosDao
+import com.terraformation.backend.db.tables.daos.ThumbnailsDao
+import com.terraformation.backend.db.tables.pojos.PhotosRow
+import com.terraformation.backend.db.tables.pojos.ThumbnailsRow
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.URI
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import javax.imageio.ImageIO
+import javax.imageio.stream.MemoryCacheImageInputStream
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
+
+internal class ThumbnailStoreTest : DatabaseTest() {
+  private val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)!!
+  private val fileStore: FileStore = mockk()
+
+  private lateinit var photosDao: PhotosDao
+  private lateinit var store: ThumbnailStore
+  private lateinit var thumbnailsDao: ThumbnailsDao
+
+  private val photoId = PhotoId(1000)
+  private val photoStorageUrl = URI("file:///a/b/c/original.jpg")
+
+  override val sequencesToReset: List<String>
+    get() = listOf("thumbnail_id_seq")
+
+  @BeforeEach
+  fun setUp() {
+    val jooqConfig = dslContext.configuration()
+    photosDao = PhotosDao(jooqConfig)
+    thumbnailsDao = ThumbnailsDao(jooqConfig)
+
+    store = ThumbnailStore(clock, dslContext, fileStore, photosDao, thumbnailsDao)
+
+    photosDao.insert(
+        PhotosRow(
+            id = photoId,
+            capturedTime = clock.instant(),
+            contentType = MediaType.IMAGE_JPEG_VALUE,
+            createdTime = clock.instant(),
+            modifiedTime = clock.instant(),
+            size = 1,
+            fileName = "test.jpg",
+            storageUrl = photoStorageUrl))
+
+    every { fileStore.getUrl(any()) } answers { URI("file://${firstArg<Path>()}") }
+    every { fileStore.read(any()) } throws NoSuchFileException("Not found")
+    every { fileStore.read(photoStorageUrl) } answers
+        {
+          SizedInputStream(ByteArrayInputStream(photoJpegData), photoJpegData.size.toLong())
+        }
+  }
+
+  private fun insertThumbnail(
+      width: Int,
+      height: Int,
+      imageData: ByteArray = Random.nextBytes(10),
+      storageUrl: URI = URI("file:///a/b/c/thumb/original-${width}x$height.jpg")
+  ): ThumbnailsRow {
+    val thumbnailsRow =
+        ThumbnailsRow(
+            photoId = photoId,
+            width = width,
+            height = height,
+            contentType = MediaType.IMAGE_JPEG_VALUE,
+            createdTime = clock.instant(),
+            size = imageData.size,
+            storageUrl = storageUrl)
+    thumbnailsDao.insert(thumbnailsRow)
+
+    every { fileStore.read(storageUrl) } returns
+        SizedInputStream(ByteArrayInputStream(imageData), imageData.size.toLong())
+
+    return thumbnailsRow
+  }
+
+  @Test
+  fun `returns existing thumbnail of requested size`() {
+    val expected = Random.nextBytes(10)
+
+    insertThumbnail(80, 70, expected)
+
+    val actual = store.getThumbnailData(photoId, 80, 70)
+
+    assertArrayEquals(expected, actual.readAllBytes())
+  }
+
+  @Test
+  fun `returns existing thumbnail if only width is specified`() {
+    val expected = Random.nextBytes(10)
+
+    insertThumbnail(80, 70, expected)
+
+    val actual = store.getThumbnailData(photoId, 80, null)
+
+    assertArrayEquals(expected, actual.readAllBytes())
+  }
+
+  @Test
+  fun `returns existing thumbnail if only height is specified`() {
+    val expected = Random.nextBytes(10)
+
+    insertThumbnail(80, 70, expected)
+
+    val actual = store.getThumbnailData(photoId, null, 70)
+
+    assertArrayEquals(expected, actual.readAllBytes())
+  }
+
+  @Test
+  fun `requires width and height to be within valid range`() {
+    val testCases =
+        mapOf(
+            "no dimensions" to listOf(null, null),
+            "zero width" to listOf(0, 500),
+            "zero height" to listOf(500, 0),
+            "negative width" to listOf(-1, 500),
+            "negative height" to listOf(500, -1),
+            "huge width" to listOf(100000, 500),
+            "huge height" to listOf(500, 100000),
+        )
+
+    testCases.forEach { description, (width, height) ->
+      assertThrows<IllegalArgumentException>(description) {
+        store.getThumbnailData(photoId, width, height)
+      }
+    }
+  }
+
+  @Test
+  fun `returns shorter thumbnail that matches requested width`() {
+    val expected = Random.nextBytes(10)
+    val width = 80
+    val height = 70
+
+    insertThumbnail(width, height - 1, expected)
+
+    val actual = store.getThumbnailData(photoId, width, height)
+
+    assertArrayEquals(expected, actual.readAllBytes())
+  }
+
+  @Test
+  fun `returns narrower thumbnail that matches requested height`() {
+    val expected = Random.nextBytes(10)
+    val width = 80
+    val height = 70
+
+    insertThumbnail(width - 1, height, expected)
+
+    val actual = store.getThumbnailData(photoId, width, height)
+
+    assertArrayEquals(expected, actual.readAllBytes())
+  }
+
+  @Test
+  fun `generates new thumbnail if none exists with requested size`() {
+    val width = photoWidth / 10
+    val height = photoHeight / 10
+
+    insertThumbnail(width, height + 1)
+    insertThumbnail(width + 1, height)
+    insertThumbnail(width - 1, height - 1)
+
+    val thumbUrlSlot: CapturingSlot<URI> = slot()
+    val streamSlot: CapturingSlot<InputStream> = slot()
+    justRun { fileStore.write(capture(thumbUrlSlot), capture(streamSlot), any()) }
+
+    val actual = store.getThumbnailData(photoId, width, height)
+
+    verify(exactly = 1) { fileStore.write(any(), any(), any()) }
+
+    assertEquals(
+        URI("file:///a/b/c/thumb/original-${width}x$height.jpg"),
+        thumbUrlSlot.captured,
+        "Should have derived thumbnail URL from original photo URL")
+    assertArrayEquals(
+        actual.readAllBytes(),
+        streamSlot.captured.readAllBytes(),
+        "Should have written same image to file store that was returned to caller")
+  }
+
+  @Test
+  fun `generates thumbnails as valid JPEG files`() {
+    val width = photoWidth / 10
+    val height = photoHeight / 10
+
+    justRun { fileStore.write(any(), any(), any()) }
+
+    val actual = store.getThumbnailData(photoId, width, height)
+    val actualData = actual.readAllBytes()
+
+    val imageReader = ImageIO.getImageReadersByFormatName("JPEG").next()
+    imageReader.input = MemoryCacheImageInputStream(ByteArrayInputStream(actualData))
+    val thumbnailImage = imageReader.read(0)
+
+    assertEquals(width, thumbnailImage.width, "Thumbnail width")
+    assertEquals(height, thumbnailImage.height, "Thumbnail height")
+  }
+
+  @Test
+  fun `generates thumbnails above minimum high-quality dimensions`() {
+    justRun { fileStore.write(any(), any(), any()) }
+
+    val actual =
+        store.getThumbnailData(photoId, store.minSizeForHighQuality, store.minSizeForHighQuality)
+    val actualData = actual.readAllBytes()
+
+    val imageReader = ImageIO.getImageReadersByFormatName("JPEG").next()
+    imageReader.input = MemoryCacheImageInputStream(ByteArrayInputStream(actualData))
+    val thumbnailImage = imageReader.read(0)
+
+    assertEquals(store.minSizeForHighQuality, thumbnailImage.width, "Thumbnail width")
+  }
+
+  @Test
+  fun `inserts database row for existing thumbnail if file already exists`() {
+    val width = photoWidth / 10
+    val height = photoHeight / 10
+
+    every { fileStore.write(any(), any(), any()) } throws FileAlreadyExistsException("Exists")
+
+    val actual = store.getThumbnailData(photoId, width, height)
+
+    assertEquals(
+        listOf(
+            ThumbnailsRow(
+                id = ThumbnailId(1),
+                photoId = photoId,
+                width = width,
+                height = height,
+                contentType = MediaType.IMAGE_JPEG_VALUE,
+                createdTime = Instant.EPOCH,
+                size = actual.size.toInt(),
+                storageUrl = URI("file:///a/b/c/thumb/original-${width}x$height.jpg"))),
+        thumbnailsDao.findAll())
+  }
+
+  @Test
+  fun `regenerates thumbnail if file is missing`() {
+    val width = photoWidth / 10
+    val height = photoHeight / 10
+
+    val existingRow = insertThumbnail(width, height)
+
+    every { fileStore.read(existingRow.storageUrl!!) } throws NoSuchFileException("Nope")
+    justRun { fileStore.write(any(), any(), any()) }
+
+    val actual = store.getThumbnailData(photoId, width, height)
+
+    verify { fileStore.write(existingRow.storageUrl!!, any(), any()) }
+
+    assertEquals(
+        listOf(
+            ThumbnailsRow(
+                photoId = photoId,
+                width = width,
+                height = height,
+                contentType = MediaType.IMAGE_JPEG_VALUE,
+                createdTime = Instant.EPOCH,
+                size = actual.size.toInt(),
+                storageUrl = existingRow.storageUrl!!)),
+        thumbnailsDao.findAll().map { it.copy(id = null) })
+  }
+
+  companion object {
+    private const val photoWidth = 640
+    private const val photoHeight = 480
+
+    private val photoJpegData: ByteArray by lazy {
+      val canvas = BufferedImage(photoWidth, photoHeight, BufferedImage.TYPE_INT_RGB)
+      val outputStream = ByteArrayOutputStream()
+      ImageIO.write(canvas, "JPEG", outputStream)
+      outputStream.toByteArray()
+    }
+  }
+}


### PR DESCRIPTION
    Add optional `maxWidth` and `maxHeight` query string parameters to the endpoints
    that download photos. If one or both are specified, the server will return a
    scaled-down copy of the photo.
    
    Currently, the scaling happens on demand the first time a user requests a version
    with a particular size. The scaled-down images are cached in the file store and
    the cached versions are returned on subsequent requests.