### PR TITLE
SW-1049 Make ProjectStore.fetchOneById non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.NotificationType
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.device.db.DeviceStore
@@ -137,8 +136,7 @@ class AppNotificationService(
   fun on(event: UserAddedToProjectEvent) {
     userStore.fetchById(event.addedBy) ?: throw UserNotFoundException(event.addedBy)
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
-    val project =
-        projectStore.fetchById(event.projectId) ?: throw ProjectNotFoundException(event.projectId)
+    val project = projectStore.fetchOneById(event.projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
 
     val organizationProjectUrl = webAppUrls.organizationProject(event.projectId)

--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.tables.pojos.SitesRow
@@ -50,8 +49,7 @@ class OrganizationService(
       projectIds.forEach { addProjectUser(it) }
     }
 
-    val projects =
-        projectIds.map { projectStore.fetchById(it) ?: throw ProjectNotFoundException(it) }
+    val projects = projectIds.map { projectStore.fetchOneById(it) }
     if (projects.any { it.organizationId != organizationId }) {
       throw IllegalArgumentException("Cannot add user to projects from a different organization")
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/ProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/ProjectService.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.event.UserAddedToProjectEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserId
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
@@ -24,7 +23,7 @@ class ProjectService(
   fun addUser(projectId: ProjectId, userId: UserId) {
     requirePermissions { addProjectUser(projectId) }
 
-    val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
+    val project = projectStore.fetchOneById(projectId)
     val organizationId = project.organizationId
     if (organizationId !in permissionStore.fetchOrganizationRoles(userId)) {
       throw IllegalArgumentException(

--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.ProjectOrganizationWideException
 import com.terraformation.backend.db.ProjectStatus
 import com.terraformation.backend.db.ProjectType
@@ -54,7 +53,7 @@ class ProjectsController(
       @Schema(description = "If true, include the total number of users in the project.")
       totalUsers: Boolean?,
   ): ListProjectsResponsePayload {
-    val projects = projectStore.fetchAll()
+    val projects = projectStore.findAll()
     val userTotals =
         if (totalUsers == true) {
           projectStore.countUsers(projects.map { it.id })
@@ -76,7 +75,7 @@ class ProjectsController(
       @Schema(description = "If true, include the total number of users in the project.")
       totalUsers: Boolean?,
   ): GetProjectResponsePayload {
-    val project = projectStore.fetchById(projectId) ?: throw ProjectNotFoundException(projectId)
+    val project = projectStore.fetchOneById(projectId)
     val count =
         if (totalUsers == true) {
           projectStore.countUsers(projectId)

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.GerminationTestType
 import com.terraformation.backend.db.OrganizationNotFoundException
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.pojos.OrganizationsRow
@@ -181,8 +180,7 @@ class EmailNotificationService(
   fun on(event: UserAddedToProjectEvent) {
     val admin = userStore.fetchById(event.addedBy) ?: throw UserNotFoundException(event.addedBy)
     val user = userStore.fetchById(event.userId) ?: throw UserNotFoundException(event.userId)
-    val project =
-        projectStore.fetchById(event.projectId) ?: throw ProjectNotFoundException(event.projectId)
+    val project = projectStore.fetchOneById(event.projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
 
     val organizationProjectUrl =

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -184,6 +184,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadDevice(any()) } returns true
     every { user.canReadFacility(any()) } returns true
     every { user.canReadOrganization(organizationId) } returns true
+    every { user.canReadProject(projectId) } returns true
     every { user.projectRoles } returns mapOf(projectId to Role.OWNER)
     every { user.organizationRoles } returns mapOf(organizationId to Role.ADMIN)
 


### PR DESCRIPTION
Move the "throw exception if the organization isn't readable" logic from the call
sites to the fetch method, and rename it from `fetchById` to `fetchOneById` for
consistency with other store classes. Also rename `fetchAll` to `findAll` for the
same reason.

This requires adding project-read permission to `AppNotificationServiceTest`, but
the new permission is consistent with the existing ones in that test.