### PR TITLE
SW-1845 Refactor accession number generation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
@@ -1,0 +1,65 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.db.seedbank.sequences.ACCESSION_NUMBER_SEQ
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.seedbank.db.AccessionStore
+import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+@ManagedBean
+class IdentifierGenerator(
+    private val clock: Clock,
+    private val dslContext: DSLContext,
+) {
+  private val log = perClassLogger()
+
+  /**
+   * Returns the next unused user-facing identifier. This is used in places where we need a unique
+   * value to identify a resource but it's not acceptable to display the underlying integer ID from
+   * the database, e.g., accession numbers.
+   *
+   * Identifiers are of the form YYYYMMDDXXX where XXX is a numeric suffix of three or more digits
+   * that starts at 000 for the first identifier created on a particular date. The desired behavior
+   * is for the suffix to represent the order in which entries were added to the system, so ideally
+   * we want to avoid gaps or out-of-order values, though it's fine for that to be best-effort.
+   *
+   * The implementation uses a database sequence. The sequence's values follow the same pattern as
+   * the identifiers, but the suffix is always 10 digits; it is rendered as a 3-or-more-digit value
+   * by this method.
+   *
+   * If the date part of the sequence value doesn't match the current date, this method resets the
+   * sequence to the zero suffix for the current date.
+   *
+   * Note that there is a bit of a race condition if multiple terraware-server instances happen to
+   * allocate their first identifier of a given day at the same time; they might both reset the
+   * sequence. To guard against that, [AccessionStore.create] will retry a few times if it gets a
+   * unique constraint violation on the accession number.
+   */
+  fun generateIdentifier(): String {
+    val suffixMultiplier = 10000000000L
+    val todayAsLong = LocalDate.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE).toLong()
+
+    val sequenceValue =
+        dslContext.select(ACCESSION_NUMBER_SEQ.nextval()).fetchOne(ACCESSION_NUMBER_SEQ.nextval())!!
+    val datePart = sequenceValue / suffixMultiplier
+    val suffixPart = sequenceValue.rem(suffixMultiplier)
+
+    val suffix =
+        if (todayAsLong != datePart) {
+          val firstValueForToday = todayAsLong * suffixMultiplier
+          dslContext
+              .alterSequence(ACCESSION_NUMBER_SEQ)
+              .restartWith(firstValueForToday + 1)
+              .execute()
+          log.info("Resetting identifier sequence to $firstValueForToday")
+          0
+        } else {
+          suffixPart
+        }
+
+    return "%08d%03d".format(todayAsLong, suffix)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.NotificationId
@@ -98,6 +99,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             WithdrawalStore(dslContext, clock, mockk(), parentStore),
             clock,
             mockk(),
+            IdentifierGenerator(clock, dslContext),
         )
     automationStore = AutomationStore(automationsDao, clock, dslContext, objectMapper, parentStore)
     deviceStore = DeviceStore(devicesDao)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.UploadNotAwaitingActionException
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
@@ -79,7 +80,9 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         speciesService,
         WithdrawalStore(dslContext, clock, messages, parentStore),
         clock,
-        messages)
+        messages,
+        IdentifierGenerator(clock, dslContext),
+    )
   }
   private val clock: Clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
   private val fileStore: FileStore = mockk()

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityTypeMismatchException
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -183,6 +184,7 @@ internal class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             WithdrawalStore(dslContext, clock, messages, parentStore),
             clock,
             messages,
+            IdentifierGenerator(clock, dslContext),
         )
 
     insertSiteData()

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -89,6 +89,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             clock,
             mockk(),
+            mockk(),
         )
 
     tempDir = Files.createTempDirectory(javaClass.simpleName)


### PR DESCRIPTION
We're going to need to allocate user-facing identifiers from the same pool of
values for accessions and seedling batches, as well as change them so they're
scoped per organization rather than globally.

This first step is to decouple the generation of these identifiers from the
seedbank code.

No change in functionality here, just moving the logic out of `AccessionStore`.