### PR TITLE
Don't treat layer tile set name as required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3296,7 +3296,6 @@ components:
       - layerType
       - proposed
       - siteId
-      - tileSetName
       type: object
       properties:
         id:

--- a/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
@@ -127,7 +127,7 @@ data class LayerResponse(
     val id: LayerId,
     val siteId: SiteId,
     val layerType: LayerType,
-    val tileSetName: String,
+    val tileSetName: String?,
     val proposed: Boolean,
     val hidden: Boolean,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/gis/db/LayerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/LayerStore.kt
@@ -108,7 +108,7 @@ class LayerStore(
             id = record[ID],
             siteId = record[SITE_ID]!!,
             layerType = record[LAYER_TYPE_ID]!!,
-            tileSetName = record[TILE_SET_NAME]!!,
+            tileSetName = record[TILE_SET_NAME],
             proposed = record[LAYERS.PROPOSED]!!,
             hidden = record[LAYERS.HIDDEN]!!,
             deleted = record[LAYERS.DELETED],

--- a/src/main/kotlin/com/terraformation/backend/gis/model/LayerModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/model/LayerModel.kt
@@ -9,7 +9,7 @@ data class LayerModel(
     val id: LayerId? = null,
     val siteId: SiteId,
     val layerType: LayerType,
-    val tileSetName: String,
+    val tileSetName: String?,
     val proposed: Boolean,
     val hidden: Boolean,
     val deleted: Boolean? = null,


### PR DESCRIPTION
The corresponding column in the database is nullable, and we don't populate
it when we import data from shapefiles.

Previously, if you tried to get layer data for a layer imported from a
shapefile, the server would return HTTP 500.
