### PR TITLE
TRACK-464 Generalize permission checking in search queries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/search/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/search/SearchTables.kt
@@ -49,6 +49,10 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
           return ACCESSIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
         }
 
+        // Table has facility ID
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
+
         override fun conditionForMultiset(): Condition? {
           // No-op; this is always the topmost table
           return null
@@ -62,9 +66,12 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
 
   val facilities =
       object : AccessionParentTable<FacilityId>(FACILITIES.ID, ACCESSIONS.FACILITY_ID) {
-        override fun conditionForPermissions(): Condition? {
+        override fun conditionForPermissions(): Condition {
           return FACILITIES.ID.`in`(currentUser().facilityRoles.keys)
         }
+
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
       }
 
   val geolocations = object : AccessionChildTable(GEOLOCATIONS.ACCESSION_ID) {}
@@ -85,16 +92,15 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
         }
 
         override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
-          return query
-              .join(GERMINATION_TESTS)
-              .on(GERMINATIONS.TEST_ID.eq(GERMINATION_TESTS.ID))
-              .join(ACCESSIONS)
-              .on(GERMINATION_TESTS.ACCESSION_ID.eq(ACCESSIONS.ID))
+          return query.join(GERMINATION_TESTS).on(GERMINATIONS.TEST_ID.eq(GERMINATION_TESTS.ID))
         }
 
         override fun conditionForPermissions(): Condition {
           return ACCESSIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
         }
+
+        override val inheritsPermissionsFrom: SearchTable
+          get() = germinationTests
 
         override fun conditionForMultiset(): Condition {
           return GERMINATIONS.TEST_ID.eq(GERMINATION_TESTS.ID)
@@ -108,6 +114,9 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
         override fun conditionForPermissions(): Condition {
           return COLLECTORS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
         }
+
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
       }
 
   val species =
@@ -115,6 +124,10 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
         override fun conditionForPermissions(): Condition? {
           return null
         }
+
+        // TODO: Make this check species ownership once we have per-org species.
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
       }
 
   val families =
@@ -122,6 +135,9 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
         override fun conditionForPermissions(): Condition? {
           return null
         }
+
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
       }
 
   val storageLocations =
@@ -131,6 +147,9 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
         override fun conditionForPermissions(): Condition {
           return STORAGE_LOCATIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
         }
+
+        override val inheritsPermissionsFrom: SearchTable?
+          get() = null
       }
 
   val withdrawals = object : AccessionChildTable(WITHDRAWALS.ACCESSION_ID) {}
@@ -184,8 +203,11 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
     }
 
     override fun conditionForPermissions(): Condition? {
-      return ACCESSIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
+      return null
     }
+
+    override val inheritsPermissionsFrom: SearchTable?
+      get() = accessions
 
     override fun conditionForMultiset(): Condition? {
       return accessionIdField.eq(ACCESSIONS.ID)


### PR DESCRIPTION
When we construct a query in the search code, we need to make sure the query
takes into account what data the user has permission to see. Concretely, that
means we need to make sure there's a join to a table that has an identifier we
can check against the list of things the user is allowed to access, e.g., a
facility ID we can check against `UserModel.facilityRoles`.

Previously, the search code was always searching the accessions table, so it
could count on being able to look there for a facility ID, and all we had to do
was make sure we joined with that table if we were doing a search that only
selected fields from a child or grandchild table. In practice, that was only
an issue with the `germinations` table where we had to make sure to join with
`germination_tests` so we could join to `accessions` from there.

But once clients are able to specify the root of a search query, we can't count
on there being a single hardwired place to look for permission information,
and we can't count on the presence of a facility ID. They might be searching
map layers or projects.

Permissions are inherited: your ability to see a germination test is inherited
from your ability to see its accession, which is inherited from your ability
to see the accession's facility, etc.

Add a property to `SearchTable` to represent the permission inheritance
hierarchy, and change `SearchService` to walk that hierarchy (recursively, if
necessary) to construct the proper `JOIN` statements for permission checking.

There is no change in behavior here; for accession queries, this ends up
constructing the same joins as the existing code. Existing test cases continue
to pass without changes.
