### PR TITLE
Remove workaround for old jOOQ bug

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -164,11 +164,10 @@ class AccessionsTable(
    */
   inner class ActiveField(override val fieldName: String, override val displayName: String) :
       SearchField {
-    private val selectField = ACCESSIONS.STATE_ID.`as`("active_state")
     override val table: SearchTable
       get() = this@AccessionsTable
     override val selectFields
-      get() = listOf(selectField)
+      get() = listOf(ACCESSIONS.STATE_ID)
     override val possibleValues = AccessionActive::class.java.enumConstants!!.map { "$it" }
     override val nullable
       get() = false
@@ -187,7 +186,7 @@ class AccessionsTable(
     }
 
     override fun computeValue(record: Record): String? {
-      return record[selectField]?.toActiveEnum()?.toString()
+      return record[ACCESSIONS.STATE_ID]?.toActiveEnum()?.toString()
     }
 
     override val orderByField: Field<*>


### PR DESCRIPTION
Commit a23eae83 added a workaround for https://github.com/jOOQ/jOOQ/issues/12704
which was causing queries to fail when the same column was included twice in the
SELECT clause. The bug is fixed in jOOQ 3.16, which we're now using. Remove the
workaround, but keep the test case that was added as part of that same commit.