### PR TITLE
SW-1350 Migrate to accession_collectors table 1/4

### DIFF
--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -8,6 +8,8 @@
 --
 -- Put "(Enum)" at the beginnings of comments on tables that define a fixed set of values.
 
+COMMENT ON TABLE accession_collectors IS 'Names of people who collected each accession.';
+
 COMMENT ON TABLE accession_photos IS 'Linking table between `accessions` and `photos`.';
 
 COMMENT ON TABLE accession_secondary_collectors IS 'Associates additional collectors with accessions. The primary collector is not included here, but is instead stored in `accessions.primary_collector_name`.';

--- a/src/main/resources/db/migration/V110__AccessionCollectors.sql
+++ b/src/main/resources/db/migration/V110__AccessionCollectors.sql
@@ -1,0 +1,16 @@
+CREATE TABLE accession_collectors (
+    accession_id BIGINT NOT NULL REFERENCES accessions ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (accession_id, position),
+    CHECK (position >= 0)
+);
+
+-- Add cascading deletes to accession_secondary_collectors so we can get rid of the DELETE statement
+-- on that table in accession deletion; this will make it safer to stop writing to
+-- accession_secondary_collectors in a later code change.
+ALTER TABLE accession_secondary_collectors
+    ADD CONSTRAINT accession_secondary_collectors_accession_id_fkey
+        FOREIGN KEY (accession_id) REFERENCES accessions ON DELETE CASCADE;
+ALTER TABLE accession_secondary_collectors
+    DROP CONSTRAINT accession_secondary_collector_accession_id_fkey;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.Role
+import com.terraformation.backend.db.tables.daos.AccessionCollectorsDao
 import com.terraformation.backend.db.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.tables.daos.AccessionsDao
 import com.terraformation.backend.db.tables.daos.AppDevicesDao
@@ -188,6 +189,7 @@ abstract class DatabaseTest {
     }
   }
 
+  protected val accessionCollectorsDao: AccessionCollectorsDao by lazyDao()
   protected val accessionPhotosDao: AccessionPhotosDao by lazyDao()
   protected val accessionsDao: AccessionsDao by lazyDao()
   protected val appDevicesDao: AppDevicesDao by lazyDao()

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -119,6 +119,7 @@ class SchemaDocsGenerator : DatabaseTest() {
    */
   private val tableSlices =
       mapOf(
+          "accession_collectors" to setOf(ALL, SEEDBANK),
           "accession_photos" to setOf(ALL, SEEDBANK),
           "accession_secondary_collectors" to setOf(ALL, SEEDBANK),
           "accession_state_history" to setOf(ALL, SEEDBANK),


### PR DESCRIPTION
We're getting rid of the distinction between primary and secondary collectors,
replacing them with a simple ordered list of collectors for each accession.

We'll migrate collector names to a single unified table. The migration will
happen in four steps:

1. Introduce the new table and start writing to it. Continue writing the old
   column/table as well, and continue reading from the old column/table.
   (This PR.)
2. Copy existing data to the new table. Start reading the new table.
3. Stop writing the old column/table.
4. Drop the old column/table.

This sequence eliminates any time windows when requests come in during the
middle of code deployment and we end up with data inconsistencies.

The API will be updated as well, but that'll happen after the data migration.