### PR TITLE
TRACK-483 Improve GeoJSON parsing and rendering

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -60,7 +60,11 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
     val description = request.getDescription(false)
     controllerLogger(ex)
         .warn("Generic response exception thrown on $description use ClientFacingException", ex)
-    return simpleErrorResponse(ex.message ?: ex.status.reasonPhrase, ex.status, request)
+
+    @Suppress("USELESS_ELVIS") // ex.message can be null despite being annotated otherwise
+    val message = ex.message ?: ex.status.reasonPhrase
+
+    return simpleErrorResponse(message, ex.status, request)
   }
 
   /**
@@ -167,7 +171,7 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
             is MissingKotlinParameterException -> "Required field not present"
             is InvalidNullException -> "Field value cannot be null"
             is InvalidFormatException -> "Field value has incorrect format"
-            else -> "Field value invalid"
+            else -> cause.originalMessage ?: "Field value invalid"
           }
 
       return simpleErrorResponse("$message: $path", status, request)

--- a/src/test/kotlin/com/terraformation/backend/db/GeometryDeserializerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/GeometryDeserializerTest.kt
@@ -1,0 +1,160 @@
+package com.terraformation.backend.db
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import net.postgis.jdbc.geometry.Geometry
+import net.postgis.jdbc.geometry.LineString
+import net.postgis.jdbc.geometry.LinearRing
+import net.postgis.jdbc.geometry.Point
+import net.postgis.jdbc.geometry.Polygon
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class GeometryDeserializerTest {
+  private val objectMapper = ObjectMapper().registerModule(GeometryModule())
+
+  @Test
+  fun `well-formed point`() {
+    val actual =
+        objectMapper.readValue<Geometry>("""{ "type": "Point", "coordinates": [1.1, 2.2, 3.3] }""")
+
+    assertEquals(Point(1.1, 2.2, 3.3).apply { srid = SRID.LONG_LAT }, actual)
+  }
+
+  @Test
+  fun `well-formed explicit SRID`() {
+    val actual =
+        objectMapper.readValue<Geometry>(
+            """{
+          |"type": "Point",
+          |"coordinates": [1.1, 2.2, 3.3],
+          |"crs":{
+          |  "type": "name",
+          |  "properties": {
+          |    "name": "EPSG:${SRID.SPHERICAL_MERCATOR}"
+          |  }
+          |}
+          |}""".trimMargin())
+
+    assertEquals(Point(1.1, 2.2, 3.3).apply { srid = SRID.SPHERICAL_MERCATOR }, actual)
+  }
+
+  @Test
+  fun `well-formed polygon`() {
+    val actual =
+        objectMapper.readValue<Geometry>(
+            """{
+      |"type": "Polygon",
+      |"coordinates":
+      |  [
+      |    [
+      |      [0.0, 0.0, 0.0],
+      |      [1.0, 0.0, 0.0],
+      |      [0.0, 1.0, 0.0],
+      |      [0.0, 0.0, 0.0]
+      |    ]
+      |  ]
+      |}""".trimMargin())
+
+    assertEquals(
+        Polygon(
+                arrayOf(
+                    LinearRing(
+                        arrayOf(
+                            Point(0.0, 0.0, 0.0),
+                            Point(1.0, 0.0, 0.0),
+                            Point(0.0, 1.0, 0.0),
+                            Point(0.0, 0.0, 0.0),
+                        ))))
+            .apply { srid = SRID.LONG_LAT },
+        actual)
+  }
+
+  @Test
+  fun `well-formed linestring`() {
+    val actual =
+        objectMapper.readValue<Geometry>(
+            """{
+      |"type": "LineString",
+      |"coordinates":
+      |  [
+      |    [0.0, 0.0, 0.0],
+      |    [1.0, 0.0, 0.0],
+      |    [0.0, 1.0, 0.0]
+      |  ]
+      |}""".trimMargin())
+
+    assertEquals(
+        LineString(
+                arrayOf(
+                    Point(0.0, 0.0, 0.0),
+                    Point(1.0, 0.0, 0.0),
+                    Point(0.0, 1.0, 0.0),
+                ))
+            .apply { srid = SRID.LONG_LAT },
+        actual)
+  }
+
+  @Test
+  fun `line with too few points`() {
+    assertThrows<JsonParseException> {
+      objectMapper.readValue<Geometry>(
+          """{ "type": "LineString", "coordinates": [ [0.0, 0.0, 0.0] ] }""")
+    }
+  }
+
+  @Test
+  fun `polygon with too few points`() {
+    assertThrows<JsonParseException> {
+      objectMapper.readValue<Geometry>(
+          """{
+      |"type": "Polygon",
+      |"coordinates":
+      |  [
+      |    [
+      |      [0.0, 0.0, 0.0],
+      |      [1.0, 0.0, 0.0],
+      |      [0.0, 0.0, 0.0]
+      |    ]
+      |  ]
+      |}""".trimMargin())
+    }
+  }
+
+  @Test
+  fun `geometry values without coordinates`() {
+    listOf(
+        "GeometryCollection",
+        "LineString",
+        "MultiLineString",
+        "MultiPoint",
+        "MultiPolygon",
+        "Point",
+        "Polygon",
+    )
+        .forEach { typeName ->
+          assertThrows<JsonParseException>(typeName) {
+            objectMapper.readValue<Geometry>("""{"type": "$typeName"}""")
+          }
+        }
+  }
+
+  @Test
+  fun `bogus SRID`() {
+    assertThrows<JsonParseException> {
+      objectMapper.readValue<Geometry>(
+          """{
+          |"type": "Point",
+          |"coordinates": [1.1, 2.2, 3.3],
+          |"crs":{
+          |  "type": "name",
+          |  "properties": {
+          |    "name": "EPSG:bogus"
+          |  }
+          |}
+          |}""".trimMargin())
+    }
+  }
+}


### PR DESCRIPTION
Add more input validation to the GeoJSON parser so we can return helpful error
messages to the client, e.g., when they send us a polygon that doesn't have
enough points. Previously, we were accepting values that were syntactically
well-formed, even if they didn't make sense; PostGIS would catch the problems
when we tried to store the values in the database, but we wouldn't always get
back an error message that was suitable to return to the client.

When returning GeoJSON values to the client, round coordinates to 8 digits
after the decimal point so our rendered values don't have bogus-looking floating
point inaccuracies due to the fact that we do coordinate system conversion in
the database. This was especially glaring if you tried to create a feature
with longitude/latitude coordinates; when you read it back from the server, you
would almost always get ugly-looking values like 121.0000000000001.