### PR TITLE
SW-929 Add endpoint to delete organization

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -461,6 +461,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleSuccessResponsePayload'
+    delete:
+      tags:
+      - Customer
+      summary: Deletes an existing organization.
+      description: Organizations can only be deleted if they have no members other
+        than the current user.
+      operationId: deleteOrganization
+      parameters:
+      - name: organizationId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "409":
+          description: The organization has other members and cannot be deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponsePayload'
   /api/v1/organizations/{organizationId}/projects:
     get:
       tags:

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -363,11 +363,17 @@ class OrganizationStore(
    * owners.
    * @throws UserNotFoundException The user was not a member of the organization.
    */
-  fun removeUser(organizationId: OrganizationId, userId: UserId) {
+  fun removeUser(
+      organizationId: OrganizationId,
+      userId: UserId,
+      allowRemovingLastOwner: Boolean = false,
+  ) {
     requirePermissions { removeOrganizationUser(organizationId, userId) }
 
     dslContext.transaction { _ ->
-      ensureOtherOwners(organizationId, userId)
+      if (!allowRemovingLastOwner) {
+        ensureOtherOwners(organizationId, userId)
+      }
 
       dslContext
           .deleteFrom(PROJECT_USERS)

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.OrganizationId
+
+/**
+ * Published when an organization's owner deletes it. This indicates the organization has been
+ * deleted from the user's point of view; the database may still contain data about the
+ * organization.
+ */
+data class OrganizationDeletedEvent(val organizationId: OrganizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -267,6 +267,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deleteOrganization(organizationId: OrganizationId) {
+    if (!user.canDeleteOrganization(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException("No permission to delete organization $organizationId")
+    }
+  }
+
   fun listOrganizationUsers(organizationId: OrganizationId) {
     if (!user.canListOrganizationUsers(organizationId)) {
       readOrganization(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -46,6 +46,9 @@ open class KeycloakRequestFailedException(
 /** Keycloak couldn't find a user that we expected to be able to find. */
 class KeycloakUserNotFoundException(message: String) : EntityNotFoundException(message)
 
+class OrganizationHasOtherUsersException(val organizationId: OrganizationId) :
+    RuntimeException("Organization $organizationId has other users")
+
 class OrganizationNotFoundException(val organizationId: OrganizationId) :
     EntityNotFoundException("Organization $organizationId not found")
 

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -10,27 +10,36 @@ import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.db.SiteStore
 import com.terraformation.backend.customer.db.UserStore
+import com.terraformation.backend.customer.event.OrganizationDeletedEvent
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.ProjectModel
+import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.SiteModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
+import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.StorageCondition
+import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
+import com.terraformation.backend.db.tables.records.OrganizationUsersRecord
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.PROJECTS
 import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import java.time.Clock
 import java.time.Instant
 import org.jooq.Record
@@ -38,9 +47,11 @@ import org.jooq.Table
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.keycloak.admin.client.resource.RealmResource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.security.access.AccessDeniedException
 
 internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
@@ -104,8 +115,12 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateProject(any()) } returns true
     every { user.canCreateSite(any()) } returns true
     every { user.canCreateStorageLocation(any()) } returns true
+    every { user.canDeleteOrganization(any()) } returns true
+    every { user.canListOrganizationUsers(any()) } returns true
     every { user.canReadFacility(any()) } returns true
+    every { user.canReadOrganization(any()) } returns true
     every { user.canReadStorageLocation(any()) } returns true
+    every { user.canRemoveOrganizationUser(any(), any()) } returns true
   }
 
   @Test
@@ -190,5 +205,59 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             OrganizationsRow(name = "Test Organization"), createSeedBank = false)
 
     assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `deleteOrganization throws exception if organization has users other than the current one`() {
+    val organizationId = OrganizationId(1)
+    val otherUserId = UserId(100)
+
+    insertUser(user.userId)
+    insertUser(otherUserId)
+    insertOrganization(organizationId)
+    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
+    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
+
+    assertThrows<OrganizationHasOtherUsersException> { service.deleteOrganization(organizationId) }
+  }
+
+  @Test
+  fun `deleteOrganization throws exception if user has no permission to delete organization`() {
+    val organizationId = OrganizationId(1)
+    every { user.canDeleteOrganization(organizationId) } returns false
+
+    assertThrows<AccessDeniedException> { service.deleteOrganization(organizationId) }
+  }
+
+  @Test
+  fun `deleteOrganization removes current user from organization`() {
+    val organizationId = OrganizationId(1)
+
+    insertUser()
+    insertOrganization(organizationId)
+    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
+
+    every { publisher.publishEvent(any<OrganizationDeletedEvent>()) } just Runs
+
+    service.deleteOrganization(organizationId)
+
+    val expected = emptyList<OrganizationUsersRecord>()
+    val actual = dslContext.selectFrom(ORGANIZATION_USERS).fetch()
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `deleteOrganization publishes event on success`() {
+    val organizationId = OrganizationId(1)
+
+    insertUser()
+    insertOrganization(organizationId)
+    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
+
+    every { publisher.publishEvent(any<OrganizationDeletedEvent>()) } just Runs
+
+    service.deleteOrganization(organizationId)
+
+    verify { publisher.publishEvent(OrganizationDeletedEvent(organizationId)) }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -347,6 +347,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun deleteOrganization() {
+    assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.deleteOrganization(organizationId) }
+
+    grant { user.canDeleteOrganization(organizationId) }
+    requirements.deleteOrganization(organizationId)
+  }
+
+  @Test
   fun listOrganizationUsers() {
     assertThrows<OrganizationNotFoundException> {
       requirements.listOrganizationUsers(organizationId)


### PR DESCRIPTION
Allow the owner to delete an organization if there aren't any other users.

Currently, this just removes the owner from the organization, making it
inaccessible. A subsequent change will add a background job to purge the
organization's data from the database.