### PR TITLE
Distinguish optional vs. mandatory to-one relationships

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchFieldPath.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFieldPath.kt
@@ -46,6 +46,15 @@ data class SearchFieldPrefix(
       return sublists.isNotEmpty() && sublists.first().isFlattened
     }
 
+  /**
+   * True if the sublist represented by this prefix is guaranteed to have at least one value if the
+   * root has a value. For example, if the root namespace is `sites`, then a prefix with a prefix of
+   * `project` and `organization` is required because every site must have a project and every
+   * project must have an organization.
+   */
+  val isRequired: Boolean
+    get() = isRoot || sublists.all { it.isRequired }
+
   /** Which sublist this prefix refers to, or null if this is a root prefix. */
   val sublistField: SublistField?
     get() = sublists.lastOrNull()
@@ -157,7 +166,7 @@ data class SearchFieldPrefix(
  * structure would be `[{"file":"contents"}]`. This is very significant to the client because it
  * controls how results are grouped together when there are multiple values for a particular field.
  */
-class SearchFieldPath(private val prefix: SearchFieldPrefix, val searchField: SearchField) {
+class SearchFieldPath(val prefix: SearchFieldPrefix, val searchField: SearchField) {
   val sublists: List<SublistField>
     get() = prefix.sublists
 

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -156,11 +156,16 @@ abstract class SearchTable(val fuzzySearchOperators: FuzzySearchOperators) {
    * another table and this one. For example, `site` is a single-value sublist of `facilities`
    * because each facility is only associated with one site.
    */
-  fun asSingleValueSublist(name: String, conditionForMultiset: Condition): SublistField {
+  fun asSingleValueSublist(
+      name: String,
+      conditionForMultiset: Condition,
+      isRequired: Boolean = true
+  ): SublistField {
     return SublistField(
         name = name,
         searchTable = this,
         isMultiValue = false,
+        isRequired = isRequired,
         conditionForMultiset = conditionForMultiset)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/SublistField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SublistField.kt
@@ -56,6 +56,13 @@ data class SublistField(
      * See [NestedQueryBuilder] for examples of how flattened sublists work.
      */
     val isFlattened: Boolean = false,
+
+    /**
+     * If true, this sublist always contains a value. For example, this is true for a single-value
+     * sublist that represents a parent-child relationship from the child's point of view. It is
+     * used to determine whether fields are nullable.
+     */
+    val isRequired: Boolean = false,
 ) {
   val delimiter: Char
     get() = if (isFlattened) FLATTENED_SUBLIST_DELIMITER else NESTED_SUBLIST_DELIMITER

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -42,15 +42,20 @@ class AccessionsTable(
               ACCESSIONS.ID.eq(ACCESSION_GERMINATION_TEST_TYPES.ACCESSION_ID)),
           bags.asMultiValueSublist("bags", ACCESSIONS.ID.eq(BAGS.ACCESSION_ID)),
           collectors.asSingleValueSublist(
-              "primaryCollector", ACCESSIONS.PRIMARY_COLLECTOR_ID.eq(COLLECTORS.ID)),
+              "primaryCollector",
+              ACCESSIONS.PRIMARY_COLLECTOR_ID.eq(COLLECTORS.ID),
+              isRequired = false),
           facilities.asSingleValueSublist("facility", ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID)),
           geolocations.asMultiValueSublist(
               "geolocations", ACCESSIONS.ID.eq(GEOLOCATIONS.ACCESSION_ID)),
           germinationTests.asMultiValueSublist(
               "germinationTests", ACCESSIONS.ID.eq(GERMINATION_TESTS.ACCESSION_ID)),
-          species.asSingleValueSublist("species", ACCESSIONS.SPECIES_ID.eq(SPECIES.ID)),
+          species.asSingleValueSublist(
+              "species", ACCESSIONS.SPECIES_ID.eq(SPECIES.ID), isRequired = false),
           storageLocations.asSingleValueSublist(
-              "storageLocation", ACCESSIONS.STORAGE_LOCATION_ID.eq(STORAGE_LOCATIONS.ID)),
+              "storageLocation",
+              ACCESSIONS.STORAGE_LOCATION_ID.eq(STORAGE_LOCATIONS.ID),
+              isRequired = false),
           withdrawals.asMultiValueSublist(
               "withdrawals", ACCESSIONS.ID.eq(WITHDRAWALS.ACCESSION_ID)),
       )

--- a/src/main/kotlin/com/terraformation/backend/search/table/FeaturesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FeaturesTable.kt
@@ -21,7 +21,8 @@ class FeaturesTable(private val tables: SearchTables, fuzzySearchOperators: Fuzz
     with(tables) {
       listOf(
           layers.asSingleValueSublist("layer", FEATURES.LAYER_ID.eq(LAYERS.ID)),
-          plants.asSingleValueSublist("plant", FEATURES.ID.eq(PLANTS.FEATURE_ID)),
+          plants.asSingleValueSublist(
+              "plant", FEATURES.ID.eq(PLANTS.FEATURE_ID), isRequired = false),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -22,10 +22,12 @@ class OrganizationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearch
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          countries.asSingleValueSublist("country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
+          countries.asSingleValueSublist(
+              "country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE), isRequired = false),
           countrySubdivisions.asSingleValueSublist(
               "countrySubdivision",
-              ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE)),
+              ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE),
+              isRequired = false),
           projects.asMultiValueSublist("projects", ORGANIZATIONS.ID.eq(PROJECTS.ORGANIZATION_ID)),
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantsTable.kt
@@ -21,7 +21,8 @@ class PlantsTable(private val tables: SearchTables, fuzzySearchOperators: FuzzyS
     with(tables) {
       listOf(
           features.asSingleValueSublist("feature", PLANTS.FEATURE_ID.eq(FEATURES.ID)),
-          species.asSingleValueSublist("species", PLANTS.SPECIES_ID.eq(SPECIES.ID)),
+          species.asSingleValueSublist(
+              "species", PLANTS.SPECIES_ID.eq(SPECIES.ID), isRequired = false),
       )
     }
   }


### PR DESCRIPTION
Keep track of which single-value sublists represent relationships where there
will always be a value. This will be used to determine whether or not a given
search field is nullable.