### PR TITLE
Use fully qualified class names for Spring beans

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/Application.kt
+++ b/src/main/kotlin/com/terraformation/backend/Application.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator
 import org.springframework.scheduling.annotation.EnableScheduling
 
 /**
@@ -41,7 +42,8 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableScheduling
 @SpringBootApplication(
     // https://github.com/spring-projects/spring-boot/issues/26439
-    exclude = [R2dbcAutoConfiguration::class])
+    exclude = [R2dbcAutoConfiguration::class],
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator::class)
 class Application
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
By default, when Spring registers a class as a bean due to the presence of an
annotation, it uses the unqualified class name as the bean name. We don't refer
to beans by name in our code, just by class, but internally Spring requires
each bean to have a unique name.

The default naming strategy is going to cause collisions once we have multiple
database tables with the same name in different schemas, because each table gets
a DAO class that is annotated as a Spring bean, e.g., we'll have two separate
`WithdrawalsDao` classes in different packages.

Tell Spring to base its default bean names on fully-qualified class names instead.