### PR TITLE
SW-1183 Add facilities to organization payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -321,6 +321,8 @@ data class OrganizationPayload(
     val countrySubdivisionCode: String?,
     val createdTime: Instant,
     val description: String?,
+    @Schema(description = "This organization's facilities. Only included if depth is \"Facility\".")
+    val facilities: List<FacilityPayload>?,
     val id: OrganizationId,
     val name: String,
     @Schema(description = "This organization's projects. Omitted if depth is \"Organization\".")
@@ -341,6 +343,7 @@ data class OrganizationPayload(
       model.countrySubdivisionCode,
       model.createdTime.truncatedTo(ChronoUnit.SECONDS),
       model.description,
+      model.facilities?.map { FacilityPayload(it) },
       model.id,
       model.name,
       model.projects?.map { ProjectPayload(it) },

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
@@ -16,11 +16,13 @@ data class OrganizationModel(
     val countrySubdivisionCode: String? = null,
     val createdTime: Instant,
     val disabledTime: Instant? = null,
+    val facilities: List<FacilityModel>? = null,
     val projects: List<ProjectModel>? = null,
     val totalUsers: Int,
 ) {
   constructor(
       record: Record,
+      facilitiesMultiset: Field<List<FacilityModel>>?,
       projectsMultiset: Field<List<ProjectModel>?>,
       totalUsersSubquery: Field<Int>,
   ) : this(
@@ -30,6 +32,7 @@ data class OrganizationModel(
               ?: throw IllegalArgumentException("Created time is required"),
       description = record[ORGANIZATIONS.DESCRIPTION],
       disabledTime = record[ORGANIZATIONS.DISABLED_TIME],
+      facilities = record[facilitiesMultiset],
       id = record[ORGANIZATIONS.ID] ?: throw IllegalArgumentException("ID is required"),
       name = record[ORGANIZATIONS.NAME] ?: throw IllegalArgumentException("Name is required"),
       projects = record[projectsMultiset],


### PR DESCRIPTION
In preparation for removing projects and sites from our data model, add a
`facilities` field to the response payloads of `/api/v1/organizations` and
`/api/v1/organizations/{id}` that contains a list of all the facilities the
user has access to. It is populated if the `depth` query parameter is set to
`Facility`.

The facilities continue to also be included under sites so as not to break
existing clients.