### PR TITLE
TRACK-520 Support preregistered users

### DIFF
--- a/src/main/resources/db/migration/common/V62__NullAuthId.sql
+++ b/src/main/resources/db/migration/common/V62__NullAuthId.sql
@@ -1,0 +1,3 @@
+-- Allow users to be inserted without an auth_id, so we can hold information about people who
+-- haven't gone through registration yet.
+ALTER TABLE users ALTER COLUMN auth_id DROP NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -145,6 +145,28 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `fetchByAuthId adds auth ID and name to existing user with matching email address`() {
+    val row =
+        UsersRow(
+            email = userRepresentation.email,
+            userTypeId = UserType.Individual,
+            createdTime = clock.instant(),
+            modifiedTime = clock.instant())
+
+    usersDao.insert(row)
+
+    val user = userStore.fetchByAuthId(authId)
+
+    assertEquals(row.id, user.userId, "Should use existing user ID")
+
+    val updatedRow = usersDao.fetchOneById(user.userId)!!
+
+    assertEquals(userRepresentation.firstName, updatedRow.firstName, "First name")
+    assertEquals(userRepresentation.lastName, updatedRow.lastName, "Last name")
+    assertEquals(authId, updatedRow.authId, "Auth ID")
+  }
+
+  @Test
   fun `fetchByAuthId throws exception if user not found in Keycloak`() {
     assertThrows<KeycloakUserNotFoundException> { userStore.fetchByAuthId("nonexistent") }
   }


### PR DESCRIPTION
Allow users to be created without Keycloak user identifiers. When they log in for
the first time, associate their Keycloak identities (including their first and
last names, which they will have supplied as part of registration) with the existing
user ID by matching the email address.

There is currently no externally-accessible way to create users in that state, but
future changes will use it to represent pending invitations.