### PR TITLE
Upgrade JDBC driver to get security fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ jacksonVersion=2.13.0
 jooqVersion=3.15.4
 keycloakVersion=15.0.2
 kotlinVersion=1.6.10
-postgresJdbcVersion=42.3.1
+postgresJdbcVersion=42.3.3
 springDocVersion=1.6.1
 
 # For code generation, we run database migrations against an ephemeral database in a Docker


### PR DESCRIPTION
Version 4.3.1 of the PostgreSQL JDBC driver had a vulnerability (CVE-2022-21724).
Upgrade to get the fix.