### PR TITLE
SW-1803 Parse updated accession CSV template

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
@@ -37,10 +37,6 @@ class AccessionCsvValidator(
 
     validateHeaderRow(csvReader.readNext())
 
-    // Ignore instructions row.
-    rowNum++
-    csvReader.readNext()
-
     csvReader.forEach { rawValues ->
       rowNum++
       validateRow(rawValues)
@@ -93,7 +89,9 @@ class AccessionCsvValidator(
     // Our example template file has a zillion rows where only the status and collection source
     // columns have values; we don't want to flag those rows as errors if the user downloads the
     // template, edits some of the rows, and leaves the other example rows in place.
-    if (values[5] != null && values[14] != null && values.count { it != null } == 2) {
+    val columnsWithValues = values.count { it != null }
+    if (columnsWithValues == 0 ||
+        (values[5] != null && values[14] != null && columnsWithValues == 2)) {
       return
     }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -154,8 +154,7 @@ class AccessionImporter(
         dslContext.transaction { _ ->
           val csvReader = CSVReader(InputStreamReader(inputStream))
 
-          // Consume header and instruction lines
-          csvReader.readNext()
+          // Consume header row
           csvReader.readNext()
 
           csvReader.forEach { importRow(it, organizationId, facilityId, overwriteExisting) }
@@ -177,7 +176,9 @@ class AccessionImporter(
     // Our example template file has a zillion rows where only the status and collection source
     // columns have values; we don't want to try to create accessions for them if the user downloads
     // the template, edits some of the rows, and leaves the other example rows in place.
-    if (values[5] != null && values[14] != null && values.count { it != null } == 2) {
+    val columnsWithValues = values.count { it != null }
+    if (columnsWithValues == 0 ||
+        (values[5] != null && values[14] != null && columnsWithValues == 2)) {
       return
     }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -268,6 +268,12 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `accepts rows where all columns are blank`() {
+      every { scheduler.enqueue<AccessionImporter>(any()) } returns JobId(UUID.randomUUID())
+      testValidation(",,,,  ,,,,,    ,,,\"  \",,,,\n", UploadStatus.AwaitingProcessing)
+    }
+
+    @Test
     fun `rejects rows with wrong number of columns`() {
       testValidation(
           ",Species name,,,,",
@@ -277,7 +283,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 3,
+              position = 2,
               message = messages.csvWrongFieldCount(17, 6)))
     }
 
@@ -294,7 +300,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MissingRequiredValue,
               isError = true,
-              position = 3,
+              position = 2,
               field = "Species (Scientific Name)",
               message = messages.csvScientificNameMissing()),
           UploadProblemsRow(
@@ -302,7 +308,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 4,
+              position = 3,
               field = "Species (Scientific Name)",
               message = messages.csvScientificNameTooShort(),
               value = "Name"),
@@ -311,7 +317,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 5,
+              position = 4,
               field = "Species (Scientific Name)",
               message = messages.csvScientificNameTooLong(),
               value = "A very long name with too many words"),
@@ -320,7 +326,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 6,
+              position = 5,
               field = "Species (Scientific Name)",
               message = messages.csvScientificNameInvalidChar("?"),
               value = "Bad name?"),
@@ -342,7 +348,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MissingRequiredValue,
               isError = true,
-              position = 3,
+              position = 2,
               field = "Collection Date",
               message = messages.csvRequiredFieldMissing()),
           UploadProblemsRow(
@@ -350,7 +356,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 4,
+              position = 3,
               field = "Collection Date",
               message = messages.csvDateMalformed(),
               value = "January 6"),
@@ -359,7 +365,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 5,
+              position = 4,
               field = "Collection Date",
               message = messages.csvDateMalformed(),
               value = "2022-99-99"),
@@ -368,7 +374,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 6,
+              position = 5,
               field = "Collection Date",
               message = messages.csvDateMalformed(),
               value = "2022/03/04"),
@@ -377,7 +383,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 7,
+              position = 6,
               field = "Collection Date",
               message = messages.csvDateMalformed(),
               value = "2022-3-4"),
@@ -386,7 +392,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.MalformedValue,
               isError = true,
-              position = 8,
+              position = 7,
               field = "Collection Date",
               message = messages.csvDateMalformed(),
               value = "20220304"),
@@ -405,7 +411,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.UnrecognizedValue,
               isError = true,
-              position = 3,
+              position = 2,
               field = "Status",
               message = messages.accessionCsvStatusInvalid(),
               value = "Bogus"),
@@ -414,7 +420,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.UnrecognizedValue,
               isError = true,
-              position = 4,
+              position = 3,
               field = "Status",
               message = messages.accessionCsvStatusInvalid(),
               value = "Withdrawn"),
@@ -431,7 +437,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.UnrecognizedValue,
               isError = true,
-              position = 3,
+              position = 2,
               field = "Collection Source",
               message = messages.accessionCsvCollectionSourceInvalid(),
               value = "Unknown"))
@@ -449,7 +455,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.DuplicateValue,
               isError = false,
-              position = 3,
+              position = 2,
               field = "Accession Number",
               message = messages.accessionCsvNumberExists(),
               value = "123"))
@@ -466,9 +472,9 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
               uploadId = uploadId,
               typeId = UploadProblemType.DuplicateValue,
               isError = true,
-              position = 4,
+              position = 3,
               field = "Accession Number",
-              message = messages.accessionCsvNumberDuplicate(3),
+              message = messages.accessionCsvNumberDuplicate(2),
               value = "123"))
     }
 
