### PR TITLE
Enable cascading deletes on accession child tables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -147,10 +147,6 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
 
     if (deletedTestIds.isNotEmpty()) {
       dslContext
-          .deleteFrom(VIABILITY_TEST_RESULTS)
-          .where(VIABILITY_TEST_RESULTS.TEST_ID.`in`(deletedTestIds))
-          .execute()
-      dslContext
           .deleteFrom(VIABILITY_TESTS)
           .where(VIABILITY_TESTS.ID.`in`(deletedTestIds))
           .execute()

--- a/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
+++ b/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
@@ -1,0 +1,15 @@
+-- We know for sure which user created the accession.
+UPDATE accession_state_history
+SET updated_by = (SELECT created_by
+                  FROM accessions
+                  WHERE accessions.id = accession_state_history.accession_id)
+WHERE old_state_id IS NULL
+  AND updated_by IS NULL;
+
+-- But after that, we can't tell if state changes were automated or user-initiated, so attribute
+-- them all to the system user rather than possibly attributing them to the wrong human.
+UPDATE accession_state_history
+SET updated_by = (SELECT id FROM users WHERE user_type_id = 4)
+WHERE updated_by IS NULL;
+
+ALTER TABLE accession_state_history ALTER COLUMN updated_by SET NOT NULL;

--- a/src/main/resources/db/migration/V116__AccessionsCascadeDeletes.sql
+++ b/src/main/resources/db/migration/V116__AccessionsCascadeDeletes.sql
@@ -1,0 +1,35 @@
+-- The foreign key constraints on various children of the accessions table didn't enable cascading
+-- deletes because originally we didn't allow deleting accessions at all. Replace them with versions
+-- that cascade deletes so we don't have to explicitly clean them up.
+--
+-- The constraint on accession_photos remains as-is because that table contains references to
+-- the actual photo files outside the database; we need to explicitly delete those before we can
+-- remove the references to them in our database or we'll accumulate orphaned files.
+
+ALTER TABLE accession_state_history DROP CONSTRAINT accession_state_history_accession_id_fkey;
+ALTER TABLE accession_state_history ADD CONSTRAINT accession_state_history_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE bags DROP CONSTRAINT bag_accession_id_fkey;
+ALTER TABLE bags ADD CONSTRAINT bags_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE geolocations DROP CONSTRAINT collection_event_accession_id_fkey;
+ALTER TABLE geolocations ADD CONSTRAINT geolocations_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_test_selections DROP CONSTRAINT viability_test_selections_accession_id_fkey;
+ALTER TABLE viability_test_selections ADD CONSTRAINT viability_test_selections_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_test_results DROP CONSTRAINT viability_test_results_test_id_fkey;
+ALTER TABLE viability_test_results ADD CONSTRAINT viability_test_results_test_id_fkey
+    FOREIGN KEY (test_id) REFERENCES viability_tests (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_tests DROP CONSTRAINT viability_tests_accession_id_fkey;
+ALTER TABLE viability_tests ADD CONSTRAINT viability_tests_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE withdrawals DROP CONSTRAINT withdrawal_accession_id_fkey;
+ALTER TABLE withdrawals ADD CONSTRAINT withdrawals_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1194,6 +1194,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
           .set(
               AccessionStateHistoryRecord(
                   accessionId = accessionId,
+                  updatedBy = user.userId,
                   updatedTime = Instant.ofEpochMilli(processingStartTime.toLong()),
                   oldStateId = AccessionState.Pending,
                   newStateId = AccessionState.Processing,
@@ -1206,6 +1207,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             .set(
                 AccessionStateHistoryRecord(
                     accessionId = accessionId,
+                    updatedBy = user.userId,
                     updatedTime = Instant.ofEpochMilli(processedStartTime.toLong()),
                     oldStateId = AccessionState.Processing,
                     newStateId = AccessionState.Processed,


### PR DESCRIPTION
The initial version of the app didn't allow deleting accessions, so I erred on the
side of safety and didn't put `ON DELETE CASCADE` clauses on the foreign-key
constraints on the various child tables.

Now we support deleting accessions, though, so it makes sense to modify the
constraints to auto-delete rows in tables that exist purely to hold lists of
values in accessions. There is never a situation where, e.g., we'll want the
existence of a viability test on an accession to cause us to be unable to delete
the accession.

However, we _do_ want that behavior for accession photos: if we haven't deleted
an accession's photos from the file store yet, we shouldn't be able to delete the
accession since it would cause the files to be orphaned.