### PR TITLE
SW-1284 Add endpoint to delete accession

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -114,6 +114,7 @@ data class DeviceManagerUser(
   override fun canCreateFacility(organizationId: OrganizationId): Boolean = false
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
+  override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = false
   override fun canDeleteStorageLocation(storageLocationId: StorageLocationId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -101,6 +101,10 @@ data class IndividualUser(
     return canReadAccession(accessionId)
   }
 
+  override fun canDeleteAccession(accessionId: AccessionId): Boolean {
+    return canUpdateAccession(accessionId)
+  }
+
   override fun canCreateAutomation(facilityId: FacilityId): Boolean {
     return canUpdateFacility(facilityId)
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -104,6 +104,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deleteAccession(accessionId: AccessionId) {
+    if (!user.canDeleteAccession(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to delete accession $accessionId")
+    }
+  }
+
   fun createAutomation(facilityId: FacilityId) {
     if (!user.canCreateAutomation(facilityId)) {
       readFacility(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -104,6 +104,7 @@ class SystemUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
+  override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -72,6 +72,7 @@ interface TerrawareUser : Principal {
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
+  fun canDeleteAccession(accessionId: AccessionId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean
   fun canDeleteSpecies(speciesId: SpeciesId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -1,0 +1,24 @@
+package com.terraformation.backend.seedbank
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.db.PhotoRepository
+import javax.annotation.ManagedBean
+
+@ManagedBean
+class AccessionService(
+    private val accessionStore: AccessionStore,
+    private val photoRepository: PhotoRepository,
+) {
+  /** Deletes an accession and all its associated data. */
+  fun deleteAccession(accessionId: AccessionId) {
+    requirePermissions { deleteAccession(accessionId) }
+
+    // Note that this is not wrapped in a transaction; if this bombs out after having deleted some
+    // but not all photos from the file store, we don't want to roll back the removal of the photos
+    // that were successfully deleted or else we'll end up with dangling storage URLs.
+    photoRepository.deleteAllPhotos(accessionId)
+    accessionStore.delete(accessionId)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionController.kt
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.SeedBankAppEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
@@ -24,6 +26,7 @@ import com.terraformation.backend.db.ViabilityTestTreatment
 import com.terraformation.backend.db.ViabilityTestType
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalPurpose
+import com.terraformation.backend.seedbank.AccessionService
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.model.AccessionActive
 import com.terraformation.backend.seedbank.model.AccessionModel
@@ -43,6 +46,7 @@ import java.time.Instant
 import java.time.LocalDate
 import javax.validation.Valid
 import javax.validation.constraints.PositiveOrZero
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -55,7 +59,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/seedbank/accession", "/api/v1/seedbank/accessions")
 @RestController
 @SeedBankAppEndpoint
-class AccessionController(private val accessionStore: AccessionStore, private val clock: Clock) {
+class AccessionController(
+    private val accessionService: AccessionService,
+    private val accessionStore: AccessionStore,
+    private val clock: Clock
+) {
   @ApiResponse(
       responseCode = "200",
       description =
@@ -102,6 +110,14 @@ class AccessionController(private val accessionStore: AccessionStore, private va
   fun read(@PathVariable("id") accessionId: AccessionId): GetAccessionResponsePayload {
     val accession = accessionStore.fetchOneById(accessionId)
     return GetAccessionResponsePayload(AccessionPayload(accession, clock))
+  }
+
+  @ApiResponseSimpleSuccess
+  @ApiResponse404
+  @DeleteMapping("/{id}")
+  fun delete(@PathVariable("id") accessionId: AccessionId): SimpleSuccessResponsePayload {
+    accessionService.deleteAccession(accessionId)
+    return SimpleSuccessResponsePayload()
   }
 
   @ApiResponse(responseCode = "200")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -102,6 +102,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun deleteAccession() {
+    assertThrows<AccessionNotFoundException> { requirements.deleteAccession(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    assertThrows<AccessDeniedException> { requirements.deleteAccession(accessionId) }
+
+    grant { user.canDeleteAccession(accessionId) }
+    requirements.deleteAccession(accessionId)
+  }
+
+  @Test
   fun createAutomation() {
     assertThrows<FacilityNotFoundException> { requirements.createAutomation(facilityId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -213,6 +213,7 @@ internal class PermissionTest : DatabaseTest() {
         *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
+        deleteAccession = true,
     )
 
     permissions.expect(
@@ -326,6 +327,7 @@ internal class PermissionTest : DatabaseTest() {
         *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
+        deleteAccession = true,
     )
 
     permissions.expect(
@@ -394,6 +396,7 @@ internal class PermissionTest : DatabaseTest() {
         *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
+        deleteAccession = true,
     )
 
     permissions.expect(
@@ -451,6 +454,7 @@ internal class PermissionTest : DatabaseTest() {
         *accessionIds.forOrg1(),
         readAccession = true,
         updateAccession = true,
+        deleteAccession = true,
     )
 
     permissions.expect(
@@ -729,6 +733,7 @@ internal class PermissionTest : DatabaseTest() {
         vararg accessions: AccessionId,
         readAccession: Boolean = false,
         updateAccession: Boolean = false,
+        deleteAccession: Boolean = false,
     ) {
       accessions.forEach { accessionId ->
         assertEquals(
@@ -737,6 +742,10 @@ internal class PermissionTest : DatabaseTest() {
             updateAccession,
             user.canUpdateAccession(accessionId),
             "Can update accession $accessionId")
+        assertEquals(
+            deleteAccession,
+            user.canDeleteAccession(accessionId),
+            "Can delete accession $accessionId")
 
         uncheckedAccessions.remove(accessionId)
       }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -1,0 +1,61 @@
+package com.terraformation.backend.seedbank
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.db.PhotoRepository
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.jooq.exception.DataAccessException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class AccessionServiceTest : RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val accessionStore: AccessionStore = mockk()
+  private val photoRepository: PhotoRepository = mockk()
+
+  private val service = AccessionService(accessionStore, photoRepository)
+
+  private val accessionId = AccessionId(1)
+
+  @BeforeEach
+  fun setUp() {
+    every { accessionStore.delete(any()) } just Runs
+    every { photoRepository.deleteAllPhotos(any()) } just Runs
+    every { user.canDeleteAccession(any()) } returns true
+    every { user.canReadAccession(any()) } returns true
+  }
+
+  @Test
+  fun `deleteAccession throws exception if user has no permission`() {
+    every { user.canDeleteAccession(any()) } returns false
+
+    assertThrows<AccessDeniedException> { service.deleteAccession(accessionId) }
+  }
+
+  @Test
+  fun `deleteAccession does not try to delete accession if photo deletion fails`() {
+    every { photoRepository.deleteAllPhotos(any()) } throws DataAccessException("uh oh")
+
+    assertThrows<DataAccessException> { service.deleteAccession(accessionId) }
+
+    verify(exactly = 0) { accessionStore.delete(accessionId) }
+  }
+
+  @Test
+  fun `deleteAccession deletes photos and accession data`() {
+    service.deleteAccession(accessionId)
+
+    verify { photoRepository.deleteAllPhotos(accessionId) }
+    verify { accessionStore.delete(accessionId) }
+  }
+}


### PR DESCRIPTION
`/api/v1/seedbank/accessions/{id}` now accepts DELETE requests, which do what
the name suggests.