### PR TITLE
TRACK-718 Use standard error message for invalid email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -114,7 +114,7 @@ class OrganizationsController(
       @RequestBody payload: AddOrganizationUserRequestPayload
   ): CreateOrganizationUserResponsePayload {
     if (!emailValidator.isValid(payload.email)) {
-      throw BadRequestException("Invalid email address")
+      throw BadRequestException("Field value has incorrect format: email")
     }
 
     val userId =


### PR DESCRIPTION
When there's a structural problem with a request payload, e.g., the client passing
in an integer for a field that should be a boolean, the server returns an error
message, "Field value has incorrect format: X".

Use the same message if the client makes a POST request to
`/api/v1/organizations/{id}/users` with an invalid email address.

Eventually we'll want to return machine-readable information about validation
failures, but for now, this will at least make the error consistent with
validation failures in other fields.