### PR TITLE
SW-1069 Don't check names of deleted species

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -129,6 +129,7 @@ class SpeciesStore(
         .join(SPECIES)
         .on(SPECIES_PROBLEMS.SPECIES_ID.eq(SPECIES.ID))
         .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
+        .and(SPECIES.DELETED_TIME.isNull)
         .fetchInto(SpeciesProblemsRow::class.java)
         .groupBy { row ->
           row.speciesId ?: throw IllegalStateException("Species problem has no species ID")


### PR DESCRIPTION
If an organization has a deleted species that was deleted before its name
was checked, the "check all the species that haven't been checked yet" logic
that runs after CSV upload was trying to check the deleted species, which
failed because a deleted species is treated as not existing by most of the
data access code.