### PR TITLE
SW-287 Redirect /admin to /admin/

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -52,7 +52,13 @@ class AdminController(
   private val log = perClassLogger()
   private val prefix = "/admin"
 
+  /** Redirects /admin to /admin/ so relative URLs in the UI will work. */
   @GetMapping
+  fun redirectToTrailingSlash(): String {
+    return "redirect:/admin/"
+  }
+
+  @GetMapping("/")
   fun index(model: Model): String {
     val organizations = organizationStore.fetchAll().sortedBy { it.id.value }
 


### PR DESCRIPTION
The placeholder admin UI uses relative URLs, but they all need to resolve to
paths with the `/admin/` prefix to get routed to the right place. If the user
navigates to `/admin`, redirect them to `/admin/` so relative URLs retain the
prefix.
