### PR TITLE
TRACK-464 Move accession search to a separate service

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.search
 
 import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.seedbank.search.AccessionsNamespace
-import com.terraformation.backend.seedbank.search.SearchService
 import com.terraformation.backend.util.MemoizedValue
 import org.jooq.Condition
 import org.jooq.DSLContext

--- a/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
@@ -1,7 +1,5 @@
 package com.terraformation.backend.search
 
-import com.terraformation.backend.seedbank.search.SearchService
-
 /** Return value from [SearchService.search]. */
 data class SearchResults(
     /**

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -1,20 +1,13 @@
-package com.terraformation.backend.seedbank.search
+package com.terraformation.backend.search
 
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.log.debugWithTiming
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.search.AndNode
-import com.terraformation.backend.search.FieldNode
-import com.terraformation.backend.search.NestedQueryBuilder
-import com.terraformation.backend.search.SearchFieldPath
-import com.terraformation.backend.search.SearchFieldPrefix
-import com.terraformation.backend.search.SearchNode
-import com.terraformation.backend.search.SearchResults
-import com.terraformation.backend.search.SearchSortField
-import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.AccessionsNamespace
+import com.terraformation.backend.seedbank.search.SearchTables
 import javax.annotation.ManagedBean
 import org.jooq.Condition
 import org.jooq.DSLContext

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.search.field.TextField
 import com.terraformation.backend.search.field.TimestampField
 import com.terraformation.backend.search.field.UpperCaseTextField
-import com.terraformation.backend.seedbank.search.SearchService
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate

--- a/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
@@ -3,8 +3,8 @@ package com.terraformation.backend.search.field
 import com.fasterxml.jackson.annotation.JsonValue
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.SearchTable
-import com.terraformation.backend.seedbank.search.SearchService
 import java.util.*
 import org.jooq.Condition
 import org.jooq.Field

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SearchController.kt
@@ -17,8 +17,9 @@ import com.terraformation.backend.search.SearchFieldPath
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchNode
 import com.terraformation.backend.search.SearchResults
+import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.SearchSortField
-import com.terraformation.backend.seedbank.search.SearchService
+import com.terraformation.backend.seedbank.search.AccessionSearchService
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -47,7 +48,10 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/seedbank/search")
 @RestController
 @SeedBankAppEndpoint
-class SearchController(private val clock: Clock, private val searchService: SearchService) {
+class SearchController(
+    private val clock: Clock,
+    private val accessionSearchService: AccessionSearchService
+) {
   @Operation(summary = "Searches for accessions based on filter criteria.")
   @PostMapping
   fun search(
@@ -80,7 +84,7 @@ class SearchController(private val clock: Clock, private val searchService: Sear
       payload: SearchRequestPayload
   ): SearchResponsePayload {
     return SearchResponsePayload(
-        searchService.search(
+        accessionSearchService.search(
             payload.facilityId,
             payload.fields,
             payload.toSearchNode(),
@@ -102,7 +106,7 @@ class SearchController(private val clock: Clock, private val searchService: Sear
     }
 
     val searchResults =
-        searchService.search(
+        accessionSearchService.search(
             payload.facilityId,
             payload.fields,
             payload.toSearchNode(),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -16,8 +16,8 @@ import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.tables.daos.SpeciesDao
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.search.SearchFieldPath
+import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.seedbank.db.StorageLocationStore
-import com.terraformation.backend.seedbank.search.SearchService
 import com.terraformation.backend.species.db.SpeciesStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema

--- a/src/main/kotlin/com/terraformation/backend/seedbank/search/AccessionSearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/search/AccessionSearchService.kt
@@ -1,0 +1,29 @@
+package com.terraformation.backend.seedbank.search
+
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.search.SearchFieldPath
+import com.terraformation.backend.search.SearchNode
+import com.terraformation.backend.search.SearchResults
+import com.terraformation.backend.search.SearchService
+import com.terraformation.backend.search.SearchSortField
+import javax.annotation.ManagedBean
+
+@ManagedBean
+class AccessionSearchService(private val searchService: SearchService) {
+  /**
+   * Queries the values of a list of fields on accessions that match a list of filter criteria.
+   *
+   * This is a thin wrapper around [SearchService.search] to maintain compatibility with the
+   * accession search API as [SearchService] is generalized.
+   */
+  fun search(
+      facilityId: FacilityId,
+      fields: List<SearchFieldPath>,
+      criteria: SearchNode,
+      sortOrder: List<SearchSortField> = emptyList(),
+      cursor: String? = null,
+      limit: Int = Int.MAX_VALUE,
+  ): SearchResults {
+    return searchService.search(facilityId, fields, criteria, sortOrder, cursor, limit)
+  }
+}


### PR DESCRIPTION
Introduce `AccessionSearchService` so there's a separate entrypoint for searching
accessions that mimics the existing search API. This is groundwork for changing
`SearchService` to make it more general; at that point the logic for adding the
default set of accession fields and the facility ID filter will need to live
somewhere else.

This change is a mostly-mechanical one with no functionality difference, to reduce
clutter in later changes that change how the code works. For now,
`AccessionSearchService.search` is a pass-through for `SearchService.search`.

Specifically:

* Move `SearchService` out of the `com.terraformation.backend.seedbank.search`
  package and into `com.terraformation.backend.search`.
* Add `AccessionSearchService` with a single method that calls through to
  `SearchService`.
* Update calling code to call `AccessionSearchService.search`.

A subsequent change will turn the new wrapper method into more than just a no-op,
but with this change in place, callers will remain unaffected.