### PR TITLE
Fix test clock bootstrapping on empty DB

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -129,7 +129,7 @@ class SystemUser(
   override fun canSendAlert(facilityId: FacilityId): Boolean = true
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true
-  override fun canSetTestClock(): Boolean = false
+  override fun canSetTestClock(): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
   override fun canUpdateAutomation(automationId: AutomationId): Boolean = true

--- a/src/test/kotlin/com/terraformation/backend/time/DatabaseBackedClockTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/time/DatabaseBackedClockTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.time
 import com.terraformation.backend.Application
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.tables.references.TEST_CLOCK
@@ -33,6 +34,7 @@ internal class DatabaseBackedClockTest : DatabaseTest(), RunsAsUser {
 
   private val config: TerrawareServerConfig = mockk()
   private val publisher: ApplicationEventPublisher = mockk()
+  private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
 
   /** Lazily-instantiated test subject; this will pick up per-test config values. */
   private val clock: DatabaseBackedClock by lazy { newDatabaseBackedClock() }
@@ -203,7 +205,6 @@ internal class DatabaseBackedClockTest : DatabaseTest(), RunsAsUser {
   }
 
   private fun newDatabaseBackedClock(): DatabaseBackedClock {
-    val clock = DatabaseBackedClock(config, dslContext, publisher, refreshInterval = null)
-    return clock
+    return DatabaseBackedClock(config, dslContext, publisher, systemUser, refreshInterval = null)
   }
 }


### PR DESCRIPTION
Commit 1fb15c0c added test clock management to the admin UI, which meant it needed
to start doing permission checks. Unfortunately, the permission check prevents the
test clock from being bootstrapped if the server is started with a completely
empty database. Make the initialization code run as the system user in that case.