### PR TITLE
Refactor species CSV import code

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.GrowthForm
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SeedStorageBehavior
-import com.terraformation.backend.db.SpeciesId
 import com.terraformation.backend.db.UploadId
 import com.terraformation.backend.db.UploadNotAwaitingActionException
 import com.terraformation.backend.db.UploadNotFoundException
@@ -16,8 +15,8 @@ import com.terraformation.backend.db.UploadType
 import com.terraformation.backend.db.UserId
 import com.terraformation.backend.db.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.tables.daos.UploadsDao
+import com.terraformation.backend.db.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.tables.references.SPECIES
-import com.terraformation.backend.db.tables.references.UPLOADS
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.UploadService
 import com.terraformation.backend.file.UploadStore
@@ -25,7 +24,6 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.time.Clock
 import javax.annotation.ManagedBean
 import org.apache.commons.lang3.BooleanUtils
 import org.jobrunr.scheduling.JobScheduler
@@ -34,13 +32,13 @@ import org.springframework.context.annotation.Lazy
 
 @ManagedBean
 class SpeciesImporter(
-    private val clock: Clock,
     private val dslContext: DSLContext,
     private val fileStore: FileStore,
     private val messages: Messages,
     // JobRunr is disabled when generating OpenAPI docs from Gradle
     @Lazy private val scheduler: JobScheduler,
     private val speciesChecker: SpeciesChecker,
+    private val speciesStore: SpeciesStore,
     private val uploadProblemsDao: UploadProblemsDao,
     private val uploadsDao: UploadsDao,
     private val uploadService: UploadService,
@@ -73,19 +71,19 @@ class SpeciesImporter(
 
   @Throws(UploadNotAwaitingActionException::class)
   fun cancelProcessing(uploadId: UploadId) {
-    requireAwaitingAction(uploadId)
+    uploadStore.requireAwaitingAction(uploadId)
     uploadService.delete(uploadId)
   }
 
   @Throws(UploadNotAwaitingActionException::class)
   fun resolveWarnings(uploadId: UploadId, overwriteExisting: Boolean) {
-    requireAwaitingAction(uploadId)
+    uploadStore.requireAwaitingAction(uploadId)
 
     dslContext.transaction { _ ->
       scheduler.enqueue<SpeciesImporter> {
         importCsv(uploadId, currentUser().userId, overwriteExisting)
       }
-      updateStatus(uploadId, UploadStatus.AwaitingProcessing)
+      uploadStore.updateStatus(uploadId, UploadStatus.AwaitingProcessing)
       uploadStore.deleteProblems(uploadId)
     }
   }
@@ -146,16 +144,16 @@ class SpeciesImporter(
           log.info("Uploaded species list $uploadId has validation errors")
 
           uploadProblemsDao.insert(validator.errors)
-          updateStatus(uploadId, UploadStatus.Invalid)
+          uploadStore.updateStatus(uploadId, UploadStatus.Invalid)
         } else if (validator.warnings.isNotEmpty()) {
           log.info("Uploaded species list $uploadId has warnings; awaiting user action")
 
           uploadProblemsDao.insert(validator.warnings)
-          updateStatus(uploadId, UploadStatus.AwaitingUserAction)
+          uploadStore.updateStatus(uploadId, UploadStatus.AwaitingUserAction)
         } else {
           log.info("Uploaded species list $uploadId had no problems; importing it")
           scheduler.enqueue<SpeciesImporter> { importCsv(uploadId, userId, true) }
-          updateStatus(uploadId, UploadStatus.AwaitingProcessing)
+          uploadStore.updateStatus(uploadId, UploadStatus.AwaitingProcessing)
         }
       }
     }
@@ -184,7 +182,7 @@ class SpeciesImporter(
         throw IllegalStateException("Upload is not awaiting processing")
       }
 
