### PR TITLE
Remove v1-only fields from v2 accession payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -106,6 +106,15 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
         dateField("dryingMoveDate", "Drying move date", ACCESSIONS.DRYING_MOVE_DATE),
         dateField("dryingStartDate", "Drying start date", ACCESSIONS.DRYING_START_DATE),
         enumField("endangered", "Endangered", ACCESSIONS.SPECIES_ENDANGERED_TYPE_ID),
+        integerField("estimatedCount", "Estimated seed count", ACCESSIONS.EST_SEED_COUNT),
+        gramsField("estimatedWeightGrams", "Estimated weight (grams)", ACCESSIONS.EST_WEIGHT_GRAMS),
+        bigDecimalField(
+            "estimatedWeightQuantity",
+            "Estimated weight (quantity)",
+            ACCESSIONS.EST_WEIGHT_QUANTITY),
+        enumField(
+            "estimatedWeightUnits", "Estimated weight (units)", ACCESSIONS.EST_WEIGHT_UNITS_ID),
+        // TODO: Remove this once clients no longer need it (new name is estimatedCount)
         integerField(
             "estimatedSeedsIncoming", "Estimated seeds incoming", ACCESSIONS.EST_SEED_COUNT),
         textField("familyName", "Family name", ACCESSIONS.FAMILY_NAME),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.CollectionSource
 import com.terraformation.backend.db.DataSource
 import com.terraformation.backend.db.FacilityId
-import com.terraformation.backend.db.ProcessingMethod
 import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.model.AccessionActive
