### PR TITLE
SW-1021 Add endpoint to list devices' timeseries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/model/Models.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.device.model
+
+import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.TimeseriesId
+import com.terraformation.backend.db.TimeseriesType
+import com.terraformation.backend.db.tables.references.TIMESERIES
+import com.terraformation.backend.db.tables.references.TIMESERIES_VALUES
+import java.time.Instant
+import org.jooq.Record
+
+data class TimeseriesValueModel(
+    val timeseriesId: TimeseriesId,
+    val createdTime: Instant,
+    val value: String,
+) {
+  companion object {
+    fun ofRecord(record: Record): TimeseriesValueModel? {
+      return TimeseriesValueModel(
+          record[TIMESERIES_VALUES.TIMESERIES_ID] ?: return null,
+          record[TIMESERIES_VALUES.CREATED_TIME] ?: return null,
+          record[TIMESERIES_VALUES.VALUE] ?: return null,
+      )
+    }
+  }
+}
+
+data class TimeseriesModel(
+    val id: TimeseriesId,
+    val deviceId: DeviceId,
+    val name: String,
+    val type: TimeseriesType,
+    val decimalPlaces: Int?,
+    val units: String?,
+    val latestValue: TimeseriesValueModel? = null,
+) {
+  constructor(
+      record: Record,
+      latestValue: TimeseriesValueModel?
+  ) : this(
+      record[TIMESERIES.ID] ?: throw IllegalArgumentException("ID must be non-null"),
+      record[TIMESERIES.DEVICE_ID] ?: throw IllegalArgumentException("Device ID must be non-null"),
+      record[TIMESERIES.NAME] ?: throw IllegalArgumentException("Name must be non-null"),
+      record[TIMESERIES.TYPE_ID] ?: throw IllegalArgumentException("Type must be non-null"),
+      record[TIMESERIES.DECIMAL_PLACES],
+      record[TIMESERIES.UNITS],
+      latestValue,
+  )
+}


### PR DESCRIPTION
Previously, there was no way for a client to discover which timeseries existed for
a device, just to probe whether a timeseries with a specific name existed.

Add an endpoint to list the timeseries for one or more devices.

The response payload includes the latest value for each timeseries, if any,
including its timestamp.

The immediate use case for this is a tool to generate dummy timeseries data, but
it should be generally useful for any client that needs to show a list of
available timeseries.