### PR TITLE
TRACK-642 Create Plants Planted layer for new sites

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3575,6 +3575,26 @@ components:
       properties:
         description:
           type: string
+        layerTypes:
+          uniqueItems: true
+          type: array
+          description: Create map layers of these types. Pass an empty list to skip
+            creating layers. Default is to create a Plants Planted layer.
+          items:
+            type: string
+            enum:
+            - Aerial Photos
+            - Surface Color Map
+            - Terrain Color Map
+            - Boundaries
+            - Plants Planted
+            - Plants Existing
+            - Irrigation
+            - Infrastructure
+            - Partner Input
+            - Restoration Zones
+            - Site Prep
+            - Map notes
         location:
           $ref: '#/components/schemas/Point'
         locale:

--- a/src/main/kotlin/com/terraformation/backend/customer/SiteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/SiteService.kt
@@ -1,0 +1,38 @@
+package com.terraformation.backend.customer
+
+import com.terraformation.backend.customer.db.SiteStore
+import com.terraformation.backend.customer.model.SiteModel
+import com.terraformation.backend.db.LayerType
+import com.terraformation.backend.db.tables.pojos.SitesRow
+import com.terraformation.backend.gis.db.LayerStore
+import com.terraformation.backend.gis.model.LayerModel
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+/** Site-related business logic that needs to interact with multiple services. */
+@ManagedBean
+class SiteService(
+    private val dslContext: DSLContext,
+    private val siteStore: SiteStore,
+    private val layerStore: LayerStore,
+) {
+  /** Creates a new site with an initial set of map layers. */
+  fun create(row: SitesRow, layerTypes: Set<LayerType>): SiteModel {
+    return dslContext.transactionResult { _ ->
+      val siteModel = siteStore.create(row)
+
+      layerTypes.forEach { layerType ->
+        layerStore.createLayer(
+            LayerModel(
+                hidden = false,
+                layerType = layerType,
+                proposed = false,
+                siteId = siteModel.id,
+                tileSetName = null,
+            ))
+      }
+
+      siteModel
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SitesController.kt
@@ -6,14 +6,17 @@ import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.SiteService
 import com.terraformation.backend.customer.db.SiteStore
 import com.terraformation.backend.customer.model.SiteModel
+import com.terraformation.backend.db.LayerType
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.tables.pojos.SitesRow
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
@@ -33,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController
 @CustomerEndpoint
 @RestController
 @RequestMapping("/api/v1/sites")
-class SitesController(private val siteStore: SiteStore) {
+class SitesController(private val siteService: SiteService, private val siteStore: SiteStore) {
   @ApiResponse(responseCode = "200", description = "Retrieved list of sites.")
   @GetMapping
   @Operation(summary = "Gets all of the sites the current user can access.")
@@ -71,7 +74,8 @@ class SitesController(private val siteStore: SiteStore) {
   @PostMapping
   @Operation(summary = "Creates a new site.")
   fun createSite(@RequestBody @Valid payload: CreateSiteRequestPayload): CreateSiteResponsePayload {
-    val site = siteStore.create(payload.toRow())
+    val site =
+        siteService.create(payload.toRow(), payload.layerTypes ?: setOf(LayerType.PlantsPlanted))
     return CreateSiteResponsePayload(site.id)
   }
 
@@ -142,6 +146,13 @@ data class GetSiteResponsePayload(val site: SiteElement) : SuccessResponsePayloa
 
 data class CreateSiteRequestPayload(
     val description: String?,
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "Create map layers of these types. Pass an empty list to skip creating " +
+                        "layers. Default is to create a Plants Planted layer."))
+    val layerTypes: Set<LayerType>?,
     val location: Point?,
     val locale: String?,
     @field:NotEmpty val name: String,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/SiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/SiteStore.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.SiteService
 import com.terraformation.backend.customer.model.SiteModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.customer.model.toModel
@@ -57,6 +58,8 @@ class SiteStore(
    * Creates a new site.
    *
    * @param row Initial site information. Project ID is required; ID and timestamps are ignored.
+   *
+   * @see SiteService.create
    */
   fun create(row: SitesRow): SiteModel {
     val projectId = row.projectId ?: throw IllegalArgumentException("Must specify project ID")

--- a/src/test/kotlin/com/terraformation/backend/customer/SiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/SiteServiceTest.kt
@@ -1,0 +1,140 @@
+package com.terraformation.backend.customer
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.db.SiteStore
+import com.terraformation.backend.customer.model.SiteModel
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.LayerType
+import com.terraformation.backend.db.ProjectId
+import com.terraformation.backend.db.SiteId
+import com.terraformation.backend.db.tables.pojos.LayersRow
+import com.terraformation.backend.db.tables.pojos.SitesRow
+import com.terraformation.backend.gis.db.LayerStore
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class SiteServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+  override val sequencesToReset: List<String> = listOf("layers_id_seq", "site_id_seq")
+
+  private val clock: Clock = mockk()
+
+  private lateinit var service: SiteService
+
+  private val projectId = ProjectId(2)
+
+  @BeforeEach
+  fun setUp() {
+    service =
+        SiteService(
+            dslContext,
+            SiteStore(clock, dslContext, ParentStore(dslContext), sitesDao),
+            LayerStore(clock, dslContext))
+
+    every { clock.instant() } returns Instant.EPOCH
+    every { user.canCreateLayer(any()) } returns true
+    every { user.canCreateSite(any()) } returns true
+    every { user.canReadProject(any()) } returns true
+    every { user.canReadSite(any()) } returns true
+
+    insertUser()
+    insertOrganization(1, "dev")
+    insertProject(projectId, 1, "project")
+  }
+
+  @Test
+  fun `create creates site and layers`() {
+    val newRow = SitesRow(projectId = projectId, name = "Test Site")
+    val layerTypes = setOf(LayerType.AerialPhotos, LayerType.PlantsPlanted)
+    val siteId = SiteId(1)
+
+    val expectedSiteModel =
+        SiteModel(
+            createdTime = clock.instant(),
+            description = null,
+            id = siteId,
+            location = null,
+            modifiedTime = clock.instant(),
+            name = "Test Site",
+            projectId = projectId,
+        )
+
+    val actualSiteModel = service.create(newRow, layerTypes)
+    assertEquals(expectedSiteModel, actualSiteModel)
+
+    val expectedSites =
+        listOf(
+            newRow.copy(
+                createdBy = user.userId,
+                createdTime = clock.instant(),
+                enabled = true,
+                id = siteId,
+                modifiedBy = user.userId,
+                modifiedTime = clock.instant(),
+            ))
+
+    val actualSites = sitesDao.fetchByProjectId(projectId)
+    assertEquals(expectedSites, actualSites)
+
+    val expectedLayers =
+        setOf(
+            LayersRow(
+                createdBy = user.userId,
+                createdTime = clock.instant(),
+                deleted = false,
+                hidden = false,
+                layerTypeId = LayerType.AerialPhotos,
+                modifiedBy = user.userId,
+                modifiedTime = clock.instant(),
+                proposed = false,
+                siteId = siteId,
+            ),
+            LayersRow(
+                createdBy = user.userId,
+                createdTime = clock.instant(),
+                deleted = false,
+                hidden = false,
+                layerTypeId = LayerType.PlantsPlanted,
+                modifiedBy = user.userId,
+                modifiedTime = clock.instant(),
+                proposed = false,
+                siteId = siteId,
+            ),
+        )
+
+    val actualLayers = layersDao.fetchBySiteId(siteId).map { it.copy(id = null) }.toSet()
+    assertEquals(expectedLayers, actualLayers, "Should have created layers")
+  }
+
+  @Test
+  fun `create throws exception and does not insert site if user has no permission to create layers`() {
+    every { user.canCreateLayer(any()) } returns false
+
+    assertThrows<AccessDeniedException> {
+      service.create(
+          SitesRow(projectId = projectId, name = "Test Site"), setOf(LayerType.PlantsPlanted))
+    }
+
+    val sites = sitesDao.fetchByProjectId(projectId)
+    assertEquals(emptyList<SitesRow>(), sites, "Should not have created the site")
+  }
+
+  @Test
+  fun `create throws exception if user has no permission to create sites`() {
+    every { user.canCreateSite(any()) } returns false
+
+    assertThrows<AccessDeniedException> {
+      service.create(SitesRow(projectId = projectId, name = "Test Site"), emptySet())
+    }
+  }
+}


### PR DESCRIPTION
There isn't currently a way for users to manage layers, so as a stopgap,
automatically create a "Plants Planted" layer when a new site is created.

The API allows the client to specify a list of layer types to create.