### PR TITLE
SW-1107 Omit API clients from user lists

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -134,11 +134,9 @@ class AdminController(
 
     if (currentUser().canListApiKeys(organizationId)) {
       val apiClients =
-          users
-              .filter { it.userType == UserType.APIClient }
-              .map {
-                it.copy(email = it.email.substringAfter(config.keycloak.apiClientUsernamePrefix))
-              }
+          organizationStore.fetchApiClients(organizationId).map {
+            it.copy(email = it.email.substringAfter(config.keycloak.apiClientUsernamePrefix))
+          }
 
       // Thymeleaf templates only know how to render Instant in the server's time zone, so we
       // need to format the timestamps here. In a real admin UI we'd let the client render these

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -216,10 +216,22 @@ class OrganizationStore(
     }
   }
 
+  /** Returns a list of the organization's individual users. */
   fun fetchUsers(organizationId: OrganizationId): List<OrganizationUserModel> {
     requirePermissions { listOrganizationUsers(organizationId) }
 
-    return queryOrganizationUsers(ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId))
+    return queryOrganizationUsers(
+        ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId)
+            .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin)))
+  }
+
+  /** Returns a list of the organization's API client users. */
+  fun fetchApiClients(organizationId: OrganizationId): List<OrganizationUserModel> {
+    requirePermissions { listOrganizationUsers(organizationId) }
+
+    return queryOrganizationUsers(
+        ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId)
+            .and(USERS.USER_TYPE_ID.eq(UserType.APIClient)))
   }
 
   fun fetchUser(organizationId: OrganizationId, userId: UserId): OrganizationUserModel {

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.FuzzySearchOperators
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.PROJECT_USERS
@@ -13,6 +14,7 @@ import com.terraformation.backend.search.field.SearchField
 import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
+import org.jooq.impl.DSL
 
 class OrganizationUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
     SearchTable(fuzzySearchOperators) {
@@ -52,5 +54,11 @@ class OrganizationUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySe
 
   override fun conditionForPermissions(): Condition {
     return ORGANIZATION_USERS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
+        .and(
+            DSL.exists(
+                DSL.selectOne()
+                    .from(USERS)
+                    .where(USERS.ID.eq(ORGANIZATION_USERS.USER_ID))
+                    .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin))))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -381,7 +381,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
                 "user2@x.com",
                 "First2",
                 "Last2",
-                UserType.Individual,
+                UserType.SuperAdmin,
                 clock.instant(),
                 organizationId,
                 Role.CONTRIBUTOR,
@@ -390,6 +390,17 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     insertProject(otherProjectId)
     expected.forEach { configureUser(it) }
+    configureUser(
+        OrganizationUserModel(
+            UserId(102),
+            "balena-12345",
+            "Api",
+            "Client",
+            UserType.APIClient,
+            clock.instant(),
+            organizationId,
+            Role.CONTRIBUTOR,
+            emptyList()))
 
     val actual = store.fetchUsers(organizationId)
 
@@ -430,6 +441,42 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     val expected = listOf(model)
     val actual = store.fetchUsers(organizationId)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `fetchApiClients returns information about API client users`() {
+    val otherProjectId = ProjectId(11)
+    val expected =
+        listOf(
+            OrganizationUserModel(
+                UserId(100),
+                "balena-12345",
+                "Api",
+                "Client",
+                UserType.APIClient,
+                clock.instant(),
+                organizationId,
+                Role.CONTRIBUTOR,
+                emptyList()))
+
+    insertProject(otherProjectId)
+    expected.forEach { configureUser(it) }
+    configureUser(
+        OrganizationUserModel(
+            UserId(101),
+            "user1@x.com",
+            "First1",
+            "Last1",
+            UserType.Individual,
+            clock.instant(),
+            organizationId,
+            Role.ADMIN,
+            emptyList()),
+    )
+
+    val actual = store.fetchApiClients(organizationId)
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.pojos.AccessionGerminationTestTypesRow
 import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.BagsRow
@@ -1599,14 +1600,17 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     private val otherOrgProjectId = ProjectId(20)
     private val bothOrgsUserId = UserId(4)
     private val otherOrgUserId = UserId(5)
+    private val apiClientUserId = UserId(6)
 
     @BeforeEach
     fun insertOtherUsers() {
+      insertUser(apiClientUserId, type = UserType.APIClient)
       insertUser(bothOrgsUserId)
       insertUser(otherOrgUserId)
 
       insertOrganization(otherOrganizationId)
 
+      insertOrganizationUser(apiClientUserId, organizationId)
       insertOrganizationUser(bothOrgsUserId, organizationId, Role.ADMIN)
       insertOrganizationUser(bothOrgsUserId, otherOrganizationId, Role.ADMIN)
       insertOrganizationUser(otherOrgUserId, otherOrganizationId)


### PR DESCRIPTION
Filter API client users out of the user lists returned by the search API
and `/api/v1/organizations/X/users` so they don't show up in the UI.