### PR TITLE
SEED-119 Retain checked-in state when accession is edited

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -297,7 +297,11 @@ class AccessionStore(
 
     requirePermissions { updateAccession(accessionId) }
 
-    val accession = updated.withCalculatedValues(clock, existing)
+    // Some fields are significant to the state machine, but can't be directly set on update; pull
+    // them from the existing accession for purposes of value calculation.
+    val updatedWithReadOnlyValues = updated.copy(checkedInTime = existing.checkedInTime)
+
+    val accession = updatedWithReadOnlyValues.withCalculatedValues(clock, existing)
     val todayLocal = LocalDate.now(clock)
 
     if (accession.storageStartDate?.isAfter(todayLocal) == true) {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1022,6 +1022,18 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `checkedInTime in model is ignored by update`() {
+    every { config.enableAwaitingCheckIn } returns false
+    val initial = store.create(AccessionModel(facilityId = facilityId))
+
+    store.update(initial.copy(checkedInTime = null, primaryCollector = "test"))
+    val updated = store.fetchById(initial.id!!)!!
+
+    assertEquals(AccessionState.Pending, updated.state, "State")
+    assertEquals(Instant.EPOCH, updated.checkedInTime, "Checked-in time")
+  }
+
+  @Test
   fun `state transitions to Processing when seed count entered`() {
     val initial = store.create(AccessionModel(facilityId = facilityId))
     store.update(initial.copy(processingMethod = ProcessingMethod.Count, total = seeds(100)))


### PR DESCRIPTION
We ignore the `checkedInTime` field in the request payload when updating an
accession, but the fact that it's null in the model that gets passed to
`AccessionStore.update()` was causing the accession state calculation to
think the accession should no longer be considered checked in.
