### PR TITLE
SW-1049 Make OrganizationStore.fetchOneById non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.NotificationType
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
@@ -116,9 +115,7 @@ class AppNotificationService(
   fun on(event: UserAddedToOrganizationEvent) {
     userStore.fetchById(event.addedBy) ?: throw UserNotFoundException(event.addedBy)
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
-    val organization =
-        organizationStore.fetchById(event.organizationId)
-            ?: throw OrganizationNotFoundException(event.organizationId)
+    val organization = organizationStore.fetchOneById(event.organizationId)
 
     val organizationHomeUrl = webAppUrls.organizationHome(event.organizationId)
     val message = messages.userAddedToOrganizationNotification(organization.name)
@@ -142,9 +139,7 @@ class AppNotificationService(
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
     val project =
         projectStore.fetchById(event.projectId) ?: throw ProjectNotFoundException(event.projectId)
-    val organization =
-        organizationStore.fetchById(project.organizationId)
-            ?: throw OrganizationNotFoundException(project.organizationId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
 
     val organizationProjectUrl = webAppUrls.organizationProject(event.projectId)
     val message = messages.userAddedToProjectNotification(project.name)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -19,7 +19,6 @@ import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.SRID
@@ -125,9 +124,7 @@ class AdminController(
 
   @GetMapping("/organization/{organizationId}")
   fun getOrganization(@PathVariable organizationId: OrganizationId, model: Model): String {
-    val organization =
-        organizationStore.fetchById(organizationId)
-            ?: throw OrganizationNotFoundException(organizationId)
+    val organization = organizationStore.fetchOneById(organizationId)
     val projects = projectStore.fetchByOrganization(organizationId).sortedBy { it.name }
     val users = organizationStore.fetchUsers(organizationId).sortedBy { it.email }
 
@@ -167,7 +164,7 @@ class AdminController(
   @GetMapping("/project/{projectId}")
   fun getProject(@PathVariable projectId: ProjectId, model: Model): String {
     val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
-    val organization = organizationStore.fetchById(project.organizationId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
     val orgUsers = organizationStore.fetchUsers(project.organizationId).sortedBy { it.email }
     val projectUsers = orgUsers.filter { projectId in it.projectIds }
     val availableUsers = orgUsers.filter { projectId !in it.projectIds }
@@ -189,7 +186,7 @@ class AdminController(
     val site = siteStore.fetchById(siteId) ?: throw SiteNotFoundException(siteId)
     val projectId = site.projectId
     val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
-    val organization = organizationStore.fetchById(project.organizationId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
     val facilities = facilityStore.fetchBySiteId(siteId).sortedBy { it.name }
 
     model.addAttribute("canCreateFacility", currentUser().canCreateFacility(siteId))
@@ -209,9 +206,7 @@ class AdminController(
     val site = siteStore.fetchById(facility.siteId) ?: throw SiteNotFoundException(facility.siteId)
     val project =
         projectStore.fetchById(site.projectId) ?: throw ProjectNotFoundException(site.projectId)
-    val organization =
-        organizationStore.fetchById(project.organizationId)
-            ?: throw OrganizationNotFoundException(project.organizationId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
     val recipients = projectStore.fetchEmailRecipients(project.id)
     val storageLocations = facilityStore.fetchStorageLocations(facilityId)
     val deviceManager = deviceManagerStore.fetchOneByFacilityId(facilityId)
@@ -704,7 +699,7 @@ class AdminController(
       return organization(organizationId)
     }
 
-    val organization = organizationStore.fetchById(organizationId)
+    val organization = organizationStore.fetchOneById(organizationId)
 
     model.addAttribute("organization", organization)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -79,9 +79,7 @@ class OrganizationsController(
       @Schema(description = "Return this level of information about the organization's contents.")
       depth: OrganizationStore.FetchDepth,
   ): GetOrganizationResponsePayload {
-    val model =
-        organizationStore.fetchById(organizationId, depth)
-            ?: throw OrganizationNotFoundException(organizationId)
+    val model = organizationStore.fetchOneById(organizationId, depth)
     return GetOrganizationResponsePayload(OrganizationPayload(model, getRole(model)))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -167,9 +167,7 @@ class EmailNotificationService(
   fun on(event: UserAddedToOrganizationEvent) {
     val admin = userStore.fetchById(event.addedBy) ?: throw UserNotFoundException(event.addedBy)
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
-    val organization =
-        organizationStore.fetchById(event.organizationId)
-            ?: throw OrganizationNotFoundException(event.organizationId)
+    val organization = organizationStore.fetchOneById(event.organizationId)
 
     val organizationHomeUrl = webAppUrls.fullOrganizationHome(event.organizationId).toString()
 
@@ -185,9 +183,7 @@ class EmailNotificationService(
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
     val project =
         projectStore.fetchById(event.projectId) ?: throw ProjectNotFoundException(event.projectId)
-    val organization =
-        organizationStore.fetchById(project.organizationId)
-            ?: throw OrganizationNotFoundException(project.organizationId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
 
     val organizationProjectUrl =
         webAppUrls.fullOrganizationProject(event.projectId, project.organizationId).toString()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -36,7 +36,6 @@ import org.jooq.Record
 import org.jooq.Table
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -168,24 +167,24 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchById honors fetch depth`() {
     assertEquals(
         organizationModel,
-        store.fetchById(organizationId, OrganizationStore.FetchDepth.Facility),
+        store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Facility),
         "Fetch depth = Facility")
 
     assertEquals(
         organizationModel.copy(
             projects =
                 listOf(projectModel.copy(sites = listOf(siteModel.copy(facilities = null))))),
-        store.fetchById(organizationId, OrganizationStore.FetchDepth.Site),
+        store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Site),
         "Fetch depth = Site")
 
     assertEquals(
         organizationModel.copy(projects = listOf(projectModel.copy(sites = null))),
-        store.fetchById(organizationId, OrganizationStore.FetchDepth.Project),
+        store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Project),
         "Fetch depth = Project")
 
     assertEquals(
         organizationModel.copy(projects = null),
-        store.fetchById(organizationId, OrganizationStore.FetchDepth.Organization),
+        store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Organization),
         "Fetch depth = Organization")
   }
 
@@ -193,7 +192,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchById requires user to be in the organization`() {
     every { user.organizationRoles } returns emptyMap()
 
-    assertNull(store.fetchById(organizationId))
+    assertThrows<OrganizationNotFoundException> { store.fetchOneById(organizationId) }
   }
 
   @Test
@@ -206,7 +205,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
       insertOrganizationUser(userId)
     }
 
-    assertEquals(expectedTotalUsers, store.fetchById(organizationId)!!.totalUsers)
+    assertEquals(expectedTotalUsers, store.fetchOneById(organizationId).totalUsers)
   }
 
   @Test
@@ -222,7 +221,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     val expected = organizationModel.copy(projects = emptyList())
 
-    val actual = store.fetchById(organizationId, OrganizationStore.FetchDepth.Project)
+    val actual = store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Project)
     assertEquals(expected, actual)
   }
 


### PR DESCRIPTION
Move the "throw exception if the organization isn't readable" logic from the call
sites to the fetch method, and rename it from `fetchById` to `fetchOneById` for
consistency with other store classes.