### PR TITLE
Fix minor API behavior changes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -7,6 +7,8 @@ import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.SpeciesNotFoundException
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @SeedBankAppEndpoint
 class ValuesController(
+    private val config: TerrawareServerConfig,
     private val storageLocationStore: StorageLocationStore,
     private val searchService: SearchService,
     private val speciesDao: SpeciesDao,
@@ -119,7 +122,13 @@ class ValuesController(
 
     val values =
         payload.fields.associateWith { searchField ->
-          val values = searchService.fetchAllValues(searchField, limit)
+          var values = searchService.fetchAllValues(searchField, limit)
+
+          // TODO: Remove this once front end is updated to know about Awaiting Check-In state
+          if (searchField.fieldName == "state" && !config.enableAwaitingCheckIn) {
+            values = values.filter { it != AccessionState.AwaitingCheckIn.displayName }
+          }
+
           val partial = values.size > limit
           AllFieldValuesPayload(values.take(limit), partial)
         }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/GerminationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/GerminationStore.kt
@@ -54,7 +54,7 @@ class GerminationStore(private val dslContext: DSLContext) {
                   record[TOTAL_SEEDS_GERMINATED],
                   record[NOTES],
                   record[STAFF_RESPONSIBLE],
-                  record[germinationsMultiset],
+                  record[germinationsMultiset]?.ifEmpty { null },
                   SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
               )
             }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -466,10 +466,15 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             )),
         updatedTests)
 
-    val updatedAccession = accessionsDao.fetchOneById(AccessionId(1))
-    assertNull(updatedAccession?.totalViabilityPercent, "totalViabilityPercent")
-    assertNull(updatedAccession?.latestViabilityPercent, "latestViabilityPercent")
-    assertNull(updatedAccession?.latestGerminationRecordingDate, "latestGerminationRecordingDate")
+    val updatedRow = accessionsDao.fetchOneById(AccessionId(1))
+    assertNull(updatedRow?.totalViabilityPercent, "totalViabilityPercent")
+    assertNull(updatedRow?.latestViabilityPercent, "latestViabilityPercent")
+    assertNull(updatedRow?.latestGerminationRecordingDate, "latestGerminationRecordingDate")
+
+    val updatedAccession = store.fetchById(AccessionId(1))!!
+    assertNull(
+        updatedAccession.germinationTests.first().germinations,
+        "Empty list of germinations should be null in model")
   }
 
   @Test


### PR DESCRIPTION
The web front-end test suite uncovered a couple of unintentional minor behavior
changes from recent commits.

* If an accession had a germination test with no germinations, the response
  payload of `GET /api/v1/seedbank/accession/{id}` included a field
  `"germinations": []` in the germination test object. Empty lists are
  supposed to be omitted from the payload entirely.

* The "Awaiting Check-In" state was included in the list of available values
  for the `state` field even if the `enableAwaitingCheckIn` config flag was
  set to false. That state should only be shown as a possible search filter
  value if it's enabled on the server.
