### PR TITLE
SW-1512 Add permissions for setting withdrawal user IDs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -125,6 +125,8 @@ data class DeviceManagerUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
+  override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      false
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
@@ -135,6 +137,7 @@ data class DeviceManagerUser(
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       false
   override fun canSetTestClock(): Boolean = false
+  override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
   override fun canUpdateAppVersions(): Boolean = false
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import org.springframework.security.access.AccessDeniedException
@@ -284,6 +285,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readOrganizationUser(organizationId: OrganizationId, userId: UserId) {
+    if (!user.canReadOrganizationUser(organizationId, userId)) {
+      readOrganization(organizationId)
+      throw UserNotFoundException(userId)
+    }
+  }
+
   fun readSpecies(speciesId: SpeciesId) {
     if (!user.canReadSpecies(speciesId)) {
       throw SpeciesNotFoundException(speciesId)
@@ -346,6 +354,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun setTestClock() {
     if (!user.canSetTestClock()) {
       throw AccessDeniedException("No permission to set test clock")
+    }
+  }
+
+  fun setWithdrawalUser(accessionId: AccessionId) {
+    if (!user.canSetWithdrawalUser(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to set withdrawal user for accession $accessionId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -128,6 +128,8 @@ class SystemUser(
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
   override fun canReadNotification(notificationId: NotificationId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
+  override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
@@ -140,6 +142,7 @@ class SystemUser(
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true
   override fun canSetTestClock(): Boolean = true
+  override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
   override fun canUpdateAppVersions(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -93,6 +93,7 @@ interface TerrawareUser : Principal {
   fun canReadFacility(facilityId: FacilityId): Boolean
   fun canReadNotification(notificationId: NotificationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
+  fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
@@ -103,6 +104,7 @@ interface TerrawareUser : Principal {
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
   fun canSetTestClock(): Boolean
+  fun canSetWithdrawalUser(accessionId: AccessionId): Boolean
   fun canTriggerAutomation(automationId: AutomationId): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean
   fun canUpdateAppVersions(): Boolean

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -153,7 +153,9 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: AccessionDryingEndEvent) {
-    val organizationId = parentStore.getOrganizationId(event.accessionId)
+    val organizationId =
+        parentStore.getOrganizationId(event.accessionId)
+            ?: throw AccessionNotFoundException(event.accessionId)
     val facilityName = parentStore.getFacilityName(event.accessionId)
     val accessionUrl = webAppUrls.fullAccession(event.accessionId, organizationId).toString()
     getRecipients(event.accessionId).forEach { user ->

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.StorageLocationNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import io.mockk.MockKMatcherScope
@@ -372,6 +373,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun readOrganizationUser() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.readOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<UserNotFoundException> {
+      requirements.readOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canReadOrganizationUser(organizationId, userId) }
+    requirements.readOrganizationUser(organizationId, userId)
+  }
+
+  @Test
   fun readSpecies() {
     assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
 
@@ -460,6 +476,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canSetTestClock() }
     requirements.setTestClock()
+  }
+
+  @Test
+  fun setWithdrawalUser() {
+    assertThrows<AccessionNotFoundException> { requirements.setWithdrawalUser(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    assertThrows<AccessDeniedException> { requirements.setWithdrawalUser(accessionId) }
+
+    grant { user.canSetWithdrawalUser(accessionId) }
+    requirements.setWithdrawalUser(accessionId)
   }
 
   @Test


### PR DESCRIPTION
We're adding a "withdrawn by" field to withdrawals; managers, admins, and owners
can set it to the identity of any user in the organization, but contributors can
only set it to themselves.

Add two permissions to support this logic:

* `canReadOrganizationUser` is true if you have permission to read the membership
  information for a given user in a given organization.
* `canSetWithdrawalUser` is true if you have permission to set the user ID on a
  withdrawal for an accession.

No application code uses these new permissions yet; this is groundwork for a
subsequent change.