### PR TITLE
Fix bug in api/v1/plants/list/summary{layerId}

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -714,7 +714,8 @@ paths:
       tags:
       - GISApp
       summary: Fetch a count of how many plants of each species exist in a layer.
-        Can filter based on enteredTime.
+        Can filter based on enteredTime. Plants that are not associated with any species
+        will be grouped together and keyed on the sentinel value of -1.
       operationId: getPlantSummary
       parameters:
       - name: minEnteredTime
@@ -2321,8 +2322,8 @@ components:
           type: string
           description: "Name of the coordinate reference system. This must be in the\
             \ form EPSG:nnnn where nnnn is the numeric identifier of a coordinate\
-            \ system in the EPSG dataset. The default is 4326, the defined coordinate\
-            \ system for GeoJSON."
+            \ system in the EPSG dataset. The default is Longitude/Latitude EPSG:4326,\
+            \ which is the coordinate system +for GeoJSON."
           example: EPSG:4326
           externalDocs:
             url: https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset

--- a/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
@@ -148,7 +148,8 @@ abstract class GeoJsonOpenApiSchema {
           description =
               "Name of the coordinate reference system. This must be in the form EPSG:nnnn where " +
                   "nnnn is the numeric identifier of a coordinate system in the EPSG dataset. " +
-                  "The default is 4326, the defined coordinate system for GeoJSON.",
+                  "The default is Longitude/Latitude EPSG:4326, which is the coordinate system +" +
+                  "for GeoJSON.",
           example = "EPSG:4326",
           externalDocs =
               ExternalDocumentation(

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
@@ -80,7 +80,8 @@ class PlantController(private val plantStore: PlantStore) {
   @Operation(
       summary =
           "Fetch a count of how many plants of each species exist in a layer. " +
-              "Can filter based on enteredTime.")
+              "Can filter based on enteredTime. Plants that are not associated with any species " +
+              "will be grouped together and keyed on the sentinel value of -1.")
   @GetMapping("/list/summary/{layerId}")
   fun getPlantSummary(
       @QueryParam("minEnteredTime") minEnteredTime: Instant? = null,

--- a/src/main/kotlin/com/terraformation/backend/gis/db/PlantStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/PlantStore.kt
@@ -169,7 +169,10 @@ class PlantStore(
             .fetch()
 
     val summaryMap = mutableMapOf<SpeciesId, Int>()
-    records.forEach { record -> summaryMap[record.get(PLANTS.SPECIES_ID)!!] = record.get(1) as Int }
+    records.forEach { record ->
+      val speciesId = record[PLANTS.SPECIES_ID] ?: SpeciesId(-1)
+      summaryMap[speciesId] = record.get(1) as Int
+    }
     return summaryMap
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/Helpers.kt
@@ -20,12 +20,12 @@ fun newPoint(x: Double, y: Double, z: Double, srid: Int): Point {
 fun mercatorPoint(x: Double, y: Double, z: Double) = newPoint(x, y, z, SRID.SPHERICAL_MERCATOR)
 
 /**
- * Assert Point coordinate data is equal. Since the coordinates probably went through at least one
+ * Assert two Point coordinates are equal. Since the coordinates probably went through at least one
  * coordinate system conversion in the database write/read, allow a small fuzz factor in the x and y
  * coordinates.
  */
 fun assertPointsEqual(expected: Geometry?, actual: Geometry?, message: String = "Point") {
-  assertNotNull(expected, "$message BUG! Expected value was null")
+  assertNotNull(expected, "$message BUG! Cannot use null for expected Point")
   assertNotNull(actual, message)
 
   expected!!

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -135,7 +135,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `create always returns coordinates in LongLat (srid = 4326) even if they are provided in another coordinate reference system`() {
+  fun `create always returns coordinates in LongLat (srid = 4326) even if they are provided in another coordinate system`() {
     val featureModel = store.createFeature(validCreateRequest.copy(geom = sphericalMercatorPoint))
     assertPointsEqual(longLatPoint, featureModel.geom)
   }
@@ -159,6 +159,13 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     val fetchedFeature = store.fetchFeature(newFeature.id!!)
     assertNotNull(fetchedFeature)
     assertEquals(newFeature, fetchedFeature)
+  }
+
+  @Test
+  fun `read returns coordinates in LongLat (srid = 4326)`() {
+    val newFeature = store.createFeature(validCreateRequest.copy(geom = sphericalMercatorPoint))
+    val fetchedFeature = store.fetchFeature(newFeature.id!!)
+    assertPointsEqual(longLatPoint, fetchedFeature!!.geom!!)
   }
 
   @Test
@@ -260,7 +267,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `update returns coordinates in LongLat (srid = 4326) even if they are provided in another coordinate reference system`() {
+  fun `update returns coordinates in LongLat (srid = 4326) even if they are provided in another coordinate system`() {
     val feature = store.createFeature(validCreateRequest)
     val updatedFeature = store.updateFeature(feature.copy(geom = sphericalMercatorPoint))
     assertPointsEqual(longLatPoint, updatedFeature.geom)

--- a/src/test/kotlin/com/terraformation/backend/gis/db/PlantStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/PlantStoreTest.kt
@@ -203,7 +203,7 @@ internal class PlantStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchPlantList elements contain the same data we would have gotten from get feature and get plant`() {
+  fun `fetchPlantList elements contain all feature and plant data`() {
     val feature =
         FeatureModel(
             id = nonExistentFeatureId,
@@ -355,6 +355,22 @@ internal class PlantStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchPlantSummary counts how many plants of each species exist in a layer`() {
     insertSeveralPlants(speciesIdsToCount)
     assertEquals(speciesIdsToCount, store.fetchPlantSummary(layerId))
+  }
+
+  @Test
+  fun `fetchPlantSummary uses -1 as a sentinel species ID to count plants where species ID = null`() {
+    insertSeveralPlants(speciesIdsToCount)
+    val featuresWithoutSpecies = mutableListOf<FeatureId>()
+    repeat(3) {
+      val randomFeatureId = FeatureId(Random.nextLong())
+      featuresWithoutSpecies.add(randomFeatureId)
+      insertFeature(id = randomFeatureId.value, layerId = layerId.value, enteredTime = time1)
+      plantsDao.insert(
+          PlantsRow(featureId = randomFeatureId, createdTime = time1, modifiedTime = time2))
+    }
+    val expectedSpeciesIdsToCount = speciesIdsToCount.toMutableMap()
+    expectedSpeciesIdsToCount[SpeciesId(-1)] = 3
+    assertEquals(expectedSpeciesIdsToCount, store.fetchPlantSummary(layerId))
   }
 
   @Test


### PR DESCRIPTION
Before this change, the list plant summary endpoint would return a 500 error when any
plant in the layer had a null species ID. Now, the return value may contain a sentinel
species id of -1, which is used to group all the plants that have a null species ID.

This commit also includes some minor comment changes and one test that was accidentally
omitted from #57.