### PR TITLE
SW-916 Support search filters on compound primary keys

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -253,12 +253,14 @@ tasks {
         withIncludes(".*")
         withExcludes(generator.excludes())
         withForcedTypes(generator.forcedTypes(basePackageName))
+        withEmbeddables(generator.embeddables())
         // Fix compiler warnings for PostGIS functions; see https://github.com/jOOQ/jOOQ/issues/8587
         withTableValuedFunctions(false)
       }
 
       generate.apply {
         isDaos = true
+        isEmbeddables = true
         isJavaTimeTypes = true
         isPojos = true
         isPojosAsKotlinDataClasses = true

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -1,5 +1,7 @@
 package com.terraformation.backend.jooq
 
+import org.jooq.meta.jaxb.EmbeddableDefinitionType
+
 /**
  * See the definition of EnumTable for general information. There are roughly two ways to specify
  * items in the includeExpression list. Both require use of regex.
@@ -74,4 +76,22 @@ val ID_WRAPPERS =
         IdWrapper(
             "UserId", listOf("users\\.id", ".*\\.user_id", ".*\\.created_by", ".*\\.modified_by")),
         IdWrapper("WithdrawalId", listOf("withdrawals\\.id", ".*\\.withdrawal_id")),
+    )
+
+/**
+ * Defines the synthetic data types that are embedded in the column lists of tables. We mostly use
+ * this to represent compound primary keys.
+ *
+ * @see https://www.jooq.org/doc/latest/manual/code-generation/codegen-embeddable-types/
+ */
+val EMBEDDABLES =
+    listOf(
+        EmbeddableDefinitionType()
+            .withName("organization_user_id")
+            .withTables("organization_users")
+            .withColumns("organization_id", "user_id"),
+        EmbeddableDefinitionType()
+            .withName("project_user_id")
+            .withTables("project_users")
+            .withColumns("project_id", "user_id"),
     )

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Extensions.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Extensions.kt
@@ -1,4 +1,11 @@
 package com.terraformation.backend.jooq
 
+import org.jooq.meta.jaxb.EmbeddableDefinitionType
+import org.jooq.meta.jaxb.EmbeddableField
+
 /** Converts "foo_bar_baz" to "FooBarBaz". */
 fun String.toPascalCase() = replace(Regex("_(.)")) { it.groupValues[1].capitalize() }.capitalize()
+
+fun EmbeddableDefinitionType.withColumns(vararg columns: String): EmbeddableDefinitionType {
+  return withFields(columns.map { EmbeddableField().withExpression(it) })
+}

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -135,5 +135,7 @@ class TerrawareGenerator : KotlinGenerator() {
     return types
   }
 
+  fun embeddables() = EMBEDDABLES
+
   fun excludes() = ENUM_TABLES.joinToString("|") { "$it\$" }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -50,7 +50,7 @@ class OrganizationUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySe
       )
 
   override val primaryKey: TableField<out Record, out Any?>
-    get() = ORGANIZATION_USERS.USER_ID
+    get() = ORGANIZATION_USERS.ORGANIZATION_USER_ID
 
   override fun conditionForPermissions(): Condition {
     return ORGANIZATION_USERS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
@@ -30,7 +30,7 @@ class ProjectUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchO
       )
 
   override val primaryKey: TableField<out Record, out Any?>
-    get() = PROJECT_USERS.USER_ID
+    get() = PROJECT_USERS.PROJECT_USER_ID
 
   override fun conditionForPermissions(): Condition {
     return PROJECT_USERS.PROJECT_ID.`in`(currentUser().projectRoles.keys)


### PR DESCRIPTION
Previously, the search table definitions for the `organization_users` and
`project_users` tables treated user ID as the primary key. But that caused a
problem: since search criteria are implemented using an `IN` clause that
selects the top-level objects by primary key, the results weren't being filtered
by organization, just by user.

So for example, if you searched for organization members with a role of "Admin"
in a particular organization ID, you would only get search results for users who
had the admin role in that organization, but you would get the membership details
for _all_ their organizations, not just the one you specified.

The fix is to not ignore the fact that organization users (and project users) have
compound primary keys.

Luckily, jOOQ has a feature called "embeddable types" that lets us solve this
without having to revamp our search implementation: you can define synthetic data
types that combine multiple columns into a single field that acts, from the
application's point of view, like a single atomic value. Configuring the search
tables to use these embeddable types as the primary key, rather than the user ID,
causes the filtering to be applied to both the organization and user at the same
time, and the queries return the expected results.