### PR TITLE
SW-1406 Add collection source field to API

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -21,6 +21,7 @@ val ENUM_TABLES =
                 "accessions\\.state_id",
                 ".*\\.accession_state_id",
                 "accession_state_history\\.(old|new)_state_id")),
+        EnumTable("collection_sources", ".*\\.collection_source_id"),
         EnumTable(
             "device_template_categories",
             listOf("device_templates\\.category_id"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -104,6 +104,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.COLLECTION_SITE_LANDOWNER),
         textField("collectionSiteName", "Collection site name", ACCESSIONS.COLLECTION_SITE_NAME),
         textField("collectionSiteNotes", "Collection site notes", ACCESSIONS.COLLECTION_SITE_NOTES),
+        enumField("collectionSource", "Collection source", ACCESSIONS.COLLECTION_SOURCE_ID),
         integerField(
             "cutTestSeedsCompromised",
             "Number of seeds compromised",

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.RareType
@@ -162,6 +163,13 @@ private fun backwardCompatibleCollectors(
   }
 }
 
+/** Maps a source plant origin to the equivalent collection source for backward compatibility. */
+private fun SourcePlantOrigin.toCollectionSource(): CollectionSource =
+    when (this) {
+      SourcePlantOrigin.Outplant -> CollectionSource.Cultivated
+      SourcePlantOrigin.Wild -> CollectionSource.Wild
+    }
+
 // Mark all fields as write-only in the schema
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class CreateAccessionRequestPayload(
@@ -173,6 +181,7 @@ data class CreateAccessionRequestPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String>? = null,
     val deviceInfo: DeviceInfoPayload? = null,
     val endangered: SpeciesEndangeredType? = null,
@@ -212,6 +221,7 @@ data class CreateAccessionRequestPayload(
         collectionSiteLandowner = landowner ?: collectionSiteLandowner,
         collectionSiteName = siteLocation ?: collectionSiteName,
         collectionSiteNotes = environmentalNotes ?: collectionSiteNotes,
+        collectionSource = sourcePlantOrigin?.toCollectionSource() ?: collectionSource,
         collectors =
             backwardCompatibleCollectors(primaryCollector, secondaryCollectors, collectors),
         deviceInfo = deviceInfo?.toModel(),
@@ -241,6 +251,7 @@ data class UpdateAccessionRequestPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String>? = null,
     val cutTestSeedsCompromised: Int? = null,
     val cutTestSeedsEmpty: Int? = null,
@@ -308,6 +319,7 @@ data class UpdateAccessionRequestPayload(
           collectionSiteLandowner = landowner ?: collectionSiteLandowner,
           collectionSiteName = siteLocation ?: collectionSiteName,
           collectionSiteNotes = environmentalNotes ?: collectionSiteNotes,
+          collectionSource = sourcePlantOrigin?.toCollectionSource() ?: collectionSource,
           collectors =
               backwardCompatibleCollectors(primaryCollector, secondaryCollectors, collectors),
           cutTestSeedsCompromised = cutTestSeedsCompromised,
@@ -368,6 +380,7 @@ data class AccessionPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     @Schema(description = "Names of the people who collected the seeds.")
     val collectors: List<String>?,
     val deviceInfo: DeviceInfoPayload?,
@@ -491,6 +504,7 @@ data class AccessionPayload(
       model.collectionSiteLandowner,
       model.collectionSiteName,
       model.collectionSiteNotes,
+      model.collectionSource,
       model.collectors.orNull(),
       model.deviceInfo?.let { DeviceInfoPayload(it) },
       model.cutTestSeedsCompromised,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -129,6 +129,7 @@ class AccessionStore(
           collectionSiteLandowner = record[COLLECTION_SITE_LANDOWNER],
           collectionSiteName = record[COLLECTION_SITE_NAME],
           collectionSiteNotes = record[COLLECTION_SITE_NOTES],
+          collectionSource = record[COLLECTION_SOURCE_ID],
           collectors = record[collectorsField],
           cutTestSeedsCompromised = record[CUT_TEST_SEEDS_COMPROMISED],
           cutTestSeedsEmpty = record[CUT_TEST_SEEDS_EMPTY],
@@ -220,6 +221,7 @@ class AccessionStore(
                         .set(COLLECTION_SITE_LANDOWNER, accession.collectionSiteLandowner)
                         .set(COLLECTION_SITE_NAME, accession.collectionSiteName)
                         .set(COLLECTION_SITE_NOTES, accession.collectionSiteNotes)
+                        .set(COLLECTION_SOURCE_ID, accession.collectionSource)
                         .set(CREATED_BY, currentUser().userId)
                         .set(CREATED_TIME, clock.instant())
                         .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
@@ -368,6 +370,7 @@ class AccessionStore(
                 .set(COLLECTION_SITE_LANDOWNER, accession.collectionSiteLandowner)
                 .set(COLLECTION_SITE_NAME, accession.collectionSiteName)
                 .set(COLLECTION_SITE_NOTES, accession.collectionSiteNotes)
+                .set(COLLECTION_SOURCE_ID, accession.collectionSource)
                 .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
                 .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
                 .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.seedbank.model
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.RareType
@@ -68,6 +69,7 @@ data class AccessionModel(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String> = emptyList(),
     val cutTestSeedsCompromised: Int? = null,
     val cutTestSeedsEmpty: Int? = null,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -30,6 +30,8 @@ COMMENT ON TABLE automations IS 'Configuration of automatic processes run by the
 
 COMMENT ON TABLE bags IS 'Individual bags of seeds that are part of an accession. An accession can consist of multiple bags.';
 
+COMMENT ON TABLE collection_sources IS '(Enum) Types of source plants that seeds can be collected from.';
+
 COMMENT ON TABLE countries IS 'Country information per ISO-3166.';
 COMMENT ON COLUMN countries.code IS 'ISO-3166 alpha-2 country code.';
 COMMENT ON COLUMN countries.name IS 'Name of country in US English.';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -9,6 +9,13 @@ VALUES (10, 'Pending', TRUE),
        (80, 'Nursery', FALSE)
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
+INSERT INTO collection_sources (id, name)
+VALUES (1, 'Wild'),
+       (2, 'Reintroduced'),
+       (3, 'Cultivated'),
+       (4, 'Other')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO device_template_categories (id, name)
 VALUES (1, 'PV'),
        (2, 'Seed Bank Default')

--- a/src/main/resources/db/migration/V120__CollectionSources.sql
+++ b/src/main/resources/db/migration/V120__CollectionSources.sql
@@ -1,0 +1,6 @@
+CREATE TABLE collection_sources (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+ALTER TABLE accessions ADD COLUMN collection_source_id INTEGER REFERENCES collection_sources (id);

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -127,6 +127,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "app_devices" to setOf(ALL, SEEDBANK),
           "automations" to setOf(ALL, DEVICE),
           "bags" to setOf(ALL, SEEDBANK),
+          "collection_sources" to setOf(ALL, SEEDBANK),
           "countries" to setOf(ALL, CUSTOMER),
           "country_subdivisions" to setOf(ALL, CUSTOMER),
           "devices" to setOf(ALL, DEVICE),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.AppDeviceId
 import com.terraformation.backend.db.BagId
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
@@ -1431,6 +1432,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "siteName",
             collectionSiteNotes = "siteNotes",
+            collectionSource = CollectionSource.Other,
             collectors = listOf("primaryCollector", "second1", "second2"),
             deviceInfo =
                 DeviceInfoPayload(
@@ -1504,6 +1506,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "name",
             collectionSiteNotes = "notes",
+            collectionSource = CollectionSource.Reintroduced,
             collectors = listOf("primaryCollector", "second1", "second2"),
             cutTestSeedsCompromised = 20,
             cutTestSeedsEmpty = 21,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.GrowthForm
@@ -174,6 +175,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "siteName",
             collectionSiteNotes = "siteNotes",
+            collectionSourceId = CollectionSource.Reintroduced,
             createdBy = user.userId,
             createdTime = now,
             facilityId = facilityId,
@@ -2882,6 +2884,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "collectionSiteLandowner" to "landowner",
                       "collectionSiteName" to "siteName",
                       "collectionSiteNotes" to "siteNotes",
+                      "collectionSource" to "Reintroduced",
                       "collectors" to
                           listOf(
                               mapOf("name" to "primary", "position" to "0"),


### PR DESCRIPTION
The upcoming version of the web app is replacing the "source plant origin"
accession field with "collection source." Add the new field.

The list of allowed values is different; it's possible to losslessly map the
old values to the new ones but not the other way around. So we can't do this as
a purely server-side data model change that supports both fields interchangeably.
Once clients have been updated to use the new field, existing accessions that have
source plant origin values will be backfilled and the old field will be removed.