### PR TITLE
Reduce log spew from daily accession tasks

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/daily/DateNotificationTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/daily/DateNotificationTask.kt
@@ -4,8 +4,6 @@ import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.daily.DailyTaskRunner
 import com.terraformation.backend.daily.TimePeriodTask
 import com.terraformation.backend.db.AccessionId
-import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.db.AccessionNotificationStore
@@ -23,7 +21,6 @@ class DateNotificationTask(
     private val accessionStore: AccessionStore,
     private val dailyTaskRunner: DailyTaskRunner,
     private val dslContext: DSLContext,
-    private val facilitiesDao: FacilitiesDao,
     private val messages: Messages,
     private val accessionNotificationStore: AccessionNotificationStore,
 ) : TimePeriodTask {
@@ -41,46 +38,33 @@ class DateNotificationTask(
     log.info("Generating date update notifications for due dates since $since")
 
     dslContext.transaction { _ ->
-      facilitiesDao.findAll().mapNotNull { it.id }.forEach { facilityId ->
-        moveToDryingCabinet(facilityId, since, until)
-        germinationTest(facilityId, since, until)
-        withdraw(facilityId, since, until)
-      }
+      moveToDryingCabinet(since, until)
+      germinationTest(since, until)
+      withdraw(since, until)
     }
   }
 
-  private fun moveToDryingCabinet(
-      facilityId: FacilityId,
-      after: TemporalAccessor,
-      until: TemporalAccessor
-  ) {
-    accessionStore.fetchDryingMoveDue(facilityId, after, until).forEach { (number, id) ->
-      insert(facilityId, id, messages.dryingMoveDateNotification(number))
+  private fun moveToDryingCabinet(after: TemporalAccessor, until: TemporalAccessor) {
+    accessionStore.fetchDryingMoveDue(after, until).forEach { (number, id) ->
+      insert(id, messages.dryingMoveDateNotification(number))
     }
   }
 
-  private fun germinationTest(
-      facilityId: FacilityId,
-      after: TemporalAccessor,
-      until: TemporalAccessor
-  ) {
-    accessionStore.fetchGerminationTestDue(facilityId, after, until).forEach { (number, test) ->
-      insert(
-          facilityId,
-          test.accessionId!!,
-          messages.germinationTestDateNotification(number, test.testType!!))
+  private fun germinationTest(after: TemporalAccessor, until: TemporalAccessor) {
+    accessionStore.fetchGerminationTestDue(after, until).forEach { (number, test) ->
+      insert(test.accessionId!!, messages.germinationTestDateNotification(number, test.testType!!))
     }
   }
 
-  private fun withdraw(facilityId: FacilityId, after: TemporalAccessor, until: TemporalAccessor) {
-    accessionStore.fetchWithdrawalDue(facilityId, after, until).forEach { (number, id) ->
-      insert(facilityId, id, messages.withdrawalDateNotification(number))
+  private fun withdraw(after: TemporalAccessor, until: TemporalAccessor) {
+    accessionStore.fetchWithdrawalDue(after, until).forEach { (number, id) ->
+      insert(id, messages.withdrawalDateNotification(number))
     }
   }
 
-  private fun insert(facilityId: FacilityId, accessionId: AccessionId, message: String) {
+  private fun insert(accessionId: AccessionId, message: String) {
     log.info("Generated notification: $message")
-    accessionNotificationStore.insertDateNotification(facilityId, accessionId, message)
+    accessionNotificationStore.insertDateNotification(accessionId, message)
   }
 
   class FinishedEvent


### PR DESCRIPTION
The daily tasks that move accessions to new states and generate notifications
about due dates were implemented when we were planning to have the server run
locally in each seed bank. When we moved to a centralized model, we updated the
logic to treat each seed bank facility as its own little universe so there
wouldn't be any potential behavior changes.

Unfortunately, that means we started generating a separate set of log messages
for each facility, whether or not there was actually any work to do. It's now at a
point where these messages account for a significant percentage of the server's
log volume.

Improve the situation a few ways:

* Make some of the daily tasks operate on the entire set of accessions rather than
  looping through each facility one by one. This will have the added bonus of
  making the jobs run faster since there'll be far fewer database queries needed.
  The state summary task remains per-facility since it needs to generate
  statistics on a per-facility basis anyway.
* Remove some uninteresting log messages like "No notifications generated."
* Fold some query timing messages together.