### PR TITLE
SW-1228 Add withdrawals to accession history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -475,7 +475,9 @@ class AccessionStore(
               }
             }
 
-    return stateChanges.sorted()
+    val withdrawals = withdrawalStore.fetchHistory(accessionId)
+
+    return (stateChanges + withdrawals).sorted()
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -97,7 +97,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             ViabilityTestStore(dslContext),
             parentStore,
             mockk(),
-            WithdrawalStore(dslContext, clock),
+            WithdrawalStore(dslContext, clock, mockk()),
             clock,
             mockk(),
         )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.tables.pojos.ViabilityTestsRow
 import com.terraformation.backend.db.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.WITHDRAWALS
+import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.grams
 import com.terraformation.backend.seedbank.milligrams
@@ -47,7 +48,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setup() {
-    store = WithdrawalStore(dslContext, clock)
+    store = WithdrawalStore(dslContext, clock, Messages())
 
     every { clock.instant() } returns Instant.now()
 


### PR DESCRIPTION
Include withdrawal events in the `/api/v1/seedbank/accessions/{id}/history` API.

Currently these events are attributed to the person whose name is entered into the
"staff responsible" field in the app, which may or may not be a Terraware user's
name. In the near future we'll be constraining that field to the list of
organization members, but with the current data model, we have to treat it as an
optional text value.