### PR TITLE
Remove workaround for JobRunr parameters

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
@@ -21,11 +21,7 @@ class IdWrapper(
   }
 
   fun render(out: JavaWriter) {
-    // JsonAutoDetect is needed to allow ID wrappers to be passed as parameters in JobRunr jobs.
-    // https://github.com/jobrunr/jobrunr/issues/451
     out.println("""
-      @JsonAutoDetect(
-          fieldVisibility = NONE, getterVisibility = PUBLIC_ONLY, creatorVisibility = PUBLIC_ONLY)
       class $className @JsonCreator constructor(@get:JsonValue val value: Long) {
         constructor(value: String) : this(value.toLong())
         override fun equals(other: Any?): Boolean = other is $className && other.value == value

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -28,9 +28,6 @@ class TerrawareGenerator : KotlinGenerator() {
     out.printImports()
     out.println(
         """
-      import com.fasterxml.jackson.annotation.JsonAutoDetect
-      import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE
-      import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY
       import com.fasterxml.jackson.annotation.JsonCreator
       import com.fasterxml.jackson.annotation.JsonValue
       import org.jooq.impl.AbstractConverter


### PR DESCRIPTION
Previously, JobRunr wasn't able to handle our ID wrapper classes as job
parameters. But the problem is fixed in the current release, which we're now
using. Remove the workaround.

To test, upload a species list CSV file (which passes the upload ID between
JobRunr jobs).