### PR TITLE
Allow uploading GBIF backbone zipfile to admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,32 @@ terraware:
     subject-prefix: "[DEV]"
 ```
 
+## Super-Admins
+
+Some operations are not available to regular users of the system; they must be requested by privileged administrative users. Internally, these are referred to as "super-admins".
+
+Marking a user as a super-admin currently requires connecting to the server's database and modifying the users table directly. The exact command you'll need to run to connect to the database will vary a bit depending on where it's running (local host, Docker container, managed cloud database service, etc.). For a database running on your local host, `psql terraware` will usually work.
+
+Once you're connected to the database, run the following query to change the user with a particular email address to a super-admin:
+
+```sql
+UPDATE users SET user_type_id = 2 WHERE email = 'your_email@your.domain';
+```
+
+## Importing GBIF backbone data
+
+The server uses a public species database from the [Global Biodiversity Information Facility (GBIF)](https://gbif.org/). If you're working with species-related parts of the code, you'll need to import the data into your local database.
+
+This must be done by a super-admin; see above for more information on that.
+
+1. Download `backbone.zip` from [the GBIF backbone dataset page](https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c) (it's the "Source archive" item in the download menu at the top of the page).
+2. Log into the admin interface on your terraware-server instance. For a locally-running server instance, it'll typically be [http://localhost:8080/admin/](http://localhost:8080/admin/).
+3. If you are a super-admin, you'll see an "Import GBIF species data" section on the admin home page. If you don't see that section, make sure you've set your user type properly as described in the "Super-Admins" section above.
+4. Select the zipfile you downloaded from the GBIF site, and hit the "Upload Zipfile" button.
+5. Watch the server logs to monitor the progress of the import. It will take several minutes to finish.
+
+Once it's done, the species lookup endpoints under `/api/v1/species/lookup` should start returning real results.
+
 ## How to contribute
 
 We welcome your contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for information about contributing to the project's development, including a discussion of coding conventions.

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -21,5 +21,18 @@
     <input type="submit" value=" Create Organization "/>
 </form>
 
+<div th:if="${canImportGlobalSpeciesData}">
+    <h2>Import GBIF species data</h2>
+
+    <p>You can download the data
+        <a href="https://hosted-datasets.gbif.org/datasets/backbone/current/backbone.zip">here</a>.
+    </p>
+
+    <form method="POST" enctype="multipart/form-data" action="uploadGbif">
+        <input type="file" name="zipfile" accept="application/zip" />
+        <input type="submit" value=" Upload Zipfile " />
+        (can take several minutes)
+    </form>
+</div>
 </body>
 </html>


### PR DESCRIPTION
The existing API endpoint for importing GBIF backbone data requires unpacking
the zipfile from the GBIF website and then constructing a correct URL to point
to the location of the unpacked files.

That's workable, but kind of a hassle, especially in dev environments.

Add a section to the admin UI to allow uploading the original zipfile without
having to unpack it or construct a URL for it. (I chose to do this as a file
upload rather than having the server directly download from the GBIF site
because we'll need to import the data over and over again in dev environments
and it's not nice to eat GBIF's bandwidth repeatedly downloading the same big
file.)

Importing species data is only permitted for super-admin users. There wasn't
previously any documentation describing how to set someone as a super-admin,
so add a section to `README.md` about that.