### PR TITLE
SW-1053 Apply previous name changes on species CSV import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
@@ -14,6 +14,8 @@ import org.apache.commons.lang3.BooleanUtils
 class SpeciesCsvValidator(
     private val uploadId: UploadId,
     private val existingScientificNames: Set<String>,
+    /** Map of initial scientific names to current names for species that have been renamed. */
+    private val existingRenames: Map<String, String>,
     private val messages: Messages,
 ) {
   private var rowNum = 1
@@ -106,6 +108,12 @@ class SpeciesCsvValidator(
             UploadProblemType.DuplicateValue,
             field,
             value,
+            messages.speciesCsvScientificNameExists())
+      } else if (value in existingRenames) {
+        addWarning(
+            UploadProblemType.DuplicateValue,
+            field,
+            "${existingRenames[value]} ($value)",
             messages.speciesCsvScientificNameExists())
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -178,6 +178,7 @@ class SpeciesStore(
               deletedBy = null,
               deletedTime = null,
               id = null,
+              initialScientificName = row.scientificName,
               modifiedBy = currentUser().userId,
               modifiedTime = clock.instant(),
           )
@@ -208,6 +209,7 @@ class SpeciesStore(
             createdTime = existing.createdTime,
             deletedBy = existing.deletedBy,
             deletedTime = existing.deletedTime,
+            initialScientificName = existing.initialScientificName,
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             organizationId = existing.organizationId,

--- a/src/main/resources/db/migration/common/V95__SpeciesInitialScientificName.sql
+++ b/src/main/resources/db/migration/common/V95__SpeciesInitialScientificName.sql
@@ -1,0 +1,7 @@
+ALTER TABLE species ADD COLUMN initial_scientific_name TEXT;
+UPDATE species
+SET initial_scientific_name = scientific_name
+WHERE species.initial_scientific_name IS NULL;
+ALTER TABLE species ALTER COLUMN initial_scientific_name SET NOT NULL;
+
+CREATE INDEX ON species (organization_id, initial_scientific_name);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -419,6 +419,7 @@ abstract class DatabaseTest {
       organizationId: Any = "$speciesId".toLong() / 10,
       deletedTime: Instant? = null,
       checkedTime: Instant? = null,
+      initialScientificName: String = scientificName,
   ) {
     val speciesIdWrapper = speciesId.toIdWrapper { SpeciesId(it) }
     val organizationIdWrapper = organizationId.toIdWrapper { OrganizationId(it) }
@@ -432,6 +433,7 @@ abstract class DatabaseTest {
           .set(DELETED_BY, if (deletedTime != null) createdBy else null)
           .set(DELETED_TIME, deletedTime)
           .set(ID, speciesIdWrapper)
+          .set(INITIAL_SCIENTIFIC_NAME, initialScientificName)
           .set(MODIFIED_BY, createdBy)
           .set(MODIFIED_TIME, modifiedTime)
           .set(ORGANIZATION_ID, organizationIdWrapper)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -126,6 +126,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         SpeciesRow(
             id = SpeciesId(10000),
             scientificName = "Kousa Dogwood",
+            initialScientificName = "Kousa Dogwood",
             commonName = "Common 1",
             rare = false,
             growthFormId = GrowthForm.Graminoid,
@@ -138,6 +139,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         SpeciesRow(
             id = SpeciesId(10001),
             scientificName = "Other Dogwood",
+            initialScientificName = "Other Dogwood",
             commonName = "Common 2",
             endangered = true,
             seedStorageBehaviorId = SeedStorageBehavior.Orthodox,

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -75,6 +75,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         listOf(
             row.copy(
                 id = speciesId,
+                initialScientificName = "test",
                 createdBy = user.userId,
                 createdTime = Instant.EPOCH,
                 deletedBy = null,
@@ -151,6 +152,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             createdBy = originalRow.createdBy,
             createdTime = originalRow.createdTime,
             id = originalSpeciesId,
+            initialScientificName = "test",
             modifiedBy = user.userId,
             modifiedTime = clock.instant())
     val actual = speciesDao.fetchOneById(reusedSpeciesId)
@@ -207,6 +209,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             familyName = "new family",
             growthFormId = GrowthForm.Fern,
             id = speciesId,
+            initialScientificName = "new initial",
             modifiedBy = bogusUserId,
             modifiedTime = bogusInstant,
             organizationId = bogusOrganizationId,
@@ -221,6 +224,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             createdTime = Instant.EPOCH,
             deletedBy = null,
             deletedTime = null,
+            initialScientificName = "original scientific",
             modifiedBy = user.userId,
             modifiedTime = newInstant,
             organizationId = organizationId,
@@ -285,6 +289,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             createdBy = user.userId,
             createdTime = clock.instant(),
             id = speciesId,
+            initialScientificName = "test",
             modifiedBy = user.userId,
             modifiedTime = clock.instant(),
             organizationId = organizationId,


### PR DESCRIPTION
If the user uploads a species list CSV then changes the scientific name of one of
the species from the CSV (e.g., by accepting a suggested name change from the
app), we want to remember the name change if they upload their species list again.

Add an "initial scientific name" to the species table where we track the name that
was used when the species was first created. Species CSV validation and import now
looks at the initial name in addition to the current name, and will attempt to
update the existing species if the CSV still lists it with its original name.