### PR TITLE
SW-1055 Remove duplicate species names from lookup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -54,7 +54,8 @@ class GbifStore(private val dslContext: DSLContext) {
     // order-sensitive, but we don't require them to start at the beginning of the name. That is,
     // this search should match species 'Abc def' and 'Xyz abc var. def' but not species 'Def abc'.
 
-    val selectFrom = dslContext.selectDistinct(GBIF_NAMES.asterisk()).from(GBIF_NAMES)
+    val selectFrom =
+        dslContext.selectDistinct(GBIF_NAMES.asterisk()).on(GBIF_NAMES.NAME).from(GBIF_NAMES)
 
     // A separate table alias for each prefix
     val wordsAliases = normalizedPrefixes.indices.map { GBIF_NAME_WORDS.`as`("gnw_$it") }


### PR DESCRIPTION
When we import the GBIF data, we calculate the scientific name for each
taxon such that it is formatted in a consistent way. That calculation can
result in the same scientific name for more than one GBIF species entry
if, e.g., we are stripping off the publication date or the name of the
person who discovered the species.

Update `/api/v1/species/lookup/names` to remove the duplicate names.