### PR TITLE
Alphabetize withdrawal and viability test models

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -676,16 +676,16 @@ data class ViabilityTestPayload(
 
   fun toModel() =
       ViabilityTestModel(
-          testResults = testResults?.map { it.toModel() },
-          id = id,
           endDate = endDate,
+          id = id,
           notes = notes,
+          remaining = remainingQuantity?.toModel(),
           seedsTested = seedsSown,
           seedType = seedType,
           staffResponsible = staffResponsible,
           startDate = startDate,
           substrate = substrate?.v2Type,
-          remaining = remainingQuantity?.toModel(),
+          testResults = testResults?.map { it.toModel() },
           testType = testType.v2Type,
           treatment = treatment?.v2Type,
       )
@@ -700,7 +700,7 @@ data class ViabilityTestResultPayload(
 ) {
   constructor(model: ViabilityTestResultModel) : this(model.recordingDate, model.seedsGerminated)
 
-  fun toModel() = ViabilityTestResultModel(null, null, recordingDate, seedsGerminated)
+  fun toModel() = ViabilityTestResultModel(null, recordingDate, seedsGerminated, null)
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -772,12 +772,12 @@ data class WithdrawalPayload(
       WithdrawalModel(
           date = date,
           destination = destination,
-          viabilityTestId = viabilityTestId,
           id = id,
           notes = notes,
           purpose = purpose,
           remaining = remainingQuantity?.toModel(),
           staffResponsible = staffResponsible,
+          viabilityTestId = viabilityTestId,
           withdrawn = withdrawnQuantity?.toModel(),
       )
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -97,23 +97,24 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
   ): ViabilityTestModel {
     return with(VIABILITY_TESTS) {
       ViabilityTestModel(
-          record[ID]!!,
-          record[ACCESSION_ID]!!,
-          record[TEST_TYPE]!!,
-          record[START_DATE],
-          record[END_DATE],
-          record[SEED_TYPE_ID],
-          record[SUBSTRATE_ID],
-          record[TREATMENT_ID],
-          record[SEEDS_SOWN],
-          record[TOTAL_PERCENT_GERMINATED],
-          record[TOTAL_SEEDS_GERMINATED],
-          record[NOTES],
-          record[STAFF_RESPONSIBLE],
-          record[viabilityTestResultsMultiset]?.ifEmpty { null },
-          SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
-          record[USERS.ID],
-          IndividualUser.makeFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME]),
+          accessionId = record[ACCESSION_ID]!!,
+          endDate = record[END_DATE],
+          id = record[ID]!!,
+          notes = record[NOTES],
+          remaining = SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
+          seedsTested = record[SEEDS_SOWN],
+          seedType = record[SEED_TYPE_ID],
+          staffResponsible = record[STAFF_RESPONSIBLE],
+          startDate = record[START_DATE],
+          substrate = record[SUBSTRATE_ID],
+          testResults = record[viabilityTestResultsMultiset]?.ifEmpty { null },
+          testType = record[TEST_TYPE]!!,
+          totalPercentGerminated = record[TOTAL_PERCENT_GERMINATED],
+          totalSeedsGerminated = record[TOTAL_SEEDS_GERMINATED],
+          treatment = record[TREATMENT_ID],
+          withdrawnByName =
+              IndividualUser.makeFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME]),
+          withdrawnByUserId = record[USERS.ID],
       )
     }
   }
