### PR TITLE
Fix v1 compatibility in viability test API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -83,7 +83,7 @@ class AccessionService(
     return dslContext.transactionResult { _ ->
       lockAccession(accessionId)
 
-      val existing = accessionStore.fetchOneById(accessionId)
+      val existing = accessionStore.fetchOneById(accessionId).toV2Compatible(clock)
       val modified = modify(existing)
       accessionStore.updateAndFetch(modified)
     }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -26,6 +26,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -127,6 +128,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       assertEquals(seeds(7), updatedAccession.remaining, "Seeds remaining")
       assertEquals(2, updatedAccession.withdrawals.size, "Number of withdrawals")
       assertEquals(seeds(3), updatedAccession.withdrawals[1].withdrawn, "Size of new withdrawal")
+      assertTrue(updatedAccession.isManualState, "Accession is converted to v2")
       verify { accessionStore.updateAndFetch(any()) }
     }
 


### PR DESCRIPTION
The v2 viability test POST and PUT endpoints didn't implicitly upgrade an
accesssion to the v2 quantity-tracking model, which caused them to fail with a
validation error if you tried to create a viability test on a weight-based
accession that was most recently written with the v1 API.