### PR TITLE
SW-1350 Migrate to accession_collectors table 2/4

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -148,7 +148,7 @@ data class CreateAccessionRequestPayload(
     val primaryCollector: String? = null,
     val rare: RareType? = null,
     val receivedDate: LocalDate? = null,
-    val secondaryCollectors: Set<String>? = null,
+    val secondaryCollectors: List<String>? = null,
     val siteLocation: String? = null,
     val sourcePlantOrigin: SourcePlantOrigin? = null,
     val species: String? = null,
@@ -211,7 +211,7 @@ data class UpdateAccessionRequestPayload(
     val processingStartDate: LocalDate? = null,
     val rare: RareType? = null,
     val receivedDate: LocalDate? = null,
-    val secondaryCollectors: Set<String>? = null,
+    val secondaryCollectors: List<String>? = null,
     val siteLocation: String? = null,
     val sourcePlantOrigin: SourcePlantOrigin? = null,
     val species: String? = null,
@@ -333,7 +333,7 @@ data class AccessionPayload(
             "Number or weight of seeds remaining for withdrawal and testing. Calculated by the " +
                 "server when the accession's total size is known.")
     val remainingQuantity: SeedQuantityPayload?,
-    val secondaryCollectors: Set<String>?,
+    val secondaryCollectors: List<String>?,
     val siteLocation: String?,
     @Schema(
         description =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -79,7 +79,7 @@ class AccessionStore(
     val bagNumbersField = bagStore.bagNumbersMultiset()
     val geolocationsField = geolocationStore.geolocationsMultiset()
     val photoFilenamesField = photoFilenamesMultiset()
-    val secondaryCollectorsField = secondaryCollectorsMultiset()
+    val collectorsField = collectorsMultiset()
     val viabilityTestsField = viabilityTestStore.viabilityTestsMultiset()
     val withdrawalsField = withdrawalStore.withdrawalsMultiset()
 
@@ -99,7 +99,7 @@ class AccessionStore(
                 bagNumbersField,
                 geolocationsField,
                 photoFilenamesField,
-                secondaryCollectorsField,
+                collectorsField,
                 viabilityTestsField,
                 withdrawalsField,
             )
@@ -140,7 +140,7 @@ class AccessionStore(
           numberOfTrees = record[TREES_COLLECTED_FROM],
           nurseryStartDate = record[NURSERY_START_DATE],
           photoFilenames = record[photoFilenamesField],
-          primaryCollector = record[PRIMARY_COLLECTOR_NAME],
+          primaryCollector = record[collectorsField].getOrNull(0),
           processingMethod = record[PROCESSING_METHOD_ID],
           processingNotes = record[PROCESSING_NOTES],
           processingStaffResponsible = record[PROCESSING_STAFF_RESPONSIBLE],
@@ -148,7 +148,7 @@ class AccessionStore(
           rare = record[RARE_TYPE_ID],
           receivedDate = record[RECEIVED_DATE],
           remaining = SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
-          secondaryCollectors = record[secondaryCollectorsField],
+          secondaryCollectors = record[collectorsField].drop(1),
           siteLocation = record[COLLECTION_SITE_NAME],
           source = source,
           sourcePlantOrigin = record[SOURCE_PLANT_ORIGIN_ID],
@@ -584,13 +584,13 @@ class AccessionStore(
         .convertFrom { result -> result.map { it.value1() } }
   }
 
-  private fun secondaryCollectorsMultiset(): Field<Set<String>> {
+  private fun collectorsMultiset(): Field<List<String>> {
     return DSL.multiset(
-            DSL.select(ACCESSION_SECONDARY_COLLECTORS.NAME)
-                .from(ACCESSION_SECONDARY_COLLECTORS)
-                .where(ACCESSION_SECONDARY_COLLECTORS.ACCESSION_ID.eq(ACCESSIONS.ID))
-                .orderBy(ACCESSION_SECONDARY_COLLECTORS.NAME))
-        .convertFrom { result -> result.map { it.value1() }.toSet() }
+            DSL.select(ACCESSION_COLLECTORS.NAME)
+                .from(ACCESSION_COLLECTORS)
+                .where(ACCESSION_COLLECTORS.ACCESSION_ID.eq(ACCESSIONS.ID))
+                .orderBy(ACCESSION_COLLECTORS.POSITION))
+        .convertFrom { result -> result.map { it.value1() } }
   }
 
   private fun insertSecondaryCollectors(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -91,7 +91,7 @@ data class AccessionModel(
     val rare: RareType? = null,
     val receivedDate: LocalDate? = null,
     val remaining: SeedQuantityModel? = null,
-    val secondaryCollectors: Set<String> = emptySet(),
+    val secondaryCollectors: List<String> = emptyList(),
     val siteLocation: String? = null,
     val source: AccessionSource? = null,
     val sourcePlantOrigin: SourcePlantOrigin? = null,

--- a/src/main/resources/db/migration/V111__AccessionCollectorsBackfill.sql
+++ b/src/main/resources/db/migration/V111__AccessionCollectorsBackfill.sql
@@ -1,0 +1,22 @@
+-- Backfill accession_collectors from the primary and secondary collectors of existing accessions.
+--
+-- For each accession, we want a list of names with the primary collector first, followed by the
+-- secondary collectors in order of their IDs. We treat the primary collector as having an ID of -1
+-- so it always sorts to the top.
+--
+-- Accessions that were written by the previous version of the code will already have populated
+-- accession_collectors, so it's safe to ignore any conflicts.
+
+WITH combined AS (SELECT accession_id, id, name
+                  FROM accession_secondary_collectors
+                  UNION
+                  SELECT id AS accession_id, -1 AS id, primary_collector_name AS name
+                  FROM accessions
+                  WHERE primary_collector_name IS NOT NULL)
+INSERT INTO accession_collectors (accession_id, position, name)
+SELECT accession_id, rownum - 1, name
+FROM (SELECT accession_id,
+             ROW_NUMBER() OVER (PARTITION BY accession_id ORDER BY id) AS rownum,
+             name
+      FROM combined) sc
+ON CONFLICT DO NOTHING;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -231,7 +231,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             facilityId = facilityId,
             family = "test family",
             primaryCollector = "primary collector",
-            secondaryCollectors = setOf("secondary 1", "secondary 2"),
+            secondaryCollectors = listOf("secondary 1", "secondary 2"),
             species = "test species")
 
     // First time inserts the reference table rows
@@ -1453,7 +1453,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             primaryCollector = "primaryCollector",
             rare = RareType.Yes,
             receivedDate = today,
-            secondaryCollectors = setOf("second1", "second2"),
+            secondaryCollectors = listOf("second1", "second2"),
             siteLocation = "siteLocation",
             sourcePlantOrigin = SourcePlantOrigin.Wild,
             species = "species",
@@ -1521,7 +1521,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             processingStartDate = today,
             rare = RareType.Yes,
             receivedDate = today,
-            secondaryCollectors = setOf("second1", "second2"),
+            secondaryCollectors = listOf("second1", "second2"),
             siteLocation = "siteLocation",
             sourcePlantOrigin = SourcePlantOrigin.Wild,
             species = "species",
@@ -1600,9 +1600,9 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             AccessionModel(
                 facilityId = facilityId,
                 primaryCollector = "primary",
-                secondaryCollectors = setOf("second1", "second2")))
+                secondaryCollectors = listOf("second1", "second2")))
 
-    store.update(initial.copy(primaryCollector = null, secondaryCollectors = setOf("second1")))
+    store.update(initial.copy(primaryCollector = null, secondaryCollectors = listOf("second1")))
 
     assertEquals(
         listOf(AccessionCollectorsRow(initial.id, 0, "second1")),
@@ -1712,7 +1712,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             initialQuantity = kilograms(432),
             processingMethod = ProcessingMethod.Weight,
             receivedDate = today,
-            secondaryCollectors = setOf("second1", "second2"),
+            secondaryCollectors = listOf("second1", "second2"),
             species = "species",
             storageLocation = storageLocationName,
             viabilityTests =


### PR DESCRIPTION
This is step 2 of a sequence of changes to move the collector names from
`accessions.primary_collector_name` and `accession_secondary_collectors` to a
new `accession_collectors` table.

In this step, we backfill `accession_collectors` from the existing data and
update the code to read from it instead of from the old locations. We continue
to write both locations so there isn't data inconsistency while this is in the
middle of being deployed and there are still requests being handled by the
previous code version.

Step 3 will stop writing to the old column and table, and step 4 will drop them.