@@ -135,9 +136,9 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
           result.map { record ->
             ViabilityTestResultModel(
                 record[VIABILITY_TEST_RESULTS.ID]!!,
-                record[VIABILITY_TEST_RESULTS.TEST_ID]!!,
                 record[VIABILITY_TEST_RESULTS.RECORDING_DATE]!!,
                 record[VIABILITY_TEST_RESULTS.SEEDS_GERMINATED]!!,
+                record[VIABILITY_TEST_RESULTS.TEST_ID]!!,
             )
           }
         }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -12,29 +12,29 @@ import java.time.LocalDate
 
 data class ViabilityTestResultModel(
     val id: ViabilityTestResultId? = null,
-    val testId: ViabilityTestId? = null,
     val recordingDate: LocalDate,
-    val seedsGerminated: Int
+    val seedsGerminated: Int,
+    val testId: ViabilityTestId? = null
 )
 
 data class ViabilityTestModel(
-    val id: ViabilityTestId? = null,
     val accessionId: AccessionId? = null,
-    val testType: ViabilityTestType,
-    val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
-    val seedType: ViabilityTestSeedType? = null,
-    val substrate: ViabilityTestSubstrate? = null,
-    val treatment: ViabilityTestTreatment? = null,
+    val id: ViabilityTestId? = null,
+    val notes: String? = null,
+    val remaining: SeedQuantityModel? = null,
     val seedsTested: Int? = null,
+    val seedType: ViabilityTestSeedType? = null,
+    val staffResponsible: String? = null,
+    val startDate: LocalDate? = null,
+    val substrate: ViabilityTestSubstrate? = null,
+    val testResults: Collection<ViabilityTestResultModel>? = null,
+    val testType: ViabilityTestType,
     val totalPercentGerminated: Int? = null,
     val totalSeedsGerminated: Int? = null,
-    val notes: String? = null,
-    val staffResponsible: String? = null,
-    val testResults: Collection<ViabilityTestResultModel>? = null,
-    val remaining: SeedQuantityModel? = null,
-    val withdrawnByUserId: UserId? = null,
+    val treatment: ViabilityTestTreatment? = null,
     val withdrawnByName: String? = null,
+    val withdrawnByUserId: UserId? = null,
 ) {
   fun validateV2() {
     val isLab = testType == ViabilityTestType.Lab

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -14,28 +14,28 @@ import java.time.ZoneOffset
 import org.jooq.Record
 
 data class WithdrawalModel(
-    val id: WithdrawalId? = null,
     val accessionId: AccessionId? = null,
     val createdTime: Instant? = null,
     val date: LocalDate,
+    val destination: String? = null,
     val estimatedCount: Int? = null,
     val estimatedWeight: SeedQuantityModel? = null,
-    val purpose: WithdrawalPurpose? = null,
-    val destination: String? = null,
+    val id: WithdrawalId? = null,
     val notes: String? = null,
-    val staffResponsible: String? = null,
-    val viabilityTestId: ViabilityTestId? = null,
+    val purpose: WithdrawalPurpose? = null,
     val remaining: SeedQuantityModel? = null,
-    /** The user-entered withdrawal quantity. */
-    val withdrawn: SeedQuantityModel? = null,
-    val withdrawnByUserId: UserId? = null,
-    val withdrawnByName: String? = null,
+    val staffResponsible: String? = null,
     val viabilityTest: ViabilityTestModel? = null,
+    val viabilityTestId: ViabilityTestId? = null,
     /**
      * The server-calculated withdrawal weight based on the difference between [remaining] on this
      * withdrawal and the previous one. Only valid for weight-based accessions.
      */
     val weightDifference: SeedQuantityModel? = null,
+    /** The user-entered withdrawal quantity. */
+    val withdrawn: SeedQuantityModel? = null,
+    val withdrawnByName: String? = null,
+    val withdrawnByUserId: UserId? = null,
 ) {
   constructor(
       record: Record,
@@ -57,12 +57,12 @@ data class WithdrawalModel(
           SeedQuantityModel.of(
               record[WITHDRAWALS.REMAINING_QUANTITY], record[WITHDRAWALS.REMAINING_UNITS_ID]),
       staffResponsible = record[WITHDRAWALS.STAFF_RESPONSIBLE],
+      viabilityTestId = record[WITHDRAWALS.VIABILITY_TEST_ID],
       withdrawn =
           SeedQuantityModel.of(
               record[WITHDRAWALS.WITHDRAWN_QUANTITY], record[WITHDRAWALS.WITHDRAWN_UNITS_ID]),
       withdrawnByName = fullName,
       withdrawnByUserId = record[WITHDRAWALS.WITHDRAWN_BY],
-      viabilityTestId = record[WITHDRAWALS.VIABILITY_TEST_ID],
   )
 
   init {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -477,12 +477,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 listOf(
                     ViabilityTestModel(
                         id = initial.viabilityTests[0].id,
-                        testType = ViabilityTestType.Lab,
-                        seedType = ViabilityTestSeedType.Fresh,
-                        treatment = ViabilityTestTreatment.Scarify,
-                        substrate = ViabilityTestSubstrate.Paper,
                         notes = "notes",
-                        seedsTested = 5)))
+                        seedsTested = 5,
+                        seedType = ViabilityTestSeedType.Fresh,
+                        substrate = ViabilityTestSubstrate.Paper,
+                        testType = ViabilityTestType.Lab,
+                        treatment = ViabilityTestTreatment.Scarify)))
     store.update(desired)
 
     val updatedTests = viabilityTestsDao.fetchByAccessionId(AccessionId(1))
@@ -571,12 +571,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 listOf(
                     ViabilityTestModel(
                         id = other.viabilityTests[0].id,
-                        testType = ViabilityTestType.Lab,
-                        seedType = ViabilityTestSeedType.Fresh,
-                        treatment = ViabilityTestTreatment.Scarify,
-                        substrate = ViabilityTestSubstrate.Paper,
                         notes = "notes",
-                        seedsTested = 5)))
+                        seedsTested = 5,
+                        seedType = ViabilityTestSeedType.Fresh,
+                        substrate = ViabilityTestSubstrate.Paper,
+                        testType = ViabilityTestType.Lab,
+                        treatment = ViabilityTestTreatment.Scarify)))
 
     assertThrows<IllegalArgumentException> { store.update(desired) }
   }
