### PR TITLE
SW-1117 Filter deleted species out of search results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -51,5 +51,6 @@ class SpeciesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperat
 
   override fun conditionForPermissions(): Condition {
     return SPECIES.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
+        .and(SPECIES.DELETED_TIME.isNull)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -148,6 +148,18 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
             modifiedBy = user.userId,
             modifiedTime = now,
             organizationId = organizationId))
+    speciesDao.insert(
+        SpeciesRow(
+            id = SpeciesId(10002),
+            scientificName = "Deleted species",
+            initialScientificName = "Deleted species",
+            createdBy = user.userId,
+            createdTime = now,
+            modifiedBy = user.userId,
+            modifiedTime = now,
+            deletedBy = user.userId,
+            deletedTime = now,
+            organizationId = organizationId))
 
     accessionsDao.insert(
         AccessionsRow(


### PR DESCRIPTION
Previously, the search API wasn't paying attention to whether or not a species was
deleted. One option is to let the client decide whether or not to include deleted
species. But users shouldn't be able to see deleted species at all, so instead,
treat it as a permissions filter that always gets applied.