### PR TITLE
Upgrade to jOOQ 3.16

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfil
 
 awsSdkVersion=2.17.100
 jacksonVersion=2.13.0
-jooqVersion=3.15.4
+jooqVersion=3.16.4
 keycloakVersion=15.0.2
 kotlinVersion=1.6.10
 postgresJdbcVersion=42.3.1

--- a/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
@@ -17,6 +17,14 @@ import org.jooq.Converter
 import org.jooq.impl.DSL
 
 /**
+ * Alias for jOOQ's Geometry class. The application code uses the [Geometry] class from the PostGIS
+ * library, but jOOQ uses its own class of the same name to represent the raw values of `GEOMETRY`
+ * columns. [GeometryBinding] needs to convert between the two; define a typealias to make the code
+ * easier to understand.
+ */
+private typealias JooqGeometry = org.jooq.Geometry
+
+/**
  * jOOQ binding for the PostGIS Java library's [Geometry] type hierarchy. Allows application code to
  * read and write GEOMETRY columns.
  *
@@ -28,21 +36,21 @@ import org.jooq.impl.DSL
  * geometries of multiple types, that is, a given query might return a mix of [Point] and [Polygon]
  * and other geometry objects.
  */
-class GeometryBinding : Binding<Any, Geometry> {
+class GeometryBinding : Binding<JooqGeometry, Geometry> {
   private val converter = GeometryConverter()
 
-  class GeometryConverter : Converter<Any, Geometry> {
-    override fun from(databaseObject: Any?): Geometry? {
-      return databaseObject?.let { GeometryBuilder.geomFromString("$it") }
+  class GeometryConverter : Converter<JooqGeometry, Geometry> {
+    override fun from(databaseObject: JooqGeometry?): Geometry? {
+      return databaseObject?.let { GeometryBuilder.geomFromString(it.data()) }
     }
 
     /**
      * Renders a geometry in WKT (Well Known Text) form with SRID included. PostGIS knows how to
      * cast WKT strings to the GEOMETRY type.
      */
-    override fun to(userObject: Geometry?) = userObject?.toString()
+    override fun to(userObject: Geometry?) = userObject?.toJooqGeometry()
 
-    override fun fromType() = Any::class.java
+    override fun fromType() = org.jooq.Geometry::class.java
 
     override fun toType() = Geometry::class.java
   }
@@ -58,15 +66,15 @@ class GeometryBinding : Binding<Any, Geometry> {
   }
 
   override fun set(ctx: BindingSetStatementContext<Geometry>) {
-    ctx.statement().setObject(ctx.index(), ctx.convert(converter).value())
+    ctx.statement().setObject(ctx.index(), ctx.convert(converter).value()?.data())
   }
 
   override fun get(ctx: BindingGetResultSetContext<Geometry>) {
-    ctx.convert(converter).value(ctx.resultSet().getObject(ctx.index()))
+    ctx.convert(converter).value(ctx.resultSet().getObject(ctx.index())?.toJooqGeometry())
   }
 
   override fun get(ctx: BindingGetStatementContext<Geometry>) {
-    ctx.convert(converter).value(ctx.statement().getObject(ctx.index()))
+    ctx.convert(converter).value(ctx.statement().getObject(ctx.index())?.toJooqGeometry())
   }
 
   override fun set(ctx: BindingSetSQLOutputContext<Geometry>) {
@@ -75,5 +83,10 @@ class GeometryBinding : Binding<Any, Geometry> {
 
   override fun get(ctx: BindingGetSQLInputContext<Geometry>) {
     throw SQLFeatureNotSupportedException("Oracle-specific API does not apply to PostgreSQL")
+  }
+
+  companion object {
+    /** Wraps the string representation of a geometry value in a jOOQ Geometry object. */
+    private fun Any.toJooqGeometry(): JooqGeometry = org.jooq.Geometry.valueOf("$this")
   }
 }


### PR DESCRIPTION
The latest version of jOOQ has started adding support for spatial data types
such as the PostgreSQL `GEOMETRY` type. For now, we want to continue using the
PostGIS library since it is more feature-rich, but the binding code that
converts raw database values to classes from the PostGIS library needs to be
updated to recognize that the "raw database values" are now jOOQ `Geometry`
objects rather than simple strings.

This change doesn't affect the application code aside from `GeometryBinding`,
but it's required if we ever want to upgrade to subsequent jOOQ versions to get
additional features.