@@ -717,6 +723,21 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
       importer.importCsv(uploadId, true)
 
       assertEquals(emptyList<AccessionsRow>(), accessionsDao.findAll())
+    }
+
+    @Test
+    fun `ignores empty rows`() {
+      insertAccessionUpload(
+          ",\" \",, ,,, ,,,,,,,,,,\n" +
+              ",Species name,,10,,,2022-03-04,,,,,,,,,,\n" +
+              ",,,,,,,,,,,,,,,,\n",
+          UploadStatus.AwaitingProcessing)
+
+      importer.importCsv(uploadId, false)
+
+      val accessions = accessionsDao.findAll()
+      assertEquals(1, accessions.size, "Should have inserted 1 accession")
+      assertEquals(BigDecimal.TEN, accessions[0].remainingQuantity, "Quantity")
     }
   }
 

--- a/src/test/resources/seedbank/accession/HappyPath.csv
+++ b/src/test/resources/seedbank/accession/HappyPath.csv
@@ -1,22 +1,33 @@
-Accession Number,Species (Scientific Name)*,Species (Common Name),QTY,QTY Units,Status,Collection Date*,Collecting Site Name,Landowner,City or County,State / Province / Region,Country,Site Description / Notes,"Collector Name (First, Last)",Collection Source,Number of Plants ,Plant ID
-,"Please input the scientific name in the following format:
+Accession Number,"Species (Scientific Name)*
 
-Genus species ",,Only enter numbers or an error will occur during upload. ,"Please choose from the following list or an error will occur during upload:
+Please input the scientific name in the following format:
+
+Genus species ",Species (Common Name),"QTY
+
+Only enter numbers or an error will occur during upload. ","QTY Units
+
+Please choose from the following list or an error will occur during upload:
 - Count
 - Grams
 - Kilograms
-- Milligrams 
+- Milligrams
 - Pounds
-- Ounces ","Please choose from the following list or an error will occur during upload:
-- Awaiting Processing 
+- Ounces ","Status
+
+Please choose from the following list or an error will occur during upload:
+- Awaiting Processing
 - Processing
 - Drying
 - In Storage
-- Used Up ",Please enter in YYYY-MM-DD format or an error will occur during upload. If you are unsure of the exact date an estimate is fine!,,,,,,,,"Please choose from the following list or an error will occur during upload:
+- Used Up ","Collection Date*
+
+Please enter in YYYY-MM-DD format or an error will occur during upload. If you are unsure of the exact date an estimate is fine!",Collecting Site Name,Landowner,City or County,State / Province / Region,Country,Site Description / Notes,Collector Name ,"Collection Source
+
+Please choose from the following list or an error will occur during upload:
 - Wild (In Situ)
-- Reintroduced 
+- Reintroduced
 - Cultivated (Ex Situ)
-- Other",,
+- Other",Number of Plants ,Plant ID
 12345,New species var. new,New common name,100,Seeds,Drying,2022-03-04,New site name,New landowner,"City name",Hawaii,US,"Site description
 with multiple
 lines","Collector,Name",Reintroduced,5,PlantID

--- a/src/test/resources/seedbank/accession/HeaderRows.csv
+++ b/src/test/resources/seedbank/accession/HeaderRows.csv
@@ -1,19 +1,30 @@
-Accession Number,Species (Scientific Name)*,Species (Common Name),QTY,QTY Units,Status,Collection Date*,Collecting Site Name,Landowner,City or County,State / Province / Region,Country,Site Description / Notes,"Collector Name (First, Last)",Collection Source,Number of Plants ,Plant ID
-,"Please input the scientific name in the following format:
+Accession Number,"Species (Scientific Name)*
 
-Genus species ",,Only enter numbers or an error will occur during upload. ,"Please choose from the following list or an error will occur during upload:
+Please input the scientific name in the following format:
+
+Genus species ",Species (Common Name),"QTY
+
+Only enter numbers or an error will occur during upload. ","QTY Units
+
+Please choose from the following list or an error will occur during upload:
 - Count
 - Grams
 - Kilograms
-- Milligrams 
+- Milligrams
 - Pounds
-- Ounces ","Please choose from the following list or an error will occur during upload:
-- Awaiting Processing 
+- Ounces ","Status
+
+Please choose from the following list or an error will occur during upload:
+- Awaiting Processing
 - Processing
 - Drying
 - In Storage
-- Used Up ",Please enter in YYYY-MM-DD format or an error will occur during upload. If you are unsure of the exact date an estimate is fine!,,,,,,,,"Please choose from the following list or an error will occur during upload:
+- Used Up ","Collection Date*
+
+Please enter in YYYY-MM-DD format or an error will occur during upload. If you are unsure of the exact date an estimate is fine!",Collecting Site Name,Landowner,City or County,State / Province / Region,Country,Site Description / Notes,Collector Name ,"Collection Source
+
+Please choose from the following list or an error will occur during upload:
 - Wild (In Situ)
-- Reintroduced 
+- Reintroduced
 - Cultivated (Ex Situ)
-- Other",,
+- Other",Number of Plants ,Plant ID


### PR DESCRIPTION
The CSV importer was based on an early draft of the CSV template where the
instructions were on a separate row from the column names, but the final template
includes the instructions and column names in a single row, followed by a blank
row. Users might fill in values in the blank row, or they might not; handle either
situation by only skipping the first (header) row and ignoring blank rows
elsewhere in the file.