### PR TITLE
SW-1310 Regenerate device manager credentials

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -127,6 +127,7 @@ data class DeviceManagerUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
+  override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -354,6 +354,10 @@ data class IndividualUser(
     return userType == UserType.SuperAdmin
   }
 
+  override fun canRegenerateAllDeviceManagerTokens(): Boolean {
+    return userType == UserType.SuperAdmin
+  }
+
   /** Returns true if the user is an admin or owner of any organizations. */
   override fun hasAnyAdminRole(): Boolean =
       organizationRoles.values.any { it == Role.OWNER || it == Role.ADMIN }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -433,4 +433,10 @@ class PermissionRequirements(private val user: TerrawareUser) {
       throw AccessDeniedException("No permission to set test clock")
     }
   }
+
+  fun regenerateAllDeviceManagerTokens() {
+    if (!user.canRegenerateAllDeviceManagerTokens()) {
+      throw AccessDeniedException("No permission to regenerate all device manager tokens")
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -124,6 +124,7 @@ class SystemUser(
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
   override fun canReadUpload(uploadId: UploadId): Boolean = true
+  override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
   override fun canSendAlert(facilityId: FacilityId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -92,6 +92,7 @@ interface TerrawareUser : Principal {
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
   fun canReadUpload(uploadId: UploadId): Boolean
+  fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean

--- a/src/main/resources/templates/admin/deviceManager.html
+++ b/src/main/resources/templates/admin/deviceManager.html
@@ -96,5 +96,13 @@
 
 </form>
 
+<form th:if="${manager.userId} != null"
+      th:action="|${prefix}/deviceManagers/${manager.id}/generateToken|"
+      method="POST">
+
+    <input type="submit" value="Generate New Offline Refresh Token"/>
+
+</form>
+
 </body>
 </html>

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -55,5 +55,26 @@
 
 </div>
 
+<div th:if="${canRegenerateAllDeviceManagerTokens}">
+
+    <h3>Regenerate All Device Manager Offline Refresh Tokens</h3>
+
+    <p>
+        This will invalidate all existing device manager offline refresh tokens and generate new
+        ones. It should be used when there is a configuration change that causes existing tokens
+        to no longer work. It applies to all device managers across all organizations.
+    </p>
+
+    <p>
+        If there are a lot of device managers or Balena's API is slow, this may time out! Check the
+        server logs to monitor its progress in that case.
+    </p>
+
+    <form th:action="|${prefix}/deviceManagers/regenerateAllTokens|" method="POST">
+        <input type="submit" value="Regenerate All Tokens"/>
+    </form>
+
+</div>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -591,4 +591,12 @@ internal class PermissionRequirementsTest : RunsAsUser {
     grant { user.canSetTestClock() }
     requirements.setTestClock()
   }
+
+  @Test
+  fun regenerateAllDeviceManagerTokens() {
+    assertThrows<AccessDeniedException> { requirements.regenerateAllDeviceManagerTokens() }
+
+    grant { user.canRegenerateAllDeviceManagerTokens() }
+    requirements.regenerateAllDeviceManagerTokens()
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -562,6 +562,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         createDeviceManager = true,
         importGlobalSpeciesData = true,
+        regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
         updateDeviceTemplates = true,
     )
@@ -872,6 +873,7 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         createDeviceManager: Boolean = false,
         importGlobalSpeciesData: Boolean = false,
+        regenerateAllDeviceManagerTokens: Boolean = false,
         setTestClock: Boolean = false,
         updateDeviceTemplates: Boolean = false,
     ) {
@@ -880,6 +882,10 @@ internal class PermissionTest : DatabaseTest() {
           importGlobalSpeciesData,
           user.canImportGlobalSpeciesData(),
           "Can import global species data")
+      assertEquals(
+          regenerateAllDeviceManagerTokens,
+          user.canRegenerateAllDeviceManagerTokens(),
+          "Can regenerate all device manager tokens")
       assertEquals(setTestClock, user.canSetTestClock(), "Can set test clock")
       assertEquals(
           updateDeviceTemplates, user.canUpdateDeviceTemplates(), "Can update device templates")


### PR DESCRIPTION
Upgrading Keycloak changed the format of authentication URLs, and since the URLs
are embedded in offline refresh tokens, existing tokens won't work.

Add a button to the device managers page in the admin UI to generate fresh tokens
for all device managers that are associated with users. This is only available for
super-admins since it cuts across all organizations.

Also add a button to generate a new token for a single device manager.