### PR TITLE
Reduce noise in database tests

### DIFF
--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -17,3 +17,4 @@ terraware:
 logging:
   level:
     com.terraformation: DEBUG
+    org.springframework: WARN


### PR DESCRIPTION
The Spring test framework logs a few very verbose INFO messages for each test
method as it sets up and tears down the database connection. This makes it more
of a pain to see the test results when running tests interactively.

Change the logging configuration to only show Spring log messages at WARN and
ERROR levels.