### PR TITLE
SW-1322 Add viability test selection

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -506,6 +506,12 @@ data class ViabilityTestPayload(
     val remainingQuantity: SeedQuantityPayload? = null,
     val staffResponsible: String? = null,
     val seedsSown: Int? = null,
+    @Schema(
+        description =
+            "If true, this viability test's results are used as the viability percentage for the " +
+                "accession as a whole. At most one test can be marked as selected.",
+        defaultValue = "false")
+    val selected: Boolean = false,
     @Valid val testResults: List<ViabilityTestResultPayload>? = null,
     val totalPercentGerminated: Int? = null,
     val totalSeedsGerminated: Int? = null,
@@ -524,6 +530,7 @@ data class ViabilityTestPayload(
       model.remaining?.toPayload(),
       model.staffResponsible,
       model.seedsSown,
+      model.selected,
       model.testResults?.map { ViabilityTestResultPayload(it) },
       model.totalPercentGerminated,
       model.totalSeedsGerminated,
@@ -537,6 +544,7 @@ data class ViabilityTestPayload(
           notes = notes,
           seedsSown = seedsSown,
           seedType = seedType,
+          selected = selected,
           staffResponsible = staffResponsible,
           startDate = startDate,
           substrate = substrate,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tables.references.VIABILITY_TEST_RESULTS
+import com.terraformation.backend.db.tables.references.VIABILITY_TEST_SELECTIONS
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.ViabilityTestResultModel
@@ -22,8 +23,13 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
 
     return with(VIABILITY_TESTS) {
       DSL.multiset(
-              DSL.select(VIABILITY_TESTS.asterisk(), viabilityTestResultsMultiset)
+              DSL.select(
+                      VIABILITY_TESTS.asterisk(),
+                      VIABILITY_TEST_SELECTIONS.VIABILITY_TEST_ID,
+                      viabilityTestResultsMultiset)
                   .from(VIABILITY_TESTS)
+                  .leftJoin(VIABILITY_TEST_SELECTIONS)
+                  .on(ID.eq(VIABILITY_TEST_SELECTIONS.VIABILITY_TEST_ID))
                   .where(ACCESSION_ID.eq(idField))
                   .orderBy(ID))
           .convertFrom { result ->
@@ -44,6 +50,7 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
                   record[STAFF_RESPONSIBLE],
                   record[viabilityTestResultsMultiset]?.ifEmpty { null },
                   SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
+                  record[VIABILITY_TEST_SELECTIONS.VIABILITY_TEST_ID] != null,
               )
             }
           }
@@ -107,6 +114,10 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
 
     calculatedTest.testResults?.forEach { insertTestResult(testId, it) }
 
+    if (viabilityTest.selected) {
+      insertViabilityTestSelection(accessionId, testId)
+    }
+
     return calculatedTest.copy(id = testId)
   }
 
@@ -130,6 +141,10 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
     val desired = desiredTests ?: emptyList()
     val deletedTestIds = existingIds.minus(desired.mapNotNull { it.id }.toSet())
 
+    if (desired.count { it.selected } > 1) {
+      throw IllegalArgumentException("At most one test can be selected.")
+    }
+
     if (deletedTestIds.isNotEmpty()) {
       dslContext
           .deleteFrom(VIABILITY_TEST_RESULTS)
@@ -141,47 +156,77 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
           .execute()
     }
 
-    desired
-        .map { it.withCalculatedValues() }
-        .forEach { desiredTest ->
-          val testId = desiredTest.id
+    val testsWithIds =
+        desired
+            .map { it.withCalculatedValues() }
+            .map { desiredTest ->
+              val testId = desiredTest.id
 
-          if (testId == null) {
-            insertViabilityTest(accessionId, desiredTest)
-          } else {
-            val existingTest =
-                existingById[testId]
-                    ?: throw IllegalArgumentException(
-                        "Viability test IDs must refer to existing tests; leave ID off to insert a new test.")
-            if (!desiredTest.fieldsEqual(existingTest)) {
-              with(VIABILITY_TESTS) {
+              if (testId == null) {
+                insertViabilityTest(accessionId, desiredTest)
+              } else {
+                val existingTest =
+                    existingById[testId]
+                        ?: throw IllegalArgumentException(
+                            "Viability test IDs must refer to existing tests; leave ID off to insert a new test.")
+                if (!desiredTest.fieldsEqual(existingTest)) {
+                  with(VIABILITY_TESTS) {
+                    dslContext
+                        .update(VIABILITY_TESTS)
+                        .set(END_DATE, desiredTest.endDate)
+                        .set(NOTES, desiredTest.notes)
+                        .set(REMAINING_GRAMS, desiredTest.remaining?.grams)
+                        .set(REMAINING_QUANTITY, desiredTest.remaining?.quantity)
+                        .set(REMAINING_UNITS_ID, desiredTest.remaining?.units)
+                        .set(SEED_TYPE_ID, desiredTest.seedType)
+                        .set(SEEDS_SOWN, desiredTest.seedsSown)
+                        .set(SUBSTRATE_ID, desiredTest.substrate)
+                        .set(STAFF_RESPONSIBLE, desiredTest.staffResponsible)
+                        .set(START_DATE, desiredTest.startDate)
+                        .set(TOTAL_PERCENT_GERMINATED, desiredTest.totalPercentGerminated)
+                        .set(TOTAL_SEEDS_GERMINATED, desiredTest.totalSeedsGerminated)
+                        .set(TREATMENT_ID, desiredTest.treatment)
+                        .where(ID.eq(testId))
+                        .execute()
+                  }
+                }
+
+                // TODO: Smarter diff of test results
                 dslContext
-                    .update(VIABILITY_TESTS)
-                    .set(END_DATE, desiredTest.endDate)
-                    .set(NOTES, desiredTest.notes)
-                    .set(REMAINING_GRAMS, desiredTest.remaining?.grams)
-                    .set(REMAINING_QUANTITY, desiredTest.remaining?.quantity)
-                    .set(REMAINING_UNITS_ID, desiredTest.remaining?.units)
-                    .set(SEED_TYPE_ID, desiredTest.seedType)
-                    .set(SEEDS_SOWN, desiredTest.seedsSown)
-                    .set(SUBSTRATE_ID, desiredTest.substrate)
-                    .set(STAFF_RESPONSIBLE, desiredTest.staffResponsible)
-                    .set(START_DATE, desiredTest.startDate)
-                    .set(TOTAL_PERCENT_GERMINATED, desiredTest.totalPercentGerminated)
-                    .set(TOTAL_SEEDS_GERMINATED, desiredTest.totalSeedsGerminated)
-                    .set(TREATMENT_ID, desiredTest.treatment)
-                    .where(ID.eq(testId))
+                    .deleteFrom(VIABILITY_TEST_RESULTS)
+                    .where(VIABILITY_TEST_RESULTS.TEST_ID.eq(testId))
                     .execute()
+                desiredTest.testResults?.forEach { insertTestResult(testId, it) }
+
+                desiredTest
               }
             }
 
-            // TODO: Smarter diff of test results
-            dslContext
-                .deleteFrom(VIABILITY_TEST_RESULTS)
-                .where(VIABILITY_TEST_RESULTS.TEST_ID.eq(testId))
-                .execute()
-            desiredTest.testResults?.forEach { insertTestResult(testId, it) }
-          }
-        }
+    val desiredSelectedId = testsWithIds.firstOrNull { it.selected }?.id
+    val existingSelectedId = existing.firstOrNull { it.selected }?.id
+
+    if (desiredSelectedId != null && desiredSelectedId != existingSelectedId) {
+      insertViabilityTestSelection(accessionId, desiredSelectedId)
+    } else if (desiredSelectedId == null &&
+        existingSelectedId != null &&
+        existingSelectedId !in deletedTestIds) {
+      dslContext
+          .deleteFrom(VIABILITY_TEST_SELECTIONS)
+          .where(VIABILITY_TEST_SELECTIONS.ACCESSION_ID.eq(accessionId))
+          .execute()
+    }
+  }
+
+  private fun insertViabilityTestSelection(accessionId: AccessionId, testId: ViabilityTestId) {
+    with(VIABILITY_TEST_SELECTIONS) {
+      dslContext
+          .insertInto(VIABILITY_TEST_SELECTIONS)
+          .set(ACCESSION_ID, accessionId)
+          .set(VIABILITY_TEST_ID, testId)
+          .onConflict(ACCESSION_ID)
+          .doUpdate()
+          .set(VIABILITY_TEST_ID, testId)
+          .execute()
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -182,6 +182,10 @@ data class AccessionModel(
             "Cannot withdraw from accession before setting total accession size")
       }
     }
+
+    if (viabilityTests.count { it.selected } > 1) {
+      throw IllegalArgumentException("Cannot select multiple viability tests")
+    }
   }
 
   private fun validateCountBased() {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -32,6 +32,7 @@ data class ViabilityTestModel(
     val staffResponsible: String? = null,
     val testResults: Collection<ViabilityTestResultModel>? = null,
     val remaining: SeedQuantityModel? = null,
+    val selected: Boolean = false,
 ) {
   fun fieldsEqual(other: ViabilityTestModel): Boolean {
     return endDate == other.endDate &&
@@ -39,6 +40,7 @@ data class ViabilityTestModel(
         remaining.equalsIgnoreScale(other.remaining) &&
         seedsSown == other.seedsSown &&
         seedType == other.seedType &&
+        selected == other.selected &&
         staffResponsible == other.staffResponsible &&
         startDate == other.startDate &&
         substrate == other.substrate &&

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -167,6 +167,8 @@ COMMENT ON TABLE viability_test_results IS 'Result from a viability test of a ba
 
 COMMENT ON TABLE viability_test_seed_types IS '(Enum) Types of seeds that can be tested for viability. This refers to how the seeds were stored, not the physical characteristics of the seeds themselves.';
 
+COMMENT ON TABLE viability_test_selections IS 'Linking table that stores the currently-selected viability test for each accession.';
+
 COMMENT ON TABLE viability_test_substrates IS '(Enum) Types of substrate that can be used to test seeds for viability.';
 
 COMMENT ON TABLE viability_test_treatments IS '(Enum) Techniques that can be used to treat seeds before testing them for viability.';

--- a/src/main/resources/db/migration/V109__ViabilityTestSelections.sql
+++ b/src/main/resources/db/migration/V109__ViabilityTestSelections.sql
@@ -1,0 +1,18 @@
+-- Each accession can optionally have a single viability test that is considered the "selected" one.
+-- There are three ways we could model this: as a "selected test ID" column on the accessions table,
+-- as an "is selected" flag on the viability_tests table, or as a separate table. The first two
+-- options are more complicated to update when, e.g., the selected test is being deleted or the
+-- selection is switching to a newly-inserted test.
+
+
+-- viability_tests.id is already unique, but we want to use a foreign key to guarantee that we don't
+-- mark a test from accession 1 as the selection for accession 2, and the target columns of a
+-- foreign key have to have a unique constraint.
+ALTER TABLE viability_tests ADD CONSTRAINT viability_tests_id_accession_unique UNIQUE (id, accession_id);
+
+CREATE TABLE viability_test_selections (
+    accession_id BIGINT PRIMARY KEY REFERENCES accessions,
+    viability_test_id BIGINT NOT NULL,
+    UNIQUE (viability_test_id),
+    FOREIGN KEY (viability_test_id, accession_id) REFERENCES viability_tests (id, accession_id) ON DELETE CASCADE
+);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -28,6 +28,7 @@ import com.terraformation.backend.db.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.tables.daos.UploadsDao
 import com.terraformation.backend.db.tables.daos.UsersDao
 import com.terraformation.backend.db.tables.daos.ViabilityTestResultsDao
+import com.terraformation.backend.db.tables.daos.ViabilityTestSelectionsDao
 import com.terraformation.backend.db.tables.daos.ViabilityTestsDao
 import com.terraformation.backend.db.tables.daos.WithdrawalsDao
 import com.terraformation.backend.db.tables.references.AUTOMATIONS
@@ -210,6 +211,7 @@ abstract class DatabaseTest {
   protected val usersDao: UsersDao by lazyDao()
   protected val viabilityTestResultsDao: ViabilityTestResultsDao by lazyDao()
   protected val viabilityTestsDao: ViabilityTestsDao by lazyDao()
+  protected val viabilityTestSelectionsDao: ViabilityTestSelectionsDao by lazyDao()
   protected val withdrawalsDao: WithdrawalsDao by lazyDao()
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -182,6 +182,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "users" to setOf(ALL, CUSTOMER),
           "viability_test_results" to setOf(ALL, SEEDBANK),
           "viability_test_seed_types" to setOf(ALL, SEEDBANK),
+          "viability_test_selections" to setOf(ALL, SEEDBANK),
           "viability_test_substrates" to setOf(ALL, SEEDBANK),
           "viability_test_treatments" to setOf(ALL, SEEDBANK),
           "viability_test_types" to setOf(ALL, SEEDBANK),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -402,6 +402,134 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     assertNull(
         updatedAccession.viabilityTests.first().testResults,
         "Empty list of viability test results should be null in model")
+    assertNull(
+        viabilityTestSelectionsDao.fetchOneByAccessionId(AccessionId(1)),
+        "Test should not be selected")
+  }
+
+  @Test
+  fun `viability test may be selected at creation time`() {
+    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val withTest =
+        initial
+            .toUpdatePayload()
+            .copy(
+                viabilityTests =
+                    listOf(
+                        ViabilityTestPayload(
+                            selected = true,
+                            startDate = LocalDate.of(2020, 1, 1),
+                            testType = ViabilityTestType.Lab)),
+                processingMethod = ProcessingMethod.Count,
+                initialQuantity = seeds(100))
+    store.update(withTest.toModel(id = initial.id!!))
+
+    val updated = store.fetchOneById(initial.id!!)
+
+    assertTrue(updated.viabilityTests.first().selected, "Test should be selected")
+  }
+
+  @Test
+  fun `viability tests may be deselected`() {
+    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val withTests =
+        initial
+            .toUpdatePayload()
+            .copy(
+                viabilityTests =
+                    listOf(
+                        ViabilityTestPayload(
+                            selected = true,
+                            startDate = LocalDate.of(2020, 1, 1),
+                            testType = ViabilityTestType.Lab)),
+                processingMethod = ProcessingMethod.Count,
+                initialQuantity = seeds(100))
+    store.update(withTests.toModel(id = initial.id!!))
+
+    val updatedWithTests = store.fetchOneById(initial.id!!)
+
+    store.update(
+        updatedWithTests.copy(
+            viabilityTests = updatedWithTests.viabilityTests.map { it.copy(selected = false) }))
+
+    val updatedAfterDeselecting = store.fetchOneById(initial.id!!)
+
+    assertEquals(1, updatedAfterDeselecting.viabilityTests.size, "Number of tests")
+    assertTrue(
+        updatedAfterDeselecting.viabilityTests.none { it.selected }, "No test should be selected")
+  }
+
+  @Test
+  fun `deleting the selected viability test does not select another test`() {
+    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val withTests =
+        initial
+            .toUpdatePayload()
+            .copy(
+                viabilityTests =
+                    listOf(
+                        ViabilityTestPayload(
+                            selected = true,
+                            startDate = LocalDate.of(2020, 1, 1),
+                            testType = ViabilityTestType.Lab),
+                        ViabilityTestPayload(
+                            startDate = LocalDate.of(2020, 1, 2),
+                            testType = ViabilityTestType.Nursery)),
+                processingMethod = ProcessingMethod.Count,
+                initialQuantity = seeds(100))
+    store.update(withTests.toModel(id = initial.id!!))
+
+    val updatedWithTests = store.fetchOneById(initial.id!!)
+
+    store.update(
+        updatedWithTests.copy(
+            viabilityTests = updatedWithTests.viabilityTests.filterNot { it.selected }))
+
+    val updatedAfterDeletingTest = store.fetchOneById(initial.id!!)
+
+    assertTrue(
+        updatedAfterDeletingTest.viabilityTests.none { it.selected }, "No test should be selected")
+  }
+
+  @Test
+  fun `viability test selection can be changed`() {
+    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val withTests =
+        initial
+            .toUpdatePayload()
+            .copy(
+                viabilityTests =
+                    listOf(
+                        ViabilityTestPayload(
+                            selected = true,
+                            startDate = LocalDate.of(2020, 1, 1),
+                            testType = ViabilityTestType.Lab),
+                        ViabilityTestPayload(
+                            startDate = LocalDate.of(2020, 1, 2),
+                            testType = ViabilityTestType.Nursery)),
+                processingMethod = ProcessingMethod.Count,
+                initialQuantity = seeds(100))
+    store.update(withTests.toModel(id = initial.id!!))
+
+    val updatedWithTests = store.fetchOneById(initial.id!!)
+
+    store.update(
+        updatedWithTests.copy(
+            viabilityTests =
+                listOf(
+                    updatedWithTests.viabilityTests.first { it.selected }.copy(selected = false),
+                    updatedWithTests.viabilityTests.first { !it.selected }.copy(selected = true))))
+
+    val updatedAfterChangingSelection = store.fetchOneById(initial.id!!)
+
+    assertEquals(
+        1,
+        updatedAfterChangingSelection.viabilityTests.count { it.selected },
+        "Number of selected tests")
+    assertEquals(
+        LocalDate.of(2020, 1, 2),
+        updatedAfterChangingSelection.viabilityTests.first { it.selected }.startDate,
+        "Date of selected test")
   }
 
   @Test


### PR DESCRIPTION
Add a `selected` field to the viability test objects in the accession API
payloads. Selecting a viability test doesn't actually do anything yet; this is
just the implementation of the ability to select and deselect tests. Subsequent
changes will add logic to use the results of the selected test as the accession's
overall viability.

At most one test may be marked as selected for a particular accession. It is
completely valid for none of an accession's tests to be selected.