### PR TITLE
SW-1222 Generate system_power timeseries for PV devices

### DIFF
--- a/scripts/timeseries.py
+++ b/scripts/timeseries.py
@@ -27,6 +27,7 @@ timeseries_config = {
         "interval": 30,
         "timeseries": {
             "system_current": {"min": 60, "max": 120},
+            "system_power": {"min": 100, "max": 5000},
             "system_voltage": {"min": 53, "max": 56},
             "relative_state_of_charge": {"min": 80, "max": 100},
             "state_of_health": {"min": 90, "max": 100},
@@ -41,6 +42,14 @@ timeseries_config = {
             "dc_voltage": {"min": 530, "max": 540},
             "relative_state_of_charge": {"min": 80, "max": 100},
             "state_of_health": {"min": 90, "max": 100},
+            "system_power": {"min": 100, "max": 5000},
+        },
+    },
+    ("Victron", "Cerbo GX"): {
+        "interval": 30,
+        "timeseries": {
+            "relative_state_of_charge": {"min": 80, "max": 100},
+            "system_power": {"min": 100, "max": 5000},
         },
     },
 }

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -19,8 +19,16 @@
                     make: "Blue Ion",
                     model: "LV",
                     name: "BMU-1",
-                    address: "192.168.2.40",
+                    address: "192.168.2.50",
                     protocol: "modbus"
+                },
+                cerboGx: {
+                    type: "BMU",
+                    make: "Victron",
+                    model: "Cerbo GX",
+                    name: "BMU-1",
+                    address: "192.168.2.40",
+                    protocol: "mqtt"
                 },
                 omniSense: {
                     type: "sensor",
@@ -140,6 +148,7 @@
     <div>
         Common configurations:
         <a href="#" id="blueIon">Blue Ion PV</a> -
+        <a href="#" id="cerboGx">Cerbo GX PV</a> -
         <a href="#" id="omniSense">Temperature/Humidity Sensor</a> -
         <a href="#" id="omniSenseHub">OmniSense Hub</a>
     </div>


### PR DESCRIPTION
Add a `system_power` timeseries to the dummy data generation script for Blue Ion
BMUs, and add a new configuration for Cerbo GX BMUs.