### PR TITLE
SEED-167 Remove feature flag for Awaiting Check-In

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -65,12 +65,6 @@ class TerrawareServerConfig(
      */
     val allowAdminUiForNonAdmins: Boolean = false,
 
-    /**
-     * If true, put new accessions in the "Awaiting Check-In" state. If false (default), put new
-     * accessions in the "Pending" state.
-     */
-    val enableAwaitingCheckIn: Boolean = false,
-
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -2,8 +2,6 @@ package com.terraformation.backend.seedbank.api
 
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
-import com.terraformation.backend.config.TerrawareServerConfig
-import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.search.SearchFieldPrefix
@@ -28,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @SeedBankAppEndpoint
 class ValuesController(
-    private val config: TerrawareServerConfig,
     namespaces: SearchFieldNamespaces,
     private val storageLocationStore: StorageLocationStore,
     private val searchService: SearchService,
@@ -81,12 +78,7 @@ class ValuesController(
     val values =
         payload.fields.associateWith { fieldName ->
           val searchField = rootPrefix.resolve(fieldName)
-          var values = searchService.fetchAllValues(searchField, limit)
-
-          // TODO: Remove this once front end is updated to know about Awaiting Check-In state
-          if (fieldName == "state" && !config.enableAwaitingCheckIn) {
-            values = values.filter { it != AccessionState.AwaitingCheckIn.displayName }
-          }
+          val values = searchService.fetchAllValues(searchField, limit)
 
           val partial = values.size > limit
           AllFieldValuesPayload(values.take(limit), partial)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -105,7 +105,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             clock,
             StoreSupport(dslContext),
-            config,
         )
 
     tempDir = Files.createTempDirectory(javaClass.simpleName)


### PR DESCRIPTION
The front end code knows about the Awaiting Check-In accession state, so remove
the temporary backward-compatibility setting to disable it on the server side.