### PR TITLE
SW-1120 Fix slow scientific name typeahead queries

### DIFF
--- a/src/main/resources/db/migration/common/V97__GbifNameWordsCollate.sql
+++ b/src/main/resources/db/migration/common/V97__GbifNameWordsCollate.sql
@@ -1,0 +1,5 @@
+-- Explicitly select the "C" collation for the GBIF name words index so it will support prefix
+-- lookups using LIKE.
+DROP INDEX gbif_name_words_word_gbif_name_id_idx;
+ALTER TABLE gbif_name_words ALTER COLUMN word SET DATA TYPE TEXT COLLATE "C";
+CREATE INDEX ON gbif_name_words (word, gbif_name_id);


### PR DESCRIPTION
The database query that gets run when the user starts typing a scientific name
in the Add Species dialog wasn't able to use the index on `gbif_name_words` to
look up word prefixes because the default collation on the database is a
Unicode locale (`en_US.UTF-8`). PostgreSQL can only use an index for `LIKE`
prefix searches if the index's collation type doesn't allow different byte
sequences to be treated as the same character.

Update the collation on the column in question to "C" which basically means
"treat the value as a blob of bytes" and allows efficient prefix matching.

We are only ever looking up scientific names using this table, so there is no
correctness issue here; we'll never be asked to look up a word that contains a
character with multiple valid UTF-8 representations.