### PR TITLE
SW-885 Allow users to leave organizations and projects

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -253,19 +253,10 @@ class AdminController(
         organizationStore
             .fetchAll()
             .map { it.id }
-            .filter {
-              currentUser().canRemoveOrganizationUser(it) ||
-                  currentUser().canAddOrganizationUser(it)
-            }
+            .filter { currentUser().canAddOrganizationUser(it) }
             .toSet()
     val adminProjectIds =
-        projectStore
-            .fetchAll()
-            .map { it.id }
-            .filter {
-              currentUser().canRemoveProjectUser(it) || currentUser().canAddProjectUser(it)
-            }
-            .toSet()
+        projectStore.fetchAll().map { it.id }.filter { currentUser().canAddProjectUser(it) }.toSet()
 
     val organizationsToAdd = organizationIds - user.organizationRoles.keys
     val organizationsToRemove = adminOrganizationIds - organizationIds

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -338,7 +338,7 @@ class OrganizationStore(
    * @throws UserNotFoundException The user was not a member of the organization.
    */
   fun removeUser(organizationId: OrganizationId, userId: UserId) {
-    requirePermissions { removeOrganizationUser(organizationId) }
+    requirePermissions { removeOrganizationUser(organizationId, userId) }
 
     dslContext.transaction { _ ->
       ensureOtherOwners(organizationId, userId)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -224,7 +224,7 @@ class ProjectStore(
    * @throws UserNotFoundException The user is not a member of the project.
    */
   fun removeUser(projectId: ProjectId, userId: UserId) {
-    requirePermissions { removeProjectUser(projectId) }
+    requirePermissions { removeProjectUser(projectId, userId) }
 
     val rowsDeleted =
         dslContext

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -285,8 +285,8 @@ data class IndividualUser(
     return role == Role.MANAGER || role == Role.ADMIN || role == Role.OWNER
   }
 
-  override fun canRemoveProjectUser(projectId: ProjectId): Boolean {
-    return canAddProjectUser(projectId)
+  override fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean {
+    return projectId in projectRoles && (userId == this.userId || canAddProjectUser(projectId))
   }
 
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean {
@@ -299,8 +299,9 @@ data class IndividualUser(
     return role == Role.ADMIN || role == Role.OWNER
   }
 
-  override fun canRemoveOrganizationUser(organizationId: OrganizationId): Boolean {
-    return canAddOrganizationUser(organizationId)
+  override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean {
+    return organizationId in organizationRoles &&
+        (userId == this.userId || canAddOrganizationUser(organizationId))
   }
 
   override fun canSetOrganizationUserRole(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -28,6 +28,7 @@ import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.StorageLocationNotFoundException
 import com.terraformation.backend.db.TimeseriesNotFoundException
+import com.terraformation.backend.db.UserId
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -319,10 +320,10 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun removeProjectUser(projectId: ProjectId) {
-    if (!user.canRemoveProjectUser(projectId)) {
+  fun removeProjectUser(projectId: ProjectId, userId: UserId) {
+    if (!user.canRemoveProjectUser(projectId, userId)) {
       readProject(projectId)
-      throw AccessDeniedException("No permission to remove users from project $projectId")
+      throw AccessDeniedException("No permission to remove user $userId from project $projectId")
     }
   }
 
@@ -353,10 +354,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun removeOrganizationUser(organizationId: OrganizationId) {
-    if (!user.canRemoveOrganizationUser(organizationId)) {
+  fun removeOrganizationUser(organizationId: OrganizationId, userId: UserId) {
+    if (!user.canRemoveOrganizationUser(organizationId, userId)) {
       readOrganization(organizationId)
-      throw AccessDeniedException("No permission to remove users from organization $organizationId")
+      throw AccessDeniedException(
+          "No permission to remove user $userId from organization $organizationId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -133,8 +133,9 @@ class SystemUser(usersDao: UsersDao) : TerrawareUser {
   override fun canReadSpeciesName(speciesNameId: SpeciesNameId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
-  override fun canRemoveOrganizationUser(organizationId: OrganizationId): Boolean = true
-  override fun canRemoveProjectUser(projectId: ProjectId): Boolean = true
+  override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      true
+  override fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean = true
   override fun canSendAlert(facilityId: FacilityId): Boolean = true
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -109,8 +109,8 @@ interface TerrawareUser : Principal {
   fun canReadSpeciesName(speciesNameId: SpeciesNameId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
-  fun canRemoveOrganizationUser(organizationId: OrganizationId): Boolean
-  fun canRemoveProjectUser(projectId: ProjectId): Boolean
+  fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
+  fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -111,7 +111,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateOrganization(any()) } returns true
     every { user.canAddOrganizationUser(any()) } returns true
     every { user.canListOrganizationUsers(any()) } returns true
-    every { user.canRemoveOrganizationUser(any()) } returns true
+    every { user.canRemoveOrganizationUser(any(), any()) } returns true
     every { user.canSetOrganizationUserRole(any(), any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canReadSite(any()) } returns true
@@ -434,7 +434,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `removeUser throws exception if no permission to remove users`() {
-    every { user.canRemoveOrganizationUser(organizationId) } returns false
+    every { user.canRemoveOrganizationUser(organizationId, currentUser().userId) } returns false
 
     assertThrows<AccessDeniedException> { store.removeUser(organizationId, currentUser().userId) }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -42,7 +42,7 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadProject(any()) } returns true
     every { user.canUpdateProject(any()) } returns true
     every { user.canAddProjectUser(any()) } returns true
-    every { user.canRemoveProjectUser(any()) } returns true
+    every { user.canRemoveProjectUser(any(), any()) } returns true
 
     store = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
 
@@ -128,7 +128,7 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `removeProjectUser throws exception if no permission to remove users`() {
-    every { user.canRemoveProjectUser(any()) } returns false
+    every { user.canRemoveProjectUser(any(), any()) } returns false
 
     assertThrows<AccessDeniedException> { store.removeUser(projectId, UserId(1)) }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -88,7 +88,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canDeleteApiKey(organizationId) } returns true
     every { user.canListApiKeys(organizationId) } returns true
     every { user.canReadOrganization(organizationId) } returns true
-    every { user.canRemoveOrganizationUser(organizationId) } returns true
+    every { user.canRemoveOrganizationUser(organizationId, any()) } returns true
     every { user.canSetOrganizationUserRole(organizationId, Role.CONTRIBUTOR) } returns true
 
     keycloakProperties.apply {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.SpeciesNameNotFoundException
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.StorageLocationNotFoundException
+import com.terraformation.backend.db.UserId
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -67,6 +68,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val speciesId = SpeciesId(1)
   private val speciesNameId = SpeciesNameId(1)
   private val storageLocationId = StorageLocationId(1)
+  private val userId = UserId(1)
 
   /**
    * Grants permission to perform a particular operation. This is a simple wrapper around a MockK
@@ -426,13 +428,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun removeProjectUser() {
-    assertThrows<ProjectNotFoundException> { requirements.removeProjectUser(projectId) }
+    assertThrows<ProjectNotFoundException> { requirements.removeProjectUser(projectId, userId) }
 
     grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.removeProjectUser(projectId) }
+    assertThrows<AccessDeniedException> { requirements.removeProjectUser(projectId, userId) }
 
-    grant { user.canRemoveProjectUser(projectId) }
-    requirements.removeProjectUser(projectId)
+    grant { user.canRemoveProjectUser(projectId, userId) }
+    requirements.removeProjectUser(projectId, userId)
   }
 
   @Test
@@ -481,14 +483,16 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun removeOrganizationUser() {
     assertThrows<OrganizationNotFoundException> {
-      requirements.removeOrganizationUser(organizationId)
+      requirements.removeOrganizationUser(organizationId, userId)
     }
 
     grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.removeOrganizationUser(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.removeOrganizationUser(organizationId, userId)
+    }
 
-    grant { user.canRemoveOrganizationUser(organizationId) }
-    requirements.removeOrganizationUser(organizationId)
+    grant { user.canRemoveOrganizationUser(organizationId, userId) }
+    requirements.removeOrganizationUser(organizationId, userId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -170,6 +170,8 @@ internal class PermissionTest : DatabaseTest() {
   private val org1StorageLocationIds = storageLocationIds.toTypedArray()
   private val project10StorageLocationIds = storageLocationIds.take(4).toTypedArray()
 
+  private val otherUserId = UserId(8765)
+
   @BeforeEach
   fun setUp() {
     every { realmResource.users() } returns mockk()
@@ -191,6 +193,7 @@ internal class PermissionTest : DatabaseTest() {
             usersDao)
 
     insertUser(userId)
+    insertUser(otherUserId)
     organizationIds.forEach { insertOrganization(it, createdBy = userId) }
     projectIds.forEach { insertProject(it, createdBy = userId) }
     siteIds.forEach { insertSite(it, createdBy = userId) }
@@ -245,6 +248,7 @@ internal class PermissionTest : DatabaseTest() {
         listOrganizationUsers = true,
         addOrganizationUser = true,
         removeOrganizationUser = true,
+        removeOrganizationSelf = true,
         createSpecies = true,
         updateSpecies = true,
         deleteSpecies = true,
@@ -259,6 +263,7 @@ internal class PermissionTest : DatabaseTest() {
         createSite = true,
         listSites = true,
         removeProjectUser = true,
+        removeProjectSelf = true,
     )
 
     permissions.expect(
@@ -358,6 +363,7 @@ internal class PermissionTest : DatabaseTest() {
         listOrganizationUsers = true,
         addOrganizationUser = true,
         removeOrganizationUser = true,
+        removeOrganizationSelf = true,
         createSpecies = true,
         updateSpecies = true,
         deleteSpecies = true,
@@ -389,6 +395,7 @@ internal class PermissionTest : DatabaseTest() {
         listOrganizationUsers = true,
         addOrganizationUser = true,
         removeOrganizationUser = true,
+        removeOrganizationSelf = true,
         createSpecies = true,
         updateSpecies = true,
         deleteSpecies = true,
@@ -403,6 +410,7 @@ internal class PermissionTest : DatabaseTest() {
         createSite = true,
         listSites = true,
         removeProjectUser = true,
+        removeProjectSelf = true,
     )
 
     permissions.expect(
@@ -497,6 +505,7 @@ internal class PermissionTest : DatabaseTest() {
         listProjects = true,
         readOrganization = true,
         listOrganizationUsers = true,
+        removeOrganizationSelf = true,
         createSpecies = true,
         updateSpecies = true,
         deleteSpecies = true,
@@ -509,6 +518,7 @@ internal class PermissionTest : DatabaseTest() {
         addProjectUser = true,
         listSites = true,
         removeProjectUser = true,
+        removeProjectSelf = true,
     )
 
     permissions.expect(
@@ -597,12 +607,14 @@ internal class PermissionTest : DatabaseTest() {
         org1Id,
         listProjects = true,
         readOrganization = true,
+        removeOrganizationSelf = true,
     )
 
     permissions.expect(
         project10Id,
         readProject = true,
         listSites = true,
+        removeProjectSelf = true,
     )
 
     permissions.expect(
@@ -689,12 +701,14 @@ internal class PermissionTest : DatabaseTest() {
         org1Id,
         listProjects = true,
         readOrganization = true,
+        removeOrganizationSelf = true,
     )
 
     permissions.expect(
         *org1ProjectIds,
         readProject = true,
         listSites = true,
+        removeProjectSelf = true,
     )
 
     permissions.expect(
@@ -856,6 +870,7 @@ internal class PermissionTest : DatabaseTest() {
         listOrganizationUsers: Boolean = false,
         addOrganizationUser: Boolean = false,
         removeOrganizationUser: Boolean = false,
+        removeOrganizationSelf: Boolean = false,
         createSpecies: Boolean = false,
         updateSpecies: Boolean = false,
         deleteSpecies: Boolean = false,
@@ -892,8 +907,12 @@ internal class PermissionTest : DatabaseTest() {
             "Can add organization $organizationId user")
         assertEquals(
             removeOrganizationUser,
-            user.canRemoveOrganizationUser(organizationId),
+            user.canRemoveOrganizationUser(organizationId, otherUserId),
             "Can remove user from organization $organizationId")
+        assertEquals(
+            removeOrganizationSelf,
+            user.canRemoveOrganizationUser(organizationId, userId),
+            "Can remove self from organization $organizationId")
         assertEquals(
             createSpecies,
             user.canCreateSpecies(organizationId),
@@ -924,6 +943,7 @@ internal class PermissionTest : DatabaseTest() {
         createSite: Boolean = false,
         listSites: Boolean = false,
         removeProjectUser: Boolean = false,
+        removeProjectSelf: Boolean = false,
     ) {
       projects.forEach { projectId ->
         assertEquals(readProject, user.canReadProject(projectId), "Can read project $projectId")
@@ -937,8 +957,12 @@ internal class PermissionTest : DatabaseTest() {
             listSites, user.canListSites(projectId), "Can list sites in project $projectId")
         assertEquals(
             removeProjectUser,
-            user.canRemoveProjectUser(projectId),
+            user.canRemoveProjectUser(projectId, otherUserId),
             "Can remove project $projectId user")
+        assertEquals(
+            removeProjectSelf,
+            user.canRemoveProjectUser(projectId, userId),
+            "Can remove self from project $projectId")
 
         uncheckedProjects.remove(projectId)
       }


### PR DESCRIPTION
Currently, only admins can remove users from organizations, which means there's no
way for a non-admin user to leave an organization.

Update the permission checks so that people always have permission to remove
themselves from organizations and projects they're in, but only admins can remove
people other than themselves.