### PR TITLE
Centralize frequently-used IDs in DatabaseTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -23,12 +23,9 @@ import com.terraformation.backend.db.AutomationId
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.DeviceNotFoundException
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.GerminationTestType
 import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.NotificationType
-import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.NotificationsRow
 import com.terraformation.backend.db.tables.references.NOTIFICATIONS
@@ -77,10 +74,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Autowired private lateinit var config: TerrawareServerConfig
 
-  private val facilityId = FacilityId(100)
-  private val organizationId = OrganizationId(1)
   private val otherUserId = UserId(100)
-  private val projectId = ProjectId(2)
 
   private val clock: Clock = mockk()
   private val messages: Messages = mockk()

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -37,8 +37,6 @@ internal class ProjectServiceTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(ORGANIZATIONS, PROJECTS)
 
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(2)
   private val otherUserId = UserId(100)
 
   private val clock: Clock = mockk()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AutomationId
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
@@ -27,7 +26,6 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   private val deviceId = DeviceId(1000)
-  private val facilityId = FacilityId(100)
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UserId
@@ -35,8 +34,6 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   private lateinit var store: FacilityStore
 
-  private val facilityId = FacilityId(100)
-  private val siteId = SiteId(10)
   private val storageLocationId = StorageLocationId(1000)
 
   @BeforeEach

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.NotificationType
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
@@ -40,9 +39,6 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   private lateinit var permissionStore: PermissionStore
   private lateinit var store: NotificationStore
-
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(2)
 
   private fun notificationModel(
       globalNotification: Boolean = false,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.CannotRemoveLastOwnerException
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityConnectionState
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -20,7 +19,6 @@ import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectStatus
 import com.terraformation.backend.db.ProjectType
 import com.terraformation.backend.db.SRID
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.UserType
@@ -52,11 +50,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   private lateinit var permissionStore: PermissionStore
   private lateinit var store: OrganizationStore
-
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(10)
-  private val siteId = SiteId(100)
-  private val facilityId = FacilityId(1000)
 
   // This gets converted to Mercator in the DB; using smaller values causes floating-point
   // inaccuracies that make assertEquals() fail. The values here work on x86_64; keep an eye on
@@ -137,12 +130,13 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             countrySubdivisionCode = organizationModel.countrySubdivisionCode))
     insertProject(
         projectId,
+        organizationId,
         description = projectModel.description,
         startDate = projectModel.startDate,
         status = projectModel.status,
         types = projectModel.types)
