### PR TITLE
SW-1195 Make facility permissions organization-level

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -186,7 +186,7 @@ class AdminController(
     val organization = organizationStore.fetchOneById(project.organizationId)
     val facilities = facilityStore.fetchBySiteId(siteId).sortedBy { it.name }
 
-    model.addAttribute("canCreateFacility", currentUser().canCreateFacility(siteId))
+    model.addAttribute("canCreateFacility", currentUser().canCreateFacility(organization.id))
     model.addAttribute("facilities", facilities)
     model.addAttribute("facilityTypes", FacilityType.values())
     model.addAttribute("organization", organization)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -63,7 +63,9 @@ class FacilityStore(
 
   /** Returns all the facilities the current user can access at a site. */
   fun fetchBySiteId(siteId: SiteId): List<FacilityModel> {
-    return if (currentUser().canListFacilities(siteId)) {
+    val organizationId =
+        parentStore.getOrganizationId(siteId) ?: throw SiteNotFoundException(siteId)
+    return if (currentUser().canListFacilities(organizationId)) {
       facilitiesDao.fetchBySiteId(siteId).map { it.toModel() }
     } else {
       emptyList()
@@ -84,10 +86,10 @@ class FacilityStore(
       maxIdleMinutes: Int = DEFAULT_MAX_IDLE_MINUTES,
       createStorageLocations: Boolean = true,
   ): FacilityModel {
-    requirePermissions { createFacility(siteId) }
-
     val organizationId =
         parentStore.getOrganizationId(siteId) ?: throw SiteNotFoundException(siteId)
+
+    requirePermissions { createFacility(organizationId) }
 
     val row =
         FacilitiesRow(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -148,14 +148,14 @@ data class IndividualUser(
     return canAccessAutomation(automationId)
   }
 
-  override fun canCreateFacility(siteId: SiteId): Boolean {
-    val role = siteRoles[siteId]
+  override fun canCreateFacility(organizationId: OrganizationId): Boolean {
+    val role = organizationRoles[organizationId]
     return role == Role.ADMIN || role == Role.OWNER
   }
 
-  override fun canListFacilities(siteId: SiteId): Boolean {
+  override fun canListFacilities(organizationId: OrganizationId): Boolean {
     // Any user who has access to a site can list its facilities.
-    return siteRoles[siteId] != null
+    return organizationId in organizationRoles
   }
 
   override fun canReadFacility(facilityId: FacilityId): Boolean {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -149,10 +149,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun createFacility(siteId: SiteId) {
-    if (!user.canCreateFacility(siteId)) {
-      readSite(siteId)
-      throw AccessDeniedException("No permission to create facilities in site $siteId")
+  fun createFacility(organizationId: OrganizationId) {
+    if (!user.canCreateFacility(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to create facilities in organization $organizationId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -104,7 +104,7 @@ class SystemUser(
   override fun canCreateAutomation(facilityId: FacilityId): Boolean = true
   override fun canCreateDevice(facilityId: FacilityId): Boolean = true
   override fun canCreateDeviceManager(): Boolean = true
-  override fun canCreateFacility(siteId: SiteId): Boolean = true
+  override fun canCreateFacility(organizationId: OrganizationId): Boolean = true
   override fun canCreateProject(organizationId: OrganizationId): Boolean = true
   override fun canCreateSite(projectId: ProjectId): Boolean = true
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
@@ -120,7 +120,7 @@ class SystemUser(
   override fun canImportGlobalSpeciesData(): Boolean = false
   override fun canListApiKeys(organizationId: OrganizationId): Boolean = true
   override fun canListAutomations(facilityId: FacilityId): Boolean = true
-  override fun canListFacilities(siteId: SiteId): Boolean = true
+  override fun canListFacilities(organizationId: OrganizationId): Boolean = true
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
   override fun canListProjects(organizationId: OrganizationId): Boolean = true
   override fun canListSites(projectId: ProjectId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -71,7 +71,7 @@ interface TerrawareUser : Principal {
   fun canCreateAutomation(facilityId: FacilityId): Boolean
   fun canCreateDevice(facilityId: FacilityId): Boolean
   fun canCreateDeviceManager(): Boolean
-  fun canCreateFacility(siteId: SiteId): Boolean
+  fun canCreateFacility(organizationId: OrganizationId): Boolean
   fun canCreateProject(organizationId: OrganizationId): Boolean
   fun canCreateSite(projectId: ProjectId): Boolean
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
@@ -87,7 +87,7 @@ interface TerrawareUser : Principal {
   fun canImportGlobalSpeciesData(): Boolean
   fun canListApiKeys(organizationId: OrganizationId): Boolean
   fun canListAutomations(facilityId: FacilityId): Boolean
-  fun canListFacilities(siteId: SiteId): Boolean
+  fun canListFacilities(organizationId: OrganizationId): Boolean
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
   fun canListProjects(organizationId: OrganizationId): Boolean
   fun canListSites(projectId: ProjectId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -294,6 +294,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `create throws exception if no permission to create facilities`() {
     every { user.canCreateFacility(any()) } returns false
+    every { user.canReadOrganization(any()) } returns true
 
     assertThrows<AccessDeniedException> { store.create(siteId, FacilityType.SeedBank, "Test") }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -172,13 +172,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun createFacility() {
-    assertThrows<SiteNotFoundException> { requirements.createFacility(siteId) }
+    assertThrows<OrganizationNotFoundException> { requirements.createFacility(organizationId) }
 
-    grant { user.canReadSite(siteId) }
-    assertThrows<AccessDeniedException> { requirements.createFacility(siteId) }
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.createFacility(organizationId) }
 
-    grant { user.canCreateFacility(siteId) }
-    requirements.createFacility(siteId)
+    grant { user.canCreateFacility(organizationId) }
+    requirements.createFacility(organizationId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -228,6 +228,8 @@ internal class PermissionTest : DatabaseTest() {
         removeOrganizationUser = true,
         removeOrganizationSelf = true,
         createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -243,8 +245,6 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *siteIds.forOrg1(),
-        createFacility = true,
-        listFacilities = true,
         readSite = true,
         updateSite = true,
         deleteSite = true,
@@ -326,6 +326,8 @@ internal class PermissionTest : DatabaseTest() {
         removeOrganizationUser = true,
         removeOrganizationSelf = true,
         createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -361,6 +363,8 @@ internal class PermissionTest : DatabaseTest() {
         removeOrganizationUser = true,
         removeOrganizationSelf = true,
         createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -376,8 +380,6 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *siteIds.forOrg1(),
-        createFacility = true,
-        listFacilities = true,
         readSite = true,
         updateSite = true,
         deleteSite = true,
@@ -454,6 +456,7 @@ internal class PermissionTest : DatabaseTest() {
         listOrganizationUsers = true,
         removeOrganizationSelf = true,
         createSpecies = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -467,7 +470,6 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *siteIds.forOrg1(),
-        listFacilities = true,
         readSite = true,
     )
 
@@ -535,6 +537,7 @@ internal class PermissionTest : DatabaseTest() {
         listProjects = true,
         readOrganization = true,
         removeOrganizationSelf = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -546,7 +549,6 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *siteIds.forOrg1(),
-        listFacilities = true,
         readSite = true,
     )
 
@@ -613,6 +615,7 @@ internal class PermissionTest : DatabaseTest() {
         listProjects = true,
         readOrganization = true,
         removeOrganizationSelf = true,
+        listFacilities = true,
     )
 
     permissions.expect(
@@ -624,7 +627,6 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *siteIds.forOrg1(),
-        listFacilities = true,
         readSite = true,
     )
 
@@ -799,6 +801,8 @@ internal class PermissionTest : DatabaseTest() {
         removeOrganizationUser: Boolean = false,
         removeOrganizationSelf: Boolean = false,
         createSpecies: Boolean = false,
+        createFacility: Boolean = false,
+        listFacilities: Boolean = false,
     ) {
       organizations.forEach { organizationId ->
         assertEquals(
@@ -841,6 +845,14 @@ internal class PermissionTest : DatabaseTest() {
             createSpecies,
             user.canCreateSpecies(organizationId),
             "Can create species in organization $organizationId")
+        assertEquals(
+            createFacility,
+            user.canCreateFacility(organizationId),
+            "Can create facility in organization $organizationId")
+        assertEquals(
+            listFacilities,
+            user.canListFacilities(organizationId),
+            "Can list facilities in organization $organizationId")
 
         uncheckedOrgs.remove(organizationId)
       }
@@ -881,17 +893,11 @@ internal class PermissionTest : DatabaseTest() {
 
     fun expect(
         vararg sites: SiteId,
-        createFacility: Boolean = false,
-        listFacilities: Boolean = false,
         readSite: Boolean = false,
         updateSite: Boolean = false,
         deleteSite: Boolean = false,
     ) {
       sites.forEach { siteId ->
-        assertEquals(
-            createFacility, user.canCreateFacility(siteId), "Can create site $siteId facility")
-        assertEquals(
-            listFacilities, user.canListFacilities(siteId), "Can list site $siteId facilities")
         assertEquals(readSite, user.canReadSite(siteId), "Can read site $siteId")
         assertEquals(updateSite, user.canUpdateSite(siteId), "Can update site $siteId")
         assertEquals(deleteSite, user.canDeleteSite(siteId), "Can delete site $siteId")


### PR DESCRIPTION
Even after removing projects and sites, we still need to have permissions for
listing and creating facilities. But they need to be based on the organization,
not the site.