### PR TITLE
Fix bug in sort order generation in search queries

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2625,6 +2625,56 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `can sort on scalar field that is after nested field in field list`() {
+      // We want the surrounding fields to sort in the opposite order of the nested field so we
+      // can detect if the ORDER BY clause is using the wrong field.
+      accessionsDao.update(
+          accessionsDao
+              .fetchOneById(AccessionId(1000))!!
+              .copy(number = "B", receivedDate = LocalDate.of(2020, 1, 2)))
+      accessionsDao.update(
+          accessionsDao
+              .fetchOneById(AccessionId(1001))!!
+              .copy(number = "A", receivedDate = LocalDate.of(2020, 1, 1)))
+
+      val selectFields = listOf(accessionNumberField, bagsNumberField, receivedDateField)
+      val sortOrder =
+          listOf(
+              SearchSortField(receivedDateField, SearchDirection.Descending),
+              SearchSortField(bagsNumberField, SearchDirection.Descending),
+              SearchSortField(accessionNumberField),
+          )
+
+      val result = searchService.search(rootPrefix, selectFields, NoConditionNode(), sortOrder)
+
+      val expected =
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "accessionNumber" to "B",
+                      "bags" to
+                          listOf(
+                              mapOf("number" to "5"),
+                              mapOf("number" to "1"),
+                          ),
+                      "receivedDate" to "2020-01-02",
+                  ),
+                  mapOf(
+                      "accessionNumber" to "A",
+                      "bags" to
+                          listOf(
+                              mapOf("number" to "6"),
+                              mapOf("number" to "2"),
+                          ),
+                      "receivedDate" to "2020-01-01",
+                  ),
+              ),
+              cursor = null)
+
+      assertEquals(expected, result)
+    }
+
+    @Test
     fun `can sort on flattened field that is not in list of query fields`() {
       val sortOrder = listOf(SearchSortField(bagNumberFlattenedField, SearchDirection.Descending))
 


### PR DESCRIPTION
The search code generates `ORDER BY` clauses that use field positions to refer to
fields that are also in the `SELECT` clause, e.g., `SELECT a, b FROM c ORDER BY 2`
to sort by the `b` column. It thus keeps track of what order the fields are added
to the `SELECT` clause so it can use the correct position numbers.

Unfortunately, the code that was actually generating the `SELECT` clause would
always put all the scalar fields first in the list, before all the sublist fields,
even if the caller had specified that the sublist fields should come first. Thus
the `ORDER BY` clause would sometimes use the wrong positions, causing the results
to be incorrectly sorted.

Modify the code to put the fields in the positions the `ORDER BY` construction
code expects them to be, and add a test case that verifies the fix.