### PR TITLE
SW-1426 Add new accession states

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -26,13 +26,16 @@ enum class AccessionActive {
 fun AccessionState.toActiveEnum() =
     when (this) {
       AccessionState.Withdrawn,
-      AccessionState.Nursery -> AccessionActive.Inactive
+      AccessionState.Nursery,
+      AccessionState.UsedUp -> AccessionActive.Inactive
 
       // Don't use "else" here -- we want it to be a compile error if we add a state and forget
       // to specify whether it is active or inactive.
       AccessionState.AwaitingCheckIn,
+      AccessionState.AwaitingProcessing,
       AccessionState.Pending,
       AccessionState.Processing,
+      AccessionState.Cleaning,
       AccessionState.Processed,
       AccessionState.Drying,
       AccessionState.Dried,

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -1,11 +1,15 @@
 INSERT INTO accession_states (id, name, active)
-VALUES (10, 'Pending', TRUE),
+VALUES (5, 'Awaiting Check-In', TRUE),
+       (10, 'Pending', TRUE),
+       (15, 'Awaiting Processing', TRUE),
        (20, 'Processing', TRUE),
+       (25, 'Cleaning', TRUE),
        (30, 'Processed', TRUE),
        (40, 'Drying', TRUE),
        (50, 'Dried', TRUE),
        (60, 'In Storage', TRUE),
        (70, 'Withdrawn', FALSE),
+       (75, 'Used Up', FALSE),
        (80, 'Nursery', FALSE)
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1914,6 +1914,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
           mapOf(
               facilityId to
                   mapOf(
+                      AccessionState.AwaitingProcessing to 2,
                       AccessionState.Dried to 1,
                       AccessionState.Drying to 2,
                       AccessionState.InStorage to 3,
@@ -1921,6 +1922,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                       AccessionState.Pending to 4,
                       AccessionState.Processed to 1,
                       AccessionState.Processing to 2,
+                      AccessionState.UsedUp to 2,
                       AccessionState.Withdrawn to 1,
                   ),
               otherOrgFacilityId to
@@ -1930,6 +1932,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   ),
               sameOrgFacilityId to
                   mapOf(
+                      AccessionState.Cleaning to 2,
                       AccessionState.Dried to 1,
                       AccessionState.Processed to 2,
                       AccessionState.Withdrawn to 1,
@@ -1954,6 +1957,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           mapOf(
               AccessionState.AwaitingCheckIn to 0,
+              AccessionState.AwaitingProcessing to 2,
+              AccessionState.Cleaning to 0,
               AccessionState.Dried to 1,
               AccessionState.Drying to 2,
               AccessionState.InStorage to 3,
@@ -1967,6 +1972,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           mapOf(
               AccessionState.AwaitingCheckIn to 0,
+              AccessionState.AwaitingProcessing to 2,
+              AccessionState.Cleaning to 2,
               AccessionState.Dried to 2,
               AccessionState.Drying to 2,
               AccessionState.InStorage to 3,


### PR DESCRIPTION
The new version of the app is going to switch to a simplified list of accession
states. Some of them are the same as existing states, but there are also a few
brand-new ones. Add them to the list of states.

No accessions should ever be in these states at the moment, but with this change,
they'll be included in the OpenAPI schema and will also be returned by API
endpoints that list all the values of enums.