### PR TITLE
Fetch accessions using single SQL queries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ buildscript {
       setForcedModules(
           // https://github.com/revolut-engineering/jooq-plugin/pull/17
           "com.github.docker-java:docker-java-transport-okhttp:3.2.12",
+          "org.jooq:jooq:$jooqVersion",
           "org.jooq:jooq-codegen:$jooqVersion",
       )
     }
@@ -53,6 +54,7 @@ repositories { mavenCentral() }
 dependencies {
   val awsSdkVersion: String by project
   val jacksonVersion: String by project
+  val jooqVersion: String by project
   val postgresJdbcVersion: String by project
   val springDocVersion: String by project
 
@@ -81,6 +83,7 @@ dependencies {
   implementation("org.apache.tika:tika-core:2.1.0")
   implementation("org.codehaus.janino:janino:3.1.3")
   implementation("org.flywaydb:flyway-core:7.5.4")
+  implementation("org.jooq:jooq:$jooqVersion")
   implementation(platform("org.keycloak.bom:keycloak-adapter-bom:14.0.0"))
   implementation("org.keycloak:keycloak-spring-boot-starter")
   implementation("org.keycloak:keycloak-admin-client:14.0.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfil
 
 awsSdkVersion=2.17.22
 jacksonVersion=2.11.3
-jooqVersion=3.14.7
+jooqVersion=3.15.3
 kotlinVersion=1.5.10
-postgresJdbcVersion=42.2.19
+postgresJdbcVersion=42.2.24
 springDocVersion=1.5.10

--- a/src/main/kotlin/com/terraformation/backend/Application.kt
+++ b/src/main/kotlin/com/terraformation/backend/Application.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.info.License
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.scheduling.annotation.EnableScheduling
 
@@ -25,7 +26,9 @@ import org.springframework.scheduling.annotation.EnableScheduling
     tags = [Tag(name = "SeedBankApp"), Tag(name = "DeviceManager"), Tag(name = "GISApp")])
 @EnableConfigurationProperties(TerrawareServerConfig::class)
 @EnableScheduling
-@SpringBootApplication
+@SpringBootApplication(
+    // https://github.com/spring-projects/spring-boot/issues/26439
+    exclude = [R2dbcAutoConfiguration::class])
 class Application
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AppDeviceStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AppDeviceStore.kt
@@ -2,12 +2,15 @@ package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AppDeviceId
+import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.APP_DEVICES
 import com.terraformation.backend.util.eqOrIsNull
 import java.time.Clock
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.exception.DataAccessException
+import org.jooq.impl.DSL
 
 @ManagedBean
 class AppDeviceStore(private val dslContext: DSLContext, private val clock: Clock) {
@@ -66,5 +69,12 @@ class AppDeviceStore(private val dslContext: DSLContext, private val clock: Cloc
     } else {
       null
     }
+  }
+
+  fun appDeviceMultiset(
+      idField: Field<AppDeviceId?> = ACCESSIONS.APP_DEVICE_ID
+  ): Field<AppDeviceModel?> {
+    return DSL.multiset(DSL.selectFrom(APP_DEVICES).where(APP_DEVICES.ID.eq(idField)))
+        .convertFrom { result -> result.firstOrNull()?.let { AppDeviceModel(it) } }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/BagStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/BagStore.kt
@@ -1,21 +1,22 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.BAGS
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.impl.DSL
 
 @ManagedBean
 class BagStore(private val dslContext: DSLContext) {
-  fun fetchBagNumbers(accessionId: AccessionId): Set<String> {
-    return dslContext
-        .select(BAGS.BAG_NUMBER)
-        .from(BAGS)
-        .where(BAGS.ACCESSION_ID.eq(accessionId))
-        .orderBy(BAGS.BAG_NUMBER)
-        .fetch(BAGS.BAG_NUMBER)
-        .filterNotNull()
-        .toSet()
+  fun bagNumbersMultiset(idField: Field<AccessionId?> = ACCESSIONS.ID): Field<Set<String>> {
+    return DSL.multiset(
+            DSL.select(BAGS.BAG_NUMBER)
+                .from(BAGS)
+                .where(BAGS.ACCESSION_ID.eq(idField))
+                .orderBy(BAGS.BAG_NUMBER))
+        .convertFrom { result -> result.map { it.get(BAGS.BAG_NUMBER) }.toSet() }
   }
 
   fun updateBags(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.GerminationTestId
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalPurpose
+import com.terraformation.backend.db.tables.records.WithdrawalsRecord
 import com.terraformation.backend.util.compareNullsFirst
 import java.time.LocalDate
 
@@ -26,6 +27,20 @@ data class WithdrawalModel(
      */
     val weightDifference: SeedQuantityModel? = null,
 ) {
+  constructor(
+      record: WithdrawalsRecord
+  ) : this(
+      record.id,
+      record.accessionId,
+      record.date!!,
+      record.purposeId!!,
+      record.destination,
+      record.notes,
+      record.staffResponsible,
+      record.germinationTestId,
+      SeedQuantityModel.of(record.remainingQuantity, record.remainingUnitsId),
+      SeedQuantityModel.of(record.withdrawnQuantity, record.withdrawnUnitsId),
+  )
 
   fun validate() {
     withdrawn?.quantity?.signum()?.let { signum ->

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -185,12 +185,10 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     store =
         AccessionStore(
             dslContext,
-            accessionPhotosDao,
             AppDeviceStore(dslContext, clock),
             BagStore(dslContext),
             GeolocationStore(dslContext, clock),
             GerminationStore(dslContext),
-            photosDao,
             speciesStore,
             WithdrawalStore(dslContext, clock),
             clock,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -97,12 +97,10 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     accessionStore =
         AccessionStore(
             dslContext,
-            accessionPhotosDao,
             mockk(),
             mockk(),
             mockk(),
             mockk(),
-            photosDao,
             mockk(),
             mockk(),
             clock,


### PR DESCRIPTION
Previously, to fetch an accession, we first did a query that loaded all the scalar
values for the accession, then did a separate query for each table where there
could be zero or more of something associated with a particular accession. That
requires a bunch of database round-trips.

Start using jOOQ 3.15's "multiset" feature to load everything in one query.

This not only makes accession loading a bit more efficient since the database
server can parallelize or reorder the child table lookups, but also acts as a way
to introduce multisets to the code base in preparation for using them in other
places such as the seed bank search API.
