### PR TITLE
TRACK-648 Add hidden flag to projects

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4987,6 +4987,7 @@ components:
     ProjectPayload:
       required:
       - createdTime
+      - hidden
       - id
       - name
       - organizationId
@@ -4998,6 +4999,10 @@ components:
           format: date-time
         description:
           type: string
+        hidden:
+          type: boolean
+          description: "If true, the project and its associated sites and facilities\
+            \ should not be displayed to end users."
         id:
           type: integer
           format: int64

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -160,6 +160,11 @@ class OrganizationProjectsController(private val projectStore: ProjectStore) {
 data class ProjectPayload(
     val createdTime: Instant,
     val description: String?,
+    @Schema(
+        description =
+            "If true, the project and its associated sites and facilities should not be " +
+                "displayed to end users.")
+    val hidden: Boolean,
     val id: ProjectId,
     val name: String,
     val organizationId: OrganizationId,
@@ -180,6 +185,7 @@ data class ProjectPayload(
   ) : this(
       createdTime = model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       description = model.description,
+      hidden = model.hidden,
       id = model.id,
       name = model.name,
       organizationId = model.organizationId,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -14,6 +14,7 @@ import org.jooq.Record
 data class ProjectModel(
     val createdTime: Instant,
     val description: String?,
+    val hidden: Boolean,
     val id: ProjectId,
     val organizationId: OrganizationId,
     val organizationWide: Boolean,
@@ -31,6 +32,7 @@ data class ProjectModel(
       createdTime = record[PROJECTS.CREATED_TIME]
               ?: throw IllegalArgumentException("Created time is required"),
       description = record[PROJECTS.DESCRIPTION],
+      hidden = record[PROJECTS.HIDDEN] ?: throw IllegalArgumentException("Hidden is required"),
       id = record[PROJECTS.ID] ?: throw IllegalArgumentException("ID is required"),
       organizationId = record[PROJECTS.ORGANIZATION_ID]
               ?: throw IllegalArgumentException("Organization is required"),
@@ -48,6 +50,7 @@ fun ProjectsRow.toModel(types: Set<ProjectType> = emptySet()) =
     ProjectModel(
         createdTime = createdTime ?: throw IllegalArgumentException("Created time is required"),
         description = description,
+        hidden = hidden ?: throw IllegalArgumentException("Hidden is required"),
         id = id ?: throw IllegalArgumentException("ID is required"),
         organizationId = organizationId
                 ?: throw IllegalArgumentException("Organization is required"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -36,6 +36,7 @@ class ProjectsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOpera
           timestampField(
               "createdTime", "Project created time", PROJECTS.CREATED_TIME, nullable = false),
           textField("description", "Project description", PROJECTS.DESCRIPTION),
+          booleanField("hidden", "Project is hidden", PROJECTS.HIDDEN, nullable = false),
           idWrapperField("id", "Project ID", PROJECTS.ID) { ProjectId(it) },
           textField("name", "Project name", PROJECTS.NAME, nullable = false),
           booleanField(

--- a/src/main/resources/db/migration/common/R__Comments.sql
+++ b/src/main/resources/db/migration/common/R__Comments.sql
@@ -109,6 +109,7 @@ COMMENT ON TABLE project_type_selections IS 'Which project types are selected fo
 COMMENT ON TABLE project_users IS 'Linking table between `projects` and `users` defining which users are allowed to access which projects.';
 
 COMMENT ON TABLE projects IS 'Information about a single restoration project. A project can span multiple sites.';
+COMMENT ON COLUMN projects.hidden IS 'If true, the project and its associated sites and facilities should not be displayed to end users.';
 COMMENT ON COLUMN projects.organization_wide IS 'If true, the project is accessible to the entire organization. If true, the project is only accessible to users who are added to it.';
 
 COMMENT ON TABLE rare_types IS '(Enum) Possible values of the "Rare" attribute of an accession. This refers to whether the seed is rare at a site, not whether the species as a whole is rare or endangered.';

--- a/src/main/resources/db/migration/common/V69__ProjectsHidden.sql
+++ b/src/main/resources/db/migration/common/V69__ProjectsHidden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN hidden BOOLEAN NOT NULL DEFAULT false;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -82,6 +82,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
       ProjectModel(
           createdTime = Instant.EPOCH,
           description = "Project description $projectId",
+          hidden = false,
           id = projectId,
           organizationId = organizationId,
           organizationWide = false,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2268,6 +2268,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           listOf(
               mapOf(
                   "createdTime" to "1970-01-01T00:00:00Z",
+                  "hidden" to "false",
                   "id" to "2",
                   "name" to "project",
                   "organizationWide" to "false",


### PR DESCRIPTION
We'll be automatically creating a seed bank facility when a new organization is
created, which requires a project and a site. But we don't want the project and
its children to appear in the UI. Add a project-level flag to indicate to the
front end that it should hide the project and its children.

The flag doesn't do anything on the server side; it's purely for client use.

Currently the flag is read-only; we'll set it when we auto-create the seed bank
during organization creation, but clients aren't yet able to set it.