### PR TITLE
SW-342 Move timeseries endpoints out of seedbank API namespace

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1557,7 +1557,7 @@ paths:
       tags:
       - DeviceManager
       summary: Records new values for one or more timeseries.
-      operationId: recordTimeseriesValues
+      operationId: recordTimeseriesValues_1
       requestBody:
         content:
           application/json:
@@ -2035,6 +2035,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponsePayload'
+  /api/v1/timeseries/create:
+    post:
+      tags:
+      - DeviceManager
+      summary: Defines a list of timeseries for one or more devices.
+      description: "If there are existing timeseries with the same names, the old\
+        \ definitions will be overwritten."
+      operationId: createMultipleTimeseries_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTimeseriesRequestPayload'
+        required: true
+      responses:
+        "200":
+          description: The requested operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleSuccessResponsePayload'
+  /api/v1/timeseries/values:
+    post:
+      tags:
+      - DeviceManager
+      summary: Records new values for one or more timeseries.
+      operationId: recordTimeseriesValues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordTimeseriesValuesRequestPayload'
+        required: true
+      responses:
+        "200":
+          description: "Successfully processed the request. Note that this status\
+            \ will be returned even if the server was unable to record some of the\
+            \ values. In that case, the failed values will be returned in the response\
+            \ payload."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordTimeseriesValuesResponsePayload'
 components:
   schemas:
     AccessionPayload:

--- a/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
@@ -22,7 +22,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @DeviceManagerAppEndpoint
-@RequestMapping("/api/v1/seedbank/timeseries")
+@RequestMapping(
+    "/api/v1/timeseries",
+    // TODO: Remove the following once the device manager is updated to use /api/v1/timeseries
+    "/api/v1/seedbank/timeseries")
 @RestController
 class TimeseriesController(private val timeSeriesStore: TimeseriesStore) {
   private val log = perClassLogger()


### PR DESCRIPTION
The timeseries endpoints were under `/api/v1/seedbank` which is wrong since
they have nothing to do with seed banking.

Move them up a level, but retain the existing names for now to avoid breaking
the existing device manager code. Once the device manager is updated to use the
new names, we can remove the old names.
