### PR TITLE
SW-1316 Add species common name to accession payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -345,7 +345,14 @@ data class AccessionPayload(
                 "the presence of the deviceInfo field.")
     val source: AccessionSource?,
     val sourcePlantOrigin: SourcePlantOrigin?,
+    @Schema(
+        description = "Scientific name of the species.",
+    )
     val species: String?,
+    @Schema(
+        description = "Common name of the species, if defined.",
+    )
+    val speciesCommonName: String?,
     @Schema(
         description = "Server-generated unique ID of the species.",
     )
@@ -429,6 +436,7 @@ data class AccessionPayload(
       model.source,
       model.sourcePlantOrigin,
       model.species,
+      model.speciesCommonName,
       model.speciesId,
       model.state ?: AccessionState.Pending,
       model.storageCondition,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -91,6 +91,7 @@ class AccessionStore(
         dslContext
             .select(
                 ACCESSIONS.asterisk(),
+                ACCESSIONS.species().COMMON_NAME,
                 ACCESSIONS.species().SCIENTIFIC_NAME,
                 ACCESSIONS.STATE_ID,
                 ACCESSIONS.storageLocations().NAME,
@@ -157,6 +158,7 @@ class AccessionStore(
           source = source,
           sourcePlantOrigin = record[SOURCE_PLANT_ORIGIN_ID],
           species = record[species().SCIENTIFIC_NAME],
+          speciesCommonName = record[species().COMMON_NAME],
           speciesId = record[SPECIES_ID],
           state = record[STATE_ID]!!,
           storageCondition = record[storageLocations().CONDITION_ID],

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -84,6 +84,7 @@ data class AccessionModel(
     val source: AccessionSource? = null,
     val sourcePlantOrigin: SourcePlantOrigin? = null,
     val species: String? = null,
+    val speciesCommonName: String? = null,
     val speciesId: SpeciesId? = null,
     val state: AccessionState? = null,
     val storageCondition: StorageCondition? = null,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -345,6 +345,7 @@ abstract class DatabaseTest {
       deletedTime: Instant? = null,
       checkedTime: Instant? = null,
       initialScientificName: String = scientificName,
+      commonName: String? = null,
   ) {
     val speciesIdWrapper = speciesId.toIdWrapper { SpeciesId(it) }
     val organizationIdWrapper = organizationId.toIdWrapper { OrganizationId(it) }
@@ -353,6 +354,7 @@ abstract class DatabaseTest {
       dslContext
           .insertInto(SPECIES)
           .set(CHECKED_TIME, checkedTime)
+          .set(COMMON_NAME, commonName)
           .set(CREATED_BY, createdBy)
           .set(CREATED_TIME, createdTime)
           .set(DELETED_BY, if (deletedTime != null) createdBy else null)


### PR DESCRIPTION
To make it more efficient for the web app to show the common name of the species
as part of the accession details UI, add it to the accession payload. This is a
read-only field; to edit a species' common name, you have to use the species API.