### PR TITLE
SW-1200 Remove references to project users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationUserModel.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.db.OrganizationId
-import com.terraformation.backend.db.ProjectId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import java.time.Instant
@@ -15,5 +14,4 @@ data class OrganizationUserModel(
     val createdTime: Instant,
     val organizationId: OrganizationId,
     val role: Role,
-    val projectIds: List<ProjectId>,
 )

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -219,8 +219,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertUser(otherUserId)
     insertOrganizationUser()
     insertOrganizationUser(otherUserId)
-    insertProjectUser()
-    insertProjectUser(otherUserId)
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -264,7 +262,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
     insertOrganizationUser()
-    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -297,7 +294,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
     insertOrganizationUser()
-    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -334,7 +330,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
     insertOrganizationUser()
-    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -371,7 +366,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
     insertOrganizationUser()
-    insertProjectUser()
 
     val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
     assertNotNull(accessionModel)
@@ -404,7 +398,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // add a second user to check for multiple notifications
     insertUser(otherUserId)
     insertOrganizationUser()
-    insertProjectUser()
 
     service.on(AccessionsAwaitingProcessingEvent(facilityId, 5, AccessionState.Pending))
 
@@ -432,7 +425,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store accessions ready for testing notification`() {
     insertOrganizationUser()
-    insertProjectUser()
 
     service.on(AccessionsReadyForTestingEvent(facilityId, 5, 2, AccessionState.Processed))
 
@@ -460,7 +452,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store accessions finished drying notification`() {
     insertOrganizationUser()
-    insertProjectUser()
 
     service.on(AccessionsFinishedDryingEvent(facilityId, 5, AccessionState.Dried))
 
@@ -488,7 +479,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store facility idle notification`() {
     insertOrganizationUser()
-    insertProjectUser()
 
     service.on(FacilityIdleEvent(facilityId))
 
@@ -522,7 +512,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val badValue = 5.678
 
     insertOrganizationUser()
-    insertProjectUser()
     insertDevice(deviceId)
     insertAutomation(automationId, deviceId = deviceId, timeseriesName = timeseriesName)
 
@@ -560,7 +549,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val message = "message"
 
     insertOrganizationUser()
-    insertProjectUser()
     insertAutomation(automationId, name = automationName, type = automationType, deviceId = null)
 
     val title = "Automation $automationId triggered at $facilityName"
@@ -593,7 +581,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val deviceName = "test device"
 
     insertOrganizationUser()
-    insertProjectUser()
     insertDevice(deviceId, name = deviceName, type = "sensor")
 
     every { messages.deviceUnresponsive(deviceName) } returns

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -23,7 +23,6 @@ import com.terraformation.backend.db.tables.daos.NotificationsDao
 import com.terraformation.backend.db.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.tables.daos.PhotosDao
 import com.terraformation.backend.db.tables.daos.ProjectTypeSelectionsDao
-import com.terraformation.backend.db.tables.daos.ProjectUsersDao
 import com.terraformation.backend.db.tables.daos.ProjectsDao
 import com.terraformation.backend.db.tables.daos.SitesDao
 import com.terraformation.backend.db.tables.daos.SpeciesDao
@@ -43,7 +42,6 @@ import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.PROJECTS
 import com.terraformation.backend.db.tables.references.PROJECT_TYPE_SELECTIONS
-import com.terraformation.backend.db.tables.references.PROJECT_USERS
 import com.terraformation.backend.db.tables.references.SITES
 import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
@@ -218,7 +216,6 @@ abstract class DatabaseTest {
   protected val photosDao: PhotosDao by lazyDao()
   protected val projectsDao: ProjectsDao by lazyDao()
   protected val projectTypeSelectionsDao: ProjectTypeSelectionsDao by lazyDao()
-  protected val projectUsersDao: ProjectUsersDao by lazyDao()
   protected val sitesDao: SitesDao by lazyDao()
   protected val speciesDao: SpeciesDao by lazyDao()
   protected val speciesProblemsDao: SpeciesProblemsDao by lazyDao()
@@ -492,25 +489,6 @@ abstract class DatabaseTest {
           .set(MODIFIED_TIME, Instant.EPOCH)
           .set(ORGANIZATION_ID, organizationId.toIdWrapper { OrganizationId(it) })
           .set(ROLE_ID, role.id)
-          .set(USER_ID, userId.toIdWrapper { UserId(it) })
-          .execute()
-    }
-  }
-
-  /** Adds a user to a project. */
-  fun insertProjectUser(
-      userId: Any = currentUser().userId,
-      projectId: Any = this.projectId,
-      createdBy: UserId = currentUser().userId,
-  ) {
-    with(PROJECT_USERS) {
-      dslContext
-          .insertInto(PROJECT_USERS)
-          .set(CREATED_BY, createdBy)
-          .set(CREATED_TIME, Instant.EPOCH)
-          .set(MODIFIED_BY, createdBy)
-          .set(MODIFIED_TIME, Instant.EPOCH)
-          .set(PROJECT_ID, projectId.toIdWrapper { ProjectId(it) })
           .set(USER_ID, userId.toIdWrapper { UserId(it) })
           .execute()
     }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -112,7 +112,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     insertSiteData()
 
     insertOrganizationUser(role = Role.MANAGER)
-    insertProjectUser()
 
     val now = Instant.now()
 
@@ -1610,11 +1609,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
       insertProject(sameOrgProjectId)
       insertProject(otherOrgProjectId)
-
-      insertProjectUser(bothOrgsUserId, projectId)
-      insertProjectUser(bothOrgsUserId, sameOrgProjectId)
-      insertProjectUser(bothOrgsUserId, otherOrgProjectId)
-      insertProjectUser(otherOrgUserId, otherOrgProjectId)
     }
 
     @Test


### PR DESCRIPTION
There is no longer any way to add users to projects, and project membershihp no
longer matters for permissions; remove the remaining references to the "project
users" concept. The `project_users` table will be dropped in a subsequent change.