### PR TITLE
Return user ID when adding a user to an organization

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1310,7 +1310,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SimpleSuccessResponsePayload'
+                $ref: '#/components/schemas/CreateOrganizationUserResponsePayload'
   /api/v1/organizations/{organizationId}/users/{userId}:
     get:
       tags:
@@ -3448,6 +3448,18 @@ components:
           type: string
         name:
           type: string
+    CreateOrganizationUserResponsePayload:
+      required:
+      - id
+      - status
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The ID of the newly-added user.
+          format: int64
+        status:
+          $ref: '#/components/schemas/SuccessOrError'
     CreatePlantRequestPayload:
       required:
       - featureId

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -112,14 +112,15 @@ class OrganizationsController(
   fun addOrganizationUser(
       @PathVariable("organizationId") organizationId: OrganizationId,
       @RequestBody payload: AddOrganizationUserRequestPayload
-  ): SimpleSuccessResponsePayload {
+  ): CreateOrganizationUserResponsePayload {
     if (!emailValidator.isValid(payload.email)) {
       throw BadRequestException("Invalid email address")
     }
 
-    organizationService.addUser(
-        payload.email, organizationId, payload.role, payload.projectIds ?: emptyList())
-    return SimpleSuccessResponsePayload()
+    val userId =
+        organizationService.addUser(
+            payload.email, organizationId, payload.role, payload.projectIds ?: emptyList())
+    return CreateOrganizationUserResponsePayload(userId)
   }
 
   @GetMapping("/{organizationId}/users/{userId}")
@@ -346,6 +347,13 @@ data class GetOrganizationUserResponsePayload(val user: OrganizationUserPayload)
 
 data class ListOrganizationUsersResponsePayload(val users: List<OrganizationUserPayload>) :
     SuccessResponsePayload
+
+data class CreateOrganizationUserResponsePayload(
+    @Schema(
+        description = "The ID of the newly-added user.",
+    )
+    val id: UserId
+) : SuccessResponsePayload
 
 data class ListOrganizationsResponsePayload(val organizations: List<OrganizationPayload>) :
     SuccessResponsePayload


### PR DESCRIPTION
This saves the client from having to immediately list the organization's users to
look up the newly-added one's ID.