@@ -596,12 +596,12 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 listOf(
                     ViabilityTestModel(
                         id = initial.viabilityTests[0].id,
-                        testType = ViabilityTestType.Lab,
                         seedsTested = 200,
                         testResults =
                             listOf(
                                 ViabilityTestResultModel(
-                                    recordingDate = localDate, seedsGerminated = 75)))))
+                                    recordingDate = localDate, seedsGerminated = 75)),
+                        testType = ViabilityTestType.Lab)))
     store.update(desired)
 
     val viabilityTests = viabilityTestsDao.fetchByAccessionId(AccessionId(1))
@@ -817,17 +817,17 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(
         listOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accession.id,
                 createdTime = clock.instant(),
                 date = test.startDate!!,
                 estimatedCount = 5,
+                id = WithdrawalId(1),
                 purpose = WithdrawalPurpose.ViabilityTesting,
-                withdrawn = SeedQuantityModel(BigDecimal(5), SeedQuantityUnits.Seeds),
-                withdrawnByUserId = user.userId,
-                withdrawnByName = user.fullName,
-                viabilityTestId = test.id,
                 remaining = seeds(5),
+                viabilityTestId = test.id,
+                withdrawn = SeedQuantityModel(BigDecimal(5), SeedQuantityUnits.Seeds),
+                withdrawnByName = user.fullName,
+                withdrawnByUserId = user.userId,
             )),
         accession.withdrawals)
   }
@@ -892,8 +892,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
         WithdrawalModel(
             date = LocalDate.now(),
             purpose = WithdrawalPurpose.ViabilityTesting,
-            withdrawn = seeds(1),
-            viabilityTestId = initialWithdrawal.viabilityTestId)
+            viabilityTestId = initialWithdrawal.viabilityTestId,
+            withdrawn = seeds(1))
 
     val updated =
         store.updateAndFetch(
@@ -984,7 +984,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 withdrawals =
                     listOf(
                         WithdrawalModel(
-                            date = LocalDate.EPOCH, withdrawn = seeds(1), remaining = seeds(0)))))
+                            date = LocalDate.EPOCH, remaining = seeds(0), withdrawn = seeds(1)))))
 
     assertEquals(AccessionState.UsedUp, updated.state)
   }
@@ -1189,8 +1189,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   listOf(
                       WithdrawalModel(
                           date = LocalDate.now(clock),
-                          withdrawn = grams(1),
-                          purpose = WithdrawalPurpose.Other))))
+                          purpose = WithdrawalPurpose.Other,
+                          withdrawn = grams(1)))))
     }
   }
 
@@ -2336,9 +2336,9 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                   viabilityTests =
                       listOf(
                           ViabilityTestModel(
-                              testType = ViabilityTestType.Lab,
-                              startDate = LocalDate.ofInstant(secondWithdrawalTime, ZoneOffset.UTC),
                               seedsTested = 29,
+                              startDate = LocalDate.ofInstant(secondWithdrawalTime, ZoneOffset.UTC),
+                              testType = ViabilityTestType.Lab,
                               withdrawnByUserId = viabilityTesterUserId))))
 
       every { clock.instant() } returns backdatedWithdrawalTime

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -124,28 +124,28 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = Instant.EPOCH,
                 date = pojos[0].date!!,
+                destination = pojos[0].destination,
+                id = WithdrawalId(1),
                 notes = pojos[0].notes,
                 purpose = pojos[0].purposeId,
                 remaining = milligrams(100),
