### PR TITLE
SW-1161 Restore the Manager role

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -243,7 +243,7 @@ data class IndividualUser(
 
   override fun canAddProjectUser(projectId: ProjectId): Boolean {
     val role = projectRoles[projectId]
-    return role == Role.ADMIN || role == Role.OWNER
+    return role == Role.MANAGER || role == Role.ADMIN || role == Role.OWNER
   }
 
   override fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean {
@@ -252,7 +252,7 @@ data class IndividualUser(
 
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean {
     val role = organizationRoles[organizationId]
-    return role == Role.ADMIN || role == Role.OWNER
+    return role == Role.MANAGER || role == Role.ADMIN || role == Role.OWNER
   }
 
   override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean {
@@ -310,7 +310,8 @@ data class IndividualUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean {
     return when (organizationRoles[organizationId]) {
       Role.OWNER,
-      Role.ADMIN -> true
+      Role.ADMIN,
+      Role.MANAGER -> true
       else -> false
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/Role.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/Role.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonValue
  */
 enum class Role(val id: Int, @get:JsonValue val displayName: String) {
   CONTRIBUTOR(1, "Contributor"),
+  MANAGER(2, "Manager"),
   ADMIN(3, "Admin"),
   OWNER(4, "Owner");
 

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -84,6 +84,7 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO roles (id, name)
 VALUES (1, 'Contributor'),
+       (2, 'Manager'),
        (3, 'Admin'),
        (4, 'Owner')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -587,6 +587,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         mapOf(
             Role.ADMIN to 0,
+            Role.MANAGER to 0,
             Role.CONTRIBUTOR to 1,
             Role.OWNER to 2,
         )

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -28,7 +28,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchFacilityRoles only includes non-organization-wide projects the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(FacilityId(1000) to Role.CONTRIBUTOR, FacilityId(1001) to Role.CONTRIBUTOR),
+        mapOf(FacilityId(1000) to Role.MANAGER, FacilityId(1001) to Role.MANAGER),
         permissionStore.fetchFacilityRoles(UserId(5)))
   }
 
@@ -39,9 +39,9 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         mapOf(
-            FacilityId(1000) to Role.CONTRIBUTOR,
-            FacilityId(1001) to Role.CONTRIBUTOR,
-            FacilityId(1100) to Role.CONTRIBUTOR),
+            FacilityId(1000) to Role.MANAGER,
+            FacilityId(1001) to Role.MANAGER,
+            FacilityId(1100) to Role.MANAGER),
         permissionStore.fetchFacilityRoles(UserId(5)))
   }
 
@@ -53,7 +53,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
             FacilityId(1000) to Role.CONTRIBUTOR,
             FacilityId(1001) to Role.CONTRIBUTOR,
             FacilityId(1100) to Role.CONTRIBUTOR,
-            FacilityId(2000) to Role.CONTRIBUTOR),
+            FacilityId(2000) to Role.MANAGER),
         permissionStore.fetchFacilityRoles(UserId(7)))
   }
 
@@ -68,15 +68,14 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchOrganizationRoles includes all organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(OrganizationId(1) to Role.CONTRIBUTOR, OrganizationId(2) to Role.CONTRIBUTOR),
+        mapOf(OrganizationId(1) to Role.CONTRIBUTOR, OrganizationId(2) to Role.MANAGER),
         permissionStore.fetchOrganizationRoles(UserId(7)))
   }
 
   @Test
   fun `fetchProjectRoles only includes organization-wide projects the user is in`() {
     insertTestData()
-    assertEquals(
-        mapOf(ProjectId(10) to Role.CONTRIBUTOR), permissionStore.fetchProjectRoles(UserId(5)))
+    assertEquals(mapOf(ProjectId(10) to Role.MANAGER), permissionStore.fetchProjectRoles(UserId(5)))
   }
 
   @Test
