### PR TITLE
Add extension method to deserialize JSON HTTP responses

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -1,10 +1,14 @@
 package com.terraformation.backend.util
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import freemarker.template.Template
 import java.io.StringWriter
 import java.math.BigDecimal
 import java.net.URI
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
 import java.util.EnumSet
+import java.util.function.Supplier
 import org.jooq.Field
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
@@ -66,3 +70,53 @@ fun URI.appendPath(additionalPath: String): URI {
 fun <T> Sequence<T>.onChunk(chunkSize: Int, func: (List<T>) -> Unit): Sequence<T> {
   return chunked(chunkSize).onEach { func(it) }.flatten()
 }
+
+/**
+ * Returns a handler that deserializes a JSON HTTP response to a particular class. This can be
+ * passed to [java.net.http.HttpClient.send].
+ *
+ * The handler actually returns a [Supplier] that returns the deserialized value. The value isn't
+ * deserialized until [Supplier.get] is called. That allows callers to first check whether the HTTP
+ * request succeeded.
+ *
+ * Usage example:
+ * ```
+ * val response = httpClient.send(httpRequest, objectMapper.bodyHandler(SomeClass::class.java)
+ * if (HttpStatus.resolve(response.statusCode())?.is2xxSuccessful == true) {
+ *   val payload = response.body().get()
+ * }
+ * ```
+ */
+fun <T> ObjectMapper.bodyHandler(responseClass: Class<T>): BodyHandler<Supplier<T>> {
+  return BodyHandler {
+    HttpResponse.BodySubscribers.mapping(HttpResponse.BodySubscribers.ofByteArray()) {
+      Supplier<T> {
+        if (responseClass == Unit::class.java) {
+          @Suppress("UNCHECKED_CAST")
+          Unit as T
+        } else {
+          readValue(it, responseClass)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Returns a handler that deserializes a JSON HTTP response to a particular class. This can be
+ * passed to [java.net.http.HttpClient.send].
+ *
+ * The handler actually returns a [Supplier] that returns the deserialized value. The value isn't
+ * deserialized until [Supplier.get] is called. That allows callers to first check whether the HTTP
+ * request succeeded.
+ *
+ * Usage example:
+ * ```
+ * val response = httpClient.send(httpRequest, objectMapper.bodyHandler<SomeClass>()
+ * if (HttpStatus.resolve(response.statusCode())?.is2xxSuccessful == true) {
+ *   val payload = response.body().get()
+ * }
+ * ```
+ */
+inline fun <reified T> ObjectMapper.bodyHandler(): BodyHandler<Supplier<T>> =
+    bodyHandler(T::class.java)


### PR DESCRIPTION
The JDK's HTTP client requires callers to pass "body handlers" to turn raw
response payloads into the appropriate objects. We'll often be receiving JSON
responses, e.g., from Balena's API, and we'll want to use an `ObjectMapper`
to turn the raw bytes into objects.

Add an extension method to simplify this setup.