### PR TITLE
SW-693 Authenticate with AWS using OpenID Connect

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -28,12 +28,11 @@ fi
         echo "DOCKER_TAGS=${docker_image}:$commit_sha,${docker_image}:${TIER}"
 
         # Define secret names based on the tier
+        echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
+        echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
         echo "SSH_HOST_SECRET_NAME=${TIER}_SSH_HOST"
         echo "SSH_KEY_SECRET_NAME=${TIER}_SSH_KEY"
         echo "SSH_USER_SECRET_NAME=${TIER}_SSH_USER"
-        echo "AWS_ACCESS_KEY_ID_SECRET_NAME=${TIER}_AWS_ACCESS_KEY_ID"
-        echo "AWS_SECRET_ACCESS_KEY_SECRET_NAME=${TIER}_AWS_SECRET_ACCESS_KEY"
-        echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
     fi
 
     # Build Docker images for the species branch (TODO: Remove this before merging to main)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ on:
       - v2[0-9]+.[0-9]+
   pull_request:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -109,8 +113,7 @@ jobs:
       if: env.IS_CD == 'true'
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets[env.AWS_ACCESS_KEY_ID_SECRET_NAME] }}
-        aws-secret-access-key: ${{ secrets[env.AWS_SECRET_ACCESS_KEY_SECRET_NAME] }}
+        role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
     - name: Deploy


### PR DESCRIPTION
Update the GitHub Actions workflow to stop using an access key to authenticate
with AWS during deployment. Instead, GitHub will generate a signed OpenID
Connect token and use it to request temporary access to an AWS role that only
allows access to the specific operations we need for deployment.

This will eliminate the need to rotate our access key periodically.