### PR TITLE
SW-931 Purge data when organization is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -212,13 +212,15 @@ class OrganizationStore(
   }
 
   fun fetchOrganizationIds(userId: UserId): List<OrganizationId> {
+    val user = currentUser()
+
     return dslContext
         .select(ORGANIZATION_USERS.ORGANIZATION_ID)
         .from(ORGANIZATION_USERS)
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
         .fetch(ORGANIZATION_USERS.ORGANIZATION_ID)
         .filterNotNull()
-        .filter { currentUser().canListOrganizationUsers(it) }
+        .filter { user.userId == userId || user.canListOrganizationUsers(it) }
   }
 
   private fun queryOrganizationUsers(condition: Condition): List<OrganizationUserModel> {

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletionStartedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.OrganizationId
+
+/**
+ * Published when we start deleting all the data related to an organization, but before the
+ * organization has actually been deleted from the database.
+ */
+data class OrganizationDeletionStartedEvent(val organizationId: OrganizationId)

--- a/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.OrganizationId
@@ -148,6 +149,11 @@ class UploadService(
 
       log.debug("Deleted expired upload $uploadId")
     }
+  }
+
+  @EventListener
+  fun on(event: OrganizationDeletionStartedEvent) {
+    uploadStore.fetchIdsByOrganization(event.organizationId).forEach { delete(it) }
   }
 
   companion object {

--- a/src/main/resources/db/migration/V132__OrganizationsCascadeDeletes.sql
+++ b/src/main/resources/db/migration/V132__OrganizationsCascadeDeletes.sql
@@ -1,0 +1,79 @@
+-- The foreign-key constraints on various descendants of the organizations table didn't support
+-- cascading deletes because originally we didn't allow deleting organizations (or rather, we
+-- didn't actually delete the underlying data, just made it inaccessible). Now we're adding
+-- support for true deletion, so switch to cascading deletion.
+--
+-- We don't cascade to tables that have references to external resources, e.g., URLs of photos on
+-- file stores. Those need to be deleted by application code that can also remove the external
+-- resources. We also don't cascade deletes from reference tables since deleting an enum value
+-- that's still in use is a code bug.
+--
+-- A few of the constraints we're replacing here were created prior to some changes in our table
+-- names; create them with names that follow the current naming conventions.
+
+ALTER TABLE accessions DROP CONSTRAINT accession_site_module_id_fkey;
+ALTER TABLE accessions ADD CONSTRAINT accessions_facility_id_fkey
+    FOREIGN KEY (facility_id) REFERENCES facilities (id) ON DELETE CASCADE;
+
+ALTER TABLE automations DROP CONSTRAINT automations_device_id_fkey;
+ALTER TABLE automations ADD CONSTRAINT automations_device_id_fkey
+    FOREIGN KEY (device_id) REFERENCES devices (id) ON DELETE CASCADE;
+
+ALTER TABLE automations DROP CONSTRAINT automations_facility_id_fkey;
+ALTER TABLE automations ADD CONSTRAINT automations_facility_id_fkey
+    FOREIGN KEY (facility_id) REFERENCES facilities (id) ON DELETE CASCADE;
+
+ALTER TABLE devices DROP CONSTRAINT device_site_module_id_fkey;
+ALTER TABLE devices ADD CONSTRAINT devices_facility_id_fkey
+    FOREIGN KEY (facility_id) REFERENCES facilities (id) ON DELETE CASCADE;
+
+ALTER TABLE facilities DROP CONSTRAINT facilities_organization_id_fkey;
+ALTER TABLE facilities ADD CONSTRAINT facilities_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE notifications DROP CONSTRAINT notifications_organization_id_fkey;
+ALTER TABLE notifications ADD CONSTRAINT notifications_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE organization_users DROP CONSTRAINT organization_users_organization_id_fkey;
+ALTER TABLE organization_users ADD CONSTRAINT organization_users_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE species DROP CONSTRAINT species_organization_id_fkey;
+ALTER TABLE species ADD CONSTRAINT species_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE species_problems DROP CONSTRAINT species_problems_species_id_fkey;
+ALTER TABLE species_problems ADD CONSTRAINT species_problems_species_id_fkey
+    FOREIGN KEY (species_id) REFERENCES species (id) ON DELETE CASCADE;
+
+ALTER TABLE storage_locations DROP CONSTRAINT storage_location_site_module_id_fkey;
+ALTER TABLE storage_locations ADD CONSTRAINT storage_locations_facility_id_fkey
+    FOREIGN KEY (facility_id) REFERENCES facilities (id) ON DELETE CASCADE;
+
+ALTER TABLE timeseries DROP CONSTRAINT timeseries_device_id_fkey;
+ALTER TABLE timeseries ADD CONSTRAINT timeseries_device_id_fkey
+    FOREIGN KEY (device_id) REFERENCES devices (id) ON DELETE CASCADE;
+
+-- Adding a constraint holds an exclusive lock on the table. Most of our tables are currently small
+-- enough that the lock isn't held for long enough to cause problems. But this is a large table and
+-- validating the foreign keys on the existing rows is not a quick operation.
+--
+-- Mark the constraint as NOT VALID here, and then validate it in a separate migration. A NOT VALID
+-- constraint still does what we want: it is checked on insert and update, and deletes get cascaded
+-- correctly.
+ALTER TABLE timeseries_values DROP CONSTRAINT timeseries_value_timeseries_id_fkey;
+ALTER TABLE timeseries_values ADD CONSTRAINT timeseries_values_timeseries_id_fkey
+    FOREIGN KEY (timeseries_id) REFERENCES timeseries (id) ON DELETE CASCADE NOT VALID;
+
+ALTER TABLE upload_problems DROP CONSTRAINT upload_problems_upload_id_fkey;
+ALTER TABLE upload_problems ADD CONSTRAINT upload_problems_upload_id_fkey
+    FOREIGN KEY (upload_id) REFERENCES uploads (id) ON DELETE CASCADE;
+
+ALTER TABLE uploads DROP CONSTRAINT uploads_organization_id_fkey;
+ALTER TABLE uploads ADD CONSTRAINT uploads_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_organization_id_fkey;
+ALTER TABLE user_preferences ADD CONSTRAINT user_preferences_organization_id_fkey
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V132__OrganizationsCascadeDeletes.sql
+++ b/src/main/resources/db/migration/V132__OrganizationsCascadeDeletes.sql
@@ -70,10 +70,6 @@ ALTER TABLE upload_problems DROP CONSTRAINT upload_problems_upload_id_fkey;
 ALTER TABLE upload_problems ADD CONSTRAINT upload_problems_upload_id_fkey
     FOREIGN KEY (upload_id) REFERENCES uploads (id) ON DELETE CASCADE;
 
-ALTER TABLE uploads DROP CONSTRAINT uploads_organization_id_fkey;
-ALTER TABLE uploads ADD CONSTRAINT uploads_organization_id_fkey
-    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;
-
 ALTER TABLE user_preferences DROP CONSTRAINT user_preferences_organization_id_fkey;
 ALTER TABLE user_preferences ADD CONSTRAINT user_preferences_organization_id_fkey
     FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V133__ValidateTimeseriesValues.sql
+++ b/src/main/resources/db/migration/V133__ValidateTimeseriesValues.sql
@@ -1,0 +1,7 @@
+-- The previous migration created the constraint on timeseries_values with the NOT VALID option to
+-- avoid holding an exclusive lock on it for an extended period of time. Validate the constraint
+-- in this separate migration, which will run in a new transaction and thus won't hold any locks
+-- acquired in the previous one. (Validating an existing constraint does not require an exclusive
+-- table lock.)
+
+ALTER TABLE timeseries_values VALIDATE CONSTRAINT timeseries_values_timeseries_id_fkey;

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -85,7 +85,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { realmResource.users() } returns mockk()
 
     notificationStore = NotificationStore(dslContext, clock)
-    organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
+    organizationStore = OrganizationStore(clock, dslContext, organizationsDao, mockk())
     parentStore = ParentStore(dslContext)
     accessionStore =
         AccessionStore(

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -110,7 +110,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     usersResource.create(userRepresentation)
 
-    organizationStore = OrganizationStore(clock, dslContext, organizationsDao)
+    organizationStore = OrganizationStore(clock, dslContext, organizationsDao, publisher)
     parentStore = ParentStore(dslContext)
     permissionStore = PermissionStore(dslContext)
 


### PR DESCRIPTION
When the last user is removed from an organization, delete its data.

Currently, a connected device manager counts as a user; if the organization has a
facility with a connected device manager, its data will not be removed from the
system when the last human user is removed.

Deployment note: The second database migration may take a while to run on the
production database, which may cause the deploy to look like it has gotten stuck.