### PR TITLE
Add total count to feature list response payload

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3418,12 +3418,16 @@ components:
       required:
       - features
       - status
+      - totalCount
       type: object
       properties:
         features:
           type: array
           items:
             $ref: '#/components/schemas/FeatureResponse'
+        totalCount:
+          type: integer
+          format: int32
         status:
           $ref: '#/components/schemas/SuccessOrError'
     ListFieldValuesRequestPayload:

--- a/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
@@ -89,7 +89,8 @@ class FeatureController(private val featureStore: FeatureStore) {
       @PathVariable layerId: LayerId
   ): ListFeaturesResponsePayload {
     val features = featureStore.listFeatures(layerId, skip = skip, limit = limit)
-    return ListFeaturesResponsePayload(features.map { FeatureResponse(it) })
+    val totalCount = featureStore.countFeatures(layerId)
+    return ListFeaturesResponsePayload(features.map { FeatureResponse(it) }, totalCount)
   }
 
   @ApiResponse(responseCode = "200", description = "The feature was updated successfully.")
@@ -349,7 +350,7 @@ data class GetFeatureResponsePayload(val feature: FeatureResponse) : SuccessResp
 data class ListFeaturePhotosResponsePayload(val photos: List<FeaturePhoto>) :
     SuccessResponsePayload
 
-data class ListFeaturesResponsePayload(val features: List<FeatureResponse>) :
+data class ListFeaturesResponsePayload(val features: List<FeatureResponse>, val totalCount: Int) :
     SuccessResponsePayload
 
 data class GetFeaturePhotoMetadataResponsePayload(val photo: FeaturePhoto) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
@@ -115,6 +115,20 @@ class FeatureStore(
     return noPermissionsCheckFetch(id)
   }
 
+  fun countFeatures(id: LayerId): Int {
+    if (!currentUser().canReadLayerData(id)) {
+      return 0
+    }
+
+    return dslContext
+        .selectCount()
+        .from(FEATURES)
+        .where(FEATURES.LAYER_ID.eq(id))
+        .fetchOne()
+        ?.value1()
+        ?: 0
+  }
+
   fun listFeatures(id: LayerId, skip: Int? = null, limit: Int? = null): List<FeatureModel> {
     if (!currentUser().canReadLayerData(id)) {
       return emptyList()


### PR DESCRIPTION
The front end needs to show the total number of results to the user, so add a
field to the response payload to hold it. For now, the count is calculated with
a naive `SELECT COUNT(*)` query, which should be fine unless we start dealing
with layers that have enormous numbers of features at which point we can
optimize it.
