### PR TITLE
SW-1198 Send notifications to all organization members

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -262,10 +262,9 @@ class AppNotificationService(
       message: NotificationMessage,
       localUrl: URI
   ) {
-    val projectId = parentStore.getProjectId(facilityId)!!
-    val organizationId = parentStore.getOrganizationId(projectId)!!
+    val organizationId = parentStore.getOrganizationId(facilityId)!!
     val recipients =
-        projectStore.fetchEmailRecipients(projectId, false).mapNotNull {
+        organizationStore.fetchEmailRecipients(organizationId, false).mapNotNull {
           userStore.fetchByEmail(it)
         }
     dslContext.transaction { _ ->

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -203,7 +203,7 @@ class AdminController(
     val site = siteStore.fetchOneById(facility.siteId)
     val project = projectStore.fetchOneById(site.projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
-    val recipients = projectStore.fetchEmailRecipients(project.id)
+    val recipients = organizationStore.fetchEmailRecipients(project.organizationId)
     val storageLocations = facilityStore.fetchStorageLocations(facilityId)
     val deviceManager = deviceManagerStore.fetchOneByFacilityId(facilityId)
     val devices = deviceStore.fetchByFacilityId(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.ProjectType
 import com.terraformation.backend.db.UserAlreadyInProjectException
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserNotFoundException
-import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.daos.ProjectTypeSelectionsDao
 import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.db.tables.pojos.ProjectTypeSelectionsRow
@@ -23,7 +22,6 @@ import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.PROJECTS
 import com.terraformation.backend.db.tables.references.PROJECT_TYPE_SELECTIONS
 import com.terraformation.backend.db.tables.references.PROJECT_USERS
-import com.terraformation.backend.db.tables.references.USERS
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
 import java.time.LocalDate
@@ -285,30 +283,5 @@ class ProjectStore(
    */
   fun countUsers(projectId: ProjectId): Int {
     return countUsers(listOf(projectId))[projectId] ?: 0
-  }
-
-  fun fetchEmailRecipients(projectId: ProjectId, requireOptIn: Boolean = true): List<String> {
-    val optedInCondition =
-        if (requireOptIn) USERS.EMAIL_NOTIFICATIONS_ENABLED.isTrue else DSL.trueCondition()
-
-    return dslContext
-        .select(USERS.EMAIL)
-        .from(USERS)
-        .join(ORGANIZATION_USERS)
-        .on(USERS.ID.eq(ORGANIZATION_USERS.USER_ID))
-        .join(PROJECTS)
-        .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
-        .leftJoin(PROJECT_USERS)
-        .on(USERS.ID.eq(PROJECT_USERS.USER_ID))
-        .and(PROJECTS.ID.eq(PROJECT_USERS.PROJECT_ID))
-        .where(PROJECTS.ID.eq(projectId))
-        .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin))
-        .and(
-            PROJECTS.ORGANIZATION_WIDE.isTrue
-                .or(ORGANIZATION_USERS.ROLE_ID.`in`(Role.OWNER.id, Role.ADMIN.id))
-                .or(PROJECT_USERS.USER_ID.isNotNull))
-        .and(optedInCondition)
-        .fetch(USERS.EMAIL)
-        .filterNotNull()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -338,9 +338,11 @@ class EmailNotificationService(
   }
 
   private fun getRecipients(facilityId: FacilityId): List<IndividualUser> {
-    val projectId =
-        parentStore.getProjectId(facilityId) ?: throw FacilityNotFoundException(facilityId)
-    return projectStore.fetchEmailRecipients(projectId).mapNotNull { userStore.fetchByEmail(it) }
+    val organizationId =
+        parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    return organizationStore.fetchEmailRecipients(organizationId).mapNotNull {
+      userStore.fetchByEmail(it)
+    }
   }
 
   data class EmailRequest(val user: IndividualUser, val emailTemplateModel: EmailTemplateModel)

--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.email.model.EmailTemplateModel
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.processToString
@@ -55,29 +54,10 @@ class EmailService(
       model: EmailTemplateModel,
       requireOptIn: Boolean = true
   ) {
-    val projectId =
-        parentStore.getProjectId(facilityId) ?: throw FacilityNotFoundException(facilityId)
+    val organizationId =
+        parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
 
-    sendProjectNotification(projectId, model, requireOptIn)
-  }
-
-  /**
-   * Sends an email notification to all the people who should be notified about something happening
-   * to a particular project.
-   *
-   * @param [model] Model object containing values that can be referenced by the template.
-   * @param [requireOptIn] If false, send the notification to all eligible users, even if they have
-   * opted out of email notifications. The default is to obey the user's notification preference,
-   * which is the correct thing to do in the vast majority of cases.
-   */
-  private fun sendProjectNotification(
-      projectId: ProjectId,
-      model: EmailTemplateModel,
-      requireOptIn: Boolean = true
-  ) {
-    val recipients = projectStore.fetchEmailRecipients(projectId, requireOptIn)
-
-    send(model, recipients)
+    sendOrganizationNotification(organizationId, model, requireOptIn)
   }
 
   /**
@@ -89,8 +69,7 @@ class EmailService(
    * opted out of email notifications. The default is to obey the user's notification preference,
    * which is the correct thing to do in the vast majority of cases.
    */
-  @Suppress("UNUSED")
-  fun sendOrganizationNotification(
+  private fun sendOrganizationNotification(
       organizationId: OrganizationId,
       model: EmailTemplateModel,
       requireOptIn: Boolean = true,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -200,33 +200,4 @@ internal class ProjectStoreTest : DatabaseTest(), RunsAsUser {
       store.countUsers(listOf(projectId))
     }
   }
-
-  @Test
-  fun `fetchEmailRecipients only returns opted-in project members and opted-in admins`() {
-    val optedInAdmin = UserId(100)
-    val optedOutAdmin = UserId(101)
-    val optedInNonMember = UserId(102)
-    val optedInMember = UserId(103)
-    val optedOutMember = UserId(104)
-
-    insertUser(optedInAdmin, email = "optedInAdmin@x.com", emailNotificationsEnabled = true)
-    insertUser(optedOutAdmin, email = "optedOutAdmin@x.com")
-    insertUser(optedInNonMember, email = "optedInNonMember@x.com", emailNotificationsEnabled = true)
-    insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
-    insertUser(optedOutMember, email = "optedOutMember@x.com")
-
-    insertOrganizationUser(optedInAdmin, role = Role.ADMIN)
-    insertOrganizationUser(optedOutAdmin, role = Role.ADMIN)
-    insertOrganizationUser(optedInNonMember, role = Role.CONTRIBUTOR)
-    insertOrganizationUser(optedInMember, role = Role.CONTRIBUTOR)
-    insertOrganizationUser(optedOutMember, role = Role.CONTRIBUTOR)
-
-    insertProjectUser(optedInMember)
-    insertProjectUser(optedOutMember)
-
-    val expected = setOf("optedInAdmin@x.com", "optedInMember@x.com")
-    val actual = store.fetchEmailRecipients(projectId).toSet()
-
-    assertEquals(expected, actual)
-  }
 }


### PR DESCRIPTION
Disregard project membership when figuring out which set of users should receive a
notification. Notifications go out to all users in the organization, subject to
their email opt-in settings.