### PR TITLE
SW-1803 Map accession CSV country names to codes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -47,6 +47,9 @@ class Messages {
   fun accessionCsvCollectionSourceInvalid() =
       "Collection source must be one of: $validCollectionSources"
 
+  fun accessionCsvCountryInvalid() =
+      "Country must be a valid two-letter ISO country code or a recognized country name"
+
   fun accessionCsvNumberDuplicate(lineNumber: Int) =
       "Accession number already used on line $lineNumber"
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
@@ -18,6 +18,7 @@ import java.time.format.DateTimeParseException
 class AccessionCsvValidator(
     private val uploadId: UploadId,
     private val messages: Messages,
+    private val countryCodesByLowerCsvValue: Map<String, String>,
     private val findExistingAccessionNumbers: (Collection<String>) -> Collection<String>,
 ) {
   val warnings = mutableListOf<UploadProblemsRow>()
@@ -101,6 +102,7 @@ class AccessionCsvValidator(
     validateUnits(values[4], ACCESSION_CSV_HEADERS[4])
     validateStatus(values[5], ACCESSION_CSV_HEADERS[5])
     validateCollectionDate(values[6], ACCESSION_CSV_HEADERS[6])
+    validateCountryCode(values[11], ACCESSION_CSV_HEADERS[11])
     validateCollectionSource(values[14], ACCESSION_CSV_HEADERS[14])
     validateNumberOfPlants(values[15], ACCESSION_CSV_HEADERS[15])
   }
@@ -165,6 +167,13 @@ class AccessionCsvValidator(
           field,
           value,
           messages.accessionCsvQuantityUnitsInvalid())
+    }
+  }
+
+  private fun validateCountryCode(value: String?, field: String) {
+    if (value != null && value.lowercase() !in countryCodesByLowerCsvValue) {
+      addError(
+          UploadProblemType.UnrecognizedValue, field, value, messages.accessionCsvCountryInvalid())
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.AutomationsDao
+import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.DeviceManagersDao
 import com.terraformation.backend.db.default_schema.tables.daos.DeviceTemplatesDao
 import com.terraformation.backend.db.default_schema.tables.daos.DevicesDao
@@ -219,6 +220,7 @@ abstract class DatabaseTest {
   protected val accessionsDao: AccessionsDao by lazyDao()
   protected val automationsDao: AutomationsDao by lazyDao()
   protected val bagsDao: BagsDao by lazyDao()
+  protected val countriesDao: CountriesDao by lazyDao()
   protected val deviceManagersDao: DeviceManagersDao by lazyDao()
   protected val devicesDao: DevicesDao by lazyDao()
   protected val deviceTemplatesDao: DeviceTemplatesDao by lazyDao()


### PR DESCRIPTION
In the template CSV we don't specify that the user has to feed us valid ISO
country codes in upper case, and requiring users to do that would be needlessly
annoying. Update the CSV importer to accept country names and lower-case country
codes, and add a validation check to detect unrecognized countries.