### PR TITLE
SW-1064 Disable unwanted health checks

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,17 @@ spring:
   session:
     store-type: jdbc
 
+management:
+  health:
+    diskspace:
+      # Disable checking of disk space; the server runs in a Docker container so this would be
+      # measuring the free space in the container's filesystem which isn't too useful.
+      enabled: false
+    mail:
+      # Disable checking health of mail server; we don't want to mark terraware-server as down
+      # if the mail service is having an unrelated outage.
+      enabled: false
+
 # Configuration for the Swagger API explorer. These settings are used when the server is running
 # and serving real requests; there are also settings in application-apidoc.yaml that are used when
 # generating the API documentation from the command line.


### PR DESCRIPTION
Spring Boot has a built-in component called Actuator. It sets up health checks
based on what components the application is using, e.g., if you're using a
database, it will make sure the database is reachable. We want most of the
default checks, but two of them are not useful for us: the free disk space check
(which wouldn't work right from inside a Docker container) and the mail server
connectivity check (we don't want to mark terraware-server as down if AWS's mail
service is having an outage).