### PR TITLE
Remove backward-compatible organizations endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1077,66 +1077,6 @@ paths:
         "302":
           description: "Redirects to a login page. After login, the user will be redirected\
             \ back to the URL specified in the \"redirect\" parameter."
-  /api/v1/organization:
-    get:
-      tags:
-      - Customer
-      summary: Lists all organizations.
-      description: Lists all organizations the user can access.
-      operationId: listOrganizations_1
-      parameters:
-      - name: depth
-        in: query
-        required: false
-        schema:
-          type: string
-          description: Return this level of information about the organization's contents.
-          default: Organization
-          enum:
-          - Organization
-          - Project
-          - Site
-          - Facility
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListOrganizationsResponsePayload'
-  /api/v1/organization/{organizationId}:
-    get:
-      tags:
-      - Customer
-      summary: Gets information about an organization.
-      operationId: getOrganization_1
-      parameters:
-      - name: organizationId
-        in: path
-        required: true
-        schema:
-          type: integer
-          description: ID of organization to get. User must be a member of the organization.
-          format: int64
-      - name: depth
-        in: query
-        required: false
-        schema:
-          type: string
-          description: Return this level of information about the organization's contents.
-          default: Organization
-          enum:
-          - Organization
-          - Project
-          - Site
-          - Facility
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetOrganizationResponsePayload'
   /api/v1/organizations:
     get:
       tags:

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -19,11 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @CustomerEndpoint
 @RestController
-@RequestMapping(
-    // TODO: Remove this once clients have switched over to the plural name
-    "/api/v1/organization",
-    "/api/v1/organizations",
-)
+@RequestMapping("/api/v1/organizations")
 class OrganizationsController(private val organizationStore: OrganizationStore) {
   @GetMapping
   @Operation(


### PR DESCRIPTION
The front end code is using `/api/v1/organizations`, so there is no longer any
need for the older name `/api/v1/organization`.