### PR TITLE
Rename species payload classes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2085,19 +2085,19 @@ paths:
       tags:
       - GISApp
       summary: Lists all known species.
-      operationId: speciesList
+      operationId: listSpecies
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesListResponsePayload'
+                $ref: '#/components/schemas/ListSpeciesResponsePayload'
     post:
       tags:
       - GISApp
       summary: Creates a new species.
-      operationId: speciesCreate
+      operationId: createSpecies
       requestBody:
         content:
           application/json:
@@ -2110,31 +2110,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesCreateResponsePayload'
+                $ref: '#/components/schemas/CreateSpeciesResponsePayload'
         "409":
           description: A species with the requested name already exists.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesCreateResponsePayload'
+                $ref: '#/components/schemas/CreateSpeciesResponsePayload'
   /api/v1/species/names:
     get:
       tags:
       - GISApp
       summary: Lists all species names.
-      operationId: speciesNamesListAll
+      operationId: listAllSpeciesNames
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesNamesListResponsePayload'
+                $ref: '#/components/schemas/ListSpeciesNamesResponsePayload'
     post:
       tags:
       - GISApp
       summary: Adds a new name for an existing species.
-      operationId: speciesNameCreate
+      operationId: createSpeciesName
       requestBody:
         content:
           application/json:
@@ -2147,7 +2147,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesNameCreateResponsePayload'
+                $ref: '#/components/schemas/CreateSpeciesNameResponsePayload'
         "404":
           description: The species does not exist.
           content:
@@ -2159,13 +2159,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesNameCreateResponsePayload'
+                $ref: '#/components/schemas/CreateSpeciesNameResponsePayload'
   /api/v1/species/names/{speciesNameId}:
     get:
       tags:
       - GISApp
       description: Gets information about a single species name.
-      operationId: speciesNameGet
+      operationId: getSpeciesName
       parameters:
       - name: speciesNameId
         in: path
@@ -2179,7 +2179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesNameGetResponsePayload'
+                $ref: '#/components/schemas/GetSpeciesNameResponsePayload'
         "404":
           description: The requested resource was not found.
           content:
@@ -2190,7 +2190,7 @@ paths:
       tags:
       - GISApp
       description: Updates one of the names of a species.
-      operationId: speciesNameUpdate
+      operationId: updateSpeciesName
       parameters:
       - name: speciesNameId
         in: path
@@ -2215,7 +2215,7 @@ paths:
       tags:
       - GISApp
       description: Deletes one of the secondary names of a species.
-      operationId: speciesNameDelete
+      operationId: deleteSpeciesName
       parameters:
       - name: speciesNameId
         in: path
@@ -2247,7 +2247,7 @@ paths:
       tags:
       - GISApp
       summary: Gets information about a single species.
-      operationId: speciesRead
+      operationId: getSpecies
       parameters:
       - name: speciesId
         in: path
@@ -2261,7 +2261,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesGetResponsePayload'
+                $ref: '#/components/schemas/GetSpeciesResponsePayload'
         "404":
           description: The requested resource was not found.
           content:
@@ -2272,7 +2272,7 @@ paths:
       tags:
       - GISApp
       summary: Updates an existing species.
-      operationId: speciesUpdate
+      operationId: updateSpecies
       parameters:
       - name: speciesId
         in: path
@@ -2303,7 +2303,7 @@ paths:
       tags:
       - GISApp
       summary: Delete an existing species.
-      operationId: speciesDelete
+      operationId: deleteSpecies
       parameters:
       - name: speciesId
         in: path
@@ -2334,7 +2334,7 @@ paths:
     get:
       tags:
       - GISApp
-      operationId: speciesNamesList
+      operationId: listSpeciesNames
       parameters:
       - name: speciesId
         in: path
@@ -2348,7 +2348,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SpeciesNamesListResponsePayload'
+                $ref: '#/components/schemas/ListSpeciesNamesResponsePayload'
         "404":
           description: The species does not exist.
           content:
@@ -3161,6 +3161,28 @@ components:
             - Agroforestry
             - Silvopasture
             - Sustainable Timber
+    CreateSpeciesNameResponsePayload:
+      required:
+      - id
+      - status
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
+    CreateSpeciesResponsePayload:
+      required:
+      - id
+      - status
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
     CreateTimeseriesEntry:
       required:
       - deviceId
@@ -3783,6 +3805,26 @@ components:
           $ref: '#/components/schemas/SiteElement'
         status:
           $ref: '#/components/schemas/SuccessOrError'
+    GetSpeciesNameResponsePayload:
+      required:
+      - speciesName
+      - status
+      type: object
+      properties:
+        speciesName:
+          $ref: '#/components/schemas/SpeciesNamesResponseElement'
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
+    GetSpeciesResponsePayload:
+      required:
+      - species
+      - status
+      type: object
+      properties:
+        species:
+          $ref: '#/components/schemas/SpeciesResponseElement'
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
     GetUserResponsePayload:
       required:
       - status
