### PR TITLE
SW-1004 add facilityName to accessions search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -85,6 +85,7 @@ class AccessionsTable(
         integerField(
             "estimatedSeedsIncoming", "Estimated seeds incoming", ACCESSIONS.EST_SEED_COUNT),
         textField("familyName", "Family name", ACCESSIONS.FAMILY_NAME),
+        aliasField("facilityName", "facility_name"),
         aliasField("geolocation", "geolocations_coordinates"),
         aliasField("germinationEndDate", "germinationTests_endDate"),
         aliasField("germinationPercentGerminated", "germinationTests_percentGerminated"),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2451,6 +2451,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "accessionNumber" to "ABCDEFG",
                       "active" to "Active",
                       "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6")),
+                      "facilityName" to "ohana",
                       "id" to "1001",
                       "speciesName" to "Other Dogwood",
                       "state" to "Processing",
@@ -2461,6 +2462,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "active" to "Active",
                       "checkedInTime" to "$checkedInTime",
                       "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
+                      "facilityName" to "ohana",
                       "germinationTests" to
                           listOf(
                               mapOf(


### PR DESCRIPTION
Allow searching accessions by facility name and viewing facility name in the accession response.
This will be used in the accessions UI view.