### PR TITLE
Simplify mapping of AccessionState to AccessionActive

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -20,7 +20,8 @@ val ENUM_TABLES =
             listOf(
                 "accessions\\.state_id",
                 ".*\\.accession_state_id",
-                "accession_state_history\\.(old|new)_state_id")),
+                "accession_state_history\\.(old|new)_state_id"),
+            additionalColumns = listOf(EnumTableColumnInfo("active", "Boolean"))),
         EnumTable("collection_sources", ".*\\.collection_source_id"),
         EnumTable(
             "device_template_categories",
@@ -67,7 +68,7 @@ val ENUM_TABLES =
         EnumTable(
             "upload_types",
             "uploads\\.type_id",
-            additionalColumns = listOf(EnumTableColumnInfo("expire_files", "Boolean", false))),
+            additionalColumns = listOf(EnumTableColumnInfo("expire_files", "Boolean"))),
         EnumTable("user_types", ".*\\.user_type_id"),
         EnumTable("viability_test_seed_types", "viability_tests\\.seed_type_id"),
         EnumTable("viability_test_substrates", "viability_tests\\.substrate_id"),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -18,38 +18,22 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 
+/**
+ * Enum representation of whether or not an accession is in an active state. We use this rather than
+ * a boolean because we want the API to have explicit "inactive" and "active" concepts.
+ */
 enum class AccessionActive {
   Inactive,
   Active
 }
 
-fun AccessionState.toActiveEnum() =
-    when (this) {
-      AccessionState.Withdrawn,
-      AccessionState.Nursery,
-      AccessionState.UsedUp -> AccessionActive.Inactive
-
-      // Don't use "else" here -- we want it to be a compile error if we add a state and forget
-      // to specify whether it is active or inactive.
-      AccessionState.AwaitingCheckIn,
-      AccessionState.AwaitingProcessing,
-      AccessionState.Pending,
-      AccessionState.Processing,
-      AccessionState.Cleaning,
-      AccessionState.Processed,
-      AccessionState.Drying,
-      AccessionState.Dried,
-      AccessionState.InStorage -> AccessionActive.Active
-    }
+fun AccessionState.toActiveEnum() = if (active) AccessionActive.Active else AccessionActive.Inactive
 
 /**
  * All the accession states that are considered active. This is effectively the backing field for
  * [AccessionState.Companion.activeValues], because extension properties don't have backing fields.
- * We derive this from [AccessionState.toActiveEnum] rather than the other way around so we get the
- * comprehensiveness check in the `when` expression in that function.
  */
-private val activeStates =
-    AccessionState.values().filter { it.toActiveEnum() == AccessionActive.Active }.toSet()
+private val activeStates = AccessionState.values().filter { it.active }.toSet()
 
 /** All the accession states that are considered active. */
 val AccessionState.Companion.activeValues: Set<AccessionState>


### PR DESCRIPTION
Commit eabb60b9 added the ability to include additional columns in the enum
classes that are generated from the database. Use it to expose the `active`
column on `accession_states`, and then map that to `AccessionActive` values
rather than using an exhaustive `when` statement.