### PR TITLE
TRACK-654 Remove obsolete filters field from search API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3872,10 +3872,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SearchSortOrderElement'
-        filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchFilter'
         search:
           oneOf:
           - $ref: '#/components/schemas/AndNodePayload'
@@ -4511,10 +4507,6 @@ components:
           type: array
           items:
             type: string
-        filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchFilter'
         search:
           oneOf:
           - $ref: '#/components/schemas/AndNodePayload'
@@ -5191,10 +5183,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SearchSortOrderElement'
-        filters:
-          type: array
-          items:
-            $ref: '#/components/schemas/SearchFilter'
         search:
           oneOf:
           - $ref: '#/components/schemas/AndNodePayload'
@@ -5207,33 +5195,6 @@ components:
           type: integer
           format: int32
           default: 10
-    SearchFilter:
-      required:
-      - field
-      - type
-      - values
-      type: object
-      properties:
-        field:
-          type: string
-        values:
-          minLength: 1
-          type: array
-          description: "List of values to match. For exact and fuzzy searches, a list\
-            \ of at least one value to search for; the list may include null to match\
-            \ accessions where the field does not have a value. For range searches,\
-            \ the list must contain exactly two values, the minimum and maximum; one\
-            \ of the values may be null to search for all values above a minimum or\
-            \ below a maximum."
-          items:
-            type: string
-            nullable: true
-        type:
-          type: string
-          enum:
-          - Exact
-          - Fuzzy
-          - Range
     SearchNodePayload:
       required:
       - operation

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionSearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionSearchController.kt
@@ -6,10 +6,8 @@ import com.terraformation.backend.api.writeNext
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.api.HasSearchFields
-import com.terraformation.backend.search.api.HasSearchFilters
 import com.terraformation.backend.search.api.HasSearchNode
 import com.terraformation.backend.search.api.HasSortOrder
-import com.terraformation.backend.search.api.SearchFilter
 import com.terraformation.backend.search.api.SearchNodePayload
 import com.terraformation.backend.search.api.SearchResponsePayload
 import com.terraformation.backend.search.api.SearchSortOrderElement
@@ -123,19 +121,17 @@ data class SearchAccessionsRequestPayload(
     val facilityId: FacilityId,
     @NotEmpty override val fields: List<String>,
     override val sortOrder: List<SearchSortOrderElement>? = null,
-    override val filters: List<SearchFilter>? = null,
     override val search: SearchNodePayload? = null,
     val cursor: String? = null,
     @Schema(
         defaultValue = "10",
     )
     val count: Int = 10
-) : HasSearchFields, HasSearchNode, HasSortOrder, HasSearchFilters
+) : HasSearchFields, HasSearchNode, HasSortOrder
 
 data class ExportAccessionsRequestPayload(
     val facilityId: FacilityId,
     @NotEmpty override val fields: List<String>,
     override val sortOrder: List<SearchSortOrderElement>? = null,
-    override val filters: List<SearchFilter>? = null,
     override val search: SearchNodePayload? = null,
-) : HasSearchFields, HasSearchNode, HasSortOrder, HasSearchFilters
+) : HasSearchFields, HasSearchNode, HasSortOrder

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -6,9 +6,7 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
-import com.terraformation.backend.search.api.HasSearchFilters
 import com.terraformation.backend.search.api.HasSearchNode
-import com.terraformation.backend.search.api.SearchFilter
 import com.terraformation.backend.search.api.SearchNodePayload
 import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.db.StorageLocationStore
@@ -117,9 +115,8 @@ data class FieldValuesPayload(
 data class ListFieldValuesRequestPayload(
     val facilityId: FacilityId,
     val fields: List<String>,
-    override val filters: List<SearchFilter>?,
     override val search: SearchNodePayload?,
-) : HasSearchNode, HasSearchFilters
+) : HasSearchNode
 
 data class ListFieldValuesResponsePayload(val results: Map<String, FieldValuesPayload>) :
     SuccessResponsePayload


### PR DESCRIPTION
The initial version of the search API had a less sophisticated way to specify
search criteria. We kept it around for backward compatibility since it was
still being used in the web app. The last use of it has now been removed from
the frontend code: it was only being used by the accession number search bar,
which was removed from the UI. Get rid of it on the server side.