### PR TITLE
Use centralized IDs in DatabaseTest insert methods

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -203,7 +203,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store a notification of type User Added To Organization`() {
     insertUser(otherUserId)
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(otherUserId)
 
     service.on(UserAddedToOrganizationEvent(otherUserId, organizationId, user.userId))
 
@@ -231,8 +231,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store a notification of type User Added To Project`() {
     insertUser(otherUserId)
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(otherUserId, projectId, user.userId)
+    insertOrganizationUser(otherUserId)
+    insertProjectUser(otherUserId)
 
     service.on(UserAddedToProjectEvent(otherUserId, projectId, user.userId))
 
@@ -261,10 +261,10 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accession move to drying racks notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
-    insertProjectUser(otherUserId, projectId, user.userId)
+    insertOrganizationUser()
+    insertOrganizationUser(otherUserId)
+    insertProjectUser()
+    insertProjectUser(otherUserId)
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -307,8 +307,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accession drying end date notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -340,8 +340,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accession germination test in a lab, notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -377,8 +377,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accession germination test in a nursery, notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -414,8 +414,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accession scheduled for withdrawal notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -447,8 +447,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store accessions awaiting processing notification`() {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     service.on(AccessionsAwaitingProcessingEvent(facilityId, 5, AccessionState.Pending))
 
@@ -475,8 +475,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store accessions ready for testing notification`() {
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     service.on(AccessionsReadyForTestingEvent(facilityId, 5, 2, AccessionState.Processed))
 
@@ -503,8 +503,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store accessions finished drying notification`() {
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     service.on(AccessionsFinishedDryingEvent(facilityId, 5, AccessionState.Dried))
 
@@ -531,8 +531,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store facility idle notification`() {
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     service.on(FacilityIdleEvent(facilityId))
 
@@ -562,13 +562,13 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val automationId = AutomationId(1)
     val deviceId = DeviceId(1)
     val timeseriesName = "test timeseries"
-    val facilityName = "ohana"
+    val facilityName = "Facility $facilityId"
     val badValue = 5.678
 
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
-    insertDevice(deviceId, facilityId)
-    insertAutomation(automationId, facilityId, deviceId = deviceId, timeseriesName = timeseriesName)
+    insertOrganizationUser()
+    insertProjectUser()
+    insertDevice(deviceId)
+    insertAutomation(automationId, deviceId = deviceId, timeseriesName = timeseriesName)
 
     every {
       messages.sensorBoundsAlert(
@@ -600,13 +600,12 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val automationId = AutomationId(1)
     val automationName = "automation name"
     val automationType = "unknown"
-    val facilityName = "ohana"
+    val facilityName = "Facility $facilityId"
     val message = "message"
 
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
-    insertAutomation(
-        automationId, facilityId, name = automationName, type = automationType, deviceId = null)
+    insertOrganizationUser()
+    insertProjectUser()
+    insertAutomation(automationId, name = automationName, type = automationType, deviceId = null)
 
     val title = "Automation $automationId triggered at $facilityName"
     every { messages.unknownAutomationTriggered(automationName, facilityName, message) } returns
@@ -637,9 +636,9 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val deviceId = DeviceId(1)
     val deviceName = "test device"
 
-    insertOrganizationUser(user.userId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId, user.userId)
-    insertDevice(deviceId, facilityId, deviceName, type = "sensor")
+    insertOrganizationUser()
+    insertProjectUser()
+    insertDevice(deviceId, name = deviceName, type = "sensor")
 
     every { messages.deviceUnresponsive(deviceName) } returns
         NotificationMessage("unresponsive title", "unresponsive body")

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -179,14 +179,13 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization throws exception if organization has users other than the current one`() {
-    val organizationId = OrganizationId(1)
     val otherUserId = UserId(100)
 
     insertUser(user.userId)
     insertUser(otherUserId)
-    insertOrganization(organizationId)
-    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
+    insertOrganization()
+    insertOrganizationUser(role = Role.OWNER)
+    insertOrganizationUser(otherUserId)
 
     assertThrows<OrganizationHasOtherUsersException> { service.deleteOrganization(organizationId) }
   }
@@ -201,11 +200,9 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization removes current user from organization`() {
-    val organizationId = OrganizationId(1)
-
     insertUser()
-    insertOrganization(organizationId)
-    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
+    insertOrganization()
+    insertOrganizationUser(role = Role.OWNER)
 
     every { publisher.publishEvent(any<OrganizationDeletedEvent>()) } just Runs
 
@@ -218,11 +215,9 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization publishes event on success`() {
-    val organizationId = OrganizationId(1)
-
     insertUser()
-    insertOrganization(organizationId)
-    insertOrganizationUser(user.userId, organizationId, Role.OWNER)
+    insertOrganization()
+    insertOrganizationUser(role = Role.OWNER)
 
     every { publisher.publishEvent(any<OrganizationDeletedEvent>()) } just Runs
 

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -8,8 +8,6 @@ import com.terraformation.backend.customer.event.UserAddedToProjectEvent
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
@@ -91,7 +89,7 @@ internal class ProjectServiceTest : DatabaseTest(), RunsAsUser {
         projectId in permissionStore.fetchProjectRoles(otherUserId),
         "User should not have project roles for project that user was not added to")
 
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(otherUserId)
 
     service.addUser(projectId, otherUserId)
 
@@ -102,13 +100,11 @@ internal class ProjectServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `addUser publishes event on success`() {
-    val organizationId = OrganizationId(1)
     val userId = currentUser().userId
-    val projectId = ProjectId(2)
     val otherUserId = UserId(100)
 
     insertUser(otherUserId)
-    insertOrganizationUser(otherUserId, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(otherUserId)
 
     service.addUser(projectId, otherUserId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -43,8 +43,8 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
 
     insertDevice(otherDeviceId)
 
-    insertAutomation(1, facilityId, deviceId = deviceId, objectMapper = objectMapper)
-    insertAutomation(2, facilityId, deviceId = otherDeviceId, objectMapper = objectMapper)
+    insertAutomation(1, deviceId = deviceId, objectMapper = objectMapper)
+    insertAutomation(2, deviceId = otherDeviceId, objectMapper = objectMapper)
 
     val expectedRow = automationsDao.fetchOneById(AutomationId(1))!!
     val expected = listOf(AutomationModel(expectedRow, objectMapper))

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -176,7 +176,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `updateLastTimeseriesTimes resets idle timestamps`() {
     val deviceId = DeviceId(1)
-    insertDevice(deviceId, facilityId)
+    insertDevice(deviceId)
 
     val initial = facilitiesDao.fetchOneById(facilityId)!!
     facilitiesDao.update(

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -125,18 +125,17 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(
         organizationId,
         insertOrganization(
+            null,
             name = organizationModel.name,
             countryCode = organizationModel.countryCode,
             countrySubdivisionCode = organizationModel.countrySubdivisionCode))
     insertProject(
-        projectId,
-        organizationId,
         description = projectModel.description,
         startDate = projectModel.startDate,
         status = projectModel.status,
         types = projectModel.types)
-    insertSite(siteId, projectId, description = siteModel.description, location = location)
-    insertFacility(facilityId, siteId)
+    insertSite(description = siteModel.description, location = location)
+    insertFacility()
   }
 
   @Test
@@ -204,7 +203,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     (baseUserId until expectedTotalUsers + baseUserId).forEach { userId ->
       insertUser(userId)
-      insertOrganizationUser(userId, organizationId)
+      insertOrganizationUser(userId)
     }
 
     assertEquals(expectedTotalUsers, store.fetchById(organizationId)!!.totalUsers)
@@ -515,7 +514,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     val otherOrgId = OrganizationId(5)
     val otherProjectId = ProjectId(50)
     insertOrganization(otherOrgId)
-    insertProject(otherProjectId, organizationId = otherOrgId)
+    insertProject(otherProjectId, otherOrgId)
     insertOrganizationUser(model.userId, otherOrgId)
     insertProjectUser(model.userId, otherProjectId)
 
@@ -617,9 +616,9 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
     insertUser(optedOutMember, email = "optedOutMember@x.com")
 
-    insertOrganizationUser(optedInNonMember, otherOrganizationId, Role.CONTRIBUTOR)
-    insertOrganizationUser(optedInMember, organizationId, Role.CONTRIBUTOR)
-    insertOrganizationUser(optedOutMember, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(optedInNonMember, otherOrganizationId)
+    insertOrganizationUser(optedInMember, organizationId)
+    insertOrganizationUser(optedOutMember, organizationId)
 
     val expected = setOf("optedInMember@x.com")
     val actual = store.fetchEmailRecipients(organizationId).toSet()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -42,16 +42,14 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
 
     store = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
 
-    insertUser()
-    insertOrganization(organizationId)
-    insertProject(projectId, organizationId = organizationId)
+    insertSiteData()
   }
 
   @Test
   fun `addProjectUser adds user to project`() {
     val userId = UserId(100)
     insertUser(userId)
-    insertOrganizationUser(userId, organizationId)
+    insertOrganizationUser(userId)
 
     store.addUser(projectId, userId)
 
@@ -88,7 +86,7 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
   fun `addProjectUser throws exception if project is organization-wide`() {
     val userId = UserId(100)
     insertUser(userId)
-    insertOrganizationUser(userId, organizationId)
+    insertOrganizationUser(userId)
 
     projectsDao.update(projectsDao.fetchOneById(projectId)!!.copy(organizationWide = true))
 
@@ -98,12 +96,12 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `removeProjectUser removes user from project`() {
     val otherProjectId = ProjectId(3)
-    insertProject(otherProjectId, organizationId = organizationId)
+    insertProject(otherProjectId)
 
     val userId = UserId(100)
     insertUser(userId)
-    insertOrganizationUser(userId, organizationId)
-    insertProjectUser(userId, projectId)
+    insertOrganizationUser(userId)
+    insertProjectUser(userId)
     insertProjectUser(userId, otherProjectId)
 
     store.removeUser(projectId, userId)
@@ -143,12 +141,12 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     val contributorUserId = UserId(101)
     val otherProjectId = ProjectId(3)
 
-    insertProject(otherProjectId, organizationId)
+    insertProject(otherProjectId)
     insertUser(adminUserId)
     insertUser(contributorUserId)
-    insertOrganizationUser(adminUserId, organizationId, Role.ADMIN)
-    insertOrganizationUser(contributorUserId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(contributorUserId, projectId)
+    insertOrganizationUser(adminUserId, role = Role.ADMIN)
+    insertOrganizationUser(contributorUserId, role = Role.CONTRIBUTOR)
+    insertProjectUser(contributorUserId)
 
     val expected = mapOf(projectId to 2, otherProjectId to 1)
     val actual = store.countUsers(listOf(projectId, otherProjectId))
@@ -162,11 +160,11 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     val contributorUserId = UserId(101)
     val orgWideProjectId = ProjectId(3)
 
-    insertProject(orgWideProjectId, organizationId, organizationWide = true)
+    insertProject(orgWideProjectId, organizationWide = true)
     insertUser(adminUserId)
     insertUser(contributorUserId)
-    insertOrganizationUser(adminUserId, organizationId, Role.ADMIN)
-    insertOrganizationUser(contributorUserId, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(adminUserId, role = Role.ADMIN)
+    insertOrganizationUser(contributorUserId, role = Role.CONTRIBUTOR)
 
     val expected = mapOf(projectId to 1, orgWideProjectId to 2)
     val actual = store.countUsers(listOf(projectId, orgWideProjectId))
@@ -181,10 +179,10 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
 
     insertUser(adminUserId)
     insertUser(contributorUserId)
-    insertOrganizationUser(adminUserId, organizationId, Role.ADMIN)
-    insertOrganizationUser(contributorUserId, organizationId, Role.CONTRIBUTOR)
-    insertProjectUser(adminUserId, projectId)
-    insertProjectUser(contributorUserId, projectId)
+    insertOrganizationUser(adminUserId, role = Role.ADMIN)
+    insertOrganizationUser(contributorUserId, role = Role.CONTRIBUTOR)
+    insertProjectUser(adminUserId)
+    insertProjectUser(contributorUserId)
 
     val actual = store.countUsers(projectId)
 
@@ -217,14 +215,14 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
     insertUser(optedOutMember, email = "optedOutMember@x.com")
 
-    insertOrganizationUser(optedInAdmin, organizationId, Role.ADMIN)
-    insertOrganizationUser(optedOutAdmin, organizationId, Role.ADMIN)
-    insertOrganizationUser(optedInNonMember, organizationId, Role.CONTRIBUTOR)
-    insertOrganizationUser(optedInMember, organizationId, Role.CONTRIBUTOR)
-    insertOrganizationUser(optedOutMember, organizationId, Role.CONTRIBUTOR)
+    insertOrganizationUser(optedInAdmin, role = Role.ADMIN)
+    insertOrganizationUser(optedOutAdmin, role = Role.ADMIN)
+    insertOrganizationUser(optedInNonMember, role = Role.CONTRIBUTOR)
+    insertOrganizationUser(optedInMember, role = Role.CONTRIBUTOR)
+    insertOrganizationUser(optedOutMember, role = Role.CONTRIBUTOR)
 
-    insertProjectUser(optedInMember, projectId)
-    insertProjectUser(optedOutMember, projectId)
+    insertProjectUser(optedInMember)
+    insertProjectUser(optedOutMember)
 
     val expected = setOf("optedInAdmin@x.com", "optedInMember@x.com")
     val actual = store.fetchEmailRecipients(projectId).toSet()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SiteStoreTest.kt
@@ -80,7 +80,7 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
   fun `update can move site between projects`() {
     val newProjectId = ProjectId(3)
 
-    insertProject(newProjectId, organizationId)
+    insertProject(newProjectId)
 
     val rowWithNewProject = sitesDao.fetchOneById(siteId)!!.copy(projectId = newProjectId)
 
@@ -115,7 +115,7 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `update throws exception if user has no permission to delete site from current project`() {
     val newProjectId = ProjectId(3)
-    insertProject(newProjectId, organizationId)
+    insertProject(newProjectId)
 
     every { user.canDeleteSite(siteId) } returns false
 
@@ -127,7 +127,7 @@ internal class SiteStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `update throws exception if user has no permission to create site in target project`() {
     val newProjectId = ProjectId(3)
-    insertProject(newProjectId, organizationId)
+    insertProject(newProjectId)
 
     every { user.canCreateSite(newProjectId) } returns false
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -215,7 +215,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUpOrganization() {
       insertUser()
-      insertOrganization(organizationId)
+      insertOrganization()
     }
 
     @Test
@@ -299,7 +299,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUpOrganization() {
       insertUser()
-      insertOrganization(organizationId)
+      insertOrganization()
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -171,11 +171,11 @@ internal class PermissionTest : DatabaseTest() {
     insertUser(userId)
     insertUser(otherUserId)
     organizationIds.forEach { insertOrganization(it, createdBy = userId) }
-    projectIds.forEach { insertProject(it, createdBy = userId) }
-    siteIds.forEach { insertSite(it, createdBy = userId) }
+    projectIds.forEach { insertProject(it, it.value / 10, createdBy = userId) }
+    siteIds.forEach { insertSite(it, it.value / 10, createdBy = userId) }
 
     facilityIds.forEach { facilityId ->
-      insertFacility(facilityId, createdBy = userId)
+      insertFacility(facilityId, facilityId.value / 10, createdBy = userId)
       insertDevice(facilityId.value, facilityId, createdBy = userId)
       insertAutomation(facilityId.value, facilityId, createdBy = userId)
       accessionsDao.insert(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -234,8 +234,20 @@ abstract class DatabaseTest {
   protected val usersDao: UsersDao by lazyDao()
   protected val withdrawalsDao: WithdrawalsDao by lazyDao()
 
+  /**
+   * Creates a user, organization, project, site, and facility that can be referenced by various
+   * tests.
+   */
+  fun insertSiteData() {
+    insertUser()
+    insertOrganization()
+    insertProject()
+    insertSite()
+    insertFacility()
+  }
+
   protected fun insertOrganization(
-      id: Any? = null,
+      id: Any? = this.organizationId,
       name: String = "Organization $id",
       countryCode: String? = null,
       countrySubdivisionCode: String? = null,
@@ -258,8 +270,8 @@ abstract class DatabaseTest {
   }
 
   protected fun insertProject(
-      id: Any,
-      organizationId: Any = "$id".toLong() / 10,
+      id: Any = this.projectId,
+      organizationId: Any = this.organizationId,
       name: String = "Project $id",
       createdBy: UserId = currentUser().userId,
       description: String? = null,
@@ -299,8 +311,8 @@ abstract class DatabaseTest {
   }
 
   protected fun insertSite(
-      id: Any,
-      projectId: Any = "$id".toLong() / 10,
+      id: Any = this.siteId,
+      projectId: Any = this.projectId,
       name: String = "Site $id",
       location: Point = mercatorPoint(1.0, 2.0, 0.0),
       createdBy: UserId = currentUser().userId,
@@ -323,8 +335,8 @@ abstract class DatabaseTest {
   }
 
   protected fun insertFacility(
-      id: Any,
-      siteId: Any = "$id".toLong() / 10,
+      id: Any = this.facilityId,
+      siteId: Any = this.siteId,
       name: String = "Facility $id",
       description: String? = "Description $id",
       createdBy: UserId = currentUser().userId,
@@ -357,7 +369,7 @@ abstract class DatabaseTest {
 
   protected fun insertDevice(
       id: Any,
-      facilityId: Any = "$id".toLong() / 10,
+      facilityId: Any = this.facilityId,
       name: String = "device $id",
       createdBy: UserId = currentUser().userId,
       type: String = "type"
@@ -381,7 +393,7 @@ abstract class DatabaseTest {
 
   protected fun insertAutomation(
       id: Any,
-      facilityId: Any = "$id".toLong() / 10,
+      facilityId: Any = this.facilityId,
       name: String = "automation $id",
       type: String = AutomationModel.SENSOR_BOUNDS_TYPE,
       deviceId: Any? = "$id".toLong(),
@@ -416,7 +428,7 @@ abstract class DatabaseTest {
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       modifiedTime: Instant = Instant.EPOCH,
-      organizationId: Any = "$speciesId".toLong() / 10,
+      organizationId: Any = this.organizationId,
       deletedTime: Instant? = null,
       checkedTime: Instant? = null,
       initialScientificName: String = scientificName,
@@ -440,15 +452,6 @@ abstract class DatabaseTest {
           .set(SCIENTIFIC_NAME, scientificName)
           .execute()
     }
-  }
-
-  /** Creates an organization, site, and facility that can be referenced by various tests. */
-  fun insertSiteData() {
-    insertUser()
-    insertOrganization(organizationId, "dev")
-    insertProject(projectId, organizationId, "project")
-    insertSite(siteId, projectId, "sim")
-    insertFacility(facilityId, siteId, "ohana")
   }
 
   /** Creates a user that can be referenced by various tests. */
@@ -480,7 +483,7 @@ abstract class DatabaseTest {
   /** Adds a user to an organization. */
   fun insertOrganizationUser(
       userId: Any = currentUser().userId,
-      organizationId: Any,
+      organizationId: Any = this.organizationId,
       role: Role = Role.CONTRIBUTOR,
       createdBy: UserId = currentUser().userId,
   ) {
@@ -501,7 +504,7 @@ abstract class DatabaseTest {
   /** Adds a user to a project. */
   fun insertProjectUser(
       userId: Any = currentUser().userId,
-      projectId: Any,
+      projectId: Any = this.projectId,
       createdBy: UserId = currentUser().userId,
   ) {
     with(PROJECT_USERS) {
@@ -520,7 +523,7 @@ abstract class DatabaseTest {
   /** Adds a storage location to a facility. */
   fun insertStorageLocation(
       id: Any,
-      facilityId: Any = "$id".toLong() / 10,
+      facilityId: Any = this.facilityId,
       name: String = "Location $id",
       condition: StorageCondition = StorageCondition.Freezer,
       createdBy: UserId = currentUser().userId,

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -282,7 +282,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `createDefaultDevices does nothing if facility has no default template category`() {
     val desalFacilityId = FacilityId(2)
-    insertFacility(desalFacilityId, siteId = 10, type = FacilityType.Desalination)
+    insertFacility(desalFacilityId, type = FacilityType.Desalination)
     deviceTemplatesDao.insert(
         DeviceTemplatesRow(
             categoryId = DeviceTemplateCategory.SeedBankDefault,

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -43,7 +43,7 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
     store = TimeseriesStore(clock, dslContext)
 
     insertSiteData()
-    insertDevice(deviceId, facilityId)
+    insertDevice(deviceId)
 
     every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateTimeseries(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.file
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadStatus
 import com.terraformation.backend.db.UploadType
@@ -61,11 +60,10 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
     val fileName = "test"
     val contentType = "text/csv"
     val type = UploadType.SpeciesCSV
-    val organizationId = OrganizationId(1)
 
     every { fileStore.newUrl(any(), any(), any()) } returns storageUrl
     every { fileStore.write(storageUrl, any()) } just Runs
-    insertOrganization(organizationId)
+    insertOrganization()
 
     val expected =
         listOf(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1605,7 +1605,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `update writes new facility id if it belongs to the same organization as previous facility`() {
     val anotherFacilityId = FacilityId(5000)
-    insertFacility(anotherFacilityId, SiteId(10))
+    insertFacility(anotherFacilityId)
 
     every { user.canUpdateAccession(any()) } returns true
     val initial = store.create(AccessionModel(facilityId = facilityId))
@@ -1779,7 +1779,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
 
     @BeforeEach
     fun createOtherFacility() {
-      insertFacility(otherFacilityId, 10)
+      insertFacility(otherFacilityId)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -113,8 +113,8 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
     insertSiteData()
 
-    insertOrganizationUser(user.userId, organizationId, role = Role.CONTRIBUTOR)
-    insertProjectUser(user.userId, projectId)
+    insertOrganizationUser()
+    insertProjectUser()
 
     val now = Instant.now()
 
@@ -1283,7 +1283,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1000),
-              facilityId = FacilityId(100),
+              facilityId = facilityId,
               name = "Refrigerator 1",
               conditionId = StorageCondition.Refrigerator,
               createdBy = user.userId,
@@ -1294,7 +1294,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1001),
-              facilityId = FacilityId(100),
+              facilityId = facilityId,
               name = "Freezer 1",
               conditionId = StorageCondition.Freezer,
               createdBy = user.userId,
@@ -1305,7 +1305,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       storageLocationsDao.insert(
           StorageLocationsRow(
               id = StorageLocationId(1002),
-              facilityId = FacilityId(100),
+              facilityId = facilityId,
               name = "Freezer 2",
               conditionId = StorageCondition.Freezer,
               createdBy = user.userId,
@@ -1670,8 +1670,8 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
       insertOrganization(otherOrganizationId)
 
-      insertOrganizationUser(apiClientUserId, organizationId)
-      insertOrganizationUser(bothOrgsUserId, organizationId, Role.ADMIN)
+      insertOrganizationUser(apiClientUserId)
+      insertOrganizationUser(bothOrgsUserId, role = Role.ADMIN)
       insertOrganizationUser(bothOrgsUserId, otherOrganizationId, Role.ADMIN)
       insertOrganizationUser(otherOrgUserId, otherOrganizationId)
 
@@ -2009,7 +2009,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val orgNameField =
           germinationsPrefix.resolve(
               "germinationTest.accession.facility.site.project.organization.name")
-      val orgName = "dev"
+      val orgName = "Organization $organizationId"
 
       val result =
           searchService.search(
@@ -2044,7 +2044,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val rootSeedsGerminatedField = germinationsPrefix.resolve("seedsGerminated")
       val flattenedFieldName = "germinationTest_accession_facility_site_project_organization_name"
       val orgNameField = germinationsPrefix.resolve(flattenedFieldName)
-      val orgName = "dev"
+      val orgName = "Organization $organizationId"
 
       val result =
           searchService.search(
@@ -2492,7 +2492,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                   mapOf(
                       "id" to "1000",
                       "accessionNumber" to "XYZ",
-                      "facility" to mapOf("name" to "ohana"))),
+                      "facility" to mapOf("name" to "Facility $facilityId"))),
               cursor = null)
 
       assertEquals(expected, result)
@@ -2714,7 +2714,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                   "createdTime" to "1970-01-01T00:00:00Z",
                   "description" to "Description 100",
                   "id" to "100",
-                  "name" to "ohana",
+                  "name" to "Facility 100",
                   "type" to "Seed Bank",
               ))
 
@@ -2724,7 +2724,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                   "createdTime" to "1970-01-01T00:00:00Z",
                   "facilities" to expectedFacilities,
                   "id" to "10",
-                  "name" to "sim",
+                  "name" to "Site 10",
                   "location" to
                       """{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:3857"}},"coordinates":[1,2,0]}""",
               ))
@@ -2762,7 +2762,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                   "hidden" to "false",
                   "id" to "2",
                   "members" to expectedProjectUsers,
-                  "name" to "project",
+                  "name" to "Project 2",
                   "organizationWide" to "false",
                   "sites" to expectedSites,
               ))
@@ -2785,7 +2785,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
               mapOf(
                   "createdTime" to "1970-01-01T00:00:00Z",
                   "id" to "1",
-                  "name" to "dev",
+                  "name" to "Organization 1",
                   "projects" to expectedProjects,
                   "members" to expectedOrganizationUsers,
                   "species" to expectedSpecies,

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -50,7 +50,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     val speciesId = SpeciesId(1)
     val scientificName = "test"
 
-    insertSpecies(speciesId, scientificName = scientificName, organizationId = organizationId)
+    insertSpecies(speciesId, scientificName = scientificName)
 
     assertEquals(speciesId, service.getOrCreateSpecies(organizationId, scientificName))
   }
@@ -89,7 +89,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   fun `updateSpecies checks for problems with species data`() {
     val speciesId = SpeciesId(1)
 
-    insertSpecies(speciesId, "Old name", organizationId = organizationId)
+    insertSpecies(speciesId, "Old name")
     val originalRow = speciesDao.fetchOneById(speciesId)!!
 
     val updatedRow = service.updateSpecies(originalRow.copy(scientificName = "New name"))

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -83,7 +83,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     userId = user.userId
     insertUser()
-    insertOrganization(organizationId)
+    insertOrganization()
 
     every { clock.instant() } returns Instant.EPOCH
     every { speciesChecker.checkAllUncheckedSpecies(organizationId) } just Runs
@@ -166,7 +166,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingValidation,
         storageUrl = storageUrl)
-    insertSpecies(1, "Existing name", organizationId = organizationId)
+    insertSpecies(1, "Existing name")
 
     importer.validateCsv(uploadId, user.userId)
 
@@ -195,11 +195,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(
-        2,
-        "Corrected name",
-        organizationId = organizationId,
-        initialScientificName = "Initial name")
+    insertSpecies(2, "Corrected name", initialScientificName = "Initial name")
 
     importer.validateCsv(uploadId, userId)
 
@@ -228,7 +224,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingValidation,
         storageUrl = storageUrl)
-    insertSpecies(1, "Existing name", deletedTime = Instant.EPOCH, organizationId = organizationId)
+    insertSpecies(1, "Existing name", deletedTime = Instant.EPOCH)
 
     importer.validateCsv(uploadId, userId)
 
@@ -289,7 +285,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(2, "Existing name", organizationId = organizationId)
+    insertSpecies(2, "Existing name")
 
     importer.importCsv(uploadId, userId, true)
 
@@ -349,9 +345,8 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(2, "Existing name", organizationId = organizationId)
-    insertSpecies(
-        3, "New name", organizationId = organizationId, initialScientificName = "Initial name")
+    insertSpecies(2, "Existing name")
+    insertSpecies(3, "New name", initialScientificName = "Initial name")
 
     val now = clock.instant() + Duration.ofDays(1)
     every { clock.instant() } returns now
@@ -406,16 +401,8 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(
-        2,
-        "Duplicate name",
-        organizationId = organizationId,
-        initialScientificName = "Initial name")
-    insertSpecies(
-        3,
-        "Nonduplicate name",
-        organizationId = organizationId,
-        initialScientificName = "Duplicate name")
+    insertSpecies(2, "Duplicate name", initialScientificName = "Initial name")
+    insertSpecies(3, "Nonduplicate name", initialScientificName = "Duplicate name")
 
     val now = clock.instant() + Duration.ofDays(1)
     every { clock.instant() } returns now
@@ -466,9 +453,8 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(10, "Existing name", organizationId = organizationId)
-    insertSpecies(
-        11, "New name", organizationId = organizationId, initialScientificName = "Initial name")
+    insertSpecies(10, "Existing name")
+    insertSpecies(11, "New name", initialScientificName = "Initial name")
 
     every { clock.instant() } returns Instant.EPOCH + Duration.ofDays(1)
 
@@ -490,7 +476,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
-    insertSpecies(2, "Existing name", organizationId = organizationId, deletedTime = Instant.EPOCH)
+    insertSpecies(2, "Existing name", deletedTime = Instant.EPOCH)
 
     val now = clock.instant() + Duration.ofDays(1)
     every { clock.instant() } returns now
@@ -530,11 +516,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
     insertSpecies(
-        2,
-        "Renamed name",
-        organizationId = organizationId,
-        deletedTime = Instant.EPOCH,
-        initialScientificName = "Initial name")
+        2, "Renamed name", deletedTime = Instant.EPOCH, initialScientificName = "Initial name")
 
     val now = clock.instant() + Duration.ofDays(1)
     every { clock.instant() } returns now
@@ -586,7 +568,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         status = UploadStatus.AwaitingProcessing,
         storageUrl = storageUrl)
     // Species ID will collide with the autogenerated primary key
-    insertSpecies(1, "Existing name", organizationId = organizationId)
+    insertSpecies(1, "Existing name")
 
     val expected = speciesDao.findAll()
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -312,8 +312,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val checkedSpeciesId = SpeciesId(1)
     val uncheckedSpeciesId = SpeciesId(2)
 
-    insertSpecies(checkedSpeciesId, organizationId = organizationId, checkedTime = Instant.EPOCH)
-    insertSpecies(uncheckedSpeciesId, organizationId = organizationId)
+    insertSpecies(checkedSpeciesId, checkedTime = Instant.EPOCH)
+    insertSpecies(uncheckedSpeciesId)
 
     assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
   }


### PR DESCRIPTION
Now that the IDs for site data are centrally managed, there's no longer any point
forcing tests to pass those IDs into helper methods like `insertFacility()`.
Update those methods to use the standard IDs by default, and update the tests to
stop passing them in.

In many cases, this means the insert methods can be called with no arguments at
all and will do the right thing. To support that goal, update `insertSiteData()`
to stop passing in PacFlight-themed names for the site data; instead, it uses the
default names that include the object IDs, e.g., `Facility 100`.