### PR TITLE
SW-1057 Remove backward compatibility for short codes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
@@ -30,12 +30,9 @@ class DeviceManagersController(
 ) {
   @GetMapping
   fun getDeviceManagers(
-      @RequestParam("sensorKitId") sensorKitIdParam: String?,
-      // TODO: Remove this once frontend is updated to use sensorKitId
-      @RequestParam("shortCode") shortCode: String?,
+      @RequestParam("sensorKitId") sensorKitId: String?,
       @RequestParam("facilityId") facilityId: FacilityId?,
   ): GetDeviceManagersResponsePayload {
-    val sensorKitId: String? = sensorKitIdParam ?: shortCode
     return when {
       sensorKitId != null && facilityId == null -> {
         val manager =
@@ -76,8 +73,6 @@ class DeviceManagersController(
 data class DeviceManagerPayload(
     val id: DeviceManagerId,
     val sensorKitId: String,
-    // TODO: Remove this once frontend is updated to use sensorKitId
-    val shortCode: String,
     @Schema(description = "If true, this device manager is available to connect to a facility.")
     val available: Boolean,
     @Schema(
@@ -110,7 +105,6 @@ data class DeviceManagerPayload(
       isOnline = row.isOnline!!,
       onlineChangedTime = row.lastConnectivityEvent,
       sensorKitId = row.sensorKitId!!,
-      shortCode = row.sensorKitId!!,
       updateProgress = row.updateProgress,
   )
 }

--- a/src/test/kotlin/com/terraformation/backend/device/api/DeviceManagersControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/api/DeviceManagersControllerTest.kt
@@ -25,14 +25,14 @@ internal class DeviceManagersControllerTest : RunsAsUser {
   @Test
   fun `throws exception when neither sensorKitId nor facility ID are specified`() {
     assertThrows<IllegalArgumentException> {
-      deviceManagersController.getDeviceManagers(null, null, null)
+      deviceManagersController.getDeviceManagers(null, null)
     }
   }
 
   @Test
   fun `throws exception when both sensorKitId and facility ID are specified`() {
     assertThrows<IllegalArgumentException> {
-      deviceManagersController.getDeviceManagers("123456", null, FacilityId(1))
+      deviceManagersController.getDeviceManagers("123456", FacilityId(1))
     }
   }
 
@@ -58,11 +58,10 @@ internal class DeviceManagersControllerTest : RunsAsUser {
                     isOnline = true,
                     onlineChangedTime = deviceManager.lastConnectivityEvent!!,
                     sensorKitId = deviceManager.sensorKitId!!,
-                    shortCode = deviceManager.sensorKitId!!,
                     updateProgress = deviceManager.updateProgress!!,
                 )))
 
-    assertEquals(expected, deviceManagersController.getDeviceManagers("123456", null, null))
+    assertEquals(expected, deviceManagersController.getDeviceManagers("123456", null))
   }
 
   @Test
@@ -75,44 +74,6 @@ internal class DeviceManagersControllerTest : RunsAsUser {
             facilityId = FacilityId(2))
     every { deviceManagerStore.fetchOneByFacilityId(FacilityId(2)) } returns deviceManager
     val expected = GetDeviceManagersResponsePayload(listOf(DeviceManagerPayload(deviceManager)))
-    assertEquals(expected, deviceManagersController.getDeviceManagers(null, null, FacilityId(2)))
-  }
-
-  // TODO: Remove this once frontend is updated to use sensorKitId
-  @Test
-  fun `throws exception when both shortCode and facility ID are specified`() {
-    assertThrows<IllegalArgumentException> {
-      deviceManagersController.getDeviceManagers(null, "123456", FacilityId(1))
-    }
-  }
-
-  // TODO: Remove this once frontend is updated to use sensorKitId
-  @Test
-  fun `returns device manager for shortCode`() {
-    val deviceManager =
-        DeviceManagersRow(
-            id = DeviceManagerId(1),
-            isOnline = true,
-            lastConnectivityEvent = Instant.ofEpochSecond(1000),
-            sensorKitId = "123456",
-            updateProgress = 12345)
-
-    every { deviceManagerStore.fetchOneBySensorKitId("123456") } returns deviceManager
-
-    val expected =
-        GetDeviceManagersResponsePayload(
-            listOf(
-                DeviceManagerPayload(
-                    available = true,
-                    facilityId = null,
-                    id = deviceManager.id!!,
-                    isOnline = true,
-                    onlineChangedTime = deviceManager.lastConnectivityEvent!!,
-                    sensorKitId = deviceManager.sensorKitId!!,
-                    shortCode = deviceManager.sensorKitId!!,
-                    updateProgress = deviceManager.updateProgress!!,
-                )))
-
-    assertEquals(expected, deviceManagersController.getDeviceManagers(null, "123456", null))
+    assertEquals(expected, deviceManagersController.getDeviceManagers(null, FacilityId(2)))
   }
 }


### PR DESCRIPTION
Now that the client has been updated to use `sensorKitId` instead of `shortCode`,
remove the old name from the API.