### PR TITLE
SW-1322 Add viability test selection as a search field

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.search.field.BooleanField
 import com.terraformation.backend.search.field.DateField
 import com.terraformation.backend.search.field.DoubleField
 import com.terraformation.backend.search.field.EnumField
+import com.terraformation.backend.search.field.ExistsField
 import com.terraformation.backend.search.field.GeometryField
 import com.terraformation.backend.search.field.GramsField
 import com.terraformation.backend.search.field.IdWrapperField
@@ -26,6 +27,7 @@ import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.OrderField
 import org.jooq.Record
+import org.jooq.Select
 import org.jooq.SelectJoinStep
 import org.jooq.Table
 import org.jooq.TableField
@@ -228,6 +230,13 @@ abstract class SearchTable {
       databaseField: TableField<*, Double?>,
       nullable: Boolean = false
   ) = DoubleField(fieldName, displayName, databaseField, this, nullable)
+
+  fun existsField(
+      fieldName: String,
+      displayName: String,
+      parentIdField: Field<*>,
+      selectQuery: Select<*>,
+  ) = ExistsField(fieldName, displayName, parentIdField, selectQuery, this)
 
   inline fun <E : Enum<E>, reified T : EnumFromReferenceTable<E>> enumField(
       fieldName: String,

--- a/src/main/kotlin/com/terraformation/backend/search/field/ExistsField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/ExistsField.kt
@@ -1,0 +1,78 @@
+package com.terraformation.backend.search.field
+
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchTable
+import java.util.EnumSet
+import org.jooq.Condition
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Select
+import org.jooq.impl.DSL
+
+/**
+ * Search field for columns that indicate the existence of something. This is typically used to
+ * check for the existence of a foreign key reference to the table this field belongs to.
+ */
+class ExistsField(
+    override val fieldName: String,
+    override val displayName: String,
+    private val parentIdField: Field<*>,
+    selectQuery: Select<*>,
+    override val table: SearchTable,
+) : SearchField {
+  private val existsCondition = DSL.exists(selectQuery)
+  private val existsField = DSL.field(existsCondition)
+
+  override val nullable: Boolean
+    get() = false
+  override val orderByField: Field<*>
+    get() = existsField
+  override val selectFields: List<Field<*>> = listOf(parentIdField, existsField)
+  override val supportedFilterTypes: Set<SearchFilterType>
+    get() = EnumSet.of(SearchFilterType.Exact)
+
+  override fun getConditions(fieldNode: FieldNode): List<Condition> {
+    val booleanValues =
+        fieldNode.values.map { stringValue ->
+          when (stringValue?.lowercase()) {
+            "true" -> true
+            "false" -> false
+            null -> throw IllegalArgumentException("Field is not nullable")
+            else -> throw IllegalArgumentException("Unrecognized value $stringValue")
+          }
+        }
+
+    val wantExists = booleanValues.any { it }
+    val wantNotExists = booleanValues.any { !it }
+
+    return when (fieldNode.type) {
+      SearchFilterType.Exact -> {
+        listOf(
+            when {
+              // "Exists or not" is a no-op
+              wantExists && wantNotExists -> parentIdField.isNotNull
+              wantExists -> existsCondition.and(parentIdField.isNotNull)
+              wantNotExists -> DSL.not(existsCondition).and(parentIdField.isNotNull)
+              else -> DSL.falseCondition()
+            })
+      }
+      SearchFilterType.Fuzzy ->
+          throw RuntimeException("Fuzzy search not supported for boolean fields")
+      SearchFilterType.Range ->
+          throw RuntimeException("Range search not supported for boolean fields")
+    }
+  }
+
+  override fun computeValue(record: Record): String? {
+    return if (record[parentIdField] != null) {
+      when (record[existsField]) {
+        true -> "true"
+        false -> "false"
+        null -> null
+      }
+    } else {
+      null
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
@@ -1,14 +1,17 @@
 package com.terraformation.backend.search.table
 
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tables.references.VIABILITY_TEST_RESULTS
+import com.terraformation.backend.db.tables.references.VIABILITY_TEST_SELECTIONS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
+import org.jooq.impl.DSL
 
 class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
@@ -28,11 +31,19 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           dateField("endDate", "Viability test end date", VIABILITY_TESTS.END_DATE),
+          idWrapperField("id", "Viability test ID", VIABILITY_TESTS.ID) { ViabilityTestId(it) },
           textField("notes", "Notes (viability test)", VIABILITY_TESTS.NOTES),
           integerField(
               "percentGerminated", "% Viability", VIABILITY_TESTS.TOTAL_PERCENT_GERMINATED),
           enumField("seedType", "Seed type", VIABILITY_TESTS.SEED_TYPE_ID),
           integerField("seedsSown", "Number of seeds sown", VIABILITY_TESTS.SEEDS_SOWN),
+          existsField(
+              "selected",
+              "Viability test selected",
+              VIABILITY_TESTS.ID,
+              DSL.selectOne()
+                  .from(VIABILITY_TEST_SELECTIONS)
+                  .where(VIABILITY_TEST_SELECTIONS.VIABILITY_TEST_ID.eq(VIABILITY_TESTS.ID))),
           dateField("startDate", "Viability test start date", VIABILITY_TESTS.START_DATE),
           enumField("substrate", "Germination substrate", VIABILITY_TESTS.SUBSTRATE_ID),
           enumField("treatment", "Germination treatment", VIABILITY_TESTS.TREATMENT_ID),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.tables.pojos.BagsRow
 import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.tables.pojos.StorageLocationsRow
 import com.terraformation.backend.db.tables.pojos.ViabilityTestResultsRow
+import com.terraformation.backend.db.tables.pojos.ViabilityTestSelectionsRow
 import com.terraformation.backend.db.tables.pojos.ViabilityTestsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.mockUser
@@ -1319,6 +1320,126 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       assertThrows<IllegalArgumentException> {
         accessionSearchService.search(facilityId, fields, searchNode)
       }
+    }
+  }
+
+  @Nested
+  inner class ExistsFieldTest {
+    private val nonSelectedTestId = ViabilityTestId(1)
+    private val selectedTestId = ViabilityTestId(2)
+
+    private val selectedField = rootPrefix.resolve("viabilityTests.selected")
+    private val selectedFlattenedField = rootPrefix.resolve("viabilityTests_selected")
+    private val testIdField = rootPrefix.resolve("viabilityTests.id")
+    private val testIdFlattenedField = rootPrefix.resolve("viabilityTests_id")
+
+    @BeforeEach
+    fun insertViabilityTests() {
+      viabilityTestsDao.insert(
+          ViabilityTestsRow(
+              nonSelectedTestId,
+              AccessionId(1000),
+              ViabilityTestType.Lab,
+              remainingQuantity = BigDecimal.ONE,
+              remainingUnitsId = SeedQuantityUnits.Seeds),
+          ViabilityTestsRow(
+              selectedTestId,
+              AccessionId(1000),
+              ViabilityTestType.Lab,
+              remainingQuantity = BigDecimal.ONE,
+              remainingUnitsId = SeedQuantityUnits.Seeds),
+      )
+      viabilityTestSelectionsDao.insert(
+          ViabilityTestSelectionsRow(AccessionId(1000), selectedTestId))
+    }
+
+    @Test
+    fun `returns true if nested target exists and false if not`() {
+      val fields = listOf(accessionNumberField, selectedField, testIdField)
+      val searchNode = NoConditionNode()
+      val sortFields = listOf(SearchSortField(accessionNumberField), SearchSortField(selectedField))
+
+      val expected =
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "accessionNumber" to "ABCDEFG",
+                  ),
+                  mapOf(
+                      "accessionNumber" to "XYZ",
+                      "viabilityTests" to
+                          listOf(
+                              mapOf("id" to "$nonSelectedTestId", "selected" to "false"),
+                              mapOf("id" to "$selectedTestId", "selected" to "true"),
+                          ),
+                  ),
+              ),
+              null)
+
+      val actual = searchService.search(rootPrefix, fields, searchNode, sortFields)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns true if flattened target exists and false if not`() {
+      val fields = listOf(accessionNumberField, selectedFlattenedField, testIdFlattenedField)
+      val searchNode = NoConditionNode()
+      val sortFields =
+          listOf(
+              SearchSortField(accessionNumberField),
+              SearchSortField(selectedFlattenedField, SearchDirection.Descending))
+
+      val expected =
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "accessionNumber" to "ABCDEFG",
+                  ),
+                  mapOf(
+                      "accessionNumber" to "XYZ",
+                      "viabilityTests_id" to "$selectedTestId",
+                      "viabilityTests_selected" to "true",
+                  ),
+                  mapOf(
+                      "accessionNumber" to "XYZ",
+                      "viabilityTests_id" to "$nonSelectedTestId",
+                      "viabilityTests_selected" to "false",
+                  ),
+              ),
+              null)
+
+      val actual = searchService.search(rootPrefix, fields, searchNode, sortFields)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `searching for nonexistence filters out results where parent sublist does not exist`() {
+      val fields = listOf(accessionNumberField, testIdField)
+      val searchNode = FieldNode(selectedField, listOf("false"))
+      val sortFields = listOf(SearchSortField(selectedField))
+
+      val expected =
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "accessionNumber" to "XYZ",
+                      "viabilityTests" to
+                          listOf(
+                              // Both IDs are listed here because search filters control which
+                              // top-level results are returned, not which sublist elements.
+                              mapOf("id" to "$nonSelectedTestId"),
+                              mapOf("id" to "$selectedTestId"),
+                          ),
+                  ),
+                  // We don't expect the other accession because it has no tests.
+                  ),
+              null)
+
+      val actual = searchService.search(rootPrefix, fields, searchNode, sortFields)
+
+      assertEquals(expected, actual)
     }
   }
 
@@ -2756,8 +2877,10 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                                           mapOf(
                                               "recordingDate" to "1970-01-02",
                                               "seedsGerminated" to "10")),
+                                  "id" to "$testId",
                                   "type" to "Lab",
                                   "seedsSown" to "15",
+                                  "selected" to "false",
                               ),
                           ),
                   ))


### PR DESCRIPTION
Add a boolean search field that acts the same as the `selected` field on viability
test API payloads.

Under the covers, this is a new kind of search field that wraps an `EXISTS()` SQL
expression, since field selection is actually stored in a separate table rather
than as a simple boolean column on `viability_tests`. From the client's point of
view, though, it acts like any other boolean search field.