### PR TITLE
SW-1577 Add cut test support to v2 API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
@@ -38,10 +38,18 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
           // TODO: Remove this once clients are no longer using it (new name is viabilityPercent)
           integerField(
               "percentGerminated", "% Viability", VIABILITY_TESTS.TOTAL_PERCENT_GERMINATED),
-          enumField("seedType", "Seed type", VIABILITY_TESTS.SEED_TYPE_ID),
+          integerField(
+              "seedsCompromised",
+              "Number of seeds compromised (cut test)",
+              VIABILITY_TESTS.SEEDS_COMPROMISED),
+          integerField(
+              "seedsEmpty", "Number of seeds empty (cut test)", VIABILITY_TESTS.SEEDS_EMPTY),
+          integerField(
+              "seedsFilled", "Number of seeds filled (cut test)", VIABILITY_TESTS.SEEDS_FILLED),
           // TODO: Remove this once clients are no longer using it (new name is seedsTested)
           integerField("seedsSown", "Number of seeds sown", VIABILITY_TESTS.SEEDS_SOWN),
           integerField("seedsTested", "Number of seeds tested", VIABILITY_TESTS.SEEDS_SOWN),
+          enumField("seedType", "Seed type", VIABILITY_TESTS.SEED_TYPE_ID),
           dateField("startDate", "Viability test start date", VIABILITY_TESTS.START_DATE),
           enumField("substrate", "Germination substrate", VIABILITY_TESTS.SUBSTRATE_ID),
           enumField("treatment", "Germination treatment", VIABILITY_TESTS.TREATMENT_ID),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -513,8 +513,19 @@ data class AccessionPayload(
       model.calculateTotalScheduledWithdrawalQuantity(clock)?.toPayload(),
       model.totalViabilityPercent,
       model.calculateTotalWithdrawalQuantity(clock)?.toPayload(),
-      model.viabilityTests.map { ViabilityTestPayload(it) }.orNull(),
-      model.withdrawals.map { WithdrawalPayload(it) }.orNull(),
+      model.viabilityTests
+          .filter { it.testType != ViabilityTestType.Cut }
+          .map { ViabilityTestPayload(it) }
+          .orNull(),
+      model.withdrawals
+          .filter { withdrawal ->
+            withdrawal.viabilityTestId == null ||
+                model.viabilityTests
+                    .firstOrNull { test -> test.id == withdrawal.viabilityTestId }
+                    ?.testType != ViabilityTestType.Cut
+          }
+          .map { WithdrawalPayload(it) }
+          .orNull(),
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -519,10 +519,16 @@ data class AccessionPayload(
           .orNull(),
       model.withdrawals
           .filter { withdrawal ->
-            withdrawal.viabilityTestId == null ||
-                model.viabilityTests
-                    .firstOrNull { test -> test.id == withdrawal.viabilityTestId }
-                    ?.testType != ViabilityTestType.Cut
+            // If this withdrawal is for a viability test, only include it if the test is something
+            // other than a cut test. Do a linear search to find the test with the right ID for each
+            // withdrawal; accessions never have more than two or three tests, so it's not worth
+            // building a more sophisticated index here.
+            val viabilityTestForWithdrawal =
+                withdrawal.viabilityTestId?.let { testId ->
+                  model.viabilityTests.firstOrNull { it.id == testId }
+                }
+            viabilityTestForWithdrawal == null ||
+                viabilityTestForWithdrawal.testType != ViabilityTestType.Cut
           }
           .map { WithdrawalPayload(it) }
           .orNull(),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -101,6 +101,9 @@ data class GetViabilityTestPayload(
     val endDate: LocalDate? = null,
     val id: ViabilityTestId,
     val notes: String? = null,
+    val seedsCompromised: Int? = null,
+    val seedsEmpty: Int? = null,
+    val seedsFilled: Int? = null,
     val seedsTested: Int? = null,
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
@@ -109,6 +112,11 @@ data class GetViabilityTestPayload(
     val testType: ViabilityTestType,
     val totalSeedsGerminated: Int? = null,
     val treatment: ViabilityTestTreatment? = null,
+    @Schema(
+        description =
+            "Server-calculated viability percent for this test. For lab and nursery tests, this " +
+                "is based on the total seeds germinated across all test results. For cut tests, " +
+                "it is based on the number of seeds filled.")
     val viabilityPercent: Int? = null,
     @Schema(description = "Full name of user who withdrew seeds to perform the test.")
     val withdrawnByName: String? = null,
@@ -122,6 +130,9 @@ data class GetViabilityTestPayload(
       endDate = model.endDate,
       id = model.id!!,
       notes = model.notes,
+      seedsCompromised = model.seedsCompromised,
+      seedsEmpty = model.seedsEmpty,
+      seedsFilled = model.seedsFilled,
       seedsTested = model.seedsTested,
       seedType = model.seedType,
       startDate = model.startDate,
@@ -178,6 +189,9 @@ data class CreateViabilityTestRequestPayload(
 data class UpdateViabilityTestRequestPayload(
     val endDate: LocalDate? = null,
     val notes: String? = null,
+    val seedsCompromised: Int? = null,
+    val seedsEmpty: Int? = null,
+    val seedsFilled: Int? = null,
     val seedsTested: Int? = null,
     val seedType: ViabilityTestSeedType? = null,
     val startDate: LocalDate? = null,
@@ -196,6 +210,9 @@ data class UpdateViabilityTestRequestPayload(
       model.copy(
           endDate = endDate,
           notes = notes,
+          seedsCompromised = seedsCompromised,
+          seedsEmpty = seedsEmpty,
+          seedsFilled = seedsFilled,
           seedsTested = seedsTested,
           seedType = seedType,
           startDate = startDate,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -102,6 +102,9 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
           id = record[ID]!!,
           notes = record[NOTES],
           remaining = SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
+          seedsCompromised = record[SEEDS_COMPROMISED],
+          seedsEmpty = record[SEEDS_EMPTY],
+          seedsFilled = record[SEEDS_FILLED],
           seedsTested = record[SEEDS_SOWN],
           seedType = record[SEED_TYPE_ID],
           staffResponsible = record[STAFF_RESPONSIBLE],
@@ -161,6 +164,9 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
               .set(REMAINING_QUANTITY, calculatedTest.remaining?.quantity)
               .set(REMAINING_UNITS_ID, calculatedTest.remaining?.units)
               .set(SEED_TYPE_ID, calculatedTest.seedType)
+              .set(SEEDS_COMPROMISED, calculatedTest.seedsCompromised)
+              .set(SEEDS_EMPTY, calculatedTest.seedsEmpty)
+              .set(SEEDS_FILLED, calculatedTest.seedsFilled)
               .set(SEEDS_SOWN, calculatedTest.seedsTested)
               .set(STAFF_RESPONSIBLE, calculatedTest.staffResponsible)
               .set(START_DATE, calculatedTest.startDate)
@@ -228,6 +234,9 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
                     .set(REMAINING_QUANTITY, desiredTest.remaining?.quantity)
                     .set(REMAINING_UNITS_ID, desiredTest.remaining?.units)
                     .set(SEED_TYPE_ID, desiredTest.seedType)
+                    .set(SEEDS_COMPROMISED, desiredTest.seedsCompromised)
+                    .set(SEEDS_EMPTY, desiredTest.seedsEmpty)
+                    .set(SEEDS_FILLED, desiredTest.seedsFilled)
                     .set(SEEDS_SOWN, desiredTest.seedsTested)
                     .set(SUBSTRATE_ID, desiredTest.substrate)
                     .set(STAFF_RESPONSIBLE, desiredTest.staffResponsible)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -14,9 +14,11 @@ import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.StorageCondition
 import com.terraformation.backend.db.ViabilityTestId
 import com.terraformation.backend.db.ViabilityTestNotFoundException
+import com.terraformation.backend.db.ViabilityTestType
 import com.terraformation.backend.db.WithdrawalId
 import com.terraformation.backend.db.WithdrawalNotFoundException
 import com.terraformation.backend.db.WithdrawalPurpose
+import com.terraformation.backend.util.orNull
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
@@ -310,6 +312,8 @@ data class AccessionModel(
     }
 
     assertNoWithdrawalsWithoutQuantity(total)
+
+    viabilityTests.forEach { it.validateV1() }
   }
 
   private fun validateV2() {
@@ -423,6 +427,13 @@ data class AccessionModel(
             "Seeds remaining on viability tests and withdrawals cannot be negative")
       }
     }
+
+    if (!hasSeedCount() &&
+        (cutTestSeedsCompromised != null ||
+            cutTestSeedsEmpty != null ||
+            cutTestSeedsFilled != null)) {
+      throw IllegalArgumentException("Cannot record cut test results when seed count is unknown")
+    }
   }
 
   private fun getLatestViabilityTestWithResults(): ViabilityTestModel? {
@@ -493,7 +504,7 @@ data class AccessionModel(
   }
 
   fun calculateLatestViabilityPercent(): Int? {
-    return getLatestViabilityTestWithResults()?.calculateTotalPercentGerminated()
+    return getLatestViabilityTestWithResults()?.calculateViabilityPercent()
   }
 
   fun calculateTotalViabilityPercent(): Int? {
@@ -519,7 +530,7 @@ data class AccessionModel(
   }
 
   fun calculateRemaining(clock: Clock, existing: AccessionModel = this): SeedQuantityModel? {
-    val newWithdrawals = calculateWithdrawals(clock)
+    val newWithdrawals = calculateWithdrawals(clock, existing)
     val newRemaining =
         if (isManualState) {
           if (latestObservedQuantity == null ||
@@ -575,15 +586,14 @@ data class AccessionModel(
    * @return Withdrawals in descending order of seeds remaining; the last item in the list will be
    * the one with the seeds-remaining value for the accession as a whole.
    */
-  fun calculateWithdrawals(
-      clock: Clock,
-      existingWithdrawals: Collection<WithdrawalModel> = withdrawals
-  ): List<WithdrawalModel> {
-    if (withdrawals.isEmpty() && viabilityTests.isEmpty()) {
+  fun calculateWithdrawals(clock: Clock, existing: AccessionModel = this): List<WithdrawalModel> {
+    val viabilityTestsWithV1CutTest: List<ViabilityTestModel> = convertV1CutTestToV2(existing)
+
+    if (withdrawals.isEmpty() && viabilityTestsWithV1CutTest.isEmpty()) {
       return emptyList()
     }
 
-    val existingIds = existingWithdrawals.mapNotNull { it.id }.toSet()
+    val existingIds = existing.withdrawals.mapNotNull { it.id }.toSet()
     withdrawals
         .mapNotNull { it.id }
         .forEach { id ->
@@ -594,14 +604,15 @@ data class AccessionModel(
 
     val nonTestWithdrawals = withdrawals.filter { it.purpose != WithdrawalPurpose.ViabilityTesting }
     val existingTestWithdrawals =
-        existingWithdrawals
+        existing.withdrawals
             .filter { it.viabilityTestId != null }
             .associateBy { it.viabilityTestId!! }
     val testWithdrawals =
-        viabilityTests.map { test ->
+        viabilityTestsWithV1CutTest.map { test ->
           val existingWithdrawal = test.id?.let { existingTestWithdrawals[it] }
           val withdrawn =
               test.seedsTested?.let { SeedQuantityModel(BigDecimal(it), SeedQuantityUnits.Seeds) }
+
           WithdrawalModel(
               createdTime = existingWithdrawal?.createdTime,
               date = test.startDate ?: existingWithdrawal?.date ?: LocalDate.now(clock),
@@ -708,6 +719,66 @@ data class AccessionModel(
     }
   }
 
+  /**
+   * V1 COMPATIBILITY: Convert v1-style accession-level cut test fields to an entry in the list of
+   * viability tests. If the user has entered cut test results for the first time, they will need to
+   * be represented as a viability test. If they've updated existing cut test results, the new
+   * results will need to be copied to the existing viability test.
+   */
+  private fun convertV1CutTestToV2(existing: AccessionModel): List<ViabilityTestModel> {
+    val accessionFieldsNotEdited =
+        cutTestSeedsCompromised == existing.cutTestSeedsCompromised &&
+            cutTestSeedsEmpty == existing.cutTestSeedsEmpty &&
+            cutTestSeedsFilled == existing.cutTestSeedsFilled
+    val accessionFieldsNotSet =
+        cutTestSeedsCompromised == null && cutTestSeedsEmpty == null && cutTestSeedsFilled == null
+    val existingCutTest =
+        existing.viabilityTests.firstOrNull { it.testType == ViabilityTestType.Cut }
+
+    return when {
+      isManualState -> {
+        viabilityTests
+      }
+      accessionFieldsNotEdited -> {
+        // User hasn't changed the cut test results, but they won't be included in viabilityTests
+        // on a v1 PUT request, so need to pull them back in.
+        if (existingCutTest != null) {
+          viabilityTests.filter { it.testType != ViabilityTestType.Cut } + existingCutTest
+        } else {
+          viabilityTests
+        }
+      }
+      accessionFieldsNotSet -> {
+        // User has removed previously-existing cut test results.
+        viabilityTests.filter { it.testType != ViabilityTestType.Cut }
+      }
+      existingCutTest == null -> {
+        // User has entered cut test results for the first time.
+        viabilityTests +
+            ViabilityTestModel(
+                remaining = remaining ?: total,
+                seedsCompromised = cutTestSeedsCompromised,
+                seedsEmpty = cutTestSeedsEmpty,
+                seedsFilled = cutTestSeedsFilled,
+                seedsTested = (cutTestSeedsCompromised
+                        ?: 0) + (cutTestSeedsEmpty ?: 0) + (cutTestSeedsFilled ?: 0),
+                testType = ViabilityTestType.Cut,
+            )
+      }
+      else -> {
+        // User has updated existing cut test results.
+        viabilityTests.filter { it.testType != ViabilityTestType.Cut } +
+            existingCutTest.copy(
+                seedsCompromised = cutTestSeedsCompromised,
+                seedsEmpty = cutTestSeedsEmpty,
+                seedsFilled = cutTestSeedsFilled,
+                seedsTested = (cutTestSeedsCompromised
+                        ?: 0) + (cutTestSeedsEmpty ?: 0) + (cutTestSeedsFilled ?: 0),
+            )
+      }
+    }
+  }
+
   private fun foldWithdrawalQuantities(
       clock: Clock,
       predicate: (WithdrawalModel) -> Boolean = { true }
@@ -773,15 +844,22 @@ data class AccessionModel(
     val newReceivedDate =
         if (existing.source == DataSource.Web) receivedDate else existing.receivedDate
     val newRemaining = calculateRemaining(clock, existing)
-    val newWithdrawals = calculateWithdrawals(clock, existing.withdrawals)
+    val newWithdrawals = calculateWithdrawals(clock, existing)
     val newViabilityPercent =
         if (isManualState) totalViabilityPercent else calculateTotalViabilityPercent()
     val newViabilityTests = newWithdrawals.mapNotNull { it.viabilityTest }
     val newState = existing.getStateTransition(this, clock)?.newState ?: existing.state
     val newEstimatedBaseQuantity = if (isManualState) newRemaining else total
 
+    // V1 COMPATIBILITY: Total up the results of cut tests to populate the accession-level cut test
+    // fields, and reflect changes to the accession-level fields in the viability test list.
+    val cutTests = newViabilityTests.filter { it.testType == ViabilityTestType.Cut }
+
     return copy(
         collectedDate = newCollectedDate,
+        cutTestSeedsCompromised = cutTests.mapNotNull { it.seedsCompromised }.orNull()?.sum(),
+        cutTestSeedsEmpty = cutTests.mapNotNull { it.seedsEmpty }.orNull()?.sum(),
+        cutTestSeedsFilled = cutTests.mapNotNull { it.seedsFilled }.orNull()?.sum(),
         estimatedSeedCount = calculateEstimatedSeedCount(newEstimatedBaseQuantity),
         estimatedWeight = calculateEstimatedWeight(newEstimatedBaseQuantity),
         latestObservedQuantity = calculateLatestObservedQuantity(clock, existing),

--- a/src/main/resources/db/migration/V134__ViabilityTestsCut.sql
+++ b/src/main/resources/db/migration/V134__ViabilityTestsCut.sql
@@ -19,10 +19,10 @@ SELECT id,
        cut_test_seeds_compromised,
        cut_test_seeds_empty,
        cut_test_seeds_filled,
-       COALESCE(cut_test_seeds_compromised, 0)
+       (COALESCE(cut_test_seeds_compromised, 0)
            + COALESCE(cut_test_seeds_empty, 0)
-           + COALESCE(cut_test_seeds_filled, 0),
-       3 -- Cut
+           + COALESCE(cut_test_seeds_filled, 0)) AS seeds_sown,
+       3 AS test_type -- 3 is the type ID for cut tests
 FROM accessions
 WHERE (cut_test_seeds_compromised IS NOT NULL
     OR cut_test_seeds_empty IS NOT NULL

--- a/src/main/resources/db/migration/V134__ViabilityTestsCut.sql
+++ b/src/main/resources/db/migration/V134__ViabilityTestsCut.sql
@@ -1,0 +1,55 @@
+ALTER TABLE viability_tests ADD COLUMN seeds_compromised INTEGER;
+ALTER TABLE viability_tests ADD COLUMN seeds_empty INTEGER;
+ALTER TABLE viability_tests ADD COLUMN seeds_filled INTEGER;
+
+INSERT
+INTO viability_tests (accession_id,
+                      remaining_grams,
+                      remaining_quantity,
+                      remaining_units_id,
+                      seeds_compromised,
+                      seeds_empty,
+                      seeds_filled,
+                      seeds_sown,
+                      test_type)
+SELECT id,
+       remaining_grams,
+       remaining_quantity,
+       remaining_units_id,
+       cut_test_seeds_compromised,
+       cut_test_seeds_empty,
+       cut_test_seeds_filled,
+       COALESCE(cut_test_seeds_compromised, 0)
+           + COALESCE(cut_test_seeds_empty, 0)
+           + COALESCE(cut_test_seeds_filled, 0),
+       3 -- Cut
+FROM accessions
+WHERE (cut_test_seeds_compromised IS NOT NULL
+    OR cut_test_seeds_empty IS NOT NULL
+    OR cut_test_seeds_filled IS NOT NULL)
+  AND remaining_quantity IS NOT NULL;
+
+WITH system_user AS (SELECT id FROM users WHERE user_type_id = 4)
+INSERT
+INTO withdrawals (accession_id,
+                  created_by,
+                  created_time,
+                  "date",
+                  remaining_grams,
+                  remaining_quantity,
+                  remaining_units_id,
+                  updated_time,
+                  viability_test_id)
+SELECT vt.accession_id,
+       (SELECT id FROM system_user),
+       NOW(),
+       a.modified_time::DATE,
+       vt.remaining_grams,
+       vt.remaining_quantity,
+       vt.remaining_units_id,
+       NOW(),
+       vt.id
+FROM viability_tests vt
+         JOIN accessions a ON vt.accession_id = a.id
+WHERE vt.test_type = 3
+ON CONFLICT (viability_test_id) DO NOTHING;

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -1,0 +1,135 @@
+package com.terraformation.backend.seedbank.model
+
+import com.terraformation.backend.db.ViabilityTestSubstrate
+import com.terraformation.backend.db.ViabilityTestType
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+internal class ViabilityTestModelTest {
+  @Nested
+  inner class V2Validation {
+    @Test
+    fun `rejects cut tests with germination test results`() {
+      val model =
+          ViabilityTestModel(
+              testResults =
+                  listOf(
+                      ViabilityTestResultModel(
+                          recordingDate = LocalDate.EPOCH, seedsGerminated = 1)),
+              testType = ViabilityTestType.Cut)
+
+      assertThrows<IllegalArgumentException> { model.validateV2() }
+    }
+
+    @Test
+    fun `rejects lab and nursery tests with cut test results`() {
+      listOf(
+              ViabilityTestType.Lab,
+              ViabilityTestType.Nursery,
+          )
+          .forEach { testType ->
+            listOf(
+                    ViabilityTestModel(seedsCompromised = 1, testType = testType),
+                    ViabilityTestModel(seedsEmpty = 1, testType = testType),
+                    ViabilityTestModel(seedsFilled = 1, testType = testType))
+                .forEach { model ->
+                  assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+                }
+          }
+    }
+
+    @Test
+    fun `rejects invalid substrate for lab test`() {
+      val model =
+          ViabilityTestModel(
+              substrate = ViabilityTestSubstrate.Moss, testType = ViabilityTestType.Lab)
+
+      assertThrows<IllegalArgumentException> { model.validateV2() }
+    }
+
+    @Test
+    fun `rejects invalid substrate for nursery test`() {
+      val model =
+          ViabilityTestModel(
+              substrate = ViabilityTestSubstrate.Agar, testType = ViabilityTestType.Nursery)
+
+      assertThrows<IllegalArgumentException> { model.validateV2() }
+    }
+
+    @Test
+    fun `rejects cut tests with more results than seeds tested`() {
+      val model =
+          ViabilityTestModel(
+              seedsCompromised = 1,
+              seedsEmpty = 1,
+              seedsFilled = 1,
+              seedsTested = 2,
+              testType = ViabilityTestType.Cut)
+
+      assertThrows<IllegalArgumentException> { model.validateV2() }
+    }
+
+    @Test
+    fun `rejects negative seed counts`() {
+      listOf(
+              ViabilityTestModel(
+                  seedsCompromised = -1, seedsTested = 1, testType = ViabilityTestType.Cut),
+              ViabilityTestModel(
+                  seedsEmpty = -1, seedsTested = 1, testType = ViabilityTestType.Cut),
+              ViabilityTestModel(
+                  seedsFilled = -1, seedsTested = 1, testType = ViabilityTestType.Cut),
+              ViabilityTestModel(seedsTested = -1, testType = ViabilityTestType.Lab),
+          )
+          .forEach { model ->
+            assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+          }
+    }
+  }
+
+  @Nested
+  inner class ViabilityPercentCalculations {
+    @EnumSource
+    @ParameterizedTest
+    fun `no viability percent calculated when there are no results`(testType: ViabilityTestType) {
+      val model = ViabilityTestModel(seedsTested = 10, testType = testType)
+
+      assertNull(model.calculateViabilityPercent())
+    }
+
+    @EnumSource(names = ["Lab", "Nursery"])
+    @ParameterizedTest
+    fun `viability percent is based on total of all results`(testType: ViabilityTestType) {
+      val model =
+          ViabilityTestModel(
+              seedsTested = 100,
+              testResults =
+                  listOf(
+                      ViabilityTestResultModel(
+                          recordingDate = LocalDate.EPOCH, seedsGerminated = 12),
+                      ViabilityTestResultModel(
+                          recordingDate = LocalDate.EPOCH, seedsGerminated = 27),
+                  ),
+              testType = testType)
+
+      assertEquals(39, model.calculateViabilityPercent())
+    }
+
+    @Test
+    fun `viability percent of cut tests is based on seeds filled`() {
+      val model =
+          ViabilityTestModel(
+              seedsCompromised = 1,
+              seedsEmpty = 2,
+              seedsFilled = 3,
+              seedsTested = 6,
+              testType = ViabilityTestType.Cut)
+
+      assertEquals(50, model.calculateViabilityPercent())
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -2709,6 +2709,18 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
         }
       }
 
+      val cutTestRow =
+          ViabilityTestsRow(
+              accessionId = AccessionId(1000),
+              remainingQuantity = BigDecimal.ONE,
+              remainingUnitsId = SeedQuantityUnits.Seeds,
+              seedsCompromised = 1,
+              seedsEmpty = 2,
+              seedsFilled = 3,
+              seedsSown = 10,
+              testType = ViabilityTestType.Cut)
+      viabilityTestsDao.insert(cutTestRow)
+
       val expectedAccessions =
           listOf(
                   mapOf(
@@ -2769,6 +2781,15 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                                   "seedsTested" to "15",
                                   "type" to "Lab",
                                   "viabilityPercent" to "100",
+                              ),
+                              mapOf(
+                                  "id" to "${cutTestRow.id}",
+                                  "seedsCompromised" to "1",
+                                  "seedsEmpty" to "2",
+                                  "seedsFilled" to "3",
+                                  "seedsSown" to "10",
+                                  "seedsTested" to "10",
+                                  "type" to "Cut",
                               ),
                           ),
                   ))


### PR DESCRIPTION
Change the internal representation of cut test results to the v2 style, where they
are represented as another kind of viability test. This new representation is used
even when accessions are written using the v1 API, but the v1 API continues to
present cut test results as a set of accession-level fields.

Existing cut test results are converted to viability tests by a database migration.

Clients can switch back and forth between the v1 and v2 APIs, but if an accession
has multiple cut tests (which is allowed in v2) they will be collapsed to a single
aggregate test when the accession is written using the v1 API.

The interaction between cut test results and accession quantity is a little
different than before: previously, we would only subtract seeds from the accession
if all three fields (compromised, empty, filled) were filled in with values. In
the new model, a withdrawal is created even if some of those values are still
null.

Deployment note: This change will require brief downtime. If a v1 PUT request with
cut test results is handled by an older server instance after the migration here is
finished, the edit will effectively be lost because the older code won't create a
new viability test.