### PR TITLE
TRACK-515 Use correct names for accession sublists

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/namespace/AccessionsNamespace.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/namespace/AccessionsNamespace.kt
@@ -33,15 +33,15 @@ class AccessionsNamespace(private val namespaces: SearchFieldNamespaces) : Searc
               ACCESSIONS.ID.eq(ACCESSION_GERMINATION_TEST_TYPES.ACCESSION_ID)),
           bags.asMultiValueSublist("bags", ACCESSIONS.ID.eq(BAGS.ACCESSION_ID)),
           collectors.asSingleValueSublist(
-              "primaryCollectorInfo", ACCESSIONS.PRIMARY_COLLECTOR_ID.eq(COLLECTORS.ID)),
+              "primaryCollector", ACCESSIONS.PRIMARY_COLLECTOR_ID.eq(COLLECTORS.ID)),
           facilities.asSingleValueSublist("facility", ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID)),
           geolocations.asMultiValueSublist(
               "geolocations", ACCESSIONS.ID.eq(GEOLOCATIONS.ACCESSION_ID)),
           germinationTests.asMultiValueSublist(
               "germinationTests", ACCESSIONS.ID.eq(GERMINATION_TESTS.ACCESSION_ID)),
-          species.asSingleValueSublist("speciesInfo", ACCESSIONS.SPECIES_ID.eq(SPECIES.ID)),
+          species.asSingleValueSublist("species", ACCESSIONS.SPECIES_ID.eq(SPECIES.ID)),
           storageLocations.asSingleValueSublist(
-              "storageLocationInfo", ACCESSIONS.STORAGE_LOCATION_ID.eq(STORAGE_LOCATIONS.ID)),
+              "storageLocation", ACCESSIONS.STORAGE_LOCATION_ID.eq(STORAGE_LOCATIONS.ID)),
           withdrawals.asMultiValueSublist(
               "withdrawals", ACCESSIONS.ID.eq(WITHDRAWALS.ACCESSION_ID)),
       )
@@ -95,8 +95,7 @@ class AccessionsNamespace(private val namespaces: SearchFieldNamespaces) : Searc
               "Most recent % viability",
               ACCESSIONS.LATEST_VIABILITY_PERCENT),
           dateField("nurseryStartDate", "Nursery start date", ACCESSIONS.NURSERY_START_DATE),
