### PR TITLE
Insert mock user into users table in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/MockUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/MockUser.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend
+
+import com.terraformation.backend.auth.CurrentUserHolder
+import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+
+fun mockUser(userId: UserId = UserId(2)): IndividualUser {
+  val user: IndividualUser = mockk(relaxed = true)
+
+  every { user.userId } returns userId
+  every { user.email } returns "$userId@terraformation.com"
+  every { user.authId } returns "$userId"
+  every { user.firstName } returns "First"
+  every { user.lastName } returns "Last"
+  every { user.userType } returns UserType.Individual
+
+  val funcSlot = CapturingSlot<() -> Any>()
+  every { user.run(capture(funcSlot)) } answers
+      {
+        CurrentUserHolder.runAs(user, funcSlot.captured, emptyList())
+      }
+
+  return user
+}

--- a/src/test/kotlin/com/terraformation/backend/RunsAsUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/RunsAsUser.kt
@@ -22,7 +22,7 @@ interface RunsAsUser {
    * User to masquerade as while running tests. Typically, you'll want to define this as
    *
    * ```
-   * override val user: TerrawareUser = mockk()
+   * override val user: TerrawareUser = mockUser()
    * ```
    *
    * and then use the MockK API to control the behavior of the stubbed-out user.

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -21,7 +21,6 @@ import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.db.tables.daos.FacilityAlertRecipientsDao
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
@@ -32,6 +31,7 @@ import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.email.EmailService
 import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -43,7 +43,7 @@ import org.keycloak.admin.client.resource.RealmResource
 import org.springframework.beans.factory.annotation.Autowired
 
 internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   override val sequencesToReset: List<String> =
       listOf("organizations_id_seq", "projects_id_seq", "site_id_seq", "site_module_id_seq")
 
@@ -109,12 +109,11 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateFacility(any()) } returns true
     every { user.canCreateProject(any()) } returns true
     every { user.canCreateSite(any()) } returns true
