### PR TITLE
SW-339 Make accession search result items more strongly typed

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4137,8 +4137,137 @@ components:
           type: array
           items:
             type: object
-            additionalProperties:
-              type: string
+            properties:
+              accessionNumber:
+                type: string
+              active:
+                type: string
+              bagNumber:
+                type: string
+              collectedDate:
+                type: string
+              collectionNotes:
+                type: string
+              cutTestSeedsCompromised:
+                type: string
+              cutTestSeedsEmpty:
+                type: string
+              cutTestSeedsFilled:
+                type: string
+              dryingEndDate:
+                type: string
+              dryingMoveDate:
+                type: string
+              dryingStartDate:
+                type: string
+              endangered:
+                type: string
+              estimatedSeedsIncoming:
+                type: string
+              family:
+                type: string
+              geolocation:
+                type: string
+              germinationEndDate:
+                type: string
+              germinationPercentGerminated:
+                type: string
+              germinationSeedType:
+                type: string
+              germinationSeedsGerminated:
+                type: string
+              germinationSeedsSown:
+                type: string
+              germinationStartDate:
+                type: string
+              germinationSubstrate:
+                type: string
+              germinationTestNotes:
+                type: string
+              germinationTestType:
+                type: string
+              germinationTreatment:
+                type: string
+              id:
+                type: string
+              landowner:
+                type: string
+              latestGerminationTestDate:
+                type: string
+              latestViabilityPercent:
+                type: string
+              nurseryStartDate:
+                type: string
+              primaryCollector:
+                type: string
+              processingMethod:
+                type: string
+              processingNotes:
+                type: string
+              processingStartDate:
+                type: string
+              rare:
+                type: string
+              receivedDate:
+                type: string
+              remainingGrams:
+                type: string
+              remainingQuantity:
+                type: string
+              remainingUnits:
+                type: string
+              siteLocation:
+                type: string
+              sourcePlantOrigin:
+                type: string
+              species:
+                type: string
+              state:
+                type: string
+              storageCondition:
+                type: string
+              storageLocation:
+                type: string
+              storageNotes:
+                type: string
+              storagePackets:
+                type: string
+              storageStartDate:
+                type: string
+              targetStorageCondition:
+                type: string
+              totalGrams:
+                type: string
+              totalQuantity:
+                type: string
+              totalUnits:
+                type: string
+              totalViabilityPercent:
+                type: string
+              treesCollectedFrom:
+                type: string
+              viabilityTestType:
+                type: string
+              withdrawalDate:
+                type: string
+              withdrawalDestination:
+                type: string
+              withdrawalGrams:
+                type: string
+              withdrawalNotes:
+                type: string
+              withdrawalPurpose:
+                type: string
+              withdrawalRemainingGrams:
+                type: string
+              withdrawalRemainingQuantity:
+                type: string
+              withdrawalRemainingUnits:
+                type: string
+              withdrawalQuantity:
+                type: string
+              withdrawalUnits:
+                type: string
         cursor:
           type: string
     SearchSortOrderElement:


### PR DESCRIPTION
Previously, the OpenAPI schema for the `/api/v1/seedbank/search` response
payload had a `results` property that was just a generic object with string
values and no restrictions on keys. But we know what the possible keys are,
because they can only ever be the names of search fields.

Update the schema to be more precise about the response.

By itself, this doesn't really do the client much good. But when we add nested
values in search results, it will become more valuable because some values will
be objects instead of strings.
