### PR TITLE
SW-288 Improve JSON error responses

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -1,12 +1,23 @@
 package com.terraformation.backend.api
 
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.InvalidNullException
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import javax.ws.rs.QueryParam
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
@@ -15,7 +26,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  */
 @ControllerAdvice
 class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
-  @ExceptionHandler(ClientFacingException::class)
+  @ExceptionHandler
   fun handleClientFacingException(
       ex: ClientFacingException,
       request: WebRequest
@@ -23,7 +34,7 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
     return simpleErrorResponse(ex.message, ex.status, request)
   }
 
-  @ExceptionHandler(IllegalArgumentException::class)
+  @ExceptionHandler
   fun handleIllegalArgumentException(
       ex: IllegalArgumentException,
       request: WebRequest
@@ -32,7 +43,7 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
         ex.message ?: "An internal error has occurred.", HttpStatus.BAD_REQUEST, request)
   }
 
-  @ExceptionHandler(ResponseStatusException::class)
+  @ExceptionHandler
   fun handleGenericSpringResponseStatusException(
       ex: ResponseStatusException,
       request: WebRequest
@@ -43,13 +54,117 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
     return simpleErrorResponse(ex.message ?: ex.status.reasonPhrase, ex.status, request)
   }
 
-  @ExceptionHandler(Exception::class)
+  /**
+   * Handles exceptions that indicate the user didn't have permission to do something. These are
+   * rendered as HTTP 403 Forbidden responses. The exception message, which has a more precise
+   * description of what permission was missing, is passed on to the client.
+   */
+  @ExceptionHandler
+  fun handleAccessDeniedException(
+      ex: AccessDeniedException,
+      request: WebRequest
+  ): ResponseEntity<*> {
+    return simpleErrorResponse(ex.localizedMessage, HttpStatus.FORBIDDEN, request)
+  }
+
+  @ExceptionHandler
   fun handleUnknownException(ex: Exception, request: WebRequest): ResponseEntity<*> {
     val description = request.getDescription(false)
     controllerLogger(ex).error("Controller threw exception on $description", ex)
 
     return simpleErrorResponse(
         "An internal error has occurred.", HttpStatus.INTERNAL_SERVER_ERROR, request)
+  }
+
+  /**
+   * Returns an actionable error message to the client if the request has a malformed path or query
+   * string parameter. The default behavior is to return HTTP 400 with no explanation of what the
+   * problem is.
+   */
+  @ExceptionHandler
+  fun handleMethodArgumentTypeMismatchException(
+      ex: MethodArgumentTypeMismatchException,
+      request: WebRequest
+  ): ResponseEntity<*> {
+    val parameter = ex.parameter
+    val parameterName = parameter.parameterName
+
+    // We want the name of the parameter in the API schema, which might not be the same as the name
+    // of the controller method parameter. Various annotations can specify the name in the schema.
+    // Most of them, if no name is specified, default to a value of ""; in that case we want the
+    // name of the method parameter.
+    fun nameFromSchema(nameFromAnnotation: String?): String {
+      return when {
+        !nameFromAnnotation.isNullOrEmpty() -> nameFromAnnotation
+        parameterName != null -> parameterName
+        else -> ""
+      }
+    }
+
+    val pathVariable = parameter.getParameterAnnotation(PathVariable::class.java)
+    if (pathVariable != null) {
+      return simpleErrorResponse(
+          "Invalid value for URL path element ${nameFromSchema(pathVariable.name)}",
+          HttpStatus.BAD_REQUEST,
+          request)
+    }
+
+    val queryParamName =
+        parameter.getParameterAnnotation(QueryParam::class.java)?.value
+            ?: parameter.getParameterAnnotation(RequestParam::class.java)?.value
+    if (queryParamName != null) {
+      return simpleErrorResponse(
+          "Invalid value for query string parameter ${nameFromSchema(queryParamName)}",
+          HttpStatus.BAD_REQUEST,
+          request)
+    }
+
+    return simpleErrorResponse("Invalid value in request URL", HttpStatus.BAD_REQUEST, request)
+  }
+
+  /** Returns an actionable error message if the client submits a malformed request payload. */
+  override fun handleHttpMessageNotReadable(
+      ex: HttpMessageNotReadableException,
+      headers: HttpHeaders,
+      status: HttpStatus,
+      request: WebRequest
+  ): ResponseEntity<Any> {
+    val cause = ex.cause
+    if (cause is JsonMappingException) {
+      // The exception has a "path" which is the JSON parser's position in the parse tree. Array
+      // fields are represented as two path elements, one with the field name and the next with the
+      // array index; we want to render that as "fieldName[index]". We do it with a hack: it gets
+      // rendered as "fieldName.[index]" first, and then we get rid of the period.
+      //
+      // An empty path means the request was malformed to the point the parser couldn't even figure
+      // out how to start traversing it.
+      if (cause.path.isEmpty()) {
+        return simpleErrorResponse(
+            "Unable to parse request payload", HttpStatus.BAD_REQUEST, request)
+      }
+
+      val path =
+          cause
+              .path
+              .joinToString(".") { reference ->
+                val arrayIndex = if (reference.index >= 0) "[${reference.index}]" else ""
+                val fieldName = reference.fieldName ?: ""
+                "${fieldName}$arrayIndex"
+              }
+              .replace(".[", "[")
+
+      val message =
+          when (cause) {
+            is MissingKotlinParameterException -> "Required field not present"
+            is InvalidNullException -> "Field value cannot be null"
+            is InvalidFormatException -> "Field value has incorrect format"
+            else -> "Field value invalid"
+          }
+
+      return simpleErrorResponse("$message: $path", status, request)
+    } else {
+      return simpleErrorResponse(ex.localizedMessage, status, request)
+    }
   }
 
   private fun controllerLogger(ex: Exception): Logger {
@@ -61,12 +176,14 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
    * Returns an error in the server's documented JSON error format unless the request only accepts
    * text/plain responses, in which case it just returns the error message. This is needed to work
    * with rhizo-client which only accepts text/plain responses.
+   *
+   * TODO: For clients that want HTML, render this using a custom error template.
    */
   private fun simpleErrorResponse(
       message: String,
       status: HttpStatus,
       request: WebRequest
-  ): ResponseEntity<*> {
+  ): ResponseEntity<Any> {
     return if (request.getHeader("Accept") == "text/plain") {
       ResponseEntity(message, status)
     } else {


### PR DESCRIPTION
Handle a few more kinds of exceptions bubbling up from controller methods or
from Spring's request handling infrastructure. These are rendered using our
`ErrorResponsePayload` response schema for consistency.

`AccessDeniedException` turns into HTTP 403.

Invalid request payloads turn into HTTP 400 with a description of exactly
which field had the problem, if possible. For example (formatted for clarity):

    {
      "error": {
        "message": "Required field not present: timeseries[0].values[1].timestamp"
      },
      "status": "error"
    }

Invalid URLs (path variables or query string arguments) turn into HTTP 400
with a description of which field had the problem.

This is focused on JSON responses; a subsequent change will address the fact
that we use Spring's default HTML error page for non-JSON requests.
