### PR TITLE
SW-315 Increase link validity time to 3 days; minor cleanup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/KeycloakRequiredActions.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/KeycloakRequiredActions.kt
@@ -1,0 +1,14 @@
+package com.terraformation.backend.auth
+
+/**
+ * Actions that can be marked as required on a Keycloak user. Technically, these are dynamic because
+ * they can be renamed in the Keycloak admin UI, so they aren't declared as constants in the
+ * Keycloak client library. But we use the default names.
+ */
+enum class KeycloakRequiredActions(val keyword: String) {
+  /**
+   * Require the user to change their password on next login. This can also be set on a newly
+   * created user who has no password at all yet.
+   */
+  UpdatePassword("UPDATE_PASSWORD")
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.terraformation.backend.auth.KeycloakRequiredActions
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.Role
@@ -27,6 +28,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.time.Clock
+import java.time.Duration
 import java.util.Base64
 import javax.annotation.ManagedBean
 import javax.ws.rs.core.MediaType
@@ -156,6 +158,14 @@ class UserStore(
   /**
    * Creates a new user as a member of an organization. This registers them in Keycloak and also
    * adds them to the `users` table.
+   *
+   * @param sendPasswordEmail If true, send an email notification to the user with a link to set
+   * their password.
+   * @param linkLifetime How long the link in the password change email will remain valid. Only
+   * relevant if [sendPasswordEmail] is true.
+   * @param redirectUrl Where to redirect the user after they have changed their password using the
+   * link in the generated email. Only relevant if [sendPasswordEmail] is true. If this is null,
+   * Keycloak will display a page with a success message after the user sets their password.
    */
   fun createUser(
       organizationId: OrganizationId,
@@ -163,8 +173,9 @@ class UserStore(
       email: String,
       firstName: String? = null,
       lastName: String? = null,
+      sendPasswordEmail: Boolean = true,
       redirectUrl: URI? = null,
-      requireResetPassword: Boolean = true,
+      linkLifetime: Duration = Duration.ofDays(3),
   ): UserModel {
     if (!currentUser().canAddOrganizationUser(organizationId)) {
       throw AccessDeniedException("No permission to add users to this organization")
@@ -183,26 +194,28 @@ class UserStore(
 
     log.info("Creating new user $email")
 
-    val keycloakUser = registerKeycloakUser(email, firstName, lastName)
+    val keycloakUser =
+        registerKeycloakUser(
+            email,
+            firstName,
+            lastName,
+            requiredActions = setOf(KeycloakRequiredActions.UpdatePassword))
     val usersRow = insertKeycloakUser(keycloakUser)
     val user = rowToDetails(usersRow)
 
     organizationStore.addUser(organizationId, user.userId, role)
 
-    val userResource =
-        usersResource.get(keycloakUser.id)
-            ?: throw IllegalStateException("Registered user with Keycloak but could not find them")
-
-    if (requireResetPassword) {
-      keycloakUser.requiredActions = listOf("UPDATE_PASSWORD")
-
-      userResource.update(keycloakUser)
+    if (sendPasswordEmail) {
+      val linkLifetimeSecs = linkLifetime.seconds.toInt()
+      val userResource = usersResource.get(user.authId)
 
       if (redirectUrl != null) {
+        // Client ID is required when specifying a redirect URL.
+        val keycloakClientId = keycloakProperties.resource
         userResource.executeActionsEmail(
-            keycloakProperties.resource, "$redirectUrl", keycloakUser.requiredActions)
+            keycloakClientId, "$redirectUrl", linkLifetimeSecs, keycloakUser.requiredActions)
       } else {
-        userResource.executeActionsEmail(keycloakUser.requiredActions)
+        userResource.executeActionsEmail(keycloakUser.requiredActions, linkLifetimeSecs)
       }
     }
 
@@ -289,7 +302,8 @@ class UserStore(
       username: String,
       firstName: String?,
       lastName: String?,
-      type: UserType = UserType.Individual
+      type: UserType = UserType.Individual,
+      requiredActions: Collection<KeycloakRequiredActions>? = null,
   ): UserRepresentation {
     val newKeycloakUser = UserRepresentation()
     newKeycloakUser.isEmailVerified = true
@@ -299,6 +313,7 @@ class UserStore(
     newKeycloakUser.groups = defaultKeycloakGroups[type]
     newKeycloakUser.lastName = lastName
     newKeycloakUser.username = username
+    newKeycloakUser.requiredActions = requiredActions?.map { it.keyword }
 
     log.debug("Creating user $username in Keycloak")
 
@@ -343,9 +358,7 @@ class UserStore(
       throw IllegalArgumentException("Offline tokens may only be generated for API clients")
     }
 
-    val user =
-        usersResource.get(authId)
-            ?: throw KeycloakUserNotFoundException("Keycloak could not find user")
+    val user = usersResource.get(authId)
 
     // Reset the user's password, so we can use it to authenticate to Keycloak and request a new
     // offline token. There is no administrative Keycloak API to do that on behalf of a user.


### PR DESCRIPTION
Feedback from the product team was that the default validity time on "reset
password" links, 12 hours, was too short when they were creating a bunch of
alpha users who might not be at their computers. Increase it to 72 hours as
requested.

Pass the "must set password" setting to Keycloak at user creation time rather
than setting it after creation, to reduce the number of places where a failure
could leave the system in an inconsistent state.

Stop assuming (incorrectly) that the Keycloak admin client `UsersResource.get`
method checks to see if the user exists; it just returns a client object that
can be used to make Keycloak admin API requests related to a specific user.
