### PR TITLE
TRACK-523 Add endpoint to update user's organization info

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1281,6 +1281,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetOrganizationUserResponsePayload'
+    put:
+      tags:
+      - Customer
+      summary: Updates the user's organization information.
+      description: "Only includes organization-level information that can be modified\
+        \ by organization administrators. Use /api/v1/projects/{projectId}/users/{userId}\
+        \ to change the user's projects."
+      operationId: updateOrganizationUser
+      parameters:
+      - name: organizationId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateOrganizationUserRequestPayload'
+        required: true
+      responses:
+        "200":
+          description: The requested operation succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleSuccessResponsePayload'
+        "404":
+          description: The user is not a member of the organization.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponsePayload'
     delete:
       tags:
       - Customer
@@ -5708,6 +5748,18 @@ components:
           type: string
         name:
           type: string
+    UpdateOrganizationUserRequestPayload:
+      required:
+      - role
+      type: object
+      properties:
+        role:
+          type: string
+          enum:
+          - Contributor
+          - Manager
+          - Admin
+          - Owner
     UpdatePlantRequestPayload:
       type: object
       properties:

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -377,15 +377,14 @@ class AdminController(
     }
 
     try {
-      if (organizationStore.setUserRole(organizationId, userId, role)) {
-        redirectAttributes.addFlashAttribute("successMessage", "User role updated.")
-      } else {
-        redirectAttributes.addFlashAttribute(
-            "failureMessage", "User was not a member of the organization.")
-      }
+      organizationStore.setUserRole(organizationId, userId, role)
+      redirectAttributes.addFlashAttribute("successMessage", "User role updated.")
     } catch (e: AccessDeniedException) {
       redirectAttributes.addFlashAttribute(
           "failureMessage", "No permission to set user roles for this organization.")
+    } catch (e: UserNotFoundException) {
+      redirectAttributes.addFlashAttribute(
+          "failureMessage", "User was not a member of the organization.")
     }
 
     return organization(organizationId)


### PR DESCRIPTION
Allow admins to update the organization-level settings for users. Currently, the
only setting is the user's role, but the endpoint can be extended to cover other
information in the future if needed.