### PR TITLE
TRACK-520 Track users who are invited to organizations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
@@ -52,6 +52,7 @@ class PermissionStore(private val dslContext: DSLContext) {
         .on(PROJECTS.ID.eq(PROJECT_USERS.PROJECT_ID))
         .and(ORGANIZATION_USERS.USER_ID.eq(PROJECT_USERS.USER_ID))
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
+        .and(ORGANIZATION_USERS.PENDING_INVITATION_TIME.isNull)
         .and(
             ORGANIZATION_USERS
                 .ROLE_ID
@@ -67,6 +68,7 @@ class PermissionStore(private val dslContext: DSLContext) {
         .select(ORGANIZATION_USERS.ORGANIZATION_ID, ORGANIZATION_USERS.ROLE_ID)
         .from(ORGANIZATION_USERS)
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
+        .and(ORGANIZATION_USERS.PENDING_INVITATION_TIME.isNull)
         .fetchMap({ row -> row.value1() }, { row -> row.value2()?.let { Role.of(it) } })
   }
 
@@ -91,6 +93,7 @@ class PermissionStore(private val dslContext: DSLContext) {
         .on(PROJECTS.ID.eq(PROJECT_USERS.PROJECT_ID))
         .and(ORGANIZATION_USERS.USER_ID.eq(PROJECT_USERS.USER_ID))
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
+        .and(ORGANIZATION_USERS.PENDING_INVITATION_TIME.isNull)
         .and(
             ORGANIZATION_USERS
                 .ROLE_ID
@@ -123,6 +126,7 @@ class PermissionStore(private val dslContext: DSLContext) {
         .on(PROJECTS.ID.eq(PROJECT_USERS.PROJECT_ID))
         .and(ORGANIZATION_USERS.USER_ID.eq(PROJECT_USERS.USER_ID))
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
+        .and(ORGANIZATION_USERS.PENDING_INVITATION_TIME.isNull)
         .and(
             ORGANIZATION_USERS
                 .ROLE_ID

--- a/src/main/resources/db/migration/common/R__Comments.sql
+++ b/src/main/resources/db/migration/common/R__Comments.sql
@@ -86,6 +86,7 @@ COMMENT ON COLUMN notifications.accession_id IS 'Null if this notification is no
 COMMENT ON COLUMN notifications.accession_state_id IS 'For state notifications, which state is being notified about. Null otherwise.';
 
 COMMENT ON TABLE organization_users IS 'Organization membership and role information.';
+COMMENT ON COLUMN organization_users.pending_invitation_time IS 'When the most recent invitation was sent to a user who has not yet joined the organization. Null if the user is a regular member of the organization (i.e., they have accepted the invitation).';
 
 COMMENT ON TABLE organizations IS 'Top-level information about organizations.';
 COMMENT ON COLUMN organizations.id IS 'Unique numeric identifier of the organization.';

--- a/src/main/resources/db/migration/common/V63__UserInvitedTime.sql
+++ b/src/main/resources/db/migration/common/V63__UserInvitedTime.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organization_users ADD COLUMN pending_invitation_time TIMESTAMP WITH TIME ZONE;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -57,6 +57,13 @@ internal class PermissionStoreTest : DatabaseTest() {
   }
 
   @Test
+  fun `fetchFacilityRoles does not include pending invitations`() {
+    insertTestData()
+    markAsInvitationPending(UserId(5), OrganizationId(1))
+    assertEquals(emptyMap<FacilityId, Role>(), permissionStore.fetchFacilityRoles(UserId(5)))
+  }
+
+  @Test
   fun `fetchFacilityRoles includes facilities from multiple organizations`() {
     insertTestData()
     assertEquals(
@@ -84,6 +91,14 @@ internal class PermissionStoreTest : DatabaseTest() {
   }
 
   @Test
+  fun `fetchOrganizationRoles does not include pending invitations`() {
+    insertTestData()
+    markAsInvitationPending(UserId(5), OrganizationId(1))
+    assertEquals(
+        emptyMap<OrganizationId, Role>(), permissionStore.fetchOrganizationRoles(UserId(5)))
+  }
+
+  @Test
   fun `fetchProjectRoles only includes projects the user is in`() {
     insertTestData()
     assertEquals(mapOf(ProjectId(10) to Role.MANAGER), permissionStore.fetchProjectRoles(UserId(5)))
@@ -98,6 +113,13 @@ internal class PermissionStoreTest : DatabaseTest() {
             ProjectId(11) to Role.CONTRIBUTOR,
             ProjectId(20) to Role.MANAGER),
         permissionStore.fetchProjectRoles(UserId(7)))
+  }
+
+  @Test
+  fun `fetchProjectRoles does not include pending invitations`() {
+    insertTestData()
+    markAsInvitationPending(UserId(5), OrganizationId(1))
+    assertEquals(emptyMap<ProjectId, Role>(), permissionStore.fetchProjectRoles(UserId(5)))
   }
 
   @Test
@@ -118,6 +140,13 @@ internal class PermissionStoreTest : DatabaseTest() {
             SiteId(110) to Role.CONTRIBUTOR,
             SiteId(200) to Role.MANAGER),
         permissionStore.fetchSiteRoles(UserId(7)))
+  }
+
+  @Test
+  fun `fetchSiteRoles does not include pending invitations`() {
+    insertTestData()
+    markAsInvitationPending(UserId(5), OrganizationId(1))
+    assertEquals(emptyMap<SiteId, Role>(), permissionStore.fetchSiteRoles(UserId(5)))
   }
 
   /**
@@ -260,6 +289,16 @@ internal class PermissionStoreTest : DatabaseTest() {
             .set(MODIFIED_TIME, Instant.EPOCH)
             .execute()
       }
+    }
+  }
+
+  private fun markAsInvitationPending(userId: UserId, organizationId: OrganizationId) {
+    with(ORGANIZATION_USERS) {
+      dslContext
+          .update(ORGANIZATION_USERS)
+          .set(PENDING_INVITATION_TIME, Instant.EPOCH)
+          .where(USER_ID.eq(userId).and(ORGANIZATION_ID.eq(organizationId)))
+          .execute()
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -687,6 +687,19 @@ internal class PermissionTest : DatabaseTest() {
     PermissionsTracker().andNothingElse()
   }
 
+  @Test
+  fun `user with pending invitation has no access to organization or projects`() {
+    givenRole(org1Id, Role.ADMIN, *org1ProjectIds)
+
+    dslContext
+        .update(ORGANIZATION_USERS)
+        .set(ORGANIZATION_USERS.PENDING_INVITATION_TIME, Instant.EPOCH)
+        .where(ORGANIZATION_USERS.USER_ID.eq(userId))
+        .execute()
+
+    PermissionsTracker().andNothingElse()
+  }
+
   private fun givenRole(organizationId: OrganizationId, role: Role, vararg projects: ProjectId) {
     with(ORGANIZATION_USERS) {
       dslContext


### PR DESCRIPTION
Add a column to `organization_users` to track whether a user has been invited to
the organization but hasn't yet accepted the invitation.

Users shouldn't have access to organizations until they accept their invitations.
Update the permission code to ignore pending invitations when it computes the list
of projects and organizations the user has permission to access.

There is no way for a client to create a user with a pending invitation yet; this
just lays the groundwork for adding an invitation API.