@@ -88,7 +87,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
         projectsDao.fetchOneById(organizationWideProjectId)!!.copy(organizationWide = true))
 
     assertEquals(
-        mapOf(ProjectId(10) to Role.CONTRIBUTOR, organizationWideProjectId to Role.CONTRIBUTOR),
+        mapOf(ProjectId(10) to Role.MANAGER, organizationWideProjectId to Role.MANAGER),
         permissionStore.fetchProjectRoles(UserId(5)))
   }
 
@@ -99,7 +98,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
         mapOf(
             ProjectId(10) to Role.CONTRIBUTOR,
             ProjectId(11) to Role.CONTRIBUTOR,
-            ProjectId(20) to Role.CONTRIBUTOR),
+            ProjectId(20) to Role.MANAGER),
         permissionStore.fetchProjectRoles(UserId(7)))
   }
 
@@ -107,7 +106,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchSiteRoles only includes sites from non-organization-wide projects the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(SiteId(100) to Role.CONTRIBUTOR, SiteId(101) to Role.CONTRIBUTOR),
+        mapOf(SiteId(100) to Role.MANAGER, SiteId(101) to Role.MANAGER),
         permissionStore.fetchSiteRoles(UserId(5)))
   }
 
@@ -118,9 +117,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         mapOf(
-            SiteId(100) to Role.CONTRIBUTOR,
-            SiteId(101) to Role.CONTRIBUTOR,
-            SiteId(110) to Role.CONTRIBUTOR),
+            SiteId(100) to Role.MANAGER, SiteId(101) to Role.MANAGER, SiteId(110) to Role.MANAGER),
         permissionStore.fetchSiteRoles(UserId(5)))
   }
 
@@ -132,7 +129,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
             SiteId(100) to Role.CONTRIBUTOR,
             SiteId(101) to Role.CONTRIBUTOR,
             SiteId(110) to Role.CONTRIBUTOR,
-            SiteId(200) to Role.CONTRIBUTOR),
+            SiteId(200) to Role.MANAGER),
         permissionStore.fetchSiteRoles(UserId(7)))
   }
 
@@ -155,7 +152,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
    *       - Facility 2000
    *
    * - User 5
-   *   - Org 1 role: contributor
+   *   - Org 1 role: manager
    *     - Member of project 10
    * - User 6
    *   - Org 2 role: owner
@@ -163,7 +160,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
    *   - Org 1 role: contributor
    *     - Member of project 10
    *     - Member of project 11
