### PR TITLE
Allow passing ID wrappers to test data setup methods

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -191,7 +191,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createApiClient registers user in Keycloak and adds it to organization`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
 
     val description = "Description"
     val user = userStore.createApiClient(organizationId, description)
@@ -220,7 +220,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteApiClient removes user from Keycloak`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
 
     assertNotNull(usersResource.get(user.authId), "User exists in Keycloak after creation")
@@ -232,7 +232,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteApiClient causes user to no longer be findable`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
 
     assertTrue(userStore.deleteApiClient(user.userId), "Deletion should have succeeded")
@@ -249,7 +249,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteApiClient deletes user locally even if already deleted from Keycloak`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
 
     usersResource.delete(user.authId)
@@ -268,7 +268,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `generateOfflineToken requests a token from Keycloak`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
     val expectedToken = "token"
 
@@ -287,7 +287,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `generateOfflineToken throws exception if Keycloak returns a malformed token response`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
 
     val response: HttpResponse<String> = mockk()
@@ -302,7 +302,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `generateOfflineToken throws exception if Keycloak does not generate a token`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
 
     val response: HttpResponse<String> = mockk()
@@ -317,7 +317,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `generateOfflineToken generates a temporary password and removes it if token creation fails`() {
-    insertOrganization(organizationId.value)
+    insertOrganization(organizationId)
     val user = userStore.createApiClient(organizationId, null)
     val keycloakUser = usersResource.get(user.authId)!!
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -188,12 +188,12 @@ internal class PermissionTest : DatabaseTest() {
             realmResource,
             usersDao)
 
-    organizationIds.forEach { insertOrganization(it.value) }
-    projectIds.forEach { insertProject(it.value) }
-    siteIds.forEach { insertSite(it.value) }
+    organizationIds.forEach { insertOrganization(it) }
+    projectIds.forEach { insertProject(it) }
+    siteIds.forEach { insertSite(it) }
 
     facilityIds.forEach { facilityId ->
-      insertFacility(facilityId.value)
+      insertFacility(facilityId)
       accessionsDao.insert(
           AccessionsRow(
               id = AccessionId(facilityId.value),
@@ -217,11 +217,11 @@ internal class PermissionTest : DatabaseTest() {
               model = "model"))
     }
 
-    layerIds.forEach { insertLayer(it.value) }
-    featureIds.forEach { insertFeature(it.value) }
+    layerIds.forEach { insertLayer(it) }
+    featureIds.forEach { insertFeature(it) }
     photoIds.forEach {
-      insertPhoto(it.value)
-      insertFeaturePhoto(it.value)
+      insertPhoto(it)
+      insertFeaturePhoto(it)
     }
 
     usersDao.insert(

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -131,7 +131,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canDeleteFeaturePhoto(any()) } returns true
 
     insertSiteData()
-    insertLayer(layerId.value, siteId.value, LayerType.PlantsPlanted)
+    insertLayer(layerId, siteId, LayerType.PlantsPlanted)
   }
 
   @Test
@@ -197,7 +197,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     val featureIds = (1..5).map { store.createFeature(validCreateRequest).id!! }
 
     val otherLayerId = LayerId(200)
-    insertLayer(otherLayerId.value, siteId.value, LayerType.Infrastructure)
+    insertLayer(otherLayerId, siteId, LayerType.Infrastructure)
     store.createFeature(validCreateRequest.copy(layerId = otherLayerId))
 
     val listResult = store.listFeatures(layerId)
@@ -262,7 +262,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     repeat(5) { store.createFeature(validCreateRequest) }
 
     val otherLayerId = LayerId(200)
-    insertLayer(otherLayerId.value, siteId.value, LayerType.Infrastructure)
+    insertLayer(otherLayerId, siteId, LayerType.Infrastructure)
     store.createFeature(validCreateRequest.copy(layerId = otherLayerId))
 
     assertEquals(5, store.countFeatures(layerId))
@@ -705,7 +705,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
       layersDao = LayersDao(jooqConfig)
       speciesDao = SpeciesDao(jooqConfig)
 
-      insertFeature(id = featureId.value, layerId = layerId.value)
+      insertFeature(id = featureId, layerId = layerId)
     }
 
     private fun insertSeveralPlants(
@@ -729,8 +729,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
           featureIds.add(randomFeatureId)
 
           // All features are associated with the class variable layerId
-          insertFeature(
-              id = randomFeatureId.value, layerId = layerId.value, enteredTime = enteredTime)
+          insertFeature(id = randomFeatureId, layerId = layerId, enteredTime = enteredTime)
 
           plantsDao.insert(PlantsRow(featureId = randomFeatureId, speciesId = currSpeciesId))
         }
@@ -809,8 +808,8 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
               enteredTime = time1,
           )
       insertFeature(
-          feature.id!!.value,
-          feature.layerId.value,
+          feature.id!!,
+          feature.layerId,
           feature.geom,
           feature.gpsHorizAccuracy,
           feature.gpsVertAccuracy,
@@ -964,7 +963,7 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
       repeat(3) {
         val randomFeatureId = FeatureId(Random.nextLong())
         featuresWithoutSpecies.add(randomFeatureId)
-        insertFeature(id = randomFeatureId.value, layerId = layerId.value, enteredTime = time1)
+        insertFeature(id = randomFeatureId, layerId = layerId, enteredTime = time1)
         plantsDao.insert(PlantsRow(featureId = randomFeatureId))
       }
       val expectedSpeciesIdsToCount = speciesIdsToCount.toMutableMap()

--- a/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
@@ -140,7 +140,7 @@ internal class LayerStoreTest : DatabaseTest(), RunsAsUser {
     val layerIds = (1..3).map { store.createLayer(validCreateRequestModel).id!! }
 
     val otherSite = SiteId(20)
-    insertSite(id = otherSite.value, projectId = 2)
+    insertSite(id = otherSite, projectId = 2)
     store.createLayer(validCreateRequestModel.copy(siteId = otherSite))
 
     val listResult = store.listLayers(siteId)

--- a/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
@@ -81,9 +81,9 @@ internal class PlantObservationsStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateFeature(any()) } returns true
 
     insertSiteData()
-    insertLayer(id = layerId.value, siteId = siteId.value, layerType = LayerType.PlantsPlanted)
-    insertFeature(id = featureId.value, layerId = layerId.value)
-    insertPlant(featureId = featureId.value)
+    insertLayer(id = layerId, siteId = siteId, layerType = LayerType.PlantsPlanted)
+    insertFeature(id = featureId, layerId = layerId)
+    insertPlant(featureId = featureId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1624,7 +1624,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
 
     @BeforeEach
     fun createOtherFacility() {
-      insertFacility(otherFacilityId.value, 10)
+      insertFacility(otherFacilityId, 10)
     }
 
     @Test


### PR DESCRIPTION
The test data setup methods in `DatabaseTest` take `Long` arguments. That
helps make tests succinct when ID values are specified explicitly (you can do
`insertOrganization(1)` and so on) but if we already have a wrapped ID, it
means we have to unwrap it before we can insert it.

Modify those methods to accept either wrapped IDs or raw numbers. Stop
unwrapping IDs in tests where we needed to do so before.
