### PR TITLE
TRACK-588 Make organization ID mandatory on species endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2320,12 +2320,12 @@ paths:
     get:
       tags:
       - GISApp
-      summary: Lists all known species.
+      summary: Lists all the species available in an organization.
       operationId: listSpecies
       parameters:
       - name: organizationId
         in: query
-        required: false
+        required: true
         schema:
           type: integer
           description: Organization whose species should be listed. (Currently ignored.)
@@ -2370,7 +2370,7 @@ paths:
       parameters:
       - name: organizationId
         in: query
-        required: false
+        required: true
         schema:
           type: integer
           description: Organization whose species names should be listed. (Currently
@@ -2510,7 +2510,7 @@ paths:
           format: int64
       - name: organizationId
         in: query
-        required: false
+        required: true
         schema:
           type: integer
           description: Gets information about how the species is listed at this organization.
@@ -2574,7 +2574,7 @@ paths:
           format: int64
       - name: organizationId
         in: query
-        required: false
+        required: true
         schema:
           type: integer
           description: Organization from which the species should be deleted. (Currently
@@ -2613,7 +2613,7 @@ paths:
           format: int64
       - name: organizationId
         in: query
-        required: false
+        required: true
         schema:
           type: integer
           description: Organization whose names for the species should be listed.
@@ -5346,6 +5346,7 @@ components:
     SpeciesNameRequestPayload:
       required:
       - name
+      - organizationId
       - speciesId
       type: object
       properties:
@@ -5385,6 +5386,7 @@ components:
     SpeciesRequestPayload:
       required:
       - name
+      - organizationId
       type: object
       properties:
         conservationStatus:

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -59,11 +59,11 @@ class SpeciesController(
     private val speciesStore: SpeciesStore,
 ) {
   @GetMapping
-  @Operation(summary = "Lists all known species.")
+  @Operation(summary = "Lists all the species available in an organization.")
   fun listSpecies(
-      @RequestParam("organizationId")
+      @RequestParam("organizationId", required = true)
       @Schema(description = "Organization whose species should be listed. (Currently ignored.)")
-      organizationId: OrganizationId? = null
+      organizationId: OrganizationId
   ): ListSpeciesResponsePayload {
     val species = speciesDao.findAll()
     return ListSpeciesResponsePayload(species.map { SpeciesResponseElement(it) })
@@ -90,12 +90,12 @@ class SpeciesController(
   @Operation(summary = "Gets information about a single species.")
   fun getSpecies(
       @PathVariable speciesId: SpeciesId,
-      @RequestParam("organizationId")
+      @RequestParam("organizationId", required = true)
       @Schema(
           description =
               "Gets information about how the species is listed at this organization. " +
                   "(Currently ignored.)")
-      organizationId: OrganizationId? = null,
+      organizationId: OrganizationId,
   ): GetSpeciesResponsePayload {
     val row =
         speciesDao.fetchOneById(speciesId)
@@ -126,11 +126,11 @@ class SpeciesController(
   @Operation(summary = "Deletes an existing species.")
   fun deleteSpecies(
       @PathVariable speciesId: SpeciesId,
-      @RequestParam("organizationId")
+      @RequestParam("organizationId", required = true)
       @Schema(
           description =
               "Organization from which the species should be deleted. (Currently ignored.)")
-      organizationId: OrganizationId? = null,
+      organizationId: OrganizationId,
   ): SimpleSuccessResponsePayload {
     try {
       speciesStore.deleteSpecies(speciesId)
@@ -143,10 +143,10 @@ class SpeciesController(
   @GetMapping("/names")
   @Operation(summary = "Lists all species names.")
   fun listAllSpeciesNames(
-      @RequestParam("organizationId")
+      @RequestParam("organizationId", required = true)
       @Schema(
           description = "Organization whose species names should be listed. (Currently ignored.)")
-      organizationId: OrganizationId? = null,
+      organizationId: OrganizationId,
   ): ListSpeciesNamesResponsePayload {
     val names = speciesNamesDao.findAll()
     return ListSpeciesNamesResponsePayload(names.map { SpeciesNamesResponseElement(it) })
@@ -175,11 +175,11 @@ class SpeciesController(
   @GetMapping("/{speciesId}/names")
   fun listSpeciesNames(
       @PathVariable speciesId: SpeciesId,
-      @RequestParam("organizationId")
+      @RequestParam("organizationId", required = true)
       @Schema(
           description =
               "Organization whose names for the species should be listed. (Currently ignored.)")
-      organizationId: OrganizationId? = null,
+      organizationId: OrganizationId,
   ): ListSpeciesNamesResponsePayload {
     val names = speciesStore.listAllSpeciesNames(speciesId)
     return ListSpeciesNamesResponsePayload(names.map { SpeciesNamesResponseElement(it) })
@@ -254,7 +254,7 @@ data class SpeciesRequestPayload(
     val isScientific: Boolean?,
     val name: String,
     @Schema(description = "Which organization's species list to update. (Currently ignored.)")
-    val organizationId: OrganizationId? = null,
+    val organizationId: OrganizationId,
     val plantForm: PlantForm?,
     val rare: RareType?,
     @Schema(
@@ -299,7 +299,7 @@ data class SpeciesNameRequestPayload(
     val locale: String?,
     val name: String,
     @Schema(description = "Which organization's species list to update. (Currently ignored.)")
-    val organizationId: OrganizationId? = null,
+    val organizationId: OrganizationId,
     val speciesId: SpeciesId,
 ) {
   fun toRow() =


### PR DESCRIPTION
Require the client to specify the organization ID when it works with species data.

This is purely an API schema change; a subsequent change will start using the ID.