### PR TITLE
Fix missing update of germination test totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/GerminationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/GerminationStore.kt
@@ -90,33 +90,35 @@ class GerminationStore(private val dslContext: DSLContext) {
       accessionId: AccessionId,
       germinationTest: GerminationTestModel
   ): GerminationTestModel {
+    val calculatedTest: GerminationTestModel = germinationTest.withCalculatedValues()
+
     val testId =
         with(GERMINATION_TESTS) {
           dslContext
               .insertInto(GERMINATION_TESTS)
               .set(ACCESSION_ID, accessionId)
-              .set(END_DATE, germinationTest.endDate)
-              .set(NOTES, germinationTest.notes)
-              .set(REMAINING_GRAMS, germinationTest.remaining?.grams)
-              .set(REMAINING_QUANTITY, germinationTest.remaining?.quantity)
-              .set(REMAINING_UNITS_ID, germinationTest.remaining?.units)
-              .set(SEED_TYPE_ID, germinationTest.seedType)
-              .set(SEEDS_SOWN, germinationTest.seedsSown)
-              .set(STAFF_RESPONSIBLE, germinationTest.staffResponsible)
-              .set(START_DATE, germinationTest.startDate)
-              .set(SUBSTRATE_ID, germinationTest.substrate)
-              .set(TEST_TYPE, germinationTest.testType)
-              .set(TOTAL_PERCENT_GERMINATED, germinationTest.calculateTotalPercentGerminated())
-              .set(TOTAL_SEEDS_GERMINATED, germinationTest.calculateTotalSeedsGerminated())
-              .set(TREATMENT_ID, germinationTest.treatment)
+              .set(END_DATE, calculatedTest.endDate)
+              .set(NOTES, calculatedTest.notes)
+              .set(REMAINING_GRAMS, calculatedTest.remaining?.grams)
+              .set(REMAINING_QUANTITY, calculatedTest.remaining?.quantity)
+              .set(REMAINING_UNITS_ID, calculatedTest.remaining?.units)
+              .set(SEED_TYPE_ID, calculatedTest.seedType)
+              .set(SEEDS_SOWN, calculatedTest.seedsSown)
+              .set(STAFF_RESPONSIBLE, calculatedTest.staffResponsible)
+              .set(START_DATE, calculatedTest.startDate)
+              .set(SUBSTRATE_ID, calculatedTest.substrate)
+              .set(TEST_TYPE, calculatedTest.testType)
+              .set(TOTAL_PERCENT_GERMINATED, calculatedTest.totalPercentGerminated)
+              .set(TOTAL_SEEDS_GERMINATED, calculatedTest.totalSeedsGerminated)
+              .set(TREATMENT_ID, calculatedTest.treatment)
               .returning(ID)
               .fetchOne()
               ?.get(ID)!!
         }
 
-    germinationTest.germinations?.forEach { insertGermination(testId, it) }
+    calculatedTest.germinations?.forEach { insertGermination(testId, it) }
 
-    return germinationTest.copy(id = testId)
+    return calculatedTest.copy(id = testId)
   }
 
   private fun insertGermination(testId: GerminationTestId, germination: GerminationModel) {
@@ -174,7 +176,7 @@ class GerminationStore(private val dslContext: DSLContext) {
           .execute()
     }
 
-    desired.forEach { desiredTest ->
+    desired.map { it.withCalculatedValues() }.forEach { desiredTest ->
       val testId = desiredTest.id
 
       if (testId == null) {
@@ -198,8 +200,8 @@ class GerminationStore(private val dslContext: DSLContext) {
                 .set(SUBSTRATE_ID, desiredTest.substrate)
                 .set(STAFF_RESPONSIBLE, desiredTest.staffResponsible)
                 .set(START_DATE, desiredTest.startDate)
-                .set(TOTAL_PERCENT_GERMINATED, desiredTest.calculateTotalPercentGerminated())
-                .set(TOTAL_SEEDS_GERMINATED, desiredTest.calculateTotalSeedsGerminated())
+                .set(TOTAL_PERCENT_GERMINATED, desiredTest.totalPercentGerminated)
+                .set(TOTAL_SEEDS_GERMINATED, desiredTest.totalSeedsGerminated)
                 .set(TREATMENT_ID, desiredTest.treatment)
                 .where(ID.eq(testId))
                 .execute()

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Germination.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Germination.kt
@@ -52,7 +52,7 @@ data class GerminationTestModel(
     return germinations?.maxOfOrNull { it.recordingDate }
   }
 
-  fun calculateTotalSeedsGerminated(): Int? {
+  private fun calculateTotalSeedsGerminated(): Int? {
     return germinations?.sumOf { it.seedsGerminated }
   }
 
@@ -65,5 +65,12 @@ data class GerminationTestModel(
         null
       }
     }
+  }
+
+  fun withCalculatedValues(): GerminationTestModel {
+    return copy(
+        totalPercentGerminated = calculateTotalPercentGerminated(),
+        totalSeedsGerminated = calculateTotalSeedsGerminated(),
+    )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -610,11 +610,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     val initial = createAndUpdate {
       it.copy(
           processingMethod = ProcessingMethod.Count,
-          initialQuantity = seeds(100),
+          initialQuantity = seeds(2000),
           germinationTests =
               listOf(
                   GerminationTestPayload(
                       testType = GerminationTestType.Lab,
+                      seedsSown = 1000,
                       germinations =
                           listOf(
                               GerminationPayload(recordingDate = localDate, seedsGerminated = 75),
@@ -626,10 +627,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
         initial.copy(
             germinationTests =
                 listOf(
-                    GerminationTestModel(
-                        id = initial.germinationTests[0].id,
-                        testType = GerminationTestType.Lab,
-                        seedsSown = 100,
+                    initial.germinationTests[0].copy(
                         germinations =
                             listOf(
                                 GerminationModel(
@@ -642,9 +640,13 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
         germinations.any { it.recordingDate == localDate && it.seedsGerminated == 75 },
         "First germination preserved")
 
+    val updatedGerminationTest = germinationTestsDao.fetchOneById(GerminationTestId(1))!!
+    assertEquals(7, updatedGerminationTest.totalPercentGerminated, "totalPercentGerminated")
+    assertEquals(75, updatedGerminationTest.totalSeedsGerminated, "totalSeedsGerminated")
+
     val updatedAccession = accessionsDao.fetchOneById(AccessionId(1))
-    assertEquals(75, updatedAccession?.totalViabilityPercent, "totalViabilityPercent")
-    assertEquals(75, updatedAccession?.latestViabilityPercent, "latestViabilityPercent")
+    assertEquals(7, updatedAccession?.totalViabilityPercent, "totalViabilityPercent")
+    assertEquals(7, updatedAccession?.latestViabilityPercent, "latestViabilityPercent")
     assertEquals(
         localDate,
         updatedAccession?.latestGerminationRecordingDate,


### PR DESCRIPTION
Editing the list of germinations on an existing germination test wasn't updating
the germination test's total seeds germinated or total percent germinated. (The
accession-level percentage was being updated correctly.)

In addition, though this wasn't client-visible, the updated `GerminationTestModel`
returned after inserting a new test didn't include those calculated totals, though
they were correctly inserted into the database.