### PR TITLE
Remove support for non-PostgreSQL fuzzy text search

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search
 
 import com.terraformation.backend.db.EnumFromReferenceTable
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.search.field.AliasField
 import com.terraformation.backend.search.field.BigDecimalField
 import com.terraformation.backend.search.field.BooleanField
@@ -50,7 +49,7 @@ import org.jooq.TableField
  * code goes to look up names when it is turning a client-specified field name into a
  * [SearchFieldPath].
  */
-abstract class SearchTable(val fuzzySearchOperators: FuzzySearchOperators) {
+abstract class SearchTable {
   /** Scalar fields that are valid in this table. Subclasses must supply this. */
   abstract val fields: List<SearchField>
 
@@ -275,7 +274,7 @@ abstract class SearchTable(val fuzzySearchOperators: FuzzySearchOperators) {
       displayName: String,
       databaseField: Field<String?>,
       nullable: Boolean = true
-  ) = TextField(fieldName, displayName, databaseField, this, nullable, fuzzySearchOperators)
+  ) = TextField(fieldName, displayName, databaseField, this, nullable)
 
   fun timestampField(
       fieldName: String,
@@ -289,7 +288,5 @@ abstract class SearchTable(val fuzzySearchOperators: FuzzySearchOperators) {
       displayName: String,
       databaseField: Field<String?>,
       nullable: Boolean = true
-  ) =
-      UpperCaseTextField(
-          fieldName, displayName, databaseField, this, nullable, fuzzySearchOperators)
+  ) = UpperCaseTextField(fieldName, displayName, databaseField, this, nullable)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.field
 
-import com.terraformation.backend.db.FuzzySearchOperators
-import com.terraformation.backend.db.UsesFuzzySearchOperators
+import com.terraformation.backend.db.likeFuzzy
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
@@ -20,8 +19,7 @@ class TextField(
     override val databaseField: Field<String?>,
     override val table: SearchTable,
     override val nullable: Boolean = true,
-    override val fuzzySearchOperators: FuzzySearchOperators,
-) : SingleColumnSearchField<String>(), UsesFuzzySearchOperators {
+) : SingleColumnSearchField<String>() {
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy)
 

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.field
 
-import com.terraformation.backend.db.FuzzySearchOperators
-import com.terraformation.backend.db.UsesFuzzySearchOperators
+import com.terraformation.backend.db.likeFuzzy
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
@@ -17,8 +16,7 @@ class UpperCaseTextField(
     override val databaseField: Field<String?>,
     override val table: SearchTable,
     override val nullable: Boolean = true,
-    override val fuzzySearchOperators: FuzzySearchOperators
-) : SingleColumnSearchField<String>(), UsesFuzzySearchOperators {
+) : SingleColumnSearchField<String>() {
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy)
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionGerminationTestTypesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionGerminationTestTypesTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_GERMINATION_TEST_TYPES
 import com.terraformation.backend.search.SearchTable
@@ -10,10 +9,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class AccessionGerminationTestTypesTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class AccessionGerminationTestTypesTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = ACCESSION_GERMINATION_TEST_TYPES.ACCESSION_ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionSecondaryCollectorsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionSecondaryCollectorsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_SECONDARY_COLLECTORS
 import com.terraformation.backend.search.SearchTable
@@ -10,10 +9,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class AccessionSecondaryCollectorsTable(
-    tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class AccessionSecondaryCollectorsTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = ACCESSION_SECONDARY_COLLECTORS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_GERMINATION_TEST_TYPES
 import com.terraformation.backend.db.tables.references.ACCESSION_SECONDARY_COLLECTORS
@@ -30,10 +29,7 @@ import org.jooq.Record
 import org.jooq.TableField
 import org.jooq.impl.DSL
 
-class AccessionsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class AccessionsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = ACCESSIONS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.BAGS
 import com.terraformation.backend.search.SearchTable
@@ -10,8 +9,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class BagsTable(private val tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class BagsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = BAGS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
@@ -10,8 +9,7 @@ import com.terraformation.backend.search.field.SearchField
 import org.jooq.Record
 import org.jooq.TableField
 
-class CountriesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class CountriesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = COUNTRIES.CODE
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
@@ -10,8 +9,7 @@ import com.terraformation.backend.search.field.SearchField
 import org.jooq.Record
 import org.jooq.TableField
 
-class CountrySubdivisionsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class CountrySubdivisionsTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = COUNTRY_SUBDIVISIONS.CODE
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.SITES
@@ -17,8 +16,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class FacilitiesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class FacilitiesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = FACILITIES.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.GEOLOCATIONS
 import com.terraformation.backend.search.FieldNode
@@ -16,10 +15,7 @@ import org.jooq.SelectJoinStep
 import org.jooq.TableField
 import org.jooq.impl.DSL
 
-class GeolocationsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class GeolocationsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = GEOLOCATIONS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GerminationTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GerminationTestsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.GERMINATIONS
 import com.terraformation.backend.db.tables.references.GERMINATION_TESTS
@@ -11,10 +10,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class GerminationTestsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class GerminationTestsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = GERMINATION_TESTS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GerminationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GerminationsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.GERMINATIONS
 import com.terraformation.backend.db.tables.references.GERMINATION_TESTS
 import com.terraformation.backend.search.SearchTable
@@ -10,10 +9,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class GerminationsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators,
-) : SearchTable(fuzzySearchOperators) {
+class GerminationsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = GERMINATIONS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.Role
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
@@ -16,8 +15,7 @@ import org.jooq.Record
 import org.jooq.TableField
 import org.jooq.impl.DSL
 
-class OrganizationUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class OrganizationUsersTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
@@ -16,8 +15,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class OrganizationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class OrganizationsTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = ORGANIZATIONS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectTypeSelectionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectTypeSelectionsTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.PROJECT_TYPE_SELECTIONS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -10,8 +9,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class ProjectTypeSelectionsTable(fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class ProjectTypeSelectionsTable : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = PROJECT_TYPE_SELECTIONS.PROJECT_ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectUsersTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.PROJECTS
 import com.terraformation.backend.db.tables.references.PROJECT_USERS
 import com.terraformation.backend.db.tables.references.USERS
@@ -12,8 +11,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class ProjectUsersTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class ProjectUsersTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.PROJECTS
@@ -15,8 +14,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class ProjectsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class ProjectsTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = PROJECTS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.search.SearchTable
 import javax.annotation.ManagedBean
 
@@ -21,26 +20,26 @@ import javax.annotation.ManagedBean
  * successfully initialized.
  */
 @ManagedBean
-class SearchTables(val fuzzySearchOperators: FuzzySearchOperators) {
-  val accessionGerminationTestTypes = AccessionGerminationTestTypesTable(this, fuzzySearchOperators)
-  val accessions = AccessionsTable(this, fuzzySearchOperators)
-  val accessionSecondaryCollectors = AccessionSecondaryCollectorsTable(this, fuzzySearchOperators)
-  val bags = BagsTable(this, fuzzySearchOperators)
-  val countries = CountriesTable(this, fuzzySearchOperators)
-  val countrySubdivisions = CountrySubdivisionsTable(this, fuzzySearchOperators)
-  val facilities = FacilitiesTable(this, fuzzySearchOperators)
-  val geolocations = GeolocationsTable(this, fuzzySearchOperators)
-  val germinations = GerminationsTable(this, fuzzySearchOperators)
-  val germinationTests = GerminationTestsTable(this, fuzzySearchOperators)
-  val organizations = OrganizationsTable(this, fuzzySearchOperators)
-  val organizationUsers = OrganizationUsersTable(this, fuzzySearchOperators)
-  val projects = ProjectsTable(this, fuzzySearchOperators)
-  val projectTypeSelections = ProjectTypeSelectionsTable(fuzzySearchOperators)
-  val projectUsers = ProjectUsersTable(this, fuzzySearchOperators)
-  val sites = SitesTable(this, fuzzySearchOperators)
-  val species = SpeciesTable(this, fuzzySearchOperators)
-  val speciesProblems = SpeciesProblemsTable(this, fuzzySearchOperators)
-  val storageLocations = StorageLocationsTable(this, fuzzySearchOperators)
-  val users = UsersTable(this, fuzzySearchOperators)
-  val withdrawals = WithdrawalsTable(this, fuzzySearchOperators)
+class SearchTables {
+  val accessionGerminationTestTypes = AccessionGerminationTestTypesTable(this)
+  val accessions = AccessionsTable(this)
+  val accessionSecondaryCollectors = AccessionSecondaryCollectorsTable(this)
+  val bags = BagsTable(this)
+  val countries = CountriesTable(this)
+  val countrySubdivisions = CountrySubdivisionsTable(this)
+  val facilities = FacilitiesTable(this)
+  val geolocations = GeolocationsTable(this)
+  val germinations = GerminationsTable(this)
+  val germinationTests = GerminationTestsTable(this)
+  val organizations = OrganizationsTable(this)
+  val organizationUsers = OrganizationUsersTable(this)
+  val projects = ProjectsTable(this)
+  val projectTypeSelections = ProjectTypeSelectionsTable()
+  val projectUsers = ProjectUsersTable(this)
+  val sites = SitesTable(this)
+  val species = SpeciesTable(this)
+  val speciesProblems = SpeciesProblemsTable(this)
+  val storageLocations = StorageLocationsTable(this)
+  val users = UsersTable(this)
+  val withdrawals = WithdrawalsTable(this)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SitesTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.PROJECTS
@@ -13,8 +12,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class SitesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class SitesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = SITES.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesProblemsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesProblemsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.SpeciesProblemId
 import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.SPECIES_PROBLEMS
@@ -11,10 +10,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class SpeciesProblemsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class SpeciesProblemsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = SPECIES_PROBLEMS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.SPECIES
@@ -13,8 +12,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class SpeciesTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class SpeciesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = SPECIES.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
@@ -12,8 +11,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
-class StorageLocationsTable(tables: SearchTables, fuzzySearchOperators: FuzzySearchOperators) :
-    SearchTable(fuzzySearchOperators) {
+class StorageLocationsTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = STORAGE_LOCATIONS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
@@ -15,10 +14,7 @@ import org.jooq.Record
 import org.jooq.TableField
 import org.jooq.impl.DSL
 
-class UsersTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators,
-) : SearchTable(fuzzySearchOperators) {
+class UsersTable(private val tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(

--- a/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.WITHDRAWALS
 import com.terraformation.backend.search.SearchTable
@@ -10,10 +9,7 @@ import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class WithdrawalsTable(
-    private val tables: SearchTables,
-    fuzzySearchOperators: FuzzySearchOperators
-) : SearchTable(fuzzySearchOperators) {
+class WithdrawalsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = WITHDRAWALS.ID
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -1,9 +1,9 @@
 package com.terraformation.backend.species.db
 
-import com.terraformation.backend.db.FuzzySearchOperators
 import com.terraformation.backend.db.SpeciesProblemField
 import com.terraformation.backend.db.SpeciesProblemType
-import com.terraformation.backend.db.UsesFuzzySearchOperators
+import com.terraformation.backend.db.likeFuzzy
+import com.terraformation.backend.db.similarity
 import com.terraformation.backend.db.tables.pojos.GbifNamesRow
 import com.terraformation.backend.db.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.db.tables.references.GBIF_DISTRIBUTIONS
@@ -18,10 +18,7 @@ import org.jooq.DSLContext
 import org.jooq.impl.DSL
 
 @ManagedBean
-class GbifStore(
-    private val dslContext: DSLContext,
-    override val fuzzySearchOperators: FuzzySearchOperators
-) : UsesFuzzySearchOperators {
+class GbifStore(private val dslContext: DSLContext) {
   /**
    * Returns the species names whose words begin with a list of prefixes.
    *

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.GerminationTestId
 import com.terraformation.backend.db.GerminationTestType
 import com.terraformation.backend.db.GrowthForm
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.PostgresFuzzySearchOperators
 import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SeedQuantityUnits
@@ -83,7 +82,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   private val checkedInTime = Instant.parse(checkedInTimeString)
   private val searchScopes = listOf(OrganizationIdScope(organizationId))
 
-  private val tables = SearchTables(PostgresFuzzySearchOperators())
+  private val tables = SearchTables()
   private val accessionsTable = tables.accessions
   private val rootPrefix = SearchFieldPrefix(root = accessionsTable)
   private val accessionNumberField = rootPrefix.resolve("accessionNumber")

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.species.db
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.GbifNameId
 import com.terraformation.backend.db.GbifTaxonId
-import com.terraformation.backend.db.PostgresFuzzySearchOperators
 import com.terraformation.backend.db.SpeciesProblemField
 import com.terraformation.backend.db.SpeciesProblemType
 import com.terraformation.backend.db.tables.pojos.GbifNamesRow
@@ -24,7 +23,7 @@ import org.junit.jupiter.api.assertThrows
 internal class GbifStoreTest : DatabaseTest() {
   override val tablesToResetSequences = listOf(GBIF_NAMES)
 
-  private val store: GbifStore by lazy { GbifStore(dslContext, PostgresFuzzySearchOperators()) }
+  private val store: GbifStore by lazy { GbifStore(dslContext) }
 
   @Nested
   inner class FindNamesByWordPrefixes {


### PR DESCRIPTION
Previously, fuzzy text search was implemented in such a way that it would be
possible for the code to support more than one database engine. But we've
decided to only target PostgreSQL, so there's no need for the added indirection.

Turn the `likeFuzzy` and `similarity` methods into top-level extension methods
and get rid of the classes that used to be needed to support runtime-selectable
implementations.