-    insertSite(siteId, description = siteModel.description, location = location)
-    insertFacility(facilityId)
+    insertSite(siteId, projectId, description = siteModel.description, location = location)
+    insertFacility(facilityId, siteId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.ProjectOrganizationWideException
@@ -28,9 +27,6 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
 
   private val clock: Clock = mockk()
   private lateinit var store: ProjectStore
-
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(2)
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.mercatorPoint
 import com.terraformation.backend.db.tables.pojos.SitesRow
@@ -26,10 +25,6 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   private lateinit var parentStore: ParentStore
   private lateinit var store: SiteStore
-
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(2)
-  private val siteId = SiteId(10)
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.KeycloakRequestFailedException
 import com.terraformation.backend.db.KeycloakUserNotFoundException
-import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.mockUser
 import io.mockk.Runs
@@ -66,7 +65,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private val keycloakProperties = KeycloakSpringBootProperties()
 
   private val authId = "authId"
-  private val organizationId = OrganizationId(1)
   private val userRepresentation =
       UserRepresentation().apply {
         email = "email"

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -132,6 +132,13 @@ abstract class DatabaseTest {
   protected val tablesToResetSequences: List<Table<out Record>>
     get() = emptyList()
 
+  // ID values inserted by insertSiteData(). These are used in most database-backed tests. They are
+  // marked as final so they can be referenced in constructor-initialized properties in subclasses.
+  protected final val organizationId: OrganizationId = OrganizationId(1)
+  protected final val projectId: ProjectId = ProjectId(2)
+  protected final val siteId: SiteId = SiteId(10)
+  protected final val facilityId: FacilityId = FacilityId(100)
+
   @BeforeEach
   fun resetSequences() {
     sequencesToReset.forEach { sequence -> dslContext.alterSequence(sequence).restart().execute() }
@@ -438,10 +445,10 @@ abstract class DatabaseTest {
   /** Creates an organization, site, and facility that can be referenced by various tests. */
   fun insertSiteData() {
     insertUser()
-    insertOrganization(1, "dev")
-    insertProject(2, 1, "project")
-    insertSite(10, 2, "sim")
-    insertFacility(100, 10, "ohana")
+    insertOrganization(organizationId, "dev")
+    insertProject(projectId, organizationId, "project")
+    insertSite(siteId, projectId, "sim")
+    insertFacility(facilityId, siteId, "ohana")
   }
 
   /** Creates a user that can be referenced by various tests. */

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -55,8 +55,6 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
     )
   }
 
-  private val facilityId = FacilityId(100)
-
   private val bmuRow =
       DevicesRow(
           facilityId = facilityId,

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -32,7 +32,6 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   private val deviceManagerId = DeviceManagerId(1)
-  private val facilityId = FacilityId(100)
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.TimeseriesId
 import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.TimeseriesType
@@ -36,7 +35,6 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
   private lateinit var store: TimeseriesStore
 
   private val deviceId = DeviceId(1)
-  private val facilityId = FacilityId(100)
 
   private lateinit var timeseriesRow: TimeseriesRow
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -129,9 +129,6 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   private lateinit var store: AccessionStore
   private lateinit var parentStore: ParentStore
 
-  private val facilityId = FacilityId(100)
-  private val organizationId = OrganizationId(1)
-
   @BeforeEach
   fun init() {
     parentStore = ParentStore(dslContext)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.mercatorPoint
 import com.terraformation.backend.db.tables.pojos.AccessionPhotosRow
@@ -73,7 +72,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private val accessionNumber = "ZYXWVUTSRQPO"
   private val capturedTime = Instant.ofEpochMilli(1000)
   private val contentType = MediaType.IMAGE_JPEG_VALUE
-  private val facilityId = FacilityId(100)
   private val filename = "test-photo.jpg"
   private val latitude = 23.456
   private val longitude = 76.5432

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.GerminationTestId
 import com.terraformation.backend.db.GerminationTestType
 import com.terraformation.backend.db.SeedQuantityUnits
@@ -41,7 +40,6 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
 
   private val accessionId = AccessionId(9999)
-  private val facilityId = FacilityId(100)
   private val germinationTestId = GerminationTestId(9998)
 
   override val tablesToResetSequences: List<Table<out Record>>

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -75,9 +75,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   private lateinit var accessionSearchService: AccessionSearchService
   private lateinit var searchService: SearchService
 
-  private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(2)
-  private val facilityId = FacilityId(100)
   private val checkedInTimeString = "2021-08-18T11:33:55Z"
   private val checkedInTime = Instant.parse(checkedInTimeString)
   private val searchScopes = listOf(OrganizationIdScope(organizationId))

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -32,8 +32,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     SpeciesService(dslContext, speciesChecker, speciesStore)
   }
 
-  private val organizationId = OrganizationId(1)
-
   @BeforeEach
   fun setUp() {
     every { clock.instant() } returns Instant.EPOCH

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.GrowthForm
-import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SeedStorageBehavior
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.UploadId
@@ -77,7 +76,6 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
       "Scientific Name,Common Name,Family,Endangered,Rare,Growth Form,Seed Storage Behavior"
 
   private val storageUrl = URI.create("file:///test")
-  private val organizationId = OrganizationId(1)
   private val uploadId = UploadId(10)
   private lateinit var userId: UserId
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -30,8 +30,6 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
 internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
-  private val organizationId = OrganizationId(1)
-
   private val clock: Clock = mockk()
   override val user: TerrawareUser = mockUser()
 


### PR DESCRIPTION
It is annoying to have to repeatedly declare the same IDs in tests that use
`insertSiteData()`, which is a large percentage of the database-backed tests.
Pull the ID properties up into `DatabaseTest`.