### PR TITLE
SW-1731 Add Nursery as a facility type

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityConnectionState
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.FacilityType
 import com.terraformation.backend.db.NotificationId
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.SpeciesId
@@ -95,6 +96,10 @@ class ParentStore(private val dslContext: DSLContext) {
     return fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.NAME)
         ?: throw FacilityNotFoundException(facilityId)
   }
+
+  fun getFacilityType(facilityId: FacilityId): FacilityType =
+      fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.TYPE_ID)
+          ?: throw FacilityNotFoundException(facilityId)
 
   fun getUserId(uploadId: UploadId): UserId? =
       fetchFieldById(uploadId, UPLOADS.ID, UPLOADS.CREATED_BY)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -50,6 +50,7 @@ data class FacilityModel(
         when (type) {
           FacilityType.SeedBank -> DeviceTemplateCategory.SeedBankDefault
           FacilityType.Desalination,
+          FacilityType.Nursery,
           FacilityType.ReverseOsmosis -> null
         }
 }

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -54,6 +54,9 @@ class FacilityAlreadyConnectedException(val facilityId: FacilityId) :
 class FacilityNotFoundException(val facilityId: FacilityId) :
     EntityNotFoundException("Facility $facilityId not found")
 
+class FacilityTypeMismatchException(val facilityId: FacilityId, val requiredType: FacilityType) :
+    MismatchedStateException("Facility $facilityId is not of type ${requiredType.displayName}")
+
 /** A request to the Keycloak authentication server failed. */
 open class KeycloakRequestFailedException(
     override val message: String,

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -45,7 +45,8 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 INSERT INTO facility_types (id, name)
 VALUES (1, 'Seed Bank'),
        (2, 'Desalination'),
-       (3, 'Reverse Osmosis')
+       (3, 'Reverse Osmosis'),
+       (4, 'Nursery')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO growth_forms (id, name)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -14,6 +14,8 @@ import com.terraformation.backend.db.DataSource
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityId
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.FacilityType
+import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.GeolocationId
 import com.terraformation.backend.db.OrganizationId
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -328,6 +330,17 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(newSpeciesId, initial.speciesId, "Species ID")
     assertEquals(newSpeciesName, initial.species, "Species name")
+  }
+
+  @Test
+  fun `create does not allow creating an accession at a nursery facility`() {
+    val nurseryFacilityId = FacilityId(2)
+
+    insertFacility(nurseryFacilityId, type = FacilityType.Nursery)
+
+    assertThrows<FacilityTypeMismatchException> {
+      store.create(AccessionModel(facilityId = nurseryFacilityId))
+    }
   }
 
   @Test


### PR DESCRIPTION
Allow clients to create (and edit) nursery facilities using the existing
`/api/v1/facilities` endpoints.

Disallow creating accessions at a nursery facility.