### PR TITLE
SW-1537 Detect v2 withdrawals of too many seeds

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
@@ -168,12 +168,10 @@ data class CreateWithdrawalRequestPayload(
     val withdrawnByUserId: UserId? = null,
     @Schema(
         description =
-            "Quantity of seeds withdrawn. For viability testing withdrawals, this is always " +
-                "the same as the test's \"seedsSown\" value. Otherwise, it is a user-supplied " +
-                "value. If this quantity is in weight and the remaining quantity of the " +
-                "accession is in seeds or vice versa, the accession must have a subset weight " +
-                "and count.")
-    val withdrawnQuantity: SeedQuantityPayload? = null,
+            "Quantity of seeds withdrawn. If this quantity is in weight and the remaining " +
+                "quantity of the accession is in seeds or vice versa, the accession must have a " +
+                "subset weight and count.")
+    val withdrawnQuantity: SeedQuantityPayload,
 ) {
   fun toModel(accessionId: AccessionId): WithdrawalModel =
       WithdrawalModel(
@@ -181,7 +179,7 @@ data class CreateWithdrawalRequestPayload(
           date = date,
           notes = notes,
           purpose = purpose,
-          withdrawn = withdrawnQuantity?.toModel(),
+          withdrawn = withdrawnQuantity.toModel(),
       )
 }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -382,6 +382,16 @@ internal class AccessionModelTest {
     }
 
     @Test
+    fun `cannot add withdrawal with more seeds than exist in the accession`() {
+      val accession =
+          accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+
+      assertThrows<IllegalArgumentException> {
+        accession.addWithdrawal(WithdrawalModel(date = today, withdrawn = seeds(11)), tomorrowClock)
+      }
+    }
+
+    @Test
     fun `cannot specify negative seeds remaining for weight-based accessions`() {
       assertThrows<IllegalArgumentException>("Viability tests") {
         accession(


### PR DESCRIPTION
Check that a newly-added withdrawal wouldn't cause the accession's remaining
quantity to drop below zero.