-    every { user.userId } returns UserId(100)
   }
 
   @Test
   fun `createOrganization creates seed bank`() {
-    insertUser(user.userId)
+    insertUser()
 
     val expected =
         OrganizationModel(
@@ -161,7 +160,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createOrganization does not create seed bank if creation flag is false`() {
-    insertUser(user.userId)
+    insertUser()
 
     val expected =
         OrganizationModel(

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.references.PROJECT_USERS
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -41,7 +42,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   override val sequencesToReset: List<String> = listOf("organizations_id_seq")
 
   private val clock: Clock = mockk()
@@ -122,7 +123,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     every { user.organizationRoles } returns mapOf(organizationId to Role.OWNER)
     every { user.projectRoles } returns mapOf(projectId to Role.OWNER)
-    every { user.userId } returns UserId(2)
 
     assertEquals(
         organizationId,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.tables.daos.ProjectTypeSelectionsDao
 import com.terraformation.backend.db.tables.daos.ProjectUsersDao
 import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.db.tables.pojos.ProjectUsersRow
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
   private lateinit var projectsDao: ProjectsDao

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.mercatorPoint
 import com.terraformation.backend.db.tables.daos.SitesDao
 import com.terraformation.backend.db.tables.pojos.SitesRow
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
   private lateinit var parentStore: ParentStore

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.UsersRow
+import com.terraformation.backend.mockUser
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -50,7 +51,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private val httpClient: HttpClient = mockk()
   private val realmResource: RealmResource = mockk()
   private val usersResource = InMemoryKeycloakUsersResource()
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private lateinit var organizationsDao: OrganizationsDao
   private lateinit var organizationStore: OrganizationStore

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -381,6 +381,7 @@ abstract class DatabaseTest {
 
   /** Creates an organization, site, and facility that can be referenced by various tests. */
   fun insertSiteData() {
+    insertUser()
     insertOrganization(1, "dev")
     insertProject(2, 1, "project")
     insertSite(10, 2, "sim")

--- a/src/test/kotlin/com/terraformation/backend/device/api/TimeseriesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/api/TimeseriesControllerTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.TimeseriesId
 import com.terraformation.backend.db.tables.pojos.TimeseriesRow
 import com.terraformation.backend.device.db.TimeseriesStore
+import com.terraformation.backend.mockUser
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -18,7 +19,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.dao.DuplicateKeyException
 
 internal class TimeseriesControllerTest : RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   private val store: TimeseriesStore = mockk()
 
   private val controller = TimeseriesController(store)

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -14,8 +14,8 @@ import com.terraformation.backend.db.tables.pojos.DevicesRow
 import com.terraformation.backend.db.tables.pojos.TimeseriesRow
 import com.terraformation.backend.db.tables.pojos.TimeseriesValuesRow
 import com.terraformation.backend.db.tables.references.TIMESERIES_VALUES
+import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -26,7 +26,7 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
 internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private lateinit var devicesDao: DevicesDao
   private lateinit var store: TimeseriesStore

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.gis.model.FeatureModel
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -65,7 +66,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 
 internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   private val siteId = SiteId(10)
   private val layerId = LayerId(100)
   private val nonExistentLayerId = LayerId(401)

--- a/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.LayerType
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.tables.daos.LayersDao
 import com.terraformation.backend.gis.model.LayerModel
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -25,7 +26,7 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.access.AccessDeniedException
 
 internal class LayerStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   private lateinit var store: LayerStore
   private lateinit var layersDao: LayersDao
 

--- a/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.tables.daos.PlantObservationsDao
 import com.terraformation.backend.db.tables.daos.PlantsDao
 import com.terraformation.backend.db.tables.daos.SpeciesDao
 import com.terraformation.backend.db.tables.pojos.PlantObservationsRow
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -33,7 +34,7 @@ import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.access.AccessDeniedException
 
 internal class PlantObservationsStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   private val siteId = SiteId(10)
   private val layerId = LayerId(100)
   private val featureId = FeatureId(1000)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -53,6 +53,7 @@ import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_GERMINATION_TEST_TYPES
 import com.terraformation.backend.db.tables.references.ACCESSION_SECONDARY_COLLECTORS
 import com.terraformation.backend.db.tables.references.ACCESSION_STATE_HISTORY
+import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.api.CreateAccessionRequestPayload
 import com.terraformation.backend.seedbank.api.DeviceInfoPayload
 import com.terraformation.backend.seedbank.api.GerminationPayload
@@ -97,7 +98,7 @@ import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 
 internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   override val sequencesToReset
     get() =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.file.LocalFileStore
 import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
+import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.model.PhotoMetadata
 import io.mockk.every
 import io.mockk.mockk
@@ -68,7 +69,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private lateinit var repository: PhotoRepository
   private val thumbnailStore: ThumbnailStore = mockk()
 
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private lateinit var photoPath: Path
   private lateinit var photoStorageUrl: URI

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -1,5 +1,7 @@
 package com.terraformation.backend.seedbank.db
 
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.DatabaseTest
@@ -14,6 +16,7 @@ import com.terraformation.backend.db.tables.daos.WithdrawalsDao
 import com.terraformation.backend.db.tables.pojos.GerminationTestsRow
 import com.terraformation.backend.db.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
+import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.grams
 import com.terraformation.backend.seedbank.milligrams
 import com.terraformation.backend.seedbank.model.WithdrawalModel
@@ -29,7 +32,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-internal class WithdrawalStoreTest : DatabaseTest() {
+internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
   private lateinit var germinationTestsDao: GerminationTestsDao
   private lateinit var store: WithdrawalStore
   private lateinit var withdrawalsDao: WithdrawalsDao

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -35,6 +35,7 @@ import com.terraformation.backend.db.tables.pojos.GerminationTestsRow
 import com.terraformation.backend.db.tables.pojos.GerminationsRow
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.tables.pojos.StorageLocationsRow
+import com.terraformation.backend.mockUser
 import com.terraformation.backend.search.AndNode
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
@@ -52,7 +53,6 @@ import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.field.AliasField
 import com.terraformation.backend.search.table.SearchTables
 import io.mockk.every
-import io.mockk.mockk
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 
 class SearchServiceTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
   override val sequencesToReset: List<String> = listOf("accession_id_seq")
 
   private lateinit var accessionsDao: AccessionsDao

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.tables.daos.SpeciesOptionsDao
 import com.terraformation.backend.db.tables.pojos.SpeciesNamesRow
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.tables.references.SPECIES_OPTIONS
+import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -41,7 +42,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   private val organizationId = OrganizationId(1)
 
   private val clock: Clock = mockk()
-  override val user: TerrawareUser = mockk()
+  override val user: TerrawareUser = mockUser()
 
   private lateinit var speciesDao: SpeciesDao
   private lateinit var speciesNamesDao: SpeciesNamesDao


### PR DESCRIPTION
Tracking which users created/modified things will mean adding user ID columns to a
number of tables. Those user IDs will need to refer to IDs that exist in the users
table. That has an impact on tests, where previously we could get away with just
using an in-memory mock object. We'll still do that, but the mock needs to have a
user ID, and the user will need to exist in the users table.

Address this by introducing a helper function to create a mock user with a
reasonable set of default behaviors, and modify `insertSiteData()` to insert a
user before it inserts the organization and so forth.