### PR TITLE
SW-907 Add endpoint to fetch GBIF species details

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1668,6 +1668,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateSpeciesResponsePayload'
+  /api/v1/species/lookup/details:
+    get:
+      tags:
+      - Customer
+      summary: Gets more information about a species with a particular scientific
+        name.
+      operationId: getSpeciesDetails
+      parameters:
+      - name: scientificName
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Exact scientific name to look up. This name is case-sensitive.
+      - name: language
+        in: query
+        required: false
+        schema:
+          type: string
+          description: "If specified, only return common names in this language or\
+            \ whose language is unknown. Names with unknown languages are always included.\
+            \ This is a two-letter ISO 639-1 language code."
+          example: en
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpeciesLookupDetailsResponsePayload'
+        "404":
+          description: The scientific name was not found in the server's taxonomic
+            database.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponsePayload'
   /api/v1/species/lookup/names:
     get:
       tags:
@@ -3904,6 +3941,39 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FacilityPayload'
+    SpeciesLookupCommonNamePayload:
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          type: string
+        language:
+          type: string
+          description: ISO 639-1 two-letter language code indicating the name's language.
+            Some common names in the server's taxonomic database are not tagged with
+            languages; this value will not be present for those names.
+    SpeciesLookupDetailsResponsePayload:
+      required:
+      - familyName
+      - scientificName
+      type: object
+      properties:
+        scientificName:
+          type: string
+        commonNames:
+          type: array
+          description: "List of known common names for the species, if any."
+          items:
+            $ref: '#/components/schemas/SpeciesLookupCommonNamePayload'
+        familyName:
+          type: string
+        endangered:
+          type: boolean
+          description: "True if the species is known to be endangered, false if the\
+            \ species is known to not be endangered. This value will not be present\
+            \ if the server's taxonomic database doesn't indicate whether or not the\
+            \ species is endangered."
     SpeciesLookupNamesResponsePayload:
       required:
       - names

--- a/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.species.model
+
+import com.terraformation.backend.db.GbifTaxonId
+import com.terraformation.backend.db.tables.references.GBIF_VERNACULAR_NAMES
+import org.jooq.Record
+
+data class GbifVernacularNameModel(
+    val name: String,
+    val language: String?,
+) {
+  constructor(
+      record: Record
+  ) : this(
+      record[GBIF_VERNACULAR_NAMES.VERNACULAR_NAME]
+          ?: throw IllegalArgumentException("Name must be non-null"),
+      record[GBIF_VERNACULAR_NAMES.LANGUAGE])
+}
+
+data class GbifTaxonModel(
+    val taxonId: GbifTaxonId,
+    val scientificName: String,
+    val familyName: String,
+    val vernacularNames: List<GbifVernacularNameModel>,
+    val threatStatus: String?,
+) {
+  /**
+   * Whether or not the species should be considered endangered by our app. This is derived from the
+   * "threat status" value in the GBIF distributions dataset; we consider certain threat statuses to
+   * be endangered, certain statuses to be non-endangered, and unrecognized statuses to be
+   * inconclusive.
+   */
+  val isEndangered: Boolean?
+    get() = threatStatus?.let { endangeredThreatStatuses[it] }
+
+  companion object {
+    private val endangeredThreatStatuses =
+        mapOf(
+            // IUCN Red List categories
+            "least concern" to false,
+            "vulnerable" to false,
+            "near threatened" to false,
+            "endangered" to true,
+            "critically endangered" to true,
+            "extinct" to true,
+            "extinct in the wild" to true,
+        )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
@@ -1,0 +1,49 @@
+package com.terraformation.backend.species.model
+
+import com.terraformation.backend.db.GbifTaxonId
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class GbifTaxonModelTest {
+  @ParameterizedTest
+  @ValueSource(strings = ["critically endangered", "endangered", "extinct", "extinct in the wild"])
+  fun `treats IUCN Red List categories of Endangered or worse as endangered`(threatStatus: String) {
+    val model =
+        GbifTaxonModel(
+            taxonId = GbifTaxonId(1),
+            scientificName = "name",
+            familyName = "family",
+            vernacularNames = emptyList(),
+            threatStatus = threatStatus)
+    assertEquals(true, model.isEndangered)
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["least concern", "near threatened", "vulnerable"])
+  fun `treats IUCN Red list categories of Vulnerable or better as non-endangered`(
+      threatStatus: String
+  ) {
+    val model =
+        GbifTaxonModel(
+            taxonId = GbifTaxonId(1),
+            scientificName = "name",
+            familyName = "family",
+            vernacularNames = emptyList(),
+            threatStatus = threatStatus)
+    assertEquals(false, model.isEndangered)
+  }
+
+  @Test
+  fun `treats unrecognized threat statuses as unknown`() {
+    val model =
+        GbifTaxonModel(
+            taxonId = GbifTaxonId(1),
+            scientificName = "name",
+            familyName = "family",
+            vernacularNames = emptyList(),
+            threatStatus = "bogus")
+    assertNull(model.isEndangered)
+  }
+}


### PR DESCRIPTION
When the user selects a preexisting species name while adding a new species, we
need to fill out some of the fields in the add-species form with values from the
GBIF database. Add an endpoint to return the relevant details if available.