### PR TITLE
SW-1398 Track user ID in accession state history 1/2

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -108,7 +108,8 @@ val ID_WRAPPERS =
                 ".*\\.user_id",
                 ".*\\.created_by",
                 ".*\\.deleted_by",
-                ".*\\.modified_by")),
+                ".*\\.modified_by",
+                ".*\\.updated_by")),
         IdWrapper(
             "ViabilityTestId",
             listOf(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -249,6 +249,7 @@ class AccessionStore(
                     .set(ACCESSION_ID, accessionId)
                     .set(REASON, "Accession created")
                     .set(NEW_STATE_ID, state)
+                    .set(UPDATED_BY, currentUser().userId)
                     .set(UPDATED_TIME, clock.instant())
                     .execute()
               }
@@ -451,6 +452,7 @@ class AccessionStore(
               .set(NEW_STATE_ID, stateTransition.newState)
               .set(OLD_STATE_ID, before.state)
               .set(REASON, stateTransition.reason)
+              .set(UPDATED_BY, currentUser().userId)
               .set(UPDATED_TIME, clock.instant())
               .execute()
         }

--- a/src/main/resources/db/migration/V114__AccessionStateHistoryUser.sql
+++ b/src/main/resources/db/migration/V114__AccessionStateHistoryUser.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accession_state_history ADD COLUMN updated_by BIGINT REFERENCES users(id);

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -987,6 +987,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 accessionId = AccessionId(1),
                 newStateId = AccessionState.AwaitingCheckIn,
                 reason = "Accession created",
+                updatedBy = user.userId,
                 updatedTime = clock.instant())),
         historyRecords)
   }
@@ -1018,6 +1019,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 newStateId = AccessionState.Pending,
                 oldStateId = AccessionState.AwaitingCheckIn,
                 reason = "Accession has been checked in",
+                updatedBy = user.userId,
                 updatedTime = clock.instant())),
         historyRecords)
 
@@ -1069,6 +1071,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 newStateId = AccessionState.Processing,
                 oldStateId = AccessionState.AwaitingCheckIn,
                 reason = "Seed count/weight has been entered",
+                updatedBy = user.userId,
                 updatedTime = clock.instant())),
         historyRecords)
   }


### PR DESCRIPTION
We already keep track of the history of accession state changes; this was needed
to support the "changes since last week" summary statistics. Those statistics are
gone in the new version of the web app, but we're going to need to start showing
the history of changes to an accession, including which user made each change.

Add a user ID column to `accession_state_history` and start populating it.

The second change in this series will backfill the existing history entries and
make the column non-nullable. These changes need to be deployed in sequence to
maintain bidirectional compatibility during code deployment.