### PR TITLE
SW-1016 Fix jOOQ forced type warning

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -40,7 +40,8 @@ val ENUM_TABLES =
         EnumTable(
             "notification_criticalities",
             listOf(".*\\.notification_criticality_id"),
-            "NotificationCriticality"),
+            "NotificationCriticality",
+            generateForcedType = false),
         EnumTable(
             "notification_types",
             listOf(".*\\.notification_type_id"),

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -148,8 +148,8 @@ class TerrawareGenerator : KotlinGenerator() {
                 .withConverter("com.terraformation.backend.db.UriConverter")
                 .withUserType("java.net.URI"))
 
-    ENUM_TABLES.forEach { types.add(it.forcedType(targetPackage)) }
-    ID_WRAPPERS.forEach { types.add(it.forcedType(targetPackage)) }
+    ENUM_TABLES.mapNotNull { it.forcedType(targetPackage) }.forEach { types.add(it) }
+    ID_WRAPPERS.mapNotNull { it.forcedType(targetPackage) }.forEach { types.add(it) }
 
     return types
   }


### PR DESCRIPTION
We generate an enum for the `notification_criticalities` table, but that table is
only ever referenced by the `notification_types` table, which itself gets turned
into an enum.

For each of our generated enums, we use a "forced type" to tell jOOQ to use it
instead of the underlying integer type when it generates the Kotlin
representation of a table. But in the case of `notification_criticalities`,
jOOQ never generates any code that references it, which causes jOOQ to emit a
warning about the type being unused.

There doesn't seem to be any straightforward way to automatically detect that
situation in such a way that we wouldn't also suppress legitimate warnings when
we misspell a table or column name in the configuration. So add an explicit
config option to turn the forced type generation off.