### PR TITLE
SW-1353 Remove primary/secondary collectors from API

### DIFF
--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -180,12 +180,8 @@ def generate_initial_quantity() -> Dict:
 
 
 def generate_accession(facility_id: int) -> Dict:
-    primary_collector = generate_staff_responsible()
-    secondary_collectors = (
-        [generate_staff_responsible()] if randint(0, 4) == 0 else None
-    )
-    if secondary_collectors and secondary_collectors[0] == primary_collector:
-        secondary_collectors = None
+    num_collectors = randint(1, 3) if randint(0, 2) == 0 else 0
+    collectors = [generate_staff_responsible() for n in range(num_collectors)] or None
 
     bag_numbers = generate_bag_numbers()
     geolocations = (
@@ -204,6 +200,7 @@ def generate_accession(facility_id: int) -> Dict:
     return {
         "bagNumbers": bag_numbers,
         "collectedDate": str(collected_date) if collected_date else None,
+        "collectors": collectors,
         "endangered": generate_endangered(),
         "environmentalNotes": generate_notes(),
         "facilityId": facility_id,
@@ -213,10 +210,8 @@ def generate_accession(facility_id: int) -> Dict:
         "geolocations": geolocations,
         "landowner": generate_staff_responsible(),
         "numberOfTrees": randint(1, 10),
-        "primaryCollector": primary_collector,
         "rare": generate_rare(),
         "receivedDate": str(received_date) if received_date else None,
-        "secondaryCollectors": secondary_collectors,
         "siteLocation": generate_site_location(),
         "source": generate_source(),
         "sourcePlantOrigin": generate_source_plant_origin(),

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -44,16 +44,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
               isRequired = false),
           accessionCollectors.asMultiValueSublist(
               "collectors", ACCESSIONS.ID.eq(ACCESSION_COLLECTORS.ACCESSION_ID)),
-          // TODO: Remove this once client is updated to search the unified collectors list
-          accessionCollectors.asMultiValueSublist(
-              "primaryCollectors",
-              ACCESSIONS.ID.eq(ACCESSION_COLLECTORS.ACCESSION_ID)
-                  .and(ACCESSION_COLLECTORS.POSITION.eq(0))),
-          // TODO: Remove this once client is updated to search the unified collectors list
-          accessionCollectors.asMultiValueSublist(
-              "secondaryCollectors",
-              ACCESSIONS.ID.eq(ACCESSION_COLLECTORS.ACCESSION_ID)
-                  .and(ACCESSION_COLLECTORS.POSITION.gt(0))),
           bags.asMultiValueSublist("bags", ACCESSIONS.ID.eq(BAGS.ACCESSION_ID)),
           facilities.asSingleValueSublist("facility", ACCESSIONS.FACILITY_ID.eq(FACILITIES.ID)),
           geolocations.asMultiValueSublist(
@@ -131,7 +121,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             "Most recent viability test result date",
             ACCESSIONS.LATEST_GERMINATION_RECORDING_DATE),
         dateField("nurseryStartDate", "Nursery start date", ACCESSIONS.NURSERY_START_DATE),
-        aliasField("primaryCollectorName", "primaryCollectors_name"),
         enumField("processingMethod", "Processing method", ACCESSIONS.PROCESSING_METHOD_ID),
         textField("processingNotes", "Notes (processing)", ACCESSIONS.PROCESSING_NOTES),
         dateField("processingStartDate", "Processing start date", ACCESSIONS.PROCESSING_START_DATE),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -75,7 +75,6 @@ import com.terraformation.backend.seedbank.seeds
 import com.terraformation.backend.species.SpeciesService
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
-import com.terraformation.backend.util.orNull
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -1450,10 +1449,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                         accuracy = BigDecimal(3))),
             landowner = "landowner",
             numberOfTrees = 10,
-            primaryCollector = "primaryCollector",
             rare = RareType.Yes,
             receivedDate = today,
-            secondaryCollectors = listOf("second1", "second2"),
             siteLocation = "siteLocation",
             source = DataSource.FileImport,
             sourcePlantOrigin = SourcePlantOrigin.Wild,
@@ -1526,14 +1523,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             landowner = "landowner",
             numberOfTrees = 10,
             nurseryStartDate = today,
-            primaryCollector = "primaryCollector",
             processingMethod = ProcessingMethod.Weight,
             processingNotes = "processingNotes",
             processingStaffResponsible = "procStaff",
             processingStartDate = today,
             rare = RareType.Yes,
             receivedDate = today,
-            secondaryCollectors = listOf("second1", "second2"),
             siteLocation = "siteLocation",
             sourcePlantOrigin = SourcePlantOrigin.Wild,
             species = "species",
@@ -1722,7 +1717,6 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             initialQuantity = kilograms(432),
             processingMethod = ProcessingMethod.Weight,
             receivedDate = today,
-            secondaryCollectors = listOf("second1", "second2"),
             species = "species",
             storageLocation = storageLocationName,
             viabilityTests =
@@ -2571,14 +2565,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
         landowner = collectionSiteLandowner,
         numberOfTrees = numberOfTrees,
         nurseryStartDate = nurseryStartDate,
-        primaryCollector = collectors.getOrNull(0),
         processingMethod = processingMethod,
         processingNotes = processingNotes,
         processingStaffResponsible = processingStaffResponsible,
         processingStartDate = processingStartDate,
         rare = rare,
         receivedDate = receivedDate,
-        secondaryCollectors = collectors.drop(1).orNull(),
         siteLocation = collectionSiteName,
         sourcePlantOrigin = sourcePlantOrigin,
         species = species,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -201,9 +201,9 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
             treesCollectedFrom = 2))
 
     accessionCollectorsDao.insert(
-        AccessionCollectorsRow(AccessionId(1000), 0, "primary"),
-        AccessionCollectorsRow(AccessionId(1000), 1, "secondary 1"),
-        AccessionCollectorsRow(AccessionId(1000), 2, "secondary 2"),
+        AccessionCollectorsRow(AccessionId(1000), 0, "collector 1"),
+        AccessionCollectorsRow(AccessionId(1000), 1, "collector 2"),
+        AccessionCollectorsRow(AccessionId(1000), 2, "collector 3"),
     )
   }
 
@@ -2934,23 +2934,13 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "collectionSource" to "Reintroduced",
                       "collectors" to
                           listOf(
-                              mapOf("name" to "primary", "position" to "0"),
-                              mapOf("name" to "secondary 1", "position" to "1"),
-                              mapOf("name" to "secondary 2", "position" to "2"),
+                              mapOf("name" to "collector 1", "position" to "0"),
+                              mapOf("name" to "collector 2", "position" to "1"),
+                              mapOf("name" to "collector 3", "position" to "2"),
                           ),
                       "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
                       "id" to "1000",
                       "landowner" to "landowner",
-                      "primaryCollectorName" to "primary",
-                      "primaryCollectors" to
-                          listOf(
-                              mapOf("name" to "primary", "position" to "0"),
-                          ),
-                      "secondaryCollectors" to
-                          listOf(
-                              mapOf("name" to "secondary 1", "position" to "1"),
-                              mapOf("name" to "secondary 2", "position" to "2"),
-                          ),
                       "siteLocation" to "siteName",
                       "source" to "Seed Collector App",
                       "speciesName" to "Kousa Dogwood",


### PR DESCRIPTION
The web and mobile apps have been updated to use the unified `collectors`
accession field rather than primary/secondary collectors, so there's no more need
to keep the old fields around for backward compatibility.