### PR TITLE
SW-1566 Add viability test endpoints

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser, Namespace
 import requests
-from typing import Dict, Optional
+from typing import Optional
 
 DEFAULT_URL = "http://localhost:8080"
 
@@ -94,6 +94,18 @@ class TerrawareClient:
 
     def delete_accession(self, accession_id):
         return self.delete(f"/api/v1/seedbank/accessions/{accession_id}")
+
+    def create_viability_test(self, accession_id, payload):
+        uri = f"/api/v2/seedbank/accessions/{accession_id}/viabilityTests"
+        return self.post(uri, json=payload)["accession"]
+
+    def delete_viability_test(self, accession_id, viability_test_id):
+        uri = f"/api/v2/seedbank/accessions/{accession_id}/viabilityTests/{viability_test_id}"
+        return self.delete(uri)["accession"]
+
+    def update_viability_test(self, accession_id, viability_test_id, payload):
+        uri = f"/api/v2/seedbank/accessions/{accession_id}/viabilityTests/{viability_test_id}"
+        return self.put(uri, json=payload)["accession"]
 
     def export_search(self, payload):
         """Return a response with a text/csv content type."""

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tables.references.AUTOMATIONS
@@ -26,6 +27,7 @@ import com.terraformation.backend.db.tables.references.NOTIFICATIONS
 import com.terraformation.backend.db.tables.references.SPECIES
 import com.terraformation.backend.db.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.db.tables.references.UPLOADS
