### PR TITLE
SW-1571 v2->v1: Recalculate "initial" quantity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -51,7 +51,17 @@ data class WithdrawalModel(
       SeedQuantityModel.of(record.withdrawnQuantity, record.withdrawnUnitsId),
   )
 
+  init {
+    validate()
+  }
+
   fun validate() {
+    remaining?.quantity?.signum()?.let { signum ->
+      if (signum < 0) {
+        throw IllegalArgumentException("Remaining quantity may not be negative")
+      }
+    }
+
     withdrawn?.quantity?.signum()?.let { signum ->
       if (signum <= 0) {
         throw IllegalArgumentException("Withdrawn quantity must be greater than 0")


### PR DESCRIPTION
In the v1 logic for count-based accessions, the remaining quantity is derived from
the initial (total) quantity and the quantities of all the withdrawals, and it has
to add up to zero or more. In the v2 logic, since the user can reset the remaining
quantity at will, the withdrawal quantities can add up to more than the initial
quantity. Previously, that situation would cause an `IllegalArgumentException`
in v2->v1 conversion because the calculated remaining quantity would be negative.

Fix it by recalculating the "initial" quantity in v2->v1 conversion so the numbers
all match up.

Weight-based accessions don't need this fix because the remaining quantity is user
input rather than a calculated value in v1.