### PR TITLE
SW-1007 Sync device managers from Balena once a minute

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.config
 
 import java.net.URI
 import java.nio.file.Path
+import java.time.Duration
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -222,12 +223,20 @@ class TerrawareServerConfig(
       val apiKey: String? = null,
       @DefaultValue("false") val enabled: Boolean = false,
       val fleetId: Long? = null,
+      /**
+       * How frequently to poll for device updates. Value must be in
+       * [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+       */
+      @DefaultValue("PT1M") val pollInterval: Duration = Duration.ofMinutes(1),
       @DefaultValue(BALENA_API_URL) val url: URI = URI(BALENA_API_URL),
   ) {
     init {
       if (enabled) {
         if (apiKey == null || fleetId == null) {
-          throw IllegalArgumentException("API key and fleet name are required if Balena is enabled")
+          throw IllegalArgumentException("API key and fleet ID are required if Balena is enabled")
+        }
+        if (pollInterval <= Duration.ZERO) {
+          throw IllegalArgumentException("Poll interval must be greater than 0")
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
@@ -1,0 +1,105 @@
+package com.terraformation.backend.device.balena
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.tables.pojos.DeviceManagersRow
+import com.terraformation.backend.db.tables.references.DEVICE_MANAGERS
+import com.terraformation.backend.device.db.DeviceManagerStore
+import com.terraformation.backend.log.perClassLogger
+import java.time.Clock
+import java.time.Instant
+import javax.annotation.ManagedBean
+import javax.inject.Inject
+import org.jobrunr.scheduling.JobScheduler
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+@ManagedBean
+class BalenaPoller(
+    private val balenaClient: BalenaClient,
+    private val clock: Clock,
+    private val deviceManagerStore: DeviceManagerStore,
+    private val dslContext: DSLContext,
+    private val systemUser: SystemUser,
+) {
+  private val log = perClassLogger()
+
+  @Inject
+  @Suppress("unused")
+  fun schedule(config: TerrawareServerConfig, scheduler: JobScheduler) {
+    val jobId = javaClass.simpleName
+
+    if (config.balena.enabled) {
+      scheduler.scheduleRecurrently<BalenaPoller>(jobId, config.balena.pollInterval) {
+        updateBalenaDevices()
+      }
+    } else {
+      scheduler.delete(jobId)
+    }
+  }
+
+  fun updateBalenaDevices() {
+    try {
+      systemUser.run {
+        val mostRecentModifiedTime =
+            dslContext
+                .select(DSL.max(DEVICE_MANAGERS.BALENA_MODIFIED_TIME))
+                .from(DEVICE_MANAGERS)
+                .fetchOne()
+                ?.value1()
+                ?: Instant.EPOCH
+
+        val modifiedDevices = balenaClient.listModifiedDevices(mostRecentModifiedTime)
+
+        dslContext.transaction { _ ->
+          modifiedDevices.forEach { device ->
+            val existingRow = deviceManagerStore.fetchOneByBalenaId(device.id)
+            if (existingRow == null) {
+              val shortCode = balenaClient.getShortCodeForBalenaId(device.id)
+
+              if (shortCode == null) {
+                log.warn("No short code found for Balena device ${device.id}")
+              } else {
+                val newRow =
+                    DeviceManagersRow(
+                        balenaId = device.id,
+                        balenaModifiedTime = device.modifiedAt,
+                        balenaUuid = device.uuid,
+                        createdTime = clock.instant(),
+                        deviceName = device.deviceName,
+                        isOnline = device.isOnline,
+                        lastConnectivityEvent = device.lastConnectivityEvent,
+                        refreshedTime = clock.instant(),
+                        shortCode = shortCode,
+                        updateProgress = device.overallProgress,
+                    )
+
+                deviceManagerStore.insert(newRow)
+
+                log.info(
+                    "Added device manager ${newRow.id} for Balena device ${device.id} with " +
+                        "short code $shortCode")
+              }
+            } else {
+              existingRow.apply {
+                balenaModifiedTime = device.modifiedAt
+                isOnline = device.isOnline
+                lastConnectivityEvent = device.lastConnectivityEvent
+                refreshedTime = clock.instant()
+                updateProgress = device.overallProgress
+              }
+
+              deviceManagerStore.update(existingRow)
+
+              log.info(
+                  "Updated information for device manager ${existingRow.id} from Balena " +
+                      "device ${device.id}")
+            }
+          }
+        }
+      }
+    } catch (e: Exception) {
+      log.error("Unable to process Balena device updates", e)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
@@ -1,0 +1,207 @@
+package com.terraformation.backend.device.balena
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.BalenaDeviceId
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.DeviceManagerId
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.tables.pojos.DeviceManagersRow
+import com.terraformation.backend.device.db.DeviceManagerStore
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Clock
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val balenaClient: BalenaClient = mockk()
+  private val clock: Clock = mockk()
+
+  private val poller: BalenaPoller by lazy {
+    BalenaPoller(
+        balenaClient,
+        clock,
+        DeviceManagerStore(clock, deviceManagersDao, dslContext),
+        dslContext,
+        SystemUser(usersDao))
+  }
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+    every { balenaClient.listModifiedDevices(any()) } returns emptyList()
+
+    insertSiteData()
+  }
+
+  @Test
+  fun `scans for all devices on first run`() {
+    poller.updateBalenaDevices()
+
+    verify { balenaClient.listModifiedDevices(Instant.EPOCH) }
+  }
+
+  @Test
+  fun `scans since most recent modified timestamp from Balena servers`() {
+    insertDeviceManager(
+        1,
+        balenaModifiedTime = Instant.ofEpochSecond(1000),
+        refreshedTime = Instant.ofEpochSecond(5000))
+    insertDeviceManager(
+        2,
+        balenaModifiedTime = Instant.ofEpochSecond(3000),
+        refreshedTime = Instant.ofEpochSecond(6000))
+    insertDeviceManager(
+        3,
+        balenaModifiedTime = Instant.ofEpochSecond(2000),
+        refreshedTime = Instant.ofEpochSecond(7000))
+
+    poller.updateBalenaDevices()
+
+    verify { balenaClient.listModifiedDevices(Instant.ofEpochSecond(3000)) }
+  }
+
+  @Test
+  fun `inserts new device managers for unrecognized balena IDs`() {
+    val device = balenaDevice(1)
+
+    every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
+    every { balenaClient.getShortCodeForBalenaId(device.id) } returns "${device.id}"
+
+    poller.updateBalenaDevices()
+
+    val expected = listOf(deviceManagersRow(balenaId = device.id))
+    val actual = deviceManagersDao.findAll().onEach { it.id = null }
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `skips new devices that do not have short codes`() {
+    val device = balenaDevice(1)
+
+    every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
+    every { balenaClient.getShortCodeForBalenaId(device.id) } returns null
+
+    poller.updateBalenaDevices()
+
+    val expected = emptyList<DeviceManagersRow>()
+    val actual = deviceManagersDao.findAll()
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `updates existing devices based on Balena device ID`() {
+    val device =
+        balenaDevice(
+            123,
+            isOnline = true,
+            lastConnectivityEvent = Instant.ofEpochSecond(50),
+            modifiedAt = Instant.ofEpochSecond(100),
+            overallProgress = 30,
+        )
+
+    val existingRow = insertDeviceManager(456, balenaId = device.id, facilityId = 100)
+
+    every { clock.instant() } returns Instant.ofEpochSecond(200)
+    every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
+
+    poller.updateBalenaDevices()
+
+    val expected =
+        listOf(
+            existingRow.copy(
+                balenaModifiedTime = device.modifiedAt,
+                isOnline = device.isOnline,
+                lastConnectivityEvent = device.lastConnectivityEvent,
+                refreshedTime = clock.instant(),
+                updateProgress = device.overallProgress))
+    val actual = deviceManagersDao.findAll()
+
+    assertEquals(expected, actual)
+  }
+
+  private fun balenaDevice(
+      id: Any,
+      deviceName: String = "Device $id",
+      isActive: Boolean = false,
+      isOnline: Boolean = false,
+      lastConnectivityEvent: Instant? = null,
+      modifiedAt: Instant = clock.instant(),
+      overallProgress: Int? = null,
+      provisioningState: String? = null,
+      status: String? = null,
+      uuid: String = "uuid-$id",
+  ): BalenaDevice {
+    return BalenaDevice(
+        deviceName,
+        id.toIdWrapper { BalenaDeviceId(it) },
+        isActive,
+        isOnline,
+        lastConnectivityEvent,
+        modifiedAt,
+        overallProgress,
+        provisioningState,
+        status,
+        uuid)
+  }
+
+  private fun deviceManagersRow(
+      id: Any? = null,
+      balenaId: Any = "$id".toLong(),
+      balenaUuid: String = "uuid-$balenaId",
+      balenaModifiedTime: Instant = Instant.EPOCH,
+      facilityId: Any? = null,
+      isOnline: Boolean = false,
+      shortCode: String = "$balenaId",
+      refreshedTime: Instant = Instant.EPOCH,
+  ): DeviceManagersRow {
+    return DeviceManagersRow(
+        balenaModifiedTime = balenaModifiedTime,
+        balenaId = balenaId.toIdWrapper { BalenaDeviceId(it) },
+        balenaUuid = balenaUuid,
+        createdTime = clock.instant(),
+        deviceName = "Device $balenaId",
+        facilityId = facilityId?.toIdWrapper { FacilityId(it) },
+        id = id?.toIdWrapper { DeviceManagerId(it) },
+        isOnline = isOnline,
+        refreshedTime = refreshedTime,
+        shortCode = shortCode,
+        userId = if (facilityId != null) user.userId else null,
+    )
+  }
+
+  private fun insertDeviceManager(
+      id: Any,
+      balenaId: Any = "$id".toLong(),
+      balenaUuid: String = "uuid-$balenaId",
+      balenaModifiedTime: Instant = Instant.EPOCH,
+      facilityId: Any? = null,
+      isOnline: Boolean = false,
+      shortCode: String = "$balenaId",
+      refreshedTime: Instant = Instant.EPOCH,
+  ): DeviceManagersRow {
+    val row =
+        deviceManagersRow(
+            id,
+            balenaId,
+            balenaUuid,
+            balenaModifiedTime,
+            facilityId,
+            isOnline,
+            shortCode,
+            refreshedTime)
+
+    deviceManagersDao.insert(row)
+    return row
+  }
+}


### PR DESCRIPTION
Add a recurring job that polls Balena once a minute and updates the
`device_managers` table to reflect any changes.