### PR TITLE
SW-1390 More detailed collection site data 2/3

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -88,7 +88,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
         aliasField("bagNumber", "bags_number"),
         timestampField("checkedInTime", "Checked-In Time", ACCESSIONS.CHECKED_IN_TIME),
         dateField("collectedDate", "Collected on", ACCESSIONS.COLLECTED_DATE),
-        textField("collectionNotes", "Notes (collection)", ACCESSIONS.ENVIRONMENTAL_NOTES),
+        textField("collectionNotes", "Notes (collection)", ACCESSIONS.COLLECTION_SITE_NOTES),
         textField("collectionSiteCity", "Collection site city", ACCESSIONS.COLLECTION_SITE_CITY),
         textField(
             "collectionSiteCountryCode",
@@ -103,7 +103,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             "Collection site landowner",
             ACCESSIONS.COLLECTION_SITE_LANDOWNER),
         textField("collectionSiteName", "Collection site name", ACCESSIONS.COLLECTION_SITE_NAME),
-        textField("collectionSiteNotes", "Collection site notes", ACCESSIONS.ENVIRONMENTAL_NOTES),
+        textField("collectionSiteNotes", "Collection site notes", ACCESSIONS.COLLECTION_SITE_NOTES),
         integerField(
             "cutTestSeedsCompromised",
             "Number of seeds compromised",

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -128,7 +128,7 @@ class AccessionStore(
           collectionSiteCountrySubdivision = record[COLLECTION_SITE_COUNTRY_SUBDIVISION],
           collectionSiteLandowner = record[COLLECTION_SITE_LANDOWNER],
           collectionSiteName = record[COLLECTION_SITE_NAME],
-          collectionSiteNotes = record[ENVIRONMENTAL_NOTES],
+          collectionSiteNotes = record[COLLECTION_SITE_NOTES],
           collectors = record[collectorsField],
           cutTestSeedsCompromised = record[CUT_TEST_SEEDS_COMPROMISED],
           cutTestSeedsEmpty = record[CUT_TEST_SEEDS_EMPTY],
@@ -225,7 +225,6 @@ class AccessionStore(
                         .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
                         .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
                         .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)
-                        .set(ENVIRONMENTAL_NOTES, accession.collectionSiteNotes)
                         .set(FACILITY_ID, facilityId)
                         .set(FAMILY_NAME, accession.family)
                         .set(FIELD_NOTES, accession.fieldNotes)
@@ -375,7 +374,6 @@ class AccessionStore(
                 .set(DRYING_END_DATE, accession.dryingEndDate)
                 .set(DRYING_MOVE_DATE, accession.dryingMoveDate)
                 .set(DRYING_START_DATE, accession.dryingStartDate)
-                .set(ENVIRONMENTAL_NOTES, accession.collectionSiteNotes)
                 .set(EST_SEED_COUNT, accession.estimatedSeedCount)
                 .set(FACILITY_ID, facilityId)
                 .set(FAMILY_NAME, accession.family)

--- a/src/main/resources/db/migration/V118__CollectionSiteNotesBackfill.sql
+++ b/src/main/resources/db/migration/V118__CollectionSiteNotesBackfill.sql
@@ -1,0 +1,6 @@
+-- Migrate existing data from environmental_notes to collection_site_notes (code is already writing
+-- to both columns) in preparation for dropping environmental_notes.
+UPDATE accessions
+SET collection_site_notes = environmental_notes
+WHERE collection_site_notes IS NULL
+AND environmental_notes IS NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2876,13 +2876,13 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "ageYears" to "1",
                       "checkedInTime" to "$checkedInTime",
                       "collectedDate" to "2019-03-02",
-                      "collectionNotes" to "envNotes",
+                      "collectionNotes" to "siteNotes",
                       "collectionSiteCity" to "city",
                       "collectionSiteCountryCode" to "UG",
                       "collectionSiteCountrySubdivision" to "subdivision",
                       "collectionSiteLandowner" to "landowner",
                       "collectionSiteName" to "siteName",
-                      "collectionSiteNotes" to "envNotes",
+                      "collectionSiteNotes" to "siteNotes",
                       "collectors" to
                           listOf(
                               mapOf("name" to "primary", "position" to "0"),


### PR DESCRIPTION
This is an internal change so we can roll out the new fields without data loss.
In this change, we stop reading and writing `accessions.environmental_notes`
and start reading `accessions.collection_site_notes`. Notes for existing
accessions are copied to the new column here.