### PR TITLE
SW-1561 Honor search scopes on all tables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -216,9 +216,8 @@ class SearchService(private val dslContext: DSLContext) {
           val selectFields =
               field.selectFields + listOf(field.orderByField.`as`(DSL.field("order_by_field")))
           val searchTable = fieldPath.searchTable
-          val permsCondition = conditionForVisibility(fieldPath.searchTable)
-          val searchConditions =
-              searchScopes.mapNotNull { fieldPath.searchTable.conditionForScope(it) }
+          val permsCondition = conditionForVisibility(searchTable)
+          val searchConditions = searchScopes.mapNotNull { searchTable.conditionForScope(it) }
           val conditions = listOfNotNull(permsCondition) + searchConditions
 
           val fullQuery =

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -109,7 +109,7 @@ abstract class SearchTable {
   open fun conditionForVisibility(): Condition? = null
 
   /** Returns a condition for scoping the table's search results where relevant. */
-  open fun conditionForScope(scope: SearchScope): Condition? = null
+  abstract fun conditionForScope(scope: SearchScope): Condition?
 
   /**
    * The default fields to sort on. These are included when doing non-distinct queries; if there are

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionCollectorsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionCollectorsTable.kt
@@ -2,14 +2,18 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.ACCESSION_COLLECTORS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
 
-class AccessionCollectorsTable(tables: SearchTables) : SearchTable() {
+class AccessionCollectorsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
     get() = ACCESSION_COLLECTORS.ACCESSION_COLLECTOR_ID
 
@@ -28,9 +32,18 @@ class AccessionCollectorsTable(tables: SearchTables) : SearchTable() {
           integerField("position", "Collector list position", ACCESSION_COLLECTORS.POSITION),
       )
 
-  override val inheritsVisibilityFrom: SearchTable = tables.accessions
+  override val inheritsVisibilityFrom: SearchTable
+    get() = tables.accessions
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(ACCESSION_COLLECTORS.ACCESSION_ID.eq(ACCESSIONS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BagsTable.kt
@@ -2,9 +2,13 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.BAGS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
@@ -31,5 +35,13 @@ class BagsTable(private val tables: SearchTables) : SearchTable() {
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(BAGS.ACCESSION_ID.eq(ACCESSIONS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
@@ -3,9 +3,11 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
@@ -29,4 +31,6 @@ class CountriesTable(tables: SearchTables) : SearchTable() {
           textField("code", "Country code", COUNTRIES.CODE),
           textField("name", "Country name", COUNTRIES.NAME),
       )
+
+  override fun conditionForScope(scope: SearchScope): Condition? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
@@ -3,9 +3,11 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.db.tables.references.COUNTRIES
 import com.terraformation.backend.db.tables.references.COUNTRY_SUBDIVISIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
 
@@ -30,4 +32,6 @@ class CountrySubdivisionsTable(tables: SearchTables) : SearchTable() {
           textField("code", "Country subdivision code", COUNTRY_SUBDIVISIONS.CODE),
           textField("name", "Country subdivision name", COUNTRY_SUBDIVISIONS.NAME),
       )
+
+  override fun conditionForScope(scope: SearchScope): Condition? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
@@ -2,8 +2,11 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.GEOLOCATIONS
+import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.OrganizationIdScope
 import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -41,6 +44,14 @@ class GeolocationsTable(private val tables: SearchTables) : SearchTable() {
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(GEOLOCATIONS.ACCESSION_ID.eq(ACCESSIONS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -3,9 +3,13 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.UserType
+import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.USERS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -51,5 +55,16 @@ class OrganizationUsersTable(tables: SearchTables) : SearchTable() {
                     .from(USERS)
                     .where(USERS.ID.eq(ORGANIZATION_USERS.USER_ID))
                     .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin))))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    return when (scope) {
+      is OrganizationIdScope -> ORGANIZATION_USERS.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope ->
+          ORGANIZATION_USERS.ORGANIZATION_ID.eq(
+              DSL.select(FACILITIES.ORGANIZATION_ID)
+                  .from(FACILITIES)
+                  .where(FACILITIES.ID.eq(scope.facilityId)))
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/StorageLocationsTable.kt
@@ -4,6 +4,9 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.FACILITIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -34,5 +37,13 @@ class StorageLocationsTable(tables: SearchTables) : SearchTable() {
 
   override fun conditionForVisibility(): Condition {
     return STORAGE_LOCATIONS.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    return when (scope) {
+      is OrganizationIdScope ->
+          STORAGE_LOCATIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> STORAGE_LOCATIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.tables.references.USERS
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -50,4 +51,6 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
                         ORGANIZATION_USERS.ORGANIZATION_ID.`in`(
                             currentUser().organizationRoles.keys))))
   }
+
+  override fun conditionForScope(scope: SearchScope): Condition? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestResultsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestResultsTable.kt
@@ -1,10 +1,15 @@
 package com.terraformation.backend.search.table
 
+import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tables.references.VIABILITY_TEST_RESULTS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
@@ -39,5 +44,13 @@ class ViabilityTestResultsTable(private val tables: SearchTables) : SearchTable(
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(VIABILITY_TESTS).on(VIABILITY_TEST_RESULTS.TEST_ID.eq(VIABILITY_TESTS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
@@ -4,9 +4,13 @@ import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tables.references.VIABILITY_TEST_RESULTS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
@@ -46,5 +50,13 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(VIABILITY_TESTS.ACCESSION_ID.eq(ACCESSIONS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/WithdrawalsTable.kt
@@ -2,9 +2,13 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.WITHDRAWALS
+import com.terraformation.backend.search.FacilityIdScope
+import com.terraformation.backend.search.OrganizationIdScope
+import com.terraformation.backend.search.SearchScope
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
@@ -52,5 +56,13 @@ class WithdrawalsTable(private val tables: SearchTables) : SearchTable() {
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query.join(ACCESSIONS).on(WITHDRAWALS.ACCESSION_ID.eq(ACCESSIONS.ID))
+  }
+
+  override fun conditionForScope(scope: SearchScope): Condition {
+    // Accessions table will have already been referenced by joinForVisibility.
+    return when (scope) {
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
+      is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
@@ -1,0 +1,103 @@
+package com.terraformation.backend.seedbank.api
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.Role
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.AccessionState
+import com.terraformation.backend.db.DataSource
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.FacilityId
+import com.terraformation.backend.db.OrganizationId
+import com.terraformation.backend.db.SeedQuantityUnits
+import com.terraformation.backend.db.ViabilityTestType
+import com.terraformation.backend.db.tables.pojos.AccessionCollectorsRow
+import com.terraformation.backend.db.tables.pojos.AccessionsRow
+import com.terraformation.backend.db.tables.pojos.ViabilityTestsRow
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.search.SearchService
+import com.terraformation.backend.search.table.SearchTables
+import com.terraformation.backend.seedbank.db.StorageLocationStore
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class ValuesControllerTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock: Clock = mockk()
+  private val controller: ValuesController by lazy {
+    ValuesController(
+        SearchTables(clock), StorageLocationStore(dslContext), SearchService(dslContext))
+  }
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+
+    insertSiteData()
+
+    insertOrganizationUser(user.userId, organizationId)
+  }
+
+  @Test
+  fun `listAllFieldValues returns values from the requested organization`() {
+    val otherOrganizationId = OrganizationId(2)
+    val otherFacilityId = FacilityId(2)
+
+    insertOrganization(otherOrganizationId)
+    insertOrganizationUser(user.userId, otherOrganizationId)
+    insertFacility(otherFacilityId, otherOrganizationId)
+
+    every { user.facilityRoles } returns
+        mapOf(facilityId to Role.MANAGER, otherFacilityId to Role.MANAGER)
+
+    val accessionsRow =
+        AccessionsRow(
+            createdBy = user.userId,
+            createdTime = Instant.EPOCH,
+            dataSourceId = DataSource.Web,
+            facilityId = facilityId,
+            isManualState = true,
+            modifiedBy = user.userId,
+            modifiedTime = Instant.EPOCH,
+            stateId = AccessionState.Cleaning,
+        )
+
+    val org1Accession = accessionsRow.copy(facilityId = facilityId)
+    val org2Accession = accessionsRow.copy(facilityId = otherFacilityId)
+    accessionsDao.insert(org1Accession, org2Accession)
+
+    accessionCollectorsDao.insert(
+        AccessionCollectorsRow(org1Accession.id, 0, "o1c0"),
+        AccessionCollectorsRow(org1Accession.id, 1, "o1c1"),
+        AccessionCollectorsRow(org2Accession.id, 0, "o2c0"),
+    )
+
+    val viabilityTestsRow =
+        ViabilityTestsRow(
+            testType = ViabilityTestType.Lab,
+            remainingQuantity = BigDecimal.ONE,
+            remainingUnitsId = SeedQuantityUnits.Seeds)
+    val org1Test = viabilityTestsRow.copy(accessionId = org1Accession.id, notes = "o1")
+    val org2Test = viabilityTestsRow.copy(accessionId = org2Accession.id, notes = "o2")
+    viabilityTestsDao.insert(org1Test, org2Test)
+
+    val request =
+        ListAllFieldValuesRequestPayload(
+            null, listOf("collectors_name", "viabilityTests_notes"), organizationId)
+
+    val expected =
+        ListAllFieldValuesResponsePayload(
+            mapOf(
+                "collectors_name" to AllFieldValuesPayload(listOf(null, "o1c0", "o1c1"), false),
+                "viabilityTests_notes" to AllFieldValuesPayload(listOf(null, "o1"), false)))
+
+    val actual = controller.listAllFieldValues(request)
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
`/api/v1/seedbank/values/all` has a concept of a "search scope" where we limit
results to the ones relevant to a particular organization or facility. The scope
was being honored for searches on the accessions table, but not for searches on
other tables. So if you asked for, e.g., all the values of `bags_number` for a
given facility ID, you'd actually get all the bag numbers across all the
facilities you had access to.

Eventually we're going to want to revamp how that endpoint works (SW-552) but
in the meantime, the API ought to work as advertised.