### PR TITLE
SW-1797 Allow moving out of Used Up if remaining quantity is set

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -264,7 +264,7 @@ data class AccessionModel(
       newModel: AccessionModel,
       clock: Clock
   ): AccessionStateTransition? {
-    val seedsRemaining = newModel.calculateRemaining(clock)
+    val seedsRemaining = newModel.calculateRemaining(clock, this)
     val allSeedsWithdrawn = seedsRemaining != null && seedsRemaining.quantity <= BigDecimal.ZERO
     val oldState = state ?: AccessionState.AwaitingProcessing
     val newState = newModel.state ?: AccessionState.AwaitingProcessing

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/AccessionModelTest.kt
@@ -1612,6 +1612,29 @@ internal class AccessionModelTest {
 
       return tests
     }
+
+    @Test
+    fun `can move out of Used Up if remaining quantity and state are set at the same time`() {
+      val initial =
+          accession()
+              .copy(isManualState = true, remaining = seeds(10))
+              .withCalculatedValues(clock)
+              .addWithdrawal(withdrawal(seeds(10), id = null), clock)
+
+      assertEquals(
+          AccessionState.UsedUp, initial.state, "Withdrawal of all seeds sets state to Used Up")
+
+      val updated =
+          initial
+              .copy(
+                  remaining = seeds(5),
+                  state = AccessionState.Drying,
+                  latestObservedQuantityCalculated = false)
+              .withCalculatedValues(clock, initial)
+
+      assertEquals(seeds(5), updated.remaining, "Manual update of remaining quantity is accepted")
+      assertEquals(AccessionState.Drying, updated.state, "Manual update of state is accepted")
+    }
   }
 
   @Nested


### PR DESCRIPTION
The user is supposed to be able to change an accession from Used Up to some other
state if they set the remaining quantity at the same time, but the server wasn't
accepting the state change.