### PR TITLE
SW-1228 Add endpoint to fetch accession history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -1,8 +1,11 @@
 package com.terraformation.backend.i18n
 
+import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.GrowthForm
 import com.terraformation.backend.db.SeedStorageBehavior
 import com.terraformation.backend.db.tables.pojos.DevicesRow
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.annotation.ManagedBean
 
 /** Helper class to encapsulate notification message semantics */
@@ -102,7 +105,28 @@ class Messages {
           title = "$deviceName cannot be detected.",
           body = "$deviceName cannot be detected. Please check on it.")
 
+  fun historyAccessionCreated() = "created accession"
+
+  fun historyAccessionStateChanged(newState: AccessionState) =
+      "updated the status to ${newState.displayName}"
+
+  /**
+   * Returns the full name of a user based on their first and last names. It's possible for users to
+   * not have first or last names, e.g., if they were created by being added to an organization and
+   * haven't gone through the registration flow yet; returns null in that case. If the user has only
+   * a first name or only a last name, returns whichever name exists.
+   */
+  fun userFullName(firstName: String?, lastName: String?): String? =
+      if (firstName != null && lastName != null) {
+        "$firstName $lastName"
+      } else {
+        lastName ?: firstName
+      }
+
   private val validGrowthForms = GrowthForm.values().joinToString { it.displayName }
   private val validSeedStorageBehaviors =
       SeedStorageBehavior.values().joinToString { it.displayName }
+
+  /** Renders a date in the appropriate format. For now, this is always ISO YYYY-MM-DD format. */
+  private fun LocalDate.render() = DateTimeFormatter.ISO_LOCAL_DATE.format(this)
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -765,15 +765,13 @@ data class AccessionHistoryEntryPayload(
         description = "Human-readable description of the event. Does not include date or userName.",
         example = "updated the status to Drying")
     val description: String,
+    @Schema(description = "Full name of the person responsible for the event, if known.")
+    val fullName: String?,
     val type: AccessionHistoryType,
