### PR TITLE
TRACK-593 Record timestamp of most recent user activity

### DIFF
--- a/src/main/resources/db/migration/common/R__Comments.sql
+++ b/src/main/resources/db/migration/common/R__Comments.sql
@@ -163,6 +163,7 @@ COMMENT ON TABLE user_types IS '(Enum) Types of users. Most users are of type 1,
 
 COMMENT ON TABLE users IS 'User identities. A user can be associated with organizations via `organization_users`.';
 COMMENT ON COLUMN users.auth_id IS 'Unique identifier of the user in the authentication system. Currently, this is a Keycloak user ID.';
+COMMENT ON COLUMN users.last_activity_time IS 'When the user most recently interacted with the system.';
 
 COMMENT ON TABLE withdrawal_purposes IS '(Enum) Reasons that someone can withdraw seeds from a seed bank.';
 

--- a/src/main/resources/db/migration/common/V71__UsersLastActivityTime.sql
+++ b/src/main/resources/db/migration/common/V71__UsersLastActivityTime.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN last_activity_time TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
Add a column to the users table to record when the system most recently received a
request from the user.

This makes use of an application event that gets automatically published by
Spring's request handling code when a request is finished processing.