### PR TITLE
Fix NPE in PUT handler for /api/v1/gis/features/{id}

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/db/FeatureStore.kt
@@ -193,7 +193,11 @@ class FeatureStore(
         }
       }
 
-      newModel.copy(modifiedTime = currTime, geom = longLatGeom)
+      newModel.copy(
+          geom = longLatGeom,
+          layerId = oldModel.layerId,
+          modifiedTime = currTime,
+      )
     }
   }
 


### PR DESCRIPTION
Commit 3c2ccf6d1 changed the implementation of `FeatureStore.updateFeature` to
no longer require the caller to pass in a layer ID. Unfortunately, that meant
that its return value also didn't include a layer ID (since it returns a copy
of its input) which caused the handler for PUT requests to bomb out because it
expected the layer ID to be set.

Fix it by setting the layer ID in the return value; this is consistent with the
idea that that method should return a fully-formed model object.
