### PR TITLE
Support unknown-length files in FileStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
@@ -60,8 +60,6 @@ interface FileStore {
    * @param contents File contents to copy to the storage system. When this method returns
    * successfully, this stream will have been completely consumed. The caller is responsible for
    * closing this.
-   * @param size Size of the file contents in bytes. If this value doesn't match the number of bytes
-   * in the stream, the results are implementation-dependent.
    * @throws FileAlreadyExistsException The file already existed.
    * @throws IOException An error occurred while writing the file or while reading [contents].
    * Implementations should attempt to delete files that weren't written successfully, though
@@ -69,7 +67,7 @@ interface FileStore {
    * @throws InvalidStorageLocationException The URL referred to a file that isn't managed by this
    * file store.
    */
-  fun write(url: URI, contents: InputStream, size: Long)
+  fun write(url: URI, contents: InputStream)
 
   /** Returns true if this file store can accept a URI. */
   fun canAccept(url: URI): Boolean

--- a/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
@@ -50,7 +50,7 @@ class LocalFileStore(
     return getFullPath(url).fileSize()
   }
 
-  override fun write(url: URI, contents: InputStream, size: Long) {
+  override fun write(url: URI, contents: InputStream) {
     // The file might be in a subdirectory that doesn't exist yet.
     val fullPath = getFullPath(url)
     val directory = fullPath.parent

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -115,7 +115,7 @@ class ThumbnailStore(
     val thumbUrl = getThumbnailUrl(photoUrl, resizedImage.width, resizedImage.height)
 
     try {
-      fileStore.write(thumbUrl, ByteArrayInputStream(buffer), size.toLong())
+      fileStore.write(thumbUrl, ByteArrayInputStream(buffer))
     } catch (e: FileAlreadyExistsException) {
       // This is suspicious if it happens a lot, but we expect to see it if, e.g., two users
       // run the same search at the same time and there isn't already a thumbnail for one of

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -53,7 +53,7 @@ class PhotoRepository(
     val photoUrl = fileStore.newUrl(clock.instant(), "accession", metadata.contentType)
 
     try {
-      fileStore.write(photoUrl, data, size)
+      fileStore.write(photoUrl, data)
 
       dslContext.transaction { _ ->
         val photosRow =

--- a/src/test/kotlin/com/terraformation/backend/file/FileStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileStoreTest.kt
@@ -88,31 +88,29 @@ abstract class FileStoreTest {
   }
 
   @Test
-  fun `store creates new file`() {
+  fun `write creates new file`() {
     val url = makeUrl()
     val bytesToWrite = Random.nextBytes(100)
 
-    store.write(url, bytesToWrite.inputStream(), bytesToWrite.size.toLong())
+    store.write(url, bytesToWrite.inputStream())
 
     val bytesWritten = readFile(url)
     assertArrayEquals(bytesToWrite, bytesWritten)
   }
 
   @Test
-  fun `store throws exception if file already exists`() {
+  fun `write throws exception if file already exists`() {
     val url = makeUrl()
 
     createFile(url)
 
-    assertThrows<FileAlreadyExistsException> {
-      store.write(url, Random.nextBytes(1).inputStream(), 1)
-    }
+    assertThrows<FileAlreadyExistsException> { store.write(url, Random.nextBytes(1).inputStream()) }
   }
 
   @Test
-  fun `store throws exception if URL is invalid`() {
+  fun `write throws exception if URL is invalid`() {
     assertThrows<InvalidStorageLocationException> {
-      store.write(badUrl, Random.nextBytes(1).inputStream(), 1)
+      store.write(badUrl, Random.nextBytes(1).inputStream())
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -190,11 +190,11 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
 
     val thumbUrlSlot: CapturingSlot<URI> = slot()
     val streamSlot: CapturingSlot<InputStream> = slot()
-    justRun { fileStore.write(capture(thumbUrlSlot), capture(streamSlot), any()) }
+    justRun { fileStore.write(capture(thumbUrlSlot), capture(streamSlot)) }
 
     val actual = store.getThumbnailData(photoId, width, height)
 
-    verify(exactly = 1) { fileStore.write(any(), any(), any()) }
+    verify(exactly = 1) { fileStore.write(any(), any()) }
 
     assertEquals(
         URI("file:///a/b/c/thumb/original-${width}x$height.jpg"),
@@ -211,7 +211,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
     val width = photoWidth / 10
     val height = photoHeight / 10
 
-    justRun { fileStore.write(any(), any(), any()) }
+    justRun { fileStore.write(any(), any()) }
 
     val actual = store.getThumbnailData(photoId, width, height)
     val actualData = actual.readAllBytes()
@@ -226,7 +226,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `generates thumbnails above minimum high-quality dimensions`() {
-    justRun { fileStore.write(any(), any(), any()) }
+    justRun { fileStore.write(any(), any()) }
 
     val actual =
         store.getThumbnailData(photoId, store.minSizeForHighQuality, store.minSizeForHighQuality)
@@ -244,7 +244,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
     val width = photoWidth / 10
     val height = photoHeight / 10
 
-    every { fileStore.write(any(), any(), any()) } throws FileAlreadyExistsException("Exists")
+    every { fileStore.write(any(), any()) } throws FileAlreadyExistsException("Exists")
 
     val actual = store.getThumbnailData(photoId, width, height)
 
@@ -270,11 +270,11 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
     val existingRow = insertThumbnail(width, height)
 
     every { fileStore.read(existingRow.storageUrl!!) } throws NoSuchFileException("Nope")
-    justRun { fileStore.write(any(), any(), any()) }
+    justRun { fileStore.write(any(), any()) }
 
     val actual = store.getThumbnailData(photoId, width, height)
 
-    verify { fileStore.write(existingRow.storageUrl!!, any(), any()) }
+    verify { fileStore.write(existingRow.storageUrl!!, any()) }
 
     assertEquals(
         listOf(


### PR DESCRIPTION
Previously, mostly due to the fact that we were using the simple `PutObject` S3
API, callers had to tell `FileStore.write()` the length of the file they wanted
to store.

Unfortunately, that doesn't play well with streaming uploads, where the incoming
request doesn't specify a content length.

Change `S3FileStore` to use the S3 multipart upload API, which supports uploading
a series of chunks and then explicitly marking the upload as complete after the
last chunk is written.

With that change in place, remove the `size` argument from `FileStore.write()`
and update callers accordingly.