### PR TITLE
TRACK-657 Include createdTime in org-related payloads

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3660,12 +3660,16 @@ components:
           - $ref: '#/components/schemas/OrNodePayload'
     FacilityPayload:
       required:
+      - createdTime
       - id
       - name
       - siteId
       - type
       type: object
       properties:
+        createdTime:
+          type: string
+          format: date-time
         id:
           type: integer
           format: int64
@@ -4703,6 +4707,7 @@ components:
       - $ref: '#/components/schemas/SearchNodePayload'
     OrganizationPayload:
       required:
+      - createdTime
       - id
       - name
       - role
@@ -4722,6 +4727,9 @@ components:
             \ province, region, etc.) This is the full ISO 3166-2 code including the\
             \ country prefix. If this is set, countryCode will also be set."
           example: US-HI
+        createdTime:
+          type: string
+          format: date-time
         description:
           type: string
         id:
@@ -4903,11 +4911,15 @@ components:
                   format: double
     ProjectPayload:
       required:
+      - createdTime
       - id
       - name
       - organizationId
       type: object
       properties:
+        createdTime:
+          type: string
+          format: date-time
         description:
           type: string
         id:
@@ -5188,12 +5200,16 @@ components:
           $ref: '#/components/schemas/SuccessOrError'
     SiteElement:
       required:
+      - createdTime
       - id
       - location
       - name
       - projectId
       type: object
       properties:
