### PR TITLE
Improve performance of /api/v1/species/lookup/details

### DIFF
--- a/src/main/resources/db/migration/V100__GbifNamesName.sql
+++ b/src/main/resources/db/migration/V100__GbifNamesName.sql
@@ -1,3 +1,4 @@
 -- The trigram index on gbif_names.name can be used for exact lookups, but only on PostgreSQL 14
--- and higher, and even there, it is significantly slower than a B-tree index.
+-- and higher, and even there, it is significantly slower than a B-tree index. Create a B-tree index
+-- to cover exact-name queries.
 CREATE INDEX ON gbif_names (name, is_scientific);


### PR DESCRIPTION
This endpoint does an exact name lookup on a species to get additional information
about it from the GBIF database, e.g., its family name and common names.

On PostgreSQL 14 and higher, it uses the trigram index on `gbif_names.name`. But
using trigram indexes for exact lookups isn't supported on PostgreSQL 13, which we
are running in prod/staging. So the endpoint has to fall back to a full scan of
`gbif_names`. That scan isn't disastrously slow, but it's noticeably slower than
an index lookup.

Add a B-tree index to support exact lookups on earlier PostgreSQL versions.

Even after we upgrade the prod/staging databases, we'll probably still want to
keep this index since trigram index lookups are slower than B-tree lookups for
exact values.