-    @Schema(
-        description = "Name of the user who performed the action, if known.",
-    )
-    val userName: String?,
 ) {
   constructor(
       model: AccessionHistoryModel
-  ) : this(model.date, model.description, model.type, model.userName)
+  ) : this(model.date, model.description, model.fullName, model.type)
 }
 
 data class CreateAccessionResponsePayload(val accession: AccessionPayload) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -19,9 +19,13 @@ import com.terraformation.backend.db.tables.references.ACCESSION_PHOTOS
 import com.terraformation.backend.db.tables.references.ACCESSION_STATE_HISTORY
 import com.terraformation.backend.db.tables.references.PHOTOS
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
+import com.terraformation.backend.db.tables.references.USERS
+import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.debugWithTiming
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.AccessionService
+import com.terraformation.backend.seedbank.model.AccessionHistoryModel
+import com.terraformation.backend.seedbank.model.AccessionHistoryType
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.AccessionSource
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
@@ -31,6 +35,7 @@ import com.terraformation.backend.species.SpeciesService
 import com.terraformation.backend.time.toInstant
 import java.time.Clock
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAccessor
@@ -54,6 +59,7 @@ class AccessionStore(
     private val speciesService: SpeciesService,
     private val withdrawalStore: WithdrawalStore,
     private val clock: Clock,
+    private val messages: Messages,
 ) {
   companion object {
     /** Number of times to try generating a unique accession number before giving up. */
@@ -421,6 +427,52 @@ class AccessionStore(
       // removed from the file store.
       dslContext.deleteFrom(ACCESSIONS).where(ACCESSIONS.ID.eq(accessionId)).execute()
     }
+  }
+
+  fun fetchHistory(accessionId: AccessionId): List<AccessionHistoryModel> {
+    requirePermissions { readAccession(accessionId) }
+
+    val stateChanges =
+        dslContext
+            .select(
+                ACCESSION_STATE_HISTORY.NEW_STATE_ID,
+                ACCESSION_STATE_HISTORY.OLD_STATE_ID,
+                ACCESSION_STATE_HISTORY.UPDATED_BY,
+                ACCESSION_STATE_HISTORY.UPDATED_TIME,
+                USERS.FIRST_NAME,
+                USERS.LAST_NAME)
+            .from(ACCESSION_STATE_HISTORY)
+            .join(USERS)
+            .on(ACCESSION_STATE_HISTORY.UPDATED_BY.eq(USERS.ID))
+            .where(ACCESSION_STATE_HISTORY.ACCESSION_ID.eq(accessionId))
+            .orderBy(ACCESSION_STATE_HISTORY.UPDATED_TIME.desc())
+            .fetch { record ->
+              val date =
+                  LocalDate.ofInstant(
+                      record[ACCESSION_STATE_HISTORY.UPDATED_TIME]!!, ZoneOffset.UTC)
+              val userId = record[ACCESSION_STATE_HISTORY.UPDATED_BY]!!
+              val userName =
+                  messages.userFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME])
+
+              if (record[ACCESSION_STATE_HISTORY.OLD_STATE_ID] == null) {
+                AccessionHistoryModel(
+                    date,
+                    messages.historyAccessionCreated(),
+                    AccessionHistoryType.Created,
+                    userId,
+                    userName)
+              } else {
+                AccessionHistoryModel(
+                    date,
+                    messages.historyAccessionStateChanged(
+                        record[ACCESSION_STATE_HISTORY.NEW_STATE_ID]!!),
+                    AccessionHistoryType.StateChanged,
+                    userId,
+                    userName)
+              }
+            }
+
+    return stateChanges
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -147,10 +147,6 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
 
     if (deletedTestIds.isNotEmpty()) {
       dslContext
-          .deleteFrom(VIABILITY_TEST_RESULTS)
-          .where(VIABILITY_TEST_RESULTS.TEST_ID.`in`(deletedTestIds))
-          .execute()
-      dslContext
           .deleteFrom(VIABILITY_TESTS)
           .where(VIABILITY_TESTS.ID.`in`(deletedTestIds))
           .execute()

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
@@ -1,17 +1,57 @@
 package com.terraformation.backend.seedbank.model
 
 import com.terraformation.backend.db.UserId
+import java.time.Instant
 import java.time.LocalDate
 
 enum class AccessionHistoryType {
   Created,
+  /** Manual edits to the accession's seed quantity, not including withdrawals. */
+  QuantityUpdated,
   StateChanged,
+  /** A withdrawal for the purpose of viability testing. */
+  ViabilityTesting,
+  /** A withdrawal for a purpose other than viability testing. */
+  Withdrawal,
 }
 
 data class AccessionHistoryModel(
+    /**
+     * When the underlying object representing the event was created. Used as a secondary sort key
+     * when multiple events happened on the same date.
+     */
+    val createdTime: Instant,
+    /**
+     * The effective date of the event. For example, if the event is a withdrawal, this would be the
+     * withdrawal date entered by the user (which might not be the same day as [createdTime].)
+     */
     val date: LocalDate,
     val description: String,
+    /**
+     * The full name of the user who was responsible for the event. This may or may not be a
+     * registered Terraware user; in some places in the app, we let people enter names of other
+     * people as plain text fields.
+     */
+    val fullName: String?,
     val type: AccessionHistoryType,
-    val userId: UserId,
-    val userName: String?,
-)
+    /** If the event was attributed to a Terraware user, that user's ID. */
+    val userId: UserId?,
+) : Comparable<AccessionHistoryModel> {
+  /**
+   * Compares two history models for sorting purposes. We sort history in reverse [date] order, with
+   * each day's history sorted in reverse [createdTime] order. We do it this way rather than just
+   * sorting by [createdTime] because some kinds of history can be backdated, e.g., on Tuesday you
+   * can tell the system that a withdrawal happened on Monday, and it should show up with Monday's
+   * date in the history records.
+   */
+  override fun compareTo(other: AccessionHistoryModel): Int {
+    // We sort history in reverse time order, so the comparison results are flipped here.
+    return when {
+      date < other.date -> 1
+      date > other.date -> -1
+      createdTime < other.createdTime -> 1
+      createdTime > other.createdTime -> -1
+      else -> other.type.ordinal - type.ordinal
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
@@ -1,0 +1,17 @@
+package com.terraformation.backend.seedbank.model
+
+import com.terraformation.backend.db.UserId
+import java.time.LocalDate
+
+enum class AccessionHistoryType {
+  Created,
+  StateChanged,
+}
+
+data class AccessionHistoryModel(
+    val date: LocalDate,
+    val description: String,
+    val type: AccessionHistoryType,
+    val userId: UserId,
+    val userName: String?,
+)

--- a/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
+++ b/src/main/resources/db/migration/V115__AccessionStateHistoryBackfill.sql
@@ -1,0 +1,15 @@
+-- We know for sure which user created the accession.
+UPDATE accession_state_history
+SET updated_by = (SELECT created_by
+                  FROM accessions
+                  WHERE accessions.id = accession_state_history.accession_id)
+WHERE old_state_id IS NULL
+  AND updated_by IS NULL;
+
+-- But after that, we can't tell if state changes were automated or user-initiated, so attribute
+-- them all to the system user rather than possibly attributing them to the wrong human.
+UPDATE accession_state_history
+SET updated_by = (SELECT id FROM users WHERE user_type_id = 4)
+WHERE updated_by IS NULL;
+
+ALTER TABLE accession_state_history ALTER COLUMN updated_by SET NOT NULL;

--- a/src/main/resources/db/migration/V116__AccessionsCascadeDeletes.sql
+++ b/src/main/resources/db/migration/V116__AccessionsCascadeDeletes.sql
@@ -1,0 +1,35 @@
+-- The foreign key constraints on various children of the accessions table didn't enable cascading
+-- deletes because originally we didn't allow deleting accessions at all. Replace them with versions
+-- that cascade deletes so we don't have to explicitly clean them up.
+--
+-- The constraint on accession_photos remains as-is because that table contains references to
+-- the actual photo files outside the database; we need to explicitly delete those before we can
+-- remove the references to them in our database or we'll accumulate orphaned files.
+
+ALTER TABLE accession_state_history DROP CONSTRAINT accession_state_history_accession_id_fkey;
+ALTER TABLE accession_state_history ADD CONSTRAINT accession_state_history_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE bags DROP CONSTRAINT bag_accession_id_fkey;
+ALTER TABLE bags ADD CONSTRAINT bags_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE geolocations DROP CONSTRAINT collection_event_accession_id_fkey;
+ALTER TABLE geolocations ADD CONSTRAINT geolocations_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_test_selections DROP CONSTRAINT viability_test_selections_accession_id_fkey;
+ALTER TABLE viability_test_selections ADD CONSTRAINT viability_test_selections_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_test_results DROP CONSTRAINT viability_test_results_test_id_fkey;
+ALTER TABLE viability_test_results ADD CONSTRAINT viability_test_results_test_id_fkey
+    FOREIGN KEY (test_id) REFERENCES viability_tests (id) ON DELETE CASCADE;
+
+ALTER TABLE viability_tests DROP CONSTRAINT viability_tests_accession_id_fkey;
+ALTER TABLE viability_tests ADD CONSTRAINT viability_tests_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;
+
+ALTER TABLE withdrawals DROP CONSTRAINT withdrawal_accession_id_fkey;
+ALTER TABLE withdrawals ADD CONSTRAINT withdrawals_accession_id_fkey
+    FOREIGN KEY (accession_id) REFERENCES accessions (id) ON DELETE CASCADE;

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -99,6 +99,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             mockk(),
             WithdrawalStore(dslContext, clock),
             clock,
+            mockk(),
         )
     automationStore = AutomationStore(automationsDao, clock, dslContext, objectMapper, parentStore)
     deviceStore = DeviceStore(devicesDao)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1194,6 +1194,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
           .set(
               AccessionStateHistoryRecord(
                   accessionId = accessionId,
+                  updatedBy = user.userId,
                   updatedTime = Instant.ofEpochMilli(processingStartTime.toLong()),
                   oldStateId = AccessionState.Pending,
                   newStateId = AccessionState.Processing,
@@ -1206,6 +1207,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             .set(
                 AccessionStateHistoryRecord(
                     accessionId = accessionId,
+                    updatedBy = user.userId,
                     updatedTime = Instant.ofEpochMilli(processedStartTime.toLong()),
                     oldStateId = AccessionState.Processing,
                     newStateId = AccessionState.Processed,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -2385,25 +2385,28 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       val expected =
           listOf(
               AccessionHistoryModel(
+                  createdTime = processTime,
                   date = LocalDate.ofInstant(processTime, ZoneOffset.UTC),
                   description = "updated the status to Processing",
+                  fullName = "Bono",
                   type = AccessionHistoryType.StateChanged,
                   userId = processUserId,
-                  userName = "Bono",
               ),
               AccessionHistoryModel(
+                  createdTime = checkInTime,
                   date = LocalDate.ofInstant(checkInTime, ZoneOffset.UTC),
                   description = "updated the status to Pending",
+                  fullName = null,
                   type = AccessionHistoryType.StateChanged,
                   userId = checkInUserId,
-                  userName = null,
               ),
               AccessionHistoryModel(
+                  createdTime = createTime,
                   date = LocalDate.ofInstant(createTime, ZoneOffset.UTC),
                   description = "created accession",
+                  fullName = "First Last",
                   type = AccessionHistoryType.Created,
                   userId = createUserId,
-                  userName = "First Last",
               ),
           )
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -95,6 +95,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             mockk(),
             clock,
+            mockk(),
         )
 
     tempDir = Files.createTempDirectory(javaClass.simpleName)


### PR DESCRIPTION
In the new version of the web app, we need to show a tab with the history of
certain kinds of changes to the accession. Add an endpoint that returns a
time-ordered list of items to show in that UI.

This initial implementation only includes accession creation and state change
events, but those should be enough to start building the UI. Additional types
of history will be added later, but the same API endpoint will return them.