### PR TITLE
Update create_accessions.py to send v2 requests

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -50,6 +50,9 @@ class TerrawareClient:
         r.raise_for_status()
         return r.json()
 
+    def get_facility(self, facility_id):
+        return self.get(f"/api/v1/facilities/{facility_id}")["facility"]
+
     def list_facilities(self):
         return self.get("/api/v1/facilities")["facilities"]
 
@@ -106,6 +109,9 @@ class TerrawareClient:
 
     def search_all_accession_values(self, payload):
         return self.post("/api/v1/seedbank/values/all", json=payload)["results"]
+
+    def list_species(self, organization_id):
+        return self.get(f"/api/v1/species?organizationId={organization_id}")["species"]
 
 
 def add_terraware_args(parser: ArgumentParser):

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -1,6 +1,6 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 import requests
-from typing import Optional
+from typing import Dict, Optional
 
 DEFAULT_URL = "http://localhost:8080"
 
@@ -135,5 +135,5 @@ def add_terraware_args(parser: ArgumentParser):
     )
 
 
-def client_from_args(args: str) -> TerrawareClient:
+def client_from_args(args: Namespace) -> TerrawareClient:
     return TerrawareClient(args.bearer, args.session, args.url)

--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -305,9 +305,7 @@ def generate_accession_update_v2(accession: Dict) -> Dict:
     }
 
 
-def create_accession(
-    client: TerrawareClient, facility_id: int, species_ids: List[int]
-) -> Dict:
+def create_accession(client: TerrawareClient, facility_id: int) -> Dict:
     create_payload = generate_accession(facility_id)
 
     try:
@@ -397,13 +395,17 @@ def main():
         ][0]
 
     organization_id = client.get_facility(facility_id)["organizationId"]
-    species_ids = [species["id"] for species in client.list_species(organization_id)]
+
+    if args.version == 2:
+        species_ids = [
+            species["id"] for species in client.list_species(organization_id)
+        ]
 
     for n in range(0, args.number):
         if args.version == 2:
             accession = create_accession_v2(client, facility_id, species_ids)
         else:
-            accession = create_accession(client, facility_id, species_ids)
+            accession = create_accession(client, facility_id)
         if args.verbose:
             print(json.dumps(accession, indent=2))
         else:

--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -5,7 +5,7 @@ from example_values import TREE_SPECIES, FIRST_NAMES
 import json
 import random
 from random import randint
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 from client import TerrawareClient, add_terraware_args, client_from_args
 
 
@@ -26,7 +26,7 @@ def generate_rare() -> Optional[str]:
 
 
 def generate_species() -> Optional[str]:
-    return random.choice(TREE_SPECIES + [None])
+    return random.choice([*TREE_SPECIES, None])
 
 
 def generate_family(species) -> Optional[str]:
@@ -180,7 +180,7 @@ def generate_initial_quantity() -> Dict:
     quantity = generate_quantity()
     return {
         "processingMethod": "Count" if quantity["units"] == "Seeds" else "Weight",
-        "initialQuantity": generate_quantity(unit_type),
+        "initialQuantity": quantity,
     }
 
 
@@ -234,9 +234,6 @@ def generate_accession_v2(facility_id: int, species_ids: List[int]) -> Dict:
         list([generate_geolocation() for x in bag_numbers]) if bag_numbers else None
     )
     viability_test_types = [generate_test_type()]
-
-    species = generate_species()
-    family = generate_family(species)
 
     collected_date = generate_recent_date()
     received_date = (


### PR DESCRIPTION
Update the test script that creates random accessions so it can optionally do so
using the v2 API endpoints. This allows a limited form of fuzz testing of the v2
API: it doesn't check for correctness but can detect if the request handler bombs
out on what ought to be valid input.