### PR TITLE
SW-856 Unify notification template rendering

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.email.model
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.OrganizationModel
+import com.terraformation.backend.customer.model.TerrawareUser
 
 /**
  * Marker interface to denote classes that can be passed as models when rendering email templates.
@@ -10,6 +11,13 @@ import com.terraformation.backend.customer.model.OrganizationModel
  * objects don't get passed.
  */
 interface EmailTemplateModel
+
+data class FacilityAlert(
+    val body: String,
+    val facility: FacilityModel,
+    val requestedBy: TerrawareUser,
+    val subject: String,
+) : EmailTemplateModel
 
 data class FacilityIdle(
     val facility: FacilityModel,

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -47,17 +47,11 @@ class Messages {
   fun withdrawalDateNotification(accessionNumber: String) =
       "$accessionNumber is scheduled for a withdrawal today!"
 
-  fun userAddedToOrganizationSubject(adminName: String?, organizationName: String) =
-      if (adminName != null) "$adminName has added you to $organizationName on Terraware"
-      else "An admin has added you to $organizationName on Terraware"
-
   /**
    * The name to use for the project, site, and facility that's automatically created when a new
    * organization is created.
    */
   fun seedBankDefaultName() = "Seed Bank"
-
-  fun facilityIdleSubject(facilityName: String) = "No data received from $facilityName"
 
   fun dateAndTime(instant: Instant?): String =
       if (instant != null) {

--- a/src/main/resources/templates/email/README.md
+++ b/src/main/resources/templates/email/README.md
@@ -2,8 +2,9 @@
 
 This directory contains templates for server-generated email messages. Each template is in its own subdirectory.
 
-Each subdirectory can contain two template files:
+Each subdirectory can contain three template files:
 
+- `subject.ftl` is the subject line of the email message.
 - `body.txt.ftl` is the plaintext body of the message. If it doesn't exist, the message will only be sent as HTML.
 - `body.ftlh.mjml` is the source for the HTML version. It isn't actual HTML; the HTML is generated from [MJML](https://mjml.io/). If it doesn't exist, the message will only be sent as plaintext.
 

--- a/src/main/resources/templates/email/facilityAlert/body.txt.ftl
+++ b/src/main/resources/templates/email/facilityAlert/body.txt.ftl
@@ -1,0 +1,4 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityAlert" -->
+Alert received from facility ${facility.name}:
+
+${body}

--- a/src/main/resources/templates/email/facilityAlert/subject.ftl
+++ b/src/main/resources/templates/email/facilityAlert/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityAlert" -->
+Alert: ${subject}

--- a/src/main/resources/templates/email/facilityIdle/subject.ftl
+++ b/src/main/resources/templates/email/facilityIdle/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityIdle" -->
+No data received from ${facility.name}

--- a/src/main/resources/templates/email/userAddedToOrganization/subject.ftl
+++ b/src/main/resources/templates/email/userAddedToOrganization/subject.ftl
@@ -1,0 +1,6 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" -->
+<#if admin.fullName?has_content>
+    ${admin.fullName} has added you to ${organization.name} on Terraware
+<#else>
+    An admin has added you to ${organization.name} on Terraware
+</#if>


### PR DESCRIPTION
Refactor `EmailService` to use a set of generic methods to send notifications to
a particular target audience using the contents of a particular template directory.
This will be less repetitive and error-prone than constructing each notification
message completely from scratch.

As part of this, subject lines are now rendered from templates rather than treated
as localizable messages.