### PR TITLE
TRACK-860 Don't allow removing last organization owner

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1377,6 +1377,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleErrorResponsePayload'
+        "409":
+          description: An organization must have at least one owner; cannot change
+            the role of an organization's only owner.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponsePayload'
     delete:
       tags:
       - Customer
@@ -1405,6 +1412,13 @@ paths:
                 $ref: '#/components/schemas/SimpleSuccessResponsePayload'
         "404":
           description: The user is not a member of the organization.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponsePayload'
+        "409":
+          description: The user is the organization's only owner and an organization
+            must have at least one owner.
           content:
             application/json:
               schema:

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -32,15 +32,24 @@ annotation class CustomerEndpoint
 annotation class SearchEndpoint
 
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
 @ApiResponse(
-    responseCode = "404",
     content =
         [
             Content(
                 mediaType = MediaType.APPLICATION_JSON_VALUE,
                 schema = Schema(implementation = SimpleErrorResponsePayload::class))])
+annotation class ApiResponseSimpleError(val responseCode: String)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@ApiResponseSimpleError(responseCode = "404")
 annotation class ApiResponse404(val description: String = "The requested resource was not found.")
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@ApiResponseSimpleError(responseCode = "409")
+annotation class ApiResponse409(val description: String = "The request would cause a conflict.")
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -28,6 +28,9 @@ class AccessionNotFoundException(val accessionId: AccessionId) :
 class AutomationNotFoundException(val automationId: AutomationId) :
     EntityNotFoundException("Automation $automationId not found")
 
+class CannotRemoveLastOwnerException(val organizationId: OrganizationId) :
+    RuntimeException("Cannot remove last owner of organization $organizationId")
+
 class DeviceNotFoundException(val deviceId: DeviceId) :
     EntityNotFoundException("Device $deviceId not found")
 


### PR DESCRIPTION
Require that an organization always have at least one owner. Return HTTP 409
(Conflict) if you try to remove or demote the only owner of an organization.