### PR TITLE
TRACK-838 Use cluster-aware job scheduler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
   implementation("org.apache.tika:tika-core:2.1.0")
   implementation("org.codehaus.janino:janino:3.1.6")
   implementation("org.flywaydb:flyway-core:8.2.2")
+  implementation("org.jobrunr:jobrunr-spring-boot-starter:4.0.10")
   implementation("org.jooq:jooq:$jooqVersion")
   implementation(platform("org.keycloak.bom:keycloak-adapter-bom:$keycloakVersion"))
   implementation("org.keycloak:keycloak-spring-boot-starter")

--- a/src/main/kotlin/com/terraformation/backend/time/ClockAdvancedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/time/ClockAdvancedEvent.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.time
+
+import java.time.Duration
+
+/**
+ * Published when the application's clock is advanced by an administrator. This only happens in test
+ * environments; it is used to test time-based workflows by advancing the clock to the time when an
+ * operation is scheduled to be performed.
+ *
+ * @see DatabaseBackedClock
+ */
+data class ClockAdvancedEvent(val duration: Duration)

--- a/src/main/kotlin/com/terraformation/backend/time/api/ClockController.kt
+++ b/src/main/kotlin/com/terraformation/backend/time/api/ClockController.kt
@@ -50,7 +50,7 @@ class ClockAdjustmentController(private val clock: DatabaseBackedClock) {
     val now = ZonedDateTime.now(clock)
     val currentTime = DateTimeFormatter.RFC_1123_DATE_TIME.format(now)
     model.addAttribute("currentTime", currentTime)
-    return "test/clock"
+    return "/test/clock"
   }
 
   @PostMapping("/api/test/clock")

--- a/src/main/resources/application-apidoc.yaml
+++ b/src/main/resources/application-apidoc.yaml
@@ -37,6 +37,15 @@ keycloak:
   credentials:
     secret: dummy
 
+org:
+  jobrunr:
+    background-job-server:
+      enabled: false
+    job-scheduler:
+      enabled: false
+    database:
+      skip-create: true
+
 logging:
   level:
     root: warn

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,6 +61,12 @@ springdoc:
     disable-swagger-default-url: true
     operations-sorter: alpha
 
+org:
+  jobrunr:
+    background-job-server:
+      # All terraware-server instances can run scheduled jobs.
+      enabled: true
+
 logging:
   level:
     # Suppress a warning message about deserialization (Keycloak tries to add a serialization filter


### PR DESCRIPTION
Currently, in our AWS environments, the daily tasks (accession state transitions,
etc.) run separately on each server instance. There is locking in place to prevent
the same task from running concurrently on two instances, but it still causes the
system to do unnecessary work.

Replace the daily task runner's background thread with a third-party job scheduler
library, JobRunr. The library automatically ensures that only one instance runs
each scheduled occurrence of a job.

The more sophisticated scheduler will also be useful for other periodic tasks such
as scanning for idle device managers.

This change doesn't modify any of the logic of the daily tasks themselves,
including the logic that figures out which time ranges to scan; it just replaces
the mechanism by which the tasks are launched.