### PR TITLE
SW-1388 Query summary statistics all at once

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.seedbank.model
+
+import java.math.BigDecimal
+
+data class AccessionSummaryStatistics(
+    val accessions: Int,
+    val species: Int,
+    val subtotalBySeedCount: Long,
+    val subtotalByWeightEstimate: Long,
+    val totalSeedsRemaining: Long,
+    val unknownQuantityAccessions: Int,
+) {
+  constructor(
+      accessions: Int,
+      species: Int,
+      subtotalBySeedCount: BigDecimal,
+      subtotalByWeightEstimate: BigDecimal,
+      unknownQuantityAccessions: BigDecimal,
+  ) : this(
+      accessions = accessions,
+      species = species,
+      subtotalBySeedCount = subtotalBySeedCount.toLong(),
+      subtotalByWeightEstimate = subtotalByWeightEstimate.toLong(),
+      totalSeedsRemaining = subtotalBySeedCount.toLong() + subtotalByWeightEstimate.toLong(),
+      unknownQuantityAccessions = unknownQuantityAccessions.toInt(),
+  )
+}


### PR DESCRIPTION
We will need to generate some of the same summary statistics for search results
that we do on the accessions dashboard page. Rework the statistics computation
so we'll be able to pass it a query generated by `SearchService`.

As part of this change, we now calculate all the statistics in a single query
rather than using a separate query for each one. This makes the query a little
ugly but will improve performance when we're calculating the stats over a complex
user-defined query.