### PR TITLE
SW-178 Simplify file creation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
@@ -6,6 +6,7 @@ import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.time.Instant
 
 /**
  * Handles storage of file contents (as opposed to metadata). Implementations of this interface talk
@@ -75,4 +76,12 @@ interface FileStore {
 
   /** Returns the URL of a file with a given relative path on this file store. */
   fun getUrl(path: Path): URI
+
+  /**
+   * Creates a new URL for a file of a particular category with a particular content type.
+   *
+   * This will typically delegate the construction of the relative path to
+   * [PathGenerator.generatePath].
+   */
+  fun newUrl(timestamp: Instant, category: String, contentType: String): URI
 }

--- a/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
@@ -18,7 +18,6 @@ import com.terraformation.backend.db.tables.references.PHOTOS
 import com.terraformation.backend.db.tables.references.PLANTS
 import com.terraformation.backend.db.tables.references.PLANT_OBSERVATIONS
 import com.terraformation.backend.file.FileStore
-import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.gis.model.FeatureModel
@@ -38,7 +37,6 @@ class FeatureStore(
     private val dslContext: DSLContext,
     private val featurePhotosDao: FeaturePhotosDao,
     private val fileStore: FileStore,
-    private val pathGenerator: PathGenerator,
     private val photosDao: PhotosDao,
     private val thumbnailStore: ThumbnailStore,
     private val thumbnailsDao: ThumbnailsDao,
@@ -226,8 +224,7 @@ class FeatureStore(
     }
 
     val createdTime = clock.instant()
-    val path = pathGenerator.generatePath(createdTime, "feature", contentType)
-    val photoUrl = fileStore.getUrl(path)
+    val photoUrl = fileStore.newUrl(createdTime, "feature", contentType)
 
     try {
       fileStore.write(photoUrl, data, size)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.db.tables.references.ACCESSION_PHOTOS
 import com.terraformation.backend.db.tables.references.PHOTOS
 import com.terraformation.backend.db.transformSrid
 import com.terraformation.backend.file.FileStore
-import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.log.perClassLogger
@@ -45,7 +44,6 @@ class PhotoRepository(
     private val dslContext: DSLContext,
     private val clock: Clock,
     private val fileStore: FileStore,
-    private val pathGenerator: PathGenerator,
     private val photosDao: PhotosDao,
     private val thumbnailStore: ThumbnailStore,
 ) {
@@ -67,8 +65,7 @@ class PhotoRepository(
       throw AccessDeniedException("No permission to update accession data")
     }
 
-    val path = pathGenerator.generatePath(clock.instant(), "accession", metadata.contentType)
-    val photoUrl = fileStore.getUrl(path)
+    val photoUrl = fileStore.newUrl(clock.instant(), "accession", metadata.contentType)
 
     try {
       fileStore.write(photoUrl, data, size)

--- a/src/test/kotlin/com/terraformation/backend/file/LocalFileStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/LocalFileStoreTest.kt
@@ -28,7 +28,7 @@ class LocalFileStoreTest : FileStoreTest() {
   fun setUp() {
     every { config.photoDir } returns tempDir
 
-    store = LocalFileStore(config)
+    store = LocalFileStore(config, PathGenerator())
   }
 
   @Test
@@ -37,7 +37,7 @@ class LocalFileStoreTest : FileStoreTest() {
     tempDir.resolve("subdir").createDirectories()
 
     every { config.photoDir } returns tempDir.resolve("subdir")
-    store = LocalFileStore(config)
+    store = LocalFileStore(config, PathGenerator())
 
     assertThrows<NoSuchFileException> { store.read(URI("file:///../fileInParentDir")) }
   }

--- a/src/test/kotlin/com/terraformation/backend/file/S3FileStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/S3FileStoreTest.kt
@@ -54,7 +54,7 @@ internal class S3FileStoreTest : FileStoreTest() {
 
     every { config.s3BucketName } returns bucketName
 
-    store = S3FileStore(config)
+    store = S3FileStore(config, PathGenerator())
   }
 
   @AfterEach

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -30,7 +30,6 @@ import com.terraformation.backend.db.tables.pojos.ThumbnailsRow
 import com.terraformation.backend.db.tables.references.FEATURES
 import com.terraformation.backend.db.transformSrid
 import com.terraformation.backend.file.FileStore
-import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.gis.model.FeatureModel
@@ -42,7 +41,6 @@ import java.net.URI
 import java.nio.file.NoSuchFileException
 import java.time.Clock
 import java.time.Instant
-import kotlin.io.path.Path
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -74,7 +72,6 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
   private val time2 = time1.plusSeconds(1)
 
   private val fileStore: FileStore = mockk()
-  private val pathGenerator: PathGenerator = mockk()
   private val thumbnailStore: ThumbnailStore = mockk()
 
   private lateinit var store: FeatureStore
@@ -101,14 +98,12 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
             dslContext,
             featurePhotosDao,
             fileStore,
-            pathGenerator,
             photosDao,
             thumbnailStore,
             thumbnailsDao)
 
     every { clock.instant() } returns time1
-    every { fileStore.getUrl(any()) } returns storageUrl
-    every { pathGenerator.generatePath(any(), any(), any()) } returns Path("x")
+    every { fileStore.newUrl(any(), any(), any()) } returns storageUrl
     every { user.canCreateLayerData(featureId = any()) } returns true
     every { user.canCreateLayerData(layerId = any()) } returns true
     every { user.canReadLayerData(featureId = any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.tables.daos.PhotosDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.PhotosRow
+import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.LocalFileStore
 import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.file.SizedInputStream
@@ -61,7 +62,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private lateinit var accessionStore: AccessionStore
   private val clock: Clock = mockk()
   private val config: TerrawareServerConfig = mockk()
-  private val fileStore = LocalFileStore(config)
+  private lateinit var fileStore: FileStore
   private lateinit var photosDao: PhotosDao
   private lateinit var pathGenerator: PathGenerator
   private val random: Random = mockk()
@@ -115,6 +116,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
     every { random.nextLong() } returns 0x0123456789abcdef
     pathGenerator = PathGenerator(random)
+    fileStore = LocalFileStore(config, pathGenerator)
 
     val relativePath = Path("2021", "02", "03", "accession", "040506-0123456789ABCDEF.jpg")
 
@@ -131,7 +133,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             dslContext,
             clock,
             fileStore,
-            pathGenerator,
             photosDao,
             thumbnailStore)
 


### PR DESCRIPTION
Previously, code that wanted to create new files in a file store had to first
generate a unique path using a `PathGenerator`, then turn the path into a URL
using a `FileStore`. The return value of `PathGenerator.generatePath()` is
always immediately passed to `FileStore.getUrl()`, so there's no point making
callers do the extra work.
