### PR TITLE
SW-1049 Make AccessionStore.fetchOneById non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
-import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.GerminationSeedType
@@ -101,8 +100,7 @@ class AccessionController(private val accessionStore: AccessionStore, private va
   @GetMapping("/{id}")
   @Operation(summary = "Retrieve an existing accession.")
   fun read(@PathVariable("id") accessionId: AccessionId): GetAccessionResponsePayload {
-    val accession =
-        accessionStore.fetchById(accessionId) ?: throw AccessionNotFoundException(accessionId)
+    val accession = accessionStore.fetchOneById(accessionId)
     return GetAccessionResponsePayload(AccessionPayload(accession, clock))
   }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -185,6 +185,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateAccession(facilityId) } returns true
     every { user.canCreateAutomation(any()) } returns true
     every { user.canCreateNotification(any(), organizationId) } returns true
+    every { user.canReadAccession(any()) } returns true
     every { user.canReadAutomation(any()) } returns true
     every { user.canReadDevice(any()) } returns true
     every { user.canReadFacility(any()) } returns true


### PR DESCRIPTION
Rename `fetchById` to `fetchOneById` for consistency with other store classes.

All the call sites were throwing exceptions on failure anyway, so consolidate the
exception throwing into the fetch method and make the call sites less cluttered.
This also eliminates the need for the "skip permission check" parameter which was
always kind of screwy.