### PR TITLE
SW-1732 Preserve staff responsible in v2 API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -204,11 +204,14 @@ data class AccessionModel(
       // style accessions but that weren't calculated at the time it was written to the database.
       // First backfill those values using the v1 logic, then switch to v2, then calculate any
       // v2-specific values.
-      withCalculatedValues(clock)
+      val v1WithCalculatedValues = withCalculatedValues(clock)
+      v1WithCalculatedValues
           .copy(
               isManualState = true,
               state = state?.toV2Compatible(),
-              viabilityTests = viabilityTests.map { it.toV2Compatible() })
+              viabilityTests = v1WithCalculatedValues.viabilityTests.map { it.toV2Compatible() },
+              withdrawals = v1WithCalculatedValues.withdrawals.map { it.toV2Compatible() },
+          )
           .withCalculatedValues(clock)
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -120,7 +120,19 @@ data class ViabilityTestModel(
           }
         }
 
-    return copy(seedsTested = seedsTested ?: 1, substrate = newSubstrate)
+    val notesWithStaffResponsible =
+        when {
+          staffResponsible.isNullOrBlank() -> notes
+          notes.isNullOrBlank() -> "Staff responsible: $staffResponsible"
+          staffResponsible in notes -> notes
+          else -> "$notes\n\nStaff responsible: $staffResponsible"
+        }
+
+    return copy(
+        notes = notesWithStaffResponsible,
+        seedsTested = seedsTested ?: 1,
+        substrate = newSubstrate,
+    )
   }
 
   fun fieldsEqual(other: ViabilityTestModel): Boolean {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -124,7 +124,7 @@ data class ViabilityTestModel(
         when {
           staffResponsible.isNullOrBlank() -> notes
           notes.isNullOrBlank() -> "Staff responsible: $staffResponsible"
-          staffResponsible in notes -> notes
+          "Staff responsible: $staffResponsible" in notes -> notes
           else -> "$notes\n\nStaff responsible: $staffResponsible"
         }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -176,4 +176,16 @@ data class WithdrawalModel(
       this
     }
   }
+
+  fun toV2Compatible(): WithdrawalModel {
+    val notesWithStaffResponsible =
+        when {
+          staffResponsible.isNullOrBlank() -> notes
+          notes.isNullOrBlank() -> "Staff responsible: $staffResponsible"
+          staffResponsible in notes -> notes
+          else -> "$notes\n\nStaff responsible: $staffResponsible"
+        }
+
+    return copy(notes = notesWithStaffResponsible)
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -182,7 +182,7 @@ data class WithdrawalModel(
         when {
           staffResponsible.isNullOrBlank() -> notes
           notes.isNullOrBlank() -> "Staff responsible: $staffResponsible"
-          staffResponsible in notes -> notes
+          "Staff responsible: $staffResponsible" in notes -> notes
           else -> "$notes\n\nStaff responsible: $staffResponsible"
         }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -151,7 +151,9 @@ internal class ViabilityTestModelTest {
               model("existing notes", null) to "existing notes",
               model("existing notes", " ") to "existing notes",
               model("existing notes with staff name", "staff name") to
-                  "existing notes with staff name",
+                  "existing notes with staff name\n\nStaff responsible: staff name",
+              model("existing\nStaff responsible: staff name", "staff name") to
+                  "existing\nStaff responsible: staff name",
               model(null, "staff name") to "Staff responsible: staff name",
               model("existing notes", "staff name") to
                   "existing notes\n\nStaff responsible: staff name",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -132,4 +132,34 @@ internal class ViabilityTestModelTest {
       assertEquals(50, model.calculateViabilityPercent())
     }
   }
+
+  @Nested
+  inner class V1ToV2Conversion {
+    @Test
+    fun `staff responsible is added to notes`() {
+      fun model(notes: String?, staffResponsible: String?) =
+          ViabilityTestModel(
+              notes = notes,
+              staffResponsible = staffResponsible,
+              seedsTested = 1,
+              testType = ViabilityTestType.Lab)
+
+      val testCases: List<Pair<ViabilityTestModel, String?>> =
+          listOf(
+              model(null, null) to null,
+              model(" ", "  ") to " ",
+              model("existing notes", null) to "existing notes",
+              model("existing notes", " ") to "existing notes",
+              model("existing notes with staff name", "staff name") to
+                  "existing notes with staff name",
+              model(null, "staff name") to "Staff responsible: staff name",
+              model("existing notes", "staff name") to
+                  "existing notes\n\nStaff responsible: staff name",
+          )
+
+      val actual = testCases.map { it.first to it.first.toV2Compatible().notes }
+
+      assertEquals(testCases, actual)
+    }
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/WithdrawalModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/WithdrawalModelTest.kt
@@ -21,7 +21,9 @@ internal class WithdrawalModelTest {
               model("existing notes", null) to "existing notes",
               model("existing notes", " ") to "existing notes",
               model("existing notes with staff name", "staff name") to
-                  "existing notes with staff name",
+                  "existing notes with staff name\n\nStaff responsible: staff name",
+              model("existing\nStaff responsible: staff name", "staff name") to
+                  "existing\nStaff responsible: staff name",
               model(null, "staff name") to "Staff responsible: staff name",
               model("existing notes", "staff name") to
                   "existing notes\n\nStaff responsible: staff name",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/WithdrawalModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/WithdrawalModelTest.kt
@@ -1,0 +1,34 @@
+package com.terraformation.backend.seedbank.model
+
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class WithdrawalModelTest {
+  @Nested
+  inner class V1ToV2Conversion {
+    @Test
+    fun `staff responsible is added to notes`() {
+      fun model(notes: String?, staffResponsible: String?) =
+          WithdrawalModel(
+              date = LocalDate.EPOCH, notes = notes, staffResponsible = staffResponsible)
+
+      val testCases: List<Pair<WithdrawalModel, String?>> =
+          listOf(
+              model(null, null) to null,
+              model(" ", "  ") to " ",
+              model("existing notes", null) to "existing notes",
+              model("existing notes", " ") to "existing notes",
+              model("existing notes with staff name", "staff name") to
+                  "existing notes with staff name",
+              model(null, "staff name") to "Staff responsible: staff name",
+              model("existing notes", "staff name") to
+                  "existing notes\n\nStaff responsible: staff name",
+          )
+
+      val actual = testCases.map { it.first to it.first.toV2Compatible().notes }
+      assertEquals(testCases, actual)
+    }
+  }
+}


### PR DESCRIPTION
In v1, viability tests and withdrawals have a "Staff Responsible" field which is
an arbitrary text value. In v2, we've replaced that field with a Terraware user
ID. But we don't want to lose any text the users entered into the field in v1,
so add it to the "Notes" field.

If the "Notes" field already contains the text of the "Staff Responsible" field,
we don't modify it; this prevents us from adding it multiple times if an accession
repeatedly flips between v1 and v2 writes.