-      updateStatus(uploadId, UploadStatus.Processing)
+      uploadStore.updateStatus(uploadId, UploadStatus.Processing)
 
       try {
         var totalImported = 0
@@ -197,13 +195,28 @@ class SpeciesImporter(
             // Consume header line
             csvReader.readNext()
 
-            csvReader.forEach { rawValues ->
-              if (importRow(rawValues, organizationId, userId, overwriteExisting)) {
-                totalImported++
-              } else {
-                totalIgnored++
-              }
-            }
+            csvReader
+                .map { rawValues -> rawValues.map { it.trim().ifEmpty { null } } }
+                .map { values ->
+                  SpeciesRow(
+                      scientificName = values[0],
+                      commonName = values[1],
+                      familyName = values[2],
+                      endangered = BooleanUtils.toBooleanObject(values[3]),
+                      rare = BooleanUtils.toBooleanObject(values[4]),
+                      growthFormId = values[5]?.let { GrowthForm.forDisplayName(it) },
+                      seedStorageBehaviorId =
+                          values[6]?.let { SeedStorageBehavior.forDisplayName(it) },
+                      organizationId = organizationId,
+                  )
+                }
+                .forEach { row ->
+                  if (speciesStore.importRow(row, overwriteExisting)) {
+                    totalImported++
+                  } else {
+                    totalIgnored++
+                  }
+                }
           }
 
           // Check for misspelled species names or other problems by scanning all the unchecked
@@ -213,170 +226,14 @@ class SpeciesImporter(
           // here are the ones that have been newly inserted in the current transaction.
           speciesChecker.checkAllUncheckedSpecies(organizationId)
 
-          updateStatus(uploadId, UploadStatus.Completed)
+          uploadStore.updateStatus(uploadId, UploadStatus.Completed)
         }
 
         log.info("Imported $totalImported and ignored $totalIgnored species from upload $uploadId")
       } catch (e: Exception) {
         log.error("Unable to process species CSV $uploadId", e)
-        updateStatus(uploadId, UploadStatus.ProcessingFailed)
+        uploadStore.updateStatus(uploadId, UploadStatus.ProcessingFailed)
       }
