### PR TITLE
SW-1704 Set v2 accession state on checkin

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1052,6 +1052,17 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `checkIn of v2 accession transitions state to AwaitingProcessing`() {
+    every { clock.instant() } returns Instant.EPOCH.plusMillis(600)
+
+    val initial = store.create(AccessionModel(facilityId = facilityId, isManualState = true))
+    val updated = store.checkIn(initial.id!!)
+
+    assertEquals(AccessionState.AwaitingProcessing, updated.state, "v2 state")
+    assertEquals(AccessionState.Pending, updated.toV1Compatible(clock).state, "v1 state")
+  }
+
+  @Test
   fun `checkIn does not modify accession that is already checked in`() {
     val initial = store.create(AccessionModel(facilityId = facilityId))
     store.checkIn(initial.id!!)


### PR DESCRIPTION
The `/api/v1/seedbank/accessions/{id}/checkIn` endpoint wasn't updating the
accession's state for v2 accessions.