### PR TITLE
SW-1357 Add latest observed quantity/time to v2 API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -128,6 +128,7 @@ class AccessionStore(
           collectionSiteNotes = record[COLLECTION_SITE_NOTES],
           collectionSource = record[COLLECTION_SOURCE_ID],
           collectors = record[collectorsField],
+          createdTime = record[CREATED_TIME],
           cutTestSeedsCompromised = record[CUT_TEST_SEEDS_COMPROMISED],
           cutTestSeedsEmpty = record[CUT_TEST_SEEDS_EMPTY],
           cutTestSeedsFilled = record[CUT_TEST_SEEDS_FILLED],

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -6,11 +6,13 @@ import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalPurpose
 import com.terraformation.backend.db.tables.records.WithdrawalsRecord
 import com.terraformation.backend.util.compareNullsFirst
+import java.time.Instant
 import java.time.LocalDate
 
 data class WithdrawalModel(
     val id: WithdrawalId? = null,
     val accessionId: AccessionId? = null,
+    val createdTime: Instant? = null,
     val date: LocalDate,
     val purpose: WithdrawalPurpose? = null,
     val destination: String? = null,
@@ -32,6 +34,7 @@ data class WithdrawalModel(
   ) : this(
       record.id,
       record.accessionId,
+      record.createdTime,
       record.date!!,
       record.purposeId,
       record.destination,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -896,6 +896,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(1),
                 accessionId = accession.id,
+                createdTime = clock.instant(),
                 date = test.startDate!!,
                 purpose = WithdrawalPurpose.ViabilityTesting,
                 withdrawn = SeedQuantityModel(BigDecimal(5), SeedQuantityUnits.Seeds),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -51,7 +51,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   fun setup() {
     store = WithdrawalStore(dslContext, clock, Messages())
 
-    every { clock.instant() } returns Instant.now()
+    every { clock.instant() } returns Instant.ofEpochSecond(1000)
 
     insertSiteData()
 
@@ -61,11 +61,11 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
           .insertInto(ACCESSIONS)
           .set(ID, accessionId)
           .set(CREATED_BY, user.userId)
-          .set(CREATED_TIME, Instant.now())
+          .set(CREATED_TIME, clock.instant())
           .set(DATA_SOURCE_ID, DataSource.FileImport)
           .set(FACILITY_ID, facilityId)
           .set(MODIFIED_BY, user.userId)
-          .set(MODIFIED_TIME, Instant.now())
+          .set(MODIFIED_TIME, clock.instant())
           .set(STATE_ID, AccessionState.InStorage)
           .execute()
     }
@@ -86,7 +86,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
                 staffResponsible = "staff 1",
                 destination = "dest 1",
                 createdTime = Instant.EPOCH,
-                updatedTime = Instant.now(),
+                updatedTime = clock.instant(),
                 withdrawnGrams = BigDecimal.TEN,
                 withdrawnQuantity = BigDecimal(10000),
                 withdrawnUnitsId = SeedQuantityUnits.Milligrams,
@@ -101,8 +101,8 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
                 remainingUnitsId = SeedQuantityUnits.Milligrams,
                 staffResponsible = "staff 2",
                 destination = "dest 2",
-                createdTime = Instant.EPOCH.plusSeconds(30),
-                updatedTime = Instant.now(),
+                createdTime = Instant.ofEpochSecond(30),
+                updatedTime = clock.instant(),
                 withdrawnGrams = null,
                 withdrawnQuantity = BigDecimal(2),
                 withdrawnUnitsId = SeedQuantityUnits.Seeds,
@@ -126,7 +126,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(2),
                 accessionId = accessionId,
-                createdTime = Instant.EPOCH.plusSeconds(30),
+                createdTime = Instant.ofEpochSecond(30),
                 date = pojos[1].date!!,
                 notes = pojos[1].notes,
                 purpose = pojos[1].purposeId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -114,6 +114,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(1),
                 accessionId = accessionId,
+                createdTime = Instant.EPOCH,
                 date = pojos[0].date!!,
                 notes = pojos[0].notes,
                 purpose = pojos[0].purposeId,
@@ -125,6 +126,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(2),
                 accessionId = accessionId,
+                createdTime = Instant.EPOCH.plusSeconds(30),
                 date = pojos[1].date!!,
                 notes = pojos[1].notes,
                 purpose = pojos[1].purposeId,
@@ -160,6 +162,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(1),
                 accessionId = accessionId,
+                createdTime = clock.instant(),
                 date = newWithdrawal.date,
                 destination = newWithdrawal.destination,
                 notes = newWithdrawal.notes,
@@ -229,6 +232,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(1),
                 accessionId = accessionId,
+                createdTime = clock.instant(),
                 date = desired.date,
                 destination = desired.destination,
                 viabilityTestId = viabilityTestId,
@@ -300,6 +304,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalModel(
                 id = WithdrawalId(1),
                 accessionId = accessionId,
+                createdTime = clock.instant(),
                 date = desired.date,
                 destination = desired.destination,
                 notes = desired.notes,


### PR DESCRIPTION
In order to display a warning to the user when a change in the date of a
withdrawal would affect the remaining quantity of an accession, the frontend
code needs to know the time of the most recent user-observed accession
quantity. That timestamp won't be shown to users, just used by the frontend code.

Add `latestObservedQuantity` and `latestObservedTime` fields to the v2
accession response payloads. These are computed values, so they're not included
in the request payloads.

The v2 API doesn't support directly updating the remaining quantity yet, so for
now, these two new fields are always calculated from the v1 quantity, similarly
to the way we do an on-the-fly mapping of v1 accession states to v2 ones.
Subsequent changes will start to introduce the write path for v2-style
quantities.