### PR TITLE
SW-999 Stop autocreating seed banks for new orgs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -11,12 +11,10 @@ import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.pojos.SitesRow
@@ -83,20 +81,8 @@ class OrganizationService(
         val projectModel =
             projectStore.create(orgModel.id, name, hidden = true, organizationWide = true)
         val siteModel = siteStore.create(SitesRow(projectId = projectModel.id, name = name))
-        val facilityModel = facilityStore.create(siteModel.id, FacilityType.SeedBank, name)
 
-        (1..3).forEach { num ->
-          facilityStore.createStorageLocation(
-              facilityModel.id, "Refrigerator $num", StorageCondition.Refrigerator)
-          facilityStore.createStorageLocation(
-              facilityModel.id, "Freezer $num", StorageCondition.Freezer)
-        }
-
-        orgModel.copy(
-            projects =
-                listOf(
-                    projectModel.copy(
-                        sites = listOf(siteModel.copy(facilities = listOf(facilityModel))))))
+        orgModel.copy(projects = listOf(projectModel.copy(sites = listOf(siteModel))))
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -258,8 +258,8 @@ data class CreateOrganizationRequestPayload(
     val countrySubdivisionCode: String?,
     @Schema(
         description =
-            "If true or not specified, create a project, site, and seed bank facility " +
-                "automatically.",
+            "If true or not specified, automatically create a project and site to hold seed " +
+                "bank facilities.",
         defaultValue = "true")
     val createSeedBank: Boolean?,
     val description: String?,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -76,7 +76,8 @@ class FacilityStore(
       type: FacilityType,
       name: String,
       description: String? = null,
-      maxIdleMinutes: Int = defaultMaxIdleMinutes
+      maxIdleMinutes: Int = defaultMaxIdleMinutes,
+      createStorageLocations: Boolean = true,
   ): FacilityModel {
     requirePermissions { createFacility(siteId) }
 
@@ -94,8 +95,16 @@ class FacilityStore(
         )
 
     facilitiesDao.insert(row)
+    val model = row.toModel()
 
-    return row.toModel()
+    if (type == FacilityType.SeedBank && createStorageLocations) {
+      (1..3).forEach { num ->
+        createStorageLocation(model.id, "Refrigerator $num", StorageCondition.Refrigerator)
+        createStorageLocation(model.id, "Freezer $num", StorageCondition.Freezer)
+      }
+    }
+
+    return model
   }
 
   /** Updates the settings of an existing facility. */

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -12,20 +12,16 @@ import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.db.SiteStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.OrganizationDeletedEvent
-import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.SiteModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.records.OrganizationUsersRecord
@@ -129,7 +125,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `createOrganization creates seed bank`() {
+  fun `createOrganization creates seed bank project and site`() {
     insertUser()
 
     val expected =
@@ -158,45 +154,17 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
                                     location = null,
                                     modifiedTime = clock.instant(),
                                     name = seedBankDefaultName,
-                                    projectId = ProjectId(1),
-                                    facilities =
-                                        listOf(
-                                            FacilityModel(
-                                                createdTime = clock.instant(),
-                                                description = null,
-                                                id = FacilityId(1),
-                                                lastTimeseriesTime = null,
-                                                maxIdleMinutes = 30,
-                                                modifiedTime = clock.instant(),
-                                                name = seedBankDefaultName,
-                                                siteId = SiteId(1),
-                                                type = FacilityType.SeedBank)))))),
+                                    projectId = ProjectId(1))))),
             totalUsers = 1)
     val actual =
         service.createOrganization(
             OrganizationsRow(name = "Test Organization"), createSeedBank = true)
 
     assertEquals(expected, actual)
-
-    val storageLocations = facilityStore.fetchStorageLocations(FacilityId(1))
-
-    assertEquals(
-        3,
-        storageLocations.count {
-          it.conditionId == StorageCondition.Refrigerator &&
-              it.name?.startsWith("Refrigerator") == true
-        },
-        "Number of refrigerators")
-    assertEquals(
-        3,
-        storageLocations.count {
-          it.conditionId == StorageCondition.Freezer && it.name?.startsWith("Freezer") == true
-        },
-        "Number of freezers")
   }
 
   @Test
-  fun `createOrganization does not create seed bank if creation flag is false`() {
+  fun `createOrganization does not create seed bank project and site if creation flag is false`() {
     insertUser()
 
     val expected =


### PR DESCRIPTION
Now that we're adding the ability for users to manage their own seed banks, there
is no longer a need to automatically create a seed bank when a user creates a new
organization.

However, since the autocreated seed bank project is special (it is configured as
an organization-wide project) and we don't currently allow clients to create that
kind of project, we still want to autocreate the project and the site that clients
will use when they create new seed bank facilities.