### PR TITLE
Add test helper method to insert accession

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -6,10 +6,8 @@ import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.PermissionTest.PermissionsTracker
 import com.terraformation.backend.db.AccessionId
-import com.terraformation.backend.db.AccessionState
 import com.terraformation.backend.db.AutomationId
 import com.terraformation.backend.db.BalenaDeviceId
-import com.terraformation.backend.db.DataSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceId
 import com.terraformation.backend.db.DeviceManagerId
@@ -23,7 +21,6 @@ import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.UserType
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestType
-import com.terraformation.backend.db.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.tables.pojos.DeviceManagersRow
 import com.terraformation.backend.db.tables.pojos.ViabilityTestsRow
 import com.terraformation.backend.db.tables.references.ACCESSIONS
@@ -159,16 +156,7 @@ internal class PermissionTest : DatabaseTest() {
       insertFacility(facilityId, facilityId.value / 1000, createdBy = userId)
       insertDevice(facilityId.value, facilityId, createdBy = userId)
       insertAutomation(facilityId.value, facilityId, createdBy = userId)
-      accessionsDao.insert(
-          AccessionsRow(
-              id = AccessionId(facilityId.value),
-              facilityId = facilityId,
-              stateId = AccessionState.Pending,
-              createdBy = userId,
-              createdTime = Instant.EPOCH,
-              dataSourceId = DataSource.Web,
-              modifiedBy = userId,
-              modifiedTime = Instant.EPOCH))
+      insertAccession(id = facilityId.value, facilityId = facilityId, createdBy = userId)
       viabilityTestsDao.insert(
           ViabilityTestsRow(
               accessionId = AccessionId(facilityId.value),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1167,16 +1167,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 storageStartDate = tomorrow),
         )
 
-    (shouldMatch + shouldNotMatch).forEach { accession ->
-      accessionsDao.insert(
-          accession.copy(
-              createdBy = user.userId,
-              createdTime = clock.instant(),
-              dataSourceId = DataSource.Web,
-              facilityId = facilityId,
-              modifiedBy = user.userId,
-              modifiedTime = clock.instant()))
-    }
+    (shouldMatch + shouldNotMatch).forEach { insertAccession(it) }
 
     val expected = shouldMatch.map { it.number!! }.toSortedSet()
     val actual =
@@ -1799,17 +1790,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
 
       toCreate.forEach { (targetFacilityId, stateCounts) ->
         stateCounts.forEach { (state, count) ->
-          repeat(count) {
-            accessionsDao.insert(
-                AccessionsRow(
-                    createdBy = user.userId,
-                    createdTime = Instant.EPOCH,
-                    dataSourceId = DataSource.Web,
-                    facilityId = targetFacilityId,
-                    modifiedBy = user.userId,
-                    modifiedTime = Instant.EPOCH,
-                    stateId = state))
-          }
+          repeat(count) { insertAccession(facilityId = targetFacilityId, stateId = state) }
         }
       }
 
@@ -1919,15 +1900,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   subsetWeightGrams = BigDecimal(10),
               ),
           )
-          .forEach {
-            accessionsDao.insert(
-                it.copy(
-                    createdBy = user.userId,
-                    createdTime = clock.instant(),
-                    dataSourceId = DataSource.Web,
-                    modifiedBy = user.userId,
-                    modifiedTime = clock.instant()))
-          }
+          .forEach { insertAccession(it) }
 
       assertEquals(
           3,
@@ -2042,15 +2015,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   stateId = AccessionState.Processing,
               ),
           )
-          .forEach {
-            accessionsDao.insert(
-                it.copy(
-                    createdBy = user.userId,
-                    createdTime = clock.instant(),
-                    dataSourceId = DataSource.Web,
-                    modifiedBy = user.userId,
-                    modifiedTime = clock.instant()))
-          }
+          .forEach { insertAccession(it) }
 
       assertEquals(
           3,
@@ -2149,15 +2114,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   stateId = AccessionState.Processing,
               ),
           )
-          .forEach {
-            accessionsDao.insert(
-                it.copy(
-                    createdBy = user.userId,
-                    createdTime = clock.instant(),
-                    dataSourceId = DataSource.Web,
-                    modifiedBy = user.userId,
-                    modifiedTime = clock.instant()))
-          }
+          .forEach { insertAccession(it) }
 
       assertEquals(
           3,
@@ -2228,15 +2185,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   stateId = AccessionState.Pending,
               ),
           )
-          .forEach {
-            accessionsDao.insert(
-                it.copy(
-                    createdBy = user.userId,
-                    createdTime = clock.instant(),
-                    dataSourceId = DataSource.Web,
-                    modifiedBy = user.userId,
-                    modifiedTime = clock.instant()))
-          }
+          .forEach { insertAccession(it) }
 
       assertEquals(1, store.getSummaryStatistics(facilityId).species, "Species for single facility")
       assertEquals(


### PR DESCRIPTION
Reduce uninteresting boilerplate in tests by introducing a helper method to insert
accessions with reasonable defaults, similar to the other insert-a-value helpers.