### PR TITLE
Add seedStorageBehavior to species API payloads

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4011,14 +4011,21 @@ components:
           - Forb
           - Graminoid
           - Fern
-        scientificName:
-          type: string
         organizationId:
           type: integer
           description: Which organization's species list to update.
           format: int64
         rare:
           type: boolean
+        scientificName:
+          type: string
+        seedStorageBehavior:
+          type: string
+          enum:
+          - Orthodox
+          - Recalcitrant
+          - Intermediate
+          - Unknown
     SpeciesResponseElement:
       required:
       - id
@@ -4046,6 +4053,13 @@ components:
           type: boolean
         scientificName:
           type: string
+        seedStorageBehavior:
+          type: string
+          enum:
+          - Orthodox
+          - Recalcitrant
+          - Intermediate
+          - Unknown
     StorageLocationDetails:
       required:
       - storageCondition

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.GrowthForm
 import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.SeedStorageBehavior
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.seedbank.api.ValuesController
@@ -141,6 +142,7 @@ data class SpeciesResponseElement(
     val id: SpeciesId,
     val rare: Boolean?,
     val scientificName: String,
+    val seedStorageBehavior: SeedStorageBehavior?,
 ) {
   constructor(
       row: SpeciesRow
@@ -152,6 +154,7 @@ data class SpeciesResponseElement(
       id = row.id!!,
       rare = row.rare,
       scientificName = row.scientificName!!,
+      seedStorageBehavior = row.seedStorageBehaviorId,
   )
 }
 
@@ -160,10 +163,11 @@ data class SpeciesRequestPayload(
     val endangered: Boolean?,
     val familyName: String?,
     val growthForm: GrowthForm?,
-    val scientificName: String,
     @Schema(description = "Which organization's species list to update.")
     val organizationId: OrganizationId,
     val rare: Boolean?,
+    val scientificName: String,
+    val seedStorageBehavior: SeedStorageBehavior?,
 ) {
   fun toRow(id: SpeciesId? = null) =
       SpeciesRow(
@@ -175,6 +179,7 @@ data class SpeciesRequestPayload(
           rare = rare,
           organizationId = organizationId,
           scientificName = scientificName,
+          seedStorageBehaviorId = seedStorageBehavior,
       )
 }
 


### PR DESCRIPTION
Commit a46dd383 updated the CRUD endpoints for species data, but
failed to include payload fields for seed storage behavior.