### PR TITLE
SW-1537 Implement withdrawals POST, PUT endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -2,13 +2,22 @@ package com.terraformation.backend.seedbank
 
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.WithdrawalId
+import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.PhotoRepository
+import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.WithdrawalModel
+import java.time.Clock
 import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @ManagedBean
 class AccessionService(
     private val accessionStore: AccessionStore,
+    private val clock: Clock,
+    private val dslContext: DSLContext,
     private val photoRepository: PhotoRepository,
 ) {
   /** Deletes an accession and all its associated data. */
@@ -20,5 +29,48 @@ class AccessionService(
     // that were successfully deleted or else we'll end up with dangling storage URLs.
     photoRepository.deleteAllPhotos(accessionId)
     accessionStore.delete(accessionId)
+  }
+
+  fun createWithdrawal(withdrawal: WithdrawalModel): AccessionModel {
+    val accessionId =
+        withdrawal.accessionId ?: throw IllegalArgumentException("Accession ID must be non-null")
+
+    return updateAccession(accessionId) { it.addWithdrawal(withdrawal, clock) }
+  }
+
+  fun updateWithdrawal(
+      accessionId: AccessionId,
+      withdrawalId: WithdrawalId,
+      modify: (WithdrawalModel) -> WithdrawalModel
+  ): AccessionModel {
+    return updateAccession(accessionId) { it.updateWithdrawal(withdrawalId, clock, modify) }
+  }
+
+  fun deleteWithdrawal(accessionId: AccessionId, withdrawalId: WithdrawalId): AccessionModel {
+    return updateAccession(accessionId) { it.deleteWithdrawal(withdrawalId, clock) }
+  }
+
+  private fun updateAccession(
+      accessionId: AccessionId,
+      modify: (AccessionModel) -> AccessionModel
+  ): AccessionModel {
+    requirePermissions { updateAccession(accessionId) }
+
+    return dslContext.transactionResult { _ ->
+      lockAccession(accessionId)
+
+      val existing = accessionStore.fetchOneById(accessionId)
+      val modified = modify(existing)
+      accessionStore.updateAndFetch(modified)
+    }
+  }
+
+  private fun lockAccession(accessionId: AccessionId) {
+    dslContext
+        .select(DSL.one())
+        .from(ACCESSIONS)
+        .where(ACCESSIONS.ID.eq(accessionId))
+        .forUpdate()
+        .execute()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -3,59 +3,165 @@ package com.terraformation.backend.seedbank
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.ProcessingMethod
+import com.terraformation.backend.db.WithdrawalId
+import com.terraformation.backend.db.WithdrawalNotFoundException
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.PhotoRepository
+import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.WithdrawalModel
+import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import org.jooq.exception.DataAccessException
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
-internal class AccessionServiceTest : RunsAsUser {
+internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val accessionStore: AccessionStore = mockk()
+  private val clock: Clock = mockk()
   private val photoRepository: PhotoRepository = mockk()
 
-  private val service = AccessionService(accessionStore, photoRepository)
+  private val service: AccessionService by lazy {
+    AccessionService(accessionStore, clock, dslContext, photoRepository)
+  }
 
   private val accessionId = AccessionId(1)
 
   @BeforeEach
   fun setUp() {
     every { accessionStore.delete(any()) } just Runs
+    every { clock.instant() } returns Instant.EPOCH
+    every { clock.zone } returns ZoneOffset.UTC
     every { photoRepository.deleteAllPhotos(any()) } just Runs
     every { user.canDeleteAccession(any()) } returns true
     every { user.canReadAccession(any()) } returns true
+    every { user.canUpdateAccession(any()) } returns true
   }
 
-  @Test
-  fun `deleteAccession throws exception if user has no permission`() {
-    every { user.canDeleteAccession(any()) } returns false
+  @Nested
+  inner class DeleteAccession {
+    @Test
+    fun `throws exception if user has no permission`() {
+      every { user.canDeleteAccession(any()) } returns false
 
-    assertThrows<AccessDeniedException> { service.deleteAccession(accessionId) }
+      assertThrows<AccessDeniedException> { service.deleteAccession(accessionId) }
+    }
+
+    @Test
+    fun `does not try to delete accession if photo deletion fails`() {
+      every { photoRepository.deleteAllPhotos(any()) } throws DataAccessException("uh oh")
+
+      assertThrows<DataAccessException> { service.deleteAccession(accessionId) }
+
+      verify(exactly = 0) { accessionStore.delete(accessionId) }
+    }
+
+    @Test
+    fun `deletes photos and accession data`() {
+      service.deleteAccession(accessionId)
+
+      verify { photoRepository.deleteAllPhotos(accessionId) }
+      verify { accessionStore.delete(accessionId) }
+    }
   }
 
-  @Test
-  fun `deleteAccession does not try to delete accession if photo deletion fails`() {
-    every { photoRepository.deleteAllPhotos(any()) } throws DataAccessException("uh oh")
+  @Nested
+  inner class Withdrawals {
+    private val accessionId = AccessionId(1)
+    private val withdrawalId = WithdrawalId(1)
+    private val accessionWithOneWithdrawal =
+        AccessionModel(
+            id = accessionId,
+            facilityId = FacilityId(1),
+            processingMethod = ProcessingMethod.Count,
+            remaining = seeds(10),
+            total = seeds(15),
+            withdrawals =
+                listOf(
+                    WithdrawalModel(
+                        accessionId = accessionId,
+                        date = LocalDate.EPOCH,
+                        id = withdrawalId,
+                        withdrawn = seeds(5))))
 
-    assertThrows<DataAccessException> { service.deleteAccession(accessionId) }
+    private val updateSlot: CapturingSlot<AccessionModel> = slot()
 
-    verify(exactly = 0) { accessionStore.delete(accessionId) }
-  }
+    @BeforeEach
+    fun setUp() {
+      every { accessionStore.fetchOneById(accessionId) } returns accessionWithOneWithdrawal
+      every { accessionStore.updateAndFetch(capture(updateSlot)) } answers { updateSlot.captured }
+    }
 
-  @Test
-  fun `deleteAccession deletes photos and accession data`() {
-    service.deleteAccession(accessionId)
+    @Test
+    fun `createWithdrawal requires accession ID`() {
+      assertThrows<IllegalArgumentException> {
+        service.createWithdrawal(WithdrawalModel(date = LocalDate.EPOCH, withdrawn = seeds(1)))
+      }
+    }
 
-    verify { photoRepository.deleteAllPhotos(accessionId) }
-    verify { accessionStore.delete(accessionId) }
+    @Test
+    fun `createWithdrawal adds new withdrawal to accession`() {
+      val withdrawal =
+          WithdrawalModel(
+              accessionId = accessionId, date = LocalDate.EPOCH.plusDays(1), withdrawn = seeds(3))
+      val updatedAccession = service.createWithdrawal(withdrawal)
+
+      assertEquals(seeds(7), updatedAccession.remaining, "Seeds remaining")
+      assertEquals(2, updatedAccession.withdrawals.size, "Number of withdrawals")
+      assertEquals(seeds(3), updatedAccession.withdrawals[1].withdrawn, "Size of new withdrawal")
+      verify { accessionStore.updateAndFetch(any()) }
+    }
+
+    @Test
+    fun `updateWithdrawal throws exception if withdrawal does not exist`() {
+      assertThrows<WithdrawalNotFoundException> {
+        service.updateWithdrawal(accessionId, WithdrawalId(1000)) { it }
+      }
+    }
+
+    @Test
+    fun `updateWithdrawal applies changes to withdrawal`() {
+      val updatedAccession =
+          service.updateWithdrawal(accessionId, withdrawalId) { it.copy(withdrawn = seeds(2)) }
+
+      assertEquals(seeds(13), updatedAccession.remaining, "Seeds remaining")
+      assertEquals(1, updatedAccession.withdrawals.size, "Number of withdrawals")
+      assertEquals(seeds(2), updatedAccession.withdrawals[0].withdrawn, "Seeds withdrawn")
+      verify { accessionStore.updateAndFetch(any()) }
+    }
+
+    @Test
+    fun `deleteWithdrawal throws exception if withdrawal does not exist`() {
+      assertThrows<WithdrawalNotFoundException> {
+        service.deleteWithdrawal(accessionId, WithdrawalId(1000))
+      }
+    }
+
+    @Test
+    fun `deleteWithdrawal deletes the withdrawal`() {
+      val updatedAccession = service.deleteWithdrawal(accessionId, withdrawalId)
+
+      assertEquals(seeds(15), updatedAccession.remaining, "Seeds remaining")
+      assertEquals(0, updatedAccession.withdrawals.size, "Number of withdrawals")
+      verify { accessionStore.updateAndFetch(any()) }
+    }
   }
 }


### PR DESCRIPTION
Add implementations for the withdrawals POST (create) and PUT (update) operations.

Because updating withdrawals causes accession-level information to change, make
the write operations return the entire accession rather than just the information
about the updated withdrawal. In practice, we expect clients will always want the
latest accession details after updating a withdrawal, so no point sending back a
useless response payload and forcing the client to GET the one it actually wants.

Move the endpoints under `/api/v1/seedbank/accessions/{id}` to make it less
surprising that they now return accession payloads.

The new endpoints currently only work for count-based accessions; support for
weight-based accessions will be added as part of a larger change to quantity
management.