### PR TITLE
SW-1195 Remove per-project permissions

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -25,10 +25,13 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchFacilityRoles only includes non-organization-wide projects the user is in`() {
+  fun `fetchFacilityRoles includes facilities in all projects in organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(FacilityId(1000) to Role.MANAGER, FacilityId(1001) to Role.MANAGER),
+        mapOf(
+            FacilityId(1000) to Role.MANAGER,
+            FacilityId(1001) to Role.MANAGER,
+            FacilityId(1100) to Role.MANAGER),
         permissionStore.fetchFacilityRoles(UserId(5)))
   }
 
@@ -73,9 +76,11 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchProjectRoles only includes organization-wide projects the user is in`() {
+  fun `fetchProjectRoles includes all projects in the organizations the user is in`() {
     insertTestData()
-    assertEquals(mapOf(ProjectId(10) to Role.MANAGER), permissionStore.fetchProjectRoles(UserId(5)))
+    assertEquals(
+        mapOf(ProjectId(10) to Role.MANAGER, ProjectId(11) to Role.MANAGER),
+        permissionStore.fetchProjectRoles(UserId(5)))
   }
 
   @Test
@@ -103,10 +108,11 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchSiteRoles only includes sites from non-organization-wide projects the user is in`() {
+  fun `fetchSiteRoles includes all sites from organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(SiteId(100) to Role.MANAGER, SiteId(101) to Role.MANAGER),
+        mapOf(
+            SiteId(100) to Role.MANAGER, SiteId(101) to Role.MANAGER, SiteId(110) to Role.MANAGER),
         permissionStore.fetchSiteRoles(UserId(5)))
   }
 
@@ -203,7 +209,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
         sites.forEach { (siteId, facilities) ->
           insertSite(siteId, projectId)
 
-          facilities.forEach { facilityId -> insertFacility(facilityId, siteId) }
+          facilities.forEach { facilityId -> insertFacility(facilityId, siteId, organizationId) }
         }
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -145,7 +145,6 @@ internal class PermissionTest : DatabaseTest() {
   private inline fun <reified T> List<T>.filterStartsWith(prefix: String): Array<T> =
       filter { "$it".startsWith(prefix) }.toTypedArray()
   private inline fun <reified T> List<T>.forOrg1() = filterStartsWith("1")
-  private inline fun <reified T> List<T>.forProject10() = filterStartsWith("10")
 
   @BeforeEach
   fun setUp() {
@@ -175,7 +174,7 @@ internal class PermissionTest : DatabaseTest() {
     siteIds.forEach { insertSite(it, it.value / 10, createdBy = userId) }
 
     facilityIds.forEach { facilityId ->
-      insertFacility(facilityId, facilityId.value / 10, createdBy = userId)
+      insertFacility(facilityId, facilityId.value / 10, facilityId.value / 1000, createdBy = userId)
       insertDevice(facilityId.value, facilityId, createdBy = userId)
       insertAutomation(facilityId.value, facilityId, createdBy = userId)
       accessionsDao.insert(
@@ -443,7 +442,7 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
-  fun `managers can add users to their project, access all data associated with their project`() {
+  fun `managers can add users to projects and access all data in their organizations`() {
     givenRole(org1Id, Role.MANAGER, project10Id)
 
     val permissions = PermissionsTracker()
@@ -458,7 +457,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        project10Id,
+        *projectIds.forOrg1(),
         readProject = true,
         addProjectUser = true,
         listSites = true,
@@ -467,13 +466,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *siteIds.forProject10(),
+        *siteIds.forOrg1(),
         listFacilities = true,
         readSite = true,
     )
 
     permissions.expect(
-        *facilityIds.forProject10(),
+        *facilityIds.forOrg1(),
         createAccession = true,
         createAutomation = true,
         createDevice = true,
@@ -482,13 +481,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *accessionIds.forProject10(),
+        *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
     )
 
     permissions.expect(
-        *automationIds.forProject10(),
+        *automationIds.forOrg1(),
         readAutomation = true,
         updateAutomation = true,
         deleteAutomation = true,
@@ -496,13 +495,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *deviceManagerIds.forProject10(),
+        *deviceManagerIds.forOrg1(),
         *nonConnectedDeviceManagerIds,
         readDeviceManager = true,
     )
 
     permissions.expect(
-        *deviceIds.forProject10(),
+        *deviceIds.forOrg1(),
         createTimeseries = true,
         readTimeseries = true,
         updateTimeseries = true,
@@ -518,7 +517,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *storageLocationIds.forProject10(),
+        *storageLocationIds.forOrg1(),
         readStorageLocation = true,
     )
 
@@ -526,7 +525,7 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
-  fun `contributors have access to data associated with their project(s)`() {
+  fun `contributors have access to data associated with their organizations`() {
     givenRole(org1Id, Role.CONTRIBUTOR, project10Id)
 
     val permissions = PermissionsTracker()
@@ -539,20 +538,20 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        project10Id,
+        *projectIds.forOrg1(),
         readProject = true,
         listSites = true,
         removeProjectSelf = true,
     )
 
     permissions.expect(
-        *siteIds.forProject10(),
+        *siteIds.forOrg1(),
         listFacilities = true,
         readSite = true,
     )
 
     permissions.expect(
-        *facilityIds.forProject10(),
+        *facilityIds.forOrg1(),
         createAccession = true,
         createAutomation = true,
         createDevice = true,
@@ -561,13 +560,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *accessionIds.forProject10(),
+        *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
     )
 
     permissions.expect(
-        *automationIds.forProject10(),
+        *automationIds.forOrg1(),
         readAutomation = true,
         updateAutomation = true,
         deleteAutomation = true,
@@ -575,13 +574,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *deviceManagerIds.forProject10(),
+        *deviceManagerIds.forOrg1(),
         *nonConnectedDeviceManagerIds,
         readDeviceManager = true,
     )
 
     permissions.expect(
-        *deviceIds.forProject10(),
+        *deviceIds.forOrg1(),
         createTimeseries = true,
         readTimeseries = true,
         updateTimeseries = true,
@@ -595,7 +594,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *storageLocationIds.forProject10(),
+        *storageLocationIds.forOrg1(),
         readStorageLocation = true,
     )
 


### PR DESCRIPTION
Stop paying attention to project membership when determining which permissions a
user has; instead pay attention only to organization roles.

Effectively, this makes all projects act as if they were organization-wide for
purposes of permissions. It doesn't affect notification recipients, which are
still based on project membership.

For organizations that only have seed banks (which go under an organization-wide
project) this change won't cause any behavior differences.