### PR TITLE
SW-292 Rename APIClient user type to DeviceManager

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -119,7 +119,7 @@ class AdminController(
     model.addAttribute("organization", organization)
     model.addAttribute("prefix", prefix)
     model.addAttribute("roles", Role.values())
-    model.addAttribute("users", users.filter { it.userType != UserType.APIClient })
+    model.addAttribute("users", users.filter { it.userType != UserType.DeviceManager })
 
     return "/admin/organization"
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -23,7 +23,7 @@ import org.springframework.security.core.userdetails.UserDetails
 
 /**
  * Details about the user who is making the current request and the permissions they have. This
- * always represents a regular (presumably human) user or an API client.
+ * always represents a regular (presumably human) user or a device manager.
  *
  * To get the current user's details, call [currentUser]. See that function's docs for some caveats,
  * but this is usually what you'll want to do.

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -19,7 +19,7 @@ import java.security.Principal
  * An entity on whose behalf the system can do work.
  *
  * The vast majority of the time, this will be a [IndividualUser], which represents an individual
- * user or an API client. However, it can also be the [SystemUser], which isn't associated with a
+ * user or a device manager. However, it can also be the [SystemUser], which isn't associated with a
  * particular person or a particular organization.
  */
 interface TerrawareUser : Principal {

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
@@ -47,7 +47,7 @@ class DeviceManagerService(
 
       deviceService.createDefaultDevices(facilityId)
 
-      val apiUser = userStore.createApiClient(organizationId, "Balena ${manager.balenaUuid}")
+      val apiUser = userStore.createDeviceManager(organizationId, "Balena ${manager.balenaUuid}")
       val userId = apiUser.userId
       val token = userStore.generateOfflineToken(userId)
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -37,8 +37,8 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = USERS.ID
 
-  // Users are only visible to other people in the same organizations, and API client users are not
-  // visible via this table.
+  // Users are only visible to other people in the same organizations, and device manager users are
+  // not visible via this table.
   override fun conditionForVisibility(): Condition {
     return USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin)
         .and(

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -145,6 +145,13 @@ VALUES (1, 'Species CSV', TRUE)
 ON CONFLICT (id) DO UPDATE SET name         = excluded.name,
                                expire_files = excluded.expire_files;
 
+INSERT INTO user_types (id, name)
+VALUES (1, 'Individual'),
+       (2, 'Super Admin'),
+       (3, 'Device Manager'),
+       (4, 'System')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO withdrawal_purposes (id, name)
 VALUES (1, 'Propagation'),
        (2, 'Outreach or Education'),

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -312,7 +312,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             "balena-12345",
             "Api",
             "Client",
-            UserType.APIClient,
+            UserType.DeviceManager,
             clock.instant(),
             organizationId,
             Role.CONTRIBUTOR))

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -208,7 +208,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
-  inner class ApiClientTest {
+  inner class DeviceManagerTest {
     @BeforeEach
     fun setUpOrganization() {
       insertUser()
@@ -216,18 +216,18 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `createApiClient throws exception if user does not have permission to create clients`() {
+    fun `createDeviceManager throws exception if user does not have permission to create clients`() {
       every { user.canCreateApiKey(organizationId) } returns false
 
       assertThrows<AccessDeniedException> {
-        userStore.createApiClient(organizationId, "Description")
+        userStore.createDeviceManager(organizationId, "Description")
       }
     }
 
     @Test
-    fun `createApiClient registers user in Keycloak and adds it to organization`() {
+    fun `createDeviceManager registers user in Keycloak and adds it to organization`() {
       val description = "Description"
-      val newUser = userStore.createApiClient(organizationId, description)
+      val newUser = userStore.createDeviceManager(organizationId, description)
 
       val keycloakUser = usersResource.get(newUser.authId!!)!!.toRepresentation()
       assertEquals(
@@ -248,7 +248,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           mapOf(organizationId to Role.CONTRIBUTOR),
           newUser.organizationRoles,
-          "Should grant contributor role to API client user")
+          "Should grant contributor role to device manager user")
     }
   }
 
@@ -267,7 +267,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `generateOfflineToken requests a token from Keycloak`() {
-      val user = userStore.createApiClient(organizationId, null)
+      val user = userStore.createDeviceManager(organizationId, null)
       val expectedToken = "token"
 
       val response: HttpResponse<String> = mockk()
@@ -285,7 +285,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `generateOfflineToken throws exception if Keycloak returns a malformed token response`() {
-      val user = userStore.createApiClient(organizationId, null)
+      val user = userStore.createDeviceManager(organizationId, null)
 
       val response: HttpResponse<String> = mockk()
       val requestSlot = slot<HttpRequest>()
@@ -299,7 +299,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `generateOfflineToken throws exception if Keycloak does not generate a token`() {
-      val user = userStore.createApiClient(organizationId, null)
+      val user = userStore.createDeviceManager(organizationId, null)
 
       val response: HttpResponse<String> = mockk()
       val requestSlot = slot<HttpRequest>()
@@ -313,7 +313,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `generateOfflineToken generates a temporary password and removes it if token creation fails`() {
-      val user = userStore.createApiClient(organizationId, null)
+      val user = userStore.createDeviceManager(organizationId, null)
       val keycloakUser = usersResource.get(user.authId!!)!!
 
       val response: HttpResponse<String> = mockk()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -501,8 +501,8 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
-  fun `API clients are members of all projects, sites, and facilities`() {
-    usersDao.update(usersDao.fetchOneById(userId)!!.copy(userTypeId = UserType.APIClient))
+  fun `device managers are members of all facilities`() {
+    usersDao.update(usersDao.fetchOneById(userId)!!.copy(userTypeId = UserType.DeviceManager))
     givenRole(org1Id, Role.CONTRIBUTOR)
 
     val permissions = PermissionsTracker()

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -1589,17 +1589,17 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     private val otherOrganizationId = OrganizationId(2)
     private val bothOrgsUserId = UserId(4)
     private val otherOrgUserId = UserId(5)
-    private val apiClientUserId = UserId(6)
+    private val deviceManagerUserId = UserId(6)
 
     @BeforeEach
     fun insertOtherUsers() {
-      insertUser(apiClientUserId, type = UserType.APIClient)
+      insertUser(deviceManagerUserId, type = UserType.DeviceManager)
       insertUser(bothOrgsUserId)
       insertUser(otherOrgUserId)
 
       insertOrganization(otherOrganizationId)
 
-      insertOrganizationUser(apiClientUserId)
+      insertOrganizationUser(deviceManagerUserId)
       insertOrganizationUser(bothOrgsUserId, role = Role.ADMIN)
       insertOrganizationUser(bothOrgsUserId, otherOrganizationId, Role.ADMIN)
       insertOrganizationUser(otherOrgUserId, otherOrganizationId)


### PR DESCRIPTION
API client users are only ever used for device manager authentication. Change the
name of the user type to reflect that reality.