### PR TITLE
SW-1596 Substrates and treatments for v2 viability tests

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -26,19 +26,19 @@ class TerrawareClient:
     def delete(self, url, **kwargs):
         kwargs_with_auth = self._add_auth_header(kwargs)
         r = requests.delete(self.base_url + url, **kwargs_with_auth)
-        r.raise_for_status()
+        self.raise_for_status(r)
         return r.json()
 
     def get(self, url, **kwargs):
         kwargs_with_auth = self._add_auth_header(kwargs)
         r = requests.get(self.base_url + url, **kwargs_with_auth)
-        r.raise_for_status()
+        self.raise_for_status(r)
         return r.json()
 
     def post_raw(self, url, **kwargs):
         kwargs_with_auth = self._add_auth_header(kwargs)
         r = requests.post(self.base_url + url, **kwargs_with_auth)
-        r.raise_for_status()
+        self.raise_for_status(r)
         return r
 
     def post(self, url, **kwargs):
@@ -47,8 +47,17 @@ class TerrawareClient:
     def put(self, url, **kwargs):
         kwargs_with_auth = self._add_auth_header(kwargs)
         r = requests.put(self.base_url + url, **kwargs_with_auth)
-        r.raise_for_status()
+        self.raise_for_status(r)
         return r.json()
+
+    @staticmethod
+    def raise_for_status(r: requests.Response):
+        if r.status_code > 399:
+            if r.headers["Content-Type"].startswith("application/json"):
+                payload = r.json()
+                if "error" in payload and "message" in payload["error"]:
+                    raise requests.HTTPError(payload["error"]["message"], response=r)
+            r.raise_for_status()
 
     def get_facility(self, facility_id):
         return self.get(f"/api/v1/facilities/{facility_id}")["facility"]

--- a/scripts/create_accessions.py
+++ b/scripts/create_accessions.py
@@ -93,6 +93,15 @@ def generate_viability_test(received_date, remaining_quantity: Dict) -> Dict:
             }
         }
 
+    test_type = random.choice(["Lab", "Nursery"])
+    seed_type = random.choice([None, "Fresh", "Stored"])
+    substrate = random.choice(
+        [None, "Agar Petri Dish", "Nursery Media", "Paper Petri Dish", "Other"]
+    )
+    treatment = random.choice(
+        [None, "GA3", "Other", "Scarify", "Soak", "Stratification"]
+    )
+
     start_date = received_date + timedelta(days=randint(0, 2))
     germination_count = randint(0, 3)
 
@@ -108,13 +117,13 @@ def generate_viability_test(received_date, remaining_quantity: Dict) -> Dict:
     return {
         "notes": generate_notes(),
         "seedsSown": seeds_sown,
-        "seedType": "Fresh",
+        "seedType": seed_type,
         "staffResponsible": generate_staff_responsible(),
         "startDate": str(start_date) if start_date else None,
-        "substrate": "Nursery Media",
+        "substrate": substrate,
         "testResults": test_results or None,
-        "testType": "Lab",
-        "treatment": "Soak",
+        "testType": test_type,
+        "treatment": treatment,
         **remaining,
     }
 
@@ -125,7 +134,30 @@ def generate_viability_test_v2(received_date, remaining_quantity: Dict) -> Dict:
     else:
         seeds_tested = randint(10, 500)
 
-    test_type = random.choice(["Lab", "Nursery"])
+    test_type_substrates = {
+        "Lab": [
+            "Agar",
+            "Paper",
+            "Sand",
+            "Nursery Media",
+            "Other",
+        ],
+        "Nursery": [
+            "Media Mix",
+            "Soil",
+            "Sand",
+            "Moss",
+            "Perlite/Vermiculite",
+            "Other",
+        ],
+    }
+
+    test_type = random.choice(list(test_type_substrates.keys()))
+    seed_type = random.choice([None, "Fresh", "Stored"])
+    substrate = random.choice(test_type_substrates[test_type])
+    treatment = random.choice(
+        [None, "Chemical", "Light", "Other", "Scarify", "Soak", "Stratification"]
+    )
 
     start_date = received_date + timedelta(days=randint(0, 2))
     germination_count = randint(0, 3)
