### PR TITLE
Manage CI build concurrency

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,6 +14,10 @@ on:
       - src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
       - .github/workflows/docs.yaml
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   generate-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,11 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  # Cancel in-progress builds on PRs, but not on staging deploys.
+  cancel-in-progress: ${{ github.ref != 'main' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Currently, GitHub will launch a new build for each new commit on a branch.
This is wasteful of CPU resources in the case of updates to PRs (the results of
the previous build are irrelevant once a new build starts) and occasionally
causes deployment failures in staging if two commits hit `main` in rapid
succession and they boh try to deploy code at the same time.
    
Fix both problems using the built-in concurrency management feature of GitHub
Actions.
    
Builds on `main` will be queued up to run one at a time, since we sometimes
need to make sure a sequence of related changes are fully deployed in order.
    
Builds on branches other than `main` (in practice: builds for PRs) will cause
earlier builds on the same branch to be cancelled so we don't waste CPU cycles.