### PR TITLE
Fix field name in viability test API

### DIFF
--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -119,6 +119,38 @@ def generate_viability_test(received_date, remaining_quantity: Dict) -> Dict:
     }
 
 
+def generate_viability_test_v2(received_date, remaining_quantity: Dict) -> Dict:
+    if remaining_quantity["units"] == "Seeds":
+        seeds_tested = randint(1, remaining_quantity["quantity"])
+    else:
+        seeds_tested = randint(10, 500)
+
+    test_type = random.choice(["Lab", "Nursery"])
+
+    start_date = received_date + timedelta(days=randint(0, 2))
+    germination_count = randint(0, 3)
+
+    test_results = []
+    recording_date = start_date
+
+    for i in range(0, germination_count):
+        test_results.append(
+            generate_test_result(recording_date, seeds_tested / germination_count)
+        )
+        recording_date += timedelta(days=randint(1, 3))
+
+    return {
+        "notes": generate_notes(),
+        "seedsTested": seeds_tested,
+        "seedType": "Fresh",
+        "startDate": str(start_date) if start_date else None,
+        "substrate": "Other",
+        "testResults": test_results or None,
+        "testType": test_type,
+        "treatment": "Soak",
+    }
+
+
 def generate_geolocation() -> Dict:
     return {
         "latitude": float(randint(100, 110)),
@@ -345,7 +377,7 @@ def create_accession_v2(
 
     if "receivedDate" in updated:
         received_date = date.fromisoformat(updated["receivedDate"])
-        viability_test_payload = generate_viability_test(
+        viability_test_payload = generate_viability_test_v2(
             received_date, updated["remainingQuantity"]
         )
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -83,7 +83,7 @@ class AccessionService(
     return dslContext.transactionResult { _ ->
       lockAccession(accessionId)
 
-      val existing = accessionStore.fetchOneById(accessionId)
+      val existing = accessionStore.fetchOneById(accessionId).toV2Compatible(clock)
       val modified = modify(existing)
       accessionStore.updateAndFetch(modified)
     }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -139,7 +139,7 @@ data class GetViabilityTestPayload(
 data class CreateViabilityTestRequestPayload(
     val endDate: LocalDate? = null,
     val notes: String? = null,
-    val seedsSown: Int? = null,
+    val seedsTested: Int? = null,
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
@@ -152,7 +152,7 @@ data class CreateViabilityTestRequestPayload(
           accessionId = accessionId,
           endDate = endDate,
           notes = notes,
-          seedsSown = seedsSown,
+          seedsSown = seedsTested,
           seedType = seedType,
           startDate = startDate,
           substrate = substrate,
@@ -167,7 +167,7 @@ data class CreateViabilityTestRequestPayload(
 data class UpdateViabilityTestRequestPayload(
     val endDate: LocalDate? = null,
     val notes: String? = null,
-    val seedsSown: Int? = null,
+    val seedsTested: Int? = null,
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
@@ -180,7 +180,7 @@ data class UpdateViabilityTestRequestPayload(
       model.copy(
           endDate = endDate,
           notes = notes,
-          seedsSown = seedsSown,
+          seedsSown = seedsTested,
           seedType = seedType,
           startDate = startDate,
           substrate = substrate,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -26,6 +26,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -127,6 +128,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       assertEquals(seeds(7), updatedAccession.remaining, "Seeds remaining")
       assertEquals(2, updatedAccession.withdrawals.size, "Number of withdrawals")
       assertEquals(seeds(3), updatedAccession.withdrawals[1].withdrawn, "Size of new withdrawal")
+      assertTrue(updatedAccession.isManualState, "Accession is converted to v2")
       verify { accessionStore.updateAndFetch(any()) }
     }
 


### PR DESCRIPTION
The v2 viability test POST and PUT endpoints still used the v1 name `seedsSown`
rather than the v2 name `seedsTested` for the field containing the number of seeds
tested.