### PR TITLE
Move custom tasks out of build.gradle.kts

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,10 @@ java.targetCompatibility = JavaVersion.VERSION_1_8
 
 tasks.withType<KotlinCompile> { kotlinOptions.jvmTarget = java.targetCompatibility.majorVersion }
 
-repositories { mavenCentral() }
+repositories {
+  gradlePluginPortal()
+  mavenCentral()
+}
 
 // buildSrc is considered a separate project from the parent, so we don't have access to properties
 // from the parent by default. Load the parent's properties explicitly so we can define dependency
@@ -22,6 +25,7 @@ val rootProjectProperties =
 dependencies {
   val jooqVersion = rootProjectProperties["jooqVersion"]
 
+  implementation("com.github.node-gradle:gradle-node-plugin:3.4.0")
   implementation("org.jooq:jooq-codegen:$jooqVersion")
   implementation("org.eclipse.jgit:org.eclipse.jgit:5.10.+")
 }

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
@@ -1,0 +1,36 @@
+package com.terraformation.gradle
+
+import java.io.File
+import java.nio.file.Files
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Generates a Kotlin source file that defines the Docker image to use for database-backed tests.
+ * This defaults to a standard PostGIS image, but may be overridden locally to test against
+ * different database versions or to use an image for a platform that isn't supported by the
+ * standard PostGIS images, e.g., ARM64.
+ */
+abstract class PostgresDockerConfigTask : DefaultTask() {
+  @get:Input
+  val postgresDockerRepository: String = project.property("postgresDockerRepository")!!.toString()
+  @get:Input val postgresDockerTag: String = project.property("postgresDockerTag")!!.toString()
+
+  @get:OutputFile
+  val outputFile =
+      File("${project.buildDir}/generated-test/kotlin/com/terraformation/backend/db/DockerImage.kt")
+
+  @TaskAction
+  fun generate() {
+    val path = outputFile.toPath()
+    Files.createDirectories(path.parent)
+    Files.writeString(
+        path,
+        """package com.terraformation.backend.db
+          |const val POSTGRES_DOCKER_REPOSITORY = "$postgresDockerRepository"
+          |const val POSTGRES_DOCKER_TAG = "$postgresDockerTag"
+        """.trimMargin())
+  }
+}

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
@@ -1,0 +1,102 @@
+package com.terraformation.gradle
+
+import com.github.gradle.node.NodeExtension
+import com.github.gradle.node.exec.NodeExecConfiguration
+import com.github.gradle.node.util.PlatformHelper
+import com.github.gradle.node.util.ProjectApiHelper
+import com.github.gradle.node.variant.VariantComputer
+import com.github.gradle.node.yarn.exec.YarnExecRunner
+import com.github.gradle.node.yarn.task.YarnSetupTask
+import java.io.File
+import java.nio.file.Files
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileType
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.get
+import org.gradle.work.ChangeType
+import org.gradle.work.FileChange
+import org.gradle.work.InputChanges
+
+/** Renders MJML email bodies to FreeMarker templates that can be evaluated at runtime. */
+abstract class RenderMjmlTask : DefaultTask() {
+  @get:InputFiles
+  @get:SkipWhenEmpty
+  val mjmlFiles =
+      project.files(
+          project.fileTree("src/main/resources/templates/email") { include("**/body.ftlh.mjml") })
+
+  @get:OutputDirectory val outputDir = project.buildDir.resolve("resources/main/templates/email")
+
+  @get:Internal val projectHelper = ProjectApiHelper.newInstance(project)
+
+  @get:Inject abstract val objects: ObjectFactory
+
+  init {
+    group = "build"
+    description = "Renders MJML templates."
+    dependsOn(YarnSetupTask.NAME)
+  }
+
+  @TaskAction
+  fun exec(changes: InputChanges) {
+    changes.getFileChanges(mjmlFiles).forEach { change ->
+      if (change.fileType != FileType.DIRECTORY) {
+        val targetFile = getTargetFile(change)
+
+        if (change.changeType == ChangeType.REMOVED) {
+          targetFile.delete()
+        } else {
+          renderMjmlFile(change.file, targetFile)
+        }
+      }
+    }
+  }
+
+  /** Runs Yarn to format a single MJML file. */
+  private fun renderMjmlFile(mjmlFile: File, targetFile: File) {
+    Files.createDirectories(targetFile.toPath().parent)
+    val runner = objects.newInstance(YarnExecRunner::class.java)
+
+    runner.executeYarnCommand(
+        projectHelper,
+        NodeExtension[project],
+        NodeExecConfiguration(
+            listOf(
+                "mjml",
+                "--config.minify",
+                "true",
+                "--config.beautify",
+                "false",
+                "-o",
+                "$targetFile",
+                "$mjmlFile")),
+        VariantComputer(PlatformHelper.INSTANCE))
+  }
+
+  /**
+   * Returns the target path for the given MJML file. The upper levels of directory structure are a
+   * little different in the src and build directories; we want the following mapping:
+   *
+   * `src/main/resources/templates/email/a/b.ftlh.mjml` ->
+   * `build/resources/main/templates/email/a/b.ftlh`
+   */
+  private fun getTargetFile(change: FileChange): File {
+    val mjmlExtension = ".mjml"
+
+    if (!change.file.name.endsWith(mjmlExtension)) {
+      throw IllegalArgumentException("File ${change.file} is not an MJML file")
+    }
+
+    val targetRelativeToResourcesDir =
+        File(change.file.path.substring(0, change.file.path.length - mjmlExtension.length))
+            .relativeTo(project.projectDir.resolve("src/main/resources"))
+
+    return project.buildDir.resolve("resources/main").resolve(targetRelativeToResourcesDir)
+  }
+}

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
@@ -1,0 +1,28 @@
+package com.terraformation.gradle
+
+import java.io.File
+import java.nio.file.Files
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Generates a Kotlin source file that contains the project version number, so it can be referenced
+ * at runtime.
+ */
+abstract class VersionFileTask : DefaultTask() {
+  @get:Input val version: String = "${project.version}"
+
+  @get:OutputFile
+  val outputFile =
+      File("${project.buildDir}/generated/kotlin/com/terraformation/backend/Version.kt")
+
+  @TaskAction
+  fun generate() {
+    val path = outputFile.toPath()
+    Files.createDirectories(path.parent)
+    Files.writeString(
+        path, "package com.terraformation.backend\nconst val VERSION = \"$version\"\n")
+  }
+}


### PR DESCRIPTION
Our Gradle build script is a little hard to navigate in part because it has a
bunch of one-off custom tasks to implement custom build logic. Turn these into
full-fledged classes that use Gradle's task API. This should declutter the build
script a bit and also make it easier to improve the custom logic in the future.

The task API lets us change MJML rendering to a single Gradle task rather than
a task per MJML file.