-          aliasField("primaryCollector", "primaryCollectorInfo_name"),
-          aliasField("primaryCollectorName", "primaryCollectorInfo_name"),
+          aliasField("primaryCollectorName", "primaryCollector_name"),
           enumField("processingMethod", "Processing method", ACCESSIONS.PROCESSING_METHOD_ID),
           textField("processingNotes", "Notes (processing)", ACCESSIONS.PROCESSING_NOTES),
           dateField(
@@ -109,12 +108,10 @@ class AccessionsNamespace(private val namespaces: SearchFieldNamespaces) : Searc
           enumField("remainingUnits", "Remaining (units)", ACCESSIONS.REMAINING_UNITS_ID),
           textField("siteLocation", "Site location", ACCESSIONS.COLLECTION_SITE_NAME),
           enumField("sourcePlantOrigin", "Wild/Outplant", ACCESSIONS.SOURCE_PLANT_ORIGIN_ID),
-          aliasField("species", "speciesInfo_name"),
-          aliasField("speciesName", "speciesInfo_name"),
+          aliasField("speciesName", "species_name"),
           enumField("state", "State", ACCESSIONS.STATE_ID, nullable = false),
           enumField("storageCondition", "Storage condition", ACCESSIONS.TARGET_STORAGE_CONDITION),
-          aliasField("storageLocation", "storageLocationInfo_name"),
-          aliasField("storageLocationName", "storageLocationInfo_name"),
+          aliasField("storageLocationName", "storageLocation_name"),
           textField("storageNotes", "Notes (storage)", ACCESSIONS.STORAGE_NOTES),
           integerField("storagePackets", "Number of storage packets", ACCESSIONS.STORAGE_PACKETS),
           dateField("storageStartDate", "Storing start date", ACCESSIONS.STORAGE_START_DATE),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -99,9 +99,9 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   private val germinationSeedsSownField = rootPrefix.resolve("germinationSeedsSown")
   private val germinationTestTypeField = rootPrefix.resolve("germinationTestType")
   private val receivedDateField = rootPrefix.resolve("receivedDate")
-  private val speciesField = rootPrefix.resolve("species")
+  private val speciesNameField = rootPrefix.resolve("speciesName")
   private val stateField = rootPrefix.resolve("state")
-  private val storageLocationField = rootPrefix.resolve("storageLocation")
+  private val storageLocationNameField = rootPrefix.resolve("storageLocationName")
   private val storageNotesField = rootPrefix.resolve("storageNotes")
   private val targetStorageConditionField = rootPrefix.resolve("targetStorageCondition")
   private val totalGramsField = rootPrefix.resolve("totalGrams")
@@ -197,7 +197,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   fun `finds example rows`() {
     val fields =
         listOf(
-            speciesField,
+            speciesNameField,
             accessionNumberField,
             treesCollectedFromField,
             activeField,
@@ -212,7 +212,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         SearchResults(
             listOf(
                 mapOf(
-                    "species" to "Kousa Dogwood",
+                    "speciesName" to "Kousa Dogwood",
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
                     "treesCollectedFrom" to "1",
@@ -220,7 +220,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                     "checkedInTime" to checkedInTimeString,
                 ),
                 mapOf(
-                    "species" to "Other Dogwood",
+                    "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                     "treesCollectedFrom" to "2",
@@ -340,7 +340,8 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `honors sort order`() {
-    val fields = listOf(speciesField, accessionNumberField, treesCollectedFromField, activeField)
+    val fields =
+        listOf(speciesNameField, accessionNumberField, treesCollectedFromField, activeField)
     val sortOrder = fields.map { SearchSortField(it, SearchDirection.Descending) }
 
     val result =
@@ -351,14 +352,14 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         SearchResults(
             listOf(
                 mapOf(
-                    "species" to "Other Dogwood",
+                    "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                     "treesCollectedFrom" to "2",
                     "active" to "Active",
                 ),
                 mapOf(
-                    "species" to "Kousa Dogwood",
+                    "speciesName" to "Kousa Dogwood",
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
                     "treesCollectedFrom" to "1",
@@ -668,13 +669,14 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can use cursor to get next page of results`() {
-    val fields = listOf(speciesField, accessionNumberField, treesCollectedFromField, activeField)
+    val fields =
+        listOf(speciesNameField, accessionNumberField, treesCollectedFromField, activeField)
     val sortOrder = fields.map { SearchSortField(it) }
 
     val expectedFirstPageResults =
         listOf(
             mapOf(
-                "species" to "Kousa Dogwood",
+                "speciesName" to "Kousa Dogwood",
                 "id" to "1000",
                 "accessionNumber" to "XYZ",
                 "treesCollectedFrom" to "1",
@@ -693,7 +695,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         SearchResults(
             listOf(
                 mapOf(
-                    "species" to "Other Dogwood",
+                    "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                     "treesCollectedFrom" to "2",
@@ -1038,14 +1040,14 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   inner class FetchValuesTest {
     @Test
     fun `no criteria for simple column value`() {
-      val values = searchService.fetchValues(rootPrefix, speciesField, NoConditionNode())
+      val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
       assertEquals(listOf("Kousa Dogwood", "Other Dogwood"), values)
     }
 
     @Test
     fun `renders null values as null, not as a string`() {
       accessionsDao.update(accessionsDao.fetchOneByNumber("XYZ")!!.copy(speciesId = null))
-      val values = searchService.fetchValues(rootPrefix, speciesField, NoConditionNode())
+      val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
       assertEquals(listOf("Other Dogwood", null), values)
     }
 
@@ -1054,7 +1056,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val values =
           searchService.fetchValues(
               rootPrefix,
-              speciesField,
+              speciesNameField,
               FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.Fuzzy))
       assertEquals(listOf("Kousa Dogwood"), values)
     }
@@ -1064,7 +1066,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val values =
           searchService.fetchValues(
               rootPrefix,
-              speciesField,
+              speciesNameField,
               FieldNode(accessionNumberField, listOf("a"), SearchFilterType.Fuzzy))
       assertEquals(listOf("Other Dogwood"), values)
     }
@@ -1074,8 +1076,8 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val values =
           searchService.fetchValues(
               rootPrefix,
-              speciesField,
-              FieldNode(speciesField, listOf("dogwod"), SearchFilterType.Fuzzy))
+              speciesNameField,
+              FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy))
       assertEquals(listOf("Kousa Dogwood", "Other Dogwood"), values)
     }
 
@@ -1085,7 +1087,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           searchService.fetchValues(
               rootPrefix,
               stateField,
-              FieldNode(speciesField, listOf("dogwod"), SearchFilterType.Fuzzy))
+              FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy))
       assertEquals(listOf("Processed", "Processing"), values)
     }
 
@@ -1180,7 +1182,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns values for free-text field on accession table`() {
       val expected = listOf(null, "Kousa Dogwood", "Other Dogwood")
-      val values = searchService.fetchAllValues(speciesField)
+      val values = searchService.fetchAllValues(speciesNameField)
       assertEquals(expected, values)
     }
 
@@ -1207,7 +1209,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
               conditionId = StorageCondition.Freezer))
 
       val expected = listOf(null, "Freezer 1", "Freezer 2", "Refrigerator 1")
-      val values = searchService.fetchAllValues(storageLocationField)
+      val values = searchService.fetchAllValues(storageLocationNameField)
       assertEquals(expected, values)
     }
 
@@ -1233,7 +1235,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
       val expected = listOf(null, "Facility 100 fridge")
 
-      val actual = searchService.fetchAllValues(storageLocationField)
+      val actual = searchService.fetchAllValues(storageLocationNameField)
 
       assertEquals(expected, actual)
     }
@@ -2164,14 +2166,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `can search all the fields`() {
       val prefix = SearchFieldPrefix(namespaces.organizations)
-      val fields =
-          prefix
-              .namespace
-              .getAllFieldNames()
-              .sorted()
-              // Can't query both species and speciesName: https://github.com/jOOQ/jOOQ/issues/12704
-              .filterNot { it.endsWith(".speciesName") }
-              .map { prefix.resolve(it) }
+      val fields = prefix.namespace.getAllFieldNames().sorted().map { prefix.resolve(it) }
 
       // We're querying a mix of nested fields and the old-style fields that put nested values
       // at the top level and return a separate top-level query result for each combination of rows
@@ -2202,7 +2197,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                   "active" to "Active",
                   "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6")),
                   "id" to "1001",
-                  "species" to "Other Dogwood",
+                  "speciesName" to "Other Dogwood",
                   "state" to "Processing",
                   "treesCollectedFrom" to "2",
               ),
@@ -2226,7 +2221,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                               "seedsSown" to "15",
                           )),
                   "id" to "1000",
-                  "species" to "Kousa Dogwood",
+                  "speciesName" to "Kousa Dogwood",
                   "state" to "Processed",
                   "treesCollectedFrom" to "1",
               ))


### PR DESCRIPTION
The front end code has been updated to use alternate fields for species, storage
location, and primary collector names. Rename the sublists for those values to
remove the temporary-hack `Info` suffix, and remove the alias fields that used
to have name collisions.

Specifically:

* Remove the `primaryCollector` field and rename the `primaryCollectorInfo`
  sublist to `primaryCollector`
* Remove the `species` field and rename the `speciesInfo` sublist to `species`
* Remove the `storageLocation` field and rename the `storageLocationInfo`
  sublist to `storageLocation`

The next step in this sequence of changes is to modify the front end to directly
use flattened sublists instead of relying on alias fields, e.g., to start using
`species_name` instead of `speciesName`. Once that's done, we can remove those
alias fields entirely from the back end.