### PR TITLE
SW-1049 Make SiteStore.fetchOneById non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -22,7 +22,6 @@ import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UserId
@@ -182,7 +181,7 @@ class AdminController(
 
   @GetMapping("/site/{siteId}")
   fun getSite(@PathVariable siteId: SiteId, model: Model): String {
-    val site = siteStore.fetchById(siteId) ?: throw SiteNotFoundException(siteId)
+    val site = siteStore.fetchOneById(siteId)
     val projectId = site.projectId
     val project = projectStore.fetchOneById(projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
@@ -202,7 +201,7 @@ class AdminController(
   @GetMapping("/facility/{facilityId}")
   fun getFacility(@PathVariable facilityId: FacilityId, model: Model): String {
     val facility = facilityStore.fetchOneById(facilityId)
-    val site = siteStore.fetchById(facility.siteId) ?: throw SiteNotFoundException(facility.siteId)
+    val site = siteStore.fetchOneById(facility.siteId)
     val project = projectStore.fetchOneById(site.projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
     val recipients = projectStore.fetchEmailRecipients(project.id)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SitesController.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.customer.model.SiteModel
 import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.tables.pojos.SitesRow
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -44,7 +43,7 @@ class SitesController(private val siteStore: SiteStore) {
           defaultValue = "4326")
       srid: Int? = null
   ): ListSitesResponsePayload {
-    val sites = siteStore.fetchAll(srid ?: SRID.LONG_LAT)
+    val sites = siteStore.findAll(srid ?: SRID.LONG_LAT)
 
     return ListSitesResponsePayload(sites.map { SiteElement(it) })
   }
@@ -61,8 +60,7 @@ class SitesController(private val siteStore: SiteStore) {
           defaultValue = "4326")
       srid: Int? = null
   ): GetSiteResponsePayload {
-    val site =
-        siteStore.fetchById(siteId, srid ?: SRID.LONG_LAT) ?: throw SiteNotFoundException(siteId)
+    val site = siteStore.fetchOneById(siteId, srid ?: SRID.LONG_LAT)
 
     return GetSiteResponsePayload(SiteElement(site))
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/SiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/SiteStore.kt
@@ -25,12 +25,11 @@ class SiteStore(
     private val parentStore: ParentStore,
     private val sitesDao: SitesDao
 ) {
-  fun fetchById(siteId: SiteId, srid: Int = SRID.LONG_LAT): SiteModel? {
-    return if (currentUser().canReadSite(siteId)) {
-      return fetchModelsWhere(srid, SITES.ID.eq(siteId)).firstOrNull()
-    } else {
-      null
-    }
+  fun fetchOneById(siteId: SiteId, srid: Int = SRID.LONG_LAT): SiteModel {
+    requirePermissions { readSite(siteId) }
+
+    return fetchModelsWhere(srid, SITES.ID.eq(siteId)).firstOrNull()
+        ?: throw SiteNotFoundException(siteId)
   }
 
   fun fetchByProjectId(projectId: ProjectId, srid: Int = SRID.LONG_LAT): List<SiteModel> {
@@ -42,7 +41,7 @@ class SiteStore(
   }
 
   /** Returns all the sites the user has access to. */
-  fun fetchAll(srid: Int = SRID.LONG_LAT): List<SiteModel> {
+  fun findAll(srid: Int = SRID.LONG_LAT): List<SiteModel> {
     val user = currentUser()
     val listableProjects = user.projectRoles.keys.filter { user.canListSites(it) }
 


### PR DESCRIPTION
Move the "throw exception if the organization isn't readable" logic from the call
sites to the fetch method, and rename it from `fetchById` to `fetchOneById` for
consistency with other store classes. Also rename `fetchAll` to `findAll` for the
same reason.