### PR TITLE
Add CODEOWNERS file to set default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @terraware/back-end-dev


### PR DESCRIPTION
GitHub can automatically assign reviewers to PRs so we don't have to do it by
hand; configure the repo to assign the back-end-dev team as reviewer unless
the submitter chooses a different set of reviewers.