### PR TITLE
Use query string for GET request parameters

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -176,11 +176,24 @@ paths:
       summary: List all features associated with a layer.
       operationId: list_1
       parameters:
-      - name: payload
+      - name: skip
         in: query
-        required: true
+        required: false
         schema:
-          $ref: '#/components/schemas/ListFeaturesRequestPayload'
+          type: integer
+          description: Number of entries to skip in search results. Used in conjunction
+            with limit to paginate through large results. Default is 0 (don't skip
+            any results).
+          format: int32
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          description: Maximum number of entries to return. Used in conjunction with
+            skip to paginate through large results. The system may impose a cap on
+            this value.
+          format: int32
       - name: layerId
         in: path
         required: true
@@ -704,11 +717,18 @@ paths:
         Can filter based on enteredTime.
       operationId: getPlantSummary
       parameters:
-      - name: payload
+      - name: minEnteredTime
         in: query
-        required: true
+        required: false
         schema:
-          $ref: '#/components/schemas/GetPlantSummaryPayload'
+          type: string
+          format: date-time
+      - name: maxEnteredTime
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
       - name: layerId
         in: path
         required: true
@@ -730,11 +750,28 @@ paths:
         \ time, and/or notes filters."
       operationId: getPlantsList
       parameters:
-      - name: payload
+      - name: speciesName
         in: query
-        required: true
+        required: false
         schema:
-          $ref: '#/components/schemas/ListPlantsRequestPayload'
+          type: string
+      - name: minEnteredTime
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: maxEnteredTime
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: notes
+        in: query
+        required: false
+        schema:
+          type: string
       - name: layerId
         in: path
         required: true
@@ -3228,15 +3265,6 @@ components:
           $ref: '#/components/schemas/PlantResponse'
         status:
           $ref: '#/components/schemas/SuccessOrError'
-    GetPlantSummaryPayload:
-      type: object
-      properties:
-        minEnteredTime:
-          type: string
-          format: date-time
-        maxEnteredTime:
-          type: string
-          format: date-time
     GetProjectResponsePayload:
       required:
       - project
@@ -3383,21 +3411,6 @@ components:
             $ref: '#/components/schemas/FeaturePhoto'
         status:
           $ref: '#/components/schemas/SuccessOrError'
-    ListFeaturesRequestPayload:
-      type: object
-      properties:
-        skip:
-          type: integer
-          description: Number of entries to skip in search results. Used in conjunction
-            with limit to paginate through large results. Default is 0 (don't skip
-            any results).
-          format: int32
-        limit:
-          type: integer
-          description: Maximum number of entries to return. Used in conjunction with
-            skip to paginate through large results. The system may impose a cap on
-            this value.
-          format: int32
     ListFeaturesResponsePayload:
       required:
       - features
@@ -3532,19 +3545,6 @@ components:
             $ref: '#/components/schemas/ListPhotosResponseElement'
         status:
           $ref: '#/components/schemas/SuccessOrError'
-    ListPlantsRequestPayload:
-      type: object
-      properties:
-        speciesName:
-          type: string
-        minEnteredTime:
-          type: string
-          format: date-time
-        maxEnteredTime:
-          type: string
-          format: date-time
-        notes:
-          type: string
     ListPlantsResponseElement:
       required:
       - featureId

--- a/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
@@ -74,10 +74,21 @@ class FeatureController(private val featureStore: FeatureStore) {
   @Operation(summary = "List all features associated with a layer.")
   @GetMapping("/list/{layerId}")
   fun list(
-      @RequestBody payload: ListFeaturesRequestPayload,
+      @QueryParam("skip")
+      @Schema(
+          description =
+              "Number of entries to skip in search results. Used in conjunction with limit to " +
+                  "paginate through large results. Default is 0 (don't skip any results).")
+      skip: Int? = null,
+      @QueryParam("limit")
+      @Schema(
+          description =
+              "Maximum number of entries to return. Used in conjunction with skip to paginate " +
+                  "through large results. The system may impose a cap on this value.")
+      limit: Int? = null,
       @PathVariable layerId: LayerId
   ): ListFeaturesResponsePayload {
-    val features = featureStore.listFeatures(layerId, skip = payload.skip, limit = payload.limit)
+    val features = featureStore.listFeatures(layerId, skip = skip, limit = limit)
     return ListFeaturesResponsePayload(features.map { FeatureResponse(it) })
   }
 
@@ -245,19 +256,6 @@ data class CreateFeatureRequestPayload(
     )
   }
 }
