### PR TITLE
SW-955 Check species names for problems

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -316,6 +316,8 @@ data class IndividualUser(
   }
 
   override fun canReadSpecies(speciesId: SpeciesId): Boolean {
+    // If this logic changes, make sure to also change code that bakes this rule into SQL queries
+    // for efficiency. Example: SpeciesStore.fetchUncheckedSpeciesIds
     val organizationId = parentStore.getOrganizationId(speciesId) ?: return false
     return canReadOrganization(organizationId)
   }

--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -2,12 +2,17 @@ package com.terraformation.backend.species
 
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SpeciesId
+import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
+import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import javax.annotation.ManagedBean
+import org.jooq.DSLContext
 
 @ManagedBean
 class SpeciesService(
+    private val dslContext: DSLContext,
+    private val speciesChecker: SpeciesChecker,
     private val speciesStore: SpeciesStore,
 ) {
   /** Returns an existing species with a scientific name or creates it if it doesn't exist. */
@@ -19,11 +24,24 @@ class SpeciesService(
 
   /** Creates a new species and checks it for potential problems. */
   fun createSpecies(row: SpeciesRow): SpeciesId {
-    return speciesStore.createSpecies(row)
+    return dslContext.transactionResult { _ ->
+      val speciesId = speciesStore.createSpecies(row)
+      speciesChecker.checkSpecies(speciesId)
+      speciesId
+    }
   }
 
   /** Updates an existing species and checks it for newly-introduced problems. */
-  fun updateSpecies(row: SpeciesRow) {
-    speciesStore.updateSpecies(row)
+  fun updateSpecies(row: SpeciesRow): SpeciesRow {
+    return dslContext.transactionResult { _ ->
+      val speciesId = row.id ?: throw IllegalArgumentException("ID must be non-null")
+      val existingRow =
+          speciesStore.fetchSpeciesById(speciesId) ?: throw SpeciesNotFoundException(speciesId)
+
+      val updatedRow = speciesStore.updateSpecies(row)
+      speciesChecker.recheckSpecies(existingRow, updatedRow)
+
+      updatedRow
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
@@ -1,0 +1,46 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.SpeciesId
+import com.terraformation.backend.db.SpeciesNotFoundException
+import com.terraformation.backend.db.tables.pojos.SpeciesRow
+import javax.annotation.ManagedBean
+
+@ManagedBean
+class SpeciesChecker(
+    private val gbifStore: GbifStore,
+    private val speciesStore: SpeciesStore,
+) {
+  fun checkAllUncheckedSpecies(organizationId: OrganizationId) {
+    speciesStore.fetchUncheckedSpeciesIds(organizationId).forEach { checkSpecies(it) }
+  }
+
+  fun checkSpecies(speciesId: SpeciesId) {
+    val speciesRow =
+        speciesStore.fetchSpeciesById(speciesId) ?: throw SpeciesNotFoundException(speciesId)
+    if (speciesRow.checkedTime == null) {
+      createProblems(speciesId, speciesRow)
+    }
+  }
+
+  /**
+   * Rechecks a species after it has been updated if the update modified any values that would cause
+   * previous check results to be invalid.
+   */
+  fun recheckSpecies(before: SpeciesRow, after: SpeciesRow) {
+    val speciesId = after.id ?: throw IllegalArgumentException("Species ID must be non-null")
+
+    if (before.scientificName != after.scientificName) {
+      createProblems(speciesId, after)
+    }
+  }
+
+  private fun createProblems(speciesId: SpeciesId, speciesRow: SpeciesRow) {
+    val problems =
+        listOfNotNull(
+            speciesRow.scientificName?.let { gbifStore.checkScientificName(it) },
+        )
+
+    speciesStore.updateProblems(speciesId, problems)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.tables.daos.ProjectUsersDao
 import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.db.tables.daos.SitesDao
 import com.terraformation.backend.db.tables.daos.SpeciesDao
+import com.terraformation.backend.db.tables.daos.SpeciesProblemsDao
 import com.terraformation.backend.db.tables.daos.StorageLocationsDao
 import com.terraformation.backend.db.tables.daos.ThumbnailsDao
 import com.terraformation.backend.db.tables.daos.TimeseriesDao
@@ -216,6 +217,7 @@ abstract class DatabaseTest {
   protected val projectUsersDao: ProjectUsersDao by lazyDao()
   protected val sitesDao: SitesDao by lazyDao()
   protected val speciesDao: SpeciesDao by lazyDao()
+  protected val speciesProblemsDao: SpeciesProblemsDao by lazyDao()
   protected val storageLocationsDao: StorageLocationsDao by lazyDao()
   protected val thumbnailsDao: ThumbnailsDao by lazyDao()
   protected val timeseriesDao: TimeseriesDao by lazyDao()
@@ -414,6 +416,7 @@ abstract class DatabaseTest {
       modifiedTime: Instant = Instant.EPOCH,
       organizationId: Any = "$speciesId".toLong() / 10,
       deletedTime: Instant? = null,
+      checkedTime: Instant? = null,
   ) {
     val speciesIdWrapper = speciesId.toIdWrapper { SpeciesId(it) }
     val organizationIdWrapper = organizationId.toIdWrapper { OrganizationId(it) }
@@ -421,6 +424,7 @@ abstract class DatabaseTest {
     with(SPECIES) {
       dslContext
           .insertInto(SPECIES)
+          .set(CHECKED_TIME, checkedTime)
           .set(CREATED_BY, createdBy)
           .set(CREATED_TIME, createdTime)
           .set(DELETED_BY, if (deletedTime != null) createdBy else null)

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -5,10 +5,15 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SpeciesId
+import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import java.time.Clock
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
@@ -19,14 +24,21 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   override val user: TerrawareUser = mockUser()
 
-  private val speciesStore: SpeciesStore by lazy { SpeciesStore(clock, dslContext, speciesDao) }
-  private val service: SpeciesService by lazy { SpeciesService(speciesStore) }
+  private val speciesStore: SpeciesStore by lazy {
+    SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
+  }
+  private val speciesChecker: SpeciesChecker = mockk()
+  private val service: SpeciesService by lazy {
+    SpeciesService(dslContext, speciesChecker, speciesStore)
+  }
 
   private val organizationId = OrganizationId(1)
 
   @BeforeEach
   fun setUp() {
     every { clock.instant() } returns Instant.EPOCH
+    every { speciesChecker.checkSpecies(any()) } just Runs
+    every { speciesChecker.recheckSpecies(any(), any()) } just Runs
     every { user.canCreateSpecies(organizationId) } returns true
     every { user.canReadOrganization(organizationId) } returns true
     every { user.canReadSpecies(any()) } returns true
@@ -40,7 +52,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     val speciesId = SpeciesId(1)
     val scientificName = "test"
 
-    insertSpecies(speciesId.value, scientificName = scientificName, organizationId = organizationId)
+    insertSpecies(speciesId, scientificName = scientificName, organizationId = organizationId)
 
     assertEquals(speciesId, service.getOrCreateSpecies(organizationId, scientificName))
   }
@@ -62,5 +74,35 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
     assertNotNull(speciesId, "Should have created species")
     assertNotEquals(otherOrgSpeciesId, speciesId, "Should not use species ID from other org")
+
+    verify { speciesChecker.checkSpecies(speciesId) }
+  }
+
+  @Test
+  fun `createSpecies checks for problems with species data`() {
+    val speciesId =
+        service.createSpecies(
+            SpeciesRow(organizationId = organizationId, scientificName = "Scientific name"))
+
+    verify { speciesChecker.checkSpecies(speciesId) }
+  }
+
+  @Test
+  fun `updateSpecies checks for problems with species data`() {
+    val speciesId = SpeciesId(1)
+
+    insertSpecies(speciesId, "Old name", organizationId = organizationId)
+    val originalRow = speciesDao.fetchOneById(speciesId)!!
+
+    val updatedRow = service.updateSpecies(originalRow.copy(scientificName = "New name"))
+
+    assertEquals("New name", updatedRow.scientificName)
+
+    verify {
+      speciesChecker.recheckSpecies(
+          match { it.scientificName == "Old name" },
+          match { it.scientificName == "New name" },
+      )
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCheckerTest.kt
@@ -1,0 +1,100 @@
+package com.terraformation.backend.species.db
+
+import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.SpeciesId
+import com.terraformation.backend.db.SpeciesProblemField
+import com.terraformation.backend.db.SpeciesProblemType
+import com.terraformation.backend.db.tables.pojos.SpeciesProblemsRow
+import com.terraformation.backend.db.tables.pojos.SpeciesRow
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SpeciesCheckerTest {
+  private val gbifStore: GbifStore = mockk()
+  private val speciesStore: SpeciesStore = mockk()
+  private val checker = SpeciesChecker(gbifStore, speciesStore)
+
+  private val organizationId = OrganizationId(1)
+  private val speciesId = SpeciesId(1)
+  private val nonexistentProblem =
+      SpeciesProblemsRow(
+          speciesId = speciesId,
+          fieldId = SpeciesProblemField.ScientificName,
+          typeId = SpeciesProblemType.NameNotFound)
+
+  @BeforeEach
+  fun setUp() {
+    every { gbifStore.checkScientificName(any()) } returns null
+    every { gbifStore.checkScientificName("Bogus name") } returns nonexistentProblem
+    every { speciesStore.updateProblems(any(), any()) } just Runs
+  }
+
+  @Test
+  fun `checkAllUncheckedSpecies checks all unchecked species`() {
+    val bogusId = speciesId
+    val correctId = SpeciesId(2)
+    val uncheckedSpeciesIds = listOf(correctId, bogusId)
+
+    every { speciesStore.fetchUncheckedSpeciesIds(organizationId) } returns uncheckedSpeciesIds
+    every { speciesStore.fetchSpeciesById(correctId) } returns
+        SpeciesRow(id = correctId, organizationId = organizationId, scientificName = "Correct name")
+    every { speciesStore.fetchSpeciesById(bogusId) } returns
+        SpeciesRow(id = bogusId, organizationId = organizationId, scientificName = "Bogus name")
+
+    checker.checkAllUncheckedSpecies(organizationId)
+
+    verify { gbifStore.checkScientificName("Correct name") }
+    verify { gbifStore.checkScientificName("Bogus name") }
+    verify { speciesStore.updateProblems(correctId, emptyList()) }
+    verify { speciesStore.updateProblems(bogusId, listOf(nonexistentProblem)) }
+  }
+
+  @Test
+  fun `checkSpecies checks scientific name if species has not been checked`() {
+    every { speciesStore.fetchSpeciesById(speciesId) } returns
+        SpeciesRow(id = speciesId, scientificName = "Bogus name")
+
+    checker.checkSpecies(speciesId)
+
+    verify { gbifStore.checkScientificName("Bogus name") }
+    verify { speciesStore.updateProblems(speciesId, listOf(nonexistentProblem)) }
+  }
+
+  @Test
+  fun `checkSpecies does nothing if species has already been checked`() {
+    every { speciesStore.fetchSpeciesById(speciesId) } returns
+        SpeciesRow(id = speciesId, scientificName = "Bogus name", checkedTime = Instant.EPOCH)
+
+    checker.checkSpecies(speciesId)
+
+    verify(exactly = 0) { gbifStore.checkScientificName(any()) }
+    verify(exactly = 0) { speciesStore.updateProblems(any(), any()) }
+  }
+
+  @Test
+  fun `recheckSpecies checks scientific name again if it changed`() {
+    checker.recheckSpecies(
+        SpeciesRow(id = speciesId, scientificName = "Correct name"),
+        SpeciesRow(id = speciesId, scientificName = "Bogus name"))
+
+    verify { gbifStore.checkScientificName("Bogus name") }
+    verify { speciesStore.updateProblems(speciesId, listOf(nonexistentProblem)) }
+  }
+
+  @Test
+  fun `recheckSpecies does not check scientific name again if it did not change`() {
+    val speciesRow =
+        SpeciesRow(id = speciesId, scientificName = "Bogus name", familyName = "Old family")
+
+    checker.recheckSpecies(speciesRow, speciesRow.copy(familyName = "New family"))
+
+    verify(exactly = 0) { gbifStore.checkScientificName(any()) }
+    verify(exactly = 0) { speciesStore.updateProblems(any(), any()) }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -50,6 +50,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   private val fileStore: FileStore = mockk()
   private val messages = Messages()
   private val scheduler: JobScheduler = mockk()
+  private val speciesChecker: SpeciesChecker = mockk()
   private val uploadService: UploadService = mockk()
   private val uploadStore: UploadStore by lazy {
     UploadStore(dslContext, uploadProblemsDao, uploadsDao)
@@ -62,6 +63,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         fileStore,
         messages,
         scheduler,
+        speciesChecker,
         uploadProblemsDao,
         uploadsDao,
         uploadService,
@@ -83,6 +85,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     insertOrganization(organizationId)
 
     every { clock.instant() } returns Instant.EPOCH
+    every { speciesChecker.checkAllUncheckedSpecies(organizationId) } just Runs
     every { user.canCreateSpecies(organizationId) } returns true
     every { user.canDeleteUpload(uploadId) } returns true
     every { user.canReadOrganization(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -36,7 +36,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    store = SpeciesStore(clock, dslContext, speciesDao)
+    store = SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
 
     every { clock.instant() } returns Instant.EPOCH
 
@@ -299,6 +299,17 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     store.deleteSpecies(speciesId)
 
     assertNull(store.fetchSpeciesById(speciesId))
+  }
+
+  @Test
+  fun `fetchAllUncheckedSpecies only returns unchecked species`() {
+    val checkedSpeciesId = SpeciesId(1)
+    val uncheckedSpeciesId = SpeciesId(2)
+
+    insertSpecies(checkedSpeciesId, organizationId = organizationId, checkedTime = Instant.EPOCH)
+    insertSpecies(uncheckedSpeciesId, organizationId = organizationId)
+
+    assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
   }
 
   @Test


### PR DESCRIPTION
When species are created or their scientific names are updated, check them against
the GBIF database and record any discrepancies in the `species_problems` table.