+import com.terraformation.backend.db.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tables.references.WITHDRAWALS
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
@@ -44,6 +46,9 @@ import org.jooq.impl.DSL
  */
 @ManagedBean
 class ParentStore(private val dslContext: DSLContext) {
+  fun getAccessionId(viabilityTestId: ViabilityTestId): AccessionId? =
+      fetchFieldById(viabilityTestId, VIABILITY_TESTS.ID, VIABILITY_TESTS.ACCESSION_ID)
+
   fun getAccessionId(withdrawalId: WithdrawalId): AccessionId? =
       fetchFieldById(withdrawalId, WITHDRAWALS.ID, WITHDRAWALS.ACCESSION_ID)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.log.perClassLogger
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -127,6 +128,7 @@ data class DeviceManagerUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
+  override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = false
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.log.perClassLogger
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -284,6 +285,11 @@ data class IndividualUser(
 
   override fun canReadUpload(uploadId: UploadId): Boolean {
     return userId == parentStore.getUserId(uploadId)
+  }
+
+  override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean {
+    val accessionId = parentStore.getAccessionId(viabilityTestId) ?: return false
+    return canReadAccession(accessionId)
   }
 
   override fun canRegenerateAllDeviceManagerTokens(): Boolean {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -23,6 +23,8 @@ import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.ViabilityTestId
+import com.terraformation.backend.db.ViabilityTestNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -303,6 +305,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readUpload(uploadId: UploadId) {
     if (!user.canReadUpload(uploadId)) {
       throw UploadNotFoundException(uploadId)
+    }
+  }
+
+  fun readViabilityTest(viabilityTestId: ViabilityTestId) {
+    if (!user.canReadViabilityTest(viabilityTestId)) {
+      throw ViabilityTestNotFoundException(viabilityTestId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.tables.daos.UsersDao
 import javax.annotation.ManagedBean
 import org.springframework.context.annotation.Lazy
@@ -131,6 +132,7 @@ class SystemUser(
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
   override fun canReadUpload(uploadId: UploadId): Boolean = true
+  override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = true
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.StorageLocationId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
+import com.terraformation.backend.db.ViabilityTestId
 import java.security.Principal
 
 /**
@@ -96,6 +97,7 @@ interface TerrawareUser : Principal {
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
   fun canReadUpload(uploadId: UploadId): Boolean
+  fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean
   fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -116,6 +116,9 @@ class UserAlreadyInOrganizationException(val userId: UserId, val organizationId:
 
 class UserNotFoundException(val userId: UserId) : EntityNotFoundException("User $userId not found")
 
+class ViabilityTestNotFoundException(val viabilityTestId: ViabilityTestId) :
+    EntityNotFoundException("Viability test $viabilityTestId not found")
+
 class WithdrawalNotFoundException(val withdrawalId: WithdrawalId) :
     EntityNotFoundException("Withdrawal $withdrawalId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -2,11 +2,13 @@ package com.terraformation.backend.seedbank
 
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.tables.references.ACCESSIONS
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.PhotoRepository
 import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import java.time.Clock
 import javax.annotation.ManagedBean
@@ -48,6 +50,28 @@ class AccessionService(
 
   fun deleteWithdrawal(accessionId: AccessionId, withdrawalId: WithdrawalId): AccessionModel {
     return updateAccession(accessionId) { it.deleteWithdrawal(withdrawalId, clock) }
+  }
+
+  fun createViabilityTest(viabilityTest: ViabilityTestModel): AccessionModel {
+    val accessionId =
+        viabilityTest.accessionId ?: throw IllegalArgumentException("Accession ID must be non-null")
+
+    return updateAccession(accessionId) { it.addViabilityTest(viabilityTest, clock) }
+  }
+
+  fun updateViabilityTest(
+      accessionId: AccessionId,
+      viabilityTestId: ViabilityTestId,
+      modify: (ViabilityTestModel) -> ViabilityTestModel
+  ): AccessionModel {
+    return updateAccession(accessionId) { it.updateViabilityTest(viabilityTestId, clock, modify) }
+  }
+
+  fun deleteViabilityTest(
+      accessionId: AccessionId,
+      viabilityTestId: ViabilityTestId
+  ): AccessionModel {
+    return updateAccession(accessionId) { it.deleteViabilityTest(viabilityTestId, clock) }
   }
 
   private fun updateAccession(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import javax.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -145,8 +144,6 @@ data class AccessionPayloadV2(
             "Time of most recent user observation of seeds remaining in the accession. This is " +
                 "updated by the server whenever the \"remainingQuantity\" field is edited.")
     val latestObservedTime: Instant?,
-    val latestViabilityPercent: Int?,
-    val latestViabilityTestDate: LocalDate?,
     val notes: String?,
     val photoFilenames: List<String>?,
     val plantsCollectedFromMax: Int?,
@@ -179,8 +176,7 @@ data class AccessionPayloadV2(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
     val subsetWeight: SeedQuantityPayload?,
-    val totalViabilityPercent: Int?,
-    val viabilityTests: List<ViabilityTestPayload>?,
+    val viabilityTests: List<GetViabilityTestPayload>?,
     val withdrawals: List<GetWithdrawalPayload>?,
 ) {
   constructor(
@@ -210,8 +206,6 @@ data class AccessionPayloadV2(
       initialQuantity = model.total?.toPayload(),
       latestObservedQuantity = model.latestObservedQuantity?.toPayload(),
       latestObservedTime = model.latestObservedTime,
-      latestViabilityPercent = model.latestViabilityPercent,
-      latestViabilityTestDate = model.latestViabilityTestDate,
       notes = model.processingNotes,
       photoFilenames = model.photoFilenames.orNull(),
       // TODO replace with max/min plants
@@ -228,8 +222,7 @@ data class AccessionPayloadV2(
       storageLocation = model.storageLocation,
       subsetCount = model.subsetCount,
       subsetWeight = model.subsetWeightQuantity?.toPayload(),
-      totalViabilityPercent = model.totalViabilityPercent,
-      viabilityTests = model.viabilityTests.map { ViabilityTestPayload(it) }.orNull(),
+      viabilityTests = model.viabilityTests.map { GetViabilityTestPayload(it) }.orNull(),
       withdrawals = model.withdrawals.map { GetWithdrawalPayload(it) }.orNull(),
   )
 }
@@ -318,7 +311,6 @@ data class UpdateAccessionRequestPayloadV2(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
     private val subsetWeight: SeedQuantityPayload? = null,
-    @Valid val viabilityTests: List<ViabilityTestPayload>? = null,
 ) {
   fun applyToModel(model: AccessionModel): AccessionModel =
       model.copy(
@@ -346,7 +338,6 @@ data class UpdateAccessionRequestPayloadV2(
           storageLocation = storageLocation,
           subsetCount = subsetCount,
           subsetWeightQuantity = subsetWeight?.toModel(),
-          viabilityTests = viabilityTests.orEmpty().map { it.toModel() },
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -1,0 +1,196 @@
+package com.terraformation.backend.seedbank.api
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.ViabilityTestId
+import com.terraformation.backend.db.ViabilityTestNotFoundException
+import com.terraformation.backend.db.ViabilityTestSeedType
+import com.terraformation.backend.db.ViabilityTestSubstrate
+import com.terraformation.backend.db.ViabilityTestTreatment
+import com.terraformation.backend.db.ViabilityTestType
+import com.terraformation.backend.seedbank.AccessionService
+import com.terraformation.backend.seedbank.db.ViabilityTestStore
+import com.terraformation.backend.seedbank.model.ViabilityTestModel
+import io.swagger.v3.oas.annotations.Operation
+import java.time.LocalDate
+import javax.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v2/seedbank/accessions/{accessionId}/viabilityTests")
+@RestController
+class ViabilityTestsController(
+    private val accessionService: AccessionService,
+    private val viabilityTestStore: ViabilityTestStore,
+) {
+  @GetMapping
+  @Operation(summary = "List all of the accession's viability tests.")
+  fun listViabilityTests(
+      @PathVariable("accessionId") accessionId: AccessionId
+  ): ListViabilityTestsResponsePayload {
+    val tests = viabilityTestStore.fetchViabilityTests(accessionId)
+    return ListViabilityTestsResponsePayload(tests.map { GetViabilityTestPayload(it) })
+  }
+
+  @GetMapping("/{viabilityTestId}")
+  @Operation(summary = "Get a single viability test.")
+  fun getViabilityTest(
+      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId
+  ): GetViabilityTestResponsePayload {
+    val model = viabilityTestStore.fetchOneById(viabilityTestId)
+    if (model.accessionId != accessionId) {
+      throw ViabilityTestNotFoundException(viabilityTestId)
+    }
+
+    return GetViabilityTestResponsePayload(GetViabilityTestPayload(model))
+  }
+
+  @Operation(
+      summary = "Create a new viability test on an existing accession.",
+      description = "May cause the accession's remaining quantity to change.")
+  @PostMapping
+  fun createViabilityTest(
+      @PathVariable("accessionId") accessionId: AccessionId,
+      @RequestBody payload: CreateViabilityTestRequestPayload
+  ): UpdateAccessionResponsePayloadV2 {
+    val accession = accessionService.createViabilityTest(payload.toModel(accessionId))
+    return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(accession))
+  }
+
+  @DeleteMapping("/{viabilityTestId}")
+  @Operation(
+      summary = "Delete an existing viability test.",
+      description = "May cause the accession's remaining quantity to change.")
+  fun deleteViabilityTest(
+      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId
+  ): UpdateAccessionResponsePayloadV2 {
+    val accession = accessionService.deleteViabilityTest(accessionId, viabilityTestId)
+    return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(accession))
+  }
+
+  @Operation(
+      summary = "Update the details of an existing viability test.",
+      description = "May cause the accession's remaining quantity to change.")
+  @PostMapping("/{viabilityTestId}")
+  fun updateViabilityTest(
+      @PathVariable("accessionId") accessionId: AccessionId,
+      @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId,
+      @RequestBody payload: UpdateViabilityTestRequestPayload
+  ): UpdateAccessionResponsePayloadV2 {
+    val accession =
+        accessionService.updateViabilityTest(accessionId, viabilityTestId, payload::applyToModel)
+    return UpdateAccessionResponsePayloadV2(AccessionPayloadV2(accession))
+  }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class GetViabilityTestPayload(
+    val accessionId: AccessionId,
+    val endDate: LocalDate? = null,
+    val id: ViabilityTestId,
+    val notes: String? = null,
+    val seedsTested: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val treatment: ViabilityTestTreatment? = null,
+    val testingStaffName: String? = null,
+    val testingStaffUserId: UserId? = null,
+    val testResults: List<ViabilityTestResultPayload>? = null,
+    val testType: ViabilityTestType,
+    val totalPercentGerminated: Int? = null,
+    val totalSeedsGerminated: Int? = null,
+) {
+  constructor(
+      model: ViabilityTestModel
+  ) : this(
+      accessionId = model.accessionId!!,
+      endDate = model.endDate,
+      id = model.id!!,
+      notes = model.notes,
+      seedsTested = model.seedsSown,
+      seedType = model.seedType,
+      startDate = model.startDate,
+      substrate = model.substrate,
+      testingStaffName = model.staffResponsible,
+      testingStaffUserId = null,
+      testResults = model.testResults?.map { ViabilityTestResultPayload(it) },
+      testType = model.testType,
+      totalPercentGerminated = model.totalPercentGerminated,
+      totalSeedsGerminated = model.totalSeedsGerminated,
+      treatment = model.treatment,
+  )
+}
+
+// Mark all fields as write-only in the schema
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateViabilityTestRequestPayload(
+    val endDate: LocalDate? = null,
+    val notes: String? = null,
+    val seedsSown: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val testingStaffUserId: UserId? = null,
+    val testType: ViabilityTestType,
+    val treatment: ViabilityTestTreatment? = null,
+) {
+  fun toModel(accessionId: AccessionId) =
+      ViabilityTestModel(
+          accessionId = accessionId,
+          endDate = endDate,
+          notes = notes,
+          seedsSown = seedsSown,
+          seedType = seedType,
+          startDate = startDate,
+          substrate = substrate,
+          testType = testType,
+          treatment = treatment,
+      )
+}
+
+// Mark all fields as write-only in the schema
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class UpdateViabilityTestRequestPayload(
+    val endDate: LocalDate? = null,
+    val notes: String? = null,
+    val seedsSown: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val testingStaffUserId: UserId? = null,
+    @Valid val testResults: List<ViabilityTestResultPayload>? = null,
+    val testType: ViabilityTestType,
+    val treatment: ViabilityTestTreatment? = null,
+) {
+  fun applyToModel(model: ViabilityTestModel): ViabilityTestModel =
+      model.copy(
+          endDate = endDate,
+          notes = notes,
+          seedsSown = seedsSown,
+          seedType = seedType,
+          startDate = startDate,
+          substrate = substrate,
+          testResults = testResults?.map { it.toModel() },
+          testType = testType,
+          treatment = treatment,
+      )
+}
+
+data class GetViabilityTestResponsePayload(val viabilityTest: GetViabilityTestPayload) :
+    SuccessResponsePayload
+
+data class ListViabilityTestsResponsePayload(val viabilityTests: List<GetViabilityTestPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
@@ -30,7 +30,7 @@ class WithdrawalsController(
     private val withdrawalStore: WithdrawalStore,
 ) {
   @GetMapping
-  @Operation(summary = "List all the withdrawals matching a search criterion.")
+  @Operation(summary = "List all the withdrawals from an accession.")
   fun listWithdrawals(
       @PathVariable("accessionId") accessionId: AccessionId
   ): GetWithdrawalsResponsePayload {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -22,6 +22,8 @@ import com.terraformation.backend.db.StorageLocationNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.ViabilityTestId
+import com.terraformation.backend.db.ViabilityTestNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -61,6 +63,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val storageLocationId = StorageLocationId(1)
   private val uploadId = UploadId(1)
   private val userId = UserId(1)
+  private val viabilityTestId = ViabilityTestId(1)
 
   /**
    * Grants permission to perform a particular operation. This is a simple wrapper around a MockK
@@ -392,6 +395,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canReadUpload(uploadId) }
     requirements.readUpload(uploadId)
+  }
+
+  @Test
+  fun readViabilityTest() {
+    assertThrows<ViabilityTestNotFoundException> { requirements.readViabilityTest(viabilityTestId) }
+
+    grant { user.canReadViabilityTest(viabilityTestId) }
+    requirements.readViabilityTest(viabilityTestId)
   }
 
   @Test


### PR DESCRIPTION
Add a set of endpoints under `/api/v1/seedbank/accessions/{id}/viabilityTests` to
read and write viability tests. These work the same way as the withdrawals
endpoints: they return the entire accession.

Remove the `viabilityTests` field from the v2 accession PUT payload; the new
endpoints are the only way to write viability tests in the v2 API.

The v2 accession GET response payload no longer has the fields related to the
v1-style viability percentage calculations, since they don't make sense in the
context of v2-style tests:

* `latestViabilityPercent`
* `latestViabilityTestDate`
* `totalViabilityPercent`

A future change will add a new field to hold the user-supplied viability
percentage.