### PR TITLE
TRACK-521 Endpoint to invite a user to an organization

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
   implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
   implementation("com.opencsv:opencsv:5.5.2")
+  implementation("commons-validator:commons-validator:1.7")
   implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.1.1")
   implementation("io.swagger.core.v3:swagger-annotations:2.1.11")
   implementation("javax.inject:javax.inject:1")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1181,6 +1181,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleSuccessResponsePayload'
+  /api/v1/organizations/{organizationId}/invitations:
+    post:
+      tags:
+      - Customer
+      summary: Invites a user to an organization.
+      operationId: inviteOrganizationUser
+      parameters:
+      - name: organizationId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InviteOrganizationUserRequestPayload'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleSuccessResponsePayload'
   /api/v1/organizations/{organizationId}/projects:
     get:
       tags:
@@ -3739,6 +3765,26 @@ components:
           $ref: '#/components/schemas/UserProfilePayload'
         status:
           $ref: '#/components/schemas/SuccessOrError'
+    InviteOrganizationUserRequestPayload:
+      required:
+      - email
+      - role
+      type: object
+      properties:
+        email:
+          type: string
+        role:
+          type: string
+          enum:
+          - Contributor
+          - Manager
+          - Admin
+          - Owner
+        projectIds:
+          type: array
+          items:
+            type: integer
+            format: int64
     LayerResponse:
       required:
       - hidden

--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.InvalidNullException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.terraformation.backend.db.DuplicateEntityException
 import com.terraformation.backend.db.EntityNotFoundException
 import javax.ws.rs.QueryParam
+import javax.ws.rs.WebApplicationException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
@@ -36,6 +38,14 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
   }
 
   @ExceptionHandler
