### PR TITLE
Rename totalPercentGerminated to viabilityPercent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
@@ -35,6 +35,7 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
           dateField("endDate", "Viability test end date", VIABILITY_TESTS.END_DATE),
           idWrapperField("id", "Viability test ID", VIABILITY_TESTS.ID) { ViabilityTestId(it) },
           textField("notes", "Notes (viability test)", VIABILITY_TESTS.NOTES),
+          // TODO: Remove this once clients are no longer using it (new name is viabilityPercent)
           integerField(
               "percentGerminated", "% Viability", VIABILITY_TESTS.TOTAL_PERCENT_GERMINATED),
           enumField("seedType", "Seed type", VIABILITY_TESTS.SEED_TYPE_ID),
@@ -45,6 +46,7 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
           enumField("substrate", "Germination substrate", VIABILITY_TESTS.SUBSTRATE_ID),
           enumField("treatment", "Germination treatment", VIABILITY_TESTS.TREATMENT_ID),
           enumField("type", "Viability test type", VIABILITY_TESTS.TEST_TYPE),
+          integerField("viabilityPercent", "Viability %", VIABILITY_TESTS.TOTAL_PERCENT_GERMINATED),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -670,7 +670,7 @@ data class ViabilityTestPayload(
       model.staffResponsible,
       model.seedsTested,
       model.testResults?.map { ViabilityTestResultPayload(it) },
-      model.totalPercentGerminated,
+      model.viabilityPercent,
       model.totalSeedsGerminated,
   )
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -105,11 +105,11 @@ data class GetViabilityTestPayload(
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
-    val treatment: ViabilityTestTreatment? = null,
     val testResults: List<ViabilityTestResultPayload>? = null,
     val testType: ViabilityTestType,
-    val totalPercentGerminated: Int? = null,
     val totalSeedsGerminated: Int? = null,
+    val treatment: ViabilityTestTreatment? = null,
+    val viabilityPercent: Int? = null,
     @Schema(description = "Full name of user who withdrew seeds to perform the test.")
     val withdrawnByName: String? = null,
     @Schema(description = "ID of user who withdrew seeds to perform the test.")
@@ -128,9 +128,9 @@ data class GetViabilityTestPayload(
       substrate = model.substrate,
       testResults = model.testResults?.map { ViabilityTestResultPayload(it) },
       testType = model.testType,
-      totalPercentGerminated = model.totalPercentGerminated,
       totalSeedsGerminated = model.totalSeedsGerminated,
       treatment = model.treatment,
+      viabilityPercent = model.viabilityPercent,
       withdrawnByName = model.withdrawnByName,
       withdrawnByUserId = model.withdrawnByUserId,
   )

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -109,9 +109,9 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
           substrate = record[SUBSTRATE_ID],
           testResults = record[viabilityTestResultsMultiset]?.ifEmpty { null },
           testType = record[TEST_TYPE]!!,
-          totalPercentGerminated = record[TOTAL_PERCENT_GERMINATED],
           totalSeedsGerminated = record[TOTAL_SEEDS_GERMINATED],
           treatment = record[TREATMENT_ID],
+          viabilityPercent = record[TOTAL_PERCENT_GERMINATED],
           withdrawnByName =
               IndividualUser.makeFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME]),
           withdrawnByUserId = record[USERS.ID],
@@ -166,7 +166,7 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
               .set(START_DATE, calculatedTest.startDate)
               .set(SUBSTRATE_ID, calculatedTest.substrate)
               .set(TEST_TYPE, calculatedTest.testType)
-              .set(TOTAL_PERCENT_GERMINATED, calculatedTest.totalPercentGerminated)
+              .set(TOTAL_PERCENT_GERMINATED, calculatedTest.viabilityPercent)
               .set(TOTAL_SEEDS_GERMINATED, calculatedTest.totalSeedsGerminated)
               .set(TREATMENT_ID, calculatedTest.treatment)
               .returning(ID)
@@ -232,7 +232,7 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
                     .set(SUBSTRATE_ID, desiredTest.substrate)
                     .set(STAFF_RESPONSIBLE, desiredTest.staffResponsible)
                     .set(START_DATE, desiredTest.startDate)
-                    .set(TOTAL_PERCENT_GERMINATED, desiredTest.totalPercentGerminated)
+                    .set(TOTAL_PERCENT_GERMINATED, desiredTest.viabilityPercent)
                     .set(TOTAL_SEEDS_GERMINATED, desiredTest.totalSeedsGerminated)
                     .set(TREATMENT_ID, desiredTest.treatment)
                     .where(ID.eq(testId))

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -30,9 +30,9 @@ data class ViabilityTestModel(
     val substrate: ViabilityTestSubstrate? = null,
     val testResults: Collection<ViabilityTestResultModel>? = null,
     val testType: ViabilityTestType,
-    val totalPercentGerminated: Int? = null,
     val totalSeedsGerminated: Int? = null,
     val treatment: ViabilityTestTreatment? = null,
+    val viabilityPercent: Int? = null,
     val withdrawnByName: String? = null,
     val withdrawnByUserId: UserId? = null,
 ) {
@@ -98,9 +98,9 @@ data class ViabilityTestModel(
         startDate == other.startDate &&
         substrate == other.substrate &&
         testType == other.testType &&
-        totalPercentGerminated == other.totalPercentGerminated &&
         totalSeedsGerminated == other.totalSeedsGerminated &&
         treatment == other.treatment &&
+        viabilityPercent == other.viabilityPercent &&
         withdrawnByUserId == other.withdrawnByUserId
   }
 
@@ -125,8 +125,8 @@ data class ViabilityTestModel(
 
   fun withCalculatedValues(): ViabilityTestModel {
     return copy(
-        totalPercentGerminated = calculateTotalPercentGerminated(),
         totalSeedsGerminated = calculateTotalSeedsGerminated(),
+        viabilityPercent = calculateTotalPercentGerminated(),
     )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -1918,10 +1918,13 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val viabilityTestResultsRow =
           ViabilityTestsRow(
               accessionId = AccessionId(1000),
-              testType = ViabilityTestType.Lab,
-              seedsSown = 15,
               remainingQuantity = BigDecimal.TEN,
-              remainingUnitsId = SeedQuantityUnits.Grams)
+              remainingUnitsId = SeedQuantityUnits.Grams,
+              seedsSown = 15,
+              testType = ViabilityTestType.Lab,
+              totalPercentGerminated = 100,
+              totalSeedsGerminated = 15,
+          )
 
       viabilityTestsDao.insert(viabilityTestResultsRow)
 
@@ -2761,9 +2764,11 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                                               "recordingDate" to "1970-01-02",
                                               "seedsGerminated" to "10")),
                                   "id" to "$testId",
-                                  "type" to "Lab",
+                                  "percentGerminated" to "100",
                                   "seedsSown" to "15",
                                   "seedsTested" to "15",
+                                  "type" to "Lab",
+                                  "viabilityPercent" to "100",
                               ),
                           ),
                   ))


### PR DESCRIPTION
With the addition of cut tests, not all viability tests involve seeds germinating.
Rename the field that holds the viability percentage accordingly.

The v1 API is unchanged here, but the field is renamed in the v2 API. This is a
server-calculated field, so only the response payloads are affected. A new search
field with the revised name is also added.