### PR TITLE
Move DAO instantiation to DatabaseTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -22,14 +22,6 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.StorageCondition
-import com.terraformation.backend.db.tables.daos.FacilitiesDao
-import com.terraformation.backend.db.tables.daos.FacilityAlertRecipientsDao
-import com.terraformation.backend.db.tables.daos.OrganizationsDao
-import com.terraformation.backend.db.tables.daos.ProjectTypeSelectionsDao
-import com.terraformation.backend.db.tables.daos.ProjectsDao
-import com.terraformation.backend.db.tables.daos.SitesDao
-import com.terraformation.backend.db.tables.daos.StorageLocationsDao
-import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.email.EmailService
 import com.terraformation.backend.i18n.Messages
@@ -68,23 +60,15 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    val jooqConfig = dslContext.configuration()
-
     every { realmResource.users() } returns mockk()
 
     facilityStore =
         FacilityStore(
-            clock,
-            dslContext,
-            FacilitiesDao(jooqConfig),
-            FacilityAlertRecipientsDao(jooqConfig),
-            StorageLocationsDao(jooqConfig))
-    organizationStore = OrganizationStore(clock, dslContext, OrganizationsDao(jooqConfig))
+            clock, dslContext, facilitiesDao, facilityAlertRecipientsDao, storageLocationsDao)
+    organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
     parentStore = ParentStore(dslContext)
