### PR TITLE
SW-1512 Track withdrawal user IDs

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -109,11 +109,13 @@ val ID_WRAPPERS =
             "UserId",
             listOf(
                 "users\\.id",
+                "withdrawals\\.withdrawn_by",
                 ".*\\.user_id",
                 ".*\\.created_by",
                 ".*\\.deleted_by",
                 ".*\\.modified_by",
-                ".*\\.updated_by")),
+                ".*\\.updated_by",
+            )),
         IdWrapper(
             "ViabilityTestId",
             listOf(

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -67,6 +67,9 @@ class SecurityConfig(private val userStore: UserStore) : KeycloakWebSecurityConf
         // Allow unauthenticated users to fetch the endpoint that redirects them to the login page.
         authorize("/api/v1/login", permitAll)
 
+        // Allow unauthenticated users to check their app versions for compatibility.
+        authorize("/api/v1/versions", permitAll)
+
         authorize("/api/**", fullyAuthenticated)
         authorize("/admin/**", fullyAuthenticated)
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -627,6 +627,7 @@ class AdminController(
           AppVersionsRow(appName, platform, minimumVersion, recommendedVersion))
       redirectAttributes.successMessage = "App version updated."
     } catch (e: DuplicateKeyException) {
+      // User edited the appName/platform to collide with an existing one.
       redirectAttributes.failureMessage = "An entry for that app name and platform already exists."
     } catch (e: Exception) {
       log.error("Failed to update app version", e)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
@@ -1,0 +1,34 @@
+package com.terraformation.backend.customer.api
+
+import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.db.AppVersionStore
+import com.terraformation.backend.db.tables.pojos.AppVersionsRow
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@CustomerEndpoint
+@RequestMapping("/api/v1/versions")
+@RestController
+class VersionsController(private val appVersionStore: AppVersionStore) {
+  @GetMapping
+  fun getVersions(): VersionsResponsePayload {
+    val entries = appVersionStore.findAll().map { VersionsEntryPayload(it) }
+    return VersionsResponsePayload(entries)
+  }
+}
+
+data class VersionsResponsePayload(val versions: List<VersionsEntryPayload>) :
+    SuccessResponsePayload
+
+data class VersionsEntryPayload(
+    val appName: String,
+    val platform: String,
+    val minimumVersion: String,
+    val recommendedVersion: String,
+) {
+  constructor(
+      row: AppVersionsRow
+  ) : this(row.appName!!, row.platform!!, row.minimumVersion!!, row.recommendedVersion!!)
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
@@ -1,0 +1,51 @@
+package com.terraformation.backend.customer.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tables.daos.AppVersionsDao
+import com.terraformation.backend.db.tables.pojos.AppVersionsRow
+import com.terraformation.backend.db.tables.references.APP_VERSIONS
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+@ManagedBean
+class AppVersionStore(
+    private val appVersionsDao: AppVersionsDao,
+    private val dslContext: DSLContext
+) {
+  fun findAll(): List<AppVersionsRow> {
+    return dslContext
+        .selectFrom(APP_VERSIONS)
+        .orderBy(APP_VERSIONS.APP_NAME, APP_VERSIONS.PLATFORM)
+        .fetchInto(AppVersionsRow::class.java)
+  }
+
+  fun create(row: AppVersionsRow) {
+    requirePermissions { updateAppVersions() }
+
+    appVersionsDao.insert(row)
+  }
+
+  fun update(original: AppVersionsRow, desired: AppVersionsRow) {
+    requirePermissions { updateAppVersions() }
+
+    dslContext
+        .update(APP_VERSIONS)
+        .set(APP_VERSIONS.APP_NAME, desired.appName)
+        .set(APP_VERSIONS.PLATFORM, desired.platform)
+        .set(APP_VERSIONS.MINIMUM_VERSION, desired.minimumVersion)
+        .set(APP_VERSIONS.RECOMMENDED_VERSION, desired.recommendedVersion)
+        .where(APP_VERSIONS.APP_NAME.eq(original.appName))
+        .and(APP_VERSIONS.PLATFORM.eq(original.platform))
+        .execute()
+  }
+
+  fun delete(appName: String, platform: String) {
+    requirePermissions { updateAppVersions() }
+
+    dslContext
+        .deleteFrom(APP_VERSIONS)
+        .where(APP_VERSIONS.APP_NAME.eq(appName))
+        .and(APP_VERSIONS.PLATFORM.eq(platform))
+        .execute()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -125,6 +125,8 @@ data class DeviceManagerUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
+  override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      false
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
@@ -135,6 +137,7 @@ data class DeviceManagerUser(
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       false
   override fun canSetTestClock(): Boolean = false
+  override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
   override fun canUpdateAppVersions(): Boolean = false
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -136,6 +136,7 @@ data class DeviceManagerUser(
       false
   override fun canSetTestClock(): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
+  override fun canUpdateAppVersions(): Boolean = false
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false
   override fun canUpdateDeviceTemplates(): Boolean = false
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -326,6 +326,10 @@ data class IndividualUser(
     return canReadAccession(accessionId)
   }
 
+  override fun canUpdateAppVersions(): Boolean {
+    return userType == UserType.SuperAdmin
+  }
+
   override fun canUpdateAutomation(automationId: AutomationId): Boolean {
     val facilityId = parentStore.getFacilityId(automationId) ?: return false
     return canUpdateFacility(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import org.springframework.security.access.AccessDeniedException
@@ -284,6 +285,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readOrganizationUser(organizationId: OrganizationId, userId: UserId) {
+    if (!user.canReadOrganizationUser(organizationId, userId)) {
+      readOrganization(organizationId)
+      throw UserNotFoundException(userId)
+    }
+  }
+
   fun readSpecies(speciesId: SpeciesId) {
     if (!user.canReadSpecies(speciesId)) {
       throw SpeciesNotFoundException(speciesId)
@@ -346,6 +354,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun setTestClock() {
     if (!user.canSetTestClock()) {
       throw AccessDeniedException("No permission to set test clock")
+    }
+  }
+
+  fun setWithdrawalUser(accessionId: AccessionId) {
+    if (!user.canSetWithdrawalUser(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to set withdrawal user for accession $accessionId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -363,6 +363,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateAppVersions() {
+    if (!user.canUpdateAppVersions()) {
+      throw AccessDeniedException("No permission to update app versions")
+    }
+  }
+
   fun updateAutomation(automationId: AutomationId) {
     if (!user.canUpdateAutomation(automationId)) {
       readAutomation(automationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -142,6 +142,7 @@ class SystemUser(
   override fun canSetTestClock(): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
+  override fun canUpdateAppVersions(): Boolean = true
   override fun canUpdateAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateDevice(deviceId: DeviceId): Boolean = true
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -128,6 +128,8 @@ class SystemUser(
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
   override fun canReadNotification(notificationId: NotificationId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
+  override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
@@ -140,6 +142,7 @@ class SystemUser(
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true
   override fun canSetTestClock(): Boolean = true
+  override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
   override fun canUpdateAppVersions(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -105,6 +105,7 @@ interface TerrawareUser : Principal {
   fun canSetTestClock(): Boolean
   fun canTriggerAutomation(automationId: AutomationId): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean
+  fun canUpdateAppVersions(): Boolean
   fun canUpdateAutomation(automationId: AutomationId): Boolean
   fun canUpdateDevice(deviceId: DeviceId): Boolean
   fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -93,6 +93,7 @@ interface TerrawareUser : Principal {
   fun canReadFacility(facilityId: FacilityId): Boolean
   fun canReadNotification(notificationId: NotificationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
+  fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
@@ -103,6 +104,7 @@ interface TerrawareUser : Principal {
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
   fun canSetTestClock(): Boolean
+  fun canSetWithdrawalUser(accessionId: AccessionId): Boolean
   fun canTriggerAutomation(automationId: AutomationId): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean
   fun canUpdateAppVersions(): Boolean

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -153,7 +153,9 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: AccessionDryingEndEvent) {
-    val organizationId = parentStore.getOrganizationId(event.accessionId)
+    val organizationId =
+        parentStore.getOrganizationId(event.accessionId)
+            ?: throw AccessionNotFoundException(event.accessionId)
     val facilityName = parentStore.getFacilityName(event.accessionId)
     val accessionUrl = webAppUrls.fullAccession(event.accessionId, organizationId).toString()
     getRecipients(event.accessionId).forEach { user ->

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -130,19 +130,6 @@ class Messages {
     }
   }
 
-  /**
-   * Returns the full name of a user based on their first and last names. It's possible for users to
-   * not have first or last names, e.g., if they were created by being added to an organization and
-   * haven't gone through the registration flow yet; returns null in that case. If the user has only
-   * a first name or only a last name, returns whichever name exists.
-   */
-  fun userFullName(firstName: String?, lastName: String?): String? =
-      if (firstName != null && lastName != null) {
-        "$firstName $lastName"
-      } else {
-        lastName ?: firstName
-      }
-
   private fun seedQuantity(quantity: SeedQuantityModel): String {
     val unitsWord =
         if (quantity.quantity.equalsIgnoreScale(BigDecimal.ONE)) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.seedbank.AccessionService
 import com.terraformation.backend.seedbank.db.ViabilityTestStore
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import javax.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -105,12 +106,14 @@ data class GetViabilityTestPayload(
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
     val treatment: ViabilityTestTreatment? = null,
-    val testingStaffName: String? = null,
-    val testingStaffUserId: UserId? = null,
     val testResults: List<ViabilityTestResultPayload>? = null,
     val testType: ViabilityTestType,
     val totalPercentGerminated: Int? = null,
     val totalSeedsGerminated: Int? = null,
+    @Schema(description = "Full name of user who withdrew seeds to perform the test.")
+    val withdrawnByName: String? = null,
+    @Schema(description = "ID of user who withdrew seeds to perform the test.")
+    val withdrawnByUserId: UserId? = null,
 ) {
   constructor(
       model: ViabilityTestModel
@@ -123,13 +126,13 @@ data class GetViabilityTestPayload(
       seedType = model.seedType,
       startDate = model.startDate,
       substrate = model.substrate,
-      testingStaffName = model.staffResponsible,
-      testingStaffUserId = null,
       testResults = model.testResults?.map { ViabilityTestResultPayload(it) },
       testType = model.testType,
       totalPercentGerminated = model.totalPercentGerminated,
       totalSeedsGerminated = model.totalSeedsGerminated,
       treatment = model.treatment,
+      withdrawnByName = model.withdrawnByName,
+      withdrawnByUserId = model.withdrawnByUserId,
   )
 }
 
@@ -143,9 +146,14 @@ data class CreateViabilityTestRequestPayload(
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
-    val testingStaffUserId: UserId? = null,
     val testType: ViabilityTestType,
     val treatment: ViabilityTestTreatment? = null,
+    @Schema(
+        description =
+            "ID of user who withdrew seeds to perform the test. Defaults to the current user. If " +
+                "non-null, the current user must have permission to see the referenced user's " +
+                "membership details in the organization.")
+    val withdrawnByUserId: UserId? = null,
 ) {
   fun toModel(accessionId: AccessionId) =
       ViabilityTestModel(
@@ -158,6 +166,7 @@ data class CreateViabilityTestRequestPayload(
           substrate = substrate,
           testType = testType,
           treatment = treatment,
+          withdrawnByUserId = withdrawnByUserId,
       )
 }
 
@@ -171,10 +180,15 @@ data class UpdateViabilityTestRequestPayload(
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
-    val testingStaffUserId: UserId? = null,
     @Valid val testResults: List<ViabilityTestResultPayload>? = null,
     val testType: ViabilityTestType,
     val treatment: ViabilityTestTreatment? = null,
+    @Schema(
+        description =
+            "ID of user who withdrew seeds to perform the test. If non-null, the current user " +
+                "must have permission to see the referenced user's membership details in the " +
+                "organization. If absent or null, the existing value is left unchanged.")
+    val withdrawnByUserId: UserId? = null,
 ) {
   fun applyToModel(model: ViabilityTestModel): ViabilityTestModel =
       model.copy(
@@ -187,6 +201,7 @@ data class UpdateViabilityTestRequestPayload(
           testResults = testResults?.map { it.toModel() },
           testType = testType,
           treatment = treatment,
+          withdrawnByUserId = withdrawnByUserId ?: model.withdrawnByUserId,
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/WithdrawalsController.kt
@@ -144,8 +144,8 @@ data class GetWithdrawalPayload(
       purpose = model.purpose,
       notes = model.notes,
       viabilityTestId = model.viabilityTestId,
-      withdrawnByName = model.staffResponsible,
-      withdrawnByUserId = null,
+      withdrawnByName = model.withdrawnByName,
+      withdrawnByUserId = model.withdrawnByUserId,
       withdrawnQuantity = model.withdrawn?.toPayload(),
   )
 }
@@ -159,12 +159,9 @@ data class CreateWithdrawalRequestPayload(
     val notes: String? = null,
     @Schema(
         description =
-            "ID of the user who withdrew the seeds. Default for new withdrawals is the current " +
-                "user; for existing withdrawals, default is the withdrawal's existing user ID. " +
-                "Ignored if the current user does not have permission to list organization " +
-                "users. " +
-                "V1 COMPATIBILITY: If this is null and the withdrawal doesn't have a user ID, " +
-                "the existing \"staffResponsible\" value will be preserved.")
+            "ID of the user who withdrew the seeds. Default is the current user's ID. If " +
+                "non-null, the current user must have permission to read the referenced user's " +
+                "membership details in the organization.")
     val withdrawnByUserId: UserId? = null,
     @Schema(
         description =
@@ -192,12 +189,9 @@ data class UpdateWithdrawalRequestPayload(
     val notes: String? = null,
     @Schema(
         description =
-            "ID of the user who withdrew the seeds. Default for new withdrawals is the current " +
-                "user; for existing withdrawals, default is the withdrawal's existing user ID. " +
-                "Ignored if the current user does not have permission to list organization " +
-                "users. " +
-                "V1 COMPATIBILITY: If this is null and the withdrawal doesn't have a user ID, " +
-                "the existing \"staffResponsible\" value will be preserved.")
+            "ID of the user who withdrew the seeds. Default is the withdrawal's existing user " +
+                "ID. If non-null, the current user must have permission to read the referenced " +
+                "user's membership details in the organization.")
     val withdrawnByUserId: UserId? = null,
     @Schema(
         description =
@@ -214,6 +208,7 @@ data class UpdateWithdrawalRequestPayload(
           purpose = purpose,
           notes = notes,
           withdrawn = withdrawnQuantity?.toModel(),
+          withdrawnByUserId = withdrawnByUserId ?: model.withdrawnByUserId,
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.AccessionId
 import com.terraformation.backend.db.AccessionNotFoundException
@@ -508,7 +509,7 @@ class AccessionStore(
               val oldState = record[ACCESSION_STATE_HISTORY.OLD_STATE_ID]
               val userId = record[ACCESSION_STATE_HISTORY.UPDATED_BY]!!
               val fullName =
-                  messages.userFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME])
+                  IndividualUser.makeFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME])
 
               if (oldState == null) {
                 AccessionHistoryModel(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -613,6 +613,7 @@ data class AccessionModel(
               viabilityTestId = test.id,
               weightDifference = existingWithdrawal?.weightDifference,
               withdrawn = withdrawn,
+              withdrawnByUserId = test.withdrawnByUserId ?: existingWithdrawal?.withdrawnByUserId,
           )
         }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.model
 
 import com.terraformation.backend.db.AccessionId
+import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestResultId
 import com.terraformation.backend.db.ViabilityTestSeedType
@@ -32,6 +33,8 @@ data class ViabilityTestModel(
     val staffResponsible: String? = null,
     val testResults: Collection<ViabilityTestResultModel>? = null,
     val remaining: SeedQuantityModel? = null,
+    val withdrawnByUserId: UserId? = null,
+    val withdrawnByName: String? = null,
 ) {
   fun validateV2() {
     val isLab = testType == ViabilityTestType.Lab
@@ -97,7 +100,8 @@ data class ViabilityTestModel(
         testType == other.testType &&
         totalPercentGerminated == other.totalPercentGerminated &&
         totalSeedsGerminated == other.totalSeedsGerminated &&
-        treatment == other.treatment
+        treatment == other.treatment &&
+        withdrawnByUserId == other.withdrawnByUserId
   }
 
   fun calculateLatestRecordingDate(): LocalDate? {

--- a/src/main/resources/db/migration/R__AppVersions.sql
+++ b/src/main/resources/db/migration/R__AppVersions.sql
@@ -1,0 +1,9 @@
+-- Minimum versions of mobile apps are configured here. The statements here will only be run when
+-- this file has changed since the last time terraware-server was launched; if it hasn't, any
+-- local modifications to the version data won't be affected by a server restart.
+
+DELETE FROM app_versions;
+
+INSERT INTO app_versions (app_name, platform, minimum_version, recommended_version)
+VALUES ('SeedCollector', 'Android', '0.0.1', '0.0.1'),
+       ('SeedCollector', 'iOS',     '0.0.1', '0.0.1');

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -31,6 +31,8 @@ COMMENT ON COLUMN accessions.nursery_start_date IS 'When the accession was moved
 COMMENT ON COLUMN accessions.target_storage_condition IS 'The intended storage condition of the accession as determined during initial processing.';
 COMMENT ON COLUMN accessions.total_viability_percent IS 'Percentage of viable seeds across all tests.';
 
+COMMENT ON TABLE app_versions IS 'Minimum and recommended versions for Terraware mobile apps.';
+
 COMMENT ON TABLE automations IS 'Configuration of automatic processes run by the device manager.';
 
 COMMENT ON TABLE bags IS 'Individual bags of seeds that are part of an accession. An accession can consist of multiple bags.';

--- a/src/main/resources/db/migration/V129__AppVersions.sql
+++ b/src/main/resources/db/migration/V129__AppVersions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE app_versions (
+    app_name TEXT NOT NULL,
+    platform TEXT NOT NULL,
+    minimum_version TEXT NOT NULL,
+    recommended_version TEXT NOT NULL,
+    PRIMARY KEY (app_name, platform)
+);

--- a/src/main/resources/db/migration/V130__WIthdrawalsCreatedBy.sql
+++ b/src/main/resources/db/migration/V130__WIthdrawalsCreatedBy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE withdrawals ADD COLUMN created_by BIGINT REFERENCES users;
+ALTER TABLE withdrawals ADD COLUMN withdrawn_by BIGINT REFERENCES users;

--- a/src/main/resources/templates/admin/appVersions.html
+++ b/src/main/resources/templates/admin/appVersions.html
@@ -1,0 +1,88 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/admin/header :: head"/>
+<body>
+
+<span th:include="/admin/header :: top"/>
+
+<a th:href="|${prefix}/|">Home</a>
+
+<h2>App Versions</h2>
+
+<table>
+    <thead>
+    <tr>
+        <th>App Name</th>
+        <th>Platform</th>
+        <th>Minimum</th>
+        <th>Recommended</th>
+        <th></th>
+        <th></th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <tr th:each="appVersion : ${appVersions}">
+        <td>
+            <form method="POST" th:action="|${prefix}/updateAppVersion|"
+                  th:id="|${appVersion.appName}-${appVersion.platform}|">
+                <input type="hidden" name="originalAppName" th:value="${appVersion.appName}"/>
+                <input type="hidden" name="originalPlatform" th:value="${appVersion.platform}"/>
+                <input type="text" name="appName" required th:value="${appVersion.appName}"/>
+            </form>
+        </td>
+        <td>
+            <input type="text" name="platform" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.platform}"/>
+        </td>
+        <td>
+            <input type="text" name="minimumVersion" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.minimumVersion}"/>
+        </td>
+        <td>
+            <input type="text" name="recommendedVersion" required
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   th:value="${appVersion.recommendedVersion}"/>
+        </td>
+        <td>
+            <input type="submit"
+                   th:form="|${appVersion.appName}-${appVersion.platform}|"
+                   value="Update"/>
+        </td>
+        <td>
+            <form method="POST" th:action="|${prefix}/deleteAppVersion|">
+                <input type="hidden" name="appName" th:value="${appVersion.appName}"/>
+                <input type="hidden" name="platform" th:value="${appVersion.platform}"/>
+                <input type="submit" value="Delete"/>
+            </form>
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+            <form method="POST" th:action="|${prefix}/createAppVersion|" id="create">
+                <input type="text" name="appName" required/>
+            </form>
+        </td>
+        <td>
+            <input type="text" name="platform" required form="create"/>
+        </td>
+        <td>
+            <input type="text" name="minimumVersion" required form="create"/>
+        </td>
+        <td>
+            <input type="text" name="recommendedVersion" required form="create"/>
+        </td>
+        <td>
+            <input type="submit" form="create" value="Create"/>
+        </td>
+        <td></td>
+    </tr>
+
+    </tbody>
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -40,6 +40,14 @@
     <a th:href="|${prefix}/deviceTemplates|">Device Templates</a>
 </p>
 
+<div th:if="${canUpdateAppVersions}">
+    <h2>App Versions</h2>
+
+    <p>
+        <a th:href="|${prefix}/appVersions|">Update app versions</a>
+    </p>
+</div>
+
 <div th:if="${canSetTestClock}">
     <h2>Test utilities</h2>
 

--- a/src/test/kotlin/com/terraformation/backend/MockUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/MockUser.kt
@@ -16,6 +16,7 @@ fun mockUser(userId: UserId = UserId(2)): IndividualUser {
   every { user.authId } returns "$userId"
   every { user.firstName } returns "First"
   every { user.lastName } returns "Last"
+  every { user.fullName } returns "First Last"
   every { user.userType } returns UserType.Individual
 
   val funcSlot = CapturingSlot<() -> Any>()

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -95,7 +95,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             ViabilityTestStore(dslContext),
             parentStore,
             mockk(),
-            WithdrawalStore(dslContext, clock, mockk()),
+            WithdrawalStore(dslContext, clock, mockk(), parentStore),
             clock,
             mockk(),
         )

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -485,6 +485,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun updateAppVersions() {
+    assertThrows<AccessDeniedException> { requirements.updateAppVersions() }
+
+    grant { user.canUpdateAppVersions() }
+    requirements.updateAppVersions()
+  }
+
+  @Test
   fun updateAutomation() {
     assertThrows<AutomationNotFoundException> { requirements.updateAutomation(automationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.StorageLocationNotFoundException
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotFoundException
 import com.terraformation.backend.db.UserId
+import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import io.mockk.MockKMatcherScope
@@ -372,6 +373,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun readOrganizationUser() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.readOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<UserNotFoundException> {
+      requirements.readOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canReadOrganizationUser(organizationId, userId) }
+    requirements.readOrganizationUser(organizationId, userId)
+  }
+
+  @Test
   fun readSpecies() {
     assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
 
@@ -460,6 +476,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canSetTestClock() }
     requirements.setTestClock()
+  }
+
+  @Test
+  fun setWithdrawalUser() {
+    assertThrows<AccessionNotFoundException> { requirements.setWithdrawalUser(accessionId) }
+
+    grant { user.canReadAccession(accessionId) }
+    assertThrows<AccessDeniedException> { requirements.setWithdrawalUser(accessionId) }
+
+    grant { user.canSetWithdrawalUser(accessionId) }
+    requirements.setWithdrawalUser(accessionId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -601,6 +601,7 @@ internal class PermissionTest : DatabaseTest() {
         importGlobalSpeciesData = true,
         regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
+        updateAppVersions = true,
         updateDeviceTemplates = true,
     )
   }
@@ -914,6 +915,7 @@ internal class PermissionTest : DatabaseTest() {
         importGlobalSpeciesData: Boolean = false,
         regenerateAllDeviceManagerTokens: Boolean = false,
         setTestClock: Boolean = false,
+        updateAppVersions: Boolean = false,
         updateDeviceTemplates: Boolean = false,
     ) {
       assertEquals(createDeviceManager, user.canCreateDeviceManager(), "Can create device manager")
@@ -926,6 +928,7 @@ internal class PermissionTest : DatabaseTest() {
           user.canRegenerateAllDeviceManagerTokens(),
           "Can regenerate all device manager tokens")
       assertEquals(setTestClock, user.canSetTestClock(), "Can set test clock")
+      assertEquals(updateAppVersions, user.canUpdateAppVersions(), "Can update app versions")
       assertEquals(
           updateDeviceTemplates, user.canUpdateDeviceTemplates(), "Can update device templates")
 

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -126,6 +126,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "accession_state_history" to setOf(ALL, SEEDBANK),
           "accession_states" to setOf(ALL, SEEDBANK),
           "accessions" to setOf(ALL, SEEDBANK),
+          "app_versions" to setOf(ALL, CUSTOMER),
           "automations" to setOf(ALL, DEVICE),
           "bags" to setOf(ALL, SEEDBANK),
           "collection_sources" to setOf(ALL, SEEDBANK),


### PR DESCRIPTION
Store the withdrawn-by user ID the client can optionally include in v2 withdrawal
API payloads, and return the user ID and full name in v2 withdrawal response
payloads. These fields were already present in the payloads, but didn't do
anything previously.

For viability tests, replace `testingStaffUserId` and `testingStaffName` with
`withdrawnByUserId` and `withdrawnByName`. Initially we'd understood the product
requirements to mean we needed to track separate user IDs for tests and
withdrawals, but it turns out there's only one. The new name should make the
semantics clearer at the API level.

Setting the withdrawn-by user ID via either API is subject to permissions:

* You can only set it to the ID of a user who is currently in the organization.
* If you are a contributor user, you can't set it to another user's ID; it will
  always default to you for newly-added withdrawals and it will always be ignored
  when you edit existing withdrawals.
* If you are editing an existing withdrawal, the withdrawal's existing user ID
  is always allowed, regardless of the other rules above. That is, you won't get
  a permission error if you leave it as is, even if the user in question is no
  longer in the organization or you're a contributor.

The history API is updated to return withdrawal user IDs where available and to
return the withdrawing user's full name rather than the `staffResponsible` field
when a user ID is present.