### PR TITLE
SW-1059 Rename short code to sensor kit ID

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -781,7 +781,7 @@ class AdminController(
   @PostMapping("/deviceManagers")
   fun createDeviceManager(
       redirectAttributes: RedirectAttributes,
-      @RequestParam("shortCode") shortCode: String,
+      @RequestParam("sensorKitId") sensorKitId: String,
   ): String {
     val row =
         DeviceManagersRow(
@@ -789,10 +789,10 @@ class AdminController(
             balenaUuid = UUID.randomUUID().toString(),
             balenaModifiedTime = clock.instant(),
             createdTime = clock.instant(),
-            deviceName = "Test Device $shortCode",
+            deviceName = "Test Device $sensorKitId",
             isOnline = true,
             refreshedTime = clock.instant(),
-            shortCode = shortCode,
+            sensorKitId = sensorKitId,
         )
 
     return try {

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
@@ -30,21 +30,24 @@ class DeviceManagersController(
 ) {
   @GetMapping
   fun getDeviceManagers(
+      @RequestParam("sensorKitId") sensorKitIdParam: String?,
+      // TODO: Remove this once frontend is updated to use sensorKitId
       @RequestParam("shortCode") shortCode: String?,
       @RequestParam("facilityId") facilityId: FacilityId?,
   ): GetDeviceManagersResponsePayload {
+    val sensorKitId: String? = sensorKitIdParam ?: shortCode
     return when {
-      shortCode != null && facilityId == null -> {
+      sensorKitId != null && facilityId == null -> {
         val manager =
-            deviceManagerStore.fetchOneByShortCode(shortCode)?.let { DeviceManagerPayload(it) }
+            deviceManagerStore.fetchOneBySensorKitId(sensorKitId)?.let { DeviceManagerPayload(it) }
         GetDeviceManagersResponsePayload(listOfNotNull(manager))
       }
-      shortCode == null && facilityId != null -> {
+      sensorKitId == null && facilityId != null -> {
         val manager =
             deviceManagerStore.fetchOneByFacilityId(facilityId)?.let { DeviceManagerPayload(it) }
         GetDeviceManagersResponsePayload(listOfNotNull(manager))
       }
-      else -> throw IllegalArgumentException("Must specify shortCode or facility ID but not both")
+      else -> throw IllegalArgumentException("Must specify sensorKitId or facility ID but not both")
     }
   }
 
@@ -72,6 +75,8 @@ class DeviceManagersController(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class DeviceManagerPayload(
     val id: DeviceManagerId,
+    val sensorKitId: String,
+    // TODO: Remove this once frontend is updated to use sensorKitId
     val shortCode: String,
     @Schema(description = "If true, this device manager is available to connect to a facility.")
     val available: Boolean,
@@ -104,7 +109,8 @@ data class DeviceManagerPayload(
       id = row.id!!,
       isOnline = row.isOnline!!,
       onlineChangedTime = row.lastConnectivityEvent,
-      shortCode = row.shortCode!!,
+      sensorKitId = row.sensorKitId!!,
+      shortCode = row.sensorKitId!!,
       updateProgress = row.updateProgress,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/device/balena/BalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/BalenaClient.kt
@@ -10,10 +10,10 @@ interface BalenaClient {
   fun configureDeviceManager(balenaId: BalenaDeviceId, facilityId: FacilityId, token: String)
 
   /**
-   * Returns the value of the `short_code` tag for a particular Balena device. If the tag is not
+   * Returns the value of the sensor kit ID tag for a particular Balena device. If the tag is not
    * present or the device does not exist, returns null.
    */
-  fun getShortCodeForBalenaId(balenaId: BalenaDeviceId): String?
+  fun getSensorKitIdForBalenaId(balenaId: BalenaDeviceId): String?
 
   /**
    * Returns a list of the Balena devices that have been modified after a particular time. This is

--- a/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
@@ -55,10 +55,10 @@ class BalenaPoller(
           modifiedDevices.forEach { device ->
             val existingRow = deviceManagerStore.fetchOneByBalenaId(device.id)
             if (existingRow == null) {
-              val shortCode = balenaClient.getShortCodeForBalenaId(device.id)
+              val sensorKitId = balenaClient.getSensorKitIdForBalenaId(device.id)
 
-              if (shortCode == null) {
-                log.warn("No short code found for Balena device ${device.id}")
+              if (sensorKitId == null) {
+                log.warn("No sensor kit ID found for Balena device ${device.id}")
               } else {
                 val newRow =
                     DeviceManagersRow(
@@ -70,7 +70,7 @@ class BalenaPoller(
                         isOnline = device.isOnline,
                         lastConnectivityEvent = device.lastConnectivityEvent,
                         refreshedTime = clock.instant(),
-                        shortCode = shortCode,
+                        sensorKitId = sensorKitId,
                         updateProgress = device.overallProgress,
                     )
 
@@ -78,7 +78,7 @@ class BalenaPoller(
 
                 log.info(
                     "Added device manager ${newRow.id} for Balena device ${device.id} with " +
-                        "short code $shortCode")
+                        "sensor kit ID $sensorKitId")
               }
             } else {
               existingRow.apply {

--- a/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
@@ -52,7 +52,7 @@ class LiveBalenaClient(
     setDeviceEnvironmentVar(balenaId, TOKEN_ENV_VAR_NAME, token, overwrite = false)
   }
 
-  override fun getShortCodeForBalenaId(balenaId: BalenaDeviceId): String? {
+  override fun getSensorKitIdForBalenaId(balenaId: BalenaDeviceId): String? {
     val response =
         sendRequest<GetTagsForDeviceResponse>(
             DEVICE_TAG_PATH,
@@ -61,7 +61,7 @@ class LiveBalenaClient(
                 listOf(
                     filterTerm("device/belongs_to__application", fleetId),
                     filterTerm("device/id", balenaId),
-                    filterTerm("tag_key", SHORT_CODE_TAG_KEY)),
+                    filterTerm("tag_key", SENSOR_KIT_ID_TAG_KEY)),
             select = listOf("value"))
 
     return response.body().get().d.firstOrNull()?.value
@@ -275,7 +275,7 @@ class LiveBalenaClient(
     const val DEVICE_TYPE_PATH = "/v6/device_type"
     const val FLEET_PATH = "/v6/application"
 
-    const val SHORT_CODE_TAG_KEY = "short_code"
+    const val SENSOR_KIT_ID_TAG_KEY = "sensor_kit_id"
 
     const val FACILITIES_ENV_VAR_NAME = "FACILITIES"
     const val TOKEN_ENV_VAR_NAME = "OFFLINE_REFRESH_TOKEN"

--- a/src/main/kotlin/com/terraformation/backend/device/balena/StubBalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/StubBalenaClient.kt
@@ -24,7 +24,7 @@ class StubBalenaClient : BalenaClient {
         "Would configure Balena device $balenaId with facility $facilityId, token $tokenExcerpt")
   }
 
-  override fun getShortCodeForBalenaId(balenaId: BalenaDeviceId): String? {
+  override fun getSensorKitIdForBalenaId(balenaId: BalenaDeviceId): String? {
     return null
   }
 

--- a/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
@@ -34,8 +34,8 @@ class DeviceManagerStore(
     return deviceManagersDao.fetchOneById(id)?.unlessInaccessible()
   }
 
-  fun fetchOneByShortCode(shortCode: String): DeviceManagersRow? {
-    return deviceManagersDao.fetchOneByShortCode(shortCode)?.unlessInaccessible()
+  fun fetchOneBySensorKitId(sensorKitId: String): DeviceManagersRow? {
+    return deviceManagersDao.fetchOneBySensorKitId(sensorKitId)?.unlessInaccessible()
   }
 
   /** Returns all device managers the current user has permission to see. */

--- a/src/main/resources/db/migration/common/R__Comments.sql
+++ b/src/main/resources/db/migration/common/R__Comments.sql
@@ -53,6 +53,7 @@ COMMENT ON TABLE device_managers IS 'Information about device managers. This is 
 COMMENT ON COLUMN device_managers.balena_id IS 'Balena-assigned device identifier.';
 COMMENT ON COLUMN device_managers.balena_modified_time IS 'Last modification timestamp from Balena. This is distinct from `refreshed_time`, which is updated locally.';
 COMMENT ON COLUMN device_managers.created_time IS 'When this device manager was added to the local database. The Balena device may have been created earlier.';
+COMMENT ON COLUMN device_managers.sensor_kit_id IS 'ID code that is physically printed on the sensor kit and set as a tag value in the Balena device configuration.';
 COMMENT ON COLUMN device_managers.update_progress IS 'Percent complete of software download and installation (0-100). Null if no software update is in progress.';
 
 COMMENT ON TABLE device_template_categories IS '(Enum) User-facing categories of device templates; used to show templates for a particular class of devices where the physical device type may differ from one entry to the next.';

--- a/src/main/resources/db/migration/common/V96__SensorKitId.sql
+++ b/src/main/resources/db/migration/common/V96__SensorKitId.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device_managers RENAME COLUMN short_code TO sensor_kit_id;

--- a/src/main/resources/templates/admin/deviceManager.html
+++ b/src/main/resources/templates/admin/deviceManager.html
@@ -28,8 +28,8 @@
 
 <form th:action="|${prefix}/deviceManagers/${manager.id}|" method="POST">
 
-    <label for="shortCode">Short Code</label>
-    <input type="text" name="shortCode" id="shortCode" th:value="${manager.shortCode}"/>
+    <label for="sensorKitId">Sensor Kit ID</label>
+    <input type="text" name="sensorKitId" id="sensorKitId" th:value="${manager.sensorKitId}"/>
     <br/>
 
     <label for="facilityId">Facility ID</label>

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -26,7 +26,7 @@
             <a th:href="|${prefix}/deviceManagers/${manager.id}|" th:text="${manager.id}">123</a>
         </td>
         <td>
-            <a th:href="|${prefix}/deviceManagers/${manager.id}|" th:text="${manager.shortCode}">ABCDE</a>
+            <a th:href="|${prefix}/deviceManagers/${manager.id}|" th:text="${manager.sensorKitId}">ABCDE</a>
         </td>
         <td th:text="${manager.facilityId}">
             <a th:href="|${prefix}/facility/${manager.facilityId}|" th:text="${manager.facilityId}">567</a>
@@ -46,8 +46,8 @@
     </p>
 
     <form th:action="|${prefix}/deviceManagers|" method="POST">
-        <label for="shortCode">Short Code</label>
-        <input type="text" name="shortCode" id="shortCode"/>
+        <label for="sensorKitId">Sensor Kit ID</label>
+        <input type="text" name="sensorKitId" id="sensorKitId"/>
         <br/>
 
         <input type="submit" value="Create"/>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -206,7 +206,7 @@ internal class PermissionTest : DatabaseTest() {
               isOnline = true,
               createdTime = Instant.EPOCH,
               refreshedTime = Instant.EPOCH,
-              shortCode = "$deviceManagerId",
+              sensorKitId = "$deviceManagerId",
               facilityId = if (facilityId in facilityIds) facilityId else null,
               userId = if (facilityId in facilityIds) userId else null))
     }

--- a/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
@@ -74,7 +74,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
     val device = balenaDevice(1)
 
     every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
-    every { balenaClient.getShortCodeForBalenaId(device.id) } returns "${device.id}"
+    every { balenaClient.getSensorKitIdForBalenaId(device.id) } returns "${device.id}"
 
     poller.updateBalenaDevices()
 
@@ -89,7 +89,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
     val device = balenaDevice(1)
 
     every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
-    every { balenaClient.getShortCodeForBalenaId(device.id) } returns null
+    every { balenaClient.getSensorKitIdForBalenaId(device.id) } returns null
 
     poller.updateBalenaDevices()
 
@@ -162,7 +162,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
       balenaModifiedTime: Instant = Instant.EPOCH,
       facilityId: Any? = null,
       isOnline: Boolean = false,
-      shortCode: String = "$balenaId",
+      sensorKitId: String = "$balenaId",
       refreshedTime: Instant = Instant.EPOCH,
   ): DeviceManagersRow {
     return DeviceManagersRow(
@@ -175,7 +175,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
         id = id?.toIdWrapper { DeviceManagerId(it) },
         isOnline = isOnline,
         refreshedTime = refreshedTime,
-        shortCode = shortCode,
+        sensorKitId = sensorKitId,
         userId = if (facilityId != null) user.userId else null,
     )
   }
@@ -187,7 +187,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
       balenaModifiedTime: Instant = Instant.EPOCH,
       facilityId: Any? = null,
       isOnline: Boolean = false,
-      shortCode: String = "$balenaId",
+      sensorKitId: String = "$balenaId",
       refreshedTime: Instant = Instant.EPOCH,
   ): DeviceManagersRow {
     val row =
@@ -198,7 +198,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
             balenaModifiedTime,
             facilityId,
             isOnline,
-            shortCode,
+            sensorKitId,
             refreshedTime)
 
     deviceManagersDao.insert(row)

--- a/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientTest.kt
@@ -57,7 +57,7 @@ internal class LiveBalenaClientTest {
   private lateinit var client: LiveBalenaClient
 
   private val fleetName = "test-${System.currentTimeMillis()}"
-  private val shortCode = Random.nextInt(100000, 999999).toString()
+  private val sensorKitId = Random.nextInt(100000, 999999).toString()
 
   private lateinit var deviceId: BalenaDeviceId
   private var fleetId: Long = System.getenv("TEST_BALENA_FLEET_ID")?.toLongOrNull() ?: -1
@@ -93,7 +93,7 @@ internal class LiveBalenaClientTest {
       createdFleet = true
     }
 
-    deviceId = createDevice(shortCode)
+    deviceId = createDevice(sensorKitId)
     createdDevice = true
 
     every { config.balena } returns
@@ -130,8 +130,8 @@ internal class LiveBalenaClientTest {
   }
 
   @Test
-  fun `getShortCodeForBalenaId returns short code`() {
-    Assertions.assertEquals(shortCode, client.getShortCodeForBalenaId(deviceId))
+  fun `getSensorKitIdForBalenaId returns short code`() {
+    Assertions.assertEquals(sensorKitId, client.getSensorKitIdForBalenaId(deviceId))
   }
 
   @Test
@@ -232,7 +232,7 @@ internal class LiveBalenaClientTest {
     return response.body().get().d.first { it.slug == RASPBERRY_PI_DEVICE_TYPE_SLUG }.id
   }
 
-  private fun createDevice(shortCode: String): BalenaDeviceId {
+  private fun createDevice(sensorKitId: String): BalenaDeviceId {
     val response =
         client.sendRequest<BalenaDevice>(
             LiveBalenaClient.DEVICE_PATH,
@@ -249,8 +249,8 @@ internal class LiveBalenaClientTest {
         body =
             mapOf(
                 "device" to deviceId,
-                "tag_key" to LiveBalenaClient.SHORT_CODE_TAG_KEY,
-                "value" to shortCode))
+                "tag_key" to LiveBalenaClient.SENSOR_KIT_ID_TAG_KEY,
+                "value" to sensorKitId))
 
     return deviceId
   }

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -71,33 +71,33 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchOneByShortCode returns row for device manager`() {
-    val shortCode = "xyzzy"
+  fun `fetchOneBySensorKitId returns row for device manager`() {
+    val sensorKitId = "xyzzy"
 
-    insertDeviceManager(newRow(shortCode = shortCode))
+    insertDeviceManager(newRow(sensorKitId = sensorKitId))
 
     val expected = deviceManagersDao.fetchOneById(deviceManagerId)!!
-    val actual = store.fetchOneByShortCode(shortCode)
+    val actual = store.fetchOneBySensorKitId(sensorKitId)
 
     assertEquals(expected, actual)
   }
 
   @Test
-  fun `fetchOneByShortCode returns null if user has no read permission`() {
-    val shortCode = "xyzzy"
+  fun `fetchOneBySensorKitId returns null if user has no read permission`() {
+    val sensorKitId = "xyzzy"
 
-    insertDeviceManager(newRow(shortCode = shortCode))
+    insertDeviceManager(newRow(sensorKitId = sensorKitId))
 
     every { user.canReadDeviceManager(deviceManagerId) } returns false
 
-    assertNull(store.fetchOneByShortCode(shortCode))
+    assertNull(store.fetchOneBySensorKitId(sensorKitId))
   }
 
   @Test
-  fun `fetchOneByShortCode returns null if no device manager has the short code`() {
+  fun `fetchOneBySensorKitId returns null if no device manager has the short code`() {
     insertDeviceManager()
 
-    assertNull(store.fetchOneByShortCode("nonexistentShortCode"))
+    assertNull(store.fetchOneBySensorKitId("nonexistentSensorKitId"))
   }
 
   @Test
@@ -167,7 +167,7 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
       id: Any? = this.deviceManagerId,
       balenaId: Long = id?.toString()?.toLong() ?: 1L,
       balenaUuid: String = UUID.randomUUID().toString(),
-      shortCode: String = "$id",
+      sensorKitId: String = "$id",
       userId: Any? = null,
       facilityId: Any? = null,
   ): DeviceManagersRow {
@@ -181,7 +181,7 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
         id = id?.toIdWrapper { DeviceManagerId(it) },
         isOnline = true,
         refreshedTime = Instant.EPOCH,
-        shortCode = shortCode,
+        sensorKitId = sensorKitId,
         userId = userId?.toIdWrapper { UserId(it) },
     )
   }


### PR DESCRIPTION
We decided to use the term "sensor kit ID" as the official name for the ID code
that gets printed on sensor kits and that users enter to connect a sensor kit to a
seed bank, so update the code to use the official terminology.

This affects the data model, the implementation, and the API. For now, the API
continues to also accept `shortCode` parameters in requests and continues to
include `shortCode` values in responses, alongside `sensorKitId`, to give clients
a migration path. We'll follow up and remove support for `shortCode` once the
client code has shifted to the new name.