### PR TITLE
SW-1694 Accept viability test results when creating test

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -146,6 +146,7 @@ data class CreateViabilityTestRequestPayload(
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
+    @Valid val testResults: List<ViabilityTestResultPayload>? = null,
     val testType: ViabilityTestType,
     val treatment: ViabilityTestTreatment? = null,
     @Schema(
@@ -164,6 +165,7 @@ data class CreateViabilityTestRequestPayload(
           seedType = seedType,
           startDate = startDate,
           substrate = substrate,
+          testResults = testResults?.map { it.toModel() },
           testType = testType,
           treatment = treatment,
           withdrawnByUserId = withdrawnByUserId,


### PR DESCRIPTION
To handle the case where a user is entering details about a test that has
already happened, allow test results to be included when initially creating
a viability test in the v2 API.