### PR TITLE
Use consistent naming scheme for organization payloads

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1102,7 +1102,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListOrganizationsResponse'
+                $ref: '#/components/schemas/ListOrganizationsResponsePayload'
   /api/v1/organization/{organizationId}:
     get:
       tags:
@@ -3597,7 +3597,7 @@ components:
       type: object
       properties:
         organization:
-          $ref: '#/components/schemas/ListOrganizationsElement'
+          $ref: '#/components/schemas/OrganizationPayload'
         status:
           $ref: '#/components/schemas/SuccessOrError'
     GetPlantResponsePayload:
@@ -3842,32 +3842,7 @@ components:
             $ref: '#/components/schemas/ObservationResponse'
         status:
           $ref: '#/components/schemas/SuccessOrError'
-    ListOrganizationsElement:
-      required:
-      - id
-      - name
-      - role
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-        projects:
-          type: array
-          description: This organization's projects. Omitted if depth is "Organization".
-          items:
-            $ref: '#/components/schemas/ProjectPayload'
-        role:
-          type: string
-          description: The current user's role in the organization.
-          enum:
-          - Contributor
-          - Manager
-          - Admin
-          - Owner
-    ListOrganizationsResponse:
+    ListOrganizationsResponsePayload:
       required:
       - organizations
       - status
@@ -3876,7 +3851,7 @@ components:
         organizations:
           type: array
           items:
-            $ref: '#/components/schemas/ListOrganizationsElement'
+            $ref: '#/components/schemas/OrganizationPayload'
         status:
           $ref: '#/components/schemas/SuccessOrError'
     ListPhotosResponseElement:
@@ -4227,6 +4202,31 @@ components:
         \ this will require x OR y OR z."
       allOf:
       - $ref: '#/components/schemas/SearchNodePayload'
+    OrganizationPayload:
+      required:
+      - id
+      - name
+      - role
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        projects:
+          type: array
+          description: This organization's projects. Omitted if depth is "Organization".
+          items:
+            $ref: '#/components/schemas/ProjectPayload'
+        role:
+          type: string
+          description: The current user's role in the organization.
+          enum:
+          - Contributor
+          - Manager
+          - Admin
+          - Owner
     PlantDetailsPayload:
       type: object
       properties:

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationController.kt
@@ -30,12 +30,12 @@ class OrganizationController(private val organizationStore: OrganizationStore) {
       @RequestParam("depth", defaultValue = "Organization")
       @Schema(description = "Return this level of information about the organization's contents.")
       depth: OrganizationStore.FetchDepth,
-  ): ListOrganizationsResponse {
+  ): ListOrganizationsResponsePayload {
     val elements =
         organizationStore.fetchAll(depth).map { model ->
-          ListOrganizationsElement(model, getRole(model))
+          OrganizationPayload(model, getRole(model))
         }
-    return ListOrganizationsResponse(elements)
+    return ListOrganizationsResponsePayload(elements)
   }
 
   @GetMapping("/{organizationId}")
@@ -51,7 +51,7 @@ class OrganizationController(private val organizationStore: OrganizationStore) {
     val model =
         organizationStore.fetchById(organizationId, depth)
             ?: throw OrganizationNotFoundException(organizationId)
-    return GetOrganizationResponsePayload(ListOrganizationsElement(model, getRole(model)))
+    return GetOrganizationResponsePayload(OrganizationPayload(model, getRole(model)))
   }
 
   private fun getRole(model: OrganizationModel): Role {
@@ -61,7 +61,7 @@ class OrganizationController(private val organizationStore: OrganizationStore) {
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class ListOrganizationsElement(
+data class OrganizationPayload(
     val id: OrganizationId,
     val name: String,
     @Schema(description = "This organization's projects. Omitted if depth is \"Organization\".")
@@ -82,8 +82,8 @@ data class ListOrganizationsElement(
   )
 }
 
-data class GetOrganizationResponsePayload(val organization: ListOrganizationsElement) :
+data class GetOrganizationResponsePayload(val organization: OrganizationPayload) :
     SuccessResponsePayload
 
-data class ListOrganizationsResponse(val organizations: List<ListOrganizationsElement>) :
+data class ListOrganizationsResponsePayload(val organizations: List<OrganizationPayload>) :
     SuccessResponsePayload


### PR DESCRIPTION
Bring the payload names for `/api/v1/organization` in line with the naming
convention used in most of the code.

No functional change here, though clients that are using the OpenAPI schema for
code generation will need to be updated to use the new names.