### PR TITLE
Upgrade to Spring Boot 2.4.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
   id("com.revolut.jooq-docker") version "0.3.5"
   id("com.diffplug.spotless") version "5.10.2"
-  id("org.springframework.boot") version "2.4.3"
+  id("org.springframework.boot") version "2.4.4"
   id("io.spring.dependency-management") version "1.0.11.RELEASE"
 
   // Add the build target to generate Swagger docs


### PR DESCRIPTION
While developing the search code, it was annoying to keep running into
https://github.com/spring-projects/spring-boot/issues/25717 which caused database
error messages to not show up in the logs. The bug was fixed in the patch version
of Spring Boot just after the one we were using.