### PR TITLE
Add superclass for numeric search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -1,41 +1,17 @@
 package com.terraformation.backend.search.field
 
-import com.terraformation.backend.search.FieldNode
-import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.math.BigDecimal
-import java.util.EnumSet
-import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
-import org.jooq.impl.DSL
 
 /** Search field for columns with decimal values. */
 class BigDecimalField(
-    override val fieldName: String,
-    override val displayName: String,
-    override val databaseField: TableField<*, BigDecimal?>,
-    override val table: SearchTable,
-) : SingleColumnSearchField<BigDecimal>() {
-  override val supportedFilterTypes: Set<SearchFilterType>
-    get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
-
-  override fun getCondition(fieldNode: FieldNode): Condition {
-    val bigDecimalValues = fieldNode.values.map { if (it != null) BigDecimal(it) else null }
-    val nonNullValues = bigDecimalValues.filterNotNull()
-
-    return when (fieldNode.type) {
-      SearchFilterType.Exact -> {
-        DSL.or(
-            listOfNotNull(
-                if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
-                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
-      }
-      SearchFilterType.Fuzzy ->
-          throw RuntimeException("Fuzzy search not supported for numeric fields")
-      SearchFilterType.Range -> rangeCondition(bigDecimalValues)
-    }
-  }
-
+    fieldName: String,
+    displayName: String,
+    databaseField: TableField<*, BigDecimal?>,
+    table: SearchTable,
+) : NumericSearchField<BigDecimal>(fieldName, displayName, databaseField, table) {
+  override fun fromString(value: String) = BigDecimal(value)
   override fun computeValue(record: Record) = record[databaseField]?.toPlainString()
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -1,41 +1,15 @@
 package com.terraformation.backend.search.field
 
-import com.terraformation.backend.search.FieldNode
-import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
-import java.util.EnumSet
-import org.jooq.Condition
-import org.jooq.Record
 import org.jooq.TableField
-import org.jooq.impl.DSL
 
 /** Search field for columns with floating-point values. */
 class DoubleField(
-    override val fieldName: String,
-    override val displayName: String,
-    override val databaseField: TableField<*, Double?>,
-    override val table: SearchTable,
-    override val nullable: Boolean = true,
-) : SingleColumnSearchField<Double>() {
-  override val supportedFilterTypes: Set<SearchFilterType>
-    get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
-
-  override fun getCondition(fieldNode: FieldNode): Condition {
-    val doubleValues = fieldNode.values.map { it?.toDouble() }
-    val nonNullValues = doubleValues.filterNotNull()
-
-    return when (fieldNode.type) {
-      SearchFilterType.Exact -> {
-        DSL.or(
-            listOfNotNull(
-                if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
-                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
-      }
-      SearchFilterType.Fuzzy ->
-          throw RuntimeException("Fuzzy search not supported for numeric fields")
-      SearchFilterType.Range -> rangeCondition(doubleValues)
-    }
-  }
-
-  override fun computeValue(record: Record) = record[databaseField]?.toString()
+    fieldName: String,
+    displayName: String,
+    databaseField: TableField<*, Double?>,
+    table: SearchTable,
+    nullable: Boolean = true,
+) : NumericSearchField<Double>(fieldName, displayName, databaseField, table, nullable) {
+  override fun fromString(value: String) = value.toDouble()
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/GramsField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/GramsField.kt
@@ -1,53 +1,22 @@
 package com.terraformation.backend.search.field
 
 import com.terraformation.backend.db.SeedQuantityUnits
-import com.terraformation.backend.search.FieldNode
-import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.seedbank.model.toGrams
 import java.math.BigDecimal
-import java.util.EnumSet
-import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
-import org.jooq.impl.DSL
 
 /** Search field for columns with weights in grams. Supports unit conversions on search criteria. */
 class GramsField(
-    override val fieldName: String,
-    override val displayName: String,
-    override val databaseField: TableField<*, BigDecimal?>,
-    override val table: SearchTable,
-) : SingleColumnSearchField<BigDecimal>() {
-  override val supportedFilterTypes: Set<SearchFilterType> =
-      EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
-
-  override fun computeValue(record: Record) = record[databaseField]?.toPlainString()
-
-  override fun getCondition(fieldNode: FieldNode): Condition {
-    val bigDecimalValues = fieldNode.values.map { parseGrams(it) }
-    val nonNullValues = bigDecimalValues.filterNotNull()
-
-    return when (fieldNode.type) {
-      SearchFilterType.Exact -> {
-        DSL.or(
-            listOfNotNull(
-                if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
-                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
-      }
-      SearchFilterType.Fuzzy ->
-          throw RuntimeException("Fuzzy search not supported for numeric fields")
-      SearchFilterType.Range -> rangeCondition(bigDecimalValues)
-    }
-  }
-
+    fieldName: String,
+    displayName: String,
+    databaseField: TableField<*, BigDecimal?>,
+    table: SearchTable,
+) : NumericSearchField<BigDecimal>(fieldName, displayName, databaseField, table) {
   private val formatRegex = Regex("([\\d.]+)\\s*(\\D*)")
 
-  private fun parseGrams(value: String?): BigDecimal? {
-    if (value == null) {
-      return null
-    }
-
+  override fun fromString(value: String): BigDecimal {
     val matches =
         formatRegex.matchEntire(value)
             ?: throw IllegalStateException(
@@ -62,4 +31,6 @@ class GramsField(
 
     return units.toGrams(number)
   }
+
+  override fun computeValue(record: Record) = record[databaseField]?.toPlainString()
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -1,37 +1,15 @@
 package com.terraformation.backend.search.field
 
-import com.terraformation.backend.search.FieldNode
-import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
-import java.util.*
-import org.jooq.Condition
 import org.jooq.TableField
-import org.jooq.impl.DSL
 
 /** Search field for numeric columns that don't allow fractional values. */
 class IntegerField(
-    override val fieldName: String,
-    override val displayName: String,
-    override val databaseField: TableField<*, Int?>,
-    override val table: SearchTable,
-    override val nullable: Boolean = true
-) : SingleColumnSearchField<Int>() {
-  override val supportedFilterTypes: Set<SearchFilterType>
-    get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
-
-  override fun getCondition(fieldNode: FieldNode): Condition {
-    val intValues = fieldNode.values.map { it?.toInt() }
-    val nonNullValues = intValues.filterNotNull()
-    return when (fieldNode.type) {
-      SearchFilterType.Exact ->
-          DSL.or(
-              listOfNotNull(
-                  if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
-                  if (fieldNode.values.any { it == null }) databaseField.isNull else null,
-              ))
-      SearchFilterType.Fuzzy ->
-          throw RuntimeException("Fuzzy search not supported for numeric fields")
-      SearchFilterType.Range -> rangeCondition(intValues)
-    }
-  }
+    fieldName: String,
+    displayName: String,
+    databaseField: TableField<*, Int?>,
+    table: SearchTable,
+    nullable: Boolean = true,
+) : NumericSearchField<Int>(fieldName, displayName, databaseField, table, nullable) {
+  override fun fromString(value: String) = value.toInt()
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -1,0 +1,44 @@
+package com.terraformation.backend.search.field
+
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchTable
+import java.util.EnumSet
+import org.jooq.Condition
+import org.jooq.TableField
+import org.jooq.impl.DSL
+
+/**
+ * Search field superclass for columns with numeric values. Numeric values can always be searched
+ * for exact values or ranges, but never with fuzzy matching.
+ */
+abstract class NumericSearchField<T : Number>(
+    override val fieldName: String,
+    override val displayName: String,
+    override val databaseField: TableField<*, T?>,
+    override val table: SearchTable,
+    override val nullable: Boolean = true,
+) : SingleColumnSearchField<T>() {
+  /** Parses a string value into whatever numeric type this column uses. */
+  abstract fun fromString(value: String): T
+
+  override val supportedFilterTypes: Set<SearchFilterType> =
+      EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
+
+  override fun getCondition(fieldNode: FieldNode): Condition? {
+    val numericValues = fieldNode.values.map { if (it != null) fromString(it) else null }
+    val nonNullValues = numericValues.filterNotNull()
+
+    return when (fieldNode.type) {
+      SearchFilterType.Exact -> {
+        DSL.or(
+            listOfNotNull(
+                if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
+                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      }
+      SearchFilterType.Fuzzy ->
+          throw RuntimeException("Fuzzy search not supported for numeric fields")
+      SearchFilterType.Range -> rangeCondition(numericValues)
+    }
+  }
+}


### PR DESCRIPTION
The `SearchField` classes for numeric fields had a bunch of duplicate code.
The only difference between them is how they convert string representations
to the appropriate numeric type and back again, so introduce a superclass that
ensures they work consistently apart from the string conversions.