### PR TITLE
SW-1574 Add viability percent to v2 accession API

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,7 +1,10 @@
-name: terraware-server
+name: scripts
 
 on:
   pull_request:
+    paths:
+    - scripts/**
+    - .github/workflows/scripts.yml
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -76,7 +76,7 @@ def generate_source() -> Optional[str]:
     )
 
 
-def generate_staff_responsible() -> Optional[str]:
+def generate_staff_responsible() -> str:
     return random.choice(FIRST_NAMES)
 
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -176,6 +176,7 @@ data class AccessionPayloadV2(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
     val subsetWeight: SeedQuantityPayload?,
+    val viabilityPercent: Int?,
     val viabilityTests: List<GetViabilityTestPayload>?,
     val withdrawals: List<GetWithdrawalPayload>?,
 ) {
@@ -222,6 +223,7 @@ data class AccessionPayloadV2(
       storageLocation = model.storageLocation,
       subsetCount = model.subsetCount,
       subsetWeight = model.subsetWeightQuantity?.toPayload(),
+      viabilityPercent = model.totalViabilityPercent,
       viabilityTests = model.viabilityTests.map { GetViabilityTestPayload(it) }.orNull(),
       withdrawals = model.withdrawals.map { GetWithdrawalPayload(it) }.orNull(),
   )
@@ -310,7 +312,8 @@ data class UpdateAccessionRequestPayloadV2(
     @Schema(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
-    private val subsetWeight: SeedQuantityPayload? = null,
+    val subsetWeight: SeedQuantityPayload? = null,
+    val viabilityPercent: Int? = null,
 ) {
   fun applyToModel(model: AccessionModel): AccessionModel =
       model.copy(
@@ -338,6 +341,7 @@ data class UpdateAccessionRequestPayloadV2(
           storageLocation = storageLocation,
           subsetCount = subsetCount,
           subsetWeightQuantity = subsetWeight?.toModel(),
+          totalViabilityPercent = viabilityPercent,
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -137,6 +137,10 @@ data class AccessionModel(
     val targetStorageCondition: StorageCondition? = null,
     /** The initial quantity entered by the user. */
     val total: SeedQuantityModel? = null,
+    /**
+     * The accession's viability. This is calculated as an aggregate of the results of all tests in
+     * v1 and is a user-editable value in v2 (exposed in the v2 API as `viabilityPercent`).
+     */
     val totalViabilityPercent: Int? = null,
     val viabilityTests: List<ViabilityTestModel> = emptyList(),
     val withdrawals: List<WithdrawalModel> = emptyList(),
@@ -743,6 +747,8 @@ data class AccessionModel(
         if (existing.source == DataSource.Web) receivedDate else existing.receivedDate
     val newRemaining = calculateRemaining(clock, existing)
     val newWithdrawals = calculateWithdrawals(clock, existing.withdrawals)
+    val newViabilityPercent =
+        if (isManualState) totalViabilityPercent else calculateTotalViabilityPercent()
     val newViabilityTests = newWithdrawals.mapNotNull { it.viabilityTest }
     val newState = existing.getStateTransition(this, clock)?.newState ?: existing.state
 
@@ -757,7 +763,7 @@ data class AccessionModel(
         receivedDate = newReceivedDate,
         remaining = newRemaining,
         state = newState,
-        totalViabilityPercent = calculateTotalViabilityPercent(),
+        totalViabilityPercent = newViabilityPercent,
         total = total ?: newRemaining,
         viabilityTests = newViabilityTests,
         withdrawals = newWithdrawals)


### PR DESCRIPTION
Add a read/write field for the accession's viability percentage. This may be
edited by the user or autofilled on the client side based on test results.

v1 interoperability note: This is a calculated field (`totalViabilityPercent`)
in the v1 API.  If you do a v1 PUT, any user-edited value from a previous v2
PUT will be overwritten. A v1 GET will always return the calculated value.