### PR TITLE
SW-1019 Ignore device manager data during configuration

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -589,6 +589,13 @@ class AdminController(
       @RequestParam("body") body: String,
       redirectAttributes: RedirectAttributes
   ): String {
+    if (facilityStore.fetchById(facilityId)?.connectionState !=
+        FacilityConnectionState.Configured) {
+      redirectAttributes.successMessage =
+          "Alert received, but facility is not configured so alert would be ignored."
+      return facility(facilityId)
+    }
+
     try {
       publisher.publishEvent(
           FacilityAlertRequestedEvent(facilityId, subject, body, currentUser().userId))

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -6,6 +6,8 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AutomationId
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.DeviceManagerId
+import com.terraformation.backend.db.DeviceNotFoundException
+import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.NotificationId
@@ -79,6 +81,11 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(accessionId: AccessionId): OrganizationId {
     return getOrganizationId(getProjectId(accessionId))
         ?: throw AccessionNotFoundException(accessionId)
+  }
+
+  fun getFacilityConnectionState(deviceId: DeviceId): FacilityConnectionState {
+    return fetchFieldById(deviceId, DEVICES.ID, DEVICES.facilities().CONNECTION_STATE_ID)
+        ?: throw DeviceNotFoundException(deviceId)
   }
 
   fun getFacilityName(accessionId: AccessionId): String {


### PR DESCRIPTION
When the user is in the process of placing sensors, we don't want to record bogus
temperature and humidity data or broadcast useless alerts about temperatures being
out of range.