### PR TITLE
SW-1033 Add online status to device manager API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.device.DeviceManagerService
 import com.terraformation.backend.device.db.DeviceManagerStore
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -78,6 +79,15 @@ data class DeviceManagerPayload(
         description =
             "The facility this device manager is connected to, or null if it is not connected.")
     val facilityId: FacilityId?,
+    @Schema(description = "If true, this device manager is currently online.")
+    val isOnline: Boolean,
+    @Schema(
+        description =
+            "When the device manager's isOnline value changed most recently. In other words, " +
+                "if isOnline is true, the device manager has been online since this time; if " +
+                "isOnline is false, the device manager has been offline since this time. This " +
+                "may be null if the device manager has not come online for the first time yet.")
+    val onlineChangedTime: Instant?,
     @Schema(
         description =
             "If an update is being downloaded or installed, its progress as a percentage. Not " +
@@ -92,6 +102,8 @@ data class DeviceManagerPayload(
       available = row.facilityId == null,
       facilityId = row.facilityId,
       id = row.id!!,
+      isOnline = row.isOnline!!,
+      onlineChangedTime = row.lastConnectivityEvent,
       shortCode = row.shortCode!!,
       updateProgress = row.updateProgress,
   )

--- a/src/test/kotlin/com/terraformation/backend/device/api/DeviceManagersControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/api/DeviceManagersControllerTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.device.db.DeviceManagerStore
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
+import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -37,16 +38,40 @@ internal class DeviceManagersControllerTest : RunsAsUser {
 
   @Test
   fun `returns device manager for shortCode`() {
-    val deviceManager = DeviceManagersRow(id = DeviceManagerId(1), shortCode = "123456")
+    val deviceManager =
+        DeviceManagersRow(
+            id = DeviceManagerId(1),
+            isOnline = true,
+            lastConnectivityEvent = Instant.ofEpochSecond(1000),
+            shortCode = "123456",
+            updateProgress = 12345)
+
     every { deviceManagerStore.fetchOneByShortCode("123456") } returns deviceManager
-    val expected = GetDeviceManagersResponsePayload(listOf(DeviceManagerPayload(deviceManager)))
+
+    val expected =
+        GetDeviceManagersResponsePayload(
+            listOf(
+                DeviceManagerPayload(
+                    available = true,
+                    facilityId = null,
+                    id = deviceManager.id!!,
+                    isOnline = true,
+                    onlineChangedTime = deviceManager.lastConnectivityEvent!!,
+                    shortCode = deviceManager.shortCode!!,
+                    updateProgress = deviceManager.updateProgress!!,
+                )))
+
     assertEquals(expected, deviceManagersController.getDeviceManagers("123456", null))
   }
 
   @Test
   fun `returns device manager for facilityID`() {
     val deviceManager =
-        DeviceManagersRow(id = DeviceManagerId(1), shortCode = "123456", facilityId = FacilityId(2))
+        DeviceManagersRow(
+            id = DeviceManagerId(1),
+            isOnline = false,
+            shortCode = "123456",
+            facilityId = FacilityId(2))
     every { deviceManagerStore.fetchOneByFacilityId(FacilityId(2)) } returns deviceManager
     val expected = GetDeviceManagersResponsePayload(listOf(DeviceManagerPayload(deviceManager)))
     assertEquals(expected, deviceManagersController.getDeviceManagers(null, FacilityId(2)))


### PR DESCRIPTION
Balena tells us whether a given device manager is online (connected to the
Balena servers) or not, and when it most recently connected or disconnected.
Pass that information through to clients.