### PR TITLE
SW-1034 Automatically create automations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -37,6 +37,7 @@ import com.terraformation.backend.db.tables.pojos.DeviceTemplatesRow
 import com.terraformation.backend.db.tables.pojos.DevicesRow
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.pojos.SitesRow
+import com.terraformation.backend.device.DeviceService
 import com.terraformation.backend.device.db.DeviceManagerStore
 import com.terraformation.backend.device.db.DeviceStore
 import com.terraformation.backend.log.perClassLogger
@@ -89,6 +90,7 @@ class AdminController(
     private val clock: Clock,
     private val config: TerrawareServerConfig,
     private val deviceManagerStore: DeviceManagerStore,
+    private val deviceService: DeviceService,
     private val deviceStore: DeviceStore,
     private val deviceTemplatesDao: DeviceTemplatesDao,
     private val dslContext: DSLContext,
@@ -893,7 +895,7 @@ class AdminController(
                 protocol = protocol,
             )
 
-        deviceStore.create(devicesRow)
+        deviceService.create(devicesRow)
       }
 
       redirectAttributes.successMessage =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
@@ -27,4 +27,22 @@ data class AutomationModel(
       createdTime = row.createdTime ?: throw IllegalArgumentException("createdTime is required"),
       modifiedTime = row.modifiedTime ?: throw IllegalArgumentException("modifiedTime is required"),
       configuration = row.configuration?.data()?.let { objectMapper.readValue(it) })
