### PR TITLE
Use consistent Postgres Docker image for build and test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,9 @@ keycloakVersion=15.0.2
 kotlinVersion=1.6.10
 postgresJdbcVersion=42.3.1
 springDocVersion=1.6.1
+
+# For code generation, we run database migrations against an ephemeral database in a Docker
+# container using this image. If you change this, make sure you also change DatabaseTest.kt.
+
+postgresDockerRepository=postgis/postgis
+postgresDockerTag=12-3.1

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -407,7 +407,9 @@ abstract class DatabaseTest {
   @Suppress("UPPER_BOUND_VIOLATED_WARNING")
   companion object {
     private val imageName: DockerImageName =
-        DockerImageName.parse("postgis/postgis:12-3.1").asCompatibleSubstituteFor("postgres")
+        DockerImageName.parse("$POSTGRES_DOCKER_REPOSITORY:$POSTGRES_DOCKER_TAG")
+            .asCompatibleSubstituteFor("postgres")
+
     val postgresContainer: PostgreSQLContainer<*> =
         PostgreSQLContainer<PostgreSQLContainer<*>>(imageName)
             .withDatabaseName("terraware")


### PR DESCRIPTION
We configured the Docker image that gets used for code generation separately
from the one that gets used for running database tests, but we want the two
to always match. Move the image settings to Gradle properties and write them to
a generated source file so they're used verbatim by tests.

This also allows you to use a different image locally by overriding the
properties on the command line or in `$HOME/.gradle/gradle.properties`.