### PR TITLE
SW-1425 Introduce v2 accession API endpoints

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -68,23 +68,24 @@ class TerrawareClient:
     def list_timeseries(self, device_id):
         return self.get(f"/api/v1/timeseries?deviceId={device_id}")["timeseries"]
 
-    def create_accession(self, payload):
-        return self.post("/api/v1/seedbank/accessions", json=payload)["accession"]
+    def create_accession(self, payload, version=1):
+        uri = f"/api/v{version}/seedbank/accessions"
+        return self.post(uri, json=payload)["accession"]
 
     def check_in_accession(self, accession_id):
-        return self.post(f"/api/v1/seedbank/accessions/{accession_id}/checkIn")[
-            "accession"
-        ]
+        uri = f"/api/v1/seedbank/accessions/{accession_id}/checkIn"
+        return self.post(uri)["accession"]
 
-    def get_accession(self, accession_id):
-        return self.get(f"/api/v1/seedbank/accessions/{accession_id}")["accession"]
+    def get_accession(self, accession_id, version=1):
+        uri = f"/api/v{version}/seedbank/accessions/{accession_id}"
+        return self.get(uri)["accession"]
 
-    def update_accession(self, accession_id, payload, simulate=False):
+    def update_accession(self, accession_id, payload, simulate=False, version=1):
         if simulate:
             query = "?simulate=true"
         else:
             query = ""
-        uri = f"/api/v1/seedbank/accessions/{accession_id}{query}"
+        uri = f"/api/v{version}/seedbank/accessions/{accession_id}{query}"
 
         return self.put(uri, json=payload)["accession"]
 

--- a/scripts/edit_accession.py
+++ b/scripts/edit_accession.py
@@ -24,6 +24,13 @@ def main():
         action="store_true",
         help="Show updated accession data after editing.",
     )
+    parser.add_argument(
+        "--version",
+        "-V",
+        type=int,
+        help="Version number of API endpoint",
+        default=1,
+    )
     parser.add_argument("accessionId")
     parser.add_argument(
         "file",
@@ -42,11 +49,13 @@ def main():
 
     client = client_from_args(args)
 
-    accession = client.get_accession(args.accessionId)
+    accession = client.get_accession(args.accessionId, version=args.version)
 
     accession.update(edits)
 
-    updated = client.update_accession(args.accessionId, accession, args.simulate)
+    updated = client.update_accession(
+        args.accessionId, accession, args.simulate, args.version
+    )
     if args.verbose:
         print(json.dumps(updated))
     else:

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -251,7 +251,6 @@ data class CreateAccessionRequestPayload(
   }
 }
 
