### PR TITLE
Reject invalid enum values in request payloads

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -71,6 +71,9 @@ class TerrawareGenerator : KotlinGenerator() {
     // here needs to take the trimIndent() call into account.
     val valuesCodeSnippet = values.joinToString(",\n          ")
 
+    // https://youtrack.jetbrains.com/issue/KT-2425
+    val dollarSign = '$'
+
     out.println(
         """
       enum class $enumName(
@@ -88,6 +91,7 @@ class TerrawareGenerator : KotlinGenerator() {
               @JsonCreator
               @JvmStatic
               fun forDisplayName(name: String) = byDisplayName[name]
+                  ?: throw IllegalArgumentException("Unrecognized value: ${dollarSign}name")
               
               fun forId(id: Int) = byId[id]
           }

--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.api
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.exc.InvalidNullException
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.terraformation.backend.db.DuplicateEntityException
 import com.terraformation.backend.db.EntityNotFoundException
@@ -192,6 +193,7 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
             is MissingKotlinParameterException -> "Required field not present"
             is InvalidNullException -> "Field value cannot be null"
             is InvalidFormatException -> "Field value has incorrect format"
+            is ValueInstantiationException -> "Field value invalid"
             else -> cause.originalMessage ?: "Field value invalid"
           }
 

--- a/src/main/kotlin/com/terraformation/backend/search/field/GramsField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/GramsField.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.seedbank.model.toGrams
 import java.math.BigDecimal
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
@@ -58,9 +58,7 @@ class GramsField(
 
     val units =
         if (unitsName.isEmpty()) SeedQuantityUnits.Grams
-        else
-            SeedQuantityUnits.forDisplayName(unitsName)
-                ?: throw IllegalArgumentException("Unrecognized weight unit in $value")
+        else SeedQuantityUnits.forDisplayName(unitsName)
 
     return units.toGrams(number)
   }


### PR DESCRIPTION
If a request payload includes a field whose type is one of the enum classes we
generate from reference tables, we should only accept strings that match the
display names of the enum's values. But we had a bug: we were treating unknown
values as null.