### PR TITLE
SW-1226 Rename "Germination Testing" withdrawal purpose

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -1,10 +1,8 @@
 package com.terraformation.backend.seedbank.api
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.annotation.JsonValue
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -559,7 +557,7 @@ data class WithdrawalPayload(
                 "withdrawal.")
     val id: WithdrawalId? = null,
     val date: LocalDate,
-    val purpose: ExternalWithdrawalPurpose,
+    val purpose: WithdrawalPurpose,
     val destination: String? = null,
     val notes: String? = null,
     @Schema(
@@ -611,7 +609,7 @@ data class WithdrawalPayload(
   ) : this(
       model.id,
       model.date,
-      ExternalWithdrawalPurpose.forPurpose(model.purpose),
+      model.purpose,
       model.destination,
       model.notes,
       model.remaining?.toPayload(),
@@ -630,45 +628,11 @@ data class WithdrawalPayload(
           viabilityTestId = viabilityTestId ?: germinationTestId,
           id = id,
           notes = notes,
-          purpose = purpose.purpose,
+          purpose = purpose,
           remaining = remainingQuantity?.toModel(),
           staffResponsible = staffResponsible,
           withdrawn = withdrawnQuantity?.toModel(),
       )
-}
-
-/**
- * Temporary copy of [WithdrawalPurpose] so we can accept either "Germination Testing" or "Viability
- * Testing" as a valid purpose. After the client is updated to use "Viability Testing", we'll rename
- * [WithdrawalPurpose.GerminationTesting] and get rid of this.
- */
-enum class ExternalWithdrawalPurpose(
-    val purpose: WithdrawalPurpose,
-    @get:JsonValue val displayName: String = purpose.displayName,
-    val sendToClient: Boolean = true
-) {
-  Propagation(WithdrawalPurpose.Propagation),
-  OutreachorEducation(WithdrawalPurpose.OutreachorEducation),
-  Research(WithdrawalPurpose.Research),
-  Broadcast(WithdrawalPurpose.Broadcast),
-  SharewithAnotherSite(WithdrawalPurpose.SharewithAnotherSite),
-  Other(WithdrawalPurpose.Other),
-  GerminationTesting(WithdrawalPurpose.GerminationTesting),
-  ViabilityTesting(WithdrawalPurpose.GerminationTesting, "Viability Testing", false);
-
-  companion object {
-    private val byDisplayName = values().associateBy { it.displayName }
-    private val byPurpose = values().filter { it.sendToClient }.associateBy { it.purpose }
-
-    @JsonCreator
-    @JvmStatic
-    fun forDisplayName(name: String) =
-        byDisplayName[name] ?: throw IllegalArgumentException("Unrecognized value: $name")
-
-    @JvmStatic
-    fun forPurpose(purpose: WithdrawalPurpose) =
-        byPurpose[purpose] ?: throw IllegalArgumentException("Unrecognized value: $purpose")
-  }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
@@ -53,8 +53,8 @@ class WithdrawalStore(private val dslContext: DSLContext, private val clock: Clo
       val existing = existingById[id]!!
       val desired = desiredById[id]!!
 
-      if ((existing.purpose == WithdrawalPurpose.GerminationTesting) xor
-          (desired.purpose == WithdrawalPurpose.GerminationTesting)) {
+      if ((existing.purpose == WithdrawalPurpose.ViabilityTesting) xor
+          (desired.purpose == WithdrawalPurpose.ViabilityTesting)) {
         throw IllegalArgumentException(
             "Cannot change withdrawal purpose to or from Germination Testing")
       }
@@ -65,12 +65,12 @@ class WithdrawalStore(private val dslContext: DSLContext, private val clock: Clo
     }
 
     newWithdrawals.forEach { withdrawal ->
-      if (withdrawal.purpose == WithdrawalPurpose.GerminationTesting &&
+      if (withdrawal.purpose == WithdrawalPurpose.ViabilityTesting &&
           withdrawal.viabilityTestId == null) {
         throw IllegalArgumentException("Viability testing withdrawals must have test IDs")
       }
 
-      if (withdrawal.purpose != WithdrawalPurpose.GerminationTesting &&
+      if (withdrawal.purpose != WithdrawalPurpose.ViabilityTesting &&
           withdrawal.viabilityTestId != null) {
         throw IllegalArgumentException("Only viability testing withdrawals may have test IDs")
       }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -203,7 +203,7 @@ data class AccessionModel(
     val totalWithdrawn =
         listOfNotNull(
                 withdrawals
-                    .filter { it.purpose != WithdrawalPurpose.GerminationTesting }
+                    .filter { it.purpose != WithdrawalPurpose.ViabilityTesting }
                     .mapNotNull { it.withdrawn?.quantity },
                 viabilityTests.mapNotNull { it.seedsSown?.toBigDecimal() })
             .flatten()
@@ -345,8 +345,7 @@ data class AccessionModel(
           }
         }
 
-    val nonTestWithdrawals =
-        withdrawals.filter { it.purpose != WithdrawalPurpose.GerminationTesting }
+    val nonTestWithdrawals = withdrawals.filter { it.purpose != WithdrawalPurpose.ViabilityTesting }
     val existingTestWithdrawals =
         existingWithdrawals
             .filter { it.viabilityTestId != null }
@@ -361,7 +360,7 @@ data class AccessionModel(
               viabilityTest = test,
               viabilityTestId = test.id,
               id = existingWithdrawal?.id,
-              purpose = WithdrawalPurpose.GerminationTesting,
+              purpose = WithdrawalPurpose.ViabilityTesting,
               remaining = test.remaining,
               staffResponsible = test.staffResponsible,
               withdrawn = withdrawn,
@@ -432,14 +431,14 @@ data class AccessionModel(
   fun calculateTotalScheduledNonTestQuantity(clock: Clock): SeedQuantityModel? {
     val today = LocalDate.now(clock)
     return foldWithdrawalQuantities(clock) {
-      it.purpose != WithdrawalPurpose.GerminationTesting && it.date > today
+      it.purpose != WithdrawalPurpose.ViabilityTesting && it.date > today
     }
   }
 
   fun calculateTotalScheduledTestQuantity(clock: Clock): SeedQuantityModel? {
     val today = LocalDate.now(clock)
     return foldWithdrawalQuantities(clock) {
-      it.purpose == WithdrawalPurpose.GerminationTesting && it.date > today
+      it.purpose == WithdrawalPurpose.ViabilityTesting && it.date > today
     }
   }
 

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -154,7 +154,7 @@ VALUES (1, 'Propagation'),
        (4, 'Broadcast'),
        (5, 'Share with Another Site'),
        (6, 'Other'),
-       (7, 'Germination Testing')
+       (7, 'Viability Testing')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO notification_criticalities (id, name)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -52,7 +52,6 @@ import com.terraformation.backend.db.tables.references.WITHDRAWALS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.api.CreateAccessionRequestPayload
 import com.terraformation.backend.seedbank.api.DeviceInfoPayload
-import com.terraformation.backend.seedbank.api.ExternalWithdrawalPurpose
 import com.terraformation.backend.seedbank.api.SeedQuantityPayload
 import com.terraformation.backend.seedbank.api.UpdateAccessionRequestPayload
 import com.terraformation.backend.seedbank.api.ViabilityTestPayload
@@ -829,7 +828,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 id = WithdrawalId(1),
                 accessionId = accession.id,
                 date = test.startDate!!,
-                purpose = WithdrawalPurpose.GerminationTesting,
+                purpose = WithdrawalPurpose.ViabilityTesting,
                 withdrawn = SeedQuantityModel(BigDecimal(5), SeedQuantityUnits.Seeds),
                 viabilityTestId = test.id,
                 remaining = seeds(5))),
@@ -894,7 +893,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     val newWithdrawal =
         WithdrawalModel(
             date = LocalDate.now(),
-            purpose = WithdrawalPurpose.GerminationTesting,
+            purpose = WithdrawalPurpose.ViabilityTesting,
             withdrawn = seeds(1),
             viabilityTestId = initialWithdrawal.viabilityTestId)
 
@@ -1268,7 +1267,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
               listOf(
                   WithdrawalPayload(
                       date = LocalDate.EPOCH,
-                      purpose = ExternalWithdrawalPurpose.Other,
+                      purpose = WithdrawalPurpose.Other,
                       withdrawnQuantity = seeds(10))))
     }
 
@@ -1378,7 +1377,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
               listOf(
                   WithdrawalPayload(
                       date = LocalDate.EPOCH,
-                      purpose = ExternalWithdrawalPurpose.Other,
+                      purpose = WithdrawalPurpose.Other,
                       remainingQuantity = grams(5))))
     }
 
@@ -1513,7 +1512,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 listOf(
                     WithdrawalPayload(
                         date = today,
-                        purpose = ExternalWithdrawalPurpose.Other,
+                        purpose = WithdrawalPurpose.Other,
                         destination = "destination",
                         notes = "notes",
                         remainingQuantity = grams(42),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -179,7 +179,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val desired =
         WithdrawalModel(
             date = LocalDate.now(),
-            purpose = WithdrawalPurpose.GerminationTesting,
+            purpose = WithdrawalPurpose.ViabilityTesting,
             remaining = grams(4),
             withdrawn = grams(1))
 
@@ -217,7 +217,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
         WithdrawalModel(
             date = LocalDate.now(),
             viabilityTestId = viabilityTestId,
-            purpose = WithdrawalPurpose.GerminationTesting,
+            purpose = WithdrawalPurpose.ViabilityTesting,
             remaining = grams(4),
             withdrawn = seeds(1))
 
@@ -258,7 +258,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
         WithdrawalModel(
             date = LocalDate.now(),
             viabilityTestId = viabilityTestId,
-            purpose = WithdrawalPurpose.GerminationTesting,
+            purpose = WithdrawalPurpose.ViabilityTesting,
             remaining = grams(4),
             withdrawn = seeds(1))
     store.updateWithdrawals(accessionId, emptyList(), listOf(initial))
@@ -326,7 +326,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             remaining = grams(4),
             withdrawn = grams(1),
         )
-    val desired = initial.copy(id = WithdrawalId(1), purpose = WithdrawalPurpose.GerminationTesting)
+    val desired = initial.copy(id = WithdrawalId(1), purpose = WithdrawalPurpose.ViabilityTesting)
 
     store.updateWithdrawals(accessionId, emptyList(), listOf(initial))
     val afterInsert = store.fetchWithdrawals(accessionId)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -130,7 +130,7 @@ internal class AccessionModelTest {
       date: LocalDate = january(3),
       viabilityTestId: ViabilityTestId? = null,
       purpose: WithdrawalPurpose =
-          if (viabilityTestId != null) WithdrawalPurpose.GerminationTesting
+          if (viabilityTestId != null) WithdrawalPurpose.ViabilityTesting
           else WithdrawalPurpose.Other,
       remaining: SeedQuantityModel =
           if (withdrawn.units == SeedQuantityUnits.Seeds) seeds(10) else grams(10),
@@ -527,7 +527,7 @@ internal class AccessionModelTest {
                   listOf(
                       otherExistingWithdrawal.copy(
                           viabilityTestId = viabilityTest.id,
-                          purpose = WithdrawalPurpose.GerminationTesting)))
+                          purpose = WithdrawalPurpose.ViabilityTesting)))
 
       val withdrawals =
           accession.calculateWithdrawals(
@@ -581,7 +581,7 @@ internal class AccessionModelTest {
               grams(8),
               date = tomorrow,
               viabilityTestId = futureTest.id,
-              purpose = WithdrawalPurpose.GerminationTesting,
+              purpose = WithdrawalPurpose.ViabilityTesting,
               remaining = grams(85),
           )
 
@@ -771,7 +771,7 @@ internal class AccessionModelTest {
                       withdrawal(
                           seeds(1),
                           remaining = seeds(0),
-                          purpose = WithdrawalPurpose.GerminationTesting),
+                          purpose = WithdrawalPurpose.ViabilityTesting),
                       withdrawal(seeds(5), remaining = seeds(0)),
                   ))
 
@@ -796,7 +796,7 @@ internal class AccessionModelTest {
                           date = january(15), // different from test date
                           viabilityTestId = testWithExistingWithdrawal.id,
                           id = nextWithdrawalId(),
-                          purpose = WithdrawalPurpose.GerminationTesting,
+                          purpose = WithdrawalPurpose.ViabilityTesting,
                           remaining = seeds(0),
                           withdrawn = seeds(testWithExistingWithdrawal.seedsSown!!),
                       ),


### PR DESCRIPTION
Use the term "viability testing" in the list of withdrawal purposes to align with
the app terminology.