+
+  val type: String?
+    get() = configuration?.get(TYPE_KEY)?.toString()
+
+  companion object {
+    // Configuration keys recognized by the device manager.
+
+    const val DEVICE_ID_KEY = "monitorDeviceId"
+    const val LOWER_THRESHOLD_KEY = "lowerThreshold"
+    const val TIMESERIES_NAME_KEY = "monitorTimeseriesName"
+    const val TYPE_KEY = "type"
+    const val UPPER_THRESHOLD_KEY = "upperThreshold"
+
+    // Automation types recognized by the device manager (not a complete list; just the ones the
+    // server needs to know about).
+
+    const val SENSOR_BOUNDS_TYPE = "SensorBoundsAlert"
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
@@ -1,0 +1,135 @@
+package com.terraformation.backend.device
+
+import com.terraformation.backend.customer.db.AutomationStore
+import com.terraformation.backend.customer.model.AutomationModel
+import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.DeviceNotFoundException
+import com.terraformation.backend.db.tables.pojos.DevicesRow
+import com.terraformation.backend.device.db.DeviceStore
+import com.terraformation.backend.log.perClassLogger
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+@ManagedBean
+class DeviceService(
+    private val automationStore: AutomationStore,
+    private val deviceStore: DeviceStore,
+    private val dslContext: DSLContext,
+) {
+  private val log = perClassLogger()
+
+  fun create(row: DevicesRow): DeviceId {
+    return dslContext.transactionResult { _ ->
+      val deviceId = deviceStore.create(row)
+      updateAutomations(deviceId, row)
+
+      deviceId
+    }
+  }
+
+  fun update(row: DevicesRow) {
+    val deviceId = row.id ?: throw IllegalArgumentException("No device ID specified")
+    val existingRow = deviceStore.fetchOneById(deviceId) ?: throw DeviceNotFoundException(deviceId)
+
+    dslContext.transaction { _ ->
+      deviceStore.update(row)
+
+      if (row.name != existingRow.name ||
+          row.deviceType != existingRow.deviceType ||
+          row.make != existingRow.make ||
+          row.model != existingRow.model) {
+        updateAutomations(deviceId, row.copy(facilityId = existingRow.facilityId))
+      }
+    }
+  }
+
+  private fun updateAutomations(deviceId: DeviceId, row: DevicesRow) {
+    val facilityId = row.facilityId ?: throw IllegalArgumentException("No facility ID specified")
+    val existingAutomations = automationStore.fetchByDeviceId(deviceId)
+    val desiredAutomations = automationsForDevice(deviceId, row)
+
+    existingAutomations.forEach { existingAutomation ->
+      if (existingAutomation.type == AutomationModel.SENSOR_BOUNDS_TYPE) {
+        log.info("Deleting automation ${existingAutomation.name} for device $deviceId")
+        automationStore.delete(existingAutomation.id)
+      } else {
+        log.debug(
+            "Keeping automation ${existingAutomation.name} for device $deviceId because it " +
+                "is of type ${existingAutomation.type}")
+      }
+    }
+
+    desiredAutomations.forEach { (name, configuration) ->
+      log.info("Creating automation $name for device $deviceId")
+      automationStore.create(facilityId, name, null, configuration)
+    }
+  }
+
+  private fun automationsForDevice(
+      deviceId: DeviceId,
+      row: DevicesRow
+  ): Map<String, Map<String, Any?>> {
+    val name = row.name ?: throw IllegalArgumentException("No device name specified")
+
+    return if (row.deviceType == "sensor" && row.make == "OmniSense" && row.model == "S-11") {
+      automationsForTemperatureHumiditySensor(deviceId, name)
+    } else if (row.deviceType == "BMU") {
+      automationsForBMU(deviceId, name)
+    } else {
+      emptyMap()
+    }
+  }
+
+  private fun automationsForBMU(deviceId: DeviceId, name: String): Map<String, Map<String, Any?>> {
+    return mapOf(
+        "$name 25% charge" to sensorBounds(deviceId, "relative_state_of_charge", 25.1, null),
+        "$name 10% charge" to sensorBounds(deviceId, "relative_state_of_charge", 10.1, null),
+        "$name 0% charge" to sensorBounds(deviceId, "relative_state_of_charge", 0.1, null),
+    )
+  }
+
+  private fun automationsForTemperatureHumiditySensor(
+      deviceId: DeviceId,
+      name: String
+  ): Map<String, Map<String, Any?>> {
+    return when {
+      name.startsWith("Ambient ") ->
+          mapOf(
+              "$name humidity" to sensorBounds(deviceId, "humidity", 34.0, 40.0),
+              "$name temperature" to sensorBounds(deviceId, "temperature", 21.0, 25.0),
+          )
+      name.startsWith("Dry Cabinet ") ->
+          mapOf(
+              "$name humidity" to sensorBounds(deviceId, "humidity", 27.0, 33.0),
+              "$name temperature" to sensorBounds(deviceId, "temperature", 21.0, 25.0),
+          )
+      name.startsWith("Freezer ") ->
+          mapOf(
+              "$name temperature" to sensorBounds(deviceId, "temperature", -25.0, -15.0),
+          )
+      name.startsWith("Fridge ") ->
+          mapOf(
+              "$name temperature" to sensorBounds(deviceId, "temperature", 0.0, 10.0),
+          )
+      else -> emptyMap()
+    }
+  }
+
+  private fun sensorBounds(
+      deviceId: DeviceId,
+      timeseriesName: String,
+      lowerBound: Double?,
+      upperBound: Double?,
+  ): Map<String, Any?> {
+    return with(AutomationModel) {
+      listOfNotNull(
+              TYPE_KEY to SENSOR_BOUNDS_TYPE,
+              DEVICE_ID_KEY to deviceId,
+              TIMESERIES_NAME_KEY to timeseriesName,
+              lowerBound?.let { LOWER_THRESHOLD_KEY to it },
+              upperBound?.let { UPPER_THRESHOLD_KEY to it },
+          )
+          .toMap()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.pojos.DevicesRow
+import com.terraformation.backend.device.DeviceService
 import com.terraformation.backend.device.db.DeviceStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 @DeviceManagerAppEndpoint
 @RestController
 class DeviceController(
+    private val deviceService: DeviceService,
     private val deviceStore: DeviceStore,
     private val objectMapper: ObjectMapper,
 ) {
@@ -44,7 +46,7 @@ class DeviceController(
   @PostMapping("/api/v1/devices")
   fun createDevice(@RequestBody payload: CreateDeviceRequestPayload): CreateDeviceResponsePayload {
     val devicesRow = payload.toRow(objectMapper)
-    val deviceId = deviceStore.create(devicesRow)
+    val deviceId = deviceService.create(devicesRow)
     return CreateDeviceResponsePayload(deviceId)
   }
 
@@ -66,7 +68,7 @@ class DeviceController(
       @RequestBody payload: UpdateDeviceRequestPayload
   ): SimpleSuccessResponsePayload {
     val devicesRow = payload.toRow(deviceId, objectMapper)
-    deviceStore.update(devicesRow)
+    deviceService.update(devicesRow)
     return SimpleSuccessResponsePayload()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.customer.db
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.AutomationModel
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.AutomationId
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.tables.pojos.AutomationsRow
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import org.jooq.JSONB
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock: Clock = mockk()
+  private val objectMapper = jacksonObjectMapper()
+  private val store: AutomationStore by lazy {
+    AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext))
+  }
+
+  private val deviceId = DeviceId(1000)
+  private val facilityId = FacilityId(100)
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+    every { user.canListAutomations(any()) } returns true
+
+    insertSiteData()
+    insertDevice(deviceId)
+  }
+
+  @Test
+  fun `fetchByDeviceId filters by device ID`() {
+    val otherDeviceId = DeviceId(1001)
+
+    insertDevice(otherDeviceId)
+
+    val expectedRow =
+        insertAutomation(1, facilityId, mapOf(AutomationModel.DEVICE_ID_KEY to deviceId))
+    insertAutomation(2, facilityId, mapOf(AutomationModel.DEVICE_ID_KEY to otherDeviceId))
+
+    val expected = listOf(AutomationModel(expectedRow, objectMapper))
+    val actual = store.fetchByDeviceId(deviceId)
+
+    assertEquals(expected, actual)
+  }
+
+  private fun insertAutomation(
+      id: Any,
+      facilityId: Any = "$id".toLong() / 10,
+      configuration: Map<String, Any>? = null
+  ): AutomationsRow {
+    val row =
+        AutomationsRow(
+            id = id.toIdWrapper { AutomationId(it) },
+            facilityId = facilityId.toIdWrapper { FacilityId(it) },
+            name = "Automation $id",
+            createdTime = clock.instant(),
+            createdBy = user.userId,
+            modifiedBy = user.userId,
+            modifiedTime = clock.instant(),
+            configuration =
+                configuration?.let { JSONB.jsonb(objectMapper.writeValueAsString(configuration)) },
+        )
+
+    automationsDao.insert(row)
+
+    return row
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -1,0 +1,258 @@
+package com.terraformation.backend.device
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.db.AutomationStore
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.AutomationModel.Companion.DEVICE_ID_KEY
+import com.terraformation.backend.customer.model.AutomationModel.Companion.LOWER_THRESHOLD_KEY
+import com.terraformation.backend.customer.model.AutomationModel.Companion.SENSOR_BOUNDS_TYPE
+import com.terraformation.backend.customer.model.AutomationModel.Companion.TIMESERIES_NAME_KEY
+import com.terraformation.backend.customer.model.AutomationModel.Companion.TYPE_KEY
+import com.terraformation.backend.customer.model.AutomationModel.Companion.UPPER_THRESHOLD_KEY
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.DeviceId
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.tables.pojos.AutomationsRow
+import com.terraformation.backend.db.tables.pojos.DevicesRow
+import com.terraformation.backend.device.db.DeviceStore
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.security.access.AccessDeniedException
+
+internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock: Clock = mockk()
+  private val objectMapper = jacksonObjectMapper()
+  private val service: DeviceService by lazy {
+    DeviceService(
+        AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext)),
+        DeviceStore(devicesDao),
+        dslContext)
+  }
+
+  private val facilityId = FacilityId(100)
+
+  private val bmuRow =
+      DevicesRow(
+          facilityId = facilityId,
+          name = "PV",
+          deviceType = "BMU",
+          make = "Blue Ion",
+          model = "LV",
+      )
+
+  private val omniSenseRow =
+      DevicesRow(
+          facilityId = facilityId,
+          deviceType = "sensor",
+          name = "0123ABCD",
+          make = "OmniSense",
+          model = "S-11",
+      )
+
+  /** Expected temperature and humidity ranges for temperature sensors. */
+  data class OmniSense(
+      val name: String,
+      private val temperature: Pair<Double, Double>? = null,
+      private val humidity: Pair<Double, Double>? = null,
+  ) {
+    fun toAutomationConfigs(deviceId: DeviceId): Map<String, Map<String, Any?>> {
+      return listOfNotNull(
+              humidity?.let { (min, max) ->
+                "$name humidity" to
+                    mapOf(
+                        TYPE_KEY to SENSOR_BOUNDS_TYPE,
+                        DEVICE_ID_KEY to deviceId.value.toInt(),
+                        TIMESERIES_NAME_KEY to "humidity",
+                        LOWER_THRESHOLD_KEY to min,
+                        UPPER_THRESHOLD_KEY to max,
+                    )
+              },
+              temperature?.let { (min, max) ->
+                "$name temperature" to
+                    mapOf(
+                        TYPE_KEY to SENSOR_BOUNDS_TYPE,
+                        DEVICE_ID_KEY to deviceId.value.toInt(),
+                        TIMESERIES_NAME_KEY to "temperature",
+                        LOWER_THRESHOLD_KEY to min,
+                        UPPER_THRESHOLD_KEY to max,
+                    )
+              },
+          )
+          .toMap()
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    val knownSensors =
+        listOf(
+            OmniSense("Ambient 1", 21.0 to 25.0, 34.0 to 40.0),
+            OmniSense("Dry Cabinet 1", 21.0 to 25.0, 27.0 to 33.0),
+            OmniSense("Freezer 3", -25.0 to -15.0),
+            OmniSense("Fridge 2", 0.0 to 10.0))
+  }
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+    every { user.canCreateAutomation(any()) } returns true
+    every { user.canCreateDevice(any()) } returns true
+    every { user.canDeleteAutomation(any()) } returns true
+    every { user.canListAutomations(any()) } returns true
+    every { user.canReadAutomation(any()) } returns true
+    every { user.canReadDevice(any()) } returns true
+    every { user.canReadFacility(any()) } returns true
+    every { user.canUpdateDevice(any()) } returns true
+
+    insertSiteData()
+  }
+
+  @Test
+  fun `create does not add automations if device is of unrecognized type`() {
+    service.create(
+        DevicesRow(
+            facilityId = facilityId,
+            name = "test",
+            deviceType = "random",
+            make = "company",
+            model = "product"))
+    assertEquals(emptyList<AutomationsRow>(), automationsDao.findAll())
+  }
+
+  @Test
+  fun `create adds BMU automations`() {
+    val deviceId = service.create(bmuRow)
+
+    assertHasBmuAutomations(deviceId)
+  }
+
+  @Test
+  fun `update adds BMU automations`() {
+    val deviceId =
+        service.create(
+            DevicesRow(
+                facilityId = facilityId,
+                name = "PV",
+                deviceType = "unknown",
+                make = "unknown",
+                model = "unknown"))
+
+    service.update(bmuRow.copy(id = deviceId))
+
+    assertHasBmuAutomations(deviceId)
+  }
+
+  @Test
+  fun `create does not create automations for sensor with unrecognized name`() {
+    service.create(omniSenseRow)
+
+    assertAutomationConfigsEqual(emptyMap())
+  }
+
+  @MethodSource("getKnownSensors")
+  @ParameterizedTest(name = "{0}")
+  fun `create adds automations for recognized sensor names`(omniSense: OmniSense) {
+    val deviceId = service.create(omniSenseRow.copy(name = omniSense.name))
+
+    assertAutomationConfigsEqual(omniSense.toAutomationConfigs(deviceId))
+  }
+
+  @MethodSource("getKnownSensors")
+  @ParameterizedTest(name = "{0}")
+  fun `update adds automations for recognized sensor names`(omniSense: OmniSense) {
+    val deviceId = service.create(omniSenseRow)
+    service.update(omniSenseRow.copy(id = deviceId, name = omniSense.name))
+
+    assertAutomationConfigsEqual(omniSense.toAutomationConfigs(deviceId))
+  }
+
+  @Test
+  fun `update removes automations if recognized sensor name is removed`() {
+    val deviceId = service.create(omniSenseRow.copy(name = "Fridge 1"))
+    service.update(omniSenseRow.copy(id = deviceId))
+
+    assertAutomationConfigsEqual(emptyMap())
+  }
+
+  @Test
+  fun `update switches automations if sensor is renamed from one recognized name to another`() {
+    val ambientBounds = knownSensors.first { it.name.startsWith("Ambient") }
+    val fridgeBounds = knownSensors.first { it.name.startsWith("Fridge") }
+
+    val deviceId = service.create(omniSenseRow.copy(name = fridgeBounds.name))
+    service.update(omniSenseRow.copy(id = deviceId, name = ambientBounds.name))
+
+    assertAutomationConfigsEqual(ambientBounds.toAutomationConfigs(deviceId))
+  }
+
+  @Test
+  fun `create does not create device if no permission to create automations`() {
+    every { user.canCreateAutomation(any()) } returns false
+
+    assertThrows<AccessDeniedException> { service.create(omniSenseRow.copy(name = "Fridge 1")) }
+
+    assertEquals(emptyList<DevicesRow>(), devicesDao.findAll())
+    assertAutomationConfigsEqual(emptyMap())
+  }
+
+  @Test
+  fun `update does not update device if no permission to create automations`() {
+    every { user.canCreateAutomation(any()) } returns false
+
+    val deviceId = service.create(omniSenseRow)
+    val expectedDevices = devicesDao.findAll()
+
+    assertThrows<AccessDeniedException> {
+      service.update(omniSenseRow.copy(id = deviceId, name = "Fridge 1"))
+    }
+
+    assertEquals(expectedDevices, devicesDao.findAll())
+    assertAutomationConfigsEqual(emptyMap())
+  }
+
+  private fun assertHasBmuAutomations(deviceId: DeviceId) {
+    val commonFields =
+        mapOf(
+            TYPE_KEY to SENSOR_BOUNDS_TYPE,
+            DEVICE_ID_KEY to deviceId.value.toInt(),
+            TIMESERIES_NAME_KEY to "relative_state_of_charge",
+        )
+
+    val expected =
+        mapOf(
+            "PV 25% charge" to commonFields + mapOf(LOWER_THRESHOLD_KEY to 25.1),
+            "PV 10% charge" to commonFields + mapOf(LOWER_THRESHOLD_KEY to 10.1),
+            "PV 0% charge" to commonFields + mapOf(LOWER_THRESHOLD_KEY to 0.1),
+        )
+
+    assertAutomationConfigsEqual(expected)
+  }
+
+  private fun assertAutomationConfigsEqual(expected: Map<String, Map<String, Any?>>) {
+    val actual =
+        automationsDao
+            .findAll()
+            .mapNotNull { row ->
+              row.configuration?.let { configuration ->
+                row.name to objectMapper.readValue<Map<String, Any?>>(configuration.data())
+              }
+            }
+            .toMap()
+
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
The device manager needs to know the acceptable ranges of various timeseries so it
can generate notifications if they go out of range.

The correct ranges, and the relevant timeseries, depend on various attributes of
the device, including its name. In the future, we'll likely also want to let users
edit the ranges on a per-device basis. So the server needs to be the source of
truth for the ranges.

Add logic to create and remove automations based on changes to device data.