### PR TITLE
SW-292 Reduce permissions for non-admin users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -101,38 +101,30 @@ data class IndividualUser(
     return canReadAccession(accessionId)
   }
 
-  private fun canAccessAutomations(facilityId: FacilityId): Boolean {
-    // All users that have access to the facility have full permissions on automations.
-    return facilityId in facilityRoles
-  }
-
   override fun canCreateAutomation(facilityId: FacilityId): Boolean {
-    return canAccessAutomations(facilityId)
+    return canUpdateFacility(facilityId)
   }
 
   override fun canListAutomations(facilityId: FacilityId): Boolean {
-    return canAccessAutomations(facilityId)
-  }
-
-  private fun canAccessAutomation(automationId: AutomationId): Boolean {
-    val facilityId = parentStore.getFacilityId(automationId) ?: return false
-    return canAccessAutomations(facilityId)
+    return canReadFacility(facilityId)
   }
 
   override fun canReadAutomation(automationId: AutomationId): Boolean {
-    return canAccessAutomation(automationId)
+    val facilityId = parentStore.getFacilityId(automationId) ?: return false
+    return canReadFacility(facilityId)
   }
 
   override fun canUpdateAutomation(automationId: AutomationId): Boolean {
-    return canAccessAutomation(automationId)
+    val facilityId = parentStore.getFacilityId(automationId) ?: return false
+    return canUpdateFacility(facilityId)
   }
 
   override fun canDeleteAutomation(automationId: AutomationId): Boolean {
-    return canAccessAutomation(automationId)
+    return canUpdateAutomation(automationId)
   }
 
   override fun canTriggerAutomation(automationId: AutomationId): Boolean {
-    return canAccessAutomation(automationId)
+    return canUpdateAutomation(automationId)
   }
 
   override fun canCreateFacility(organizationId: OrganizationId): Boolean {
@@ -158,12 +150,11 @@ data class IndividualUser(
   }
 
   override fun canSendAlert(facilityId: FacilityId): Boolean {
-    return facilityId in facilityRoles
+    return canUpdateFacility(facilityId)
   }
 
   override fun canCreateDevice(facilityId: FacilityId): Boolean {
-    // Any user with access to the facility can create a new device.
-    return facilityId in facilityRoles
+    return canUpdateFacility(facilityId)
   }
 
   override fun canReadDevice(deviceId: DeviceId): Boolean {
@@ -174,7 +165,7 @@ data class IndividualUser(
 
   override fun canUpdateDevice(deviceId: DeviceId): Boolean {
     val facilityId = parentStore.getFacilityId(deviceId) ?: return false
-    return facilityId in facilityRoles
+    return canUpdateFacility(facilityId)
   }
 
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean {
@@ -253,10 +244,10 @@ data class IndividualUser(
 
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean {
     val facilityId = parentStore.getFacilityId(deviceId) ?: return false
-    return facilityId in facilityRoles
+    return canUpdateFacility(facilityId)
   }
 
-  override fun canReadTimeseries(deviceId: DeviceId): Boolean = canCreateTimeseries(deviceId)
+  override fun canReadTimeseries(deviceId: DeviceId): Boolean = canReadDevice(deviceId)
 
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = canCreateTimeseries(deviceId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -387,10 +387,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *facilityIds.forOrg1(),
         createAccession = true,
-        createAutomation = true,
-        createDevice = true,
         listAutomations = true,
-        sendAlert = true,
     )
 
     permissions.expect(
@@ -402,9 +399,6 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *automationIds.forOrg1(),
         readAutomation = true,
-        updateAutomation = true,
-        deleteAutomation = true,
-        triggerAutomation = true,
     )
 
     permissions.expect(
@@ -415,11 +409,8 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *deviceIds.forOrg1(),
-        createTimeseries = true,
         readTimeseries = true,
-        updateTimeseries = true,
         readDevice = true,
-        updateDevice = true,
     )
 
     permissions.expect(
@@ -453,10 +444,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *facilityIds.forOrg1(),
         createAccession = true,
-        createAutomation = true,
-        createDevice = true,
         listAutomations = true,
-        sendAlert = true,
     )
 
     permissions.expect(
@@ -468,9 +456,6 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *automationIds.forOrg1(),
         readAutomation = true,
-        updateAutomation = true,
-        deleteAutomation = true,
-        triggerAutomation = true,
     )
 
     permissions.expect(
@@ -481,11 +466,8 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *deviceIds.forOrg1(),
-        createTimeseries = true,
         readTimeseries = true,
-        updateTimeseries = true,
         readDevice = true,
-        updateDevice = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
Previously, device manager users were assigned the Contributor role which meant
that that role had to be able to perform all the operations a device manager uses.

Now that there's a separate user type for device managers, we no longer need to
grant access to operations that a regular non-admin user has no business doing.

This only applies to Contributor and Manager user types; Owner and Admin roles
continue to grant access to device-related operations.