### PR TITLE
SW-1600 Keep track of minimum mobile app versions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -67,6 +67,9 @@ class SecurityConfig(private val userStore: UserStore) : KeycloakWebSecurityConf
         // Allow unauthenticated users to fetch the endpoint that redirects them to the login page.
         authorize("/api/v1/login", permitAll)
 
+        // Allow unauthenticated users to check their app versions for compatibility.
+        authorize("/api/v1/versions", permitAll)
+
         authorize("/api/**", fullyAuthenticated)
         authorize("/admin/**", fullyAuthenticated)
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -627,6 +627,7 @@ class AdminController(
           AppVersionsRow(appName, platform, minimumVersion, recommendedVersion))
       redirectAttributes.successMessage = "App version updated."
     } catch (e: DuplicateKeyException) {
+      // User edited the appName/platform to collide with an existing one.
       redirectAttributes.failureMessage = "An entry for that app name and platform already exists."
     } catch (e: Exception) {
       log.error("Failed to update app version", e)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
@@ -1,0 +1,34 @@
+package com.terraformation.backend.customer.api
+
+import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.db.AppVersionStore
+import com.terraformation.backend.db.tables.pojos.AppVersionsRow
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@CustomerEndpoint
+@RequestMapping("/api/v1/versions")
+@RestController
+class VersionsController(private val appVersionStore: AppVersionStore) {
+  @GetMapping
+  fun getVersions(): VersionsResponsePayload {
+    val entries = appVersionStore.findAll().map { VersionsEntryPayload(it) }
+    return VersionsResponsePayload(entries)
+  }
+}
+
+data class VersionsResponsePayload(val versions: List<VersionsEntryPayload>) :
+    SuccessResponsePayload
+
+data class VersionsEntryPayload(
+    val appName: String,
+    val platform: String,
+    val minimumVersion: String,
+    val recommendedVersion: String,
+) {
+  constructor(
+      row: AppVersionsRow
+  ) : this(row.appName!!, row.platform!!, row.minimumVersion!!, row.recommendedVersion!!)
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
@@ -1,0 +1,51 @@
+package com.terraformation.backend.customer.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tables.daos.AppVersionsDao
+import com.terraformation.backend.db.tables.pojos.AppVersionsRow
+import com.terraformation.backend.db.tables.references.APP_VERSIONS
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+@ManagedBean
+class AppVersionStore(
+    private val appVersionsDao: AppVersionsDao,
+    private val dslContext: DSLContext
+) {
+  fun findAll(): List<AppVersionsRow> {
+    return dslContext
+        .selectFrom(APP_VERSIONS)
+        .orderBy(APP_VERSIONS.APP_NAME, APP_VERSIONS.PLATFORM)
+        .fetchInto(AppVersionsRow::class.java)
+  }
+
+  fun create(row: AppVersionsRow) {
+    requirePermissions { updateAppVersions() }
+
+    appVersionsDao.insert(row)
+  }
+
+  fun update(original: AppVersionsRow, desired: AppVersionsRow) {
+    requirePermissions { updateAppVersions() }
+
+    dslContext
+        .update(APP_VERSIONS)
+        .set(APP_VERSIONS.APP_NAME, desired.appName)
+        .set(APP_VERSIONS.PLATFORM, desired.platform)
+        .set(APP_VERSIONS.MINIMUM_VERSION, desired.minimumVersion)
+        .set(APP_VERSIONS.RECOMMENDED_VERSION, desired.recommendedVersion)
+        .where(APP_VERSIONS.APP_NAME.eq(original.appName))
+        .and(APP_VERSIONS.PLATFORM.eq(original.platform))
+        .execute()
+  }
+
+  fun delete(appName: String, platform: String) {
+    requirePermissions { updateAppVersions() }
+
+    dslContext
+        .deleteFrom(APP_VERSIONS)
+        .where(APP_VERSIONS.APP_NAME.eq(appName))
+        .and(APP_VERSIONS.PLATFORM.eq(platform))
+        .execute()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -136,6 +136,7 @@ data class DeviceManagerUser(
       false
   override fun canSetTestClock(): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
+  override fun canUpdateAppVersions(): Boolean = false
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false
   override fun canUpdateDeviceTemplates(): Boolean = false
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -326,6 +326,10 @@ data class IndividualUser(
     return canReadAccession(accessionId)
   }
 
+  override fun canUpdateAppVersions(): Boolean {
+    return userType == UserType.SuperAdmin
+  }
+
   override fun canUpdateAutomation(automationId: AutomationId): Boolean {
     val facilityId = parentStore.getFacilityId(automationId) ?: return false
     return canUpdateFacility(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -363,6 +363,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateAppVersions() {
+    if (!user.canUpdateAppVersions()) {
+      throw AccessDeniedException("No permission to update app versions")
+    }
+  }
+
   fun updateAutomation(automationId: AutomationId) {
     if (!user.canUpdateAutomation(automationId)) {
       readAutomation(automationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -142,6 +142,7 @@ class SystemUser(
   override fun canSetTestClock(): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
+  override fun canUpdateAppVersions(): Boolean = true
   override fun canUpdateAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateDevice(deviceId: DeviceId): Boolean = true
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -105,6 +105,7 @@ interface TerrawareUser : Principal {
   fun canSetTestClock(): Boolean
   fun canTriggerAutomation(automationId: AutomationId): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean
+  fun canUpdateAppVersions(): Boolean
   fun canUpdateAutomation(automationId: AutomationId): Boolean
   fun canUpdateDevice(deviceId: DeviceId): Boolean
   fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean

--- a/src/main/resources/db/migration/R__AppVersions.sql
+++ b/src/main/resources/db/migration/R__AppVersions.sql
@@ -1,0 +1,9 @@
+-- Minimum versions of mobile apps are configured here. The statements here will only be run when
+-- this file has changed since the last time terraware-server was launched; if it hasn't, any
+-- local modifications to the version data won't be affected by a server restart.
+
+DELETE FROM app_versions;
+
+INSERT INTO app_versions (app_name, platform, minimum_version, recommended_version)
+VALUES ('SeedCollector', 'Android', '0.0.1', '0.0.1'),
+       ('SeedCollector', 'iOS',     '0.0.1', '0.0.1');

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -31,6 +31,8 @@ COMMENT ON COLUMN accessions.nursery_start_date IS 'When the accession was moved
 COMMENT ON COLUMN accessions.target_storage_condition IS 'The intended storage condition of the accession as determined during initial processing.';
 COMMENT ON COLUMN accessions.total_viability_percent IS 'Percentage of viable seeds across all tests.';
 
+COMMENT ON TABLE app_versions IS 'Minimum and recommended versions for Terraware mobile apps.';
+
 COMMENT ON TABLE automations IS 'Configuration of automatic processes run by the device manager.';
 
 COMMENT ON TABLE bags IS 'Individual bags of seeds that are part of an accession. An accession can consist of multiple bags.';

--- a/src/main/resources/db/migration/V129__AppVersions.sql
+++ b/src/main/resources/db/migration/V129__AppVersions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE app_versions (
+    app_name TEXT NOT NULL,
+    platform TEXT NOT NULL,
+    minimum_version TEXT NOT NULL,
+    recommended_version TEXT NOT NULL,
+    PRIMARY KEY (app_name, platform)
+);

--- a/src/main/resources/templates/admin/appVersions.html
+++ b/src/main/resources/templates/admin/appVersions.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/admin/header :: head"/>
+<body>
+
+<span th:include="/admin/header :: top"/>
+
+<a th:href="|${prefix}/|">Home</a>
+
+<h2>App Versions</h2>
+
+<table>
+    <thead>
+    <tr>
+        <th>App Name</th>
+        <th>Platform</th>
+        <th>Minimum</th>
+        <th>Recommended</th>
+        <th></th>
+        <th></th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <tr th:each="appVersion : ${appVersions}">
+        <td>
+            <form method="POST" th:action="|${prefix}/updateAppVersion|"
+                  th:id="|${appVersion.appName}-${appVersion.platform}|">
+                <input type="hidden" name="originalAppName" th:value="${appVersion.appName}"/>
+                <input type="hidden" name="originalPlatform" th:value="${appVersion.platform}"/>
+                <input type="text" name="appName" required th:value="${appVersion.appName}"/>
+            </form>
+        </td>
+        <td>
+            <input type="text" name="platform" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.platform}"/>
+        </td>
+        <td>
+            <input type="text" name="minimumVersion" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.minimumVersion}"/>
+        </td>
+        <td>
+            <input type="text" name="recommendedVersion" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.recommendedVersion}"/>
+        </td>
+        <td>
+            <input type="submit"
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   value="Update"/>
+        </td>
+        <td>
+            <form method="POST" th:action="|${prefix}/deleteAppVersion|">
+                <input type="hidden" name="appName" th:value="${appVersion.appName}"/>
+                <input type="hidden" name="platform" th:value="${appVersion.platform}"/>
+                <input type="submit" value="Delete"/>
+            </form>
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            <form method="POST" th:action="|${prefix}/createAppVersion|" id="create">
+                <input type="text" name="appName" required/>
+            </form>
+        </td>
+        <td>
+            <input type="text" name="platform" required form="create"/>
+        </td>
+        <td>
+            <input type="text" name="minimumVersion" required form="create"/>
+        </td>
+        <td>
+            <input type="text" name="recommendedVersion" required form="create"/>
+        </td>
+        <td>
+            <input type="submit" form="create" value="Create"/>
+        </td>
+        <td></td>
+    </tr>
+
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -40,6 +40,14 @@
     <a th:href="|${prefix}/deviceTemplates|">Device Templates</a>
 </p>
 
+<div th:if="${canUpdateAppVersions}">
+    <h2>App Versions</h2>
+
+    <p>
+        <a th:href="|${prefix}/appVersions|">Update app versions</a>
+    </p>
+</div>
+
 <div th:if="${canSetTestClock}">
     <h2>Test utilities</h2>
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -485,6 +485,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun updateAppVersions() {
+    assertThrows<AccessDeniedException> { requirements.updateAppVersions() }
+
+    grant { user.canUpdateAppVersions() }
+    requirements.updateAppVersions()
+  }
+
+  @Test
   fun updateAutomation() {
     assertThrows<AutomationNotFoundException> { requirements.updateAutomation(automationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -601,6 +601,7 @@ internal class PermissionTest : DatabaseTest() {
         importGlobalSpeciesData = true,
         regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
+        updateAppVersions = true,
         updateDeviceTemplates = true,
     )
   }
@@ -914,6 +915,7 @@ internal class PermissionTest : DatabaseTest() {
         importGlobalSpeciesData: Boolean = false,
         regenerateAllDeviceManagerTokens: Boolean = false,
         setTestClock: Boolean = false,
+        updateAppVersions: Boolean = false,
         updateDeviceTemplates: Boolean = false,
     ) {
       assertEquals(createDeviceManager, user.canCreateDeviceManager(), "Can create device manager")
@@ -926,6 +928,7 @@ internal class PermissionTest : DatabaseTest() {
           user.canRegenerateAllDeviceManagerTokens(),
           "Can regenerate all device manager tokens")
       assertEquals(setTestClock, user.canSetTestClock(), "Can set test clock")
+      assertEquals(updateAppVersions, user.canUpdateAppVersions(), "Can update app versions")
       assertEquals(
           updateDeviceTemplates, user.canUpdateDeviceTemplates(), "Can update device templates")
 

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -126,6 +126,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "accession_state_history" to setOf(ALL, SEEDBANK),
           "accession_states" to setOf(ALL, SEEDBANK),
           "accessions" to setOf(ALL, SEEDBANK),
+          "app_versions" to setOf(ALL, CUSTOMER),
           "automations" to setOf(ALL, DEVICE),
           "bags" to setOf(ALL, SEEDBANK),
           "collection_sources" to setOf(ALL, SEEDBANK),


### PR DESCRIPTION
To support forced updates of mobile apps if we make breaking API changes, as
well as notifying users when there significant new versions of mobile apps are
released, add an API endpoint that returns a list of our apps with a minimum
and recommended version number for each.

The list of app versions is maintained in a new repeatable database migration
so we can ensure it matches the server code as we update the API. But having to
update server-side database migrations would be annoying during mobile app
development, so the list is also editable in the admin UI for super-admin users.
Edits made in the admin UI are overwritten when the migration script is updated.