### PR TITLE
Alphabetize entries in some source files

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -21,6 +21,7 @@ val ENUM_TABLES =
                 "accessions\\.state_id",
                 ".*\\.accession_state_id",
                 "accession_state_history\\.(old|new)_state_id")),
+        EnumTable("collection_sources", ".*\\.collection_source_id"),
         EnumTable(
             "device_template_categories",
             listOf("device_templates\\.category_id"),

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -84,149 +84,6 @@ import org.springframework.security.access.AccessDeniedException
  * should make it clear what's going on.
  */
 class PermissionRequirements(private val user: TerrawareUser) {
-  fun createAccession(facilityId: FacilityId) {
-    if (!user.canCreateAccession(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to create accessions in facility $facilityId")
-    }
-  }
-
-  fun readAccession(accessionId: AccessionId) {
-    if (!user.canReadAccession(accessionId)) {
-      throw AccessionNotFoundException(accessionId)
-    }
-  }
-
-  fun updateAccession(accessionId: AccessionId) {
-    if (!user.canUpdateAccession(accessionId)) {
-      readAccession(accessionId)
-      throw AccessDeniedException("No permission to update accession $accessionId")
-    }
-  }
-
-  fun deleteAccession(accessionId: AccessionId) {
-    if (!user.canDeleteAccession(accessionId)) {
-      readAccession(accessionId)
-      throw AccessDeniedException("No permission to delete accession $accessionId")
-    }
-  }
-
-  fun createAutomation(facilityId: FacilityId) {
-    if (!user.canCreateAutomation(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to create automations in facility $facilityId")
-    }
-  }
-
-  fun listAutomations(facilityId: FacilityId) {
-    if (!user.canListAutomations(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to list automations in facility $facilityId")
-    }
-  }
-
-  fun readAutomation(automationId: AutomationId) {
-    if (!user.canReadAutomation(automationId)) {
-      throw AutomationNotFoundException(automationId)
-    }
-  }
-
-  fun updateAutomation(automationId: AutomationId) {
-    if (!user.canUpdateAutomation(automationId)) {
-      readAutomation(automationId)
-      throw AccessDeniedException("No permission to update automation $automationId")
-    }
-  }
-
-  fun deleteAutomation(automationId: AutomationId) {
-    if (!user.canDeleteAutomation(automationId)) {
-      readAutomation(automationId)
-      throw AccessDeniedException("No permission to delete automation $automationId")
-    }
-  }
-
-  fun triggerAutomation(automationId: AutomationId) {
-    if (!user.canTriggerAutomation(automationId)) {
-      readAutomation(automationId)
-      throw AccessDeniedException("No permission to trigger automation $automationId")
-    }
-  }
-
-  fun createFacility(organizationId: OrganizationId) {
-    if (!user.canCreateFacility(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException(
-          "No permission to create facilities in organization $organizationId")
-    }
-  }
-
-  fun readFacility(facilityId: FacilityId) {
-    if (!user.canReadFacility(facilityId)) {
-      throw FacilityNotFoundException(facilityId)
-    }
-  }
-
-  fun updateFacility(facilityId: FacilityId) {
-    if (!user.canUpdateFacility(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to update facility $facilityId")
-    }
-  }
-
-  fun sendAlert(facilityId: FacilityId) {
-    if (!user.canSendAlert(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to send alerts for facility $facilityId")
-    }
-  }
-
-  fun createDevice(facilityId: FacilityId) {
-    if (!user.canCreateDevice(facilityId)) {
-      readFacility(facilityId)
-      throw AccessDeniedException("No permission to create device in facility $facilityId")
-    }
-  }
-
-  fun readDevice(deviceId: DeviceId) {
-    if (!user.canReadDevice(deviceId)) {
-      throw DeviceNotFoundException(deviceId)
-    }
-  }
-
-  fun updateDevice(deviceId: DeviceId) {
-    if (!user.canUpdateDevice(deviceId)) {
-      readDevice(deviceId)
-      throw AccessDeniedException("No permission to update device $deviceId")
-    }
-  }
-
-  fun readOrganization(organizationId: OrganizationId) {
-    if (!user.canReadOrganization(organizationId)) {
-      throw OrganizationNotFoundException(organizationId)
-    }
-  }
-
-  fun updateOrganization(organizationId: OrganizationId) {
-    if (!user.canUpdateOrganization(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException("No permission to update organization $organizationId")
-    }
-  }
-
-  fun deleteOrganization(organizationId: OrganizationId) {
-    if (!user.canDeleteOrganization(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException("No permission to delete organization $organizationId")
-    }
-  }
-
-  fun listOrganizationUsers(organizationId: OrganizationId) {
-    if (!user.canListOrganizationUsers(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException("No permission to list users in organization $organizationId")
-    }
-  }
-
   fun addOrganizationUser(organizationId: OrganizationId) {
     if (!user.canAddOrganizationUser(organizationId)) {
       readOrganization(organizationId)
@@ -234,19 +91,16 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun removeOrganizationUser(organizationId: OrganizationId, userId: UserId) {
-    if (!user.canRemoveOrganizationUser(organizationId, userId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException(
-          "No permission to remove user $userId from organization $organizationId")
+  fun countNotifications() {
+    if (!user.canCountNotifications()) {
+      throw AccessDeniedException("No permission to count notifications")
     }
   }
 
-  fun setOrganizationUserRole(organizationId: OrganizationId, role: Role) {
-    if (!user.canSetOrganizationUserRole(organizationId, role)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException(
-          "No permission to grant role to users in organization $organizationId")
+  fun createAccession(facilityId: FacilityId) {
+    if (!user.canCreateAccession(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to create accessions in facility $facilityId")
     }
   }
 
@@ -258,50 +112,45 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun createAutomation(facilityId: FacilityId) {
+    if (!user.canCreateAutomation(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to create automations in facility $facilityId")
+    }
+  }
+
+  fun createDevice(facilityId: FacilityId) {
+    if (!user.canCreateDevice(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to create device in facility $facilityId")
+    }
+  }
+
+  fun createDeviceManager() {
+    if (!user.canCreateDeviceManager()) {
+      throw AccessDeniedException("No permission to create device manager")
+    }
+  }
+
+  fun createFacility(organizationId: OrganizationId) {
+    if (!user.canCreateFacility(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to create facilities in organization $organizationId")
+    }
+  }
+
+  fun createNotification(userId: UserId, organizationId: OrganizationId) {
+    readOrganization(organizationId)
+    if (!user.canCreateNotification(userId, organizationId)) {
+      throw AccessDeniedException("No permission to create notification")
+    }
+  }
+
   fun createSpecies(organizationId: OrganizationId) {
     if (!user.canCreateSpecies(organizationId)) {
       readOrganization(organizationId)
       throw AccessDeniedException("No permission to create species")
-    }
-  }
-
-  fun readSpecies(speciesId: SpeciesId) {
-    if (!user.canReadSpecies(speciesId)) {
-      throw SpeciesNotFoundException(speciesId)
-    }
-  }
-
-  fun deleteSpecies(speciesId: SpeciesId) {
-    if (!user.canDeleteSpecies(speciesId)) {
-      readSpecies(speciesId)
-      throw AccessDeniedException("No permission to delete species $speciesId")
-    }
-  }
-
-  fun updateSpecies(speciesId: SpeciesId) {
-    if (!user.canUpdateSpecies(speciesId)) {
-      readSpecies(speciesId)
-      throw AccessDeniedException("No permission to update species $speciesId")
-    }
-  }
-
-  fun createTimeseries(deviceId: DeviceId) {
-    if (!user.canCreateTimeseries(deviceId)) {
-      readDevice(deviceId)
-      throw AccessDeniedException("No permission to create timeseries on device $deviceId")
-    }
-  }
-
-  fun readTimeseries(deviceId: DeviceId) {
-    if (!user.canReadTimeseries(deviceId)) {
-      throw TimeseriesNotFoundException(deviceId)
-    }
-  }
-
-  fun updateTimeseries(deviceId: DeviceId) {
-    if (!user.canUpdateTimeseries(deviceId)) {
-      readTimeseries(deviceId)
-      throw AccessDeniedException("No permission to update timeseries on device $deviceId")
     }
   }
 
@@ -313,16 +162,38 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun readStorageLocation(storageLocationId: StorageLocationId) {
-    if (!user.canReadStorageLocation(storageLocationId)) {
-      throw StorageLocationNotFoundException(storageLocationId)
+  fun createTimeseries(deviceId: DeviceId) {
+    if (!user.canCreateTimeseries(deviceId)) {
+      readDevice(deviceId)
+      throw AccessDeniedException("No permission to create timeseries on device $deviceId")
     }
   }
 
-  fun updateStorageLocation(storageLocationId: StorageLocationId) {
-    if (!user.canUpdateStorageLocation(storageLocationId)) {
-      readStorageLocation(storageLocationId)
-      throw AccessDeniedException("No permission to update storage location")
+  fun deleteAccession(accessionId: AccessionId) {
+    if (!user.canDeleteAccession(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to delete accession $accessionId")
+    }
+  }
+
+  fun deleteAutomation(automationId: AutomationId) {
+    if (!user.canDeleteAutomation(automationId)) {
+      readAutomation(automationId)
+      throw AccessDeniedException("No permission to delete automation $automationId")
+    }
+  }
+
+  fun deleteOrganization(organizationId: OrganizationId) {
+    if (!user.canDeleteOrganization(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException("No permission to delete organization $organizationId")
+    }
+  }
+
+  fun deleteSpecies(speciesId: SpeciesId) {
+    if (!user.canDeleteSpecies(speciesId)) {
+      readSpecies(speciesId)
+      throw AccessDeniedException("No permission to delete species $speciesId")
     }
   }
 
@@ -333,15 +204,23 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deleteUpload(uploadId: UploadId) {
+    if (!user.canDeleteUpload(uploadId)) {
+      readUpload(uploadId)
+      throw AccessDeniedException("No permission to delete upload")
+    }
+  }
+
   fun importGlobalSpeciesData() {
     if (!user.canImportGlobalSpeciesData()) {
       throw AccessDeniedException("No permission to import global species data")
     }
   }
 
-  fun readNotification(notificationId: NotificationId) {
-    if (!user.canReadNotification(notificationId)) {
-      throw NotificationNotFoundException(notificationId)
+  fun listAutomations(facilityId: FacilityId) {
+    if (!user.canListAutomations(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to list automations in facility $facilityId")
     }
   }
 
@@ -354,9 +233,159 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun countNotifications() {
-    if (!user.canCountNotifications()) {
-      throw AccessDeniedException("No permission to count notifications")
+  fun listOrganizationUsers(organizationId: OrganizationId) {
+    if (!user.canListOrganizationUsers(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException("No permission to list users in organization $organizationId")
+    }
+  }
+
+  fun readAccession(accessionId: AccessionId) {
+    if (!user.canReadAccession(accessionId)) {
+      throw AccessionNotFoundException(accessionId)
+    }
+  }
+
+  fun readAutomation(automationId: AutomationId) {
+    if (!user.canReadAutomation(automationId)) {
+      throw AutomationNotFoundException(automationId)
+    }
+  }
+
+  fun readDevice(deviceId: DeviceId) {
+    if (!user.canReadDevice(deviceId)) {
+      throw DeviceNotFoundException(deviceId)
+    }
+  }
+
+  fun readDeviceManager(deviceManagerId: DeviceManagerId) {
+    if (!user.canReadDeviceManager(deviceManagerId)) {
+      throw DeviceManagerNotFoundException(deviceManagerId)
+    }
+  }
+
+  fun readFacility(facilityId: FacilityId) {
+    if (!user.canReadFacility(facilityId)) {
+      throw FacilityNotFoundException(facilityId)
+    }
+  }
+
+  fun readNotification(notificationId: NotificationId) {
+    if (!user.canReadNotification(notificationId)) {
+      throw NotificationNotFoundException(notificationId)
+    }
+  }
+
+  fun readOrganization(organizationId: OrganizationId) {
+    if (!user.canReadOrganization(organizationId)) {
+      throw OrganizationNotFoundException(organizationId)
+    }
+  }
+
+  fun readSpecies(speciesId: SpeciesId) {
+    if (!user.canReadSpecies(speciesId)) {
+      throw SpeciesNotFoundException(speciesId)
+    }
+  }
+
+  fun readStorageLocation(storageLocationId: StorageLocationId) {
+    if (!user.canReadStorageLocation(storageLocationId)) {
+      throw StorageLocationNotFoundException(storageLocationId)
+    }
+  }
+
+  fun readTimeseries(deviceId: DeviceId) {
+    if (!user.canReadTimeseries(deviceId)) {
+      throw TimeseriesNotFoundException(deviceId)
+    }
+  }
+
+  fun readUpload(uploadId: UploadId) {
+    if (!user.canReadUpload(uploadId)) {
+      throw UploadNotFoundException(uploadId)
+    }
+  }
+
+  fun regenerateAllDeviceManagerTokens() {
+    if (!user.canRegenerateAllDeviceManagerTokens()) {
+      throw AccessDeniedException("No permission to regenerate all device manager tokens")
+    }
+  }
+
+  fun removeOrganizationUser(organizationId: OrganizationId, userId: UserId) {
+    if (!user.canRemoveOrganizationUser(organizationId, userId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to remove user $userId from organization $organizationId")
+    }
+  }
+
+  fun sendAlert(facilityId: FacilityId) {
+    if (!user.canSendAlert(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to send alerts for facility $facilityId")
+    }
+  }
+
+  fun setOrganizationUserRole(organizationId: OrganizationId, role: Role) {
+    if (!user.canSetOrganizationUserRole(organizationId, role)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to grant role to users in organization $organizationId")
+    }
+  }
+
+  fun setTestClock() {
+    if (!user.canSetTestClock()) {
+      throw AccessDeniedException("No permission to set test clock")
+    }
+  }
+
+  fun triggerAutomation(automationId: AutomationId) {
+    if (!user.canTriggerAutomation(automationId)) {
+      readAutomation(automationId)
+      throw AccessDeniedException("No permission to trigger automation $automationId")
+    }
+  }
+
+  fun updateAccession(accessionId: AccessionId) {
+    if (!user.canUpdateAccession(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to update accession $accessionId")
+    }
+  }
+
+  fun updateAutomation(automationId: AutomationId) {
+    if (!user.canUpdateAutomation(automationId)) {
+      readAutomation(automationId)
+      throw AccessDeniedException("No permission to update automation $automationId")
+    }
+  }
+
+  fun updateDevice(deviceId: DeviceId) {
+    if (!user.canUpdateDevice(deviceId)) {
+      readDevice(deviceId)
+      throw AccessDeniedException("No permission to update device $deviceId")
+    }
+  }
+
+  fun updateDeviceManager(deviceManagerId: DeviceManagerId) {
+    if (!user.canUpdateDeviceManager(deviceManagerId)) {
+      readDeviceManager(deviceManagerId)
+      throw AccessDeniedException("No permission to update device manager")
+    }
+  }
+
+  fun updateDeviceTemplates() {
+    if (!user.canUpdateDeviceTemplates()) {
+      throw AccessDeniedException("No permission to update device templates")
+    }
+  }
+
+  fun updateFacility(facilityId: FacilityId) {
+    if (!user.canUpdateFacility(facilityId)) {
+      readFacility(facilityId)
+      throw AccessDeniedException("No permission to update facility $facilityId")
     }
   }
 
@@ -376,16 +405,31 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun createNotification(userId: UserId, organizationId: OrganizationId) {
-    readOrganization(organizationId)
-    if (!user.canCreateNotification(userId, organizationId)) {
-      throw AccessDeniedException("No permission to create notification")
+  fun updateOrganization(organizationId: OrganizationId) {
+    if (!user.canUpdateOrganization(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException("No permission to update organization $organizationId")
     }
   }
 
-  fun readUpload(uploadId: UploadId) {
-    if (!user.canReadUpload(uploadId)) {
-      throw UploadNotFoundException(uploadId)
+  fun updateSpecies(speciesId: SpeciesId) {
+    if (!user.canUpdateSpecies(speciesId)) {
+      readSpecies(speciesId)
+      throw AccessDeniedException("No permission to update species $speciesId")
+    }
+  }
+
+  fun updateStorageLocation(storageLocationId: StorageLocationId) {
+    if (!user.canUpdateStorageLocation(storageLocationId)) {
+      readStorageLocation(storageLocationId)
+      throw AccessDeniedException("No permission to update storage location")
+    }
+  }
+
+  fun updateTimeseries(deviceId: DeviceId) {
+    if (!user.canUpdateTimeseries(deviceId)) {
+      readTimeseries(deviceId)
+      throw AccessDeniedException("No permission to update timeseries on device $deviceId")
     }
   }
 
@@ -393,50 +437,6 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateUpload(uploadId)) {
       readUpload(uploadId)
       throw AccessDeniedException("No permission to update upload")
-    }
-  }
-
-  fun deleteUpload(uploadId: UploadId) {
-    if (!user.canDeleteUpload(uploadId)) {
-      readUpload(uploadId)
-      throw AccessDeniedException("No permission to delete upload")
-    }
-  }
-
-  fun updateDeviceTemplates() {
-    if (!user.canUpdateDeviceTemplates()) {
-      throw AccessDeniedException("No permission to update device templates")
-    }
-  }
-
-  fun createDeviceManager() {
-    if (!user.canCreateDeviceManager()) {
-      throw AccessDeniedException("No permission to create device manager")
-    }
-  }
-
-  fun readDeviceManager(deviceManagerId: DeviceManagerId) {
-    if (!user.canReadDeviceManager(deviceManagerId)) {
-      throw DeviceManagerNotFoundException(deviceManagerId)
-    }
-  }
-
-  fun updateDeviceManager(deviceManagerId: DeviceManagerId) {
-    if (!user.canUpdateDeviceManager(deviceManagerId)) {
-      readDeviceManager(deviceManagerId)
-      throw AccessDeniedException("No permission to update device manager")
-    }
-  }
-
-  fun setTestClock() {
-    if (!user.canSetTestClock()) {
-      throw AccessDeniedException("No permission to set test clock")
-    }
-  }
-
-  fun regenerateAllDeviceManagerTokens() {
-    if (!user.canRegenerateAllDeviceManagerTokens()) {
-      throw AccessDeniedException("No permission to regenerate all device manager tokens")
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -95,12 +95,17 @@ class SystemUser(
    */
 
   override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = true
+  override fun canCountNotifications(): Boolean = true
   override fun canCreateAccession(facilityId: FacilityId): Boolean = true
   override fun canCreateApiKey(organizationId: OrganizationId): Boolean = true
   override fun canCreateAutomation(facilityId: FacilityId): Boolean = true
   override fun canCreateDevice(facilityId: FacilityId): Boolean = true
   override fun canCreateDeviceManager(): Boolean = true
   override fun canCreateFacility(organizationId: OrganizationId): Boolean = true
+  override fun canCreateNotification(
+      targetUserId: UserId,
+      organizationId: OrganizationId
+  ): Boolean = true
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
@@ -113,12 +118,14 @@ class SystemUser(
   override fun canImportGlobalSpeciesData(): Boolean = false
   override fun canListAutomations(facilityId: FacilityId): Boolean = true
   override fun canListFacilities(organizationId: OrganizationId): Boolean = true
+  override fun canListNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
   override fun canReadDevice(deviceId: DeviceId): Boolean = true
   override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
+  override fun canReadNotification(notificationId: NotificationId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
@@ -138,18 +145,11 @@ class SystemUser(
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canUpdateDeviceTemplates(): Boolean = true
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
+  override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
+  override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true
   override fun canUpdateUpload(uploadId: UploadId): Boolean = true
-  override fun canReadNotification(notificationId: NotificationId): Boolean = true
-  override fun canListNotifications(organizationId: OrganizationId?): Boolean = true
-  override fun canCountNotifications(): Boolean = true
-  override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
-  override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
-  override fun canCreateNotification(
-      targetUserId: UserId,
-      organizationId: OrganizationId
-  ): Boolean = true
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -63,12 +63,14 @@ interface TerrawareUser : Principal {
    */
 
   fun canAddOrganizationUser(organizationId: OrganizationId): Boolean
+  fun canCountNotifications(): Boolean
   fun canCreateAccession(facilityId: FacilityId): Boolean
   fun canCreateApiKey(organizationId: OrganizationId): Boolean
   fun canCreateAutomation(facilityId: FacilityId): Boolean
   fun canCreateDevice(facilityId: FacilityId): Boolean
   fun canCreateDeviceManager(): Boolean
   fun canCreateFacility(organizationId: OrganizationId): Boolean
+  fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
@@ -81,12 +83,14 @@ interface TerrawareUser : Principal {
   fun canImportGlobalSpeciesData(): Boolean
   fun canListAutomations(facilityId: FacilityId): Boolean
   fun canListFacilities(organizationId: OrganizationId): Boolean
+  fun canListNotifications(organizationId: OrganizationId?): Boolean
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
   fun canReadAccession(accessionId: AccessionId): Boolean
   fun canReadAutomation(automationId: AutomationId): Boolean
   fun canReadDevice(deviceId: DeviceId): Boolean
   fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canReadFacility(facilityId: FacilityId): Boolean
+  fun canReadNotification(notificationId: NotificationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
@@ -104,15 +108,13 @@ interface TerrawareUser : Principal {
   fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canUpdateDeviceTemplates(): Boolean
   fun canUpdateFacility(facilityId: FacilityId): Boolean
+  fun canUpdateNotification(notificationId: NotificationId): Boolean
+  fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
   fun canUpdateSpecies(speciesId: SpeciesId): Boolean
   fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean
   fun canUpdateUpload(uploadId: UploadId): Boolean
-  fun canReadNotification(notificationId: NotificationId): Boolean
-  fun canListNotifications(organizationId: OrganizationId?): Boolean
-  fun canCountNotifications(): Boolean
-  fun canUpdateNotification(notificationId: NotificationId): Boolean
-  fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
-  fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean
+
+  // When adding new permissions, put them in alphabetical order in the above block.
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -104,6 +104,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.COLLECTION_SITE_LANDOWNER),
         textField("collectionSiteName", "Collection site name", ACCESSIONS.COLLECTION_SITE_NAME),
         textField("collectionSiteNotes", "Collection site notes", ACCESSIONS.COLLECTION_SITE_NOTES),
+        enumField("collectionSource", "Collection source", ACCESSIONS.COLLECTION_SOURCE_ID),
         integerField(
             "cutTestSeedsCompromised",
             "Number of seeds compromised",

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.RareType
@@ -162,6 +163,13 @@ private fun backwardCompatibleCollectors(
   }
 }
 
+/** Maps a source plant origin to the equivalent collection source for backward compatibility. */
+private fun SourcePlantOrigin.toCollectionSource(): CollectionSource =
+    when (this) {
+      SourcePlantOrigin.Outplant -> CollectionSource.Cultivated
+      SourcePlantOrigin.Wild -> CollectionSource.Wild
+    }
+
 // Mark all fields as write-only in the schema
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class CreateAccessionRequestPayload(
@@ -173,6 +181,7 @@ data class CreateAccessionRequestPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String>? = null,
     val deviceInfo: DeviceInfoPayload? = null,
     val endangered: SpeciesEndangeredType? = null,
@@ -212,6 +221,7 @@ data class CreateAccessionRequestPayload(
         collectionSiteLandowner = landowner ?: collectionSiteLandowner,
         collectionSiteName = siteLocation ?: collectionSiteName,
         collectionSiteNotes = environmentalNotes ?: collectionSiteNotes,
+        collectionSource = sourcePlantOrigin?.toCollectionSource() ?: collectionSource,
         collectors =
             backwardCompatibleCollectors(primaryCollector, secondaryCollectors, collectors),
         deviceInfo = deviceInfo?.toModel(),
@@ -241,6 +251,7 @@ data class UpdateAccessionRequestPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String>? = null,
     val cutTestSeedsCompromised: Int? = null,
     val cutTestSeedsEmpty: Int? = null,
@@ -308,6 +319,7 @@ data class UpdateAccessionRequestPayload(
           collectionSiteLandowner = landowner ?: collectionSiteLandowner,
           collectionSiteName = siteLocation ?: collectionSiteName,
           collectionSiteNotes = environmentalNotes ?: collectionSiteNotes,
+          collectionSource = sourcePlantOrigin?.toCollectionSource() ?: collectionSource,
           collectors =
               backwardCompatibleCollectors(primaryCollector, secondaryCollectors, collectors),
           cutTestSeedsCompromised = cutTestSeedsCompromised,
@@ -368,6 +380,7 @@ data class AccessionPayload(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     @Schema(description = "Names of the people who collected the seeds.")
     val collectors: List<String>?,
     val deviceInfo: DeviceInfoPayload?,
@@ -491,6 +504,7 @@ data class AccessionPayload(
       model.collectionSiteLandowner,
       model.collectionSiteName,
       model.collectionSiteNotes,
+      model.collectionSource,
       model.collectors.orNull(),
       model.deviceInfo?.let { DeviceInfoPayload(it) },
       model.cutTestSeedsCompromised,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -129,6 +129,7 @@ class AccessionStore(
           collectionSiteLandowner = record[COLLECTION_SITE_LANDOWNER],
           collectionSiteName = record[COLLECTION_SITE_NAME],
           collectionSiteNotes = record[COLLECTION_SITE_NOTES],
+          collectionSource = record[COLLECTION_SOURCE_ID],
           collectors = record[collectorsField],
           cutTestSeedsCompromised = record[CUT_TEST_SEEDS_COMPROMISED],
           cutTestSeedsEmpty = record[CUT_TEST_SEEDS_EMPTY],
@@ -220,6 +221,7 @@ class AccessionStore(
                         .set(COLLECTION_SITE_LANDOWNER, accession.collectionSiteLandowner)
                         .set(COLLECTION_SITE_NAME, accession.collectionSiteName)
                         .set(COLLECTION_SITE_NOTES, accession.collectionSiteNotes)
+                        .set(COLLECTION_SOURCE_ID, accession.collectionSource)
                         .set(CREATED_BY, currentUser().userId)
                         .set(CREATED_TIME, clock.instant())
                         .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
@@ -368,6 +370,7 @@ class AccessionStore(
                 .set(COLLECTION_SITE_LANDOWNER, accession.collectionSiteLandowner)
                 .set(COLLECTION_SITE_NAME, accession.collectionSiteName)
                 .set(COLLECTION_SITE_NOTES, accession.collectionSiteNotes)
+                .set(COLLECTION_SOURCE_ID, accession.collectionSource)
                 .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
                 .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
                 .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.seedbank.model
 import com.terraformation.backend.customer.model.AppDeviceModel
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.RareType
@@ -68,6 +69,7 @@ data class AccessionModel(
     val collectionSiteLandowner: String? = null,
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
     val collectors: List<String> = emptyList(),
     val cutTestSeedsCompromised: Int? = null,
     val cutTestSeedsEmpty: Int? = null,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -30,6 +30,8 @@ COMMENT ON TABLE automations IS 'Configuration of automatic processes run by the
 
 COMMENT ON TABLE bags IS 'Individual bags of seeds that are part of an accession. An accession can consist of multiple bags.';
 
+COMMENT ON TABLE collection_sources IS '(Enum) Types of source plants that seeds can be collected from.';
+
 COMMENT ON TABLE countries IS 'Country information per ISO-3166.';
 COMMENT ON COLUMN countries.code IS 'ISO-3166 alpha-2 country code.';
 COMMENT ON COLUMN countries.name IS 'Name of country in US English.';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -41,8 +41,6 @@ COMMENT ON COLUMN country_subdivisions.code IS 'Full ISO-3166-2 subdivision code
 COMMENT ON COLUMN country_subdivisions.country_code IS 'ISO-3166 alpha-2 country code.';
 COMMENT ON COLUMN country_subdivisions.name IS 'Name of subdivision in US English.';
 
-COMMENT ON TABLE devices IS 'Hardware devices managed by the device manager at a facility.';
-
 COMMENT ON TABLE device_managers IS 'Information about device managers. This is a combination of information from the Balena API and locally-generated values.';
 COMMENT ON COLUMN device_managers.balena_id IS 'Balena-assigned device identifier.';
 COMMENT ON COLUMN device_managers.balena_modified_time IS 'Last modification timestamp from Balena. This is distinct from `refreshed_time`, which is updated locally.';
@@ -53,6 +51,8 @@ COMMENT ON COLUMN device_managers.update_progress IS 'Percent complete of softwa
 COMMENT ON TABLE device_template_categories IS '(Enum) User-facing categories of device templates; used to show templates for a particular class of devices where the physical device type may differ from one entry to the next.';
 
 COMMENT ON TABLE device_templates IS 'Canned device configurations for use in cases where we want to show a list of possible devices to the user and create the selected device with the correct settings so that the device manager can talk to it.';
+
+COMMENT ON TABLE devices IS 'Hardware devices managed by the device manager at a facility.';
 
 COMMENT ON TABLE facilities IS 'Physical locations at a site. For example, each seed bank and each nursery is a facility.';
 COMMENT ON COLUMN facilities.idle_after_time IS 'Time at which the facility will be considered idle if no timeseries data is received. Null if the timeseries has already been marked as idle or if no timeseries data has ever been received from the facility.';
@@ -68,9 +68,9 @@ COMMENT ON TABLE flyway_schema_history IS 'Tracks which database migrations have
 
 COMMENT ON TABLE gbif_distributions IS 'Information about geographic distribution of species and their conservation statuses.';
 
-COMMENT ON TABLE gbif_names IS 'Scientific and vernacular names from the GBIF backbone dataset. Names are not required to be unique.';
-
 COMMENT ON TABLE gbif_name_words IS 'Inverted index of lower-cased words from species and family names in the GBIF backbone dataset. Used to support fast per-word prefix searches.';
+
+COMMENT ON TABLE gbif_names IS 'Scientific and vernacular names from the GBIF backbone dataset. Names are not required to be unique.';
 
 COMMENT ON TABLE gbif_taxa IS 'Taxonomic data about species and families. A subset of the GBIF backbone dataset.';
 
@@ -141,11 +141,11 @@ COMMENT ON TABLE timeseries_types IS '(Enum) Data formats of the values of a tim
 
 COMMENT ON TABLE timeseries_values IS 'Individual data points on a timeseries. For example, each time the temperature is read from a thermometer, the reading is inserted here.';
 
+COMMENT ON TABLE upload_problem_types IS '(Enum) Specific types of problems encountered while processing a user-uploaded file.';
+
 COMMENT ON TABLE upload_problems IS 'Details about problems (validation failures, etc.) in user-uploaded files.';
 COMMENT ON COLUMN upload_problems.position IS 'Where in the uploaded file the problem appears, or null if it is a problem with the file as a whole. This may be a byte offset, a line number, or a record number depending on the type of file.';
 COMMENT ON COLUMN upload_problems.field IS 'If the problem pertains to a specific field, its name. Null if the problem affects an entire record or the entire file.';
-
-COMMENT ON TABLE upload_problem_types IS '(Enum) Specific types of problems encountered while processing a user-uploaded file.';
 
 COMMENT ON TABLE upload_statuses IS '(Enum) Available statuses of user-uploaded files. Uploads progress through these statuses as the system processes the files.';
 COMMENT ON COLUMN upload_statuses.finished IS 'If true, this status means that the system is finished processing the file.';
@@ -182,3 +182,5 @@ COMMENT ON TABLE viability_tests IS 'Information about a single batch of seeds b
 COMMENT ON TABLE withdrawal_purposes IS '(Enum) Reasons that someone can withdraw seeds from a seed bank.';
 
 COMMENT ON TABLE withdrawals IS 'Information about seeds that have been withdrawn from a seed bank. Each time someone withdraws seeds, a new row is inserted here.';
+
+-- When adding new tables, put them in alphabetical (ASCII) order.

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -9,6 +9,13 @@ VALUES (10, 'Pending', TRUE),
        (80, 'Nursery', FALSE)
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
+INSERT INTO collection_sources (id, name)
+VALUES (1, 'Wild'),
+       (2, 'Reintroduced'),
+       (3, 'Cultivated'),
+       (4, 'Other')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO device_template_categories (id, name)
 VALUES (1, 'PV'),
        (2, 'Seed Bank Default')

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -21,16 +21,16 @@ VALUES (1, 'PV'),
        (2, 'Seed Bank Default')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
-INSERT INTO facility_types (id, name)
-VALUES (1, 'Seed Bank'),
-       (2, 'Desalination'),
-       (3, 'Reverse Osmosis')
-ON CONFLICT (id) DO UPDATE SET name = excluded.name;
-
 INSERT INTO facility_connection_states (id, name)
 VALUES (1, 'Not Connected'),
        (2, 'Connected'),
        (3, 'Configured')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
+INSERT INTO facility_types (id, name)
+VALUES (1, 'Seed Bank'),
+       (2, 'Desalination'),
+       (3, 'Reverse Osmosis')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO growth_forms (id, name)
@@ -40,6 +40,24 @@ VALUES (1, 'Tree'),
        (4, 'Graminoid'),
        (5, 'Fern')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
+INSERT INTO notification_criticalities (id, name)
+VALUES (1, 'Info'),
+       (2, 'Warning'),
+       (3, 'Error'),
+       (4, 'Success')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
+INSERT INTO notification_types (id, name, notification_criticality_id)
+VALUES (1, 'User Added to Organization', 1),
+       (2, 'Facility Idle', 2),
+       (3, 'Facility Alert Requested', 3),
+       (6, 'Accession Scheduled to End Drying', 1),
+       (12, 'Sensor Out Of Bounds', 3),
+       (13, 'Unknown Automation Triggered', 3),
+       (14, 'Device Unresponsive', 3)
+ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
+                               notification_criticality_id = excluded.notification_criticality_id;
 
 INSERT INTO processing_methods (id, name)
 VALUES (1, 'Count'),
@@ -164,20 +182,4 @@ VALUES (1, 'Propagation'),
        (7, 'Viability Testing')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
-INSERT INTO notification_criticalities (id, name)
-VALUES (1, 'Info'),
-       (2, 'Warning'),
-       (3, 'Error'),
-       (4, 'Success')
-ON CONFLICT (id) DO UPDATE SET name = excluded.name;
-
-INSERT INTO notification_types (id, name, notification_criticality_id)
-VALUES (1, 'User Added to Organization', 1),
-       (2, 'Facility Idle', 2),
-       (3, 'Facility Alert Requested', 3),
-       (6, 'Accession Scheduled to End Drying', 1),
-       (12, 'Sensor Out Of Bounds', 3),
-       (13, 'Unknown Automation Triggered', 3),
-       (14, 'Device Unresponsive', 3)
-ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
-                               notification_criticality_id = excluded.notification_criticality_id;
+-- When adding new tables, put them in alphabetical (ASCII) order.

--- a/src/main/resources/db/migration/V120__CollectionSources.sql
+++ b/src/main/resources/db/migration/V120__CollectionSources.sql
@@ -1,0 +1,6 @@
+CREATE TABLE collection_sources (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+ALTER TABLE accessions ADD COLUMN collection_source_id INTEGER REFERENCES collection_sources (id);

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -72,224 +72,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun createAccession() {
-    assertThrows<FacilityNotFoundException> { requirements.createAccession(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createAccession(facilityId) }
-
-    grant { user.canCreateAccession(facilityId) }
-    requirements.createAccession(facilityId)
-  }
-
-  @Test
-  fun readAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.readAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    requirements.readAccession(accessionId)
-  }
-
-  @Test
-  fun updateAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.updateAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    assertThrows<AccessDeniedException> { requirements.updateAccession(accessionId) }
-
-    grant { user.canUpdateAccession(accessionId) }
-    requirements.updateAccession(accessionId)
-  }
-
-  @Test
-  fun deleteAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.deleteAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    assertThrows<AccessDeniedException> { requirements.deleteAccession(accessionId) }
-
-    grant { user.canDeleteAccession(accessionId) }
-    requirements.deleteAccession(accessionId)
-  }
-
-  @Test
-  fun createAutomation() {
-    assertThrows<FacilityNotFoundException> { requirements.createAutomation(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createAutomation(facilityId) }
-
-    grant { user.canCreateAutomation(facilityId) }
-    requirements.createAutomation(facilityId)
-  }
-
-  @Test
-  fun listAutomations() {
-    assertThrows<FacilityNotFoundException> { requirements.listAutomations(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.listAutomations(facilityId) }
-
-    grant { user.canListAutomations(facilityId) }
-    requirements.listAutomations(facilityId)
-  }
-
-  @Test
-  fun readAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.readAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    requirements.readAutomation(automationId)
-  }
-
-  @Test
-  fun updateAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.updateAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.updateAutomation(automationId) }
-
-    grant { user.canUpdateAutomation(automationId) }
-    requirements.updateAutomation(automationId)
-  }
-
-  @Test
-  fun deleteAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.deleteAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.deleteAutomation(automationId) }
-
-    grant { user.canDeleteAutomation(automationId) }
-    requirements.deleteAutomation(automationId)
-  }
-
-  @Test
-  fun triggerAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.triggerAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.triggerAutomation(automationId) }
-
-    grant { user.canTriggerAutomation(automationId) }
-    requirements.triggerAutomation(automationId)
-  }
-
-  @Test
-  fun createFacility() {
-    assertThrows<OrganizationNotFoundException> { requirements.createFacility(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createFacility(organizationId) }
-
-    grant { user.canCreateFacility(organizationId) }
-    requirements.createFacility(organizationId)
-  }
-
-  @Test
-  fun readFacility() {
-    assertThrows<FacilityNotFoundException> { requirements.readFacility(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    requirements.readFacility(facilityId)
-  }
-
-  @Test
-  fun updateFacility() {
-    assertThrows<FacilityNotFoundException> { requirements.updateFacility(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.updateFacility(facilityId) }
-
-    grant { user.canUpdateFacility(facilityId) }
-    requirements.updateFacility(facilityId)
-  }
-
-  @Test
-  fun sendAlert() {
-    assertThrows<FacilityNotFoundException> { requirements.sendAlert(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.sendAlert(facilityId) }
-
-    grant { user.canSendAlert(facilityId) }
-    requirements.sendAlert(facilityId)
-  }
-
-  @Test
-  fun createDevice() {
-    assertThrows<FacilityNotFoundException> { requirements.createDevice(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createDevice(facilityId) }
-
-    grant { user.canCreateDevice(facilityId) }
-    requirements.createDevice(facilityId)
-  }
-
-  @Test
-  fun readDevice() {
-    assertThrows<DeviceNotFoundException> { requirements.readDevice(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    requirements.readDevice(deviceId)
-  }
-
-  @Test
-  fun updateDevice() {
-    assertThrows<DeviceNotFoundException> { requirements.updateDevice(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    assertThrows<AccessDeniedException> { requirements.updateDevice(deviceId) }
-
-    grant { user.canUpdateDevice(deviceId) }
-    requirements.updateDevice(deviceId)
-  }
-
-  @Test
-  fun readOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.readOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    requirements.readOrganization(organizationId)
-  }
-
-  @Test
-  fun updateOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.updateOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.updateOrganization(organizationId) }
-
-    grant { user.canUpdateOrganization(organizationId) }
-    requirements.updateOrganization(organizationId)
-  }
-
-  @Test
-  fun deleteOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.deleteOrganization(organizationId) }
-
-    grant { user.canDeleteOrganization(organizationId) }
-    requirements.deleteOrganization(organizationId)
-  }
-
-  @Test
-  fun listOrganizationUsers() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.listOrganizationUsers(organizationId)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.listOrganizationUsers(organizationId) }
-
-    grant { user.canListOrganizationUsers(organizationId) }
-    requirements.listOrganizationUsers(organizationId)
-  }
-
-  @Test
   fun addOrganizationUser() {
     assertThrows<OrganizationNotFoundException> { requirements.addOrganizationUser(organizationId) }
 
@@ -301,33 +83,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun removeOrganizationUser() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.removeOrganizationUser(organizationId, userId)
-    }
+  fun createAccession() {
+    assertThrows<FacilityNotFoundException> { requirements.createAccession(facilityId) }
 
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> {
-      requirements.removeOrganizationUser(organizationId, userId)
-    }
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.createAccession(facilityId) }
 
-    grant { user.canRemoveOrganizationUser(organizationId, userId) }
-    requirements.removeOrganizationUser(organizationId, userId)
-  }
-
-  @Test
-  fun setOrganizationUserRole() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.setOrganizationUserRole(organizationId, role)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> {
-      requirements.setOrganizationUserRole(organizationId, role)
-    }
-
-    grant { user.canSetOrganizationUserRole(organizationId, role) }
-    requirements.setOrganizationUserRole(organizationId, role)
+    grant { user.canCreateAccession(facilityId) }
+    requirements.createAccession(facilityId)
   }
 
   @Test
@@ -342,6 +105,62 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun createAutomation() {
+    assertThrows<FacilityNotFoundException> { requirements.createAutomation(facilityId) }
+
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.createAutomation(facilityId) }
+
+    grant { user.canCreateAutomation(facilityId) }
+    requirements.createAutomation(facilityId)
+  }
+
+  @Test
+  fun createDevice() {
+    assertThrows<FacilityNotFoundException> { requirements.createDevice(facilityId) }
+
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.createDevice(facilityId) }
+
+    grant { user.canCreateDevice(facilityId) }
+    requirements.createDevice(facilityId)
+  }
+
+  @Test
+  fun createDeviceManager() {
+    assertThrows<AccessDeniedException> { requirements.createDeviceManager() }
+
+    grant { user.canCreateDeviceManager() }
+    requirements.createDeviceManager()
+  }
+
+  @Test
+  fun createFacility() {
+    assertThrows<OrganizationNotFoundException> { requirements.createFacility(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.createFacility(organizationId) }
+
+    grant { user.canCreateFacility(organizationId) }
+    requirements.createFacility(organizationId)
+  }
+
+  @Test
+  fun createNotification() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.createNotification(notificationUserId, organizationId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.createNotification(notificationUserId, organizationId)
+    }
+
+    grant { user.canCreateNotification(notificationUserId, organizationId) }
+    requirements.createNotification(notificationUserId, organizationId)
+  }
+
+  @Test
   fun createSpecies() {
     assertThrows<OrganizationNotFoundException> { requirements.createSpecies(organizationId) }
 
@@ -350,47 +169,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canCreateSpecies(organizationId) }
     requirements.createSpecies(organizationId)
-  }
-
-  @Test
-  fun readSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    requirements.readSpecies(speciesId)
-  }
-
-  @Test
-  fun deleteSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.deleteSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    assertThrows<AccessDeniedException> { requirements.deleteSpecies(speciesId) }
-
-    grant { user.canDeleteSpecies(speciesId) }
-    requirements.deleteSpecies(speciesId)
-  }
-
-  @Test
-  fun updateSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.updateSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    assertThrows<AccessDeniedException> { requirements.updateSpecies(speciesId) }
-
-    grant { user.canUpdateSpecies(speciesId) }
-    requirements.updateSpecies(speciesId)
-  }
-
-  @Test
-  fun createTimeseries() {
-    assertThrows<DeviceNotFoundException> { requirements.createTimeseries(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    assertThrows<AccessDeniedException> { requirements.createTimeseries(deviceId) }
-
-    grant { user.canCreateTimeseries(deviceId) }
-    requirements.createTimeseries(deviceId)
   }
 
   @Test
@@ -405,13 +183,58 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun readStorageLocation() {
-    assertThrows<StorageLocationNotFoundException> {
-      requirements.readStorageLocation(storageLocationId)
-    }
+  fun createTimeseries() {
+    assertThrows<DeviceNotFoundException> { requirements.createTimeseries(deviceId) }
 
-    grant { user.canReadStorageLocation(storageLocationId) }
-    requirements.readStorageLocation(storageLocationId)
+    grant { user.canReadDevice(deviceId) }
+    assertThrows<AccessDeniedException> { requirements.createTimeseries(deviceId) }
+
+    grant { user.canCreateTimeseries(deviceId) }
+    requirements.createTimeseries(deviceId)
+  }
+
+  @Test
+  fun deleteAccession() {
+    assertThrows<AccessionNotFoundException> { requirements.deleteAccession(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    assertThrows<AccessDeniedException> { requirements.deleteAccession(accessionId) }
+
+    grant { user.canDeleteAccession(accessionId) }
+    requirements.deleteAccession(accessionId)
+  }
+
+  @Test
+  fun deleteAutomation() {
+    assertThrows<AutomationNotFoundException> { requirements.deleteAutomation(automationId) }
+
+    grant { user.canReadAutomation(automationId) }
+    assertThrows<AccessDeniedException> { requirements.deleteAutomation(automationId) }
+
+    grant { user.canDeleteAutomation(automationId) }
+    requirements.deleteAutomation(automationId)
+  }
+
+  @Test
+  fun deleteOrganization() {
+    assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.deleteOrganization(organizationId) }
+
+    grant { user.canDeleteOrganization(organizationId) }
+    requirements.deleteOrganization(organizationId)
+  }
+
+  @Test
+  fun deleteSpecies() {
+    assertThrows<SpeciesNotFoundException> { requirements.deleteSpecies(speciesId) }
+
+    grant { user.canReadSpecies(speciesId) }
+    assertThrows<AccessDeniedException> { requirements.deleteSpecies(speciesId) }
+
+    grant { user.canDeleteSpecies(speciesId) }
+    requirements.deleteSpecies(speciesId)
   }
 
   @Test
@@ -428,16 +251,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun updateStorageLocation() {
-    assertThrows<StorageLocationNotFoundException> {
-      requirements.updateStorageLocation(storageLocationId)
-    }
+  fun deleteUpload() {
+    assertThrows<UploadNotFoundException> { requirements.deleteUpload(uploadId) }
 
-    grant { user.canReadStorageLocation(storageLocationId) }
-    assertThrows<AccessDeniedException> { requirements.updateStorageLocation(storageLocationId) }
+    grant { user.canReadUpload(uploadId) }
+    assertThrows<AccessDeniedException> { requirements.deleteUpload(uploadId) }
 
-    grant { user.canUpdateStorageLocation(storageLocationId) }
-    requirements.updateStorageLocation(storageLocationId)
+    grant { user.canDeleteUpload(uploadId) }
+    requirements.deleteUpload(uploadId)
   }
 
   @Test
@@ -449,18 +270,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun createNotification() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.createNotification(notificationUserId, organizationId)
-    }
+  fun listAutomations() {
+    assertThrows<FacilityNotFoundException> { requirements.listAutomations(facilityId) }
 
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> {
-      requirements.createNotification(notificationUserId, organizationId)
-    }
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.listAutomations(facilityId) }
 
-    grant { user.canCreateNotification(notificationUserId, organizationId) }
-    requirements.createNotification(notificationUserId, organizationId)
+    grant { user.canListAutomations(facilityId) }
+    requirements.listAutomations(facilityId)
   }
 
   @Test
@@ -483,6 +300,59 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun listOrganizationUsers() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.listOrganizationUsers(organizationId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.listOrganizationUsers(organizationId) }
+
+    grant { user.canListOrganizationUsers(organizationId) }
+    requirements.listOrganizationUsers(organizationId)
+  }
+
+  @Test
+  fun readAccession() {
+    assertThrows<AccessionNotFoundException> { requirements.readAccession(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    requirements.readAccession(accessionId)
+  }
+
+  @Test
+  fun readAutomation() {
+    assertThrows<AutomationNotFoundException> { requirements.readAutomation(automationId) }
+
+    grant { user.canReadAutomation(automationId) }
+    requirements.readAutomation(automationId)
+  }
+
+  @Test
+  fun readDevice() {
+    assertThrows<DeviceNotFoundException> { requirements.readDevice(deviceId) }
+
+    grant { user.canReadDevice(deviceId) }
+    requirements.readDevice(deviceId)
+  }
+
+  @Test
+  fun readDeviceManager() {
+    assertThrows<DeviceManagerNotFoundException> { requirements.readDeviceManager(deviceManagerId) }
+
+    grant { user.canReadDeviceManager(deviceManagerId) }
+    requirements.readDeviceManager(deviceManagerId)
+  }
+
+  @Test
+  fun readFacility() {
+    assertThrows<FacilityNotFoundException> { requirements.readFacility(facilityId) }
+
+    grant { user.canReadFacility(facilityId) }
+    requirements.readFacility(facilityId)
+  }
+
+  @Test
   fun readNotification() {
     assertThrows<NotificationNotFoundException> { requirements.readNotification(notificationId) }
 
@@ -491,30 +361,29 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun updateNotification() {
-    assertThrows<NotificationNotFoundException> { requirements.updateNotification(notificationId) }
-
-    grant { user.canUpdateNotification(notificationId) }
-    requirements.updateNotification(notificationId)
-  }
-
-  @Test
-  fun updateGlobalNotifications() {
-    assertThrows<AccessDeniedException> { requirements.updateNotifications(null) }
-
-    grant { user.canUpdateNotifications(null) }
-    requirements.updateNotifications(null)
-  }
-
-  @Test
-  fun updateOrganizationNotifications() {
-    assertThrows<OrganizationNotFoundException> { requirements.updateNotifications(organizationId) }
+  fun readOrganization() {
+    assertThrows<OrganizationNotFoundException> { requirements.readOrganization(organizationId) }
 
     grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.updateNotifications(organizationId) }
+    requirements.readOrganization(organizationId)
+  }
 
-    grant { user.canUpdateNotifications(organizationId) }
-    requirements.updateNotifications(organizationId)
+  @Test
+  fun readSpecies() {
+    assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
+
+    grant { user.canReadSpecies(speciesId) }
+    requirements.readSpecies(speciesId)
+  }
+
+  @Test
+  fun readStorageLocation() {
+    assertThrows<StorageLocationNotFoundException> {
+      requirements.readStorageLocation(storageLocationId)
+    }
+
+    grant { user.canReadStorageLocation(storageLocationId) }
+    requirements.readStorageLocation(storageLocationId)
   }
 
   @Test
@@ -526,49 +395,104 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun updateUpload() {
-    assertThrows<UploadNotFoundException> { requirements.updateUpload(uploadId) }
+  fun regenerateAllDeviceManagerTokens() {
+    assertThrows<AccessDeniedException> { requirements.regenerateAllDeviceManagerTokens() }
 
-    grant { user.canReadUpload(uploadId) }
-    assertThrows<AccessDeniedException> { requirements.updateUpload(uploadId) }
-
-    grant { user.canUpdateUpload(uploadId) }
-    requirements.updateUpload(uploadId)
+    grant { user.canRegenerateAllDeviceManagerTokens() }
+    requirements.regenerateAllDeviceManagerTokens()
   }
 
   @Test
-  fun deleteUpload() {
-    assertThrows<UploadNotFoundException> { requirements.deleteUpload(uploadId) }
+  fun removeOrganizationUser() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.removeOrganizationUser(organizationId, userId)
+    }
 
-    grant { user.canReadUpload(uploadId) }
-    assertThrows<AccessDeniedException> { requirements.deleteUpload(uploadId) }
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.removeOrganizationUser(organizationId, userId)
+    }
 
-    grant { user.canDeleteUpload(uploadId) }
-    requirements.deleteUpload(uploadId)
+    grant { user.canRemoveOrganizationUser(organizationId, userId) }
+    requirements.removeOrganizationUser(organizationId, userId)
   }
 
   @Test
-  fun updateDeviceTemplates() {
-    assertThrows<AccessDeniedException> { requirements.updateDeviceTemplates() }
+  fun sendAlert() {
+    assertThrows<FacilityNotFoundException> { requirements.sendAlert(facilityId) }
 
-    grant { user.canUpdateDeviceTemplates() }
-    requirements.updateDeviceTemplates()
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.sendAlert(facilityId) }
+
+    grant { user.canSendAlert(facilityId) }
+    requirements.sendAlert(facilityId)
   }
 
   @Test
-  fun createDeviceManager() {
-    assertThrows<AccessDeniedException> { requirements.createDeviceManager() }
+  fun setOrganizationUserRole() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.setOrganizationUserRole(organizationId, role)
+    }
 
-    grant { user.canCreateDeviceManager() }
-    requirements.createDeviceManager()
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.setOrganizationUserRole(organizationId, role)
+    }
+
+    grant { user.canSetOrganizationUserRole(organizationId, role) }
+    requirements.setOrganizationUserRole(organizationId, role)
   }
 
   @Test
-  fun readDeviceManager() {
-    assertThrows<DeviceManagerNotFoundException> { requirements.readDeviceManager(deviceManagerId) }
+  fun setTestClock() {
+    assertThrows<AccessDeniedException> { requirements.setTestClock() }
 
-    grant { user.canReadDeviceManager(deviceManagerId) }
-    requirements.readDeviceManager(deviceManagerId)
+    grant { user.canSetTestClock() }
+    requirements.setTestClock()
+  }
+
+  @Test
+  fun triggerAutomation() {
+    assertThrows<AutomationNotFoundException> { requirements.triggerAutomation(automationId) }
+
+    grant { user.canReadAutomation(automationId) }
+    assertThrows<AccessDeniedException> { requirements.triggerAutomation(automationId) }
+
+    grant { user.canTriggerAutomation(automationId) }
+    requirements.triggerAutomation(automationId)
+  }
+
+  @Test
+  fun updateAccession() {
+    assertThrows<AccessionNotFoundException> { requirements.updateAccession(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    assertThrows<AccessDeniedException> { requirements.updateAccession(accessionId) }
+
+    grant { user.canUpdateAccession(accessionId) }
+    requirements.updateAccession(accessionId)
+  }
+
+  @Test
+  fun updateAutomation() {
+    assertThrows<AutomationNotFoundException> { requirements.updateAutomation(automationId) }
+
+    grant { user.canReadAutomation(automationId) }
+    assertThrows<AccessDeniedException> { requirements.updateAutomation(automationId) }
+
+    grant { user.canUpdateAutomation(automationId) }
+    requirements.updateAutomation(automationId)
+  }
+
+  @Test
+  fun updateDevice() {
+    assertThrows<DeviceNotFoundException> { requirements.updateDevice(deviceId) }
+
+    grant { user.canReadDevice(deviceId) }
+    assertThrows<AccessDeniedException> { requirements.updateDevice(deviceId) }
+
+    grant { user.canUpdateDevice(deviceId) }
+    requirements.updateDevice(deviceId)
   }
 
   @Test
@@ -585,18 +509,96 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun setTestClock() {
-    assertThrows<AccessDeniedException> { requirements.setTestClock() }
+  fun updateDeviceTemplates() {
+    assertThrows<AccessDeniedException> { requirements.updateDeviceTemplates() }
 
-    grant { user.canSetTestClock() }
-    requirements.setTestClock()
+    grant { user.canUpdateDeviceTemplates() }
+    requirements.updateDeviceTemplates()
   }
 
   @Test
-  fun regenerateAllDeviceManagerTokens() {
-    assertThrows<AccessDeniedException> { requirements.regenerateAllDeviceManagerTokens() }
+  fun updateFacility() {
+    assertThrows<FacilityNotFoundException> { requirements.updateFacility(facilityId) }
 
-    grant { user.canRegenerateAllDeviceManagerTokens() }
-    requirements.regenerateAllDeviceManagerTokens()
+    grant { user.canReadFacility(facilityId) }
+    assertThrows<AccessDeniedException> { requirements.updateFacility(facilityId) }
+
+    grant { user.canUpdateFacility(facilityId) }
+    requirements.updateFacility(facilityId)
   }
+
+  @Test
+  fun updateGlobalNotifications() {
+    assertThrows<AccessDeniedException> { requirements.updateNotifications(null) }
+
+    grant { user.canUpdateNotifications(null) }
+    requirements.updateNotifications(null)
+  }
+
+  @Test
+  fun updateNotification() {
+    assertThrows<NotificationNotFoundException> { requirements.updateNotification(notificationId) }
+
+    grant { user.canUpdateNotification(notificationId) }
+    requirements.updateNotification(notificationId)
+  }
+
+  @Test
+  fun updateOrganization() {
+    assertThrows<OrganizationNotFoundException> { requirements.updateOrganization(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.updateOrganization(organizationId) }
+
+    grant { user.canUpdateOrganization(organizationId) }
+    requirements.updateOrganization(organizationId)
+  }
+
+  @Test
+  fun updateOrganizationNotifications() {
+    assertThrows<OrganizationNotFoundException> { requirements.updateNotifications(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.updateNotifications(organizationId) }
+
+    grant { user.canUpdateNotifications(organizationId) }
+    requirements.updateNotifications(organizationId)
+  }
+
+  @Test
+  fun updateSpecies() {
+    assertThrows<SpeciesNotFoundException> { requirements.updateSpecies(speciesId) }
+
+    grant { user.canReadSpecies(speciesId) }
+    assertThrows<AccessDeniedException> { requirements.updateSpecies(speciesId) }
+
+    grant { user.canUpdateSpecies(speciesId) }
+    requirements.updateSpecies(speciesId)
+  }
+
+  @Test
+  fun updateStorageLocation() {
+    assertThrows<StorageLocationNotFoundException> {
+      requirements.updateStorageLocation(storageLocationId)
+    }
+
+    grant { user.canReadStorageLocation(storageLocationId) }
+    assertThrows<AccessDeniedException> { requirements.updateStorageLocation(storageLocationId) }
+
+    grant { user.canUpdateStorageLocation(storageLocationId) }
+    requirements.updateStorageLocation(storageLocationId)
+  }
+
+  @Test
+  fun updateUpload() {
+    assertThrows<UploadNotFoundException> { requirements.updateUpload(uploadId) }
+
+    grant { user.canReadUpload(uploadId) }
+    assertThrows<AccessDeniedException> { requirements.updateUpload(uploadId) }
+
+    grant { user.canUpdateUpload(uploadId) }
+    requirements.updateUpload(uploadId)
+  }
+
+  // When adding new permission tests, put them in alphabetical order.
 }

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -127,6 +127,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "app_devices" to setOf(ALL, SEEDBANK),
           "automations" to setOf(ALL, DEVICE),
           "bags" to setOf(ALL, SEEDBANK),
+          "collection_sources" to setOf(ALL, SEEDBANK),
           "countries" to setOf(ALL, CUSTOMER),
           "country_subdivisions" to setOf(ALL, CUSTOMER),
           "devices" to setOf(ALL, DEVICE),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.AppDeviceId
 import com.terraformation.backend.db.BagId
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
@@ -1431,6 +1432,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "siteName",
             collectionSiteNotes = "siteNotes",
+            collectionSource = CollectionSource.Other,
             collectors = listOf("primaryCollector", "second1", "second2"),
             deviceInfo =
                 DeviceInfoPayload(
@@ -1504,6 +1506,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "name",
             collectionSiteNotes = "notes",
+            collectionSource = CollectionSource.Reintroduced,
             collectors = listOf("primaryCollector", "second1", "second2"),
             cutTestSeedsCompromised = 20,
             cutTestSeedsEmpty = 21,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.GrowthForm
@@ -174,6 +175,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
             collectionSiteLandowner = "landowner",
             collectionSiteName = "siteName",
             collectionSiteNotes = "siteNotes",
+            collectionSourceId = CollectionSource.Reintroduced,
             createdBy = user.userId,
             createdTime = now,
             facilityId = facilityId,
@@ -2882,6 +2884,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "collectionSiteLandowner" to "landowner",
                       "collectionSiteName" to "siteName",
                       "collectionSiteNotes" to "siteNotes",
+                      "collectionSource" to "Reintroduced",
                       "collectors" to
                           listOf(
                               mapOf("name" to "primary", "position" to "0"),


### PR DESCRIPTION
We have a handful of source files that have lists of tables or methods that aren't
trivially short but make sense to keep grouped together. They weren't ordered in a
way that made them easy to navigate or that made it obvious exactly where to add
new entries. Update them to sort the relevant parts alphabetically.

No functional changes here, just shuffling of names.