-                destination = pojos[0].destination,
                 staffResponsible = pojos[0].staffResponsible,
                 withdrawn = milligrams(10000),
                 withdrawnByName = user.fullName,
                 withdrawnByUserId = user.userId,
             ),
             WithdrawalModel(
-                id = WithdrawalId(2),
                 accessionId = accessionId,
                 createdTime = Instant.ofEpochSecond(30),
                 date = pojos[1].date!!,
+                destination = pojos[1].destination,
+                id = WithdrawalId(2),
                 notes = pojos[1].notes,
                 purpose = pojos[1].purposeId,
                 remaining = milligrams(15000),
-                destination = pojos[1].destination,
                 staffResponsible = pojos[1].staffResponsible,
                 withdrawn = seeds(2),
                 withdrawnByName = "Other User",
@@ -176,11 +176,11 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = clock.instant(),
                 date = newWithdrawal.date,
                 destination = newWithdrawal.destination,
+                id = WithdrawalId(1),
                 notes = newWithdrawal.notes,
                 purpose = newWithdrawal.purpose,
                 remaining = grams(10),
@@ -219,11 +219,11 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = clock.instant(),
                 date = newWithdrawal.date,
                 destination = newWithdrawal.destination,
+                id = WithdrawalId(1),
                 notes = newWithdrawal.notes,
                 purpose = newWithdrawal.purpose,
                 remaining = grams(10),
@@ -328,9 +328,9 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val desired =
         WithdrawalModel(
             date = LocalDate.now(),
-            viabilityTestId = viabilityTestId,
             purpose = WithdrawalPurpose.Other,
             remaining = grams(4),
+            viabilityTestId = viabilityTestId,
             withdrawn = grams(1))
 
     assertThrows<IllegalArgumentException> {
@@ -351,24 +351,24 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val desired =
         WithdrawalModel(
             date = LocalDate.now(),
-            viabilityTestId = viabilityTestId,
             purpose = WithdrawalPurpose.ViabilityTesting,
             remaining = grams(4),
+            viabilityTestId = viabilityTestId,
             withdrawn = seeds(1))
 
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = clock.instant(),
                 date = desired.date,
                 destination = desired.destination,
-                viabilityTestId = viabilityTestId,
+                id = WithdrawalId(1),
                 notes = desired.notes,
                 purpose = desired.purpose,
                 remaining = grams(4),
                 staffResponsible = desired.staffResponsible,
+                viabilityTestId = viabilityTestId,
                 withdrawn = seeds(1),
                 withdrawnByName = user.fullName,
                 withdrawnByUserId = user.userId,
@@ -395,9 +395,9 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val initial =
         WithdrawalModel(
             date = LocalDate.now(),
-            viabilityTestId = viabilityTestId,
             purpose = WithdrawalPurpose.ViabilityTesting,
             remaining = grams(4),
+            viabilityTestId = viabilityTestId,
             withdrawn = seeds(1))
     store.updateWithdrawals(accessionId, emptyList(), listOf(initial))
     val inserted = store.fetchWithdrawals(accessionId).first()
@@ -433,11 +433,11 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = clock.instant(),
                 date = desired.date,
                 destination = desired.destination,
+                id = WithdrawalId(1),
                 notes = desired.notes,
                 purpose = desired.purpose,
                 remaining = grams(4),
@@ -487,11 +487,11 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     val expected =
         setOf(
             WithdrawalModel(
-                id = WithdrawalId(1),
                 accessionId = accessionId,
                 createdTime = clock.instant(),
                 date = desired.date,
                 destination = desired.destination,
+                id = WithdrawalId(1),
                 notes = desired.notes,
                 purpose = desired.purpose,
                 remaining = grams(4),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -130,9 +130,9 @@ internal class AccessionModelTest {
   ): ViabilityTestResultModel {
     return ViabilityTestResultModel(
         id = nextViabilityTestResultId(),
-        testId = viabilityTestId,
         recordingDate = recordingDate,
-        seedsGerminated = seedsGerminated)
+        seedsGerminated = seedsGerminated,
+        testId = viabilityTestId)
   }
 
   private fun nextWithdrawalId(): WithdrawalId {
@@ -158,10 +158,10 @@ internal class AccessionModelTest {
         accessionId = AccessionId(1),
         createdTime = createdTime,
         date = date,
-        viabilityTestId = viabilityTestId,
         id = id,
         purpose = purpose,
         remaining = remaining,
+        viabilityTestId = viabilityTestId,
         withdrawn = withdrawn,
         withdrawnByUserId = withdrawnByUserId,
     )
@@ -1199,10 +1199,10 @@ internal class AccessionModelTest {
                       WithdrawalModel(
                           accessionId = AccessionId(1),
                           date = january(15), // different from test date
-                          viabilityTestId = testWithExistingWithdrawal.id,
                           id = nextWithdrawalId(),
                           purpose = WithdrawalPurpose.ViabilityTesting,
                           remaining = seeds(0),
+                          viabilityTestId = testWithExistingWithdrawal.id,
                           withdrawn = seeds(testWithExistingWithdrawal.seedsTested!!),
                       ),
                       withdrawal(seeds(2), remaining = seeds(0), date = january(3)),
@@ -1863,9 +1863,9 @@ internal class AccessionModelTest {
                       WithdrawalModel(
                           createdTime = todayInstant,
                           date = today,
-                          id = WithdrawalId(1),
                           estimatedCount = 1,
                           estimatedWeight = grams(1),
+                          id = WithdrawalId(1),
                           purpose = WithdrawalPurpose.ViabilityTesting,
                           remaining = grams(9),
                           viabilityTest =


### PR DESCRIPTION
Keep the fields in alphabetical order so it's easier to know where to add new
ones.

No behavior change here, just a change in argument order and adding argument
names, both of which were done using IntelliJ refactoring commands.