### PR TITLE
Use "visibility" instead of "permission" in search code

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -636,26 +636,26 @@ class NestedQueryBuilder(
 
       val selectWithConditions = selectWithLateral.where(conditions)
 
-      // If this table has information that'll let us directly check permissions, add a condition.
+      // If this table has information that'll let us directly check visibility, add a condition.
       //
-      // In cases where permission is inherited from a parent table, there's no need to join with
+      // In cases where visibility is inherited from a parent table, there's no need to join with
       // that table here. There are two possibilities:
       //
-      // 1. The entire query, including root prefix, only visits tables whose permissions are
+      // 1. The entire query, including root prefix, only visits tables whose visibility is
       //    inherited from parent tables that aren't referenced in the query. In that case, we need
       //    to join with parent tables at the top level of the query, which is handled by
       //    SearchService.
-      // 2. A parent NestedQueryBuilder visited a table that can be used for permission checks.
+      // 2. A parent NestedQueryBuilder visited a table that can be used for visibility checks.
       //    In that case, the check will have been done at that point.
-      val conditionForPermissions = prefix.searchTable.conditionForPermissions()
-      val selectWithPermissions =
-          if (conditionForPermissions != null) {
-            selectWithConditions.and(conditionForPermissions)
+      val conditionForVisibility = prefix.searchTable.conditionForVisibility()
+      val selectWithVisibility =
+          if (conditionForVisibility != null) {
+            selectWithConditions.and(conditionForVisibility)
           } else {
             selectWithConditions
           }
 
-      selectWithPermissions.orderBy(getOrderBy(!distinct))
+      selectWithVisibility.orderBy(getOrderBy(!distinct))
     }
   }
 
