### PR TITLE
Don't retry failing scans for idle facilities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
@@ -15,7 +15,7 @@ class FacilityService(
     private val systemUser: SystemUser,
 ) {
   /** Sends alert email when facilities go idle. Runs once per minute. */
-  @Job(name = SCAN_FOR_IDLE_FACILITIES_JOB_NAME)
+  @Job(name = SCAN_FOR_IDLE_FACILITIES_JOB_NAME, retries = 0)
   @Recurring(id = SCAN_FOR_IDLE_FACILITIES_JOB_NAME, cron = "* * * * *")
   fun scanForIdleFacilities() {
     systemUser.run {


### PR DESCRIPTION
By default, JobRunr retries failed jobs up to 10 times with an exponential
backoff. While awaiting a retry, the job is considered in progress. That's fine
for most jobs but for the once-a-minute scan for idle facilities, the exponential
backoff quickly grows to more than a minute, meaning the job potentially won't
get retried for a significant amount of time even after the underlying problem is
fixed.

Instead, set the job to never retry on failure; it will run again a minute later.