-    projectStore =
-        ProjectStore(
-            clock, dslContext, ProjectsDao(jooqConfig), ProjectTypeSelectionsDao(jooqConfig))
-    siteStore = SiteStore(clock, dslContext, parentStore, SitesDao(jooqConfig))
+    projectStore = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
+    siteStore = SiteStore(clock, dslContext, parentStore, sitesDao)
     userStore =
         UserStore(
             clock,
@@ -97,7 +81,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             parentStore,
             PermissionStore(dslContext),
             realmResource,
-            UsersDao(jooqConfig))
+            usersDao)
 
     service =
         OrganizationService(

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AppDeviceStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AppDeviceStoreTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.customer.db
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AppDeviceId
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.tables.daos.AppDevicesDao
 import com.terraformation.backend.db.tables.pojos.AppDevicesRow
 import com.terraformation.backend.db.tables.references.APP_DEVICES
 import com.terraformation.backend.seedbank.api.DeviceInfoPayload
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Test
 internal class AppDeviceStoreTest : DatabaseTest() {
   private val clock: Clock = mockk()
 
-  private lateinit var appDevicesDao: AppDevicesDao
   private lateinit var store: AppDeviceStore
 
   override val sequencesToReset: List<String>
@@ -28,7 +26,6 @@ internal class AppDeviceStoreTest : DatabaseTest() {
 
   @BeforeEach
   fun setup() {
-    appDevicesDao = AppDevicesDao(dslContext.configuration())
     store = AppDeviceStore(dslContext, clock)
 
     every { clock.instant() } returns Instant.ofEpochMilli(50000)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -8,9 +8,6 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UserId
-import com.terraformation.backend.db.tables.daos.FacilitiesDao
-import com.terraformation.backend.db.tables.daos.FacilityAlertRecipientsDao
-import com.terraformation.backend.db.tables.daos.StorageLocationsDao
 import com.terraformation.backend.db.tables.pojos.StorageLocationsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.mockUser
@@ -29,7 +26,6 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
-  private lateinit var storageLocationsDao: StorageLocationsDao
   private lateinit var store: FacilityStore
 
   private val facilityId = FacilityId(100)
@@ -37,16 +33,9 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    val jooqConfig = dslContext.configuration()
-
-    storageLocationsDao = StorageLocationsDao(jooqConfig)
     store =
         FacilityStore(
-            clock,
-            dslContext,
-            FacilitiesDao(jooqConfig),
-            FacilityAlertRecipientsDao(jooqConfig),
-            storageLocationsDao)
+            clock, dslContext, facilitiesDao, facilityAlertRecipientsDao, storageLocationsDao)
 
     every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateStorageLocation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -23,8 +23,6 @@ import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.newPoint
-import com.terraformation.backend.db.tables.daos.OrganizationsDao
-import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.references.PROJECT_USERS
 import com.terraformation.backend.mockUser
@@ -46,9 +44,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   override val sequencesToReset: List<String> = listOf("organizations_id_seq")
 
   private val clock: Clock = mockk()
-  private lateinit var organizationsDao: OrganizationsDao
   private lateinit var permissionStore: PermissionStore
-  private lateinit var usersDao: UsersDao
   private lateinit var store: OrganizationStore
 
   private val organizationId = OrganizationId(1)
@@ -103,11 +99,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    val jooqConfig = dslContext.configuration()
-
-    organizationsDao = OrganizationsDao(jooqConfig)
     permissionStore = PermissionStore(dslContext)
-    usersDao = UsersDao(jooqConfig)
     store = OrganizationStore(clock, dslContext, organizationsDao)
 
     every { clock.instant() } returns Instant.EPOCH

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
-import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.mockUser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -19,14 +18,9 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private lateinit var permissionStore: PermissionStore
-  private lateinit var projectsDao: ProjectsDao
 
   @BeforeEach
   fun setUp() {
-    val config = dslContext.configuration()
-
-    projectsDao = ProjectsDao(config)
-
     permissionStore = PermissionStore(dslContext)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -10,9 +10,6 @@ import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.ProjectOrganizationWideException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
-import com.terraformation.backend.db.tables.daos.ProjectTypeSelectionsDao
-import com.terraformation.backend.db.tables.daos.ProjectUsersDao
-import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.db.tables.pojos.ProjectUsersRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -30,9 +27,6 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
-  private lateinit var projectsDao: ProjectsDao
-  private lateinit var projectTypeSelectionsDao: ProjectTypeSelectionsDao
-  private lateinit var projectUsersDao: ProjectUsersDao
   private lateinit var store: ProjectStore
 
   private val organizationId = OrganizationId(1)
@@ -50,11 +44,6 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canAddProjectUser(any()) } returns true
     every { user.canRemoveProjectUser(any()) } returns true
 
-    val jooqConfig = dslContext.configuration()
-
-    projectsDao = ProjectsDao(jooqConfig)
-    projectTypeSelectionsDao = ProjectTypeSelectionsDao(jooqConfig)
-    projectUsersDao = ProjectUsersDao(jooqConfig)
     store = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
 
     insertUser()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.mercatorPoint
-import com.terraformation.backend.db.tables.daos.SitesDao
 import com.terraformation.backend.db.tables.pojos.SitesRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -26,7 +25,6 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
 
   private val clock: Clock = mockk()
   private lateinit var parentStore: ParentStore
-  private lateinit var sitesDao: SitesDao
   private lateinit var store: SiteStore
 
   private val organizationId = OrganizationId(1)
@@ -36,7 +34,6 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     parentStore = ParentStore(dslContext)
-    sitesDao = SitesDao(dslContext.configuration())
     store = SiteStore(clock, dslContext, parentStore, sitesDao)
 
     every { clock.instant() } returns Instant.EPOCH

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -10,8 +10,6 @@ import com.terraformation.backend.db.KeycloakRequestFailedException
 import com.terraformation.backend.db.KeycloakUserNotFoundException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UserId
-import com.terraformation.backend.db.tables.daos.OrganizationsDao
-import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.mockUser
 import io.mockk.Runs
 import io.mockk.every
@@ -52,11 +50,9 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private val usersResource = InMemoryKeycloakUsersResource()
   override val user: TerrawareUser = mockUser()
 
-  private lateinit var organizationsDao: OrganizationsDao
   private lateinit var organizationStore: OrganizationStore
   private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
-  private lateinit var usersDao: UsersDao
   private lateinit var userStore: UserStore
 
   private val keycloakConfig =
@@ -103,10 +99,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     usersResource.create(userRepresentation)
-
-    val configuration = dslContext.configuration()
-    organizationsDao = OrganizationsDao(configuration)
-    usersDao = UsersDao(configuration)
 
     organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
     parentStore = ParentStore(dslContext)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -22,10 +22,6 @@ import com.terraformation.backend.db.SpeciesNameId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.AutomationsDao
-import com.terraformation.backend.db.tables.daos.DevicesDao
-import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.AutomationsRow
 import com.terraformation.backend.db.tables.pojos.DevicesRow
@@ -110,12 +106,8 @@ import org.springframework.beans.factory.annotation.Autowired
  * permissions other than the ones the test specifically said they should.
  */
 internal class PermissionTest : DatabaseTest() {
-  private lateinit var accessionsDao: AccessionsDao
-  private lateinit var automationsDao: AutomationsDao
-  private lateinit var devicesDao: DevicesDao
   private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
-  private lateinit var usersDao: UsersDao
   private lateinit var userStore: UserStore
 
   @Autowired private lateinit var config: TerrawareServerConfig
@@ -183,13 +175,8 @@ internal class PermissionTest : DatabaseTest() {
   fun setUp() {
     every { realmResource.users() } returns mockk()
 
-    val jooqConfig = dslContext.configuration()
-    accessionsDao = AccessionsDao(jooqConfig)
-    automationsDao = AutomationsDao(jooqConfig)
-    devicesDao = DevicesDao(jooqConfig)
     parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
-    usersDao = UsersDao(jooqConfig)
     userStore =
         UserStore(
             clock,

--- a/src/test/kotlin/com/terraformation/backend/daily/DailyTaskRunnerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/DailyTaskRunnerTest.kt
@@ -4,8 +4,6 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.tables.daos.TaskProcessedTimesDao
-import com.terraformation.backend.db.tables.daos.UsersDao
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.justRun
@@ -28,7 +26,6 @@ internal class DailyTaskRunnerTest : DatabaseTest() {
 
   private lateinit var dailyTaskRunner: DailyTaskRunner
   private lateinit var systemUser: SystemUser
-  private lateinit var taskProcessedTimesDao: TaskProcessedTimesDao
 
   private lateinit var task: TimePeriodTask
 
@@ -44,9 +41,8 @@ internal class DailyTaskRunnerTest : DatabaseTest() {
 
     task = makeMockTask()
 
-    systemUser = SystemUser(UsersDao(dslContext.configuration()))
+    systemUser = SystemUser(usersDao)
     dailyTaskRunner = DailyTaskRunner(clock, config, dslContext, publisher, systemUser)
-    taskProcessedTimesDao = TaskProcessedTimesDao(dslContext.configuration())
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -9,8 +9,6 @@ import com.terraformation.backend.db.TimeseriesId
 import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.TimeseriesType
 import com.terraformation.backend.db.UserId
-import com.terraformation.backend.db.tables.daos.DevicesDao
-import com.terraformation.backend.db.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.tables.pojos.DevicesRow
 import com.terraformation.backend.db.tables.pojos.TimeseriesRow
 import com.terraformation.backend.db.tables.pojos.TimeseriesValuesRow
@@ -32,9 +30,7 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
-  private lateinit var devicesDao: DevicesDao
   private lateinit var store: TimeseriesStore
-  private lateinit var timeseriesDao: TimeseriesDao
 
   private val deviceId = DeviceId(1)
   private val facilityId = FacilityId(100)
@@ -43,9 +39,6 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    devicesDao = DevicesDao(dslContext.configuration())
-    timeseriesDao = TimeseriesDao(dslContext.configuration())
-
     store = TimeseriesStore(clock, dslContext)
 
     insertSiteData()

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -5,8 +5,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.PhotoId
 import com.terraformation.backend.db.ThumbnailId
-import com.terraformation.backend.db.tables.daos.PhotosDao
-import com.terraformation.backend.db.tables.daos.ThumbnailsDao
 import com.terraformation.backend.db.tables.pojos.PhotosRow
 import com.terraformation.backend.db.tables.pojos.ThumbnailsRow
 import com.terraformation.backend.mockUser
@@ -42,9 +40,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
   private val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)!!
   private val fileStore: FileStore = mockk()
 
-  private lateinit var photosDao: PhotosDao
   private lateinit var store: ThumbnailStore
-  private lateinit var thumbnailsDao: ThumbnailsDao
 
   private val photoId = PhotoId(1000)
   private val photoStorageUrl = URI("file:///a/b/c/original.jpg")
@@ -54,10 +50,6 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    val jooqConfig = dslContext.configuration()
-    photosDao = PhotosDao(jooqConfig)
-    thumbnailsDao = ThumbnailsDao(jooqConfig)
-
     store = ThumbnailStore(clock, dslContext, fileStore, photosDao, thumbnailsDao)
 
     insertUser()

--- a/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/FeatureStoreTest.kt
@@ -22,14 +22,6 @@ import com.terraformation.backend.db.asGeoJson
 import com.terraformation.backend.db.assertPointsEqual
 import com.terraformation.backend.db.mercatorPoint
 import com.terraformation.backend.db.newPoint
-import com.terraformation.backend.db.tables.daos.FeaturePhotosDao
-import com.terraformation.backend.db.tables.daos.FeaturesDao
-import com.terraformation.backend.db.tables.daos.LayersDao
-import com.terraformation.backend.db.tables.daos.PhotosDao
-import com.terraformation.backend.db.tables.daos.PlantObservationsDao
-import com.terraformation.backend.db.tables.daos.PlantsDao
-import com.terraformation.backend.db.tables.daos.SpeciesDao
-import com.terraformation.backend.db.tables.daos.ThumbnailsDao
 import com.terraformation.backend.db.tables.pojos.FeaturePhotosRow
 import com.terraformation.backend.db.tables.pojos.PhotosRow
 import com.terraformation.backend.db.tables.pojos.PlantObservationsRow
@@ -94,23 +86,9 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
   private val thumbnailStore: ThumbnailStore = mockk()
 
   private lateinit var store: FeatureStore
-  private lateinit var featurePhotosDao: FeaturePhotosDao
-  private lateinit var featuresDao: FeaturesDao
-  private lateinit var plantsDao: PlantsDao
-  private lateinit var plantObservationsDao: PlantObservationsDao
-  private lateinit var photosDao: PhotosDao
-  private lateinit var thumbnailsDao: ThumbnailsDao
 
   @BeforeEach
   fun init() {
-    val jooqConfig = dslContext.configuration()
-    featurePhotosDao = FeaturePhotosDao(jooqConfig)
-    featuresDao = FeaturesDao(jooqConfig)
-    plantsDao = PlantsDao(jooqConfig)
-    plantObservationsDao = PlantObservationsDao(jooqConfig)
-    photosDao = PhotosDao(jooqConfig)
-    thumbnailsDao = ThumbnailsDao(jooqConfig)
-
     store =
         FeatureStore(
             clock,
@@ -716,17 +694,8 @@ internal class FeatureStoreTest : DatabaseTest(), RunsAsUser {
     private val speciesIdsToCount = mapOf(SpeciesId(1) to 4, SpeciesId(2) to 1, SpeciesId(3) to 3)
     private val nonExistentSpeciesId = SpeciesId(402)
 
-    private lateinit var layersDao: LayersDao
-    private lateinit var speciesDao: SpeciesDao
-
     @BeforeEach
     fun init() {
-      val jooqConfig = dslContext.configuration()
-
-      featuresDao = FeaturesDao(jooqConfig)
-      layersDao = LayersDao(jooqConfig)
-      speciesDao = SpeciesDao(jooqConfig)
-
       insertFeature(id = featureId, layerId = layerId)
     }
 

--- a/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/LayerStoreTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.LayerId
 import com.terraformation.backend.db.LayerNotFoundException
 import com.terraformation.backend.db.LayerType
 import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.tables.daos.LayersDao
 import com.terraformation.backend.gis.model.LayerModel
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -28,7 +27,6 @@ import org.springframework.security.access.AccessDeniedException
 internal class LayerStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
   private lateinit var store: LayerStore
-  private lateinit var layersDao: LayersDao
 
   private val clock = mockk<Clock>()
   private val time1 = Instant.EPOCH
@@ -47,7 +45,6 @@ internal class LayerStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun init() {
-    layersDao = LayersDao(dslContext.configuration())
     store = LayerStore(clock, dslContext)
     every { clock.instant() } returns time1
     every { user.canCreateLayer(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/db/PlantObservationsStoreTest.kt
@@ -12,11 +12,6 @@ import com.terraformation.backend.db.PlantObservationId
 import com.terraformation.backend.db.PlantObservationNotFoundException
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
-import com.terraformation.backend.db.tables.daos.FeaturesDao
-import com.terraformation.backend.db.tables.daos.LayersDao
-import com.terraformation.backend.db.tables.daos.PlantObservationsDao
-import com.terraformation.backend.db.tables.daos.PlantsDao
-import com.terraformation.backend.db.tables.daos.SpeciesDao
 import com.terraformation.backend.db.tables.pojos.PlantObservationsRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -60,23 +55,10 @@ internal class PlantObservationsStoreTest : DatabaseTest(), RunsAsUser {
       )
 
   private lateinit var store: PlantObservationsStore
-  private lateinit var featuresDao: FeaturesDao
-  private lateinit var layersDao: LayersDao
-  private lateinit var plantsDao: PlantsDao
-  private lateinit var observDao: PlantObservationsDao
-  private lateinit var speciesDao: SpeciesDao
 
   @BeforeEach
   fun init() {
-    val jooqConfig = dslContext.configuration()
-
-    featuresDao = FeaturesDao(jooqConfig)
-    layersDao = LayersDao(jooqConfig)
-    plantsDao = PlantsDao(jooqConfig)
-    observDao = PlantObservationsDao(jooqConfig)
-    speciesDao = SpeciesDao(jooqConfig)
-
-    store = PlantObservationsStore(clock, plantsDao, observDao)
+    store = PlantObservationsStore(clock, plantsDao, plantObservationsDao)
     every { clock.instant() } returns time1
     every { user.canReadFeature(any()) } returns true
     every { user.canReadLayer(any()) } returns true
@@ -101,7 +83,7 @@ internal class PlantObservationsStoreTest : DatabaseTest(), RunsAsUser {
             modifiedBy = user.userId,
             modifiedTime = time1)
     assertEquals(expected, observation)
-    assertEquals(observation, observDao.fetchOneById(observationId))
+    assertEquals(observation, plantObservationsDao.fetchOneById(observationId))
   }
 
   @Test
@@ -230,7 +212,7 @@ internal class PlantObservationsStoreTest : DatabaseTest(), RunsAsUser {
             modifiedTime = time2)
 
     assertEquals(expected, updated)
-    assertEquals(expected, observDao.fetchOneById(created.id!!))
+    assertEquals(expected, plantObservationsDao.fetchOneById(created.id!!))
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -29,18 +29,6 @@ import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalPurpose
 import com.terraformation.backend.db.sequences.ACCESSION_NUMBER_SEQ
-import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.AppDevicesDao
-import com.terraformation.backend.db.tables.daos.BagsDao
-import com.terraformation.backend.db.tables.daos.GeolocationsDao
-import com.terraformation.backend.db.tables.daos.GerminationTestsDao
-import com.terraformation.backend.db.tables.daos.GerminationsDao
-import com.terraformation.backend.db.tables.daos.PhotosDao
-import com.terraformation.backend.db.tables.daos.SpeciesDao
-import com.terraformation.backend.db.tables.daos.SpeciesNamesDao
-import com.terraformation.backend.db.tables.daos.SpeciesOptionsDao
-import com.terraformation.backend.db.tables.daos.StorageLocationsDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.db.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
@@ -128,39 +116,14 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
 
   private lateinit var store: AccessionStore
-  private lateinit var accessionsDao: AccessionsDao
-  private lateinit var accessionPhotosDao: AccessionPhotosDao
-  private lateinit var appDevicesDao: AppDevicesDao
-  private lateinit var bagsDao: BagsDao
-  private lateinit var geolocationsDao: GeolocationsDao
-  private lateinit var germinationsDao: GerminationsDao
-  private lateinit var germinationTestsDao: GerminationTestsDao
   private lateinit var parentStore: ParentStore
-  private lateinit var photosDao: PhotosDao
-  private lateinit var speciesDao: SpeciesDao
-  private lateinit var speciesNamesDao: SpeciesNamesDao
-  private lateinit var speciesOptionsDao: SpeciesOptionsDao
-  private lateinit var storageLocationsDao: StorageLocationsDao
 
   private val facilityId = FacilityId(100)
   private val organizationId = OrganizationId(1)
 
   @BeforeEach
   fun init() {
-    val jooqConfig = dslContext.configuration()
-    accessionsDao = AccessionsDao(jooqConfig)
-    accessionPhotosDao = AccessionPhotosDao(jooqConfig)
-    appDevicesDao = AppDevicesDao(jooqConfig)
-    bagsDao = BagsDao(jooqConfig)
-    geolocationsDao = GeolocationsDao(jooqConfig)
-    germinationsDao = GerminationsDao(jooqConfig)
-    germinationTestsDao = GerminationTestsDao(jooqConfig)
     parentStore = ParentStore(dslContext)
-    photosDao = PhotosDao(jooqConfig)
-    speciesDao = SpeciesDao(jooqConfig)
-    speciesNamesDao = SpeciesNamesDao(jooqConfig)
-    speciesOptionsDao = SpeciesOptionsDao(jooqConfig)
-    storageLocationsDao = StorageLocationsDao(jooqConfig)
 
     val speciesStore =
         SpeciesStore(clock, dslContext, speciesDao, speciesNamesDao, speciesOptionsDao)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -10,9 +10,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.mercatorPoint
-import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.PhotosDao
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.PhotosRow
@@ -57,13 +54,10 @@ import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 
 class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
-  private lateinit var accessionsDao: AccessionsDao
-  private lateinit var accessionPhotosDao: AccessionPhotosDao
   private lateinit var accessionStore: AccessionStore
   private val clock: Clock = mockk()
   private val config: TerrawareServerConfig = mockk()
   private lateinit var fileStore: FileStore
-  private lateinit var photosDao: PhotosDao
   private lateinit var pathGenerator: PathGenerator
   private val random: Random = mockk()
   private lateinit var repository: PhotoRepository
@@ -90,10 +84,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    accessionPhotosDao = AccessionPhotosDao(dslContext.configuration())
-    accessionsDao = AccessionsDao(dslContext.configuration())
-    photosDao = PhotosDao(dslContext.configuration())
-
     accessionStore =
         AccessionStore(
             dslContext,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -11,8 +11,6 @@ import com.terraformation.backend.db.GerminationTestType
 import com.terraformation.backend.db.SeedQuantityUnits
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalPurpose
-import com.terraformation.backend.db.tables.daos.GerminationTestsDao
-import com.terraformation.backend.db.tables.daos.WithdrawalsDao
 import com.terraformation.backend.db.tables.pojos.GerminationTestsRow
 import com.terraformation.backend.db.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
@@ -35,9 +33,7 @@ import org.junit.jupiter.api.assertThrows
 internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private lateinit var germinationTestsDao: GerminationTestsDao
   private lateinit var store: WithdrawalStore
-  private lateinit var withdrawalsDao: WithdrawalsDao
 
   private val clock: Clock = mockk()
 
@@ -50,9 +46,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setup() {
-    germinationTestsDao = GerminationTestsDao(dslContext.configuration())
     store = WithdrawalStore(dslContext, clock)
-    withdrawalsDao = WithdrawalsDao(dslContext.configuration())
 
     every { clock.instant() } returns Instant.now()
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -21,13 +21,6 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.mercatorPoint
-import com.terraformation.backend.db.tables.daos.AccessionGerminationTestTypesDao
-import com.terraformation.backend.db.tables.daos.AccessionsDao
-import com.terraformation.backend.db.tables.daos.BagsDao
-import com.terraformation.backend.db.tables.daos.GerminationTestsDao
-import com.terraformation.backend.db.tables.daos.GerminationsDao
-import com.terraformation.backend.db.tables.daos.SpeciesDao
-import com.terraformation.backend.db.tables.daos.StorageLocationsDao
 import com.terraformation.backend.db.tables.pojos.AccessionGerminationTestTypesRow
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.BagsRow
@@ -71,12 +64,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
   override val sequencesToReset: List<String> = listOf("accession_id_seq")
 
-  private lateinit var accessionsDao: AccessionsDao
-  private lateinit var accessionGerminationTestTypesDao: AccessionGerminationTestTypesDao
   private lateinit var accessionSearchService: AccessionSearchService
-  private lateinit var bagsDao: BagsDao
-  private lateinit var germinationTestsDao: GerminationTestsDao
-  private lateinit var germinationsDao: GerminationsDao
   private lateinit var searchService: SearchService
 
   private val organizationId = OrganizationId(1)
@@ -110,13 +98,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun init() {
-    val jooqConfig = dslContext.configuration()
-
-    accessionsDao = AccessionsDao(jooqConfig)
-    accessionGerminationTestTypesDao = AccessionGerminationTestTypesDao(jooqConfig)
-    bagsDao = BagsDao(jooqConfig)
-    germinationTestsDao = GerminationTestsDao(jooqConfig)
-    germinationsDao = GerminationsDao(jooqConfig)
     searchService = SearchService(dslContext)
     accessionSearchService = AccessionSearchService(tables, searchService)
 
@@ -128,7 +109,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
     val now = Instant.now()
 
-    val speciesDao = SpeciesDao(jooqConfig)
     speciesDao.insert(
         SpeciesRow(
             id = SpeciesId(10000),
@@ -1210,8 +1190,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `returns values for field from reference table`() {
-      val storageLocationDao = StorageLocationsDao(dslContext.configuration())
-      storageLocationDao.insert(
+      storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1000),
               facilityId = FacilityId(100),
@@ -1222,7 +1201,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
               modifiedBy = user.userId,
               modifiedTime = Instant.now(),
           ))
-      storageLocationDao.insert(
+      storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1001),
               facilityId = FacilityId(100),
@@ -1233,7 +1212,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
               modifiedBy = user.userId,
               modifiedTime = Instant.now(),
           ))
-      storageLocationDao.insert(
+      storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1002),
               facilityId = FacilityId(100),
@@ -1252,12 +1231,11 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `only includes storage locations the user has permission to view`() {
-      val storageLocationDao = StorageLocationsDao(dslContext.configuration())
       insertProject(11)
       insertSite(110)
       insertFacility(1100)
 
-      storageLocationDao.insert(
+      storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1000),
               facilityId = FacilityId(100),
@@ -1268,7 +1246,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
               modifiedBy = user.userId,
               modifiedTime = Instant.now(),
           ))
-      storageLocationDao.insert(
+      storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1001),
               facilityId = FacilityId(1100),
@@ -1314,9 +1292,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `only includes child table values the user has permission to view`() {
-      val germinationTestsDao = GerminationTestsDao(dslContext.configuration())
-      val germinationsDao = GerminationsDao(dslContext.configuration())
-
       val hiddenAccessionId = AccessionId(1100)
 
       insertProject(11)

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -14,9 +14,6 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.SpeciesNameId
 import com.terraformation.backend.db.SpeciesNameNotFoundException
 import com.terraformation.backend.db.SpeciesNotFoundException
-import com.terraformation.backend.db.tables.daos.SpeciesDao
-import com.terraformation.backend.db.tables.daos.SpeciesNamesDao
-import com.terraformation.backend.db.tables.daos.SpeciesOptionsDao
 import com.terraformation.backend.db.tables.pojos.SpeciesNamesRow
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.tables.references.SPECIES_OPTIONS
@@ -44,19 +41,10 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   override val user: TerrawareUser = mockUser()
 
-  private lateinit var speciesDao: SpeciesDao
-  private lateinit var speciesNamesDao: SpeciesNamesDao
-  private lateinit var speciesOptionsDao: SpeciesOptionsDao
   private lateinit var store: SpeciesStore
 
   @BeforeEach
   fun setUp() {
-    val jooqConfig = dslContext.configuration()
-
-    speciesDao = SpeciesDao(jooqConfig)
-    speciesNamesDao = SpeciesNamesDao(jooqConfig)
-    speciesOptionsDao = SpeciesOptionsDao(jooqConfig)
-
     store =
         SpeciesStore(
             clock,


### PR DESCRIPTION
Nearly all the database-based tests use one or more jOOQ DAO objects to manipulate
the database. Creating the DAOs is boilerplate and doesn't add any clarity to tests,
so there's no point repeating it all over the place.

Add all the DAOs to `DatabaseTest` so tests can reference them. Since creating a DAO
has a small but nonzero cost, make them lazy-instantiated.