### PR TITLE
Remove ClientFacingException

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -39,14 +39,6 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
   private val csvMediaType = MediaType("text", "csv", StandardCharsets.UTF_8)
 
   @ExceptionHandler
-  fun handleClientFacingException(
-      ex: ClientFacingException,
-      request: WebRequest
-  ): ResponseEntity<*> {
-    return simpleErrorResponse(ex.message, ex.status, request)
-  }
-
-  @ExceptionHandler
   fun handleDuplicateEntityException(
       ex: DuplicateEntityException,
       request: WebRequest

--- a/src/main/kotlin/com/terraformation/backend/api/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Exceptions.kt
@@ -1,37 +1,15 @@
 package com.terraformation.backend.api
 
-import org.springframework.http.HttpStatus
+import javax.ws.rs.ClientErrorException
+import javax.ws.rs.core.Response
 
-// Controller methods can throw these exceptions to return HTTP error statuses with a consistent
-// set of error messages.
-
-abstract class ClientFacingException(val status: HttpStatus, message: String) :
-    RuntimeException(message) {
-  override val message
-    get() = super.message!!
-}
+// Exceptions for HTTP status codes that aren't covered by the standard set of JAX-RS exceptions.
 
 class DuplicateNameException(message: String = "A resource with that name already exists") :
-    ClientFacingException(HttpStatus.CONFLICT, message)
-
-class InternalErrorException(message: String = "An internal error has occurred") :
-    ClientFacingException(HttpStatus.INTERNAL_SERVER_ERROR, message)
-
-class NoOrganizationException(message: String = "Client is not associated with an organization") :
-    ClientFacingException(HttpStatus.FORBIDDEN, message)
+    ClientErrorException(message, Response.Status.CONFLICT)
 
 class NotAuthenticatedException(message: String = "Client is not authenticated") :
-    ClientFacingException(HttpStatus.UNAUTHORIZED, message)
-
-class NotFoundException(message: String = "Resource not found") :
-    ClientFacingException(HttpStatus.NOT_FOUND, message)
+    ClientErrorException(message, Response.Status.UNAUTHORIZED)
 
 class ResourceInUseException(message: String = "The resource is currently in use") :
-    ClientFacingException(HttpStatus.CONFLICT, message)
-
-class UnsupportedPhotoFormatException(message: String = "Photos must be of type image/jpeg") :
-    ClientFacingException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, message)
-
-class WrongOrganizationException(
-    message: String = "Resource is owned by a different organization"
-) : ClientFacingException(HttpStatus.FORBIDDEN, message)
+    ClientErrorException(message, Response.Status.CONFLICT)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.customer.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.CustomerEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
@@ -21,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import javax.ws.rs.BadRequestException
+import javax.ws.rs.NotFoundException
 import org.apache.commons.validator.routines.EmailValidator
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -3,14 +3,13 @@ package com.terraformation.backend.customer.api
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.CustomerEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectId
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.ProjectStatus
 import com.terraformation.backend.db.ProjectType
 import io.swagger.v3.oas.annotations.Operation
