### PR TITLE
SW-1331 Add seed counts to summary API

### DIFF
--- a/src/main/resources/db/migration/R__Indexes.sql
+++ b/src/main/resources/db/migration/R__Indexes.sql
@@ -4,6 +4,7 @@
 
 -- Foreign key columns. Not all foreign keys are indexed, just ones where the index was observed
 -- to make a difference in actual query execution.
+CREATE INDEX IF NOT EXISTS accessions__facility_id_ix ON accessions (facility_id);
 CREATE INDEX IF NOT EXISTS geolocation__accession_id_ix ON geolocations (accession_id);
 CREATE INDEX IF NOT EXISTS viability_test_results__test_id_ix ON viability_test_results (test_id);
 CREATE INDEX IF NOT EXISTS viability_test__accession_id_ix ON viability_tests (accession_id);


### PR DESCRIPTION
To support showing the total seeds remaining on the accessions dashboard, add a
child object to the `/api/v1/seedbank/summary` response payload that has:

* The total number of seeds remaining in active count-based accessions
* The estimated total number of seeds remaining in active weight-based accessions
  that have subset weight/count
* The estimated total number of seeds remaining across all active accessions
  (this is just the sum of the first two numbers)
* The number of weight-based accessions that don't have subset weight/count and
  thus can't be included in the seed count estimate

The web app can use those four numbers to show a total seed count with indicators
to tell the user that the count is an estimate (`subtotalByWeightEstimate` is
nonzero) and that there are more seeds than indicated by the number
(`unknownQuantityAccessions` is nonzero).

The totals are in a separate payload class because a future change will add a way
to get the same summary statistics for search results, and we'll reuse this new
class in the response.