### PR TITLE
SW-1339 Remove unused fields from seed summary API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.api
 
 import com.terraformation.backend.api.SeedBankAppEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.AccessionState
@@ -50,18 +51,8 @@ class SummaryController(
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
 
     return SummaryResponse(
-        activeAccessions =
-            SummaryStatistic(
-                accessionStore.countActive(facilityId, now),
-                accessionStore.countActive(facilityId, startOfWeek)),
-        species =
-            SummaryStatistic(
-                speciesStore.countSpecies(organizationId, now),
-                speciesStore.countSpecies(organizationId, startOfWeek)),
-        families =
-            SummaryStatistic(
-                accessionStore.countFamilies(facilityId, now),
-                accessionStore.countFamilies(facilityId, startOfWeek)),
+        activeAccessions = accessionStore.countActive(facilityId),
+        species = speciesStore.countSpecies(organizationId),
         overduePendingAccessions =
             accessionStore.countInState(
                 facilityId, AccessionState.Pending, sinceBefore = oneWeekAgo),
@@ -107,18 +98,8 @@ class SummaryController(
     val twoWeeksAgo = startOfDay.minusDays(13)
 
     return SummaryResponse(
-        activeAccessions =
-            SummaryStatistic(
-                accessionStore.countActive(organizationId, now),
-                accessionStore.countActive(organizationId, startOfWeek)),
-        species =
-            SummaryStatistic(
-                speciesStore.countSpecies(organizationId, now),
-                speciesStore.countSpecies(organizationId, startOfWeek)),
-        families =
-            SummaryStatistic(
-                accessionStore.countFamilies(organizationId, now),
-                accessionStore.countFamilies(organizationId, startOfWeek)),
+        activeAccessions = accessionStore.countActive(organizationId),
+        species = speciesStore.countSpecies(organizationId),
         overduePendingAccessions =
             accessionStore.countInState(
                 organizationId, AccessionState.Pending, sinceBefore = oneWeekAgo),
@@ -132,14 +113,10 @@ class SummaryController(
   }
 }
 
-@Schema(description = "The current value and value as of last week for a summary statistic")
-data class SummaryStatistic(val current: Int, val lastWeek: Int)
-
 @Schema(description = "Summary of important statistics about the seed bank for the Summary page.")
 data class SummaryResponse(
-    val activeAccessions: SummaryStatistic,
-    val species: SummaryStatistic,
-    val families: SummaryStatistic,
+    val activeAccessions: Int,
+    val species: Int,
     @Schema(description = "Number of accessions in Pending state overdue for processing")
     val overduePendingAccessions: Int,
     @Schema(description = "Number of accessions in Processed state overdue for drying")
@@ -148,4 +125,4 @@ data class SummaryResponse(
     val overdueDriedAccessions: Int,
     @Schema(description = "Number of accessions withdrawn so far this week")
     val recentlyWithdrawnAccessions: Int,
-)
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -18,9 +18,7 @@ import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.SpeciesService
-import com.terraformation.backend.time.toInstant
 import java.time.Clock
-import java.time.temporal.TemporalAccessor
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
@@ -59,15 +57,14 @@ class SpeciesStore(
         ?: throw SpeciesNotFoundException(speciesId)
   }
 
-  fun countSpecies(organizationId: OrganizationId, asOf: TemporalAccessor): Int {
+  fun countSpecies(organizationId: OrganizationId): Int {
     requirePermissions { readOrganization(organizationId) }
 
     return dslContext
         .select(DSL.count())
         .from(SPECIES)
         .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
-        .and(SPECIES.CREATED_TIME.le(asOf.toInstant()))
-        .and(SPECIES.DELETED_TIME.isNull.or(SPECIES.DELETED_TIME.gt(asOf.toInstant())))
+        .and(SPECIES.DELETED_TIME.isNull)
         .fetchOne()
         ?.value1()
         ?: 0

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -353,9 +353,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadOrganization(organizationId) } returns false
     every { user.canReadSpecies(speciesId) } returns false
 
-    assertThrows<OrganizationNotFoundException> {
-      store.countSpecies(organizationId, Instant.EPOCH)
-    }
+    assertThrows<OrganizationNotFoundException> { store.countSpecies(organizationId) }
 
     assertThrows<OrganizationNotFoundException> {
       store.fetchSpeciesIdByName(organizationId, scientificName)


### PR DESCRIPTION
To support simplifying the accessions dashboard, remove some values from the
summary API that we're no longer going to be showing and thus don't need to spend
time calculating:

* The number of families. We're now only showing species counts.
* The "last week" statistics for active accessions and species. We're not going to
  show percentage changes any more.

The latter change isn't backward-compatible; it lifts the value from a child
object up into the top-level `SummaryResponse` payload.