### PR TITLE
SW-1055 Sort first-word matches to the top of species name list

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -103,16 +103,18 @@ internal class GbifStoreTest : DatabaseTest() {
     }
 
     @Test
-    fun `returns results in alphabetical order`() {
+    fun `returns results in alphabetical order with first-word matches at the top`() {
       insertTaxon(1, "Species c")
       insertTaxon(2, "Species a")
       insertTaxon(3, "Species b")
+      insertTaxon(4, "Another species")
 
       val expected =
           listOf(
               namesRow(2, 2, "Species a"),
               namesRow(3, 3, "Species b"),
               namesRow(1, 1, "Species c"),
+              namesRow(4, 4, "Another species"),
           )
 
       val actual = store.findNamesByWordPrefixes(listOf("species"))


### PR DESCRIPTION
The code that populates the species name typeahead in the UI lets the user
search for any word in a scientific name, including subspecies and so forth.
Previously, it returned all results alphabetically, which meant that if you
started typing a scientific name that happened to begin with a string that
also appears in other positions for lots of species, your species might be
sorted off the bottom of the typeahead.

Update the query so that it prioritizes search results that start with the
first word of the search phrase, but still includes matches for other words.

For example, if you search for "visco", previously, the first result would
have been "Abutilon viscosum". Now that will be the second result, and the
first will be "Viscoides pendula".