@@ -4163,6 +4205,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SiteElement'
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
+    ListSpeciesNamesResponsePayload:
+      required:
+      - speciesNames
+      - status
+      type: object
+      properties:
+        speciesNames:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpeciesNamesResponseElement'
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
+    ListSpeciesResponsePayload:
+      required:
+      - species
+      - status
+      type: object
+      properties:
+        species:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpeciesResponseElement'
         status:
           $ref: '#/components/schemas/SuccessOrError'
     ModifyAutomationRequestPayload:
@@ -4877,60 +4943,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FacilityPayload'
-    SpeciesCreateResponsePayload:
-      required:
-      - id
-      - status
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
-    SpeciesGetResponsePayload:
-      required:
-      - species
-      - status
-      type: object
-      properties:
-        species:
-          $ref: '#/components/schemas/SpeciesResponseElement'
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
-    SpeciesListResponsePayload:
-      required:
-      - species
-      - status
-      type: object
-      properties:
-        species:
-          type: array
-          items:
-            $ref: '#/components/schemas/SpeciesResponseElement'
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
-    SpeciesNameCreateResponsePayload:
-      required:
-      - id
-      - status
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
-    SpeciesNameGetResponsePayload:
-      required:
-      - speciesName
-      - status
-      type: object
-      properties:
-        speciesName:
-          $ref: '#/components/schemas/SpeciesNamesResponseElement'
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
     SpeciesNameRequestPayload:
       required:
       - name
@@ -4947,18 +4959,6 @@ components:
         speciesId:
           type: integer
           format: int64
