### PR TITLE
SW-1537 Compute v2 viability test quantities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -114,6 +114,7 @@ data class WithdrawalModel(
     return when {
       quantity == null -> null
       quantity.units != SeedQuantityUnits.Seeds -> quantity
+      weightDifference != null -> weightDifference
       subsetWeight == null || subsetCount == null -> null
       units == SeedQuantityUnits.Seeds || units == null ->
           quantity.toUnits(subsetWeight.units, subsetWeight, subsetCount)

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions
+
+/**
+ * Asserts that two objects are equal and, if they're not, outputs the comparison failure using
+ * pretty-printed JSON rather than the outputs of their `toString` methods.
+ *
+ * This makes it easier to examine differences between accession objects with lots of field values.
+ */
+fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
+  if (expected != actual) {
+    // Don't make the object mapper unless we actually need it; it's a little heavyweight.
+    val objectMapper =
+        jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+
+    Assertions.assertEquals(
+        objectMapper.writeValueAsString(expected), objectMapper.writeValueAsString(actual), message)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -1,10 +1,23 @@
 package com.terraformation.backend
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions
+
+/**
+ * ObjectMapper configured to pretty print. This is lazily instantiated since ObjectMappers aren't
+ * terribly lightweight.
+ */
+private val prettyPrintingObjectMapper: ObjectMapper by lazy {
+  jacksonObjectMapper()
+      .registerModule(JavaTimeModule())
+      .enable(SerializationFeature.INDENT_OUTPUT)
+      .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+      .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
+}
 
 /**
  * Asserts that two objects are equal and, if they're not, outputs the comparison failure using
@@ -14,15 +27,9 @@ import org.junit.jupiter.api.Assertions
  */
 fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
   if (expected != actual) {
-    // Don't make the object mapper unless we actually need it; it's a little heavyweight.
-    val objectMapper =
-        jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .enable(SerializationFeature.INDENT_OUTPUT)
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-
     Assertions.assertEquals(
-        objectMapper.writeValueAsString(expected), objectMapper.writeValueAsString(actual), message)
+        prettyPrintingObjectMapper.writeValueAsString(expected),
+        prettyPrintingObjectMapper.writeValueAsString(actual),
+        message)
   }
 }


### PR DESCRIPTION
Don't bomb out when converting a v1 weight-based accession without subset
weight/count but with a viability test that specifies the withdrawal quantity
as a seed count.