### PR TITLE
TRACK-551 Support CSV export of search results

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1403,7 +1403,7 @@ paths:
     post:
       tags:
       - Search
-      operationId: search
+      operationId: search_1
       requestBody:
         content:
           application/json:
@@ -1455,6 +1455,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SearchResponsePayload'
+            text/csv:
+              schema:
+                type: string
+                format: binary
   /api/v1/seedbank/accession:
     post:
       tags:
@@ -4754,6 +4758,7 @@ components:
           description: Maximum number of top-level search results to return. The system
             may impose a limit on this value. A separate system-imposed limit may
             also be applied to lists of child objects inside the top-level results.
+            Use a value of 0 to return the maximum number of allowed results.
           format: int32
           default: 25
         cursor:

--- a/src/main/kotlin/com/terraformation/backend/api/Csv.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Csv.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.api
+
+import com.opencsv.CSVWriter
+import java.io.ByteArrayOutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+/**
+ * Constructs an HTTP response in CSV format.
+ *
+ * @param filename Filename that will be used by default if the user saves the CSV file. If null,
+ * response will not include a filename.
+ * @param columnNames Contents of the first row of the CSV; this should be a list of the names of
+ * the columns, typically in human-readable form.
+ * @param writeRows Callback function that writes the data rows to the CSV stream. This should call
+ * [CSVWriter.writeNext] for each data row.
+ */
+fun csvResponse(
+    filename: String?,
+    columnNames: List<String>,
+    writeRows: (CSVWriter) -> Unit
+): ResponseEntity<ByteArray> {
+  val byteArrayOutputStream = ByteArrayOutputStream()
+
+  // Write a UTF-8 BOM so Excel won't screw up the character encoding if there are non-ASCII
+  // characters.
+  byteArrayOutputStream.write(239)
+  byteArrayOutputStream.write(187)
+  byteArrayOutputStream.write(191)
+
+  CSVWriter(OutputStreamWriter(byteArrayOutputStream, StandardCharsets.UTF_8)).use { csvWriter ->
+    csvWriter.writeNext(columnNames)
+    writeRows(csvWriter)
+  }
+
+  val value = byteArrayOutputStream.toByteArray()
+  val headers = HttpHeaders()
+  headers.contentLength = value.size.toLong()
+  headers["Content-type"] = "text/csv;charset=UTF-8"
+
+  if (filename != null) {
+    headers.contentDisposition = ContentDisposition.attachment().filename(filename).build()
+  }
+
+  return ResponseEntity(value, headers, HttpStatus.OK)
+}
+
+/**
+ * Writes a row of data to a CSV writer. This is a convenience wrapper that allows the caller to
+ * supply the values as `List<Any?>` rather than `Array<String?>`.
+ */
+fun CSVWriter.writeNext(nextLine: List<Any?>, applyQuotesToAll: Boolean = false) {
+  val stringValues = nextLine.map { it?.toString() }.toTypedArray()
+  writeNext(stringValues, applyQuotesToAll)
+}


### PR DESCRIPTION
Make `/api/v1/search` return a CSV file if the incoming request specifies
`text/csv` in its `Accept` header.

Allow the client to pass a maximum result count of 0 to indicate no limit, since
pagination isn't as useful for CSV downloads as it is for interactive search in
the web UI.

The existing `/api/v1/seedbank/search/export` endpoint continues to work as
before.