### PR TITLE
SW-934 Treat IUCN Vulnerable category as endangered

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
@@ -37,12 +37,12 @@ data class GbifTaxonModel(
         mapOf(
             // IUCN Red List categories
             "least concern" to false,
-            "vulnerable" to false,
             "near threatened" to false,
+            "vulnerable" to true,
             "endangered" to true,
             "critically endangered" to true,
-            "extinct" to true,
             "extinct in the wild" to true,
+            "extinct" to true,
         )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
@@ -8,8 +8,16 @@ import org.junit.jupiter.params.provider.ValueSource
 
 internal class GbifTaxonModelTest {
   @ParameterizedTest
-  @ValueSource(strings = ["critically endangered", "endangered", "extinct", "extinct in the wild"])
-  fun `treats IUCN Red List categories of Endangered or worse as endangered`(threatStatus: String) {
+  @ValueSource(
+      strings =
+          [
+              "critically endangered",
+              "endangered",
+              "extinct",
+              "extinct in the wild",
+              "vulnerable",
+          ])
+  fun `treats IUCN Red List categories of Vulnerable or worse as endangered`(threatStatus: String) {
     val model =
         GbifTaxonModel(
             taxonId = GbifTaxonId(1),
@@ -21,8 +29,8 @@ internal class GbifTaxonModelTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = ["least concern", "near threatened", "vulnerable"])
-  fun `treats IUCN Red list categories of Vulnerable or better as non-endangered`(
+  @ValueSource(strings = ["least concern", "near threatened"])
+  fun `treats IUCN Red list categories of Near Threatened or better as non-endangered`(
       threatStatus: String
   ) {
     val model =


### PR DESCRIPTION
The forestry team has clarified that we should check the Endangered
checkbox by default on the add-species dialog if the IUCN Red List
category for the species is Vulnerable; previously we treated that as
non-endangered.