### PR TITLE
Support non-Keycloak authentication for front end tests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/ExistingSessionAuthenticationProvider.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/ExistingSessionAuthenticationProvider.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.auth
+
+import java.io.ByteArrayOutputStream
+import java.io.ObjectOutputStream
+import org.keycloak.adapters.tomcat.SimplePrincipal
+import org.springframework.security.core.context.SecurityContextImpl
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
+
+/**
+ * No-op authentication provider that allows existing preauthenticated sessions to make requests.
+ *
+ * This is for use in automated tests of front end code. Before running a test suite, we insert a
+ * session into the Spring sessions table, and it has a `SPRING_SECURITY_CONTEXT` attribute that
+ * contains a [PreAuthenticatedAuthenticationToken]. (There is no way to create such a token using
+ * API requests, only by directly manipulating the database.) This class "looks up" the user's
+ * details by just creating a dummy [User] object.
+ */
+class ExistingSessionAuthenticationProvider : PreAuthenticatedAuthenticationProvider() {
+  init {
+    setPreAuthenticatedUserDetailsService { User(it.name, "PreAuthenticated", emptyList()) }
+  }
+
+  /**
+   * Returns a serialized Spring Security context suitable for inserting into the session store. You
+   * can call this from a scratch file if you are writing a new front-end test suite and you want to
+   * initialize a terraware-server database so the tests can make authenticated API calls.
+   *
+   * Typical usage:
+   *
+   * 1. Insert a user into the `users` table. Give it a random `auth_id` value.
+   * 2. Call this method with the ID you used.
+   * 3. Insert a row into the `spring_session` table. Use a random UUID as the session ID and set
+   * the expiration times far into the future.
+   * 4. Insert a row into the `spring_session_attributes` table with an attribute name of
+   * `SPRING_SECURITY_CONTEXT` and the return value of this method as the attribute value.
+   *
+   * Then you can set the `SESSION` cookie to the base64-encoded session ID, and requests will use
+   * the session without having to log in with Keycloak.
+   */
+  @Suppress("unused")
+  fun generateSecurityContext(authId: String): ByteArray {
+    val token = PreAuthenticatedAuthenticationToken(SimplePrincipal(authId), "dummy")
+    val session = SecurityContextImpl(token)
+
+    val byteStream = ByteArrayOutputStream()
+    val objStream = ObjectOutputStream(byteStream)
+    objStream.writeObject(session)
+    objStream.close()
+
+    return byteStream.toByteArray()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -110,6 +110,7 @@ class SecurityConfig(private val userStore: UserStore) : KeycloakWebSecurityConf
   /** Configures Spring Security to use the Keycloak client library to authenticate requests. */
   override fun configure(auth: AuthenticationManagerBuilder) {
     auth.authenticationProvider(KeycloakAuthenticationProvider())
+    auth.authenticationProvider(ExistingSessionAuthenticationProvider())
   }
 
   override fun sessionAuthenticationStrategy(): SessionAuthenticationStrategy {

--- a/src/main/kotlin/com/terraformation/backend/auth/UserModelFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/UserModelFilter.kt
@@ -9,6 +9,7 @@ import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken
 
 /** Populates [CurrentUserHolder] with the [UserModel] for incoming requests. */
 class UserModelFilter(private val userStore: UserStore) : Filter {
@@ -16,13 +17,14 @@ class UserModelFilter(private val userStore: UserStore) : Filter {
 
   override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
     try {
-      val keycloakUser = SecurityContextHolder.getContext().authentication
+      val authentication = SecurityContextHolder.getContext().authentication
 
-      if (keycloakUser is KeycloakAuthenticationToken) {
-        val userModel = userStore.fetchByAuthId(keycloakUser.name)
+      if (authentication is KeycloakAuthenticationToken ||
+          authentication is PreAuthenticatedAuthenticationToken) {
+        val userModel = userStore.fetchByAuthId(authentication.name)
         CurrentUserHolder.setCurrentUser(userModel)
 
-        log.trace("Loaded UserModel for auth ID ${keycloakUser.name}")
+        log.trace("Loaded UserModel for auth ID ${authentication.name}")
       }
 
       chain.doFilter(request, response)


### PR DESCRIPTION
We want to be able to write front-end tests that don't depend on Keycloak being
available. So we need the tests to be able to authenticate to the server. One
approach is to make a canned login session and have the tests pass its ID in a
cookie just like they would if they'd logged in via Keycloak.

However, it doesn't work to just serialize a real authentication token from
Keycloak, because OIDC tokens always have expiration times and there's a limit
on the maximum lifetime of a token.

So instead, add support for sessions with non-Keycloak authentication data.
There is no way for an end user to create such a session, but for tests, we can
manually create the appropriate objects and insert them into the test database.
A helper method is provided here for just that purpose.
