### PR TITLE
Allow endpoints to stream contents of uploaded files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
   implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
   implementation("com.opencsv:opencsv:5.6")
+  implementation("commons-fileupload:commons-fileupload:1.4")
   implementation("commons-validator:commons-validator:1.7")
   implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.2.5")
   implementation("io.swagger.core.v3:swagger-annotations:2.2.0")

--- a/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
@@ -1,6 +1,14 @@
 package com.terraformation.backend.api
 
+import javax.servlet.http.HttpServletRequest
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+import org.springframework.core.env.getProperty
+import org.springframework.util.unit.DataSize
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.multipart.MultipartResolver
+import org.springframework.web.multipart.commons.CommonsMultipartResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -27,5 +35,34 @@ class SpringMvcConfig(private val existingAdminRoleInterceptor: ExistingAdminRol
 
   override fun addInterceptors(registry: InterceptorRegistry) {
     registry.addInterceptor(existingAdminRoleInterceptor)
+  }
+
+  /**
+   * Configure the application's handling of multipart form data (file uploads) to allow streaming
+   * of the file data.
+   *
+   * By default, the entire request is loaded into memory before the controller method is called.
+   * With the "resolve lazily" flag, Spring will only load the request into memory if the controller
+   * method has a parameter such as a [MultipartFile] that requires everything to already be in
+   * memory.
+   *
+   * We can thus have controller methods that take [HttpServletRequest] parameters and access the
+   * underlying input stream, allowing us to support uploading huge files without requiring equally
+   * huge amounts of memory.
+   *
+   * Honors the standard Spring settings for maximum file size for file upload endpoints that need
+   * the file to be loaded into memory. Endpoints that stream the file data can check the file size
+   * explicitly if needed.
+   */
+  @Bean
+  fun customMultipartResolver(env: Environment): MultipartResolver {
+    val maxFileSize = env.getProperty<DataSize?>("spring.servlet.multipart.max-file-size")
+    val maxUploadSize = env.getProperty<DataSize?>("spring.servlet.multipart.max-request-size")
+
+    return CommonsMultipartResolver().apply {
+      setResolveLazily(true)
+      setMaxUploadSize(maxUploadSize?.toBytes() ?: -1)
+      setMaxUploadSizePerFile(maxFileSize?.toBytes() ?: -1)
+    }
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,6 +62,7 @@ spring:
 
   servlet:
     multipart:
+      enabled: false
       max-request-size: 20MB
       max-file-size: 20MB
 


### PR DESCRIPTION
The default Spring file upload handler reads requests completely into memory.
That's fine most of the time but not so great for endpoints that need to handle
uploads of large files.