-
-data class ListFeaturesRequestPayload(
-    @Schema(
-        description =
-            "Number of entries to skip in search results. Used in conjunction with limit to " +
-                "paginate through large results. Default is 0 (don't skip any results).")
-    val skip: Int? = null,
-    @Schema(
-        description =
-            "Maximum number of entries to return. Used in conjunction with skip to paginate " +
-                "through large results. The system may impose a cap on this value.")
-    val limit: Int? = null,
-)
 
 data class UpdateFeatureRequestPayload(
     val layerId: LayerId,

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
 import java.time.LocalDate
+import javax.ws.rs.QueryParam
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -57,16 +58,19 @@ class PlantController(private val plantStore: PlantStore) {
               "and/or notes filters.")
   @GetMapping("/list/{layerId}")
   fun getPlantsList(
-      @RequestBody payload: ListPlantsRequestPayload,
+      @QueryParam("speciesName") speciesName: String? = null,
+      @QueryParam("minEnteredTime") minEnteredTime: Instant? = null,
+      @QueryParam("maxEnteredTime") maxEnteredTime: Instant? = null,
+      @QueryParam("notes") notes: String? = null,
       @PathVariable layerId: LayerId
   ): ListPlantsResponsePayload {
     val plants =
         plantStore.fetchPlantsList(
             layerId = layerId,
-            speciesName = payload.speciesName,
-            minEnteredTime = payload.minEnteredTime,
-            maxEnteredTime = payload.maxEnteredTime,
-            notes = payload.notes)
+            speciesName = speciesName,
+            minEnteredTime = minEnteredTime,
+            maxEnteredTime = maxEnteredTime,
+            notes = notes)
 
     return ListPlantsResponsePayload(plants.map { ListPlantsResponseElement(it) })
   }
@@ -78,14 +82,13 @@ class PlantController(private val plantStore: PlantStore) {
               "Can filter based on enteredTime.")
   @GetMapping("/list/summary/{layerId}")
   fun getPlantSummary(
-      @RequestBody payload: GetPlantSummaryPayload,
+      @QueryParam("minEnteredTime") minEnteredTime: Instant? = null,
+      @QueryParam("maxEnteredTime") maxEnteredTime: Instant? = null,
       @PathVariable layerId: LayerId
   ): PlantSummaryResponsePayload {
     val summary =
         plantStore.fetchPlantSummary(
-            layerId,
-            minEnteredTime = payload.minEnteredTime,
-            maxEnteredTime = payload.maxEnteredTime)
+            layerId, minEnteredTime = minEnteredTime, maxEnteredTime = maxEnteredTime)
     return PlantSummaryResponsePayload(summary)
   }
 
@@ -124,18 +127,6 @@ data class CreatePlantRequestPayload(
         datePlanted = datePlanted)
   }
 }
-
-data class ListPlantsRequestPayload(
-    val speciesName: String? = null,
-    val minEnteredTime: Instant? = null,
-    val maxEnteredTime: Instant? = null,
-    val notes: String? = null,
-)
-
-data class GetPlantSummaryPayload(
-    val minEnteredTime: Instant? = null,
-    val maxEnteredTime: Instant? = null
-)
 
 data class UpdatePlantRequestPayload(
     val label: String? = null,


### PR DESCRIPTION
A couple endpoints were declared as GET requests but expected the requests to
have payloads, which GET requests generally aren't supposed to have.

Modify the endpoints to take optional arguments as query string parameters.