-// Ignore properties that are defined on AccessionFields but not accepted as input (CU-px8k25)
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class UpdateAccessionRequestPayload(
     val bagNumbers: Set<String>? = null,
@@ -600,7 +599,7 @@ data class SeedQuantityPayload(
   fun toModel() = SeedQuantityModel(quantity, units)
 }
 
-private fun SeedQuantityModel.toPayload() = SeedQuantityPayload(this)
+fun SeedQuantityModel.toPayload() = SeedQuantityPayload(this)
 
 /**
  * Test types that are compatible with the v1 API. The v2 API will change cut tests from accession

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -1,0 +1,368 @@
+package com.terraformation.backend.seedbank.api
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.SeedBankAppEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.CollectionSource
+import com.terraformation.backend.db.DataSource
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.ProcessingMethod
+import com.terraformation.backend.db.SpeciesId
+import com.terraformation.backend.db.StorageCondition
+import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.model.AccessionActive
+import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.Geolocation
+import com.terraformation.backend.seedbank.model.isV2Compatible
+import com.terraformation.backend.seedbank.model.toV2Compatible
+import com.terraformation.backend.util.orNull
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.time.Clock
+import java.time.LocalDate
+import javax.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v2/seedbank/accessions")
+@RestController
+@SeedBankAppEndpoint
+class AccessionsV2Controller(
+    private val accessionStore: AccessionStore,
+    private val clock: Clock,
+) {
+  @ApiResponse(
+      responseCode = "200",
+      description =
+          "The accession was created successfully. Response includes fields populated by the " +
+              "server, including the accession number and ID.")
+  @Operation(summary = "Creates a new accession.")
+  @PostMapping
+  fun createAccession(
+      @RequestBody payload: CreateAccessionRequestPayloadV2
+  ): CreateAccessionResponsePayloadV2 {
+    val updatedPayload = accessionStore.create(payload.toModel())
+    return CreateAccessionResponsePayloadV2(AccessionPayloadV2(updatedPayload))
+  }
+
+  @ApiResponse(
+      responseCode = "200",
+      description =
+          "The accession was updated successfully. Response includes fields populated or " +
+              "modified by the server as a result of the update.")
+  @ApiResponse404(description = "The specified accession doesn't exist.")
+  @Operation(summary = "Update an existing accession.")
+  @PutMapping("/{id}")
+  fun updateAccession(
+      @RequestBody payload: UpdateAccessionRequestPayloadV2,
+      @PathVariable("id") accessionId: AccessionId,
+      @RequestParam
+      @Schema(
+          description =
+              "If true, do not actually save the accession; just return the result that would " +
+                  "have been returned if it had been saved.")
+      simulate: Boolean?
+  ): UpdateAccessionResponsePayloadV2 {
+    val updatedModel =
+        if (simulate == true) {
+          accessionStore.dryRun(payload.toModel(accessionId))
+        } else {
+          accessionStore.updateAndFetch(payload.toModel(accessionId))
+        }
+    return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(updatedModel))
+  }
+
+  @ApiResponse(responseCode = "200")
+  @ApiResponse404
+  @GetMapping("/{id}")
+  @Operation(summary = "Retrieve an existing accession.")
+  fun getAccession(@PathVariable("id") accessionId: AccessionId): GetAccessionResponsePayloadV2 {
+    val accession = accessionStore.fetchOneById(accessionId)
+
+    // If this accession was created/updated with automated state management, it might have a state
+    // that didn't exist in the v2 API. In that case, figure out what its calculated v2 state would
+    // have been, and return that.
+    val v2CompatibleAccession =
+        if (accession.state?.isV2Compatible == true) {
+          accession
+        } else {
+          accession
+              .copy(isManualState = true, state = accession.state?.toV2Compatible())
+              .withCalculatedValues(clock)
+        }
+
+    return GetAccessionResponsePayloadV2(AccessionPayloadV2(v2CompatibleAccession))
+  }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema
+data class AccessionPayloadV2(
+    @Schema(
+        description =
+            "Server-generated human-readable identifier for the accession. This is unique " +
+                "within a single seed bank, but different seed banks may have accessions with " +
+                "the same number.")
+    val accessionNumber: String,
+    @Schema(
+        description = "Server-calculated active indicator. This is based on the accession's state.")
+    val active: AccessionActive,
+    val bagNumbers: Set<String>?,
+    val collectedDate: LocalDate?,
+    val collectionSiteCity: String? = null,
+    val collectionSiteCoordinates: Set<Geolocation>?,
+    val collectionSiteCountryCode: String? = null,
+    val collectionSiteCountrySubdivision: String? = null,
+    val collectionSiteLandowner: String? = null,
+    val collectionSiteName: String? = null,
+    val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
+    @Schema(description = "Names of the people who collected the seeds.")
+    val collectors: List<String>?,
+    val dryingEndDate: LocalDate?,
+    val estimatedSeedCount: Int?,
+    val facilityId: FacilityId,
+    val family: String?,
+    val founderId: String?,
+    @Schema(
+        description =
+            "Server-generated unique identifier for the accession. This is unique across all " +
+                "seed banks, but is not suitable for display to end users.")
+    val id: AccessionId,
+    @Schema(
+        description =
+            "Initial size of accession. The units of this value must match the measurement type " +
+                "in \"processingMethod\".")
+    val initialQuantity: SeedQuantityPayload?,
+    val latestViabilityPercent: Int?,
+    val latestViabilityTestDate: LocalDate?,
+    val notes: String?,
+    val photoFilenames: List<String>?,
+    val plantsCollectedFromMax: Int?,
+    val plantsCollectedFromMin: Int?,
+    val processingMethod: ProcessingMethod?,
+    val receivedDate: LocalDate?,
+    @Schema(
+        description =
+            "Number or weight of seeds remaining for withdrawal and testing. Calculated by the " +
+                "server when the accession's total size is known.")
+    val remainingQuantity: SeedQuantityPayload?,
+    @Schema(description = "Which source of data this accession originally came from.")
+    val source: DataSource?,
+    @Schema(
+        description = "Scientific name of the species.",
+    )
+    val speciesScientificName: String?,
+    @Schema(
+        description = "Common name of the species, if defined.",
+    )
+    val speciesCommonName: String?,
+    @Schema(
+        description = "Server-generated unique ID of the species.",
+    )
+    val speciesId: SpeciesId?,
+    @Schema(
+        description =
+            "Server-calculated accession state. Can change due to modifications to accession data " +
+                "or based on passage of time.")
+    val state: AccessionState,
+    val storageCondition: StorageCondition?,
+    val storageLocation: String?,
+    val subsetCount: Int?,
+    @Schema(
+        description =
+            "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
+    val subsetWeight: SeedQuantityPayload?,
+    val targetStorageCondition: StorageCondition?,
+    val totalViabilityPercent: Int?,
+    val viabilityTests: List<ViabilityTestPayload>?,
+    val withdrawals: List<WithdrawalPayload>?,
+) {
+  constructor(
+      model: AccessionModel
+  ) : this(
+      model.accessionNumber ?: throw IllegalArgumentException("Accession did not have a number"),
+      model.active ?: AccessionActive.Active,
+      model.bagNumbers.orNull(),
+      model.collectedDate,
+      model.collectionSiteCity,
+      model.geolocations.orNull(),
+      model.collectionSiteCountryCode,
+      model.collectionSiteCountrySubdivision,
+      model.collectionSiteLandowner,
+      model.collectionSiteName,
+      model.collectionSiteNotes,
+      model.collectionSource,
+      model.collectors.orNull(),
+      model.dryingEndDate,
+      model.estimatedSeedCount,
+      model.facilityId ?: throw IllegalArgumentException("Accession did not have a facility ID"),
+      model.family,
+      model.founderId,
+      model.id ?: throw IllegalArgumentException("Accession did not have an ID"),
+      model.total?.toPayload(),
+      model.latestViabilityPercent,
+      model.latestViabilityTestDate,
+      model.processingNotes,
+      model.photoFilenames.orNull(),
+      // TODO replace with max/min plants
+      model.numberOfTrees,
+      model.numberOfTrees,
+      model.processingMethod,
+      model.receivedDate,
+      model.remaining?.toPayload(),
+      model.source,
+      model.species,
+      model.speciesCommonName,
+      model.speciesId,
+      model.state ?: AccessionState.Pending,
+      model.storageCondition,
+      model.storageLocation,
+      model.subsetCount,
+      model.subsetWeightQuantity?.toPayload(),
+      model.targetStorageCondition,
+      model.totalViabilityPercent,
+      model.viabilityTests.map { ViabilityTestPayload(it) }.orNull(),
+      model.withdrawals.map { WithdrawalPayload(it) }.orNull(),
+  )
+}
+
+// Mark all fields as write-only in the schema
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+data class CreateAccessionRequestPayloadV2(
+    val bagNumbers: Set<String>? = null,
+    val collectedDate: LocalDate? = null,
+    val collectionSiteCity: String? = null,
+    val collectionSiteCoordinates: Set<Geolocation>? = null,
+    val collectionSiteCountryCode: String? = null,
+    val collectionSiteCountrySubdivision: String? = null,
+    val collectionSiteLandowner: String? = null,
+    val collectionSiteName: String? = null,
+    val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
+    val collectors: List<String>? = null,
+    val facilityId: FacilityId,
+    val founderId: String? = null,
+    val plantsCollectedFromMax: Int? = null,
+    val plantsCollectedFromMin: Int? = null,
+    val receivedDate: LocalDate? = null,
+    val source: DataSource? = null,
+    val speciesId: SpeciesId? = null,
+    val state: AccessionState? = null,
+) {
+  fun toModel(): AccessionModel {
+    return AccessionModel(
+        bagNumbers = bagNumbers.orEmpty(),
+        collectedDate = collectedDate,
+        collectionSiteCity = collectionSiteCity,
+        collectionSiteCountryCode = collectionSiteCountryCode,
+        collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,
+        collectionSiteLandowner = collectionSiteLandowner,
+        collectionSiteName = collectionSiteName,
+        collectionSiteNotes = collectionSiteNotes,
+        collectionSource = collectionSource,
+        collectors = collectors.orEmpty(),
+        facilityId = facilityId,
+        founderId = founderId,
+        geolocations = collectionSiteCoordinates.orEmpty(),
+        isManualState = true,
+        numberOfTrees = plantsCollectedFromMax ?: plantsCollectedFromMin,
+        receivedDate = receivedDate,
+        source = source,
+        speciesId = speciesId,
+        state = state,
+    )
+  }
+}
+
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+data class UpdateAccessionRequestPayloadV2(
+    val bagNumbers: Set<String>? = null,
+    val collectedDate: LocalDate? = null,
+    val collectionSiteCity: String? = null,
+    val collectionSiteCoordinates: Set<Geolocation>? = null,
+    val collectionSiteCountryCode: String? = null,
+    val collectionSiteCountrySubdivision: String? = null,
+    val collectionSiteLandowner: String? = null,
+    val collectionSiteName: String? = null,
+    val collectionSiteNotes: String? = null,
+    val collectionSource: CollectionSource? = null,
+    val collectors: List<String>? = null,
+    val dryingEndDate: LocalDate? = null,
+    val facilityId: FacilityId? = null,
+    val founderId: String? = null,
+    @Schema(
+        description =
+            "Initial size of accession. The units of this value must match the measurement type " +
+                "in \"processingMethod\".")
+    val initialQuantity: SeedQuantityPayload? = null,
+    val notes: String? = null,
+    val plantsCollectedFromMax: Int? = null,
+    val plantsCollectedFromMin: Int? = null,
+    val processingMethod: ProcessingMethod? = null,
+    val receivedDate: LocalDate? = null,
+    val speciesId: SpeciesId? = null,
+    val state: AccessionState,
+    val storageLocation: String? = null,
+    val subsetCount: Int? = null,
+    @Schema(
+        description =
+            "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
+    private val subsetWeight: SeedQuantityPayload? = null,
+    val targetStorageCondition: StorageCondition? = null,
+    @Valid val viabilityTests: List<ViabilityTestPayload>? = null,
+    @Valid val withdrawals: List<WithdrawalPayload>? = null,
+) {
+  fun toModel(id: AccessionId) =
+      AccessionModel(
+          bagNumbers = bagNumbers.orEmpty(),
+          collectedDate = collectedDate,
+          collectionSiteCity = collectionSiteCity,
+          collectionSiteCountryCode = collectionSiteCountryCode,
+          collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,
+          collectionSiteLandowner = collectionSiteLandowner,
+          collectionSiteName = collectionSiteName,
+          collectionSiteNotes = collectionSiteNotes,
+          collectionSource = collectionSource,
+          collectors = collectors.orEmpty(),
+          dryingEndDate = dryingEndDate,
+          facilityId = facilityId,
+          founderId = founderId,
+          geolocations = collectionSiteCoordinates.orEmpty(),
+          id = id,
+          isManualState = true,
+          numberOfTrees = plantsCollectedFromMax ?: plantsCollectedFromMin,
+          processingMethod = processingMethod,
+          processingNotes = notes,
+          receivedDate = receivedDate,
+          speciesId = speciesId,
+          state = state,
+          storageLocation = storageLocation,
+          subsetCount = subsetCount,
+          subsetWeightQuantity = subsetWeight?.toModel(),
+          targetStorageCondition = targetStorageCondition,
+          total = initialQuantity?.toModel(),
+          viabilityTests = viabilityTests.orEmpty().map { it.toModel() },
+          withdrawals = withdrawals.orEmpty().map { it.toModel() },
+      )
+}
+
+data class CreateAccessionResponsePayloadV2(val accession: AccessionPayloadV2) :
+    SuccessResponsePayload
+
+data class GetAccessionResponsePayloadV2(val accession: AccessionPayloadV2) :
+    SuccessResponsePayload
+
+data class UpdateAccessionResponsePayloadV2(val accession: AccessionPayloadV2) :
+    SuccessResponsePayload


### PR DESCRIPTION
To support the different behaviors of accessions in the upcoming version of the
seed management web app, introduce an alternate set of API endpoints. The new
endpoints will behave according to the specifications for the new version, even
for existing accessions. They omit fields that are being removed, and rename some
fields whose names no longer reflect user-facing terminology.

This initial change just covers a portion of the top-level accession payloads and
provides the ability for the client to explicitly change the state of an
accession. It does not change any of the child objects such as viability tests or
withdrawals, and it doesn't change the top-level accession fields related to
how we track changes to seed quantities or how we track overall viability levels.
Those changes will come later.

A detailed list of payload changes follows, but some specific ones to watch out
for:

* POST/PUT now require species IDs, not species names; there is no more
  "automatically create a species if the name doesn't exist" behavior since the
  user is supposed to always pick from the organization's species list.
* `numberOfTrees` is split into two fields to hold a range. In this initial
  implementation, which doesn't include any database schema changes, the min and
  max values aren't preserved individually.

Changes to `GET` payload:
-------------------------

Add fields:
* `collectionSiteCoordinates` (formerly `geolocations`)
* `notes` (formerly `processingNotes`)
* `plantsCollectedFromMax` (formerly `numberOfTrees`)
* `plantsCollectedFromMin` (formerly `numberOfTrees`)
* `speciesScientificName` (formerly `species`)

Remove fields:
* `checkedInTime` (checkin is now just a state change)
* `cutTestSeedsCompromised` (cut tests are now represented as viability tests)
* `cutTestSeedsEmpty`
* `cutTestSeedsFilled`
* `dryingMoveDate`
* `dryingStartDate`
* `endangered`
* `environmentalNotes` (it is now `collectionSiteNotes`)
* `fieldNotes`
* `geolocations` (it is now `collectionSiteCoordinates`)
* `landowner` (it is now `collectionSiteLandowner`)
* `numberOfTrees` (it is now `plantsCollectedFromMax`)
* `nurseryStartDate`
* `primaryCollector`
* `processingNotes`
* `processingStaffResponsible`
* `processingStartDate`
* `rare`
* `secondaryCollectors`
* `siteLocation` (it is now `collectionSiteName`)
* `sourcePlantOrigin` (it is now `collectionSource`)
* `species` (it is now `speciesScientificName`)
* `storageNotes`
* `storagePackets`
* `storageStaffResponsible`
* `storageStartDate`
* `totalPastWithdrawalQuantity`
* `totalScheduledNonTestQuantity`
* `totalScheduledTestQuantity`
* `totalScheduledWithdrawalQuantity`
* `totalWithdrawalQuantity`

Changes to `POST` payload:
--------------------------

Add fields:
* `collectionSiteCoordinates` (formerly `geolocations`)
* `plantsCollectedFromMax` (formerly `numberOfTrees`)
* `plantsCollectedFromMin` (formerly `numberOfTrees`)
* `speciesId`
* `state`

Remove fields:
* `endangered`
* `environmentalNotes` (it is now `collectionSiteNotes`)
* `family`
* `fieldNotes`
* `geolocations` (it is now `collectionSiteCoordinates`)
* `landowner` (it is now `collectionSiteLandowner`)
* `numberOfTrees` (it is now `plantsCollectedFromMax`)
* `primaryCollector`
* `rare`
* `secondaryCollectors`
* `siteLocation` (it is now `collectionSiteName`)
* `sourcePlantOrigin` (it is now `collectionSource`)
* `species` (pass in a species ID instead)

Changes to `PUT` payload:
-------------------------

Add fields:
* `collectionSiteCoordinates` (formerly `geolocations`)
* `notes` (formerly `processingNotes`)
* `plantsCollectedFromMax` (formerly `numberOfTrees`)
* `plantsCollectedFromMin` (formerly `numberOfTrees`)
* `speciesId`
* `state`

Remove fields:
* `cutTestSeedsCompromised` (cut tests are now represented as viability tests)
* `cutTestSeedsEmpty`
* `cutTestSeedsFilled`
* `dryingMoveDate`
* `dryingStartDate`
* `endangered`
* `environmentalNotes` (it is now `collectionSiteNotes`)
* `family`
* `fieldNotes`
* `geolocations` (it is now `collectionSiteCoordinates`)
* `landowner` (it is now `collectionSiteLandowner`)
* `numberOfTrees` (it is now `plantsCollectedFromMax`)
* `nurseryStartDate`
* `primaryCollector`
* `processingNotes`
* `processingStaffResponsible`
* `processingStartDate`
* `rare`
* `secondaryCollectors`
* `siteLocation` (it is now `collectionSiteName`)
* `sourcePlantOrigin` (it is now `collectionSource`)
* `species` (pass in a species ID instead)
* `storageNotes`
* `storagePackets`
* `storageStaffResponsible`
* `storageStartDate`