### PR TITLE
SW-1049 Make FacilityStore.fetchOneById non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.NotificationType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -76,9 +75,7 @@ class AppNotificationService(
         automation.deviceId
             ?: throw IllegalStateException("Automation ${automation.id} has no device ID")
     val device = deviceStore.fetchOneById(deviceId) ?: throw DeviceNotFoundException(deviceId)
-    val facility =
-        facilityStore.fetchById(automation.facilityId)
-            ?: throw FacilityNotFoundException(automation.facilityId)
+    val facility = facilityStore.fetchOneById(automation.facilityId)
 
     val facilityUrl = webAppUrls.facilityMonitoring(facility.id, device)
     val message = messages.sensorBoundsAlert(device, facility.name, timeseriesName, event.value)
@@ -90,9 +87,7 @@ class AppNotificationService(
   @EventListener
   fun on(event: UnknownAutomationTriggeredEvent) {
     val automation = automationStore.fetchOneById(event.automationId)
-    val facility =
-        facilityStore.fetchById(automation.facilityId)
-            ?: throw FacilityNotFoundException(automation.facilityId)
+    val facility = facilityStore.fetchOneById(automation.facilityId)
 
     val facilityUrl = webAppUrls.facilityMonitoring(facility.id)
     val message = messages.unknownAutomationTriggered(automation.name, facility.name, event.message)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -17,7 +17,6 @@ import com.terraformation.backend.db.DeviceManagerNotFoundException
 import com.terraformation.backend.db.DeviceTemplateCategory
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -206,8 +205,7 @@ class AdminController(
 
   @GetMapping("/facility/{facilityId}")
   fun getFacility(@PathVariable facilityId: FacilityId, model: Model): String {
-    val facility =
-        facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val facility = facilityStore.fetchOneById(facilityId)
     val site = siteStore.fetchById(facility.siteId) ?: throw SiteNotFoundException(facility.siteId)
     val project =
         projectStore.fetchById(site.projectId) ?: throw ProjectNotFoundException(site.projectId)
@@ -282,7 +280,7 @@ class AdminController(
     val manager =
         deviceManagerStore.fetchOneById(deviceManagerId)
             ?: throw DeviceManagerNotFoundException(deviceManagerId)
-    val facility = manager.facilityId?.let { facilityStore.fetchById(it) }
+    val facility = manager.facilityId?.let { facilityStore.fetchOneById(it) }
 
     model.addAttribute(
         "canUpdateDeviceManager", currentUser().canUpdateDeviceManager(deviceManagerId))
@@ -582,8 +580,7 @@ class AdminController(
       return facility(facilityId)
     }
 
-    val existing =
-        facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val existing = facilityStore.fetchOneById(facilityId)
     facilityStore.update(
         existing.copy(
             name = name,
@@ -607,7 +604,7 @@ class AdminController(
       @RequestParam("body") body: String,
       redirectAttributes: RedirectAttributes
   ): String {
-    if (facilityStore.fetchById(facilityId)?.connectionState !=
+    if (facilityStore.fetchOneById(facilityId).connectionState !=
         FacilityConnectionState.Configured) {
       redirectAttributes.successMessage =
           "Alert received, but facility is not configured so alert would be ignored."

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -19,7 +19,6 @@ import com.terraformation.backend.db.AutomationNotFoundException
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.log.perClassLogger
@@ -65,8 +64,7 @@ class FacilitiesController(
   @GetMapping("/{facilityId}")
   @Operation(summary = "Gets information about a single facility.")
   fun getFacility(@PathVariable facilityId: FacilityId): GetFacilityResponse {
-    val facility =
-        facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val facility = facilityStore.fetchOneById(facilityId)
 
     return GetFacilityResponse(FacilityPayload(facility))
   }
@@ -87,8 +85,7 @@ class FacilitiesController(
       @PathVariable facilityId: FacilityId,
       @RequestBody payload: UpdateFacilityRequestPayload
   ): SimpleSuccessResponsePayload {
-    val facility =
-        facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val facility = facilityStore.fetchOneById(facilityId)
 
     facilityStore.update(
         facility.copy(name = payload.name, description = payload.description?.ifEmpty { null }))
@@ -208,7 +205,7 @@ class FacilitiesController(
   ): ResponseEntity<SimpleSuccessResponsePayload> {
     requirePermissions { sendAlert(facilityId) }
 
-    val connectionState = facilityStore.fetchById(facilityId)?.connectionState
+    val connectionState = facilityStore.fetchOneById(facilityId).connectionState
     if (connectionState != FacilityConnectionState.Configured) {
       log.warn("Dropping alert from facility $facilityId with connection state $connectionState")
       log.info("Subject ${payload.subject}")

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -40,12 +40,11 @@ class FacilityStore(
 
   private val log = perClassLogger()
 
-  fun fetchById(facilityId: FacilityId): FacilityModel? {
-    return if (!currentUser().canReadFacility(facilityId)) {
-      null
-    } else {
-      facilitiesDao.fetchOneById(facilityId)?.toModel()
-    }
+  fun fetchOneById(facilityId: FacilityId): FacilityModel {
+    requirePermissions { readFacility(facilityId) }
+
+    return facilitiesDao.fetchOneById(facilityId)?.toModel()
+        ?: throw FacilityNotFoundException(facilityId)
   }
 
   /** Returns a list of all the facilities the current user can access. */

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
@@ -74,7 +74,7 @@ class DeviceService(
    * type of facility, but that it can't detect automatically.
    */
   fun createDefaultDevices(facilityId: FacilityId) {
-    val category = facilityStore.fetchById(facilityId)?.defaultDeviceTemplateCategory
+    val category = facilityStore.fetchOneById(facilityId).defaultDeviceTemplateCategory
 
     if (category != null) {
       dslContext.transaction { _ ->

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -91,9 +91,7 @@ class EmailNotificationService(
     log.info("Alert subject: ${event.subject}")
     log.info("Alert body: ${event.body}")
 
-    val facility =
-        facilityStore.fetchById(event.facilityId)
-            ?: throw FacilityNotFoundException(event.facilityId)
+    val facility = facilityStore.fetchOneById(event.facilityId)
 
     emailService.sendFacilityNotification(
         event.facilityId,
@@ -102,9 +100,7 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: FacilityIdleEvent) {
-    val facility =
-        facilityStore.fetchById(event.facilityId)
-            ?: throw FacilityNotFoundException(event.facilityId)
+    val facility = facilityStore.fetchOneById(event.facilityId)
 
     val facilityMonitoringUrl =
         webAppUrls
@@ -122,9 +118,7 @@ class EmailNotificationService(
         automation.deviceId
             ?: throw IllegalStateException("Automation ${automation.id} has no device ID")
     val device = deviceStore.fetchOneById(deviceId) ?: throw DeviceNotFoundException(deviceId)
-    val facility =
-        facilityStore.fetchById(automation.facilityId)
-            ?: throw FacilityNotFoundException(automation.facilityId)
+    val facility = facilityStore.fetchOneById(automation.facilityId)
     val organizationId =
         parentStore.getOrganizationId(facility.id) ?: throw FacilityNotFoundException(facility.id)
 
@@ -139,9 +133,7 @@ class EmailNotificationService(
   @EventListener
   fun on(event: UnknownAutomationTriggeredEvent) {
     val automation = automationStore.fetchOneById(event.automationId)
-    val facility =
-        facilityStore.fetchById(automation.facilityId)
-            ?: throw FacilityNotFoundException(automation.facilityId)
+    val facility = facilityStore.fetchOneById(automation.facilityId)
     val organizationId =
         parentStore.getOrganizationId(facility.id) ?: throw FacilityNotFoundException(facility.id)
 
@@ -160,8 +152,7 @@ class EmailNotificationService(
         deviceStore.fetchOneById(event.deviceId) ?: throw DeviceNotFoundException(event.deviceId)
     val facilityId =
         device.facilityId ?: throw IllegalStateException("Device ${event.deviceId} has no facility")
-    val facility =
-        facilityStore.fetchById(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val facility = facilityStore.fetchOneById(facilityId)
     val organizationId =
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
@@ -316,5 +317,12 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
       store.updateConnectionState(
           facilityId, FacilityConnectionState.Connected, FacilityConnectionState.Configured)
     }
+  }
+
+  @Test
+  fun `fetchOneById throws exception if no permission to read facility`() {
+    every { user.canReadFacility(facilityId) } returns false
+
+    assertThrows<FacilityNotFoundException> { store.fetchOneById(facilityId) }
   }
 }


### PR DESCRIPTION
Move the exception-throwing logic into the method, and rename it from `fetchById`
to `fetchOneById` for consistency with other store classes.