@@ -804,8 +804,8 @@ class NestedQueryBuilder(
    * Joins the top-level query with the tables referenced by flattened sublists. This is not used
    * when child tables are queried using nested sublist fields.
    *
-   * The join criteria include permission conditions in addition to foreign key equality, such that
-   * any child flattened sublists will only be joined against rows the user has permission to see.
+   * The join criteria include visibility conditions in addition to foreign key equality, such that
+   * any child flattened sublists will only be joined against rows the user is able to see.
    *
    * For example, if you're querying facility names starting from the organizations root prefix and
    * the user is a member of project 2, the query might look something like
@@ -821,15 +821,15 @@ class NestedQueryBuilder(
    *   ON sites.id = facilities.site_id
    * ```
    * With that structure, the joins with `sites` and `facilities` will automatically only include
-   * rows the user has permission to see, since inaccessible projects were filtered out already.
+   * rows the user is able to see, since inaccessible projects were filtered out already.
    */
   private fun joinFlattenedSublists(query: SelectJoinStep<Record>): SelectJoinStep<Record> {
     return flattenedSublists.fold(query) { joinedQuery, sublist ->
-      val sublistPermissionsCondition = sublist.searchTable.conditionForPermissions()
+      val sublistVisibilityCondition = sublist.searchTable.conditionForVisibility()
       val joinWithForeignKey =
           joinedQuery.leftJoin(sublist.searchTable.fromTable).on(sublist.conditionForMultiset)
-      if (sublistPermissionsCondition != null) {
-        joinWithForeignKey.and(sublistPermissionsCondition)
+      if (sublistVisibilityCondition != null) {
+        joinWithForeignKey.and(sublistVisibilityCondition)
       } else {
         joinWithForeignKey
       }

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -65,45 +65,47 @@ abstract class SearchTable(val fuzzySearchOperators: FuzzySearchOperators) {
     get() = primaryKey.table ?: throw IllegalStateException("$primaryKey has no table")
 
   /**
-   * If the user's permission to see rows in this table can't be determined directly from the
-   * contents of the table itself, the other table that the query needs to left join with in order
-   * to check permissions.
+   * If the user's ability to see a particular row in this table can't be determined directly from
+   * the contents of the row itself, the other table that the query needs to left join with in order
+   * to check whether the row is visible.
    *
    * Null if the current table has the required information to determine whether the user can see a
-   * given row. In that case, [conditionForPermissions] must be non-null.
+   * given row. In that case, [conditionForVisibility] must be non-null.
    */
-  open val inheritsPermissionsFrom: SearchTable?
+  open val inheritsVisibilityFrom: SearchTable?
     get() = null
 
   /**
    * Adds a LEFT JOIN clause to a query to connect this table to another table to calculate whether
    * the user is allowed to see a row in this table.
    *
-   * This must join to the same table referenced by [inheritsPermissionsFrom].
+   * This must join to the same table referenced by [inheritsVisibilityFrom].
    *
    * The default no-op implementation will work for any tables that have the required information
    * already, e.g., if a table has a facility ID column, there's no need to join with another table
-   * to get a facility ID. The default implementation is only valid if [inheritsPermissionsFrom]
+   * to get a facility ID. The default implementation is only valid if [inheritsVisibilityFrom]
    * returns null.
    */
-  open fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
-    if (inheritsPermissionsFrom == null) {
+  open fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
+    if (inheritsVisibilityFrom == null) {
       return query
     } else {
       throw IllegalStateException(
-          "BUG! Must override joinForPermissions if permissions are inherited from another table.")
+          "BUG! Must override joinForVisibility if visibility is inherited from another table.")
     }
   }
 
   /**
-   * Returns a condition that restricts this table's values to ones the user has permission to see.
+   * Returns a condition that restricts this table's values to ones the user has the ability to see.
+   * Visibility is usually a question of permissions, but may include other non-permission-related
+   * criteria such as an "is deleted" flag.
    *
-   * This method can safely assume that [joinForPermissions] was called, so any tables added there
+   * This method can safely assume that [joinForVisibility] was called, so any tables added there
    * are available for use in the condition.
    *
-   * If this is null, [inheritsPermissionsFrom] must be non-null.
+   * If this is null, [inheritsVisibilityFrom] must be non-null.
    */
-  open fun conditionForPermissions(): Condition? = null
+  open fun conditionForVisibility(): Condition? = null
 
   /** Returns a condition for scoping the table's search results where relevant. */
   open fun conditionForScope(scope: SearchScope): Condition? = null

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionGerminationTestTypesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionGerminationTestTypesTable.kt
@@ -27,10 +27,10 @@ class AccessionGerminationTestTypesTable(
               ACCESSION_GERMINATION_TEST_TYPES.GERMINATION_TEST_TYPE_ID),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query
         .join(ACCESSIONS)
         .on(ACCESSION_GERMINATION_TEST_TYPES.ACCESSION_ID.eq(ACCESSIONS.ID))

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionSecondaryCollectorsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionSecondaryCollectorsTable.kt
@@ -31,9 +31,9 @@ class AccessionSecondaryCollectorsTable(
           textField("name", "Collector name", ACCESSION_SECONDARY_COLLECTORS.NAME),
       )
 
-  override val inheritsPermissionsFrom: SearchTable = tables.accessions
+  override val inheritsVisibilityFrom: SearchTable = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(ACCESSION_SECONDARY_COLLECTORS.ACCESSION_ID.eq(ACCESSIONS.ID))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -153,7 +153,7 @@ class AccessionsTable(
     )
   }
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return ACCESSIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
@@ -28,10 +28,10 @@ class BagsTable(private val tables: SearchTables, fuzzySearchOperators: FuzzySea
           textField("number", "Bag number", BAGS.BAG_NUMBER),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(BAGS.ACCESSION_ID.eq(ACCESSIONS.ID))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -48,7 +48,7 @@ class FacilitiesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOpe
           enumField("type", "Facility type", FACILITIES.TYPE_ID, nullable = false),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return FACILITIES.ID.`in`(currentUser().facilityRoles.keys)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
@@ -40,10 +40,10 @@ class GeolocationsTable(
               GEOLOCATIONS.LONGITUDE),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(GEOLOCATIONS.ACCESSION_ID.eq(ACCESSIONS.ID))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GerminationTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GerminationTestsTable.kt
@@ -42,10 +42,10 @@ class GerminationTestsTable(
           enumField("type", "Germination test type", GERMINATION_TESTS.TEST_TYPE),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(GERMINATION_TESTS.ACCESSION_ID.eq(ACCESSIONS.ID))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/GerminationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GerminationsTable.kt
@@ -35,10 +35,10 @@ class GerminationsTable(
               "seedsGerminated", "Number of seeds germinated", GERMINATIONS.SEEDS_GERMINATED),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.germinationTests
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(GERMINATION_TESTS).on(GERMINATIONS.TEST_ID.eq(GERMINATION_TESTS.ID))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -52,7 +52,7 @@ class OrganizationUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySe
   override val primaryKey: TableField<out Record, out Any?>
     get() = ORGANIZATION_USERS.ORGANIZATION_USER_ID
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return ORGANIZATION_USERS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
         .and(
             DSL.exists(

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -54,7 +54,7 @@ class OrganizationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearch
           textField("name", "Organization name", ORGANIZATIONS.NAME, nullable = false),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return ORGANIZATIONS.ID.`in`(currentUser().organizationRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectTypeSelectionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectTypeSelectionsTable.kt
@@ -22,7 +22,7 @@ class ProjectTypeSelectionsTable(fuzzySearchOperators: FuzzySearchOperators) :
           enumField("type", "Project type", PROJECT_TYPE_SELECTIONS.PROJECT_TYPE_ID),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return PROJECT_TYPE_SELECTIONS.PROJECT_ID.`in`(currentUser().projectRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
@@ -32,7 +32,7 @@ class ProjectUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchO
   override val primaryKey: TableField<out Record, out Any?>
     get() = PROJECT_USERS.PROJECT_USER_ID
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return PROJECT_USERS.PROJECT_ID.`in`(currentUser().projectRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -50,7 +50,7 @@ class ProjectsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOpera
           enumField("status", "Project status", PROJECTS.STATUS_ID),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return PROJECTS.ID.`in`(currentUser().projectRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
@@ -36,7 +36,7 @@ class SitesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperator
           textField("name", "Site name", SITES.NAME, nullable = false),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return SITES.PROJECT_ID.`in`(currentUser().projectRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesProblemsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesProblemsTable.kt
@@ -37,10 +37,10 @@ class SpeciesProblemsTable(
           enumField("type", "Species problem type", SPECIES_PROBLEMS.TYPE_ID),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.species
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(SPECIES).on(SPECIES_PROBLEMS.SPECIES_ID.eq(SPECIES.ID))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -49,7 +49,7 @@ class SpeciesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperat
               SPECIES.SEED_STORAGE_BEHAVIOR_ID),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return SPECIES.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
         .and(SPECIES.DELETED_TIME.isNull)
   }

--- a/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
@@ -34,7 +34,7 @@ class StorageLocationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySea
           textField("name", "Storage location name", STORAGE_LOCATIONS.NAME),
       )
 
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return STORAGE_LOCATIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -46,7 +46,7 @@ class UsersTable(
 
   // Users are only visible to other people in the same organizations, and API client users are not
   // visible via this table.
-  override fun conditionForPermissions(): Condition {
+  override fun conditionForVisibility(): Condition {
     return USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin)
         .and(
             DSL.exists(

--- a/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
@@ -51,10 +51,10 @@ class WithdrawalsTable(
               WITHDRAWALS.WITHDRAWN_UNITS_ID),
       )
 
-  override val inheritsPermissionsFrom: SearchTable
+  override val inheritsVisibilityFrom: SearchTable
     get() = tables.accessions
 
-  override fun <T : Record> joinForPermissions(query: SelectJoinStep<T>): SelectJoinStep<T> {
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(WITHDRAWALS.ACCESSION_ID.eq(ACCESSIONS.ID))
   }
 }


### PR DESCRIPTION
Recently we've started to use `SearchTable.conditionForPermissions` to add
filtering that isn't exactly related to the permissions system, e.g., filtering
out deleted species.

Rather than thinking about those criteria as being weird sorts of permissions,
we can think of the permissions rules as a subset of visibility rules: ultimately
they are determining whether or not you can see a particular thing in search
results for whatever reason.

Update the internal terminology to reflect this broader perspective.

The code changes here are all "rename" refactorings; there are no manual edits
outside of comment text.