@@ -139,11 +138,6 @@ data class AccessionPayloadV2(
     val id: AccessionId,
     @Schema(
         description =
-            "Initial size of accession. The units of this value must match the measurement type " +
-                "in \"processingMethod\".")
-    val initialQuantity: SeedQuantityPayload?,
-    @Schema(
-        description =
             "Most recent user observation of seeds remaining in the accession. This is not " +
                 "directly editable; it is updated by the server whenever the " +
                 "\"remainingQuantity\" field is edited.")
@@ -157,7 +151,6 @@ data class AccessionPayloadV2(
     val photoFilenames: List<String>?,
     val plantsCollectedFromMax: Int?,
     val plantsCollectedFromMin: Int?,
-    val processingMethod: ProcessingMethod?,
     val receivedDate: LocalDate?,
     @Schema(
         description =
@@ -214,7 +207,6 @@ data class AccessionPayloadV2(
       family = model.family,
       founderId = model.founderId,
       id = model.id ?: throw IllegalArgumentException("Accession did not have an ID"),
-      initialQuantity = model.total?.toPayload(),
       latestObservedQuantity = model.latestObservedQuantity?.toPayload(),
       latestObservedTime = model.latestObservedTime,
       notes = model.processingNotes,
@@ -222,7 +214,6 @@ data class AccessionPayloadV2(
       // TODO replace with max/min plants
       plantsCollectedFromMax = model.numberOfTrees,
       plantsCollectedFromMin = model.numberOfTrees,
-      processingMethod = model.processingMethod,
       receivedDate = model.receivedDate,
       remainingQuantity = model.remaining?.toPayload(),
       source = model.source,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -119,7 +119,16 @@ data class AccessionPayloadV2(
     @Schema(description = "Names of the people who collected the seeds.")
     val collectors: List<String>?,
     val dryingEndDate: LocalDate?,
-    val estimatedSeedCount: Int?,
+    @Schema(
+        description =
+            "Estimated number of seeds remaining. Absent if there isn't enough " +
+                "information to calculate an estimate.")
+    val estimatedCount: Int?,
+    @Schema(
+        description =
+            "Estimated weight of seeds remaining. Absent if there isn't enough " +
+                "information to calculate an estimate.")
+    val estimatedWeight: SeedQuantityPayload?,
     val facilityId: FacilityId,
     val family: String?,
     val founderId: String?,
@@ -198,7 +207,8 @@ data class AccessionPayloadV2(
       collectionSource = model.collectionSource,
       collectors = model.collectors.orNull(),
       dryingEndDate = model.dryingEndDate,
-      estimatedSeedCount = model.estimatedSeedCount,
+      estimatedCount = model.estimatedSeedCount,
+      estimatedWeight = model.estimatedWeight?.toPayload(),
       facilityId = model.facilityId
               ?: throw IllegalArgumentException("Accession did not have a facility ID"),
       family = model.family,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -137,6 +137,8 @@ class AccessionStore(
           dryingStartDate = record[DRYING_START_DATE],
           endangered = record[SPECIES_ENDANGERED_TYPE_ID],
           estimatedSeedCount = record[EST_SEED_COUNT],
+          estimatedWeight =
+              SeedQuantityModel.of(record[EST_WEIGHT_QUANTITY], record[EST_WEIGHT_UNITS_ID]),
           facilityId = record[FACILITY_ID],
           family = record[FAMILY_NAME],
           fieldNotes = record[FIELD_NOTES],
@@ -410,6 +412,9 @@ class AccessionStore(
                 .set(DRYING_MOVE_DATE, accession.dryingMoveDate)
                 .set(DRYING_START_DATE, accession.dryingStartDate)
                 .set(EST_SEED_COUNT, accession.estimatedSeedCount)
+                .set(EST_WEIGHT_GRAMS, accession.estimatedWeight?.grams)
+                .set(EST_WEIGHT_QUANTITY, accession.estimatedWeight?.quantity)
+                .set(EST_WEIGHT_UNITS_ID, accession.estimatedWeight?.units)
                 .set(FACILITY_ID, facilityId)
                 .set(FAMILY_NAME, accession.family)
                 .set(FIELD_NOTES, accession.fieldNotes)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/SeedQuantity.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/SeedQuantity.kt
@@ -45,6 +45,16 @@ data class SeedQuantityModel(val quantity: BigDecimal, val units: SeedQuantityUn
       subsetWeight: SeedQuantityModel? = null,
       subsetCount: Int? = null,
   ): SeedQuantityModel {
+    return toUnitsOrNull(newUnits, subsetWeight, subsetCount)
+        ?: throw IllegalArgumentException(
+            "Cannot convert between weight and seed count without subset measurement")
+  }
+
+  fun toUnitsOrNull(
+      newUnits: SeedQuantityUnits,
+      subsetWeight: SeedQuantityModel? = null,
+      subsetCount: Int? = null,
+  ): SeedQuantityModel? {
     return when {
       units == newUnits -> {
         this
@@ -59,8 +69,7 @@ data class SeedQuantityModel(val quantity: BigDecimal, val units: SeedQuantityUn
         SeedQuantityModel(newUnits.fromGrams(units.toGrams(quantity)), newUnits)
       }
       subsetWeight == null || subsetCount == null -> {
-        throw IllegalArgumentException(
-            "Cannot convert between weight and seed count without subset measurement")
+        null
       }
       newUnits == SeedQuantityUnits.Seeds -> {
         // Seed count must always be an integer, so we need to round the calculated quantity.

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -51,7 +51,17 @@ data class WithdrawalModel(
       SeedQuantityModel.of(record.withdrawnQuantity, record.withdrawnUnitsId),
   )
 
+  init {
+    validate()
+  }
+
   fun validate() {
+    remaining?.quantity?.signum()?.let { signum ->
+      if (signum < 0) {
+        throw IllegalArgumentException("Remaining quantity may not be negative")
+      }
+    }
+
     withdrawn?.quantity?.signum()?.let { signum ->
       if (signum <= 0) {
         throw IllegalArgumentException("Withdrawn quantity must be greater than 0")

--- a/src/main/resources/db/migration/V128__AccessionsEstimatedWeight.sql
+++ b/src/main/resources/db/migration/V128__AccessionsEstimatedWeight.sql
@@ -1,0 +1,3 @@
+ALTER TABLE accessions ADD COLUMN est_weight_grams NUMERIC;
+ALTER TABLE accessions ADD COLUMN est_weight_quantity NUMERIC;
+ALTER TABLE accessions ADD COLUMN est_weight_units_id INTEGER REFERENCES seed_quantity_units;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -693,23 +693,26 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `update recalculates estimated seed count`() {
+  fun `update recalculates estimated seed count and weight`() {
     val initial = store.create(AccessionModel(facilityId = facilityId))
+    val total = SeedQuantityModel(BigDecimal.TEN, SeedQuantityUnits.Pounds)
     store.update(
         initial.copy(
             processingMethod = ProcessingMethod.Weight,
             subsetCount = 1,
             subsetWeightQuantity = SeedQuantityModel(BigDecimal.ONE, SeedQuantityUnits.Ounces),
-            total = SeedQuantityModel(BigDecimal.TEN, SeedQuantityUnits.Pounds)))
+            total = total))
     val fetched = store.fetchOneById(initial.id!!)
 
     assertEquals(160, fetched.estimatedSeedCount, "Estimated seed count is added")
+    assertEquals(total, fetched.estimatedWeight, "Estimated weight is added")
 
     store.update(fetched.copy(total = null))
 
     val fetchedAfterClear = store.fetchOneById(initial.id!!)
 
     assertNull(fetchedAfterClear.estimatedSeedCount, "Estimated seed count is removed")
+    assertNull(fetchedAfterClear.estimatedWeight, "Estimated weight is removed")
   }
 
   @Test


### PR DESCRIPTION
The `initialQuantity` and `processingMethod` fields are meaningless in v2 and
shouldn't be included in the v2 accession payload.