### PR TITLE
Move unit tests to ViabilityTestModelTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -2043,78 +2043,6 @@ internal class AccessionModelTest {
 
       assertJsonEquals(expected, initial.toV2Compatible(tomorrowClock))
     }
-
-    @Test
-    fun `viability test substrate is removed if it is not valid for v2 nursery test`() {
-      val v1Model =
-          AccessionModel(
-              checkedInTime = yesterdayInstant,
-              createdTime = yesterdayInstant,
-              processingMethod = ProcessingMethod.Count,
-              total = seeds(10),
-              viabilityTests =
-                  listOf(
-                      ViabilityTestModel(
-                          id = ViabilityTestId(1),
-                          seedsTested = 1,
-                          startDate = today,
-                          substrate = ViabilityTestSubstrate.Agar,
-                          testType = ViabilityTestType.Nursery,
-                      ),
-                  ),
-              withdrawals =
-                  listOf(
-                      WithdrawalModel(
-                          createdTime = todayInstant,
-                          date = today,
-                          id = WithdrawalId(1),
-                          purpose = WithdrawalPurpose.ViabilityTesting,
-                          remaining = seeds(9),
-                          viabilityTestId = ViabilityTestId(1),
-                          withdrawn = seeds(1),
-                      ),
-                  ),
-          )
-
-      val v2Model = v1Model.toV2Compatible(tomorrowClock)
-      assertNull(v2Model.viabilityTests[0].substrate)
-    }
-
-    @Test
-    fun `viability test substrate is retained if it is valid for v2 nursery test`() {
-      val v1Model =
-          AccessionModel(
-              checkedInTime = yesterdayInstant,
-              createdTime = yesterdayInstant,
-              processingMethod = ProcessingMethod.Count,
-              total = seeds(10),
-              viabilityTests =
-                  listOf(
-                      ViabilityTestModel(
-                          id = ViabilityTestId(1),
-                          seedsTested = 1,
-                          startDate = today,
-                          substrate = ViabilityTestSubstrate.Other,
-                          testType = ViabilityTestType.Nursery,
-                      ),
-                  ),
-              withdrawals =
-                  listOf(
-                      WithdrawalModel(
-                          createdTime = todayInstant,
-                          date = today,
-                          id = WithdrawalId(1),
-                          purpose = WithdrawalPurpose.ViabilityTesting,
-                          remaining = seeds(9),
-                          viabilityTestId = ViabilityTestId(1),
-                          withdrawn = seeds(1),
-                      ),
-                  ),
-          )
-
-      val v2Model = v1Model.toV2Compatible(tomorrowClock)
-      assertEquals(ViabilityTestSubstrate.Other, v2Model.viabilityTests[0].substrate)
-    }
   }
 
   @Nested
@@ -2138,36 +2066,6 @@ internal class AccessionModelTest {
 
       val v1Model = v2Model.toV1Compatible(clock)
       assertEquals(40, v1Model.totalViabilityPercent)
-    }
-
-    @Test
-    fun `viability test substrate is removed if it did not exist in v1`() {
-      val v2Model =
-          accession()
-              .copy(isManualState = true, remaining = seeds(10))
-              .withCalculatedValues(clock)
-              .addViabilityTest(
-                  viabilityTest(
-                      seedsTested = 1,
-                      testType = ViabilityTestType.Nursery,
-                      substrate = ViabilityTestSubstrate.Moss),
-                  clock)
-
-      val v1Model = v2Model.toV1Compatible(clock)
-      assertNull(v1Model.viabilityTests[0].substrate)
-    }
-
-    @Test
-    fun `viability test substrate is preserved if it existed in v1`() {
-      val v2Model =
-          accession()
-              .copy(isManualState = true, remaining = seeds(10))
-              .withCalculatedValues(clock)
-              .addViabilityTest(
-                  viabilityTest(seedsTested = 1, substrate = ViabilityTestSubstrate.Agar), clock)
-
-      val v1Model = v2Model.toV1Compatible(clock)
-      assertEquals(ViabilityTestSubstrate.Agar, v1Model.viabilityTests[0].substrate)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -163,5 +163,60 @@ internal class ViabilityTestModelTest {
 
       assertEquals(testCases, actual)
     }
+
+    @Test
+    fun `substrate is removed if it is not valid for v2 nursery test`() {
+      val v1Model =
+          ViabilityTestModel(
+              seedsTested = 1,
+              substrate = ViabilityTestSubstrate.Agar,
+              testType = ViabilityTestType.Nursery,
+          )
+
+      val v2Model = v1Model.toV2Compatible()
+      assertNull(v2Model.substrate)
+    }
+
+    @Test
+    fun `substrate is retained if it is valid for v2 nursery test`() {
+      val v1Model =
+          ViabilityTestModel(
+              seedsTested = 1,
+              substrate = ViabilityTestSubstrate.Other,
+              testType = ViabilityTestType.Nursery,
+          )
+
+      val v2Model = v1Model.toV2Compatible()
+      assertEquals(ViabilityTestSubstrate.Other, v2Model.substrate)
+    }
+  }
+
+  @Nested
+  inner class V2ToV1Conversion {
+    @Test
+    fun `substrate is removed if it did not exist in v1`() {
+      val v2Model =
+          ViabilityTestModel(
+              seedsTested = 1,
+              substrate = ViabilityTestSubstrate.Moss,
+              testType = ViabilityTestType.Nursery,
+          )
+
+      val v1Model = v2Model.toV1Compatible()
+      assertNull(v1Model.substrate)
+    }
+
+    @Test
+    fun `substrate is preserved if it existed in v1`() {
+      val v2Model =
+          ViabilityTestModel(
+              seedsTested = 1,
+              substrate = ViabilityTestSubstrate.Agar,
+              testType = ViabilityTestType.Lab,
+          )
+
+      val v1Model = v2Model.toV1Compatible()
+      assertEquals(ViabilityTestSubstrate.Agar, v1Model.substrate)
+    }
   }
 }


### PR DESCRIPTION
Some of the test cases in `AccessionModelTest` were testing behavior of
`ViabilityTestModel` that didn't depend on any data in the accession. Move them to
`ViabilityTestModelTest`.