### PR TITLE
SW-1062 Auto-create devices when facility is connected

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.model
 
+import com.terraformation.backend.db.DeviceTemplateCategory
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
@@ -37,6 +38,19 @@ data class FacilityModel(
       record[FACILITIES.LAST_TIMESERIES_TIME],
       record[FACILITIES.MAX_IDLE_MINUTES]
           ?: throw IllegalArgumentException("Max idle minutes is required"))
+
+  /**
+   * The device template category that holds the list of default devices to create when a sensor kit
+   * is connected to this facility. Null if the facility doesn't need default devices. Currently,
+   * this is based on facility type.
+   */
+  val defaultDeviceTemplateCategory: DeviceTemplateCategory?
+    get() =
+        when (type) {
+          FacilityType.SeedBank -> DeviceTemplateCategory.SeedBankDefault
+          FacilityType.Desalination,
+          FacilityType.ReverseOsmosis -> null
+        }
 }
 
 fun FacilitiesRow.toModel(): FacilityModel {

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
@@ -18,6 +18,7 @@ import org.springframework.security.access.AccessDeniedException
 class DeviceManagerService(
     private val balenaClient: BalenaClient,
     private val deviceManagerStore: DeviceManagerStore,
+    private val deviceService: DeviceService,
     private val dslContext: DSLContext,
     private val facilityStore: FacilityStore,
     private val parentStore: ParentStore,
@@ -43,6 +44,8 @@ class DeviceManagerService(
 
       facilityStore.updateConnectionState(
           facilityId, FacilityConnectionState.NotConnected, FacilityConnectionState.Connected)
+
+      deviceService.createDefaultDevices(facilityId)
 
       val apiUser = userStore.createApiClient(organizationId, "Balena ${manager.balenaUuid}")
       val userId = apiUser.userId

--- a/src/main/resources/db/migration/common/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/common/R__TypeCodes.sql
@@ -16,7 +16,8 @@ VALUES (10, 'Pending', TRUE),
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO device_template_categories (id, name)
-VALUES (1, 'PV')
+VALUES (1, 'PV'),
+       (2, 'Seed Bank Default')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO facility_types (id, name)
@@ -194,4 +195,5 @@ VALUES (1, 'User Added to Organization', 1),
        (12, 'Sensor Out Of Bounds', 3),
        (13, 'Unknown Automation Triggered', 3),
        (14, 'Device Unresponsive', 3)
-ON CONFLICT (id) DO UPDATE SET name = excluded.name, notification_criticality_id = excluded.notification_criticality_id;
+ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
+                               notification_criticality_id = excluded.notification_criticality_id;

--- a/src/main/resources/templates/admin/deviceTemplates.html
+++ b/src/main/resources/templates/admin/deviceTemplates.html
@@ -32,7 +32,8 @@
     <tbody>
     <tr th:each="template : ${templates}">
         <td>
-            <form th:action="|${prefix}/deviceTemplates|" method="POST" th:id="|template${template.id}|"
+            <form th:action="|${prefix}/deviceTemplates|" method="POST"
+                  th:id="|template${template.id}|"
                   th:if="${canUpdateDeviceTemplates}">
                 <input type="hidden" name="id" th:value="${template.id}"/>
             </form>
@@ -45,7 +46,8 @@
             <select name="categoryId" th:form="|template${template.id}|">
                 <option th:each="category : ${categories}"
                         th:selected="${template.categoryId == category}"
-                        th:text="${category.displayName}">PV
+                        th:text="${category.displayName}"
+                        th:value="${category.name}">PV
                 </option>
             </select>
         </td>
@@ -99,7 +101,8 @@
         <td></td>
         <td>
             <select name="categoryId" form="createTemplate">
-                <option th:each="category : ${categories}" th:text="${category.displayName}">PV
+                <option th:each="category : ${categories}" th:text="${category.displayName}"
+                        th:value="${category.name}">PV
                 </option>
             </select>
         </td>

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -19,14 +19,21 @@
                     make: "Blue Ion",
                     model: "LV",
                     name: "BMU-1",
-                    address: "192.168.10.40",
+                    address: "192.168.2.40",
                     protocol: "modbus"
                 },
                 omniSense: {
                     type: "sensor",
                     make: "OmniSense",
                     model: "S-11"
-                }
+                },
+                omniSenseHub: {
+                    type: "hub",
+                    make: "OmniSense",
+                    model: "G-4",
+                    name: "OmniSense Hub",
+                    address: "192.168.2.30",
+                },
             };
 
             for (let elementName in configurations) {
@@ -137,7 +144,8 @@
     <div>
         Common configurations:
         <a href="#" id="blueIon">Blue Ion PV</a> -
-        <a href="#" id="omniSense">Temperature/Humidity Sensor</a>
+        <a href="#" id="omniSense">Temperature/Humidity Sensor</a> -
+        <a href="#" id="omniSenseHub">OmniSense Hub</a>
     </div>
 
     <div>

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tables.daos.AppDevicesDao
 import com.terraformation.backend.db.tables.daos.AutomationsDao
 import com.terraformation.backend.db.tables.daos.BagsDao
 import com.terraformation.backend.db.tables.daos.DeviceManagersDao
+import com.terraformation.backend.db.tables.daos.DeviceTemplatesDao
 import com.terraformation.backend.db.tables.daos.DevicesDao
 import com.terraformation.backend.db.tables.daos.FacilitiesDao
 import com.terraformation.backend.db.tables.daos.GeolocationsDao
@@ -204,6 +205,7 @@ abstract class DatabaseTest {
   protected val bagsDao: BagsDao by lazyDao()
   protected val deviceManagersDao: DeviceManagersDao by lazyDao()
   protected val devicesDao: DevicesDao by lazyDao()
+  protected val deviceTemplatesDao: DeviceTemplatesDao by lazyDao()
   protected val facilitiesDao: FacilitiesDao by lazyDao()
   protected val geolocationsDao: GeolocationsDao by lazyDao()
   protected val germinationsDao: GerminationsDao by lazyDao()


### PR DESCRIPTION
Containerized seed banks will always have an OmniSense hub to talk to the
temperature/humidity sensors, but the device manager can't autodetect the hub.
But other facility types, such as the desal/RO installations at PacFlight,
don't have OmniSense hubs, so the device manager can't just assume a hub exists.

Add a concept of "default devices" that get created when a sensor kit is connected
to a facility. The list of default devices can vary by facility type. Use the
existing "device templates" feature: each facility type that needs default devices
(currently just seed banks) has a corresponding template category, so we can
manage the default devices using the admin UI.

Fix a bug in the admin UI's handling of template category names with whitespace.