### PR TITLE
TRACK-774 Create default storage locations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.pojos.SitesRow
@@ -77,6 +78,13 @@ class OrganizationService(
             projectStore.create(orgModel.id, name, hidden = true, organizationWide = true)
         val siteModel = siteStore.create(SitesRow(projectId = projectModel.id, name = name))
         val facilityModel = facilityStore.create(siteModel.id, name, FacilityType.SeedBank)
+
+        (1..3).forEach { num ->
+          facilityStore.createStorageLocation(
+              facilityModel.id, "Refrigerator $num", StorageCondition.Refrigerator)
+          facilityStore.createStorageLocation(
+              facilityModel.id, "Freezer $num", StorageCondition.Freezer)
+        }
 
         orgModel.copy(
             projects =

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.db.tables.daos.FacilityAlertRecipientsDao
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
@@ -114,6 +115,9 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateFacility(any()) } returns true
     every { user.canCreateProject(any()) } returns true
     every { user.canCreateSite(any()) } returns true
+    every { user.canCreateStorageLocation(any()) } returns true
+    every { user.canReadFacility(any()) } returns true
+    every { user.canReadStorageLocation(any()) } returns true
   }
 
   @Test
@@ -161,6 +165,22 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             OrganizationsRow(name = "Test Organization"), createSeedBank = true)
 
     assertEquals(expected, actual)
+
+    val storageLocations = facilityStore.fetchStorageLocations(FacilityId(1))
+
+    assertEquals(
+        3,
+        storageLocations.count {
+          it.conditionId == StorageCondition.Refrigerator &&
+              it.name?.startsWith("Refrigerator") == true
+        },
+        "Number of refrigerators")
+    assertEquals(
+        3,
+        storageLocations.count {
+          it.conditionId == StorageCondition.Freezer && it.name?.startsWith("Freezer") == true
+        },
+        "Number of freezers")
   }
 
   @Test


### PR DESCRIPTION
We create a default seed bank facility for new organizations, but if users try to
use it, the list of storage locations is empty. Eventually we'll probably need to
give users more control over this, but for now, create three refrigerators and
three freezers as part of the default setup of a seed bank, which is the correct
setup for our containerized seed banks.