### PR TITLE
SW-1111 Make text field searches case-insensitive

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -23,13 +23,14 @@ class UpperCaseTextField(
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy)
 
   override fun getCondition(fieldNode: FieldNode): Condition {
-    val values = fieldNode.values.mapNotNull { it?.uppercase() }
     return when (fieldNode.type) {
-      SearchFilterType.Exact ->
-          DSL.or(
-              listOfNotNull(
-                  if (values.isNotEmpty()) databaseField.`in`(values) else null,
-                  if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      SearchFilterType.Exact -> {
+        val values = fieldNode.values.mapNotNull { it?.uppercase() }
+        DSL.or(
+            listOfNotNull(
+                if (values.isNotEmpty()) databaseField.`in`(values) else null,
+                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      }
       SearchFilterType.Fuzzy ->
           DSL.or(
               fieldNode.values


### PR DESCRIPTION
Previously, the search API did case-sensitive matching for `Exact` search
filters on text fields and was inconsistent about case sensitivity for `Fuzzy`
searches based on the length of the search string. The latter was a side effect
of the fact that we were using a particular fuzzy match operator from the
`pg_trgm` extension.

Change it to always do case-insensitive searches and to use a more relaxed
fuzzy match operator that supports shorter search strings.