### PR TITLE
Return error payload for missing query parameters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -22,6 +22,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.PathVariable
@@ -220,6 +221,16 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
     } else {
       return simpleErrorResponse(ex.localizedMessage, status, request)
     }
+  }
+
+  override fun handleMissingServletRequestParameter(
+      ex: MissingServletRequestParameterException,
+      headers: HttpHeaders,
+      status: HttpStatus,
+      request: WebRequest
+  ): ResponseEntity<Any> {
+    return simpleErrorResponse(
+        "Missing required parameter: ${ex.parameterName}", HttpStatus.BAD_REQUEST, request)
   }
 
   private fun controllerLogger(ex: Exception): Logger {


### PR DESCRIPTION
If an endpoint requires certain parameters in the query string, Spring knows to
respond with HTTP 400 if they're missing from a request. But the default response
doesn't have a body and doesn't tell the client which parameter was missing.

Add a handler for the exception that gets thrown when a parameter is missing, such
that it returns an error payload in our normal error format with a message that
identifies the missing parameter.