### PR TITLE
SW-259 Restrict access to placeholder admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -49,3 +49,12 @@ annotation class ApiResponse404(val description: String = "The requested resourc
 annotation class ApiResponseSimpleSuccess(
     val description: String = "The requested operation succeeded."
 )
+
+/**
+ * Requires the user to be an admin or owner in at least one organization in order to access an
+ * endpoint. If this annotation is used at the class level, it applies to all the handler methods in
+ * the class.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class RequireExistingAdminRole

--- a/src/main/kotlin/com/terraformation/backend/api/ExistingAdminRoleInterceptor.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ExistingAdminRoleInterceptor.kt
@@ -1,0 +1,43 @@
+package com.terraformation.backend.api
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.config.TerrawareServerConfig
+import javax.annotation.ManagedBean
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+/**
+ * Allows endpoints to be accessible only by users who are the admin or owner of at least one
+ * organization. This is used to restrict access to the placeholder admin UI.
+ *
+ * Any controller class or handler method that has the [RequireExistingAdminRole] annotation will
+ * return HTTP 403 Forbidden to the client if the current user doesn't have an admin or owner role
+ * in any organizations.
+ *
+ * Since the admin UI is often used in development environments to bootstrap an empty database, the
+ * admin requirement can be disabled using the [TerrawareServerConfig.allowAdminUiForNonAdmins]
+ * configuration option.
+ */
+@ManagedBean
+class ExistingAdminRoleInterceptor(private val config: TerrawareServerConfig) : HandlerInterceptor {
+  override fun preHandle(
+      request: HttpServletRequest,
+      response: HttpServletResponse,
+      handler: Any
+  ): Boolean {
+    if (!config.allowAdminUiForNonAdmins &&
+        handler is HandlerMethod &&
+        (handler.hasMethodAnnotation(RequireExistingAdminRole::class.java) ||
+            handler.beanType.isAnnotationPresent(RequireExistingAdminRole::class.java)) &&
+        !currentUser().hasAnyAdminRole()) {
+      response.sendError(
+          HttpStatus.FORBIDDEN.value(), "Requires organization administrator privileges.")
+      return false
+    }
+
+    return super.preHandle(request, response, handler)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.api
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import org.springframework.web.util.pattern.PathPatternParser
@@ -10,7 +11,8 @@ import org.springframework.web.util.pattern.PathPatternParser
  * options require programmatic configuration.
  */
 @Configuration
-class SpringMvcConfig : WebMvcConfigurer {
+class SpringMvcConfig(private val existingAdminRoleInterceptor: ExistingAdminRoleInterceptor) :
+    WebMvcConfigurer {
   /**
    * Matches URLs to controller paths using a newer matcher. The default matcher doesn't have good
    * support for controllers with parameterized paths that can contain multiple path elements, e.g.,
@@ -21,5 +23,9 @@ class SpringMvcConfig : WebMvcConfigurer {
    */
   override fun configurePathMatch(configurer: PathMatchConfigurer) {
     configurer.setPatternParser(PathPatternParser())
+  }
+
+  override fun addInterceptors(registry: InterceptorRegistry) {
+    registry.addInterceptor(existingAdminRoleInterceptor)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -57,6 +57,13 @@ class TerrawareServerConfig(
      */
     val useTestClock: Boolean = false,
 
+    /**
+     * Make the placeholder administration UI available to all users. Default is false, which
+     * requires users to already be an admin or owner of at least one organization in order to
+     * access the UI.
+     */
+    val allowAdminUiForNonAdmins: Boolean = false,
+
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.api
 
 import com.terraformation.backend.api.NotFoundException
+import com.terraformation.backend.api.RequireExistingAdminRole
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.FacilityStore
@@ -35,8 +36,9 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 
-@RequestMapping("/admin")
 @Controller
+@RequestMapping("/admin")
+@RequireExistingAdminRole
 @Validated
 class AdminController(
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
@@ -273,6 +273,10 @@ class UserModel(
 
   fun canCreateFamily(): Boolean = canCreateSpecies()
 
+  /** Returns true if the user is an admin or owner of any organizations. */
+  fun hasAnyAdminRole(): Boolean =
+      organizationRoles.values.any { it == Role.OWNER || it == Role.ADMIN }
+
   /**
    * Temporary helper to get the user's facility ID.
    *

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -3,6 +3,7 @@ terraware:
     client-id: "dev-terraware-server"
   photo-dir: "/tmp/terraware-server-photos"
   use-test-clock: true
+  allow-admin-ui-for-non-admins: true
 
 spring:
   flyway:


### PR DESCRIPTION
Currently, the placeholder admin UI is accessible to all users. Anyone can
create (and thus become the owner of) a new organization.

This is useful for dev environments and testing, but we don't want random users
stumbling on this ugly UI in production.

Add logic to require the current user to already be an owner or admin before
they can access the admin UI. The idea is that we will create the first admin
user by hand, after which that user can create additional admins. Once we have
a real admin UI, we can get rid of this.

Since the admin UI is useful in dev environments, add a config option to turn
off this new access restriction. Enable the option in the `default` profile so
existing dev environments continue to work as before.
