### PR TITLE
Rename UserDeletedEvent for clarity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
 import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.OrganizationHasOtherUsersException
@@ -64,7 +64,7 @@ class OrganizationService(
   }
 
   @EventListener
-  fun on(event: UserDeletedEvent) {
+  fun on(event: UserDeletionStartedEvent) {
     val user = userStore.fetchOneById(event.userId)
 
     dslContext.transaction { _ ->

--- a/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.customer.model.NotificationCountModel
 import com.terraformation.backend.customer.model.NotificationModel
@@ -124,7 +124,7 @@ class NotificationStore(
   }
 
   @EventListener
-  fun on(event: UserDeletedEvent) {
+  fun on(event: UserDeletionStartedEvent) {
     dslContext.deleteFrom(NOTIFICATIONS).where(NOTIFICATIONS.USER_ID.eq(event.userId)).execute()
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.DeviceManagerUser
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.Role
@@ -474,7 +474,7 @@ class UserStore(
 
       // Handlers in other parts of the system will clean up dangling references to the user. Event
       // handlers run synchronously in the same transaction as the deletion.
-      publisher.publishEvent(UserDeletedEvent(user.userId))
+      publisher.publishEvent(UserDeletionStartedEvent(user.userId))
 
       // Keycloak account deletion should come last because it can't be rolled back if some other
       // step in the deletion process fails.

--- a/src/main/kotlin/com/terraformation/backend/customer/event/UserDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/UserDeletedEvent.kt
@@ -1,5 +1,0 @@
-package com.terraformation.backend.customer.event
-
-import com.terraformation.backend.db.UserId
-
-data class UserDeletedEvent(val userId: UserId)

--- a/src/main/kotlin/com/terraformation/backend/customer/event/UserDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/UserDeletionStartedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.UserId
+
+/**
+ * Published when we start deleting a user's data from the database, but before the user has
+ * actually been deleted.
+ */
+data class UserDeletionStartedEvent(val userId: UserId)

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -140,7 +140,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `UserDeletedEvent handler removes user from all their organizations`() {
+  fun `UserDeletionStartedEvent handler removes user from all their organizations`() {
     val otherUserId = UserId(100)
     val soloOrganizationId1 = OrganizationId(1)
     val soloOrganizationId2 = OrganizationId(2)
@@ -163,7 +163,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
     every { publisher.publishEvent(any<OrganizationAbandonedEvent>()) } just Runs
 
-    service.on(UserDeletedEvent(user.userId))
+    service.on(UserDeletionStartedEvent(user.userId))
 
     val expectedOrganizationUsers =
         setOf(

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsUser
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.customer.model.NotificationModel
 import com.terraformation.backend.customer.model.Role
@@ -248,7 +248,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
     store.create(notificationModel(), organizationId)
     store.create(notificationModel(true), organizationId)
 
-    store.on(UserDeletedEvent(user.userId))
+    store.on(UserDeletionStartedEvent(user.userId))
 
     assertEquals(notificationsForOtherUser, notificationsDao.findAll())
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.config.TerrawareServerConfig
-import com.terraformation.backend.customer.event.UserDeletedEvent
+import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.DeviceManagerUser
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.Role
@@ -518,7 +518,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   inner class DeleteSelf {
     @BeforeEach
     fun setUp() {
-      every { publisher.publishEvent(any<UserDeletedEvent>()) } just Runs
+      every { publisher.publishEvent(any<UserDeletionStartedEvent>()) } just Runs
       every { user.authId } returns authId
       every { user.canDeleteSelf() } returns true
     }
@@ -560,7 +560,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
       userStore.deleteSelf()
 
-      val expectedEvent = UserDeletedEvent(user.userId)
+      val expectedEvent = UserDeletionStartedEvent(user.userId)
       verify { publisher.publishEvent(expectedEvent) }
     }
 


### PR DESCRIPTION
The event class name implies the user has already been deleted, but the
event really means we're _about to start_ deleting the user. Rename it
to make this more self-evident.