+        createdTime:
+          type: string
+          format: date-time
         description:
           type: string
         id:

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilityController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilityController.kt
@@ -21,6 +21,8 @@ import com.terraformation.backend.log.perClassLogger
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import javax.ws.rs.InternalServerErrorException
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -49,11 +51,7 @@ class FacilityController(
   fun listAllFacilities(): ListFacilitiesResponse {
     val facilities = facilityStore.fetchAll()
 
-    val elements =
-        facilities.map { facility ->
-          FacilityPayload(facility.id, facility.siteId, facility.name, facility.type)
-        }
-
+    val elements = facilities.map { FacilityPayload(it) }
     return ListFacilitiesResponse(elements)
   }
 
@@ -63,8 +61,7 @@ class FacilityController(
     val facility =
         facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
 
-    return GetFacilityResponse(
-        FacilityPayload(facilityId, facility.siteId, facility.name, facility.type))
+    return GetFacilityResponse(FacilityPayload(facility))
   }
 
   @ApiResponse(responseCode = "200", description = "Success")
@@ -183,12 +180,20 @@ data class AutomationPayload(
 }
 
 data class FacilityPayload(
+    val createdTime: Instant,
     val id: FacilityId,
     val siteId: SiteId,
     val name: String,
     val type: FacilityType,
 ) {
-  constructor(model: FacilityModel) : this(model.id, model.siteId, model.name, model.type)
+  constructor(
+      model: FacilityModel
+  ) : this(
+      model.createdTime.truncatedTo(ChronoUnit.SECONDS),
+      model.id,
+      model.siteId,
+      model.name,
+      model.type)
 }
 
 data class ModifyAutomationRequestPayload(

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -238,6 +238,7 @@ data class OrganizationPayload(
         minLength = 4,
         maxLength = 6)
     val countrySubdivisionCode: String?,
+    val createdTime: Instant,
     val description: String?,
     val id: OrganizationId,
     val name: String,
@@ -254,6 +255,7 @@ data class OrganizationPayload(
   ) : this(
       model.countryCode,
       model.countrySubdivisionCode,
+      model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       model.description,
       model.id,
       model.name,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -20,7 +20,9 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Instant
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import javax.ws.rs.NotFoundException
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -147,6 +149,7 @@ class OrganizationProjectsController(private val projectStore: ProjectStore) {
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ProjectPayload(
+    val createdTime: Instant,
     val description: String?,
     val id: ProjectId,
     val name: String,
@@ -159,6 +162,7 @@ data class ProjectPayload(
   constructor(
       model: ProjectModel
   ) : this(
+      createdTime = model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       description = model.description,
       id = model.id,
       name = model.name,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SiteController.kt
@@ -13,6 +13,8 @@ import com.terraformation.backend.db.SiteNotFoundException
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import net.postgis.jdbc.geometry.Point
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -82,6 +84,7 @@ class ProjectSitesController(private val siteStore: SiteStore) {
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class SiteElement(
+    val createdTime: Instant,
     val description: String?,
     val id: SiteId,
     val name: String,
@@ -94,6 +97,7 @@ data class SiteElement(
   constructor(
       model: SiteModel
   ) : this(
+      createdTime = model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       description = model.description,
       id = model.id,
       name = model.name,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -5,27 +5,35 @@ import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.tables.references.FACILITIES
+import java.time.Instant
 import org.jooq.Record
 
 data class FacilityModel(
+    val createdTime: Instant,
     val id: FacilityId,
-    val siteId: SiteId,
+    val modifiedTime: Instant,
     val name: String,
-    val type: FacilityType
+    val siteId: SiteId,
+    val type: FacilityType,
 ) {
   constructor(
       record: Record
   ) : this(
+      record[FACILITIES.CREATED_TIME] ?: throw IllegalArgumentException("Created time is required"),
       record[FACILITIES.ID] ?: throw IllegalArgumentException("ID is required"),
-      record[FACILITIES.SITE_ID] ?: throw IllegalArgumentException("Site is required"),
+      record[FACILITIES.MODIFIED_TIME]
+          ?: throw IllegalArgumentException("Modified time is required"),
       record[FACILITIES.NAME] ?: throw IllegalArgumentException("Name is required"),
+      record[FACILITIES.SITE_ID] ?: throw IllegalArgumentException("Site is required"),
       record[FACILITIES.TYPE_ID] ?: throw IllegalArgumentException("Type is required"))
 }
 
 fun FacilitiesRow.toModel(): FacilityModel {
   return FacilityModel(
+      createdTime ?: throw IllegalArgumentException("Created time is required"),
       id ?: throw IllegalArgumentException("ID is required"),
-      siteId ?: throw IllegalArgumentException("Site is required"),
+      modifiedTime ?: throw IllegalArgumentException("Modified time is required"),
       name ?: throw IllegalArgumentException("Name is required"),
+      siteId ?: throw IllegalArgumentException("Site is required"),
       typeId ?: throw IllegalArgumentException("Type is required"))
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
@@ -14,6 +14,7 @@ data class OrganizationModel(
     val description: String? = null,
     val countryCode: String? = null,
     val countrySubdivisionCode: String? = null,
+    val createdTime: Instant,
     val disabledTime: Instant? = null,
     val projects: List<ProjectModel>? = null,
 ) {
@@ -23,6 +24,8 @@ data class OrganizationModel(
   ) : this(
       countryCode = record[ORGANIZATIONS.COUNTRY_CODE],
       countrySubdivisionCode = record[ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE],
+      createdTime = record[ORGANIZATIONS.CREATED_TIME]
+              ?: throw IllegalArgumentException("Created time is required"),
       description = record[ORGANIZATIONS.DESCRIPTION],
       disabledTime = record[ORGANIZATIONS.DISABLED_TIME],
       id = record[ORGANIZATIONS.ID] ?: throw IllegalArgumentException("ID is required"),
@@ -35,6 +38,7 @@ fun OrganizationsRow.toModel(): OrganizationModel =
     OrganizationModel(
         countryCode = countryCode,
         countrySubdivisionCode = countrySubdivisionCode,
+        createdTime = createdTime ?: throw IllegalArgumentException("Created time is required"),
         description = description,
         disabledTime = disabledTime,
         id = id ?: throw IllegalArgumentException("ID is required"),

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -6,11 +6,13 @@ import com.terraformation.backend.db.ProjectStatus
 import com.terraformation.backend.db.ProjectType
 import com.terraformation.backend.db.tables.pojos.ProjectsRow
 import com.terraformation.backend.db.tables.references.PROJECTS
+import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Field
 import org.jooq.Record
 
 data class ProjectModel(
+    val createdTime: Instant,
     val description: String?,
     val id: ProjectId,
     val organizationId: OrganizationId,
@@ -25,6 +27,8 @@ data class ProjectModel(
       sitesMultiset: Field<List<SiteModel>?>? = null,
       typesMultiset: Field<List<ProjectType>?>,
   ) : this(
+      createdTime = record[PROJECTS.CREATED_TIME]
+              ?: throw IllegalArgumentException("Created time is required"),
       description = record[PROJECTS.DESCRIPTION],
       id = record[PROJECTS.ID] ?: throw IllegalArgumentException("ID is required"),
       organizationId = record[PROJECTS.ORGANIZATION_ID]
@@ -39,6 +43,7 @@ data class ProjectModel(
 
 fun ProjectsRow.toModel(types: Set<ProjectType> = emptySet()) =
     ProjectModel(
+        createdTime = createdTime ?: throw IllegalArgumentException("Created time is required"),
         description = description,
         id = id ?: throw IllegalArgumentException("ID is required"),
         organizationId = organizationId

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -34,6 +34,8 @@ class FacilitiesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOpe
 
   override val fields: List<SearchField> =
       listOf(
+          timestampField(
+              "createdTime", "Facility created time", FACILITIES.CREATED_TIME, nullable = false),
           idWrapperField("id", "Facility ID", FACILITIES.ID) { FacilityId(it) },
           textField("name", "Facility name", FACILITIES.NAME, nullable = false),
           enumField("type", "Facility type", FACILITIES.TYPE_ID, nullable = false),

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -40,6 +40,11 @@ class OrganizationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearch
               "countrySubdivisionCode",
               "Organization country subdivision code",
               ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE),
+          timestampField(
+              "createdTime",
+              "Organization created time",
+              ORGANIZATIONS.CREATED_TIME,
+              nullable = false),
           idWrapperField("id", "Organization ID", ORGANIZATIONS.ID) { OrganizationId(it) },
           textField("name", "Organization name", ORGANIZATIONS.NAME, nullable = false),
       )

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -33,6 +33,8 @@ class ProjectsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOpera
 
   override val fields: List<SearchField> =
       listOf(
+          timestampField(
+              "createdTime", "Project created time", PROJECTS.CREATED_TIME, nullable = false),
           textField("description", "Project description", PROJECTS.DESCRIPTION),
           idWrapperField("id", "Project ID", PROJECTS.ID) { ProjectId(it) },
           textField("name", "Project name", PROJECTS.NAME, nullable = false),

--- a/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
@@ -31,6 +31,7 @@ class SitesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperator
 
   override val fields: List<SearchField> =
       listOf(
+          timestampField("createdTime", "Site created time", SITES.CREATED_TIME, nullable = false),
           textField("description", "Site description", SITES.DESCRIPTION),
           idWrapperField("id", "Site ID", SITES.ID) { SiteId(it) },
           textField("name", "Site name", SITES.NAME, nullable = false),

--- a/src/main/resources/db/migration/common/V66__FacilitiesCreatedTime.sql
+++ b/src/main/resources/db/migration/common/V66__FacilitiesCreatedTime.sql
@@ -1,0 +1,5 @@
+ALTER TABLE facilities ADD COLUMN created_time TIMESTAMP WITH TIME ZONE;
+ALTER TABLE facilities ADD COLUMN modified_time TIMESTAMP WITH TIME ZONE;
+UPDATE facilities SET created_time = NOW(), modified_time = NOW() WHERE created_time IS NULL;
+ALTER TABLE facilities ALTER COLUMN created_time SET NOT NULL;
+ALTER TABLE facilities ALTER COLUMN modified_time SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -62,9 +62,11 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   private val facilityModel =
       FacilityModel(
+          createdTime = Instant.EPOCH,
           id = facilityId,
-          siteId = siteId,
+          modifiedTime = Instant.EPOCH,
           name = "Facility $facilityId",
+          siteId = siteId,
           type = FacilityType.SeedBank)
   private val siteModel =
       SiteModel(
@@ -78,6 +80,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           facilities = listOf(facilityModel))
   private val projectModel =
       ProjectModel(
+          createdTime = Instant.EPOCH,
           description = "Project description $projectId",
           id = projectId,
           organizationId = organizationId,
@@ -88,9 +91,10 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           types = setOf(ProjectType.Agroforestry, ProjectType.SustainableTimber))
   private val organizationModel =
       OrganizationModel(
-          id = organizationId,
+          createdTime = Instant.EPOCH,
           countryCode = "US",
           countrySubdivisionCode = "US-HI",
+          id = organizationId,
           name = "Organization $organizationId",
           projects = listOf(projectModel))
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -243,7 +243,9 @@ internal class PermissionStoreTest : DatabaseTest() {
                     siteId = siteId,
                     name = "Facility $facilityId",
                     typeId = FacilityType.SeedBank,
-                    enabled = true))
+                    enabled = true,
+                    createdTime = Instant.EPOCH,
+                    modifiedTime = Instant.EPOCH))
           }
         }
       }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -192,10 +192,12 @@ abstract class DatabaseTest {
     with(FACILITIES) {
       dslContext
           .insertInto(FACILITIES)
+          .set(CREATED_TIME, Instant.EPOCH)
           .set(ID, id.toIdWrapper { FacilityId(it) })
+          .set(MODIFIED_TIME, Instant.EPOCH)
+          .set(NAME, name)
           .set(SITE_ID, siteId.toIdWrapper { SiteId(it) })
           .set(TYPE_ID, type)
-          .set(NAME, name)
           .execute()
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2249,6 +2249,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           listOf(
               mapOf(
                   "accessions" to expectedAccessions,
+                  "createdTime" to "1970-01-01T00:00:00Z",
                   "id" to "100",
                   "name" to "ohana",
                   "type" to "Seed Bank",
@@ -2257,6 +2258,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val expectedSites =
           listOf(
               mapOf(
+                  "createdTime" to "1970-01-01T00:00:00Z",
                   "facilities" to expectedFacilities,
                   "id" to "10",
                   "name" to "sim",
@@ -2265,6 +2267,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val expectedProjects =
           listOf(
               mapOf(
+                  "createdTime" to "1970-01-01T00:00:00Z",
                   "id" to "2",
                   "name" to "project",
                   "sites" to expectedSites,
@@ -2273,6 +2276,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val expected =
           listOf(
               mapOf(
+                  "createdTime" to "1970-01-01T00:00:00Z",
                   "id" to "1",
                   "name" to "dev",
                   "projects" to expectedProjects,


### PR DESCRIPTION
The web UI needs to show the creation dates/times of organizations, projects, etc.
Add `createdTime` fields to the relevant payload classes.

We weren't tracking creation time of facilities at all, so also add timestamps to
that table and set them when facilities are created or modified.