### PR TITLE
TRACK-466 Add organizations, projects, sites namespaces

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/namespace/FacilitiesNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/FacilitiesNamespace.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.search.namespace
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
+import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.search.SearchFieldNamespace
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -12,6 +13,7 @@ class FacilitiesNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamesp
     with(namespaces) {
       listOf(
           accessions.asMultiValueSublist("accessions", FACILITIES.ID.eq(ACCESSIONS.FACILITY_ID)),
+          sites.asSingleValueSublist("site", FACILITIES.SITE_ID.eq(SITES.ID)),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/OrganizationsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/OrganizationsNamespace.kt
@@ -1,0 +1,26 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.tables.references.PROJECTS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+
+class OrganizationsNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> by lazy {
+    with(namespaces) {
+      listOf(
+          projects.asMultiValueSublist("projects", ORGANIZATIONS.ID.eq(PROJECTS.ORGANIZATION_ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      with(namespaces.searchTables.organizations) {
+        listOf(
+            idWrapperField("id", "Organization ID", ORGANIZATIONS.ID) { OrganizationId(it) },
+            textField("name", "Organization name", ORGANIZATIONS.NAME, nullable = false),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/ProjectsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/ProjectsNamespace.kt
@@ -1,0 +1,29 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.ProjectId
+import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.tables.references.PROJECTS
+import com.terraformation.backend.db.tables.references.SITES
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+
+class ProjectsNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> by lazy {
+    with(namespaces) {
+      listOf(
+          organizations.asSingleValueSublist(
+              "organization", PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
+          sites.asMultiValueSublist("sites", PROJECTS.ID.eq(SITES.PROJECT_ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      with(namespaces.searchTables.projects) {
+        listOf(
+            idWrapperField("id", "Project ID", PROJECTS.ID) { ProjectId(it) },
+            textField("name", "Project name", PROJECTS.NAME, nullable = false),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
@@ -8,9 +8,9 @@ import javax.annotation.ManagedBean
  * Manages the hierarchy of [SearchFieldNamespace]s.
  *
  * Namespace initialization is complicated by the fact that there are circular references among
- * namespaces. For example, the `facilities` namespace has a multi-value sublist `accessions` that
- * refers to the `facilities` namespace, and the `accessions` namespace has a single-value sublist
- * `facility` that refers to the `facilities` namespace.
+ * namespaces. For example, the `projects` namespace has a multi-value sublist `sites` that refers
+ * to the `sites` namespace, and the `sites` namespace has a single-value sublist `project` that
+ * refers to the `projects` namespace.
  *
  * To cope with that, we take a two-phase approach. The [SearchFieldNamespace] objects are all
  * created here, but their [SearchFieldNamespace.sublists] values aren't initialized at construction
@@ -31,6 +31,9 @@ class SearchFieldNamespaces(val searchTables: SearchTables) {
   val geolocations = GeolocationsNamespace(this)
   val germinations = GerminationsNamespace(this)
   val germinationTests = GerminationTestsNamespace(this)
+  val organizations = OrganizationsNamespace(this)
+  val projects = ProjectsNamespace(this)
+  val sites = SitesNamespace(this)
   val species = SpeciesNamespace(this)
   val storageLocations = StorageLocationsNamespace(this)
   val withdrawals = WithdrawalsNamespace(this)

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/SitesNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/SitesNamespace.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.tables.references.FACILITIES
+import com.terraformation.backend.db.tables.references.PROJECTS
+import com.terraformation.backend.db.tables.references.SITES
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+
+class SitesNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> by lazy {
+    with(namespaces) {
+      listOf(
+          facilities.asMultiValueSublist("facilities", SITES.ID.eq(FACILITIES.SITE_ID)),
+          projects.asSingleValueSublist("project", SITES.PROJECT_ID.eq(PROJECTS.ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      with(namespaces.searchTables.sites) {
+        listOf(
+            idWrapperField("id", "Site ID", SITES.ID) { SiteId(it) },
+            textField("name", "Site name", SITES.NAME, nullable = false),
+        )
+      }
+}


### PR DESCRIPTION
Allow searches to ask for information about the upper layers of the data model.

The list of fields in these namespaces is minimal for now, because we're still
finalizing requirements like how a project's location should be modeled. This is
mostly just to get the top-level structure in place so we can start expanding
the search API into other parts of the data model.