### PR TITLE
SW-1723 Fix v2 withdrawal double-counting bug

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -332,6 +332,7 @@ data class UpdateAccessionRequestPayloadV2(
           geolocations = collectionSiteCoordinates.orEmpty(),
           isManualState = true,
           numberOfTrees = plantsCollectedFrom,
+          latestObservedQuantityCalculated = false,
           processingNotes = notes,
           receivedDate = receivedDate,
           remaining = remainingQuantity?.toModel(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -1048,7 +1048,8 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
                 updatedTime = clock.instant())),
         historyRecords)
 
-    assertEquals(store.fetchOneById(initial.id!!), updated, "Return value should match database")
+    val expected = updated.copy(latestObservedQuantityCalculated = false)
+    assertEquals(store.fetchOneById(initial.id!!), expected, "Return value should match database")
   }
 
   @Test


### PR DESCRIPTION
`AccessionModel.latestObservedQuantity` is supposed to reflect the most recent
remaining quantity that was specifically entered by the user. But because our
API is based on a CRUD model where the client always submits a "remaining
quantity" value whenever any accession field is updated, and the field can also
be updated by withdrawals and viability tests without the user explicitly editing
it, we need to infer manual edits by checking whether the value matches the one
that was previously written to the database.

This inference can fail if the following sequence happens:

1. Read the existing model from the database.
2. Make a change that should affect the remaining quantity, such as adding or
   removing a withdrawal.
3. Call `withCalculatedValues` to compare the newly-modified model against the
   one in the database. At this point, the code correctly concludes that the
   remaining quantity needs to change but that it wasn't due to user input.
4. Make another change that shouldn't affect the remaining quantity, such as
   transitioning to a new state.
5. Call `withCalculatedValues` again, but compare against the values in the
   database, not against the output of step 3. This sees that the remaining
   quantity has changed, detects that the change isn't due to one of the
   calculations it has performed, and concludes that the change must be due
   to user input. It updates `latestObservedQuantity`, and that value is then
   used as the base value for subsequent computations of the remaining quantity,
   resulting in double-counting of withdrawals.

Since user input is only applied to an `AccessionModel` once for a given request,
the fix is to remember that we've already calculated `latestObservedQuantity`
based on the content of the current request, and use the already-calculated value
on subsequent calls to `withCalculatedValues`.