### PR TITLE
Fix compiler warning; treat warnings as errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,6 +212,7 @@ sourceSets.main {
 
 tasks.withType<KotlinCompile> {
   dependsOn(generateVersionFile)
+  kotlinOptions.allWarningsAsErrors = true
   kotlinOptions.jvmTarget = java.targetCompatibility.majorVersion
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -115,7 +115,7 @@ class OrganizationStore(
 
           // If the user isn't in any projects, we still want to construct a properly-typed
           // multiset, but it should be empty.
-          val condition =
+          val projectsCondition =
               if (projectIds.isNotEmpty()) {
                 PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID).and(PROJECTS.ID.`in`(projectIds))
               } else {
@@ -125,7 +125,7 @@ class OrganizationStore(
           DSL.multiset(
                   DSL.select(PROJECTS.asterisk(), sitesMultiset)
                       .from(PROJECTS)
-                      .where(condition)
+                      .where(projectsCondition)
                       .orderBy(PROJECTS.ID))
               .convertFrom { result -> result.map { ProjectModel(it, sitesMultiset) } }
         } else {


### PR DESCRIPTION
Fix a shadowed variable name that's been in the code for a month or so. To stop
that kind of thing from creeping into the code again, turn on the compiler
option that treats warnings as errors. We can revisit it if it turns out to cause
too many false positives.
