### PR TITLE
RFC: Move parent lookups into a helper class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -1,0 +1,60 @@
+package com.terraformation.backend.customer.db
+
+import com.terraformation.backend.customer.model.UserModel
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.FeatureId
+import com.terraformation.backend.db.LayerId
+import com.terraformation.backend.db.PhotoId
+import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tables.references.DEVICES
+import com.terraformation.backend.db.tables.references.FEATURES
+import com.terraformation.backend.db.tables.references.FEATURE_PHOTOS
+import com.terraformation.backend.db.tables.references.LAYERS
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.TableField
+
+/**
+ * Lookup methods to get the IDs of the parents of various objects.
+ *
+ * This is mostly called by [UserModel] to evaluate permissions on child objects in cases where the
+ * children inherit permissions from parents. Putting all these lookups in one place reduces the
+ * number of dependencies in [UserModel], and also gives us a clean place to introduce caching if
+ * parent ID lookups in permission checks become a performance bottleneck.
+ */
+@ManagedBean
+class ParentStore(private val dslContext: DSLContext) {
+  fun getFacilityId(accessionId: AccessionId): FacilityId? =
+      fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.FACILITY_ID)
+
+  fun getFacilityId(deviceId: DeviceId): FacilityId? =
+      fetchFieldById(deviceId, DEVICES.ID, DEVICES.FACILITY_ID)
+
+  fun getFeatureId(photoId: PhotoId): FeatureId? =
+      fetchFieldById(photoId, FEATURE_PHOTOS.PHOTO_ID, FEATURE_PHOTOS.FEATURE_ID)
+
+  fun getLayerId(featureId: FeatureId): LayerId? =
+      fetchFieldById(featureId, FEATURES.ID, FEATURES.LAYER_ID)
+
+  fun getSiteId(layerId: LayerId): SiteId? = fetchFieldById(layerId, LAYERS.ID, LAYERS.SITE_ID)
+
+  /**
+   * Looks up a database row by an ID and returns the value of one of the columns, or null if no row
+   * had the given ID.
+   */
+  private fun <C, P, R : Record> fetchFieldById(
+      id: C,
+      idField: TableField<R, C>,
+      fieldToFetch: TableField<R, P>
+  ): P? {
+    return dslContext
+        .select(fieldToFetch)
+        .from(idField.table)
+        .where(idField.eq(id))
+        .fetchOne(fieldToFetch)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -15,11 +15,6 @@ import com.terraformation.backend.db.KeycloakUserNotFoundException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.DevicesDao
-import com.terraformation.backend.db.tables.daos.FeaturePhotosDao
-import com.terraformation.backend.db.tables.daos.FeaturesDao
-import com.terraformation.backend.db.tables.daos.LayersDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.UsersRow
 import com.terraformation.backend.log.perClassLogger
@@ -61,17 +56,13 @@ import org.springframework.http.HttpStatus
  */
 @ManagedBean
 class UserStore(
-    private val accessionsDao: AccessionsDao,
     private val clock: Clock,
     private val config: TerrawareServerConfig,
-    private val devicesDao: DevicesDao,
-    private val featurePhotosDao: FeaturePhotosDao,
-    private val featuresDao: FeaturesDao,
     private val httpClient: HttpClient,
     private val keycloakProperties: KeycloakSpringBootProperties,
-    private val layersDao: LayersDao,
     private val objectMapper: ObjectMapper,
     private val organizationStore: OrganizationStore,
+    private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
     realmResource: RealmResource,
     private val usersDao: UsersDao,
@@ -436,11 +427,7 @@ class UserStore(
         usersRow.firstName,
         usersRow.lastName,
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),
-        accessionsDao,
-        devicesDao,
-        featurePhotosDao,
-        featuresDao,
-        layersDao,
+        parentStore,
         permissionStore,
     )
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -11,11 +11,6 @@ import com.terraformation.backend.db.KeycloakRequestFailedException
 import com.terraformation.backend.db.KeycloakUserNotFoundException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UserType
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.DevicesDao
-import com.terraformation.backend.db.tables.daos.FeaturePhotosDao
-import com.terraformation.backend.db.tables.daos.FeaturesDao
-import com.terraformation.backend.db.tables.daos.LayersDao
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.UsersRow
@@ -55,13 +50,9 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private val usersResource = InMemoryKeycloakUsersResource()
   override val user: UserModel = mockk()
 
-  private lateinit var accessionsDao: AccessionsDao
-  private lateinit var devicesDao: DevicesDao
-  private lateinit var featurePhotosDao: FeaturePhotosDao
-  private lateinit var featuresDao: FeaturesDao
-  private lateinit var layersDao: LayersDao
   private lateinit var organizationsDao: OrganizationsDao
   private lateinit var organizationStore: OrganizationStore
+  private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
   private lateinit var usersDao: UsersDao
   private lateinit var userStore: UserStore
@@ -111,30 +102,22 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     usersResource.create(userRepresentation)
 
     val configuration = dslContext.configuration()
-    accessionsDao = AccessionsDao(configuration)
-    devicesDao = DevicesDao(configuration)
-    featurePhotosDao = FeaturePhotosDao(configuration)
-    featuresDao = FeaturesDao(configuration)
-    layersDao = LayersDao(configuration)
     organizationsDao = OrganizationsDao(configuration)
     usersDao = UsersDao(configuration)
 
     organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
+    parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
 
     userStore =
         UserStore(
-            accessionsDao,
             Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
             config,
-            devicesDao,
-            featurePhotosDao,
-            featuresDao,
             httpClient,
             keycloakProperties,
-            layersDao,
             ObjectMapper().registerModule(KotlinModule()),
             organizationStore,
+            parentStore,
             permissionStore,
             realmResource,
             usersDao)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.AccessionId
@@ -18,9 +19,6 @@ import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.db.tables.daos.DevicesDao
-import com.terraformation.backend.db.tables.daos.FeaturePhotosDao
-import com.terraformation.backend.db.tables.daos.FeaturesDao
-import com.terraformation.backend.db.tables.daos.LayersDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.DevicesRow
@@ -102,9 +100,7 @@ import org.springframework.beans.factory.annotation.Autowired
 internal class PermissionTest : DatabaseTest() {
   private lateinit var accessionsDao: AccessionsDao
   private lateinit var devicesDao: DevicesDao
-  private lateinit var featurePhotosDao: FeaturePhotosDao
-  private lateinit var featuresDao: FeaturesDao
-  private lateinit var layersDao: LayersDao
+  private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
   private lateinit var usersDao: UsersDao
   private lateinit var userStore: UserStore
@@ -139,24 +135,18 @@ internal class PermissionTest : DatabaseTest() {
     val jooqConfig = dslContext.configuration()
     accessionsDao = AccessionsDao(jooqConfig)
     devicesDao = DevicesDao(jooqConfig)
-    featurePhotosDao = FeaturePhotosDao(jooqConfig)
-    featuresDao = FeaturesDao(jooqConfig)
-    layersDao = LayersDao(jooqConfig)
+    parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
     usersDao = UsersDao(jooqConfig)
     userStore =
         UserStore(
-            accessionsDao,
             clock,
             config,
-            devicesDao,
-            featurePhotosDao,
-            featuresDao,
             mockk(),
             mockk(),
-            layersDao,
             mockk(),
             mockk(),
+            parentStore,
             permissionStore,
             realmResource,
             usersDao)


### PR DESCRIPTION
The number of DAOs `UserModel` needed was getting a bit out of hand, and they
are only ever used to look up parent IDs.

Try pulling that functionality out into a dedicated class so we don't have to
keep adding dependencies to `UserModel` as the data model grows.
