### PR TITLE
TRACK-843 Include organization ID in email notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -42,6 +42,7 @@ class EmailService(
     private val resourceLoader: ResourceLoader,
     private val sender: JavaMailSender,
     private val userStore: UserStore,
+    private val webAppUrls: WebAppUrls,
 ) {
   private lateinit var sesClient: SesV2Client
   private val emailValidator = EmailValidator.getInstance()
@@ -130,12 +131,14 @@ class EmailService(
     val helper = MimeMessageHelper(message, true)
 
     val webAppUrl = "${config.webAppUrl}".trimEnd('/')
+    val organizationHomeUrl = webAppUrls.organizationHome(organizationId).toString()
 
     val replacements =
         mapOf(
             "\${admin.email}" to admin.email,
             "\${admin.fullName}" to (admin.fullName ?: ""),
             "\${organization.name}" to organization.name,
+            "\${organizationHomeUrl}" to organizationHomeUrl,
         )
 
     val textBody =

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -1,0 +1,21 @@
+package com.terraformation.backend.email
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.OrganizationId
+import java.net.URI
+import javax.annotation.ManagedBean
+import javax.ws.rs.core.UriBuilder
+
+/**
+ * Constructs URLs for specific locations in the web app. These are used in things like notification
+ * email messages that need to include direct links to specific areas of the app.
+ */
+@ManagedBean
+class WebAppUrls(private val config: TerrawareServerConfig) {
+  fun organizationHome(organizationId: OrganizationId): URI {
+    return UriBuilder.fromUri(config.webAppUrl)
+        .path("/home")
+        .queryParam("organizationId", organizationId)
+        .build()
+  }
+}

--- a/src/main/resources/templates/email/userAddedToOrganization/body.mjml
+++ b/src/main/resources/templates/email/userAddedToOrganization/body.mjml
@@ -91,7 +91,7 @@
                     Please click the button below to go to your Terraware account where you can view
                     the organization.</mj-text
                 >
-                <mj-button mj-class="btn-productive-primary-md" href="${webAppUrl}/"
+                <mj-button mj-class="btn-productive-primary-md" href="${organizationHomeUrl}"
                     >Go to Terraware</mj-button
                 >
             </mj-column>

--- a/src/main/resources/templates/email/userAddedToOrganization/body.txt
+++ b/src/main/resources/templates/email/userAddedToOrganization/body.txt
@@ -3,7 +3,7 @@ You've been added to ${organization.name}!
 Added by ${admin.fullName} (${admin.email})
 
 Please click the link below to go to your Terraware account where you can view the organization.
-${webAppUrl}
+${organizationHomeUrl}
 
 
 ------------------------------


### PR DESCRIPTION
The link in an "added to organization" email notification should take the user
directly to the organization in question.

Since this won't be the last time we need to construct a link to a specific place
in the web app, add a helper class to consolidate all the link construction logic.