### PR TITLE
Add countries and subdivisions to search

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTables.kt
@@ -10,6 +10,8 @@ import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_GERMINATION_TEST_TYPES
 import com.terraformation.backend.db.tables.references.BAGS
 import com.terraformation.backend.db.tables.references.COLLECTORS
+import com.terraformation.backend.db.tables.references.COUNTRIES
+import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.FEATURES
 import com.terraformation.backend.db.tables.references.GEOLOCATIONS
@@ -48,6 +50,10 @@ class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
   val bags = object : AccessionChildTable(BAGS.ID, BAGS.ACCESSION_ID) {}
 
   val collectors = object : PerFacilityTable(COLLECTORS.ID, COLLECTORS.FACILITY_ID) {}
+
+  val countries = object : SearchTable(fuzzySearchOperators, COUNTRIES.CODE) {}
+
+  val countrySubdivisions = object : SearchTable(fuzzySearchOperators, COUNTRY_SUBDIVISIONS.CODE) {}
 
   val facilities = object : PerFacilityTable(FACILITIES.ID, FACILITIES.ID) {}
 

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/CountriesNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/CountriesNamespace.kt
@@ -1,0 +1,29 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.COUNTRIES
+import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
+import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+
+class CountriesNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> by lazy {
+    with(namespaces) {
+      listOf(
+          organizations.asMultiValueSublist(
+              "organizations", COUNTRIES.CODE.eq(ORGANIZATIONS.COUNTRY_CODE)),
+          countrySubdivisions.asMultiValueSublist(
+              "subdivisions", COUNTRIES.CODE.eq(COUNTRY_SUBDIVISIONS.COUNTRY_CODE)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      with(namespaces.searchTables.countries) {
+        listOf(
+            textField("code", "Country code", COUNTRIES.CODE),
+            textField("name", "Country name", COUNTRIES.NAME),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/CountrySubdivisionsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/CountrySubdivisionsNamespace.kt
@@ -1,0 +1,30 @@
+package com.terraformation.backend.search.namespace
+
+import com.terraformation.backend.db.tables.references.COUNTRIES
+import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
+import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.search.SearchFieldNamespace
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+
+class CountrySubdivisionsNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNamespace() {
+  override val sublists: List<SublistField> by lazy {
+    with(namespaces) {
+      listOf(
+          countries.asSingleValueSublist(
+              "country", COUNTRY_SUBDIVISIONS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
+          organizations.asMultiValueSublist(
+              "organizations",
+              COUNTRY_SUBDIVISIONS.CODE.eq(ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      with(namespaces.searchTables.countrySubdivisions) {
+        listOf(
+            textField("code", "Country subdivision code", COUNTRY_SUBDIVISIONS.CODE),
+            textField("name", "Country subdivision name", COUNTRY_SUBDIVISIONS.NAME),
+        )
+      }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/OrganizationsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/OrganizationsNamespace.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.search.namespace
 
 import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.tables.references.COUNTRIES
+import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.PROJECTS
 import com.terraformation.backend.search.SearchFieldNamespace
@@ -11,6 +13,10 @@ class OrganizationsNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNam
   override val sublists: List<SublistField> by lazy {
     with(namespaces) {
       listOf(
+          countries.asSingleValueSublist("country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
+          countrySubdivisions.asSingleValueSublist(
+              "countrySubdivision",
+              ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE)),
           projects.asMultiValueSublist("projects", ORGANIZATIONS.ID.eq(PROJECTS.ORGANIZATION_ID)),
       )
     }
@@ -19,6 +25,11 @@ class OrganizationsNamespace(namespaces: SearchFieldNamespaces) : SearchFieldNam
   override val fields: List<SearchField> =
       with(namespaces.searchTables.organizations) {
         listOf(
+            textField("countryCode", "Organization country code", ORGANIZATIONS.COUNTRY_CODE),
+            textField(
+                "countrySubdivisionCode",
+                "Organization country subdivision code",
+                ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE),
             idWrapperField("id", "Organization ID", ORGANIZATIONS.ID) { OrganizationId(it) },
             textField("name", "Organization name", ORGANIZATIONS.NAME, nullable = false),
         )

--- a/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/SearchFieldNamespaces.kt
@@ -26,6 +26,8 @@ class SearchFieldNamespaces(val searchTables: SearchTables) {
   val accessions = AccessionsNamespace(this)
   val bags = BagsNamespace(this)
   val collectors = CollectorsNamespace(this)
+  val countries = CountriesNamespace(this)
+  val countrySubdivisions = CountrySubdivisionsNamespace(this)
   val facilities = FacilitiesNamespace(this)
   val features = FeaturesNamespace(this)
   val geolocations = GeolocationsNamespace(this)


### PR DESCRIPTION
Allow clients to include organizations' country and US state in their search
requests when searching organization details. Since the client is likely to use
the ISO-3166 codes internally, I added the codes as search fields in the
organizations namespace as well as adding them as sublists that can be used to
retrieve the country/state names.

This also means the search API serves double duty as the API you can use to
dump out the list of known countries and subdivisions; pass in a prefix of
`country` and a field list of `code` and `name` with no search criteria to get
the full list of countries, and if you want a structured list of each country's
subdivisions, search for `subdivisions.code` and `subdivisions.name`.