-   *   - Org 2 role: contributor
+   *   - Org 2 role: manager
    *     - Member of project 20
    * ```
    */
@@ -211,9 +208,9 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
       }
     }
 
-    configureUser(5, mapOf(1 to Role.CONTRIBUTOR), listOf(10))
+    configureUser(5, mapOf(1 to Role.MANAGER), listOf(10))
     configureUser(6, mapOf(2 to Role.OWNER), emptyList())
-    configureUser(7, mapOf(1 to Role.CONTRIBUTOR, 2 to Role.CONTRIBUTOR), listOf(10, 11, 20))
+    configureUser(7, mapOf(1 to Role.CONTRIBUTOR, 2 to Role.MANAGER), listOf(10, 11, 20))
   }
 
   private fun configureUser(userId: Long, roles: Map<Int, Role>, projects: List<Int>) {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -443,6 +443,89 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
+  fun `managers can add users to their project, access all data associated with their project`() {
+    givenRole(org1Id, Role.MANAGER, project10Id)
+
+    val permissions = PermissionsTracker()
+
+    permissions.expect(
+        org1Id,
+        listProjects = true,
+        readOrganization = true,
+        listOrganizationUsers = true,
+        removeOrganizationSelf = true,
+        createSpecies = true,
+    )
+
+    permissions.expect(
+        project10Id,
+        readProject = true,
+        addProjectUser = true,
+        listSites = true,
+        removeProjectUser = true,
+        removeProjectSelf = true,
+    )
+
+    permissions.expect(
+        *siteIds.forProject10(),
+        listFacilities = true,
+        readSite = true,
+    )
+
+    permissions.expect(
+        *facilityIds.forProject10(),
+        createAccession = true,
+        createAutomation = true,
+        createDevice = true,
+        listAutomations = true,
+        sendAlert = true,
+    )
+
+    permissions.expect(
+        *accessionIds.forProject10(),
+        readAccession = true,
+        updateAccession = true,
+    )
+
+    permissions.expect(
+        *automationIds.forProject10(),
+        readAutomation = true,
+        updateAutomation = true,
+        deleteAutomation = true,
+        triggerAutomation = true,
+    )
+
+    permissions.expect(
+        *deviceManagerIds.forProject10(),
+        *nonConnectedDeviceManagerIds,
+        readDeviceManager = true,
+    )
+
+    permissions.expect(
+        *deviceIds.forProject10(),
+        createTimeseries = true,
+        readTimeseries = true,
+        updateTimeseries = true,
+        readDevice = true,
+        updateDevice = true,
+    )
+
+    permissions.expect(
+        *speciesIds.forOrg1(),
+        readSpecies = true,
+        updateSpecies = true,
+        deleteSpecies = true,
+    )
+
+    permissions.expect(
+        *storageLocationIds.forProject10(),
+        readStorageLocation = true,
+    )
+
+    permissions.andNothingElse()
+  }
+
+  @Test
   fun `contributors have access to data associated with their project(s)`() {
     givenRole(org1Id, Role.CONTRIBUTOR, project10Id)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -107,13 +107,13 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     searchService = SearchService(dslContext)
     accessionSearchService = AccessionSearchService(tables, searchService)
 
-    every { user.organizationRoles } returns mapOf(organizationId to Role.CONTRIBUTOR)
-    every { user.projectRoles } returns mapOf(projectId to Role.CONTRIBUTOR)
-    every { user.facilityRoles } returns mapOf(facilityId to Role.CONTRIBUTOR)
+    every { user.organizationRoles } returns mapOf(organizationId to Role.MANAGER)
+    every { user.projectRoles } returns mapOf(projectId to Role.MANAGER)
+    every { user.facilityRoles } returns mapOf(facilityId to Role.MANAGER)
 
     insertSiteData()
 
-    insertOrganizationUser()
+    insertOrganizationUser(role = Role.MANAGER)
     insertProjectUser()
 
     val now = Instant.now()
@@ -1230,7 +1230,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `includes values from accessions at multiple facilities`() {
       every { user.facilityRoles } returns
-          mapOf(facilityId to Role.CONTRIBUTOR, FacilityId(1100) to Role.CONTRIBUTOR)
+          mapOf(facilityId to Role.MANAGER, FacilityId(1100) to Role.CONTRIBUTOR)
 
       insertProject(11)
       insertSite(110)
@@ -1614,7 +1614,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `search only includes results from requested facility`() {
     every { user.facilityRoles } returns
-        mapOf(facilityId to Role.CONTRIBUTOR, FacilityId(1100) to Role.CONTRIBUTOR)
+        mapOf(facilityId to Role.MANAGER, FacilityId(1100) to Role.CONTRIBUTOR)
 
     insertProject(11)
     insertSite(110)
@@ -1701,7 +1701,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "members" to
                           listOf(
                               mapOf(
-                                  "roleName" to "Contributor",
+                                  "roleName" to "Manager",
                                   "user" to
                                       mapOf(
                                           "id" to "${user.userId}",
@@ -2745,7 +2745,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                                   mapOf(
                                       "createdTime" to "1970-01-01T00:00:00Z",
                                   )),
-                          "roleName" to "Contributor",
+                          "roleName" to "Manager",
                       )),
               "projectMemberships" to
                   listOf(
@@ -2776,7 +2776,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                           mapOf(
                               "createdTime" to "1970-01-01T00:00:00Z",
                           )),
-                  "roleName" to "Contributor",
+                  "roleName" to "Manager",
                   "user" to expectedUser,
               ))
 


### PR DESCRIPTION
This reverts commit 4c7c7e448, with edits to reflect other code changes that have
happened in the meantime.

Permissions for contributors and admins are unchanged here. Managers have the same
permissions as contributors, but can also edit species data and add/remove users
from projects.