### PR TITLE
Remove singular-noun accession endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -56,10 +56,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@RequestMapping("/api/v1/seedbank/accession", "/api/v1/seedbank/accessions")
+@RequestMapping("/api/v1/seedbank/accessions")
 @RestController
 @SeedBankAppEndpoint
-class AccessionController(
+class AccessionsController(
     private val accessionService: AccessionService,
     private val accessionStore: AccessionStore,
     private val clock: Clock

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
@@ -47,10 +47,10 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
-@RequestMapping("/api/v1/seedbank/accession/{id}/photo", "/api/v1/seedbank/accessions/{id}/photos")
+@RequestMapping("/api/v1/seedbank/accessions/{id}/photos")
 @RestController
 @SeedBankAppEndpoint
-class PhotoController(private val photoRepository: PhotoRepository) {
+class PhotosController(private val photoRepository: PhotoRepository) {
   private val log = perClassLogger()
 
   @ApiResponseSimpleSuccess


### PR DESCRIPTION
The client code is now using the endpoints with plural names, so we don't need to
keep the singular versions around for backward compatibility any more.