### PR TITLE
SW-1537 Define v2 withdrawals endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.tables.references.DEVICES
@@ -25,6 +26,7 @@ import com.terraformation.backend.db.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.db.tables.references.UPLOADS
+import com.terraformation.backend.db.tables.references.WITHDRAWALS
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -42,6 +44,9 @@ import org.jooq.impl.DSL
  */
 @ManagedBean
 class ParentStore(private val dslContext: DSLContext) {
+  fun getAccessionId(withdrawalId: WithdrawalId): AccessionId? =
+      fetchFieldById(withdrawalId, WITHDRAWALS.ID, WITHDRAWALS.ACCESSION_ID)
+
   fun getFacilityId(accessionId: AccessionId): FacilityId? =
       fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.FACILITY_ID)
 

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -116,5 +116,8 @@ class UserAlreadyInOrganizationException(val userId: UserId, val organizationId:
 
 class UserNotFoundException(val userId: UserId) : EntityNotFoundException("User $userId not found")
 
+class WithdrawalNotFoundException(val withdrawalId: WithdrawalId) :
+    EntityNotFoundException("Withdrawal $withdrawalId not found")
+
 class NotificationNotFoundException(val notificationId: NotificationId) :
     EntityNotFoundException("Notification $notificationId not found")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
@@ -1,0 +1,228 @@
+package com.terraformation.backend.seedbank.api
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.ViabilityTestId
+import com.terraformation.backend.db.WithdrawalId
+import com.terraformation.backend.db.WithdrawalNotFoundException
+import com.terraformation.backend.db.WithdrawalPurpose
+import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.db.WithdrawalStore
+import com.terraformation.backend.seedbank.model.WithdrawalModel
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import javax.ws.rs.InternalServerErrorException
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v2/seedbank/withdrawals")
+@RestController
+class WithdrawalsController(
+    private val accessionStore: AccessionStore,
+    private val parentStore: ParentStore,
+    private val withdrawalStore: WithdrawalStore,
+) {
+  @GetMapping
+  @Operation(summary = "List all the withdrawals matching a search criterion.")
+  fun listWithdrawals(
+      @RequestParam("accessionId") accessionId: AccessionId
+  ): GetWithdrawalsResponsePayload {
+    val withdrawals = withdrawalStore.fetchWithdrawals(accessionId)
+    val payloads = withdrawals.map { GetWithdrawalPayload(it) }
+
+    return GetWithdrawalsResponsePayload(payloads)
+  }
+
+  @GetMapping("/{id}")
+  @Operation(summary = "Get a single withdrawal.")
+  fun getWithdrawal(@PathVariable("id") withdrawalId: WithdrawalId): GetWithdrawalResponsePayload {
+    val model = withdrawalStore.fetchOneById(withdrawalId)
+    return GetWithdrawalResponsePayload(GetWithdrawalPayload(model))
+  }
+
+  @Operation(
+      summary = "Create a new withdrawal on an existing accession.",
+      description = "May cause the accession's remaining quantity to change.")
+  @PostMapping
+  fun createWithdrawal(
+      @RequestBody payload: CreateWithdrawalRequestPayload
+  ): UpdateWithdrawalResponsePayload {
+    throw InternalServerErrorException("Not implemented yet")
+  }
+
+  @Operation(
+      summary = "Update the details of an existing withdrawal.",
+      description = "May cause the accession's remaining quantity to change.")
+  @PutMapping("/{id}")
+  fun updateWithdrawal(
+      @PathVariable("id") withdrawalId: WithdrawalId,
+      @RequestBody payload: UpdateWithdrawalRequestPayload
+  ): UpdateWithdrawalResponsePayload {
+    throw InternalServerErrorException("Not implemented yet")
+  }
+
+  @DeleteMapping("/{id}")
+  @Operation(
+      summary = "Delete an existing withdrawal.",
+      description = "May cause the accession's remaining quantity to change.")
+  fun deleteWithdrawal(
+      @PathVariable("id") withdrawalId: WithdrawalId
+  ): SimpleSuccessResponsePayload {
+    val accessionId =
+        parentStore.getAccessionId(withdrawalId) ?: throw WithdrawalNotFoundException(withdrawalId)
+    val accession = accessionStore.fetchOneById(accessionId)
+    val editedWithdrawals = accession.withdrawals.filterNot { it.id == withdrawalId }
+
+    accessionStore.update(accession.copy(withdrawals = editedWithdrawals))
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class GetWithdrawalPayload(
+    val date: LocalDate,
+    @Schema(
+        description =
+            "Number of seeds withdrawn. Calculated by server. This is an estimate if " +
+                "\"withdrawnQuantity\" is a weight quantity and the accession has subset weight " +
+                "and count data. Absent if \"withdrawnQuantity\" is a weight quantity and the " +
+                "accession has no subset weight and count.")
+    val estimatedCount: Int? = null,
+    @Schema(
+        description =
+            "Weight of seeds withdrawn. Calculated by server. This is an estimate if " +
+                "\"withdrawnQuantity\" is a seed count and the accession has subset weight and " +
+                "count data. Absent if \"withdrawnQuantity\" is a seed count and the accession " +
+                "has no subset weight and count.")
+    val estimatedWeight: SeedQuantityPayload? = null,
+    @Schema(description = "Server-assigned unique ID of this withdrawal.")
+    val id: WithdrawalId? = null,
+    val purpose: WithdrawalPurpose? = null,
+    val notes: String? = null,
+    @Schema(
+        description =
+            "If this withdrawal is of purpose \"Viability Testing\", the ID of the test it is " +
+                "associated with.")
+    val viabilityTestId: ViabilityTestId? = null,
+    @Schema(
+        description =
+            "Full name of the person who withdrew the seeds. " +
+                "V1 COMPATIBILITY: This is the \"staffResponsible\" v1 field, which may not be " +
+                "the name of an organization user.")
+    val withdrawnByName: String? = null,
+    @Schema(
+        description =
+            "ID of the user who withdrew the seeds. Only present if the current user has " +
+                "permission to list the users in the organization. " +
+                "V1 COMPATIBILITY: Also absent if the withdrawal was written with the v1 API " +
+                "and we haven't yet written the code to figure out which user ID to assign.")
+    val withdrawnByUserId: UserId? = null,
+    @Schema(
+        description =
+            "Quantity of seeds withdrawn. For viability testing withdrawals, this is always the " +
+                "same as the test's \"seedsSown\" value.")
+    val withdrawnQuantity: SeedQuantityPayload? = null,
+) {
+  constructor(
+      model: WithdrawalModel
+  ) : this(
+      date = model.date,
+      estimatedCount = 0,
+      estimatedWeight = null,
+      id = model.id,
+      purpose = model.purpose,
+      notes = model.notes,
+      viabilityTestId = model.viabilityTestId,
+      withdrawnByName = model.staffResponsible,
+      withdrawnByUserId = null,
+      withdrawnQuantity = model.withdrawn?.toPayload(),
+  )
+}
+
+// Mark all fields as write-only in the schema
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateWithdrawalRequestPayload(
+    val accessionId: AccessionId,
+    val date: LocalDate,
+    val purpose: WithdrawalPurpose? = null,
+    val notes: String? = null,
+    @Schema(
+        description =
+            "ID of the user who withdrew the seeds. Default for new withdrawals is the current " +
+                "user; for existing withdrawals, default is the withdrawal's existing user ID. " +
+                "Ignored if the current user does not have permission to list organization " +
+                "users. " +
+                "V1 COMPATIBILITY: If this is null and the withdrawal doesn't have a user ID, " +
+                "the existing \"staffResponsible\" value will be preserved.")
+    val withdrawnByUserId: UserId? = null,
+    @Schema(
+        description =
+            "Quantity of seeds withdrawn. For viability testing withdrawals, this is always " +
+                "the same as the test's \"seedsSown\" value. Otherwise, it is a user-supplied " +
+                "value. If this quantity is in weight and the remaining quantity of the " +
+                "accession is in seeds or vice versa, the accession must have a subset weight " +
+                "and count.")
+    val withdrawnQuantity: SeedQuantityPayload? = null,
+) {
+  fun toModel() =
+      WithdrawalModel(
+          accessionId = accessionId,
+          date = date,
+          notes = notes,
+          purpose = purpose,
+          withdrawn = withdrawnQuantity?.toModel(),
+      )
+}
+
+// Mark all fields as write-only in the schema
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class UpdateWithdrawalRequestPayload(
+    val date: LocalDate,
+    val purpose: WithdrawalPurpose? = null,
+    val notes: String? = null,
+    @Schema(
+        description =
+            "ID of the user who withdrew the seeds. Default for new withdrawals is the current " +
+                "user; for existing withdrawals, default is the withdrawal's existing user ID. " +
+                "Ignored if the current user does not have permission to list organization " +
+                "users. " +
+                "V1 COMPATIBILITY: If this is null and the withdrawal doesn't have a user ID, " +
+                "the existing \"staffResponsible\" value will be preserved.")
+    val withdrawnByUserId: UserId? = null,
+    @Schema(
+        description =
+            "Quantity of seeds withdrawn. For viability testing withdrawals, this is always " +
+                "the same as the test's \"seedsSown\" value. Otherwise, it is a user-supplied " +
+                "value. If this quantity is in weight and the remaining quantity of the " +
+                "accession is in seeds or vice versa, the accession must have a subset weight " +
+                "and count.")
+    val withdrawnQuantity: SeedQuantityPayload? = null,
+) {
+  fun applyToModel(model: WithdrawalModel): WithdrawalModel =
+      model.copy(date = date, purpose = purpose, notes = notes)
+}
+
+data class UpdateWithdrawalResponsePayload(val withdrawal: GetWithdrawalPayload) :
+    SuccessResponsePayload
+
+data class GetWithdrawalResponsePayload(val withdrawal: GetWithdrawalPayload) :
+    SuccessResponsePayload
+
+data class GetWithdrawalsResponsePayload(val withdrawals: List<GetWithdrawalPayload>) :
+    SuccessResponsePayload

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -52,6 +52,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     store = WithdrawalStore(dslContext, clock, Messages())
 
     every { clock.instant() } returns Instant.ofEpochSecond(1000)
+    every { user.canReadAccession(any()) } returns true
 
     insertSiteData()
 


### PR DESCRIPTION
We want the v2 accessions API to be more fine-grained than the v1 one. Start
moving in that direction by introducing a separate set of endpoints for reading
and writing withdrawals.

`PUT /api/v2/accessions/{id}` will no longer create, delete, or update
withdrawals.

**The POST and PUT endpoints don't work yet!** They can't be implemented until
the broader updates to quantity tracking are in place. This change just defines
the URL paths and payload formats so client developers can see what they look
like.

The GET and DELETE endpoints don't depend on the new quantity tracking logic, so
they're implemented here, though the quantity values are copied verbatim from
the v1 data and may not be consistent with v2 semantics.

The payloads defined here differ from the ones that are included as children of
the accession object in the v1 API. There are now separate payloads for GET,
POST, and PUT operations, and some fields have been added and removed.

Added fields:

* `accessionId` (POST) = which accession to withdraw from.
* `estimatedCount` (GET) = the estimated number of seeds withdrawn.
* `estimatedWeight` (GET) = the estimated weight of seeds withdrawn.
* `withdrawnByName` (GET) = the full name of the person who withdrew the seeds.
  For withdrawals created with the v1 API, this will be the same as the v1
  `staffResponsible` field, but in the v2 world, it will be the full name of
  a Terraware user.
* `withdrawnByUserId` (GET, POST, PUT) = the ID of the user who withdrew the
  seeds. The way this field works can change depending on the permissions of
  the user who's making the request; see the schema docs.

Removed fields:

* `destination` is being removed from the product.
* `estimatedQuantity` is replaced by `estimatedCount` and `estimatedWeight`.
* `remainingQuantity` is no longer tracked on a per-withdrawal basis.
* `staffResponsible` is replaced by `withdrawnByName` (GET) and
  `withdrawnByUserId` (GET/POST/PUT).
* `weightDifference` isn't meaningful without `remainingQuantity`.