### PR TITLE
Add plural variants of accession endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -54,7 +54,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@RequestMapping("/api/v1/seedbank/accession")
+@RequestMapping("/api/v1/seedbank/accession", "/api/v1/seedbank/accessions")
 @RestController
 @SeedBankAppEndpoint
 class AccessionController(private val accessionStore: AccessionStore, private val clock: Clock) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotoController.kt
@@ -47,7 +47,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
-@RequestMapping("/api/v1/seedbank/accession/{id}/photo")
+@RequestMapping("/api/v1/seedbank/accession/{id}/photo", "/api/v1/seedbank/accessions/{id}/photos")
 @RestController
 @SeedBankAppEndpoint
 class PhotoController(private val photoRepository: PhotoRepository) {


### PR DESCRIPTION
The accession-related endpoints were added before we had settled on using plural
nouns for endpoint paths. Add alternate paths to them for consistency. Once the
client code has completely switched over to the plural forms, we can get rid of
the singular ones.