### PR TITLE
SW-1729 Don't allow editing viability test types

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ViabilityTestsController.kt
@@ -201,7 +201,6 @@ data class UpdateViabilityTestRequestPayload(
     val startDate: LocalDate? = null,
     val substrate: ViabilityTestSubstrate? = null,
     @Valid val testResults: List<ViabilityTestResultPayload>? = null,
-    val testType: ViabilityTestType,
     val treatment: ViabilityTestTreatment? = null,
     @Schema(
         description =
@@ -222,7 +221,6 @@ data class UpdateViabilityTestRequestPayload(
           startDate = startDate,
           substrate = substrate,
           testResults = testResults?.map { it.toModel() },
-          testType = testType,
           treatment = treatment,
           withdrawnByUserId = withdrawnByUserId ?: model.withdrawnByUserId,
       )


### PR DESCRIPTION
Since different kinds of viability tests can have wildly varying behavior,
it doesn't make sense to update the type of an existing test. Turn test type
into a create-only field.