### PR TITLE
SW-361 Return HTTP 404 if feature photo file is missing

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
@@ -311,10 +311,15 @@ class FeatureStore(
   ): SizedInputStream {
     val photosRow = getPhotoMetadata(featureId, photoId)
 
-    return if (maxWidth != null || maxHeight != null) {
-      thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight)
-    } else {
-      fileStore.read(photosRow.storageUrl!!)
+    return try {
+      if (maxWidth != null || maxHeight != null) {
+        thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight)
+      } else {
+        fileStore.read(photosRow.storageUrl!!)
+      }
+    } catch (e: NoSuchFileException) {
+      log.error("Feature $featureId photo $photoId file ${photosRow.storageUrl} not found")
+      throw PhotoNotFoundException(photoId)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -595,6 +595,17 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `getPhotoData throws exception if photo file does not exist`() {
+    val feature = store.createFeature(validCreateRequest)
+    val featureId = feature.id!!
+    val photosRow = insertFeaturePhoto(featureId)
+
+    every { fileStore.read(photosRow.storageUrl!!) } throws NoSuchFileException("error")
+
+    assertThrows<PhotoNotFoundException> { store.getPhotoData(featureId, photosRow.id!!) }
+  }
+
+  @Test
   fun `getPhotoMetadata returns photo metadata`() {
     val feature = store.createFeature(validCreateRequest)
     val featureId = feature.id!!


### PR DESCRIPTION
If a photo has a storage URL in the database but the file referred to by the
URL doesn't exist, we should return HTTP 404 instead of HTTP 500 when a client
tries to download it.
