### PR TITLE
SW-299 Map internal "X not found" exceptions to HTTP 404

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.InvalidNullException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.terraformation.backend.db.EntityNotFoundException
 import javax.ws.rs.QueryParam
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -32,6 +33,14 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
       request: WebRequest
   ): ResponseEntity<*> {
     return simpleErrorResponse(ex.message, ex.status, request)
+  }
+
+  @ExceptionHandler
+  fun handleEntityNotFoundException(
+      ex: EntityNotFoundException,
+      request: WebRequest
+  ): ResponseEntity<*> {
+    return simpleErrorResponse(ex.message, HttpStatus.NOT_FOUND, request)
   }
 
   @ExceptionHandler

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.customer.api
 
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.RequireExistingAdminRole
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
@@ -12,9 +11,12 @@ import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectId
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.log.perClassLogger
@@ -74,7 +76,9 @@ class AdminController(
 
   @GetMapping("/organization/{organizationId}")
   fun organization(@PathVariable organizationId: OrganizationId, model: Model): String {
-    val organization = organizationStore.fetchById(organizationId) ?: throw NotFoundException()
+    val organization =
+        organizationStore.fetchById(organizationId)
+            ?: throw OrganizationNotFoundException(organizationId)
     val projects = projectStore.fetchByOrganization(organizationId).sortedBy { it.name }
     val users = organizationStore.fetchUsers(listOf(organizationId)).sortedBy { it.email }
 
@@ -113,7 +117,7 @@ class AdminController(
 
   @GetMapping("/project/{projectId}")
   fun project(@PathVariable projectId: ProjectId, model: Model): String {
-    val project = projectStore.fetchById(projectId) ?: throw NotFoundException()
+    val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
     val organization = organizationStore.fetchById(project.organizationId)
     val orgUsers =
         organizationStore.fetchUsers(listOf(project.organizationId)).sortedBy { it.email }
@@ -134,9 +138,9 @@ class AdminController(
 
   @GetMapping("/site/{siteId}")
   fun site(@PathVariable siteId: SiteId, model: Model): String {
-    val site = siteStore.fetchById(siteId) ?: throw NotFoundException()
+    val site = siteStore.fetchById(siteId) ?: throw SiteNotFoundException(siteId)
     val projectId = site.projectId
-    val project = projectStore.fetchById(projectId) ?: throw NotFoundException()
+    val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
     val organization = organizationStore.fetchById(project.organizationId)
     val facilities = facilityStore.fetchBySiteId(siteId).sortedBy { it.name }
 

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -2,13 +2,24 @@ package com.terraformation.backend.db
 
 import java.io.IOException
 
-class AccessionNotFoundException(val accessionId: AccessionId) :
-    Exception("Accession $accessionId not found")
+/**
+ * Thrown when an entity wasn't found when it should have been.
+ *
+ * Subclasses of this are mapped to HTTP 404 Not Found if they are thrown by a controller method.
+ */
+abstract class EntityNotFoundException(message: String) : RuntimeException(message) {
+  override val message: String
+    get() = super.message!!
+}
 
-class DeviceNotFoundException(val deviceId: DeviceId) : Exception("Device $deviceId not found")
+class AccessionNotFoundException(val accessionId: AccessionId) :
+    EntityNotFoundException("Accession $accessionId not found")
+
+class DeviceNotFoundException(val deviceId: DeviceId) :
+    EntityNotFoundException("Device $deviceId not found")
 
 class FeatureNotFoundException(val featureId: FeatureId) :
-    Exception("Feature $featureId not found")
+    EntityNotFoundException("Feature $featureId not found")
 
 /** A request to the Keycloak authentication server failed. */
 open class KeycloakRequestFailedException(
@@ -17,26 +28,30 @@ open class KeycloakRequestFailedException(
 ) : IOException(message, cause)
 
 /** Keycloak couldn't find a user that we expected to be able to find. */
-class KeycloakUserNotFoundException(message: String) : Exception(message)
+class KeycloakUserNotFoundException(message: String) : EntityNotFoundException(message)
 
-class LayerNotFoundException(val layerId: LayerId) : Exception("Layer $layerId not found")
+class LayerNotFoundException(val layerId: LayerId) :
+    EntityNotFoundException("Layer $layerId not found")
 
 class OrganizationNotFoundException(val organizationId: OrganizationId) :
-    Exception("Organization $organizationId not found")
+    EntityNotFoundException("Organization $organizationId not found")
 
-class PhotoNotFoundException(val photoId: PhotoId) : Exception("Photo $photoId not found")
+class PhotoNotFoundException(val photoId: PhotoId) :
+    EntityNotFoundException("Photo $photoId not found")
 
 class PlantNotFoundException(val featureId: FeatureId) :
-    Exception("Plant with feature id $featureId not found")
+    EntityNotFoundException("Plant with feature id $featureId not found")
 
 class PlantObservationNotFoundException(val id: PlantObservationId) :
-    Exception("Plant observation $id not found")
+    EntityNotFoundException("Plant observation $id not found")
 
 class ProjectNotFoundException(val projectId: ProjectId) :
-    Exception("Project $projectId not found")
+    EntityNotFoundException("Project $projectId not found")
+
+class SiteNotFoundException(val siteId: SiteId) : EntityNotFoundException("Site $siteId not found")
 
 class SpeciesNotFoundException(val speciesId: SpeciesId) :
-    Exception("Species $speciesId not found")
+    EntityNotFoundException("Species $speciesId not found")
 
 class SpeciesNameNotFoundException(val speciesNameId: SpeciesNameId) :
-    RuntimeException("Species name $speciesNameId not found")
+    EntityNotFoundException("Species name $speciesNameId not found")


### PR DESCRIPTION
Add a handler that causes exceptions such as `LayerNotFoundException` to be
rendered as HTTP 404 responses if they bubble up through a controller method.
Previously, they were treated as generic exceptions and were rendered as HTTP
500 responses.