+  fun handleDuplicateEntityException(
+      ex: DuplicateEntityException,
+      request: WebRequest
+  ): ResponseEntity<*> {
+    return simpleErrorResponse(ex.message, HttpStatus.CONFLICT, request)
+  }
+
+  @ExceptionHandler
   fun handleEntityNotFoundException(
       ex: EntityNotFoundException,
       request: WebRequest
@@ -50,6 +60,17 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
   ): ResponseEntity<*> {
     return simpleErrorResponse(
         ex.message ?: "An internal error has occurred.", HttpStatus.BAD_REQUEST, request)
+  }
+
+  @ExceptionHandler
+  fun handleWebApplicationException(
+      ex: WebApplicationException,
+      request: WebRequest
+  ): ResponseEntity<*> {
+    return simpleErrorResponse(
+        ex.message ?: "An internal error has occurred.",
+        HttpStatus.valueOf(ex.response.status),
+        request)
   }
 
   @ExceptionHandler

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -26,6 +26,12 @@ import org.springframework.validation.annotation.Validated
 @Validated
 class TerrawareServerConfig(
     /**
+     * URL of the web application for this server. This is used when the server needs to generate a
+     * link for a user to follow, e.g., in invitation email messages.
+     */
+    val webAppUrl: URI,
+
+    /**
      * Name of S3 bucket to use for storage of files such as photos. If not specified, files won't
      * be stored on S3.
      */

--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.customer
+
+import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.db.ProjectStore
+import com.terraformation.backend.customer.db.UserStore
+import com.terraformation.backend.customer.model.Role
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.ProjectId
+import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.email.EmailService
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+/** Organization-related business logic that needs to interact with multiple services. */
+@ManagedBean
+class OrganizationService(
+    private val dslContext: DSLContext,
+    private val emailService: EmailService,
+    private val organizationStore: OrganizationStore,
+    private val projectStore: ProjectStore,
+    private val userStore: UserStore,
+) {
+  fun invite(
+      email: String,
+      organizationId: OrganizationId,
+      role: Role,
+      projectIds: Collection<ProjectId>
+  ) {
+    requirePermissions {
+      addOrganizationUser(organizationId)
+      setOrganizationUserRole(organizationId, role)
+      projectIds.forEach { addProjectUser(it) }
+    }
+
+    val projects =
+        projectIds.map { projectStore.fetchById(it) ?: throw ProjectNotFoundException(it) }
+    if (projects.any { it.organizationId != organizationId }) {
+      throw IllegalArgumentException("Cannot invite user to projects from a different organization")
+    }
+
+    dslContext.transaction { _ ->
+      val userModel = userStore.fetchOrCreateByEmail(email)
+
+      organizationStore.addUser(organizationId, userModel.userId, role, pending = true)
+
+      projectIds.forEach { projectStore.addUser(it, userModel.userId) }
+
+      // Send email in the transaction so the user will be rolled back if we couldn't notify them
+      // about being invited, e.g., because the email address was malformed.
+      emailService.sendInvitation(organizationId, userModel.userId)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/UserModel.kt
@@ -56,7 +56,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
  */
 data class UserModel(
     val userId: UserId,
-    val authId: String,
+    val authId: String?,
     val email: String,
     val firstName: String?,
     val lastName: String?,
@@ -388,8 +388,8 @@ data class UserModel(
     return ""
   }
 
-  override fun getName(): String = authId
-  override fun getUsername(): String = authId
+  override fun getName(): String = authId ?: throw IllegalStateException("User is unregistered")
+  override fun getUsername(): String = authId ?: throw IllegalStateException("User is unregistered")
   override fun isAccountNonExpired(): Boolean = true
   override fun isAccountNonLocked(): Boolean = true
   override fun isCredentialsNonExpired(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -12,6 +12,16 @@ abstract class EntityNotFoundException(message: String) : RuntimeException(messa
     get() = super.message!!
 }
 
+/**
+ * Thrown when the system detects a duplicate piece of data that needs to be unique.
+ *
+ * Subclasses of this are mapped to HTTP 409 Conflict if they are thrown by a controller method.
+ */
+abstract class DuplicateEntityException(message: String) : RuntimeException(message) {
+  override val message: String
+    get() = super.message!!
+}
+
 class AccessionNotFoundException(val accessionId: AccessionId) :
     EntityNotFoundException("Accession $accessionId not found")
 
@@ -69,5 +79,11 @@ class TimeseriesNotFoundException(
 ) : EntityNotFoundException(message) {
   constructor(deviceId: DeviceId) : this(deviceId, null, "Timeseries not found on device $deviceId")
 }
+
+class UserAlreadyInOrganizationException(val userId: UserId, val organizationId: OrganizationId) :
+    DuplicateEntityException("User is already in organization")
+
+class UserAlreadyInProjectException(val userId: UserId, val projectId: ProjectId) :
+    DuplicateEntityException("User is already in project")
 
 class UserNotFoundException(val userId: UserId) : EntityNotFoundException("User $userId not found")

--- a/src/main/resources/application-apidoc.yaml
+++ b/src/main/resources/application-apidoc.yaml
@@ -23,6 +23,7 @@ spring:
     store-type: none
 
 terraware:
+  web-app-url: http://dummy
   photo-dir: "/tmp"
   daily-tasks:
     enabled: false

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -1,4 +1,6 @@
 terraware:
+  # By default, the frontend dev service listens on HTTP port 3000.
+  web-app-url: "http://localhost:3000/"
   photo-dir: "/tmp/terraware-server-photos"
   use-test-clock: true
   allow-admin-ui-for-non-admins: true

--- a/src/main/resources/templates/email/invitation/body.html
+++ b/src/main/resources/templates/email/invitation/body.html
@@ -1,0 +1,42 @@
+<html>
+<style>
+    .button {
+        background-color: blue;
+        color: white;
+        padding: 1ex;
+        text-decoration: none;
+    }
+
+    .message {
+        text-align: center;
+        margin: auto;
+        border: 1px solid black;
+        max-width: fit-content;
+        padding: 1em;
+    }
+
+    div.logo {
+        text-align: center;
+    }
+</style>
+<body>
+
+<div class="logo">
+    <img src="https://assets-global.website-files.com/600f0cac30d70b8364793d7c/6063c7a4481fbc56adb6db1d_logo_terraformation.svg"
+         alt="Terraformation logo" style="height: 22px;"/>
+</div>
+
+<br/>
+
+<div class="message">
+    <h1>You've been invited to join ${organization.name}!</h1>
+    <p>
+        Please click the button below to go to your Terraware account where you can view and accept
+        the invitation.
+    </p>
+    <p>
+        <a href="${webAppUrl}" class="button">View Invitation</a>
+    </p>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email/invitation/body.txt
+++ b/src/main/resources/templates/email/invitation/body.txt
@@ -1,0 +1,6 @@
+You've been invited to join ${organization.name}!
+
+Please follow the link below to go to your Terraware account
+where you can view and accept your invitation.
+
+${webAppUrl}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -6,6 +6,7 @@ spring:
       - "classpath:db/migration/common"
 
 terraware:
+  web-app-url: "http://dummy/"
   photo-dir: "/dummy-directory"
   keycloak:
     apiClientId: "dummyClientForApiClients"


### PR DESCRIPTION
Add `POST /api/v1/organizations/{id}/invitations` to invite a new user to an
organization.

The invitation email is generated from HTML and plaintext template files.
Currently therse are placeholders to allow us to test the functionality before
the design team is finished creating the real ones.