### PR TITLE
Add organization ID to facilities table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
+import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.log.perClassLogger
 import io.swagger.v3.oas.annotations.Operation
@@ -309,8 +310,9 @@ data class FacilityPayload(
     val createdTime: Instant,
     val description: String?,
     val id: FacilityId,
-    val siteId: SiteId,
     val name: String,
+    val organizationId: OrganizationId,
+    val siteId: SiteId,
     val type: FacilityType,
 ) {
   constructor(
@@ -320,8 +322,9 @@ data class FacilityPayload(
       model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       model.description,
       model.id,
-      model.siteId,
       model.name,
+      model.organizationId,
+      model.siteId,
       model.type)
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -69,6 +69,9 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(projectId: ProjectId): OrganizationId? =
       fetchFieldById(projectId, PROJECTS.ID, PROJECTS.ORGANIZATION_ID)
 
+  fun getOrganizationId(siteId: SiteId): OrganizationId? =
+      fetchFieldById(siteId, SITES.ID, SITES.projects().ORGANIZATION_ID)
+
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.sites().projects().ORGANIZATION_ID)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.DeviceTemplateCategory
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityType
+import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.tables.references.FACILITIES
@@ -17,6 +18,7 @@ data class FacilityModel(
     val id: FacilityId,
     val modifiedTime: Instant,
     val name: String,
+    val organizationId: OrganizationId,
     val siteId: SiteId,
     val type: FacilityType,
     val lastTimeseriesTime: Instant?,
@@ -33,6 +35,8 @@ data class FacilityModel(
       record[FACILITIES.MODIFIED_TIME]
           ?: throw IllegalArgumentException("Modified time is required"),
       record[FACILITIES.NAME] ?: throw IllegalArgumentException("Name is required"),
+      record[FACILITIES.ORGANIZATION_ID]
+          ?: throw IllegalArgumentException("Organization is required"),
       record[FACILITIES.SITE_ID] ?: throw IllegalArgumentException("Site is required"),
       record[FACILITIES.TYPE_ID] ?: throw IllegalArgumentException("Type is required"),
       record[FACILITIES.LAST_TIMESERIES_TIME],
@@ -61,6 +65,7 @@ fun FacilitiesRow.toModel(): FacilityModel {
       id ?: throw IllegalArgumentException("ID is required"),
       modifiedTime ?: throw IllegalArgumentException("Modified time is required"),
       name ?: throw IllegalArgumentException("Name is required"),
+      organizationId ?: throw IllegalArgumentException("Organization is required"),
       siteId ?: throw IllegalArgumentException("Site is required"),
       typeId ?: throw IllegalArgumentException("Type is required"),
       lastTimeseriesTime,

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
+import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.search.FacilityIdScope
@@ -24,6 +25,8 @@ class FacilitiesTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           accessions.asMultiValueSublist("accessions", FACILITIES.ID.eq(ACCESSIONS.FACILITY_ID)),
+          organizations.asSingleValueSublist(
+              "organization", FACILITIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           sites.asSingleValueSublist("site", FACILITIES.SITE_ID.eq(SITES.ID)),
           storageLocations.asMultiValueSublist(
               "storageLocations", FACILITIES.ID.eq(STORAGE_LOCATIONS.FACILITY_ID)),

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
+import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.PROJECTS
@@ -28,6 +29,8 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
               "countrySubdivision",
               ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE),
               isRequired = false),
+          facilities.asMultiValueSublist(
+              "facilities", ORGANIZATIONS.ID.eq(FACILITIES.ORGANIZATION_ID)),
           projects.asMultiValueSublist("projects", ORGANIZATIONS.ID.eq(PROJECTS.ORGANIZATION_ID)),
           organizationUsers.asMultiValueSublist(
               "members", ORGANIZATIONS.ID.eq(ORGANIZATION_USERS.ORGANIZATION_ID)),

--- a/src/main/resources/db/migration/V102__FacilityOrganization.sql
+++ b/src/main/resources/db/migration/V102__FacilityOrganization.sql
@@ -1,0 +1,13 @@
+ALTER TABLE facilities ADD COLUMN organization_id BIGINT REFERENCES organizations;
+UPDATE facilities
+SET organization_id = (
+    SELECT organization_id
+    FROM sites
+    JOIN projects ON sites.project_id = projects.id
+    WHERE facilities.site_id = sites.id
+)
+WHERE organization_id IS NULL;
+
+ALTER TABLE facilities ALTER COLUMN organization_id SET NOT NULL;
+
+CREATE INDEX ON facilities (organization_id);

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -115,7 +115,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         )
     automationStore = AutomationStore(automationsDao, clock, dslContext, objectMapper, parentStore)
     deviceStore = DeviceStore(devicesDao)
-    facilityStore = FacilityStore(clock, dslContext, facilitiesDao, storageLocationsDao)
+    facilityStore =
+        FacilityStore(clock, dslContext, facilitiesDao, parentStore, storageLocationsDao)
     userStore =
         UserStore(
             clock,

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -75,9 +75,10 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     every { realmResource.users() } returns mockk()
 
-    facilityStore = FacilityStore(clock, dslContext, facilitiesDao, storageLocationsDao)
-    organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
     parentStore = ParentStore(dslContext)
+    facilityStore =
+        FacilityStore(clock, dslContext, facilitiesDao, parentStore, storageLocationsDao)
+    organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
     projectStore = ProjectStore(clock, dslContext, projectsDao, projectTypeSelectionsDao)
     siteStore = SiteStore(clock, dslContext, parentStore, sitesDao)
     userStore =

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -65,6 +65,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           maxIdleMinutes = 30,
           modifiedTime = Instant.EPOCH,
           name = "Facility $facilityId",
+          organizationId = organizationId,
           siteId = siteId,
           type = FacilityType.SeedBank)
   private val siteModel =

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -333,6 +333,7 @@ abstract class DatabaseTest {
   protected fun insertFacility(
       id: Any = this.facilityId,
       siteId: Any = this.siteId,
+      organizationId: Any = this.organizationId,
       name: String = "Facility $id",
       description: String? = "Description $id",
       createdBy: UserId = currentUser().userId,
@@ -357,6 +358,7 @@ abstract class DatabaseTest {
           .set(MODIFIED_BY, createdBy)
           .set(MODIFIED_TIME, Instant.EPOCH)
           .set(NAME, name)
+          .set(ORGANIZATION_ID, organizationId.toIdWrapper { OrganizationId(it) })
           .set(SITE_ID, siteId.toIdWrapper { SiteId(it) })
           .set(TYPE_ID, type)
           .execute()

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -44,14 +44,15 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
   private val clock: Clock = mockk()
   private val eventPublisher: ApplicationEventPublisher = mockk()
   private val objectMapper = jacksonObjectMapper()
+  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val service: DeviceService by lazy {
     DeviceService(
-        AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext)),
+        AutomationStore(automationsDao, clock, dslContext, objectMapper, parentStore),
         DeviceStore(devicesDao),
         deviceTemplatesDao,
         dslContext,
         eventPublisher,
-        FacilityStore(clock, dslContext, facilitiesDao, storageLocationsDao),
+        FacilityStore(clock, dslContext, facilitiesDao, parentStore, storageLocationsDao),
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -120,6 +120,7 @@ internal class EmailNotificationServiceTest {
           description = null,
           id = FacilityId(123),
           modifiedTime = Instant.EPOCH,
+          organizationId = organization.id,
           siteId = SiteId(1),
           name = "Test Facility",
           type = FacilityType.SeedBank,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2784,6 +2784,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           listOf(
               mapOf(
                   "createdTime" to "1970-01-01T00:00:00Z",
+                  "facilities" to expectedFacilities,
                   "id" to "1",
                   "name" to "Organization 1",
                   "projects" to expectedProjects,


### PR DESCRIPTION
In preparation for moving away from projects and sites, update the data model to
link facilities to their organizations.

This does not change the existing structure with facilities living under sites;
it is purely additive. There are a couple client-visible changes:

* The facility details payload now includes an organization ID in addition to a
  site ID.
* The search API allows navigating from organizations directly to facilities and
  back, without having to go through projects and sites. But going through
  projects and sites continues to work.

Down the road, we'll remove the site ID from facilities, but that'll be a breaking
change.