### PR TITLE
TRACK-553 Switch to non-deprecated Flyway property

### DIFF
--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -22,7 +22,7 @@ spring:
     # During development, it is convenient to temporarily add a repeatable migration and work on it
     # until it's correct, then make it a versioned migration. By default, Flyway would bomb out due
     # to the repeatable migration going missing.
-    ignore-missing-migrations: true
+    ignore-migration-patterns: "*:missing"
   thymeleaf:
     cache: false
     prefix: "file:src/main/resources/templates"


### PR DESCRIPTION
The `ignore-missing-migrations` Flyway config option is deprecated. Switch to
`ignore-migration-patterns` which is the newer option that replaces it.