### PR TITLE
Fix MJML rendering on docs branch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,8 +38,9 @@ jobs:
         path: |
           ~/.gradle
           ~/.m2
+          node_modules
         # Use the same cache key as in main.yml to pick up cached dependencies
-        key: 2-15-${{ hashFiles('*.gradle.kts', 'gradle.properties') }}
+        key: 4-${{ hashFiles('*.gradle.kts', 'gradle.properties', 'yarn.lock') }}
 
     - name: Download Docker images
       run: |

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
@@ -6,7 +6,7 @@ import com.github.gradle.node.util.PlatformHelper
 import com.github.gradle.node.util.ProjectApiHelper
 import com.github.gradle.node.variant.VariantComputer
 import com.github.gradle.node.yarn.exec.YarnExecRunner
-import com.github.gradle.node.yarn.task.YarnSetupTask
+import com.github.gradle.node.yarn.task.YarnInstallTask
 import java.io.File
 import java.nio.file.Files
 import javax.inject.Inject
@@ -42,7 +42,7 @@ abstract class RenderMjmlTask : DefaultTask() {
   init {
     group = "build"
     description = "Renders MJML templates."
-    dependsOn(YarnSetupTask.NAME)
+    dependsOn(YarnInstallTask.NAME)
   }
 
   @TaskAction


### PR DESCRIPTION
On the docs branch, we weren't caching the `node_modules` directory as part of
the build, which exposed the fact that the build was using the wrong Gradle
task to set up the MJML renderer. Use the correct task, and also start caching
`node_modules` so docs get rendered more quickly.