### PR TITLE
Improve handling of Balena identifiers

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -86,6 +86,7 @@ val ID_WRAPPERS =
         IdWrapper("AppDeviceId", listOf("app_devices\\.id", ".*\\.app_device_id")),
         IdWrapper("AutomationId", listOf("automations\\.id")),
         IdWrapper("BagId", listOf("bags\\.id", ".*\\.bag_id")),
+        IdWrapper("BalenaDeviceId", listOf("device_managers\\.balena_id")),
         IdWrapper("DeviceId", listOf("devices\\.id", "devices\\.parent_id", ".*\\.device_id")),
         IdWrapper("DeviceManagerId", listOf("device_managers\\.id")),
         IdWrapper("DeviceTemplateId", listOf("device_templates\\.id")),

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.BalenaDeviceId
 import com.terraformation.backend.db.DeviceManagerId
 import com.terraformation.backend.db.DeviceManagerNotFoundException
 import com.terraformation.backend.db.DeviceTemplateCategory
@@ -767,8 +768,8 @@ class AdminController(
   ): String {
     val row =
         DeviceManagersRow(
-            balenaId = Random.nextLong(),
-            balenaUuid = UUID.randomUUID(),
+            balenaId = BalenaDeviceId(Random.nextLong()),
+            balenaUuid = UUID.randomUUID().toString(),
             balenaModifiedTime = clock.instant(),
             createdTime = clock.instant(),
             deviceName = "Test Device $shortCode",

--- a/src/main/kotlin/com/terraformation/backend/device/BalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/BalenaClient.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.device
 
+import com.terraformation.backend.db.BalenaDeviceId
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.log.perClassLogger
 import javax.annotation.ManagedBean
@@ -9,7 +10,7 @@ import javax.annotation.ManagedBean
 class BalenaClient {
   private val log = perClassLogger()
 
-  fun configureDeviceManager(balenaId: Long, facilityId: FacilityId, token: String) {
+  fun configureDeviceManager(balenaId: BalenaDeviceId, facilityId: FacilityId, token: String) {
     val tokenExcerpt = token.substring(0..8) + "..."
     log.info("Configure Balena device $balenaId with facility $facilityId, token $tokenExcerpt")
   }

--- a/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.device.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.BalenaDeviceId
 import com.terraformation.backend.db.DeviceManagerId
 import com.terraformation.backend.db.DeviceManagerNotFoundException
 import com.terraformation.backend.db.FacilityId
@@ -21,6 +22,10 @@ class DeviceManagerStore(
     private val deviceManagersDao: DeviceManagersDao,
     private val dslContext: DSLContext,
 ) {
+  fun fetchOneByBalenaId(balenaId: BalenaDeviceId): DeviceManagersRow? {
+    return deviceManagersDao.fetchOneByBalenaId(balenaId)?.unlessInaccessible()
+  }
+
   fun fetchOneByFacilityId(facilityId: FacilityId): DeviceManagersRow? {
     return deviceManagersDao.fetchOneByFacilityId(facilityId)?.unlessInaccessible()
   }

--- a/src/main/resources/db/migration/common/V92__DeviceManagersUuid.sql
+++ b/src/main/resources/db/migration/common/V92__DeviceManagersUuid.sql
@@ -1,0 +1,10 @@
+-- Balena's "uuid" on devices is not an actual well-formed UUID, just a random hex string of
+-- variable length. So we can't use the database's UUID data type to store it.
+ALTER TABLE device_managers RENAME COLUMN balena_uuid TO balena_uuid_old;
+ALTER TABLE device_managers ADD COLUMN balena_uuid TEXT;
+UPDATE device_managers SET balena_uuid = balena_uuid_old WHERE balena_uuid IS NULL;
+ALTER TABLE device_managers DROP COLUMN balena_uuid_old;
+ALTER TABLE device_managers ALTER COLUMN balena_uuid SET NOT NULL;
+
+ALTER TABLE device_managers ADD CONSTRAINT device_managers_balena_id_unique UNIQUE (balena_id);
+ALTER TABLE device_managers ADD CONSTRAINT device_managers_balena_uuid_unique UNIQUE (balena_uuid);

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.customer.model.PermissionTest.PermissionsTrack
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.AutomationId
+import com.terraformation.backend.db.BalenaDeviceId
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.DeviceManagerId
@@ -206,8 +207,8 @@ internal class PermissionTest : DatabaseTest() {
       val facilityId = FacilityId(deviceManagerId.value)
       deviceManagersDao.insert(
           DeviceManagersRow(
-              balenaId = deviceManagerId.value,
-              balenaUuid = UUID.randomUUID(),
+              balenaId = BalenaDeviceId(deviceManagerId.value),
+              balenaUuid = UUID.randomUUID().toString(),
               balenaModifiedTime = Instant.EPOCH,
               deviceName = "$deviceManagerId",
               id = deviceManagerId,

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.device.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.BalenaDeviceId
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceManagerId
 import com.terraformation.backend.db.DeviceManagerNotFoundException
@@ -172,8 +173,8 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
   ): DeviceManagersRow {
     return DeviceManagersRow(
         balenaModifiedTime = Instant.EPOCH,
-        balenaId = balenaId,
-        balenaUuid = UUID.fromString(balenaUuid),
+        balenaId = BalenaDeviceId(balenaId),
+        balenaUuid = balenaUuid,
         createdTime = Instant.EPOCH,
         deviceName = "Device $id",
         facilityId = facilityId?.toIdWrapper { FacilityId(it) },


### PR DESCRIPTION
Balena has a device field called `uuid` but it turns out to not be an actual UUID,
just a long random hex value. Update the data model accordingly.

Also introduce an ID wrapper class for Balena-generated numeric device identifiers
so we aren't passing raw `Long` values around with no indication of where they came
from.