### PR TITLE
SW-1128 Generate report of dependency licenses

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,10 @@ on:
     branches:
       - main
     paths:
+      - build.gradle.kts
+      - gradle.properties
       - docs/**
+      - src/docs/**
       - src/main/resources/db/migration/**
       - src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
       - .github/workflows/docs.yaml
@@ -58,6 +61,9 @@ jobs:
         SCHEMA_DOCS_DIR: docs/schema
         # We want diagnostic output from schema generation, but not from Spring's test harness.
         LOGGING_LEVEL_ORG_SPRINGFRAMEWORK: ERROR
+
+    - name: Generate license report
+      run: ./gradlew generateLicenseReport
 
     - name: Deploy to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4.3.3

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 # THIS FILE GETS REMOVED AS PART OF THE CI BUILD!
 
-# Don't allow generated schema docs to be committed to the main branch.
+# Don't allow generated docs to be committed to the main branch.
+license-report
 schema

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,6 @@
-# Database schema documentation
+# Terraware Server
+
+## Database schema
 
 Available slices:
 
@@ -7,3 +9,7 @@ Available slices:
 * [Device](schema/device/relationships.html)
 * [Seed Bank](schema/seedbank/relationships.html)
 * [Species](schema/species/relationships.html)
+
+## Other docs
+
+* [Dependency license report](license-report/index.html)

--- a/src/docs/license-normalizer-bundle.json
+++ b/src/docs/license-normalizer-bundle.json
@@ -1,0 +1,19 @@
+{
+  "bundles": [
+    {
+      "bundleName": "apache2",
+      "licenseName": "Apache License, Version 2.0",
+      "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ],
+  "transformationRules": [
+    {
+      "bundleName": "apache2",
+      "licenseUrlPattern": "http://www.apache.org/licenses/LICENSE-2.0*"
+    },
+    {
+      "bundleName": "apache2",
+      "licenseUrlPattern": "https://www.apache.org/licenses/LICENSE-2.0*"
+    }
+  ]
+}


### PR DESCRIPTION
In preparation for releasing the server as open source, add documentation of
the licenses of all its dependencies. This will make it easier to confirm that
the license we choose is compatible with the licenses of all our dependencies.

The license report can be generated using `./gradlew generateLicenseReport`
and will be automatically generated and published to the repo's GitHub Pages
when dependencies are modified.