### PR TITLE
Limit the size of timeseries values requests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -48,6 +48,11 @@ annotation class ApiResponse409(val description: String = "The request would cau
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
+@ApiResponseSimpleError(responseCode = "413")
+annotation class ApiResponse413(val description: String = "The request was too large.")
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
 @ApiResponse(
     responseCode = "200",
     content =


### PR DESCRIPTION
We had an incident last week where a seed bank lost Internet connectivity for a
while and tried to send all its sensor readings when it came back online. This
resulted in a huge `/api/v1/timeseries/values` request which timed out and got
retried repeatedly, leading to high database load.

The device manager is getting updated to discard some of its sensor data when it
loses connectivity for an extended period, but to mitigate against a similar
situation in the future, we also need to limit the number of values in a single
request on the server side.

Longer term, we'll probably want more sophisticated rate limiting, but this should
at least prevent a repeat of the recent incident.

Implementation note: this checks the payload size explicitly and throws an
exception rather than using Spring's built-in validation feature because the
built-in validation doesn't have a special case for "request too large" and
returns HTTP 400. HTTP 413 is a more approprate status code to return here.