### PR TITLE
SW-1028 Use terraformation logo png asset for emails

### DIFF
--- a/src/main/resources/templates/email/logo.ftlh.mjml
+++ b/src/main/resources/templates/email/logo.ftlh.mjml
@@ -1,5 +1,5 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.EmailTemplateModel" --> -->
 <mj-hero>
-    <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.svg">
+    <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.png">
     </mj-image>
 </mj-hero>


### PR DESCRIPTION
Email template was previously using svg asset which may not be supported in many email clients.
Png has wider support.
Related PR on the frontend https://github.com/terraware/terraware-web/pull/278