### PR TITLE
SW-1317 Support storing user preferences

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -2,7 +2,9 @@ package com.terraformation.backend.api
 
 import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.customer.api.AutomationPayload
+import com.terraformation.backend.customer.api.GetUserPreferencesResponsePayload
 import com.terraformation.backend.customer.api.ModifyAutomationRequestPayload
+import com.terraformation.backend.customer.api.UpdateUserPreferencesRequestPayload
 import com.terraformation.backend.device.api.CreateDeviceRequestPayload
 import com.terraformation.backend.device.api.DeviceConfig
 import com.terraformation.backend.device.api.UpdateDeviceRequestPayload
@@ -97,8 +99,10 @@ class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomiser 
             AutomationPayload::class.swaggerSchemaName to "configuration",
             CreateDeviceRequestPayload::class.swaggerSchemaName to "settings",
             DeviceConfig::class.swaggerSchemaName to "settings",
+            GetUserPreferencesResponsePayload::class.swaggerSchemaName to "preferences",
             ModifyAutomationRequestPayload::class.swaggerSchemaName to "configuration",
             UpdateDeviceRequestPayload::class.swaggerSchemaName to "settings",
+            UpdateUserPreferencesRequestPayload::class.swaggerSchemaName to "preferences",
         )
     val listsToModify =
         listOf(

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.USERS
+import com.terraformation.backend.db.tables.references.USER_PREFERENCES
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
 import javax.annotation.ManagedBean
@@ -308,6 +309,12 @@ class OrganizationStore(
       if (rowsDeleted < 1) {
         throw UserNotFoundException(userId)
       }
+
+      dslContext
+          .deleteFrom(USER_PREFERENCES)
+          .where(USER_PREFERENCES.USER_ID.eq(userId))
+          .and(USER_PREFERENCES.ORGANIZATION_ID.eq(organizationId))
+          .execute()
     }
   }
 

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -141,15 +141,6 @@ COMMENT ON TABLE timeseries_types IS '(Enum) Data formats of the values of a tim
 
 COMMENT ON TABLE timeseries_values IS 'Individual data points on a timeseries. For example, each time the temperature is read from a thermometer, the reading is inserted here.';
 
-COMMENT ON TABLE user_types IS '(Enum) Types of users. Most users are of type 1, "Individual."';
-
-COMMENT ON TABLE users IS 'User identities. A user can be associated with organizations via `organization_users`.';
-COMMENT ON COLUMN users.auth_id IS 'Unique identifier of the user in the authentication system. Currently, this is a Keycloak user ID.';
-COMMENT ON COLUMN users.email_notifications_enabled IS 'If true, the user wants to receive notifications via email.';
-COMMENT ON COLUMN users.last_activity_time IS 'When the user most recently interacted with the system.';
-
-COMMENT ON TABLE uploads IS 'Information about the status of files uploaded by users. This is used to track the progress of file processing such as importing datafiles; contents of this table may expire and be deleted after a certain amount of time.';
-
 COMMENT ON TABLE upload_problems IS 'Details about problems (validation failures, etc.) in user-uploaded files.';
 COMMENT ON COLUMN upload_problems.position IS 'Where in the uploaded file the problem appears, or null if it is a problem with the file as a whole. This may be a byte offset, a line number, or a record number depending on the type of file.';
 COMMENT ON COLUMN upload_problems.field IS 'If the problem pertains to a specific field, its name. Null if the problem affects an entire record or the entire file.';
@@ -161,6 +152,18 @@ COMMENT ON COLUMN upload_statuses.finished IS 'If true, this status means that t
 
 COMMENT ON TABLE upload_types IS '(Enum) Types of user-uploaded files whose progress can be tracked in the uploads table.';
 COMMENT ON COLUMN upload_types.expire_files IS 'Old rows are automatically deleted from the uploads table. If this value is true, files will also be removed from the file store for old uploads of this type.';
+
+COMMENT ON TABLE uploads IS 'Information about the status of files uploaded by users. This is used to track the progress of file processing such as importing datafiles; contents of this table may expire and be deleted after a certain amount of time.';
+
+COMMENT ON TABLE user_preferences IS 'Client-defined preferences that should persist across browser sessions.';
+COMMENT ON COLUMN user_preferences.organization_id IS 'If null, preferences are global to the user. Otherwise, they are specific to the user and the organization.';
+
+COMMENT ON TABLE user_types IS '(Enum) Types of users. Most users are of type 1, "Individual."';
+
+COMMENT ON TABLE users IS 'User identities. A user can be associated with organizations via `organization_users`.';
+COMMENT ON COLUMN users.auth_id IS 'Unique identifier of the user in the authentication system. Currently, this is a Keycloak user ID.';
+COMMENT ON COLUMN users.email_notifications_enabled IS 'If true, the user wants to receive notifications via email.';
+COMMENT ON COLUMN users.last_activity_time IS 'When the user most recently interacted with the system.';
 
 COMMENT ON TABLE viability_test_results IS 'Result from a viability test of a batch of seeds. Viability tests can have multiple germinations, e.g., if different seeds germinate on different days.';
 

--- a/src/main/resources/db/migration/V107__Preferences.sql
+++ b/src/main/resources/db/migration/V107__Preferences.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_preferences (
+    user_id BIGINT NOT NULL REFERENCES users,
+    organization_id BIGINT REFERENCES organizations,
+    preferences JSONB NOT NULL
+);
+
+CREATE UNIQUE INDEX ON user_preferences (user_id) WHERE organization_id IS NULL;
+CREATE UNIQUE INDEX ON user_preferences (user_id, organization_id) WHERE organization_id IS NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -178,6 +178,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "upload_problem_types" to setOf(ALL, CUSTOMER),
           "upload_statuses" to setOf(ALL, CUSTOMER),
           "upload_types" to setOf(ALL, CUSTOMER),
+          "user_preferences" to setOf(ALL, CUSTOMER),
           "user_types" to setOf(ALL, CUSTOMER),
           "users" to setOf(ALL, CUSTOMER),
           "viability_test_results" to setOf(ALL, SEEDBANK),


### PR DESCRIPTION
The new `/api/v1/users/me/preferences` endpoint can be used to store and retrieve
user preferences. Each user has global preferences as well as a separate set of
preferences for each organization they're in. Users (even admins) can only access
their own preferences, not the preferences of other users.

Preferences are completely client-defined; they are represented as a single JSON
object which the server treats as opaque.