### PR TITLE
SW-1398 Track user ID in accession state history 2/2

### DIFF
--- a/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
+++ b/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
@@ -1,0 +1,15 @@
+-- We know for sure which user created the accession.
+UPDATE accession_state_history
+SET updated_by = (SELECT created_by
+                  FROM accessions
+                  WHERE accessions.id = accession_state_history.accession_id)
+WHERE old_state_id IS NULL
+  AND updated_by IS NULL;
+
+-- But after that, we can't tell if state changes were automated or user-initiated, so attribute
+-- them all to the system user rather than possibly attributing them to the wrong human.
+UPDATE accession_state_history
+SET updated_by = (SELECT id FROM users WHERE user_type_id = 4)
+WHERE updated_by IS NULL;
+
+ALTER TABLE accession_state_history ALTER COLUMN updated_by SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1194,6 +1194,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
           .set(
               AccessionStateHistoryRecord(
                   accessionId = accessionId,
+                  updatedBy = user.userId,
                   updatedTime = Instant.ofEpochMilli(processingStartTime.toLong()),
                   oldStateId = AccessionState.Pending,
                   newStateId = AccessionState.Processing,
@@ -1206,6 +1207,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             .set(
                 AccessionStateHistoryRecord(
                     accessionId = accessionId,
+                    updatedBy = user.userId,
                     updatedTime = Instant.ofEpochMilli(processedStartTime.toLong()),
                     oldStateId = AccessionState.Processing,
                     newStateId = AccessionState.Processed,


### PR DESCRIPTION
Backfill user IDs into the existing state history rows as best we can, and make
the user ID mandatory.

Unfortunately, there's no way to accurately attribute past state changes to
specific users, especially since the system can automatically change accessions'
states based on scheduled events. So we attribute all state changes to the system
user, aside from the initial ones which we know will always have been caused by
the user who created the accession.