### PR TITLE
Remove old-style filters field from new search endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4762,10 +4762,6 @@ components:
             \ search will be continued from where it left off. This should be the\
             \ value of the cursor that was returned in the response to a previous\
             \ search."
-        filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchFilter'
     SearchResponsePayload:
       required:
       - results

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -127,8 +127,4 @@ data class SearchRequestPayload(
                 "from where it left off. This should be the value of the cursor that was " +
                 "returned in the response to a previous search.")
     val cursor: String? = null,
-) : HasSearchNode, HasSortOrder {
-  // This was for backward compatibility with earlier versions of the accession search API.
-  override val filters: List<SearchFilter>?
-    get() = null
-}
+) : HasSearchNode, HasSortOrder

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -37,11 +37,10 @@ interface HasSortOrder {
 }
 
 interface HasSearchNode {
-  val filters: List<SearchFilter>?
   val search: SearchNodePayload?
 
   fun toSearchNode(prefix: SearchFieldPrefix): SearchNode {
-    val filters = this.filters
+    val filters = if (this is HasSearchFilters) this.filters else null
     val search = this.search
 
     return when {
@@ -50,6 +49,14 @@ interface HasSearchNode {
       else -> AndNode(filters.map { FieldNode(prefix.resolve(it.field), it.values, it.type) })
     }
   }
+}
+
+/**
+ * Backward-compatibility interface for accession search payloads that use a list of search filters
+ * rather than [SearchNodePayload].
+ */
+interface HasSearchFilters {
+  val filters: List<SearchFilter>?
 }
 
 data class SearchSortOrderElement(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionSearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionSearchController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.api.HasSearchFields
+import com.terraformation.backend.search.api.HasSearchFilters
 import com.terraformation.backend.search.api.HasSearchNode
 import com.terraformation.backend.search.api.HasSortOrder
 import com.terraformation.backend.search.api.SearchFilter
@@ -162,7 +163,7 @@ data class SearchAccessionsRequestPayload(
         defaultValue = "10",
     )
     val count: Int = 10
-) : HasSearchFields, HasSearchNode, HasSortOrder
+) : HasSearchFields, HasSearchNode, HasSortOrder, HasSearchFilters
 
 data class ExportAccessionsRequestPayload(
     val facilityId: FacilityId,
@@ -170,4 +171,4 @@ data class ExportAccessionsRequestPayload(
     override val sortOrder: List<SearchSortOrderElement>? = null,
     override val filters: List<SearchFilter>? = null,
     override val search: SearchNodePayload? = null,
-) : HasSearchFields, HasSearchNode, HasSortOrder
+) : HasSearchFields, HasSearchNode, HasSortOrder, HasSearchFilters

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
+import com.terraformation.backend.search.api.HasSearchFilters
 import com.terraformation.backend.search.api.HasSearchNode
 import com.terraformation.backend.search.api.SearchFilter
 import com.terraformation.backend.search.api.SearchNodePayload
@@ -118,7 +119,7 @@ data class ListFieldValuesRequestPayload(
     val fields: List<String>,
     override val filters: List<SearchFilter>?,
     override val search: SearchNodePayload?,
-) : HasSearchNode
+) : HasSearchNode, HasSearchFilters
 
 data class ListFieldValuesResponsePayload(val results: Map<String, FieldValuesPayload>) :
     SuccessResponsePayload


### PR DESCRIPTION
The accession search API payload has a `filters` field that takes a list of search
filters. This has been superseded by the more powerful `search` field that takes
an arbitrary Boolean expression. The old field is still supported for backward
compatibility, but we only need to care about that on the accession search
endpoints; there is no old code that calls the non-accession-specific search
endpoint.