### PR TITLE
SW-291 Use consistent alignment of API payload field declarations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
@@ -139,7 +139,10 @@ abstract class GeoJsonOpenApiSchema {
               "In that case, this element is not present. Otherwise, it specifies which " +
               "coordinate system to use.")
   internal abstract class CRS(
-      @Schema(allowableValues = ["name"]) val type: String,
+      @Schema(
+          allowableValues = ["name"],
+      )
+      val type: String,
       val properties: CRSProperties
   )
 

--- a/src/main/kotlin/com/terraformation/backend/api/ResponsePayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ResponsePayload.kt
@@ -14,7 +14,10 @@ enum class SuccessOrError {
 }
 
 interface ResponsePayload {
-  @get:Schema(required = true) val status: SuccessOrError
+  @get:Schema(
+      required = true,
+  )
+  val status: SuccessOrError
 }
 
 interface SuccessResponsePayload : ResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
@@ -111,7 +111,10 @@ class TimeseriesController(private val timeSeriesStore: TimeseriesStore) {
 }
 
 data class CreateTimeseriesEntry(
-    @Schema(description = "ID of device that produces this timeseries.") val deviceId: DeviceId,
+    @Schema(
+        description = "ID of device that produces this timeseries.",
+    )
+    val deviceId: DeviceId,
     @Schema(
         description =
             "Name of this timeseries. Duplicate timeseries names for the same device aren't " +

--- a/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/FeatureController.kt
@@ -231,7 +231,10 @@ data class CreateFeaturePhotoRequestPayload(
     val location: Point?,
     @Schema(description = "Orientation of phone/camera when photo was taken.")
     val orientation: Double?,
-    @Schema(description = "GPS horizontal accuracy in meters.") val gpsHorizAccuracy: Double?,
+    @Schema(
+        description = "GPS horizontal accuracy in meters.",
+    )
+    val gpsHorizAccuracy: Double?,
     @Schema(description = "GPS vertical (altitude) accuracy in meters.")
     val gpsVertAccuracy: Double?
 )
@@ -286,7 +289,10 @@ data class FeaturePhoto(
     val contentType: String,
     val featureId: FeatureId,
     val fileName: String,
-    @Schema(description = "GPS horizontal accuracy in meters.") val gpsHorizAccuracy: Double?,
+    @Schema(
+        description = "GPS horizontal accuracy in meters.",
+    )
+    val gpsHorizAccuracy: Double?,
     @Schema(description = "GPS vertical (altitude) accuracy in meters.")
     val gpsVertAccuracy: Double?,
     @Schema(description = "Compass heading of phone/camera when photo was taken.")

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
@@ -90,7 +90,10 @@ data class CreateObservationRequestPayload(
     val flowers: Boolean? = null,
     val seeds: Boolean? = null,
     val pests: String? = null,
-    @Schema(description = "Height in meters") val height: Double? = null,
+    @Schema(
+        description = "Height in meters",
+    )
+    val height: Double? = null,
     @Schema(description = "Diameter at breast height in meters")
     val diameterAtBreastHeight: Double? = null,
 ) {
@@ -114,7 +117,10 @@ data class UpdateObservationRequestPayload(
     val flowers: Boolean? = null,
     val seeds: Boolean? = null,
     val pests: String? = null,
-    @Schema(description = "Height in meters") val height: Double? = null,
+    @Schema(
+        description = "Height in meters",
+    )
+    val height: Double? = null,
     @Schema(description = "Diameter at breast height in meters")
     val diameterAtBreastHeight: Double? = null,
 ) {
@@ -140,7 +146,10 @@ data class ObservationResponse(
     val flowers: Boolean? = null,
     val seeds: Boolean? = null,
     val pests: String? = null,
-    @Schema(description = "Height in meters") val height: Double? = null,
+    @Schema(
+        description = "Height in meters",
+    )
+    val height: Double? = null,
     @Schema(description = "Diameter at breast height in meters")
     val diameterAtBreastHeight: Double? = null,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -336,7 +336,10 @@ data class AccessionPayload(
     val source: AccessionSource?,
     val sourcePlantOrigin: SourcePlantOrigin?,
     val species: String?,
-    @Schema(description = "Server-generated unique ID of the species.") val speciesId: SpeciesId?,
+    @Schema(
+        description = "Server-generated unique ID of the species.",
+    )
+    val speciesId: SpeciesId?,
     @Schema(
         description =
             "Server-calculated accession state. Can change due to modifications to accession data " +
@@ -531,7 +534,10 @@ data class GerminationTestPayload(
 
 data class GerminationPayload(
     val recordingDate: LocalDate,
-    @JsonProperty(required = true) val seedsGerminated: Int
+    @JsonProperty(
+        required = true,
+    )
+    val seedsGerminated: Int
 ) {
   constructor(model: GerminationModel) : this(model.recordingDate, model.seedsGerminated)
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/NotificationController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/NotificationController.kt
@@ -98,7 +98,10 @@ data class NotificationPayload(
     val id: String,
     val timestamp: Instant,
     val type: NotificationType,
-    @Schema(description = "If true, this notification has been marked as read.") val read: Boolean,
+    @Schema(
+        description = "If true, this notification has been marked as read.",
+    )
+    val read: Boolean,
     @Schema(
         description = "Plain-text body of notification.",
         example = "Accession XYZ is ready to be dried.")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
@@ -179,7 +179,10 @@ data class UploadPhotoMetadataPayload(
     @Schema(deprecated = true, description = "Use location field instead.")
     val longitude: BigDecimal?,
     val location: Point?,
-    @Schema(description = "GPS accuracy in meters.") val gpsAccuracy: Int?,
+    @Schema(
+        description = "GPS accuracy in meters.",
+    )
+    val gpsAccuracy: Int?,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -187,10 +190,21 @@ data class ListPhotosResponseElement(
     val filename: String,
     val size: Long,
     val capturedTime: Instant,
-    @Schema(deprecated = true, description = "Use location field instead.") val latitude: Double?,
-    @Schema(deprecated = true, description = "Use location field instead.") val longitude: Double?,
+    @Schema(
+        deprecated = true,
+        description = "Use location field instead.",
+    )
+    val latitude: Double?,
+    @Schema(
+        deprecated = true,
+        description = "Use location field instead.",
+    )
+    val longitude: Double?,
     val location: Point?,
-    @Schema(description = "GPS accuracy in meters.") val gpsAccuracy: Int?,
+    @Schema(
+        description = "GPS accuracy in meters.",
+    )
+    val gpsAccuracy: Int?,
 ) {
   constructor(
       metadata: PhotoMetadata

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SearchController.kt
@@ -170,7 +170,10 @@ data class SearchRequestPayload(
     override val filters: List<SearchFilter>? = null,
     override val search: SearchNodePayload? = null,
     val cursor: String? = null,
-    @Schema(defaultValue = "10") val count: Int = 10
+    @Schema(
+        defaultValue = "10",
+    )
+    val count: Int = 10
 ) : HasSearchNode, HasSortOrder
 
 data class ExportRequestPayload(
@@ -188,7 +191,10 @@ data class SearchResponsePayload(val results: List<Map<String, String>>, val cur
 
 data class SearchSortOrderElement(
     val field: SearchField,
-    @Schema(defaultValue = "Ascending") val direction: SearchDirection?
+    @Schema(
+        defaultValue = "Ascending",
+    )
+    val direction: SearchDirection?
 ) {
   fun toSearchSortField() = SearchSortField(field, direction ?: SearchDirection.Ascending)
 }


### PR DESCRIPTION
If both an annotation and a variable declaration fit on the same line, ktfmt
puts them both on one line. But it makes that decision on a per-variable basis
which means if you have a bunch of annotated variables in a row, some of them
will be line-wrapped and some won't. This is hard to visually scan.

In our code base, this is almost exclusively a problem in API payload classes
with the `@Schema` annotation.

Force ktfmt to wrap these declarations onto multiple lines by putting a
trailing comma in the annotation's parameter list. Parameter lists with
trailing commas are always split into multiple lines.

There are no functional changes here, just code formatting.