-    }
-  }
-
-  /**
-   * Inserts or updates a single species based on a row from the CSV.
-   *
-   * Species are matched based on their scientific names, but this is a little tricky because we
-   * track renamed species and want to match on the original name. The use case is someone uploading
-   * a CSV, accepting a suggested name change, then uploading the CSV again; we want to remember
-   * that species X in the CSV is really species Y in our database because the user renamed it.
-   *
-   * In addition, this needs to behave differently if there is an existing species but it is marked
-   * as deleted; sometimes we want to undelete the existing row and sometimes we want to ignore it.
-   * And it also needs to act differently depending on whether the user wants to overwrite existing
-   * data or only import new entries.
-   *
-   * Exhaustive list of the possible cases:
-   *
-   * * Current = the scientific name from the CSV is the same as the scientific name of an existing
-   * species (regardless of whether the existing species is deleted or not)
-   * * Initial = the scientific name from the CSV is the same as the initial scientific name of an
-   * existing species (regardless of whether the existing species is deleted or not)
-   * * Deleted = the existing species, if any, is marked as deleted
-   * * Overwrite = the [overwriteExisting] parameter is true, meaning the user wants to update
-   * existing species rather than ignore them
-   *
-   * ```
-   * | Current | Initial | Deleted | Overwrite | Action |
-   * | ------- | ------- | ------- | --------- | ------ |
-   * | No      | No      | No      | No        | Insert |
-   * | No      | No      | No      | Yes       | Insert |
-   * | No      | No      | Yes     | No        | (impossible) |
-   * | No      | No      | Yes     | Yes       | (impossible) |
-   * | No      | Yes     | No      | No        | No-op |
-   * | No      | Yes     | No      | Yes       | Update but use current name instead of CSV's |
-   * | No      | Yes     | Yes     | No        | Insert |
-   * | No      | Yes     | Yes     | Yes       | Insert |
-   * | Yes     | No      | No      | No        | No-op |
-   * | Yes     | No      | No      | Yes       | Update |
-   * | Yes     | No      | Yes     | No        | Update and undelete |
-   * | Yes     | No      | Yes     | Yes       | Update and undelete |
-   * | Yes     | Yes     | No      | No        | No-op |
-   * | Yes     | Yes     | No      | Yes       | Update species with same current name |
-   * | Yes     | Yes     | Yes     | No        | Update species with same current name; undelete |
-   * | Yes     | Yes     | Yes     | Yes       | Update species with same current name; undelete |
-   * ```
-   */
-  private fun importRow(
-      rawValues: Array<out String>,
-      organizationId: OrganizationId,
-      userId: UserId,
-      overwriteExisting: Boolean
-  ): Boolean {
-    val values = rawValues.map { it.trim().ifEmpty { null } }
-
-    val scientificName = values[0]
-    val commonName = values[1]
-    val familyName = values[2]
-    val endangered = BooleanUtils.toBooleanObject(values[3])
-    val rare = BooleanUtils.toBooleanObject(values[4])
-    val growthForm = values[5]?.let { GrowthForm.forDisplayName(it) }
-    val seedStorageBehavior = values[6]?.let { SeedStorageBehavior.forDisplayName(it) }
-
-    return with(SPECIES) {
-      /**
-       * Updates the editable values of an existing species and marks it as not deleted. Leaves the
-       * initial scientific name as is.
-       */
-      fun updateExisting(speciesId: SpeciesId): Boolean {
-        val rowsUpdated =
-            dslContext
-                .update(SPECIES)
-                .set(COMMON_NAME, commonName)
-                .set(FAMILY_NAME, familyName)
-                .set(ENDANGERED, endangered)
-                .set(RARE, rare)
-                .set(GROWTH_FORM_ID, growthForm)
-                .set(SEED_STORAGE_BEHAVIOR_ID, seedStorageBehavior)
-                .setNull(DELETED_TIME)
-                .setNull(DELETED_BY)
-                .set(MODIFIED_BY, userId)
-                .set(MODIFIED_TIME, clock.instant())
-                .where(ID.eq(speciesId))
-                .execute()
-        return if (rowsUpdated == 1) {
-          true
-        } else {
-          log.error("Expected to update 1 row for species $speciesId but got $rowsUpdated")
-          false
-        }
-      }
-
-      val existingByCurrentName =
-          dslContext
-              .select(SPECIES.ID, SPECIES.DELETED_TIME)
-              .from(SPECIES)
-              .where(ORGANIZATION_ID.eq(organizationId))
-              .and(SCIENTIFIC_NAME.eq(scientificName))
-              .fetchOne()
-      val existingIdByCurrentName = existingByCurrentName?.get(ID)
-
-      if (existingIdByCurrentName != null) {
-        if (overwriteExisting || existingByCurrentName[DELETED_TIME] != null) {
-          updateExisting(existingIdByCurrentName)
-        } else {
-          false
-        }
-      } else {
-        val existingIdByInitialName =
-            dslContext
-                .select(SPECIES.ID)
-                .from(SPECIES)
-                .where(ORGANIZATION_ID.eq(organizationId))
-                .and(INITIAL_SCIENTIFIC_NAME.eq(scientificName))
-                .and(DELETED_TIME.isNull)
-                .fetchOne(SPECIES.ID)
-
-        if (existingIdByInitialName == null) {
-          dslContext
-              .insertInto(SPECIES)
-              .set(SCIENTIFIC_NAME, scientificName)
-              .set(INITIAL_SCIENTIFIC_NAME, scientificName)
-              .set(COMMON_NAME, commonName)
-              .set(FAMILY_NAME, familyName)
-              .set(ENDANGERED, endangered)
-              .set(RARE, rare)
-              .set(GROWTH_FORM_ID, growthForm)
-              .set(SEED_STORAGE_BEHAVIOR_ID, seedStorageBehavior)
-              .set(CREATED_BY, userId)
-              .set(CREATED_TIME, clock.instant())
-              .set(MODIFIED_BY, userId)
-              .set(MODIFIED_TIME, clock.instant())
-              .set(ORGANIZATION_ID, organizationId)
-              .execute()
-          true
-        } else if (overwriteExisting) {
-          updateExisting(existingIdByInitialName)
-        } else {
-          false
-        }
-      }
-    }
-  }
-
-  private fun updateStatus(uploadId: UploadId, status: UploadStatus) {
-    dslContext
-        .update(UPLOADS)
-        .set(UPLOADS.STATUS_ID, status)
-        .where(UPLOADS.ID.eq(uploadId))
-        .execute()
-  }
-
-  private fun requireAwaitingAction(uploadId: UploadId) {
-    val uploadsRow = uploadsDao.fetchOneById(uploadId) ?: throw UploadNotFoundException(uploadId)
-    if (uploadsRow.statusId != UploadStatus.AwaitingUserAction) {
-      throw UploadNotAwaitingActionException(uploadId)
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -52,6 +52,9 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   private val messages = Messages()
   private val scheduler: JobScheduler = mockk()
   private val speciesChecker: SpeciesChecker = mockk()
+  private val speciesStore: SpeciesStore by lazy {
+    SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
+  }
   private val uploadService: UploadService = mockk()
   private val uploadStore: UploadStore by lazy {
     UploadStore(dslContext, uploadProblemsDao, uploadsDao)
@@ -59,12 +62,12 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   private val userStore: UserStore = mockk()
   private val importer: SpeciesImporter by lazy {
     SpeciesImporter(
-        clock,
         dslContext,
         fileStore,
         messages,
         scheduler,
         speciesChecker,
+        speciesStore,
         uploadProblemsDao,
         uploadsDao,
         uploadService,


### PR DESCRIPTION
Accession CSV import also implicitly imports species, and we want to have the same
semantics (following renames, undeleting deleted species) we do with species list
CSV importing.

Move the "import a row from the CSV" function out of `SpeciesImporter` and into
`SpeciesStore` where the accession importer can call it.

Similarly, the accession importer will need to update the status of the uploaded
file and sanity-check its current status; move those helper functions out of
`SpeciesImporter` and into `UploadStore`.

No behavior changes here, just code shuffling. Existing tests continue to pass
as-is aside from needing to pass in a different set of dependencies.