### PR TITLE
TRACK-466 Split AccessionsNamespace

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -6,12 +6,13 @@ import com.terraformation.backend.device.api.CreateDeviceRequestPayload
 import com.terraformation.backend.device.api.DeviceConfig
 import com.terraformation.backend.device.api.UpdateDeviceRequestPayload
 import com.terraformation.backend.search.SearchFieldPath
+import com.terraformation.backend.search.namespace.AccessionsNamespace
+import com.terraformation.backend.search.namespace.SearchFieldNamespaces
 import com.terraformation.backend.seedbank.api.AccessionPayload
 import com.terraformation.backend.seedbank.api.GerminationTestPayload
 import com.terraformation.backend.seedbank.api.SearchResponsePayload
 import com.terraformation.backend.seedbank.api.UpdateAccessionRequestPayload
 import com.terraformation.backend.seedbank.api.WithdrawalPayload
-import com.terraformation.backend.seedbank.search.AccessionsNamespace
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Paths
@@ -41,8 +42,10 @@ import org.springframework.beans.factory.annotation.Autowired
  * - PostGIS geometry classes use a schema defined in [GeoJsonOpenApiSchema].
  */
 @ManagedBean
-class OpenApiConfig(private val accessionsNamespace: AccessionsNamespace) : OpenApiCustomiser {
+class OpenApiConfig(namespaces: SearchFieldNamespaces) : OpenApiCustomiser {
   @Autowired(required = false) var dslContext: DSLContext? = null
+
+  private val accessionsNamespace = namespaces.accessions
 
   init {
     val config = SpringDocUtils.getConfig()

--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.search
 
 import com.terraformation.backend.search.field.SearchField
-import com.terraformation.backend.seedbank.search.AccessionsNamespace
+import com.terraformation.backend.search.namespace.AccessionsNamespace
 import com.terraformation.backend.util.MemoizedValue
 import org.jooq.Condition
 import org.jooq.DSLContext

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/BagsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/BagsNamespace.kt
@@ -1,0 +1,23 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tables.references.BAGS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.SearchTables
+
+class BagsNamespace(searchTables: SearchTables, accessionsNamespace: AccessionsNamespace) :
+    SearchFieldNamespace() {
+  override val sublists: List<SublistField> =
+      listOf(
+          accessionsNamespace.asSingleValueSublist(
+              "accession", BAGS.ACCESSION_ID.eq(ACCESSIONS.ID)))
+
+  override val fields: List<SearchField> =
+      with(searchTables) {
+        listOf(
+            bags.textField("number", "Bag number", BAGS.BAG_NUMBER),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/FacilitiesNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/FacilitiesNamespace.kt
@@ -1,0 +1,26 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tables.references.FACILITIES
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.SearchTables
+
+class FacilitiesNamespace(searchTables: SearchTables, accessionsNamespace: AccessionsNamespace) :
+    SearchFieldNamespace() {
+  override val sublists: List<SublistField> =
+      listOf(
+          accessionsNamespace.asMultiValueSublist(
+              "accessions", ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID)))
+
+  override val fields: List<SearchField> =
+      with(searchTables) {
+        listOf(
+            facilities.idWrapperField("id", "Facility ID", FACILITIES.ID) { FacilityId(it) },
+            facilities.textField("name", "Facility name", FACILITIES.NAME, nullable = false),
+            facilities.enumField("type", "Facility type", FACILITIES.TYPE_ID, nullable = false),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/GerminationTestsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/GerminationTestsNamespace.kt
@@ -1,0 +1,46 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tables.references.GERMINATIONS
+import com.terraformation.backend.db.tables.references.GERMINATION_TESTS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.SearchTables
+
+class GerminationTestsNamespace(
+    searchTables: SearchTables,
+    accessionsNamespace: AccessionsNamespace
+) : SearchFieldNamespace() {
+  private val germinationsNamespace = GerminationsNamespace(searchTables, this)
+
+  override val sublists: List<SublistField> =
+      listOf(
+          accessionsNamespace.asSingleValueSublist(
+              "accession", GERMINATION_TESTS.ACCESSION_ID.eq(ACCESSIONS.ID)),
+          germinationsNamespace.asMultiValueSublist(
+              "germinations", GERMINATION_TESTS.ID.eq(GERMINATIONS.TEST_ID)))
+
+  override val fields: List<SearchField> =
+      with(searchTables) {
+        listOf(
+            germinationTests.dateField(
+                "endDate", "Germination end date", GERMINATION_TESTS.END_DATE),
+            germinationTests.textField(
+                "notes", "Notes (germination test)", GERMINATION_TESTS.NOTES),
+            germinationTests.integerField(
+                "percentGerminated", "% Viability", GERMINATION_TESTS.TOTAL_PERCENT_GERMINATED),
+            germinationTests.enumField("seedType", "Seed type", GERMINATION_TESTS.SEED_TYPE_ID),
+            germinationTests.integerField(
+                "seedsSown", "Number of seeds sown", GERMINATION_TESTS.SEEDS_SOWN),
+            germinationTests.dateField(
+                "startDate", "Germination start date", GERMINATION_TESTS.START_DATE),
+            germinationTests.enumField(
+                "substrate", "Germination substrate", GERMINATION_TESTS.SUBSTRATE_ID),
+            germinationTests.enumField(
+                "treatment", "Germination treatment", GERMINATION_TESTS.TREATMENT_ID),
+            germinationTests.enumField(
+                "type", "Germination test type", GERMINATION_TESTS.TEST_TYPE),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/GerminationsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/GerminationsNamespace.kt
@@ -1,0 +1,30 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.GERMINATIONS
+import com.terraformation.backend.db.tables.references.GERMINATION_TESTS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.SearchTables
+
+class GerminationsNamespace(
+    searchTables: SearchTables,
+    germinationTestsNamespace: GerminationTestsNamespace
+) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> =
+      listOf(
+          germinationTestsNamespace.asSingleValueSublist(
+              "germinationTest", GERMINATIONS.TEST_ID.eq(GERMINATION_TESTS.ID)))
+
+  override val fields: List<SearchField> =
+      with(searchTables) {
+        listOf(
+            germinations.dateField(
+                "recordingDate",
+                "Recording date of germination test result",
+                GERMINATIONS.RECORDING_DATE),
+            germinations.integerField(
+                "seedsGerminated", "Number of seeds germinated", GERMINATIONS.SEEDS_GERMINATED),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
@@ -1,0 +1,15 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.seedbank.search.SearchTables
+import javax.annotation.ManagedBean
+
+/**
+ * Manages the hierarchy of [SearchFieldNamespace]s.
+ *
+ * Namespaces that are directly referenced by the application are exposed as properties here.
+ */
+@ManagedBean
+class SearchFieldNamespaces(val searchTables: SearchTables) {
+  val accessions = AccessionsNamespace(searchTables)
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/WithdrawalsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/WithdrawalsNamespace.kt
@@ -1,0 +1,46 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tables.references.WITHDRAWALS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.seedbank.search.SearchTables
+
+class WithdrawalsNamespace(searchTables: SearchTables, accessionsNamespace: AccessionsNamespace) :
+    SearchFieldNamespace() {
+  override val sublists: List<SublistField> =
+      listOf(
+          accessionsNamespace.asSingleValueSublist(
+              "accession", WITHDRAWALS.ACCESSION_ID.eq(ACCESSIONS.ID)))
+
+  override val fields: List<SearchField> =
+      with(searchTables) {
+        listOf(
+            withdrawals.dateField("date", "Date of withdrawal", WITHDRAWALS.DATE),
+            withdrawals.textField("destination", "Destination", WITHDRAWALS.DESTINATION),
+            withdrawals.gramsField(
+                "grams", "Weight of seeds withdrawn (g)", WITHDRAWALS.WITHDRAWN_GRAMS),
+            withdrawals.textField("notes", "Notes (withdrawal)", WITHDRAWALS.NOTES),
+            withdrawals.enumField("purpose", "Purpose", WITHDRAWALS.PURPOSE_ID),
+            withdrawals.bigDecimalField(
+                "quantity", "Quantity of seeds withdrawn", WITHDRAWALS.WITHDRAWN_QUANTITY),
+            withdrawals.gramsField(
+                "remainingGrams",
+                "Weight in grams of seeds remaining (withdrawal)",
+                WITHDRAWALS.REMAINING_GRAMS),
+            withdrawals.bigDecimalField(
+                "remainingQuantity",
+                "Weight or count of seeds remaining (withdrawal)",
+                WITHDRAWALS.REMAINING_QUANTITY),
+            withdrawals.enumField(
+                "remainingUnits",
+                "Units of measurement of quantity remaining (withdrawal)",
+                WITHDRAWALS.REMAINING_UNITS_ID),
+            withdrawals.enumField(
+                "units",
+                "Units of measurement of quantity withdrawn",
+                WITHDRAWALS.WITHDRAWN_UNITS_ID),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -18,8 +18,8 @@ import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.search.SearchFieldPath
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
+import com.terraformation.backend.search.namespace.SearchFieldNamespaces
 import com.terraformation.backend.seedbank.db.StorageLocationStore
-import com.terraformation.backend.seedbank.search.AccessionsNamespace
 import com.terraformation.backend.species.db.SpeciesStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -38,13 +38,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @SeedBankAppEndpoint
 class ValuesController(
-    accessionsNamespace: AccessionsNamespace,
     private val config: TerrawareServerConfig,
+    namespaces: SearchFieldNamespaces,
     private val storageLocationStore: StorageLocationStore,
     private val searchService: SearchService,
     private val speciesDao: SpeciesDao,
     private val speciesStore: SpeciesStore,
 ) {
+  private val accessionsNamespace = namespaces.accessions
   private val rootPrefix = SearchFieldPrefix(root = accessionsNamespace)
 
   @Operation(deprecated = true, description = "Use /api/v1/species instead.")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/search/AccessionSearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/search/AccessionSearchService.kt
@@ -9,13 +9,16 @@ import com.terraformation.backend.search.SearchNode
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.SearchSortField
+import com.terraformation.backend.search.namespace.AccessionsNamespace
+import com.terraformation.backend.search.namespace.SearchFieldNamespaces
 import javax.annotation.ManagedBean
 
 @ManagedBean
 class AccessionSearchService(
-    accessionsNamespace: AccessionsNamespace,
+    namespaces: SearchFieldNamespaces,
     private val searchService: SearchService
 ) {
+  private val accessionsNamespace: AccessionsNamespace = namespaces.accessions
   private val rootPrefix = SearchFieldPrefix(root = accessionsNamespace)
   private val facilityIdField = rootPrefix.resolve("facility.id")
   private val mandatoryFields =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/search/SearchFieldPathDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/search/SearchFieldPathDeserializer.kt
@@ -7,15 +7,17 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.terraformation.backend.search.SearchFieldPath
 import com.terraformation.backend.search.SearchFieldPrefix
+import com.terraformation.backend.search.namespace.SearchFieldNamespaces
 import javax.annotation.ManagedBean
 import javax.annotation.PostConstruct
 
 /** Configures the Jackson object mapper to be able to deserialize search field paths. */
 @ManagedBean
 class SearchFieldPathDeserializer(
+    namespaces: SearchFieldNamespaces,
     private val objectMapper: ObjectMapper,
-    accessionsNamespace: AccessionsNamespace,
 ) : StdDeserializer<SearchFieldPath>(SearchFieldPath::class.java) {
+  private val accessionsNamespace = namespaces.accessions
   private val root = SearchFieldPrefix(root = accessionsNamespace)
 
   @PostConstruct

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.search.SearchNode
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.SearchSortField
+import com.terraformation.backend.search.namespace.SearchFieldNamespaces
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
@@ -72,7 +73,8 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   private val checkedInTime = Instant.parse(checkedInTimeString)
 
   private val searchTables = SearchTables(PostgresFuzzySearchOperators())
-  private val accessionsNamespace = AccessionsNamespace(searchTables)
+  private val namespaces = SearchFieldNamespaces(searchTables)
+  private val accessionsNamespace = namespaces.accessions
   private val rootPrefix = SearchFieldPrefix(root = accessionsNamespace)
   private val accessionNumberField = rootPrefix.resolve("accessionNumber")
   private val activeField = rootPrefix.resolve("active")
@@ -101,7 +103,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     germinationTestsDao = GerminationTestsDao(jooqConfig)
     germinationsDao = GerminationsDao(jooqConfig)
     searchService = SearchService(dslContext)
-    accessionSearchService = AccessionSearchService(accessionsNamespace, searchService)
+    accessionSearchService = AccessionSearchService(namespaces, searchService)
 
     every { user.facilityRoles } returns mapOf(facilityId to Role.MANAGER)
 


### PR DESCRIPTION
Introduce a new class `SearchFieldNamespaces` that constructs the namespaces and
exposes them to the application as needed. For now, it only constructs the
existing accessions namespace.

Split `AccessionsNamespace` into a series of plain (non-`@ManagedBean`) classes.

No change in functionality here. A subsequent change will start introducing more
namespaces to the hierarchy.
