### PR TITLE
SW-856 Move email header/footer to include files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -55,7 +55,7 @@ class EmailNotificationService(
     emailService.sendFacilityNotification(
         event.facilityId,
         "facilityAlert",
-        FacilityAlertRequested(event.body, facility, requestedByUser, event.subject))
+        FacilityAlertRequested(config, event.body, facility, requestedByUser, event.subject))
   }
 
   @EventListener
@@ -67,7 +67,7 @@ class EmailNotificationService(
     emailService.sendFacilityNotification(
         facility.id,
         "facilityIdle",
-        FacilityIdle(facility, messages.dateAndTime(facility.lastTimeseriesTime)))
+        FacilityIdle(config, facility, messages.dateAndTime(facility.lastTimeseriesTime)))
   }
 
   @EventListener
@@ -78,13 +78,12 @@ class EmailNotificationService(
         organizationStore.fetchById(event.organizationId)
             ?: throw OrganizationNotFoundException(event.organizationId)
 
-    val webAppUrl = "${config.webAppUrl}".trimEnd('/')
     val organizationHomeUrl = webAppUrls.organizationHome(event.organizationId).toString()
 
     emailService.sendUserNotification(
         user,
         "userAddedToOrganization",
-        UserAddedToOrganization(admin, organization, organizationHomeUrl, webAppUrl),
+        UserAddedToOrganization(config, admin, organization, organizationHomeUrl),
         requireOptIn = false)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -1,32 +1,37 @@
 package com.terraformation.backend.email.model
 
+import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 
 /**
- * Marker interface to denote classes that can be passed as models when rendering email templates.
- * This is to provide a small amount of compile-time sanity checking and ensure that other random
- * objects don't get passed.
+ * Common attributes for classes that can be passed as models when rendering email templates. This
+ * includes all the values that are used by the generic header and footer sections but aren't
+ * related to the main content of the email.
  */
-interface EmailTemplateModel
+open class EmailTemplateModel(config: TerrawareServerConfig) {
+  val webAppUrl: String = "${config.webAppUrl}".trimEnd('/')
+}
 
-data class FacilityAlertRequested(
+class FacilityAlertRequested(
+    config: TerrawareServerConfig,
     val body: String,
     val facility: FacilityModel,
     val requestedBy: TerrawareUser,
     val subject: String,
-) : EmailTemplateModel
+) : EmailTemplateModel(config)
 
-data class FacilityIdle(
+class FacilityIdle(
+    config: TerrawareServerConfig,
     val facility: FacilityModel,
     val lastTimeseriesTime: String,
-) : EmailTemplateModel
+) : EmailTemplateModel(config)
 
-data class UserAddedToOrganization(
+class UserAddedToOrganization(
+    config: TerrawareServerConfig,
     val admin: IndividualUser,
     val organization: OrganizationModel,
     val organizationHomeUrl: String,
-    val webAppUrl: String,
-) : EmailTemplateModel
+) : EmailTemplateModel(config)

--- a/src/main/resources/templates/email/footer.ftlh.mjml
+++ b/src/main/resources/templates/email/footer.ftlh.mjml
@@ -1,0 +1,45 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.EmailTemplateModel" --> -->
+<mj-section padding="0px">
+    <mj-column mj-class="footer-wrapper">
+        <mj-text mj-class="text-body02 text-bold">Terraformation Inc.</mj-text>
+        <mj-text mj-class="text-body02">PO Box 3470, PMB 15777</mj-text>
+        <mj-text mj-class="text-body02">Honolulu, HI 96801-3470</mj-text>
+        <mj-social mj-class="social-wrapper">
+            <mj-social-element
+                    mj-class="social-icons"
+                    href="https://twitter.com/TF_Global"
+                    title="Twitter"
+                    src="${webAppUrl}/assets/social-twitter.png"
+            >
+            </mj-social-element>
+            <mj-social-element
+                    mj-class="social-icons"
+                    href="https://www.linkedin.com/company/terraformation"
+                    title="LinkedIn"
+                    src="${webAppUrl}/assets/social-linkedin.png"
+            >
+            </mj-social-element>
+            <mj-social-element
+                    mj-class="social-icons"
+                    href="https://www.instagram.com/globalterraform/"
+                    title="Instagram"
+                    src="${webAppUrl}/assets/social-instagram.png"
+            >
+            </mj-social-element>
+            <mj-social-element
+                    mj-class="social-icons"
+                    href="https://www.facebook.com/GlobalTerraform/"
+                    title="Facebook"
+                    src="${webAppUrl}/assets/social-facebook.png"
+            >
+            </mj-social-element>
+            <mj-social-element
+                    mj-class="social-icons"
+                    href="https://terraformation.com"
+                    title="Website"
+                    src="${webAppUrl}/assets/globe.png"
+            >
+            </mj-social-element>
+        </mj-social>
+    </mj-column>
+</mj-section>

--- a/src/main/resources/templates/email/head.ftlh.mjml
+++ b/src/main/resources/templates/email/head.ftlh.mjml
@@ -1,0 +1,73 @@
+<mj-head>
+    <mj-attributes>
+        <mj-class
+            name="logo-img"
+            width="205px"
+            align="left"
+            padding="0px"
+            padding-top="64px"
+            padding-bottom="32px"
+        />
+
+        <mj-class
+            name="body-wrapper"
+            width="650px"
+            padding="1px"
+            background-color="#A9B7B8"
+            inner-background-color="#fff"
+            border-radius="4px"
+            inner-border-radius="3px"
+        />
+        <mj-class
+            name="text-headline06-bold"
+            font-family="Inter, sans-serif"
+            font-weight="700"
+            font-size="20px"
+            line-height="28px"
+            color="#3A4445"
+            padding="32px 32px 16px 32px"
+        />
+        <mj-class
+            name="text-body03"
+            font-family="Inter, sans-serif"
+            font-weight="400"
+            font-size="14px"
+            line-height="20px"
+            color="#000000"
+            padding="0px 32px 24px 32px"
+        />
+        <mj-class
+            name="btn-productive-primary-md"
+            background-color="#0067C8"
+            color="#FFFFFF"
+            height="40px"
+            padding="0px 0px 32px 0px"
+            border-radius="1024px"
+            font-family="Inter, sans-serif"
+            font-weight="600"
+            font-size="16px"
+            line-height="24px"
+        />
+
+        <mj-class name="footer-wrapper" width="650px" padding="0px" padding-top="48px" />
+        <mj-class
+            name="text-body02"
+            font-family="Inter, sans-serif"
+            font-weight="400"
+            font-size="16px"
+            line-height="24px"
+            color="#3A4445"
+            align="center"
+            padding="0px"
+        />
+        <mj-class name="text-bold" font-weight="600" />
+        <mj-class
+            name="social-wrapper"
+            font-size="15px"
+            icon-size="24px"
+            mode="horizontal"
+            padding="32px 0px 0px 0px"
+        />
+        <mj-class name="social-icons" padding="0px 8px 0px 8px" />
+    </mj-attributes>
+</mj-head>

--- a/src/main/resources/templates/email/logo.ftlh.mjml
+++ b/src/main/resources/templates/email/logo.ftlh.mjml
@@ -1,0 +1,5 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.EmailTemplateModel" --> -->
+<mj-hero>
+    <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.svg">
+    </mj-image>
+</mj-hero>

--- a/src/main/resources/templates/email/userAddedToOrganization/body.ftlh.mjml
+++ b/src/main/resources/templates/email/userAddedToOrganization/body.ftlh.mjml
@@ -1,84 +1,9 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" --> -->
 <mjml>
-    <mj-head>
-        <mj-attributes>
-            <mj-class
-                name="logo-img"
-                width="205px"
-                align="left"
-                padding="0px"
-                padding-top="64px"
-                padding-bottom="32px"
-            />
-
-            <mj-class
-                name="body-wrapper"
-                width="650px"
-                padding="1px"
-                background-color="#A9B7B8"
-                inner-background-color="#fff"
-                border-radius="4px"
-                inner-border-radius="3px"
-            />
-            <mj-class
-                name="text-headline06-bold"
-                font-family="Inter, sans-serif"
-                font-weight="700"
-                font-size="20px"
-                line-height="28px"
-                color="#3A4445"
-                padding="32px 32px 16px 32px"
-            />
-            <mj-class
-                name="text-body03"
-                font-family="Inter, sans-serif"
-                font-weight="400"
-                font-size="14px"
-                line-height="20px"
-                color="#000000"
-                padding="0px 32px 24px 32px"
-            />
-            <mj-class
-                name="btn-productive-primary-md"
-                background-color="#0067C8"
-                color="#FFFFFF"
-                height="40px"
-                padding="0px 0px 32px 0px"
-                border-radius="1024px"
-                font-family="Inter, sans-serif"
-                font-weight="600"
-                font-size="16px"
-                line-height="24px"
-            />
-
-            <mj-class name="footer-wrapper" width="650px" padding="0px" padding-top="48px" />
-            <mj-class
-                name="text-body02"
-                font-family="Inter, sans-serif"
-                font-weight="400"
-                font-size="16px"
-                line-height="24px"
-                color="#3A4445"
-                align="center"
-                padding="0px"
-            />
-            <mj-class name="text-bold" font-weight="600" />
-            <mj-class
-                name="social-wrapper"
-                font-size="15px"
-                icon-size="24px"
-                mode="horizontal"
-                padding="32px 0px 0px 0px"
-            />
-            <mj-class name="social-icons" padding="0px 8px 0px 8px" />
-        </mj-attributes>
-    </mj-head>
+    <mj-include path="../head.ftlh.mjml" />
 
     <mj-body>
-        <mj-hero>
-            <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.svg">
-            </mj-image>
-        </mj-hero>
+        <mj-include path="../logo.ftlh.mjml" />
 
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
@@ -96,49 +21,8 @@
                     >Go to Terraware</mj-button
                 >
             </mj-column>
-
-            <mj-column mj-class="footer-wrapper">
-                <mj-text mj-class="text-body02 text-bold">Terraformation Inc.</mj-text>
-                <mj-text mj-class="text-body02">PO Box 3470, PMB 15777</mj-text>
-                <mj-text mj-class="text-body02">Honolulu, HI 96801-3470</mj-text>
-                <mj-social mj-class="social-wrapper">
-                    <mj-social-element
-                        mj-class="social-icons"
-                        href="https://twitter.com/TF_Global"
-                        title="Twitter"
-                        src="${webAppUrl}/assets/social-twitter.png"
-                    >
-                    </mj-social-element>
-                    <mj-social-element
-                        mj-class="social-icons"
-                        href="https://www.linkedin.com/company/terraformation"
-                        title="LinkedIn"
-                        src="${webAppUrl}/assets/social-linkedin.png"
-                    >
-                    </mj-social-element>
-                    <mj-social-element
-                        mj-class="social-icons"
-                        href="https://www.instagram.com/globalterraform/"
-                        title="Instagram"
-                        src="${webAppUrl}/assets/social-instagram.png"
-                    >
-                    </mj-social-element>
-                    <mj-social-element
-                        mj-class="social-icons"
-                        href="https://www.facebook.com/GlobalTerraform/"
-                        title="Facebook"
-                        src="${webAppUrl}/assets/social-facebook.png"
-                    >
-                    </mj-social-element>
-                    <mj-social-element
-                        mj-class="social-icons"
-                        href="https://terraformation.com"
-                        title="Website"
-                        src="${webAppUrl}/assets/globe.png"
-                    >
-                    </mj-social-element>
-                </mj-social>
-            </mj-column>
         </mj-section>
+
+        <mj-include path="../footer.ftlh.mjml" />
     </mj-body>
 </mjml>


### PR DESCRIPTION
To avoid having to include the boilerplate header and footer content in every
email template, move them to separate MJML files that get included by the
MJML files for individual notification types.

Since the header and footer need to know the base URL of the web app (because
they use it to construct URLs of the company logo and other images), move it
to `EmailTemplateModel` and turn that from a marker interface to a class.