@@ -41,8 +40,7 @@ class ProjectsController(private val projectStore: ProjectStore) {
   @GetMapping("/{id}")
   @Operation(summary = "Gets information about a single project.")
   fun getProject(@PathVariable("id") projectId: ProjectId): GetProjectResponsePayload {
-    val project = projectStore.fetchById(projectId) ?: throw NotFoundException()
-
+    val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
     return GetProjectResponsePayload(ProjectPayload(project))
   }
 
@@ -98,13 +96,9 @@ class OrganizationProjectsController(private val projectStore: ProjectStore) {
   fun listOrganizationProjects(
       @PathVariable organizationId: OrganizationId
   ): ListProjectsResponsePayload {
-    try {
-      val projects = projectStore.fetchByOrganization(organizationId)
+    val projects = projectStore.fetchByOrganization(organizationId)
 
-      return ListProjectsResponsePayload(projects.map { ProjectPayload(it) })
-    } catch (e: OrganizationNotFoundException) {
-      throw NotFoundException()
-    }
+    return ListProjectsResponsePayload(projects.map { ProjectPayload(it) })
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
@@ -3,13 +3,13 @@ package com.terraformation.backend.customer.api
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.CustomerEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.SiteStore
 import com.terraformation.backend.customer.model.SiteModel
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.SiteNotFoundException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -51,7 +51,8 @@ class SiteController(private val siteStore: SiteStore) {
           defaultValue = "4326")
       srid: Int? = null
   ): GetSiteResponsePayload {
-    val site = siteStore.fetchById(siteId, srid ?: SRID.LONG_LAT) ?: throw NotFoundException()
+    val site =
+        siteStore.fetchById(siteId, srid ?: SRID.LONG_LAT) ?: throw SiteNotFoundException(siteId)
 
     return GetSiteResponsePayload(SiteElement(site))
   }

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.pojos.DevicesRow
 import com.terraformation.backend.device.db.DeviceStore
@@ -53,7 +53,7 @@ class DeviceController(
   @GetMapping("/api/v1/devices/{id}")
   @Operation(summary = "Gets the configuration of a single device.")
   fun getDevice(@PathVariable("id") deviceId: DeviceId): GetDeviceResponsePayload {
-    val devicesRow = deviceStore.fetchOneById(deviceId) ?: throw NotFoundException()
+    val devicesRow = deviceStore.fetchOneById(deviceId) ?: throw DeviceNotFoundException(deviceId)
     return GetDeviceResponsePayload(DeviceConfig(devicesRow, objectMapper))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/LayerController.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.gis.api
 
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.GISAppEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.LayerId
 import com.terraformation.backend.db.LayerNotFoundException
@@ -12,6 +11,7 @@ import com.terraformation.backend.gis.db.LayerStore
 import com.terraformation.backend.gis.model.LayerModel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import javax.ws.rs.NotFoundException
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -41,10 +41,7 @@ class LayerController(private val layerStore: LayerStore) {
   @ApiResponse404(description = "The specified layer doesn't exist.")
   @GetMapping("/{layerId}")
   fun read(@PathVariable layerId: LayerId): GetLayerResponsePayload {
-    val layerModel =
-        layerStore.fetchLayer(layerId)
-            ?: throw NotFoundException("The layer with id $layerId doesn't exist.")
-
+    val layerModel = layerStore.fetchLayer(layerId) ?: throw LayerNotFoundException(layerId)
     return GetLayerResponsePayload(LayerResponse(layerModel))
   }
 
@@ -79,12 +76,8 @@ class LayerController(private val layerStore: LayerStore) {
   @ApiResponse404(description = "The specified layer doesn't exist.")
   @DeleteMapping("/{layerId}")
   fun delete(@PathVariable layerId: LayerId): DeleteLayerResponsePayload {
-    try {
-      val layerModel = layerStore.deleteLayer(layerId)
-      return DeleteLayerResponsePayload(DeleteLayerResponse(layerModel))
-    } catch (e: LayerNotFoundException) {
-      throw NotFoundException("The layer with id $layerId doesn't exist.")
-    }
+    val layerModel = layerStore.deleteLayer(layerId)
+    return DeleteLayerResponsePayload(DeleteLayerResponse(layerModel))
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantController.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.gis.api
 
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.GISAppEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.FeatureId
 import com.terraformation.backend.db.FeatureNotFoundException
@@ -16,6 +15,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
 import java.time.LocalDate
+import javax.ws.rs.NotFoundException
 import javax.ws.rs.QueryParam
 import net.postgis.jdbc.geometry.Geometry
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/PlantObservationsController.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.gis.api
 
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.GISAppEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.FeatureId
 import com.terraformation.backend.db.HealthState
@@ -46,8 +45,7 @@ class PlantObservationsController(private val observStore: PlantObservationsStor
   fun get(@PathVariable plantObservationId: PlantObservationId): GetObservationResponsePayload {
     val observation =
         observStore.fetch(plantObservationId)
-            ?: throw NotFoundException(
-                "The plant observation with id $plantObservationId doesn't exist.")
+            ?: throw PlantObservationNotFoundException(plantObservationId)
     return GetObservationResponsePayload(ObservationResponse(observation))
   }
 
@@ -71,12 +69,8 @@ class PlantObservationsController(private val observStore: PlantObservationsStor
       @RequestBody payload: UpdateObservationRequestPayload,
       @PathVariable plantObservationId: PlantObservationId
   ): UpdateObservationResponsePayload {
-    try {
-      val updated = observStore.update(payload.toRow(plantObservationId))
-      return UpdateObservationResponsePayload(ObservationResponse(updated))
-    } catch (e: PlantObservationNotFoundException) {
-      throw NotFoundException("The plant observation with id $plantObservationId doesn't exist.")
-    }
+    val updated = observStore.update(payload.toRow(plantObservationId))
+    return UpdateObservationResponsePayload(ObservationResponse(updated))
   }
 
   // To delete a plant observation, the caller must delete the entire feature

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.terraformation.backend.api.ApiResponse404
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.model.AppDeviceModel
@@ -88,17 +87,13 @@ class AccessionController(private val accessionStore: AccessionStore, private va
                   "have been returned if it had been saved.")
       simulate: Boolean?
   ): UpdateAccessionResponsePayload {
-    try {
-      val updatedModel =
-          if (simulate == true) {
-            accessionStore.dryRun(payload.toModel(accessionId))
-          } else {
-            accessionStore.updateAndFetch(payload.toModel(accessionId))
-          }
-      return UpdateAccessionResponsePayload(AccessionPayload(updatedModel, clock))
-    } catch (e: AccessionNotFoundException) {
-      throw NotFoundException()
-    }
+    val updatedModel =
+        if (simulate == true) {
+          accessionStore.dryRun(payload.toModel(accessionId))
+        } else {
+          accessionStore.updateAndFetch(payload.toModel(accessionId))
+        }
+    return UpdateAccessionResponsePayload(AccessionPayload(updatedModel, clock))
   }
 
   @ApiResponse(responseCode = "200")
@@ -107,8 +102,7 @@ class AccessionController(private val accessionStore: AccessionStore, private va
   @Operation(summary = "Retrieve an existing accession.")
   fun read(@PathVariable("id") accessionId: AccessionId): GetAccessionResponsePayload {
     val accession =
-        accessionStore.fetchById(accessionId)
-            ?: throw NotFoundException("The specified accession doesn't exist.")
+        accessionStore.fetchById(accessionId) ?: throw AccessionNotFoundException(accessionId)
     return GetAccessionResponsePayload(AccessionPayload(accession, clock))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/NotificationController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/NotificationController.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.api
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -18,6 +17,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
+import javax.ws.rs.NotFoundException
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.DuplicateNameException
 import com.terraformation.backend.api.GISAppEndpoint
-import com.terraformation.backend.api.NotFoundException
 import com.terraformation.backend.api.ResourceInUseException
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -12,7 +11,6 @@ import com.terraformation.backend.db.PlantForm
 import com.terraformation.backend.db.RareType
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.SpeciesNameId
-import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.tables.daos.SpeciesDao
 import com.terraformation.backend.db.tables.daos.SpeciesNamesDao
 import com.terraformation.backend.db.tables.pojos.SpeciesNamesRow
@@ -24,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import javax.ws.rs.NotFoundException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -142,8 +141,6 @@ class SpeciesController(
       return SpeciesNameCreateResponsePayload(speciesNameId)
     } catch (e: DataIntegrityViolationException) {
       throw DuplicateNameException("The species already has the requested name.")
-    } catch (e: SpeciesNotFoundException) {
-      throw NotFoundException("The species does not exist.")
     }
   }
 
@@ -151,12 +148,8 @@ class SpeciesController(
   @ApiResponse404("The species does not exist.")
   @GetMapping("/{speciesId}/names")
   fun speciesNamesList(@PathVariable speciesId: SpeciesId): SpeciesNamesListResponsePayload {
-    try {
-      val names = speciesStore.listAllSpeciesNames(speciesId)
-      return SpeciesNamesListResponsePayload(names.map { SpeciesNamesResponseElement(it) })
-    } catch (e: SpeciesNotFoundException) {
-      throw NotFoundException("The species does not exist.")
-    }
+    val names = speciesStore.listAllSpeciesNames(speciesId)
+    return SpeciesNamesListResponsePayload(names.map { SpeciesNamesResponseElement(it) })
   }
 
   @ApiResponse(responseCode = "200", description = "Species name retrieved.")


### PR DESCRIPTION
Our controller exception handling code has support for turning our internal
`EntityNotFoundException` classes into HTTP 404 responses, and for translating
standard JAX-RS exceptions into Spring exceptions.

We thus don't need `ClientFacingException` or most of its subclasses.