-    SpeciesNamesListResponsePayload:
-      required:
-      - speciesNames
-      - status
-      type: object
-      properties:
-        speciesNames:
-          type: array
-          items:
-            $ref: '#/components/schemas/SpeciesNamesResponseElement'
-        status:
-          $ref: '#/components/schemas/SuccessOrError'
     SpeciesNamesResponseElement:
       required:
       - id

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -58,9 +58,9 @@ class SpeciesController(
 ) {
   @GetMapping
   @Operation(summary = "Lists all known species.")
-  fun speciesList(): SpeciesListResponsePayload {
+  fun listSpecies(): ListSpeciesResponsePayload {
     val species = speciesDao.findAll()
-    return SpeciesListResponsePayload(species.map { SpeciesResponseElement(it) })
+    return ListSpeciesResponsePayload(species.map { SpeciesResponseElement(it) })
   }
 
   @ApiResponses(
@@ -69,10 +69,10 @@ class SpeciesController(
           responseCode = "409", description = "A species with the requested name already exists."))
   @Operation(summary = "Creates a new species.")
   @PostMapping
-  fun speciesCreate(@RequestBody payload: SpeciesRequestPayload): SpeciesCreateResponsePayload {
+  fun createSpecies(@RequestBody payload: SpeciesRequestPayload): CreateSpeciesResponsePayload {
     try {
       val speciesId = speciesStore.createSpecies(payload.toRow())
-      return SpeciesCreateResponsePayload(speciesId)
+      return CreateSpeciesResponsePayload(speciesId)
     } catch (e: DuplicateKeyException) {
       throw DuplicateNameException("A species with that name already exists.")
     }
@@ -82,11 +82,11 @@ class SpeciesController(
   @ApiResponse404
   @GetMapping("/{speciesId}")
   @Operation(summary = "Gets information about a single species.")
-  fun speciesRead(@PathVariable speciesId: SpeciesId): SpeciesGetResponsePayload {
+  fun getSpecies(@PathVariable speciesId: SpeciesId): GetSpeciesResponsePayload {
     val row =
         speciesDao.fetchOneById(speciesId)
             ?: throw NotFoundException("Species $speciesId not found.")
-    return SpeciesGetResponsePayload(SpeciesResponseElement(row))
+    return GetSpeciesResponsePayload(SpeciesResponseElement(row))
   }
 
   @ApiResponse(
@@ -94,7 +94,7 @@ class SpeciesController(
   @ApiResponse404
   @Operation(summary = "Updates an existing species.")
   @PutMapping("/{speciesId}")
-  fun speciesUpdate(
+  fun updateSpecies(
       @PathVariable speciesId: SpeciesId,
       @RequestBody payload: SpeciesRequestPayload
   ): SimpleSuccessResponsePayload {
@@ -110,7 +110,7 @@ class SpeciesController(
   @ApiResponse404
   @DeleteMapping("/{speciesId}")
   @Operation(summary = "Delete an existing species.")
-  fun speciesDelete(@PathVariable speciesId: SpeciesId): SimpleSuccessResponsePayload {
+  fun deleteSpecies(@PathVariable speciesId: SpeciesId): SimpleSuccessResponsePayload {
     try {
       speciesStore.deleteSpecies(speciesId)
       return SimpleSuccessResponsePayload()
@@ -121,9 +121,9 @@ class SpeciesController(
 
   @GetMapping("/names")
   @Operation(summary = "Lists all species names.")
-  fun speciesNamesListAll(): SpeciesNamesListResponsePayload {
+  fun listAllSpeciesNames(): ListSpeciesNamesResponsePayload {
     val names = speciesNamesDao.findAll()
-    return SpeciesNamesListResponsePayload(names.map { SpeciesNamesResponseElement(it) })
+    return ListSpeciesNamesResponsePayload(names.map { SpeciesNamesResponseElement(it) })
   }
 
   @ApiResponses(
@@ -133,12 +133,12 @@ class SpeciesController(
   @ApiResponse404("The species does not exist.")
   @Operation(summary = "Adds a new name for an existing species.")
   @PostMapping("/names")
-  fun speciesNameCreate(
+  fun createSpeciesName(
       @RequestBody payload: SpeciesNameRequestPayload
-  ): SpeciesNameCreateResponsePayload {
+  ): CreateSpeciesNameResponsePayload {
     try {
       val speciesNameId = speciesStore.createSpeciesName(payload.toRow())
-      return SpeciesNameCreateResponsePayload(speciesNameId)
+      return CreateSpeciesNameResponsePayload(speciesNameId)
     } catch (e: DataIntegrityViolationException) {
       throw DuplicateNameException("The species already has the requested name.")
     }
@@ -147,20 +147,20 @@ class SpeciesController(
   @ApiResponse(responseCode = "200", description = "Species names retrieved.")
   @ApiResponse404("The species does not exist.")
   @GetMapping("/{speciesId}/names")
-  fun speciesNamesList(@PathVariable speciesId: SpeciesId): SpeciesNamesListResponsePayload {
+  fun listSpeciesNames(@PathVariable speciesId: SpeciesId): ListSpeciesNamesResponsePayload {
     val names = speciesStore.listAllSpeciesNames(speciesId)
-    return SpeciesNamesListResponsePayload(names.map { SpeciesNamesResponseElement(it) })
+    return ListSpeciesNamesResponsePayload(names.map { SpeciesNamesResponseElement(it) })
   }
 
   @ApiResponse(responseCode = "200", description = "Species name retrieved.")
   @ApiResponse404
   @GetMapping("/names/{speciesNameId}")
   @Operation(description = "Gets information about a single species name.")
-  fun speciesNameGet(@PathVariable speciesNameId: SpeciesNameId): SpeciesNameGetResponsePayload {
+  fun getSpeciesName(@PathVariable speciesNameId: SpeciesNameId): GetSpeciesNameResponsePayload {
     val row =
         speciesNamesDao.fetchOneById(speciesNameId)
             ?: throw NotFoundException("Species name not found")
-    return SpeciesNameGetResponsePayload(SpeciesNamesResponseElement(row))
+    return GetSpeciesNameResponsePayload(SpeciesNamesResponseElement(row))
   }
 
   @ApiResponses(
@@ -170,14 +170,14 @@ class SpeciesController(
   @ApiResponse404
   @DeleteMapping("/names/{speciesNameId}")
   @Operation(description = "Deletes one of the secondary names of a species.")
-  fun speciesNameDelete(@PathVariable speciesNameId: SpeciesNameId): SimpleSuccessResponsePayload {
+  fun deleteSpeciesName(@PathVariable speciesNameId: SpeciesNameId): SimpleSuccessResponsePayload {
     speciesStore.deleteSpeciesName(speciesNameId)
     return SimpleSuccessResponsePayload()
   }
 
   @Operation(description = "Updates one of the names of a species.")
   @PutMapping("/names/{speciesNameId}")
-  fun speciesNameUpdate(
+  fun updateSpeciesName(
       @PathVariable speciesNameId: SpeciesNameId,
       @RequestBody payload: SpeciesNameRequestPayload
   ): SimpleSuccessResponsePayload {
@@ -270,17 +270,17 @@ data class SpeciesNameRequestPayload(
           speciesId = speciesId, name = name, isScientific = isScientific == true, locale = locale)
 }
 
-data class SpeciesCreateResponsePayload(val id: SpeciesId) : SuccessResponsePayload
+data class CreateSpeciesResponsePayload(val id: SpeciesId) : SuccessResponsePayload
 
-data class SpeciesNameCreateResponsePayload(val id: SpeciesNameId) : SuccessResponsePayload
+data class CreateSpeciesNameResponsePayload(val id: SpeciesNameId) : SuccessResponsePayload
 
-data class SpeciesGetResponsePayload(val species: SpeciesResponseElement) : SuccessResponsePayload
+data class GetSpeciesResponsePayload(val species: SpeciesResponseElement) : SuccessResponsePayload
 
-data class SpeciesNameGetResponsePayload(val speciesName: SpeciesNamesResponseElement) :
+data class GetSpeciesNameResponsePayload(val speciesName: SpeciesNamesResponseElement) :
     SuccessResponsePayload
 
-data class SpeciesListResponsePayload(val species: List<SpeciesResponseElement>) :
+data class ListSpeciesResponsePayload(val species: List<SpeciesResponseElement>) :
     SuccessResponsePayload
 
-data class SpeciesNamesListResponsePayload(val speciesNames: List<SpeciesNamesResponseElement>) :
+data class ListSpeciesNamesResponsePayload(val speciesNames: List<SpeciesNamesResponseElement>) :
     SuccessResponsePayload


### PR DESCRIPTION
Commit 58fad7bb removed the accession-specific species API endpoints and their
associated payload classes. Now we can rename the remaining payload classes to
follow our usual naming convention.