### PR TITLE
Clean up CI configuration

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,19 +3,7 @@
 mkdir -p ~/.ssh
 echo "$SSH_KEY" > ~/.ssh/key
 chmod 600 ~/.ssh/key
-cat >> ~/.ssh/config <<END
-Host bastion*
-  User $SSH_USER
-  IdentityFile ~/.ssh/key
-  ProxyCommand none
-  StrictHostKeyChecking no
-
-Host terraware*
-  User $SSH_USER
-  IdentityFile ~/.ssh/key
-  ProxyCommand ssh -n -W %h:%p $SSH_HOST
-  StrictHostKeyChecking no
-END
+echo "$SSH_CONFIG" > ~/.ssh/config
 
 aws ec2 describe-instances --filters "Name=tag:Application,Values=terraware" \
   | jq -r ' .Reservations[].Instances[].Tags[] | select(.Key == "Hostname") | .Value' \

--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -30,14 +30,7 @@ fi
         # Define secret names based on the tier
         echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
         echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
-        echo "SSH_HOST_SECRET_NAME=${TIER}_SSH_HOST"
+        echo "SSH_CONFIG_SECRET_NAME=${TIER}_SSH_CONFIG"
         echo "SSH_KEY_SECRET_NAME=${TIER}_SSH_KEY"
-        echo "SSH_USER_SECRET_NAME=${TIER}_SSH_USER"
-    fi
-
-    # Build Docker images for the species branch (TODO: Remove this before merging to main)
-    if [[ "$GITHUB_REF" == refs/heads/species ]]; then
-        echo "DOCKER_TAGS=${docker_image}:species"
     fi
 ) >> "$GITHUB_ENV"
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,6 @@ on:
       - main
       - qa
       - renovate/*
-      - species
       - wip-*
     tags:
       # Semver (these are glob-like patterns, not regexes; the "." has no special meaning)
@@ -119,7 +118,6 @@ jobs:
     - name: Deploy
       if: env.IS_CD == 'true'
       env:
-        SSH_HOST: ${{ secrets[env.SSH_HOST_SECRET_NAME] }}
+        SSH_CONFIG: ${{ secrets[env.SSH_CONFIG_SECRET_NAME] }}
         SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
-        SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
       run: ./.github/scripts/deploy.sh


### PR DESCRIPTION
To support changing how we access the AWS hosts, move the entire ssh
configuration to a GitHub secret.

Remove the temporary special-case handling of the `species` branch.