### PR TITLE
Add layer creation to admin UI

### DIFF
--- a/src/main/resources/templates/admin/project.html
+++ b/src/main/resources/templates/admin/project.html
@@ -55,6 +55,17 @@
     <label for="longitude">Longitude</label>
     <input type="number" name="longitude" id="longitude" min="-180" max="180" step="0.000001"
            required/>
+    <label for="layerTypes">Layers</label>
+    <select multiple name="layerTypes" id="layerTypes" style="vertical-align: top;">
+        <option th:each="layerType : ${defaultLayerTypes}" th:value="|${layerType}|"
+                th:text="|${layerType.displayName}|" selected="selected">
+            Layer Name
+        </option>
+        <option th:each="layerType : ${otherLayerTypes}" th:value="|${layerType}|"
+                th:text="|${layerType.displayName}|">
+            Layer Name
+        </option>
+    </select>
     <input type="submit" value=" Create Site "/>
 </form>
 

--- a/src/main/resources/templates/admin/site.html
+++ b/src/main/resources/templates/admin/site.html
@@ -43,5 +43,27 @@
     <input type="submit" value=" Create Facility "/>
 </form>
 
+<h3>Layers</h3>
+
+<ul th:if="${layers.size > 0}">
+    <li th:each="layer : ${layers}" th:text="|${layer.layerType.displayName} (${layer.id})|">
+        Layer Type (12345)
+    </li>
+</ul>
+
+<form method="POST" th:action="|${prefix}/createLayer|" th:if="${canCreateLayer}">
+    <h4>Create Layer</h4>
+
+    <input type="hidden" name="siteId" th:value="${site.id}"/>
+    <label for="layerType">Layer Type</label>
+    <select id="layerType" name="layerType">
+        <option th:each="layerType : ${layerTypes}" th:value="${layerType}"
+                th:text="${layerType.displayName}">
+            Layer Type
+        </option>
+    </select>
+    <input type="submit" value=" Create Layer "/>
+</form>
+
 </body>
 </html>


### PR DESCRIPTION
The mobile app expects a site to already have a "Plants Planted" layer if the
user is trying to upload information about plants. It could create the layer on
demand but that introduces a race condition if two users upload plants to a new
site at the same time; they'd both end up creating separate layers since it's
legal (intentionally) for a site to have multiple layers of the same type.

Add layer creation to the admin UI, and by default, create a "Plants Planted"
layer when a new site is created. The admin can deselect that option to skip
layer creation, or they can select additional layer types. They can also add
layers to existing sites if needed.

This should suffice until we've worked out the requirements for user-facing
site administration.
