### PR TITLE
Be more specific about timestamp format in JSON payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.time.Instant
 import java.time.format.DateTimeParseException
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.TableField
 import org.jooq.impl.DSL
@@ -27,7 +27,7 @@ class TimestampField(
           fieldNode.values.map { if (it != null) Instant.parse(it) else null }
         } catch (e: DateTimeParseException) {
           throw IllegalArgumentException(
-              "Timestamps must be ISO-8601 format with timezone (example: 2021-05-28T18:45:30Z)")
+              "Timestamps must be in RFC 3339 format (example: 2021-05-28T18:45:30Z)")
         }
     val nonNullInstants = instantValues.filterNotNull()
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -639,7 +639,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `can search for timestamps using different but equivalent ISO-8601 time format`() {
+  fun `can search for timestamps using different but equivalent RFC 3339 time format`() {
     val fields = listOf(checkedInTimeField)
     val searchNode =
         FieldNode(


### PR DESCRIPTION
If the client searches on a timestamp field and passes a malformed value,
return an error message that's more specific about the correct format: we want
RFC 3339 timestamps, not arbitrary ISO-8601 timestamps. ISO-8601 allows a huge
range of time formats most of which don't make sense as search terms.