### PR TITLE
Switch back to OpenJDK base Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM openjdk:17-slim-buster
 
 ARG USER_ID=1001
 


### PR DESCRIPTION
The Eclipse Temurin image was running into a problem with detecting the amount of
available memory: https://github.com/adoptium/temurin-build/issues/2974

We still want to switch to that image, but for now, stop using it so the server
will start up successfully.