### PR TITLE
TRACK-775 Reject negative seed quantities

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -569,7 +569,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       it.copy(
           germinationTests = listOf(GerminationTestPayload(testType = GerminationTestType.Lab)),
           processingMethod = ProcessingMethod.Count,
-          initialQuantity = seeds(100))
+          initialQuantity = seeds(200))
     }
     val desired =
         initial.copy(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -347,6 +347,50 @@ internal class AccessionModelTest {
         accession(processingMethod = null, total = grams(1))
       }
     }
+
+    @Test
+    fun `cannot withdraw more seeds than exist in the accession`() {
+      assertThrows<IllegalArgumentException> {
+        accession(
+            processingMethod = ProcessingMethod.Count,
+            total = seeds(1),
+            germinationTests = listOf(germinationTest(seedsSown = 1)),
+            withdrawals = listOf(withdrawal(withdrawn = seeds(1), date = tomorrow)))
+      }
+    }
+
+    @Test
+    fun `cannot specify negative seeds remaining for weight-based accessions`() {
+      assertThrows<IllegalArgumentException>("germination tests") {
+        accession(
+            processingMethod = ProcessingMethod.Weight,
+            total = grams(1),
+            germinationTests = listOf(germinationTest(seedsSown = 1, remaining = grams(-1))))
+      }
+
+      assertThrows<IllegalArgumentException>("withdrawals") {
+        accession(
+            processingMethod = ProcessingMethod.Weight,
+            total = grams(1),
+            withdrawals = listOf(withdrawal(withdrawn = grams(1), remaining = grams(-1))))
+      }
+    }
+
+    @Test
+    fun `total quantity must be greater than zero`() {
+      assertThrows<IllegalArgumentException>("zero seeds") {
+        accession(processingMethod = ProcessingMethod.Count, total = seeds(0))
+      }
+      assertThrows<IllegalArgumentException>("zero weight") {
+        accession(processingMethod = ProcessingMethod.Weight, total = grams(0))
+      }
+      assertThrows<IllegalArgumentException>("negative seeds") {
+        accession(processingMethod = ProcessingMethod.Count, total = seeds(-1))
+      }
+      assertThrows<IllegalArgumentException>("negative weight") {
+        accession(processingMethod = ProcessingMethod.Weight, total = grams(-1))
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Previously, there was no sanity checking on the quantities of withdrawals or
germination tests and it was possible to withdraw 1000 seeds from an accession
with 50 seeds remaining. Add validation checks to reject updates that cause the
remaining quantity to drop below zero.

It was also possible to specify a zero or negative total accession size; catch
that as well.