### PR TITLE
SW-1047 Add endpoint to mark device as unresponsive

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/event/DeviceUnresponsiveEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/event/DeviceUnresponsiveEvent.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.device.event
+
+import com.terraformation.backend.db.DeviceId
+import java.time.Duration
+import java.time.Instant
+
+/** Published when a device manager reports that one of its devices isn't responding. */
+data class DeviceUnresponsiveEvent(
+    val deviceId: DeviceId,
+    val lastRespondedTime: Instant?,
+    val expectedInterval: Duration?,
+)

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -77,6 +77,16 @@ class UnknownAutomationTriggered(
     get() = "device/unknownAutomation"
 }
 
+class DeviceUnresponsive(
+    config: TerrawareServerConfig,
+    val device: DevicesRow,
+    val facility: FacilityModel,
+    val facilityMonitoringUrl: String,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "device/unresponsive"
+}
+
 class UserAddedToOrganization(
     config: TerrawareServerConfig,
     val admin: IndividualUser,

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -200,6 +200,11 @@ class Messages {
           title = "$automationName triggered at $facilityName",
           body = message ?: "Please check on it.")
 
+  fun deviceUnresponsive(deviceName: String): NotificationMessage =
+      NotificationMessage(
+          title = "$deviceName cannot be detected.",
+          body = "$deviceName cannot be detected. Please check on it.")
+
   private val validGrowthForms = GrowthForm.values().joinToString { it.displayName }
   private val validSeedStorageBehaviors =
       SeedStorageBehavior.values().joinToString { it.displayName }

--- a/src/main/resources/db/migration/common/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/common/R__TypeCodes.sql
@@ -182,5 +182,6 @@ VALUES (1, 'User Added to Organization', 1),
        (10, 'Accessions Ready for Testing', 1),
        (11, 'Accessions Finished Drying', 1),
        (12, 'Sensor Out Of Bounds', 3),
-       (13, 'Unknown Automation Triggered', 3)
+       (13, 'Unknown Automation Triggered', 3),
+       (14, 'Device Unresponsive', 3)
 ON CONFLICT (id) DO UPDATE SET name = excluded.name, notification_criticality_id = excluded.notification_criticality_id;

--- a/src/main/resources/templates/email/device/unresponsive/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/unresponsive/body.ftlh.mjml
@@ -1,0 +1,19 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeviceUnresponsive" --> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-headline06-bold">
+                    ${facility.name}'s ${device.name} cannot be detected. Please check on it.
+                </mj-text>
+                <mj-include path="../../facility/link.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/device/unresponsive/body.txt.ftl
+++ b/src/main/resources/templates/email/device/unresponsive/body.txt.ftl
@@ -1,0 +1,17 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeviceUnresponsive" -->
+${facility.name}'s ${device.name} cannot be detected. Please check on it.
+
+Please click the link below to go to your Terraware account where you can view the seed bank.
+${facilityMonitoringUrl}
+
+
+------------------------------
+
+Terraformation Inc.
+PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
+
+https://twitter.com/TF_Global
+https://www.linkedin.com/company/terraformation/
+https://www.instagram.com/globalterraform/
+https://www.facebook.com/GlobalTerraform
+https://terraformation.com/

--- a/src/main/resources/templates/email/device/unresponsive/subject.ftl
+++ b/src/main/resources/templates/email/device/unresponsive/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeviceUnresponsive" -->
+${device.name} cannot be detected.

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -18,10 +18,15 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.pojos.AutomationsRow
 import com.terraformation.backend.db.tables.pojos.DevicesRow
 import com.terraformation.backend.device.db.DeviceStore
+import com.terraformation.backend.device.event.DeviceUnresponsiveEvent
 import com.terraformation.backend.mockUser
+import io.mockk.CapturingSlot
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -29,18 +34,21 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.security.access.AccessDeniedException
 
 internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock: Clock = mockk()
+  private val eventPublisher: ApplicationEventPublisher = mockk()
   private val objectMapper = jacksonObjectMapper()
   private val service: DeviceService by lazy {
     DeviceService(
         AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext)),
         DeviceStore(devicesDao),
-        dslContext)
+        dslContext,
+        eventPublisher)
   }
 
   private val facilityId = FacilityId(100)
@@ -222,6 +230,28 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(expectedDevices, devicesDao.findAll())
     assertAutomationConfigsEqual(emptyMap())
+  }
+
+  @Test
+  fun `markDeviceUnresponsive publishes event`() {
+    val slot = CapturingSlot<DeviceUnresponsiveEvent>()
+
+    every { eventPublisher.publishEvent(capture(slot)) } just Runs
+
+    val expected =
+        DeviceUnresponsiveEvent(DeviceId(1), Instant.ofEpochSecond(123), Duration.ofSeconds(30))
+
+    service.markUnresponsive(
+        expected.deviceId, expected.lastRespondedTime, expected.expectedInterval)
+
+    assertEquals(expected, slot.captured)
+  }
+
+  @Test
+  fun `markDeviceUnresponsive throws exception if no permission to update device`() {
+    every { user.canUpdateDevice(any()) } returns false
+
+    assertThrows<AccessDeniedException> { service.markUnresponsive(DeviceId(1), null, null) }
   }
 
   private fun assertHasBmuAutomations(deviceId: DeviceId) {


### PR DESCRIPTION
If the device manager isn't able to communicate with a device for more than a
certain amount of time, it can use the new `/api/v1/devices/{id}/unresponsive`
endpoint to notify the server that the device is unresponsive.

This will broadcast a notification to the facility's users.