### PR TITLE
Remove unused dependency from IndividualUser

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -73,7 +73,6 @@ class UserStore(
     private val permissionStore: PermissionStore,
     realmResource: RealmResource,
     private val usersDao: UsersDao,
-    private val notificationStore: NotificationStore,
 ) {
   private val log = perClassLogger()
   private val usersResource = realmResource.users()
@@ -531,7 +530,6 @@ class UserStore(
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),
         parentStore,
         permissionStore,
-        notificationStore,
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.customer.model
 import com.terraformation.backend.auth.CurrentUserHolder
 import com.terraformation.backend.auth.SuperAdminAuthority
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.customer.db.NotificationStore
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.AccessionId
@@ -63,7 +62,6 @@ data class IndividualUser(
     override val userType: UserType,
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
-    private val notificationStore: NotificationStore,
 ) : TerrawareUser, UserDetails {
   override val organizationRoles: Map<OrganizationId, Role> by lazy {
     permissionStore.fetchOrganizationRoles(userId)

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -120,7 +120,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             PermissionStore(dslContext),
             realmResource,
             usersDao,
-            notificationStore,
         )
     webAppUrls = WebAppUrls(config)
     service =

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.FacilityStore
-import com.terraformation.backend.customer.db.NotificationStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
@@ -67,7 +66,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   private val realmResource: RealmResource = mockk()
   private lateinit var siteStore: SiteStore
   private lateinit var userStore: UserStore
-  private lateinit var notificationStore: NotificationStore
 
   private lateinit var service: OrganizationService
 
@@ -82,7 +80,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     parentStore = ParentStore(dslContext)
     projectStore = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
     siteStore = SiteStore(clock, dslContext, parentStore, sitesDao)
-    notificationStore = NotificationStore(dslContext, clock)
     userStore =
         UserStore(
             clock,
@@ -96,7 +93,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             PermissionStore(dslContext),
             realmResource,
             usersDao,
-            notificationStore,
         )
 
     service =

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -54,7 +54,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
   private lateinit var userStore: UserStore
-  private lateinit var notificationStore: NotificationStore
 
   private val keycloakConfig =
       TerrawareServerConfig.KeycloakConfig(
@@ -104,7 +103,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
     parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
-    notificationStore = NotificationStore(dslContext, clock)
 
     userStore =
         UserStore(
@@ -119,7 +117,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
             permissionStore,
             realmResource,
             usersDao,
-            notificationStore,
         )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.config.TerrawareServerConfig
-import com.terraformation.backend.customer.db.NotificationStore
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.UserStore
@@ -96,7 +95,6 @@ internal class PermissionTest : DatabaseTest() {
   private lateinit var parentStore: ParentStore
   private lateinit var permissionStore: PermissionStore
   private lateinit var userStore: UserStore
-  private lateinit var notificationStore: NotificationStore
 
   @Autowired private lateinit var config: TerrawareServerConfig
 
@@ -155,7 +153,6 @@ internal class PermissionTest : DatabaseTest() {
 
     parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
-    notificationStore = NotificationStore(dslContext, clock)
     userStore =
         UserStore(
             clock,
@@ -169,7 +166,7 @@ internal class PermissionTest : DatabaseTest() {
             permissionStore,
             realmResource,
             usersDao,
-            notificationStore)
+        )
 
     insertUser(userId)
     insertUser(otherUserId)


### PR DESCRIPTION
We moved the accessor functions for notification permissions to `ParentStore`,
but we were still passing a `NotificationStore` argument to `IndividualUser`.

Remove it, which also means we can remove it from `UserStore`.