### PR TITLE
SW-1195 Remove project and site permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -12,8 +12,6 @@ import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
@@ -24,8 +22,6 @@ import com.terraformation.backend.db.tables.references.DEVICES
 import com.terraformation.backend.db.tables.references.DEVICE_MANAGERS
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.NOTIFICATIONS
-import com.terraformation.backend.db.tables.references.PROJECTS
-import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.db.tables.references.UPLOADS
@@ -60,14 +56,6 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getFacilityId(storageLocationId: StorageLocationId): FacilityId? =
       fetchFieldById(storageLocationId, STORAGE_LOCATIONS.ID, STORAGE_LOCATIONS.FACILITY_ID)
-
-  fun getProjectId(siteId: SiteId): ProjectId? = fetchFieldById(siteId, SITES.ID, SITES.PROJECT_ID)
-
-  fun getOrganizationId(projectId: ProjectId): OrganizationId? =
-      fetchFieldById(projectId, PROJECTS.ID, PROJECTS.ORGANIZATION_ID)
-
-  fun getOrganizationId(siteId: SiteId): OrganizationId? =
-      fetchFieldById(siteId, SITES.ID, SITES.projects().ORGANIZATION_ID)
 
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
@@ -4,13 +4,9 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
-import com.terraformation.backend.db.tables.references.PROJECTS
-import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.db.tables.references.USERS
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
@@ -46,40 +42,6 @@ class PermissionStore(private val dslContext: DSLContext) {
     return dslContext
         .select(ORGANIZATION_USERS.ORGANIZATION_ID, ORGANIZATION_USERS.ROLE_ID)
         .from(ORGANIZATION_USERS)
-        .where(ORGANIZATION_USERS.USER_ID.eq(userId))
-        .fetchMap({ row -> row.value1() }, { row -> row.value2()?.let { Role.of(it) } })
-  }
-
-  /**
-   * Returns a user's role in each project under the organizations they're in. The roles are
-   * organization-level, so will be the same across all projects of a given organization.
-   */
-  fun fetchProjectRoles(userId: UserId): Map<ProjectId, Role> {
-    return dslContext
-        .select(PROJECTS.ID, ORGANIZATION_USERS.ROLE_ID)
-        .from(ORGANIZATION_USERS)
-        .join(USERS)
-        .on(ORGANIZATION_USERS.USER_ID.eq(USERS.ID))
-        .join(PROJECTS)
-        .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
-        .where(ORGANIZATION_USERS.USER_ID.eq(userId))
-        .fetchMap({ row -> row.value1() }, { row -> row.value2()?.let { Role.of(it) } })
-  }
-
-  /**
-   * Returns a user's role in each site under the organizations they're in. The roles are
-   * organization-level, so will be the same across all projects of a given organization.
-   */
-  fun fetchSiteRoles(userId: UserId): Map<SiteId, Role> {
-    return dslContext
-        .select(SITES.ID, ORGANIZATION_USERS.ROLE_ID)
-        .from(ORGANIZATION_USERS)
-        .join(USERS)
-        .on(ORGANIZATION_USERS.USER_ID.eq(USERS.ID))
-        .join(PROJECTS)
-        .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
-        .join(SITES)
-        .on(PROJECTS.ID.eq(SITES.PROJECT_ID))
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
         .fetchMap({ row -> row.value1() }, { row -> row.value2()?.let { Role.of(it) } })
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -15,10 +15,6 @@ import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.StorageLocationId
@@ -50,7 +46,7 @@ import org.springframework.security.access.AccessDeniedException
  *
  * - Always throw the most specific exception class that describes the failure. For example, the
  * rules will say to throw [EntityNotFoundException] but you'd actually want to throw, e.g.,
- * [SiteNotFoundException] to give the caller more information about what failed.
+ * [AccessionNotFoundException] to give the caller more information about what failed.
  *
  * - Exception messages may be returned to the client and should never include any information that
  * you wouldn't want end users to see.
@@ -194,75 +190,6 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateDevice(deviceId)) {
       readDevice(deviceId)
       throw AccessDeniedException("No permission to update device $deviceId")
-    }
-  }
-
-  fun createSite(projectId: ProjectId) {
-    if (!user.canCreateSite(projectId)) {
-      readProject(projectId)
-      throw AccessDeniedException("No permission to create sites in project $projectId")
-    }
-  }
-
-  fun readSite(siteId: SiteId) {
-    if (!user.canReadSite(siteId)) {
-      throw SiteNotFoundException(siteId)
-    }
-  }
-
-  fun updateSite(siteId: SiteId) {
-    if (!user.canUpdateSite(siteId)) {
-      readSite(siteId)
-      throw AccessDeniedException("No permission to update site $siteId")
-    }
-  }
-
-  fun deleteSite(siteId: SiteId) {
-    if (!user.canDeleteSite(siteId)) {
-      readSite(siteId)
-      throw AccessDeniedException("No permission to delete site $siteId")
-    }
-  }
-
-  fun createProject(organizationId: OrganizationId) {
-    if (!user.canCreateProject(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException(
-          "No permission to create projects in organization $organizationId")
-    }
-  }
-
-  fun readProject(projectId: ProjectId) {
-    if (!user.canReadProject(projectId)) {
-      throw ProjectNotFoundException(projectId)
-    }
-  }
-
-  fun listProjects(organizationId: OrganizationId) {
-    if (!user.canListProjects(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException("No permission to list projects in organization $organizationId")
-    }
-  }
-
-  fun updateProject(projectId: ProjectId) {
-    if (!user.canUpdateProject(projectId)) {
-      readProject(projectId)
-      throw AccessDeniedException("No permission to update project $projectId")
-    }
-  }
-
-  fun addProjectUser(projectId: ProjectId) {
-    if (!user.canAddProjectUser(projectId)) {
-      readProject(projectId)
-      throw AccessDeniedException("No permission to add users to project $projectId")
-    }
-  }
-
-  fun removeProjectUser(projectId: ProjectId, userId: UserId) {
-    if (!user.canRemoveProjectUser(projectId, userId)) {
-      readProject(projectId)
-      throw AccessDeniedException("No permission to remove user $userId from project $projectId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -9,8 +9,6 @@ import com.terraformation.backend.db.DeviceManagerId
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
@@ -76,10 +74,6 @@ class SystemUser(
     get() {
       throw NotImplementedError("System user does not support enumerating roles")
     }
-  override val projectRoles: Map<ProjectId, Role>
-    get() {
-      throw NotImplementedError("System user does not support enumerating roles")
-    }
   override val facilityRoles: Map<FacilityId, Role>
     get() {
       throw NotImplementedError("System user does not support enumerating roles")
@@ -98,22 +92,18 @@ class SystemUser(
    */
 
   override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = true
-  override fun canAddProjectUser(projectId: ProjectId): Boolean = true
   override fun canCreateAccession(facilityId: FacilityId): Boolean = true
   override fun canCreateApiKey(organizationId: OrganizationId): Boolean = true
   override fun canCreateAutomation(facilityId: FacilityId): Boolean = true
   override fun canCreateDevice(facilityId: FacilityId): Boolean = true
   override fun canCreateDeviceManager(): Boolean = true
   override fun canCreateFacility(organizationId: OrganizationId): Boolean = true
-  override fun canCreateProject(organizationId: OrganizationId): Boolean = true
-  override fun canCreateSite(projectId: ProjectId): Boolean = true
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
   override fun canDeleteApiKey(organizationId: OrganizationId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
-  override fun canDeleteSite(siteId: SiteId): Boolean = true
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = true
   override fun canDeleteStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canDeleteUpload(uploadId: UploadId): Boolean = true
@@ -122,23 +112,18 @@ class SystemUser(
   override fun canListAutomations(facilityId: FacilityId): Boolean = true
   override fun canListFacilities(organizationId: OrganizationId): Boolean = true
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
-  override fun canListProjects(organizationId: OrganizationId): Boolean = true
-  override fun canListSites(projectId: ProjectId): Boolean = true
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
   override fun canReadDevice(deviceId: DeviceId): Boolean = true
   override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
-  override fun canReadProject(projectId: ProjectId): Boolean = true
-  override fun canReadSite(siteId: SiteId): Boolean = true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
   override fun canReadUpload(uploadId: UploadId): Boolean = true
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
-  override fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean = true
   override fun canSendAlert(facilityId: FacilityId): Boolean = true
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true
@@ -151,8 +136,6 @@ class SystemUser(
   override fun canUpdateDeviceTemplates(): Boolean = true
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
-  override fun canUpdateProject(projectId: ProjectId): Boolean = true
-  override fun canUpdateSite(siteId: SiteId): Boolean = true
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -8,8 +8,6 @@ import com.terraformation.backend.db.DeviceManagerId
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.SiteId
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
@@ -30,12 +28,6 @@ interface TerrawareUser : Principal {
 
   /** The user's role in each organization they belong to. */
   val organizationRoles: Map<OrganizationId, Role>
-
-  /**
-   * The user's role in each project they have access to. Currently, roles are assigned
-   * per-organization, so this is really the user's role in the organization that owns each project.
-   */
-  val projectRoles: Map<ProjectId, Role>
 
   /**
    * The user's role in each facility they have access to. Currently, roles are assigned
@@ -65,22 +57,18 @@ interface TerrawareUser : Principal {
    */
 
   fun canAddOrganizationUser(organizationId: OrganizationId): Boolean
-  fun canAddProjectUser(projectId: ProjectId): Boolean
   fun canCreateAccession(facilityId: FacilityId): Boolean
   fun canCreateApiKey(organizationId: OrganizationId): Boolean
   fun canCreateAutomation(facilityId: FacilityId): Boolean
   fun canCreateDevice(facilityId: FacilityId): Boolean
   fun canCreateDeviceManager(): Boolean
   fun canCreateFacility(organizationId: OrganizationId): Boolean
-  fun canCreateProject(organizationId: OrganizationId): Boolean
-  fun canCreateSite(projectId: ProjectId): Boolean
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
   fun canDeleteApiKey(organizationId: OrganizationId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean
-  fun canDeleteSite(siteId: SiteId): Boolean
   fun canDeleteSpecies(speciesId: SpeciesId): Boolean
   fun canDeleteStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canDeleteUpload(uploadId: UploadId): Boolean
@@ -89,22 +77,17 @@ interface TerrawareUser : Principal {
   fun canListAutomations(facilityId: FacilityId): Boolean
   fun canListFacilities(organizationId: OrganizationId): Boolean
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
-  fun canListProjects(organizationId: OrganizationId): Boolean
-  fun canListSites(projectId: ProjectId): Boolean
   fun canReadAccession(accessionId: AccessionId): Boolean
   fun canReadAutomation(automationId: AutomationId): Boolean
   fun canReadDevice(deviceId: DeviceId): Boolean
   fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canReadFacility(facilityId: FacilityId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
-  fun canReadProject(projectId: ProjectId): Boolean
-  fun canReadSite(siteId: SiteId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
   fun canReadUpload(uploadId: UploadId): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
-  fun canRemoveProjectUser(projectId: ProjectId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
   fun canSetTestClock(): Boolean
@@ -116,8 +99,6 @@ interface TerrawareUser : Principal {
   fun canUpdateDeviceTemplates(): Boolean
   fun canUpdateFacility(facilityId: FacilityId): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
-  fun canUpdateProject(projectId: ProjectId): Boolean
-  fun canUpdateSite(siteId: SiteId): Boolean
   fun canUpdateSpecies(speciesId: SpeciesId): Boolean
   fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -82,13 +82,8 @@ class OrganizationNotFoundException(val organizationId: OrganizationId) :
 class PhotoNotFoundException(val photoId: PhotoId) :
     EntityNotFoundException("Photo $photoId not found")
 
-class ProjectNotFoundException(val projectId: ProjectId) :
-    EntityNotFoundException("Project $projectId not found")
-
 class ScientificNameNotFoundException(val name: String) :
     EntityNotFoundException("Scientific name $name not found")
-
-class SiteNotFoundException(val siteId: SiteId) : EntityNotFoundException("Site $siteId not found")
 
 class SpeciesNotFoundException(val speciesId: SpeciesId) :
     EntityNotFoundException("Species $speciesId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -175,8 +175,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadDevice(any()) } returns true
     every { user.canReadFacility(any()) } returns true
     every { user.canReadOrganization(organizationId) } returns true
-    every { user.canReadProject(projectId) } returns true
-    every { user.projectRoles } returns mapOf(projectId to Role.OWNER)
     every { user.organizationRoles } returns mapOf(organizationId to Role.ADMIN)
 
     insertSiteData()

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -80,8 +80,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
     every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateFacility(any()) } returns true
-    every { user.canCreateProject(any()) } returns true
-    every { user.canCreateSite(any()) } returns true
     every { user.canCreateStorageLocation(any()) } returns true
     every { user.canDeleteOrganization(any()) } returns true
     every { user.canListOrganizationUsers(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -48,7 +48,6 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateStorageLocation(any()) } returns true
     every { user.canDeleteStorageLocation(any()) } returns true
     every { user.canReadFacility(any()) } returns true
-    every { user.canReadSite(any()) } returns true
     every { user.canReadStorageLocation(any()) } returns true
     every { user.canUpdateFacility(any()) } returns true
     every { user.canUpdateStorageLocation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -83,7 +83,6 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canCountNotifications() } returns true
 
     every { user.organizationRoles } returns mapOf(organizationId to Role.OWNER)
-    every { user.projectRoles } returns mapOf(projectId to Role.OWNER)
 
     insertSiteData()
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -78,13 +78,10 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canListOrganizationUsers(any()) } returns true
     every { user.canRemoveOrganizationUser(any(), any()) } returns true
     every { user.canSetOrganizationUserRole(any(), any()) } returns true
-    every { user.canReadProject(any()) } returns true
-    every { user.canReadSite(any()) } returns true
     every { user.canReadFacility(any()) } returns true
 
     every { user.facilityRoles } returns mapOf(facilityId to Role.OWNER)
     every { user.organizationRoles } returns mapOf(organizationId to Role.OWNER)
-    every { user.projectRoles } returns mapOf(projectId to Role.OWNER)
 
     insertUser()
     insertOrganization(
@@ -153,7 +150,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `fetchById excludes projects the user is not in`() {
     every { user.facilityRoles } returns emptyMap()
-    every { user.projectRoles } returns emptyMap()
 
     val expected = organizationModel.copy(facilities = emptyList())
 
@@ -164,7 +160,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `fetchAll excludes projects the user is not in`() {
     every { user.facilityRoles } returns emptyMap()
-    every { user.projectRoles } returns emptyMap()
 
     val expected = listOf(organizationModel.copy(facilities = emptyList()))
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -15,10 +15,6 @@ import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
-import com.terraformation.backend.db.ProjectId
-import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.SiteId
-import com.terraformation.backend.db.SiteNotFoundException
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.StorageLocationId
@@ -60,9 +56,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val notificationUserId = UserId(2)
   private val notificationId = NotificationId(1)
   private val organizationId = OrganizationId(1)
-  private val projectId = ProjectId(1)
   private val role = Role.CONTRIBUTOR
-  private val siteId = SiteId(1)
   private val speciesId = SpeciesId(1)
   private val storageLocationId = StorageLocationId(1)
   private val uploadId = UploadId(1)
@@ -239,110 +233,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canUpdateDevice(deviceId) }
     requirements.updateDevice(deviceId)
-  }
-
-  @Test
-  fun createSite() {
-    assertThrows<ProjectNotFoundException> { requirements.createSite(projectId) }
-
-    grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.createSite(projectId) }
-
-    grant { user.canCreateSite(projectId) }
-    requirements.createSite(projectId)
-  }
-
-  @Test
-  fun readSite() {
-    assertThrows<SiteNotFoundException> { requirements.readSite(siteId) }
-
-    grant { user.canReadSite(siteId) }
-    requirements.readSite(siteId)
-  }
-
-  @Test
-  fun updateSite() {
-    assertThrows<SiteNotFoundException> { requirements.updateSite(siteId) }
-
-    grant { user.canReadSite(siteId) }
-    assertThrows<AccessDeniedException> { requirements.updateSite(siteId) }
-
-    grant { user.canUpdateSite(siteId) }
-    requirements.updateSite(siteId)
-  }
-
-  @Test
-  fun deleteSite() {
-    assertThrows<SiteNotFoundException> { requirements.deleteSite(siteId) }
-
-    grant { user.canReadSite(siteId) }
-    assertThrows<AccessDeniedException> { requirements.deleteSite(siteId) }
-
-    grant { user.canDeleteSite(siteId) }
-    requirements.deleteSite(siteId)
-  }
-
-  @Test
-  fun createProject() {
-    assertThrows<OrganizationNotFoundException> { requirements.createProject(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createProject(organizationId) }
-
-    grant { user.canCreateProject(organizationId) }
-    requirements.createProject(organizationId)
-  }
-
-  @Test
-  fun readProject() {
-    assertThrows<ProjectNotFoundException> { requirements.readProject(projectId) }
-
-    grant { user.canReadProject(projectId) }
-    requirements.readProject(projectId)
-  }
-
-  @Test
-  fun listProjects() {
-    assertThrows<OrganizationNotFoundException> { requirements.listProjects(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.listProjects(organizationId) }
-
-    grant { user.canListProjects(organizationId) }
-    requirements.listProjects(organizationId)
-  }
-
-  @Test
-  fun updateProject() {
-    assertThrows<ProjectNotFoundException> { requirements.updateProject(projectId) }
-
-    grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.updateProject(projectId) }
-
-    grant { user.canUpdateProject(projectId) }
-    requirements.updateProject(projectId)
-  }
-
-  @Test
-  fun addProjectUser() {
-    assertThrows<ProjectNotFoundException> { requirements.addProjectUser(projectId) }
-
-    grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.addProjectUser(projectId) }
-
-    grant { user.canAddProjectUser(projectId) }
-    requirements.addProjectUser(projectId)
-  }
-
-  @Test
-  fun removeProjectUser() {
-    assertThrows<ProjectNotFoundException> { requirements.removeProjectUser(projectId, userId) }
-
-    grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.removeProjectUser(projectId, userId) }
-
-    grant { user.canRemoveProjectUser(projectId, userId) }
-    requirements.removeProjectUser(projectId, userId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -107,7 +107,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     accessionSearchService = AccessionSearchService(tables, searchService)
 
     every { user.organizationRoles } returns mapOf(organizationId to Role.MANAGER)
-    every { user.projectRoles } returns mapOf(projectId to Role.MANAGER)
     every { user.facilityRoles } returns mapOf(facilityId to Role.MANAGER)
 
     insertSiteData()


### PR DESCRIPTION
Since the application no longer does anything with projects or sites, we don't
need the permissions that used to control access to them.