### PR TITLE
Fix malformed SQL when mixing aliases and nested sublists

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -705,7 +705,7 @@ class NestedQueryBuilder(
   private fun addSelectField(fieldPath: SearchFieldPath) {
     val relativeField = fieldPath.relativeTo(prefix)
 
-    if (relativeField.searchField is AliasField) {
+    if (relativeField.searchField is AliasField && !relativeField.isNested) {
       addFlattenedSublists(relativeField.searchField.targetPath.sublists)
     }
 
@@ -742,6 +742,10 @@ class NestedQueryBuilder(
    */
   private fun addSortField(sortField: SearchSortField) {
     val relativeField = sortField.field.relativeTo(prefix)
+
+    if (relativeField.searchField is AliasField && !relativeField.isNested) {
+      addFlattenedSublists(relativeField.searchField.targetPath.sublists)
+    }
 
     sortFields.add(sortField)
 


### PR DESCRIPTION
If you referenced an alias in a nested sublist, and the alias pointed to
a flattened sublist, and the query didn't include any fields from the
nested sublist itself, we would generate SQL that was missing the JOIN
clause to connect the flattened sublist to the parent query.

Fix the bug and add test cases that failed without the fix.