### PR TITLE
Update body of drying notification

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -84,8 +84,7 @@ class Messages {
 
   fun accessionDryingEndNotification(accessionNumber: String): NotificationMessage =
       NotificationMessage(
-          title = "An accession has dried",
-          body = "$accessionNumber has reached its scheduled drying date.")
+          title = "An accession has dried", body = "$accessionNumber has finished drying.")
 
   fun facilityIdle(): NotificationMessage =
       NotificationMessage(


### PR DESCRIPTION
The wording of the notification didn't match the product spec.