### PR TITLE
SW-1341 Add accession counts by state to summary API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
@@ -62,7 +62,9 @@ class SummaryController(
         overdueDriedAccessions = accessionStore.countInState(facilityId, AccessionState.Dried),
         recentlyWithdrawnAccessions =
             accessionStore.countInState(
-                facilityId, AccessionState.Withdrawn, sinceAfter = startOfWeek))
+                facilityId, AccessionState.Withdrawn, sinceAfter = startOfWeek),
+        accessionsByState = accessionStore.countByState(facilityId),
+    )
   }
   @GetMapping
   @Operation(
@@ -109,7 +111,9 @@ class SummaryController(
         overdueDriedAccessions = accessionStore.countInState(organizationId, AccessionState.Dried),
         recentlyWithdrawnAccessions =
             accessionStore.countInState(
-                organizationId, AccessionState.Withdrawn, sinceAfter = startOfWeek))
+                organizationId, AccessionState.Withdrawn, sinceAfter = startOfWeek),
+        accessionsByState = accessionStore.countByState(organizationId),
+    )
   }
 }
 
@@ -117,12 +121,14 @@ class SummaryController(
 data class SummaryResponse(
     val activeAccessions: Int,
     val species: Int,
-    @Schema(description = "Number of accessions in Pending state overdue for processing")
+    @Schema(description = "Number of accessions in Pending state overdue for processing.")
     val overduePendingAccessions: Int,
-    @Schema(description = "Number of accessions in Processed state overdue for drying")
+    @Schema(description = "Number of accessions in Processed state overdue for drying.")
     val overdueProcessedAccessions: Int,
-    @Schema(description = "Number of accessions in Dried state overdue for storage")
+    @Schema(description = "Number of accessions in Dried state overdue for storage.")
     val overdueDriedAccessions: Int,
-    @Schema(description = "Number of accessions withdrawn so far this week")
+    @Schema(description = "Number of accessions withdrawn so far this week.")
     val recentlyWithdrawnAccessions: Int,
+    @Schema(description = "Number of accessions in each state.")
+    val accessionsByState: Map<AccessionState, Int>,
 ) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -38,6 +38,19 @@ fun AccessionState.toActiveEnum() =
       AccessionState.InStorage -> AccessionActive.Active
     }
 
+/**
+ * All the accession states that are considered active. This is effectively the backing field for
+ * [AccessionState.Companion.activeValues], because extension properties don't have backing fields.
+ * We derive this from [AccessionState.toActiveEnum] rather than the other way around so we get the
+ * comprehensiveness check in the `when` expression in that function.
+ */
+private val activeStates =
+    AccessionState.values().filter { it.toActiveEnum() == AccessionActive.Active }.toSet()
+
+/** All the accession states that are considered active. */
+val AccessionState.Companion.activeValues: Set<AccessionState>
+  get() = activeStates
+
 enum class AccessionSource {
   Web,
   SeedCollectorApp


### PR DESCRIPTION
To allow the web app to show a breakdown of active accessions by current state,
add a field to the `/api/v1/seedbank/summary` response that includes the count
for each state that's considered active. All active states are always included
whether or not there are any accessions in that state.