### PR TITLE
SW-1575 Remove photo metadata from API 2/2

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,7 +1,10 @@
-name: terraware-server
+name: scripts
 
 on:
   pull_request:
+    paths:
+    - scripts/**
+    - .github/workflows/scripts.yml
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -76,7 +76,7 @@ def generate_source() -> Optional[str]:
     )
 
 
-def generate_staff_responsible() -> Optional[str]:
+def generate_staff_responsible() -> str:
     return random.choice(FIRST_NAMES)
 
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -176,6 +176,7 @@ data class AccessionPayloadV2(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
     val subsetWeight: SeedQuantityPayload?,
+    val viabilityPercent: Int?,
     val viabilityTests: List<GetViabilityTestPayload>?,
     val withdrawals: List<GetWithdrawalPayload>?,
 ) {
@@ -222,6 +223,7 @@ data class AccessionPayloadV2(
       storageLocation = model.storageLocation,
       subsetCount = model.subsetCount,
       subsetWeight = model.subsetWeightQuantity?.toPayload(),
+      viabilityPercent = model.totalViabilityPercent,
       viabilityTests = model.viabilityTests.map { GetViabilityTestPayload(it) }.orNull(),
       withdrawals = model.withdrawals.map { GetWithdrawalPayload(it) }.orNull(),
   )
@@ -310,7 +312,8 @@ data class UpdateAccessionRequestPayloadV2(
     @Schema(
         description =
             "Weight of subset of seeds. Units must be a weight measurement, not \"Seeds\".")
-    private val subsetWeight: SeedQuantityPayload? = null,
+    val subsetWeight: SeedQuantityPayload? = null,
+    val viabilityPercent: Int? = null,
 ) {
   fun applyToModel(model: AccessionModel): AccessionModel =
       model.copy(
@@ -338,6 +341,7 @@ data class UpdateAccessionRequestPayloadV2(
           storageLocation = storageLocation,
           subsetCount = subsetCount,
           subsetWeightQuantity = subsetWeight?.toModel(),
+          totalViabilityPercent = viabilityPercent,
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -81,7 +82,7 @@ class ViabilityTestsController(
   @Operation(
       summary = "Update the details of an existing viability test.",
       description = "May cause the accession's remaining quantity to change.")
-  @PostMapping("/{viabilityTestId}")
+  @PutMapping("/{viabilityTestId}")
   fun updateViabilityTest(
       @PathVariable("accessionId") accessionId: AccessionId,
       @PathVariable("viabilityTestId") viabilityTestId: ViabilityTestId,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -137,6 +137,10 @@ data class AccessionModel(
     val targetStorageCondition: StorageCondition? = null,
     /** The initial quantity entered by the user. */
     val total: SeedQuantityModel? = null,
+    /**
+     * The accession's viability. This is calculated as an aggregate of the results of all tests in
+     * v1 and is a user-editable value in v2 (exposed in the v2 API as `viabilityPercent`).
+     */
     val totalViabilityPercent: Int? = null,
     val viabilityTests: List<ViabilityTestModel> = emptyList(),
     val withdrawals: List<WithdrawalModel> = emptyList(),
@@ -743,6 +747,8 @@ data class AccessionModel(
         if (existing.source == DataSource.Web) receivedDate else existing.receivedDate
     val newRemaining = calculateRemaining(clock, existing)
     val newWithdrawals = calculateWithdrawals(clock, existing.withdrawals)
+    val newViabilityPercent =
+        if (isManualState) totalViabilityPercent else calculateTotalViabilityPercent()
     val newViabilityTests = newWithdrawals.mapNotNull { it.viabilityTest }
     val newState = existing.getStateTransition(this, clock)?.newState ?: existing.state
 
@@ -757,7 +763,7 @@ data class AccessionModel(
         receivedDate = newReceivedDate,
         remaining = newRemaining,
         state = newState,
-        totalViabilityPercent = calculateTotalViabilityPercent(),
+        totalViabilityPercent = newViabilityPercent,
         total = total ?: newRemaining,
         viabilityTests = newViabilityTests,
         withdrawals = newWithdrawals)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/PhotoMetadata.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/PhotoMetadata.kt
@@ -1,13 +1,7 @@
 package com.terraformation.backend.seedbank.model
 
-import java.time.Instant
-import net.postgis.jdbc.geometry.Point
-
 data class PhotoMetadata(
     val filename: String,
     val contentType: String,
-    val capturedTime: Instant,
     val size: Long,
-    val location: Point?,
-    val gpsAccuracy: Int?,
 )

--- a/src/main/resources/db/migration/V126__PhotosMetadataNullable.sql
+++ b/src/main/resources/db/migration/V126__PhotosMetadataNullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE photos ALTER COLUMN captured_time DROP NOT NULL;

--- a/src/main/resources/db/migration/V127__DropPhotosMetadata.sql
+++ b/src/main/resources/db/migration/V127__DropPhotosMetadata.sql
@@ -1,0 +1,6 @@
+ALTER TABLE photos DROP COLUMN captured_time;
+ALTER TABLE photos DROP COLUMN gps_horiz_accuracy;
+ALTER TABLE photos DROP COLUMN gps_vert_accuracy;
+ALTER TABLE photos DROP COLUMN heading;
+ALTER TABLE photos DROP COLUMN location;
+ALTER TABLE photos DROP COLUMN orientation;

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -62,7 +62,6 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
     photosDao.insert(
         PhotosRow(
             id = photoId,
-            capturedTime = clock.instant(),
             contentType = MediaType.IMAGE_JPEG_VALUE,
             createdBy = user.userId,
             createdTime = clock.instant(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -668,7 +668,6 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             fileName = "photo.jpg",
             createdBy = user.userId,
             createdTime = Instant.now(),
-            capturedTime = Instant.now(),
             contentType = MediaType.IMAGE_JPEG_VALUE,
             modifiedBy = user.userId,
             modifiedTime = Instant.now(),


### PR DESCRIPTION
Drop a bunch of metadata columns from the photos table, both the ones that were
removed from the API in part 1 of this series and some others that were part of
our original data model design but never ended up being used.