@@ -142,12 +174,12 @@ def generate_viability_test_v2(received_date, remaining_quantity: Dict) -> Dict:
     return {
         "notes": generate_notes(),
         "seedsTested": seeds_tested,
-        "seedType": "Fresh",
+        "seedType": seed_type,
         "startDate": str(start_date) if start_date else None,
-        "substrate": "Other",
+        "substrate": substrate,
         "testResults": test_results or None,
         "testType": test_type,
-        "treatment": "Soak",
+        "treatment": treatment,
     }
 
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -188,6 +188,7 @@ data class AccessionModel(
               isManualState = false,
               processingMethod = effectiveProcessingMethod,
               total = newTotal,
+              viabilityTests = viabilityTests.map { it.toV1Compatible() },
               withdrawals = withdrawalsWithCorrectUnits,
           )
           .withCalculatedValues(clock)
@@ -203,7 +204,10 @@ data class AccessionModel(
       // First backfill those values using the v1 logic, then switch to v2, then calculate any
       // v2-specific values.
       withCalculatedValues(clock)
-          .copy(isManualState = true, state = state?.toV2Compatible())
+          .copy(
+              isManualState = true,
+              state = state?.toV2Compatible(),
+              viabilityTests = viabilityTests.map { it.toV2Compatible() })
           .withCalculatedValues(clock)
     }
   }
@@ -312,6 +316,7 @@ data class AccessionModel(
     assertRemainingQuantityNotRemoved()
     assertNoQuantityTypeChangeWithoutSubsetInfo()
     assertNoWithdrawalsWithoutQuantity(latestObservedQuantity ?: remaining)
+    viabilityTests.forEach { it.validateV2() }
   }
 
   private fun assertRemainingQuantityNotRemoved() {

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -170,17 +170,23 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO viability_test_substrates (id, name)
 VALUES (1, 'Nursery Media'),
-       (2, 'Agar Petri Dish'),
-       (3, 'Paper Petri Dish'),
-       (4, 'Other')
+       (2, 'Agar'),
+       (3, 'Paper'),
+       (4, 'Other'),
+       (5, 'Sand'),
+       (6, 'Media Mix'),
+       (7, 'Soil'),
+       (8, 'Moss'),
+       (9, 'Perlite/Vermiculite')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO viability_test_treatments (id, name)
 VALUES (1, 'Soak'),
        (2, 'Scarify'),
-       (3, 'GA3'),
+       (3, 'Chemical'),
        (4, 'Stratification'),
-       (5, 'Other')
+       (5, 'Other'),
+       (6, 'Light')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO viability_test_types (id, name)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -438,7 +438,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                         testType = ViabilityTestType.Lab,
                         seedType = ViabilityTestSeedType.Fresh,
                         treatment = ViabilityTestTreatment.Scarify,
-                        substrate = ViabilityTestSubstrate.PaperPetriDish,
+                        substrate = ViabilityTestSubstrate.Paper,
                         notes = "notes",
                         seedsSown = 5)))
     store.update(desired)
@@ -452,7 +452,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 testType = ViabilityTestType.Lab,
                 seedTypeId = ViabilityTestSeedType.Fresh,
                 treatmentId = ViabilityTestTreatment.Scarify,
-                substrateId = ViabilityTestSubstrate.PaperPetriDish,
+                substrateId = ViabilityTestSubstrate.Paper,
                 notes = "notes",
                 seedsSown = 5,
                 remainingQuantity = BigDecimal(95),
@@ -532,7 +532,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                         testType = ViabilityTestType.Lab,
                         seedType = ViabilityTestSeedType.Fresh,
                         treatment = ViabilityTestTreatment.Scarify,
-                        substrate = ViabilityTestSubstrate.PaperPetriDish,
+                        substrate = ViabilityTestSubstrate.Paper,
                         notes = "notes",
                         seedsSown = 5)))
 


### PR DESCRIPTION
In v2, we are expanding the list of viability test treatments and changing the
substrates so that there are different lists of valid values depending on test
type. Most of the existing substrate values are also being renamed, e.g., "Agar
Petri Dish" is now "Agar."

Update the underlying data model so it uses the v2 values. Continue to accept
and return the existing values from the v1 accessions endpoints.

In cases where there is no unambiguous mapping between v1 and v2 treatments,
we remove the value rather than defaulting to a possibly-incorrect default.

The search API returns the v2 values; this doesn't break the existing search
frontend code since it already asks the server for the list of possible values.
But it does potentially cause search results to be different than before.