### PR TITLE
SW-856 Use model classes to pass values to email templates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,13 +201,13 @@ val processMjmlTasks =
             // The upper levels of directory structure are a little different in the src and build
             // directories; we want the following mapping:
             //
-            // src/main/resources/templates/email/a/b.mjml ->
-            // build/resources/main/templates/email/a/b.html
+            // src/main/resources/templates/email/a/b.ftlh.mjml ->
+            // build/resources/main/templates/email/a/b.ftlh
             val htmlFile =
                 buildDir
                     .resolve("resources/main")
                     .resolve(
-                        mjmlFile.withReplacedExtensionOrNull(".mjml", ".ftlh")!!.relativeTo(
+                        mjmlFile.withReplacedExtensionOrNull(".mjml", "")!!.relativeTo(
                             File("$projectDir/src/main/resources")))
 
             // Stop these tasks from appearing in "./gradlew tasks" output.

--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -15,6 +15,8 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
+import com.terraformation.backend.email.model.FacilityIdle
+import com.terraformation.backend.email.model.UserAddedToOrganization
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.processToString
@@ -101,10 +103,7 @@ class EmailService(
     val facility =
         facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
 
-    val model =
-        mapOf(
-            "facility" to facility,
-            "lastTimeseriesTime" to messages.dateAndTime(facility.lastTimeseriesTime))
+    val model = FacilityIdle(facility, messages.dateAndTime(facility.lastTimeseriesTime))
     val textBody =
         freeMarkerConfig.getTemplate("email/facilityIdle/body.txt.ftl").processToString(model)
 
@@ -136,13 +135,7 @@ class EmailService(
     val webAppUrl = "${config.webAppUrl}".trimEnd('/')
     val organizationHomeUrl = webAppUrls.organizationHome(organizationId).toString()
 
-    val model =
-        mapOf(
-            "admin" to admin,
-            "organization" to organization,
-            "organizationHomeUrl" to organizationHomeUrl,
-            "webAppUrl" to webAppUrl,
-        )
+    val model = UserAddedToOrganization(admin, organization, organizationHomeUrl, webAppUrl)
 
     val textBody =
         freeMarkerConfig

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -1,0 +1,24 @@
+package com.terraformation.backend.email.model
+
+import com.terraformation.backend.customer.model.FacilityModel
+import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.customer.model.OrganizationModel
+
+/**
+ * Marker interface to denote classes that can be passed as models when rendering email templates.
+ * This is to provide a small amount of compile-time sanity checking and ensure that other random
+ * objects don't get passed.
+ */
+interface EmailTemplateModel
+
+data class FacilityIdle(
+    val facility: FacilityModel,
+    val lastTimeseriesTime: String,
+) : EmailTemplateModel
+
+data class UserAddedToOrganization(
+    val admin: IndividualUser,
+    val organization: OrganizationModel,
+    val organizationHomeUrl: String,
+    val webAppUrl: String,
+) : EmailTemplateModel

--- a/src/main/resources/templates/email/README.md
+++ b/src/main/resources/templates/email/README.md
@@ -2,16 +2,47 @@
 
 This directory contains templates for server-generated email messages. Each template is in its own subdirectory.
 
-There are two versions of each email message: a plaintext version and an HTML version.
+Each subdirectory can contain two template files:
 
-`body.txt` is the plaintext version.
+- `body.txt.ftl` is the plaintext body of the message. If it doesn't exist, the message will only be sent as HTML.
+- `body.ftlh.mjml` is the source for the HTML version. It isn't actual HTML; the HTML is generated from [MJML](https://mjml.io/). If it doesn't exist, the message will only be sent as plaintext.
 
-`body.mjml` is the source for the HTML version. It isn't actual HTML; the HTML is generated from [MJML](https://mjml.io/).
+At least one of the `body` files must exist.
 
 The MJML-to-HTML conversion happens as part of the build process; if you look in `build/resources/main/templates/email` after building the code, you'll see the HTML versions.
 
-## Variable substitution
+Both the plaintext and the MJML files may include placeholders that get replaced with real values at runtime. The placeholders use [FreeMarker](https://freemarker.apache.org/) expression syntax, like `${variable.name}`.
 
-Both the plaintext and the MJML files may include placeholders that get replaced with real values at runtime. The placeholders use Freemarker expression syntax, like `${variable.name}`.
+## Specifying model classes
 
-In the current implementation, messages aren't actually rendered with Freemarker per se; the server just does a bit of simple string substitution. The plan is to introduce Freemarker if at some point we need more powerful email rendering capabilities, and by using the right syntax ahead of time, we won't need to change the existing templates.
+IntelliJ provides autocomplete and error checking of FreeMarker expressions, but because the code computes the template filenames dynamically, IntelliJ can't automatically determine which model object is used to render which template.
+
+Therefore, the first line of every template file should be an IntelliJ directive to tell it which model class the template uses. See [the IntelliJ documentation](https://www.jetbrains.com/help/idea/template-data-languages.html#special-comments) for details about the directives, but briefly, you'll want
+
+```
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.YourModelClass" -->
+```
+
+at the top of the plaintext templates and
+
+```
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" --> -->
+```
+
+at the top of the MJML files. (Wrapping the directive in `<!--` is needed because otherwise the file would be invalid MJML.)
+
+## Configuring MJML and FreeMarker support in the IntelliJ editor
+
+IntelliJ Ultimate comes with FreeMarker support built in, though you might need to enable the plugin. There is also [a third-party plugin](https://plugins.jetbrains.com/plugin/16418-mjml-support) to support MJML editing; it can be installed from the plugin marketplace.
+
+To configure IntelliJ to know what to do with MJML files that have FreeMarker directives, you need to define a new file type mapping. These instructions are valid for IntelliJ 2021.3.3:
+
+1. Make sure the MJML and FreeMarker plugins are installed.
+2. Go to Preferences > Editor > File Types.
+3. Select the "FreeMarker template" file type.
+4. Click the "+" button to add a new file name pattern.
+5. For the pattern, enter `*.ftlh.mjml`.
+6. For the template data language, select "mjml" (it might also be listed as "MailJet Markup Language").
+7. Click OK.
+
+Now when you edit the MJML email templates, IntelliJ will know that they contain FreeMarker expressions.

--- a/src/main/resources/templates/email/facilityIdle/body.txt.ftl
+++ b/src/main/resources/templates/email/facilityIdle/body.txt.ftl
@@ -1,3 +1,4 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityIdle" -->
 Hello,
 
 It has been over ${facility.maxIdleMinutes} minutes since the most recent update was received from ${facility.name}.

--- a/src/main/resources/templates/email/userAddedToOrganization/body.ftlh.mjml
+++ b/src/main/resources/templates/email/userAddedToOrganization/body.ftlh.mjml
@@ -1,3 +1,4 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" --> -->
 <mjml>
     <mj-head>
         <mj-attributes>

--- a/src/main/resources/templates/email/userAddedToOrganization/body.txt.ftl
+++ b/src/main/resources/templates/email/userAddedToOrganization/body.txt.ftl
@@ -1,3 +1,4 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" -->
 You've been added to ${organization.name}!
 
 Added by ${admin.fullName} (${admin.email})


### PR DESCRIPTION
We're going to be adding a number of email templates soon. To reduce the chances
that we'll inadvertently mistype the name of a template variable, switch from
generic `Map` objects to model classes to hold the values the template can access,
and annotate the template files so IntelliJ can do autocompletion and error
checking.