### PR TITLE
Don't include empty maps in search results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -579,8 +579,10 @@ class NestedQueryBuilder(
    * The result of that conversion becomes the value of the multiset field in the parent query. See
    * the jOOQ docs for a more detailed explanation of how ad-hoc converters and nested queries
    * interact with each other.
+   *
+   * Returns null rather than an empty map if there were no values in any fields.
    */
-  fun convertToMap(record: Record): Map<String, Any> {
+  fun convertToMap(record: Record): Map<String, Any>? {
     val fieldValues = mutableMapOf<String, Any>()
 
     scalarFields.forEach { (name, field) ->
@@ -606,7 +608,7 @@ class NestedQueryBuilder(
       }
     }
 
-    return fieldValues
+    return fieldValues.ifEmpty { null }
   }
 
   /**
@@ -837,7 +839,7 @@ class NestedQueryBuilder(
       prefix.sublistField?.conditionForMultiset?.let { addCondition(it) }
 
       DSL.multiset(toSelectQuery()).`as`(alias).convertFrom { result ->
-        result.map { record -> convertToMap(record) }
+        result.mapNotNull { record -> convertToMap(record) }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -101,7 +101,7 @@ class SearchService(private val dslContext: DSLContext) {
     log.debug("search SQL query: ${queryWithLimit.getSQL(ParamType.INLINED)}")
     val startTime = System.currentTimeMillis()
 
-    val results = queryWithLimit.fetch(queryBuilder::convertToMap)
+    val results = queryWithLimit.fetch(queryBuilder::convertToMap).filterNotNull()
 
     val endTime = System.currentTimeMillis()
     log.debug("search query returned ${results.size} rows in ${endTime - startTime} ms")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -1217,6 +1217,21 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `does not return empty top-level results when only selecting sublist fields`() {
+      // Use searchService rather than accessionSearchService; we don't want to include the
+      // accession ID/number fields because those would cause the results for accession 1001 to
+      // no longer be empty.
+      val result = searchService.search(rootPrefix, listOf(seedsSownField), NoConditionNode())
+
+      val expected =
+          SearchResults(
+              listOf(mapOf("germinationTests" to listOf(mapOf("seedsSown" to "15")))),
+              cursor = null)
+
+      assertEquals(expected, result)
+    }
+
+    @Test
     fun `can filter on nested field`() {
       val fields = listOf(bagsNumberField)
       val sortOrder = fields.map { SearchSortField(it) }


### PR DESCRIPTION
This fixes a bug that was masked by the fact that accession searches always
include the accession ID and accession number in the field list. If you
searched for a sublist field, you would get back an entry in the results list
for every root-level entity that matched the filter criteria, even if there
were no values for the sublist you were asking for. That violates the contract
of the search API, which says you will never get back a completely empty map.

Fix the bug and add a regression test to verify the fix.