### PR TITLE
Redirect after POST in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -433,18 +433,25 @@ class AdminController(
         Point(longitude.toDouble(), latitude.toDouble(), 0.0).apply { srid = SRID.LONG_LAT }
     val site = siteStore.create(projectId, name, location)
 
-    layerTypes?.forEach { layerType ->
-      layerStore.createLayer(
-          LayerModel(
-              hidden = false,
-              layerType = layerType,
-              proposed = false,
-              siteId = site.id,
-              tileSetName = null,
-          ))
+    try {
+      layerTypes?.forEach { layerType ->
+        layerStore.createLayer(
+            LayerModel(
+                hidden = false,
+                layerType = layerType,
+                proposed = false,
+                siteId = site.id,
+                tileSetName = null,
+            ))
+      }
+
+      redirectAttributes.addFlashAttribute("successMessage", "Site created.")
+    } catch (e: Exception) {
+      log.error("Layer creation failed", e)
+      redirectAttributes.addFlashAttribute(
+          "failureMessage", "Created site but could not create layers.")
     }
 
-    redirectAttributes.addFlashAttribute("successMessage", "Site created.")
     return project(projectId)
   }
 


### PR DESCRIPTION
Make the POST endpoints in the admin UI redirect to GET endpoints rather than
directly returning an HTML page. This way if the user reloads the page after
submitting a form, the browser won't try to resubmit the form.

This is mostly just a straightforward use of Spring MVC flash attributes (which
are stored in the session data on the server side and get automatically added
to the model and removed from the session store after a redirect) except for
API keys, which we only want to show one time; there's now a GET endpoint to
show a just-created API key, and it redirects to the organization page with an
error message if you try to reload it.
