### PR TITLE
SW-1895 Add endpoint to read seedling batches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -23,6 +23,8 @@ import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATI
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -59,6 +61,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getFacilityId(automationId: AutomationId): FacilityId? =
       fetchFieldById(automationId, AUTOMATIONS.ID, AUTOMATIONS.FACILITY_ID)
+
+  fun getFacilityId(batchId: BatchId): FacilityId? =
+      fetchFieldById(batchId, BATCHES.ID, BATCHES.FACILITY_ID)
 
   fun getFacilityId(deviceManagerId: DeviceManagerId): FacilityId? =
       fetchFieldById(deviceManagerId, DEVICE_MANAGERS.ID, DEVICE_MANAGERS.FACILITY_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -126,6 +127,7 @@ data class DeviceManagerUser(
   override fun canListNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
+  override fun canReadBatch(batchId: BatchId): Boolean = false
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -259,6 +260,11 @@ data class IndividualUser(
   override fun canReadAutomation(automationId: AutomationId): Boolean {
     val facilityId = parentStore.getFacilityId(automationId) ?: return false
     return canReadFacility(facilityId)
+  }
+
+  override fun canReadBatch(batchId: BatchId): Boolean {
+    val facilityId = parentStore.getFacilityId(batchId) ?: return false
+    return facilityId in facilityRoles
   }
 
   override fun canReadDevice(deviceId: DeviceId): Boolean {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -23,9 +23,11 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.nursery.db.BatchNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -265,6 +267,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readAutomation(automationId: AutomationId) {
     if (!user.canReadAutomation(automationId)) {
       throw AutomationNotFoundException(automationId)
+    }
+  }
+
+  fun readBatch(batchId: BatchId) {
+    if (!user.canReadBatch(batchId)) {
+      throw BatchNotFoundException(batchId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -125,6 +126,7 @@ class SystemUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
+  override fun canReadBatch(batchId: BatchId): Boolean = true
   override fun canReadDevice(deviceId: DeviceId): Boolean = true
   override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canReadFacility(facilityId: FacilityId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -90,6 +91,7 @@ interface TerrawareUser : Principal {
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
   fun canReadAccession(accessionId: AccessionId): Boolean
   fun canReadAutomation(automationId: AutomationId): Boolean
+  fun canReadBatch(batchId: BatchId): Boolean
   fun canReadDevice(deviceId: DeviceId): Boolean
   fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canReadFacility(facilityId: FacilityId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,10 +26,16 @@ import org.springframework.web.bind.annotation.RestController
 class BatchesController(
     private val batchStore: BatchStore,
 ) {
+  @GetMapping("/{id}")
+  fun getBatch(@PathVariable("id") id: BatchId): BatchResponsePayload {
+    val row = batchStore.fetchOneById(id)
+    return BatchResponsePayload(BatchPayload(row))
+  }
+
   @PostMapping
-  fun createBatch(@RequestBody payload: CreateBatchRequestPayload): CreateBatchResponsePayload {
+  fun createBatch(@RequestBody payload: CreateBatchRequestPayload): BatchResponsePayload {
     val insertedRow = batchStore.create(payload.toRow())
-    return CreateBatchResponsePayload(BatchPayload(insertedRow))
+    return BatchResponsePayload(BatchPayload(insertedRow))
   }
 }
 
@@ -98,4 +106,4 @@ data class CreateBatchRequestPayload(
       )
 }
 
-data class CreateBatchResponsePayload(val batch: BatchPayload) : SuccessResponsePayload
+data class BatchResponsePayload(val batch: BatchPayload) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.daos.BatchQuantityHistoryDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchesDao
@@ -25,6 +26,12 @@ class BatchStore(
     private val identifierGenerator: IdentifierGenerator,
     private val parentStore: ParentStore,
 ) {
+  fun fetchOneById(batchId: BatchId): BatchesRow {
+    requirePermissions { readBatch(batchId) }
+
+    return batchesDao.fetchOneById(batchId) ?: throw BatchNotFoundException(batchId)
+  }
+
   fun create(row: BatchesRow): BatchesRow {
     val facilityId =
         row.facilityId ?: throw IllegalArgumentException("Facility ID must be non-null")

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -1,0 +1,7 @@
+package com.terraformation.backend.nursery.db
+
+import com.terraformation.backend.db.EntityNotFoundException
+import com.terraformation.backend.db.nursery.BatchId
+
+class BatchNotFoundException(val batchId: BatchId) :
+    EntityNotFoundException("Seedling batch $batchId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -22,9 +22,11 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.nursery.db.BatchNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -53,6 +55,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   private val accessionId = AccessionId(1)
   private val automationId = AutomationId(1)
+  private val batchId = BatchId(1)
   private val deviceId = DeviceId(1)
   private val deviceManagerId = DeviceManagerId(1)
   private val facilityId = FacilityId(1)
@@ -349,6 +352,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canReadAutomation(automationId) }
     requirements.readAutomation(automationId)
+  }
+
+  @Test
+  fun readBatch() {
+    assertThrows<BatchNotFoundException> { requirements.readBatch(batchId) }
+
+    grant { user.canReadBatch(batchId) }
+    requirements.readBatch(batchId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -46,8 +46,10 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.daos.BatchQuantityHistoryDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchesDao
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
@@ -569,6 +571,50 @@ abstract class DatabaseTest {
         )
 
     accessionsDao.insert(rowWithDefaults)
+
+    return rowWithDefaults.id!!
+  }
+
+  fun insertBatch(
+      row: BatchesRow = BatchesRow(),
+      addedDate: LocalDate = row.addedDate ?: LocalDate.EPOCH,
+      createdBy: UserId = row.createdBy ?: currentUser().userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      facilityId: Any = row.facilityId ?: this.facilityId,
+      germinatingQuantity: Int = row.germinatingQuantity ?: 0,
+      id: Any? = row.id,
+      modifiedBy: UserId = row.modifiedBy ?: createdBy,
+      modifiedTime: Instant = row.modifiedTime ?: createdTime,
+      notReadyQuantity: Int = row.notReadyQuantity ?: 1,
+      organizationId: Any = row.organizationId ?: this.organizationId,
+      readyQuantity: Int = row.readyQuantity ?: 2,
+      speciesId: Any = row.speciesId ?: throw IllegalArgumentException("Missing species ID"),
+      version: Int = row.version ?: 1,
+      batchNumber: String = row.batchNumber ?: id?.toString() ?: "batch",
+  ): BatchId {
+    val rowWithDefaults =
+        row.copy(
+            addedDate = addedDate,
+            batchNumber = batchNumber,
+            createdBy = createdBy,
+            createdTime = createdTime,
+            facilityId = facilityId.toIdWrapper { FacilityId(it) },
+            germinatingQuantity = germinatingQuantity,
+            id = id?.toIdWrapper { BatchId(it) },
+            latestObservedGerminatingQuantity = germinatingQuantity,
+            latestObservedNotReadyQuantity = notReadyQuantity,
+            latestObservedReadyQuantity = readyQuantity,
+            latestObservedTime = createdTime,
+            modifiedBy = createdBy,
+            modifiedTime = createdTime,
+            notReadyQuantity = notReadyQuantity,
+            organizationId = organizationId.toIdWrapper { OrganizationId(it) },
+            readyQuantity = readyQuantity,
+            speciesId = speciesId.toIdWrapper { SpeciesId(it) },
+            version = version,
+        )
+
+    batchesDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!
   }


### PR DESCRIPTION
Add the `GET /api/v1/nursery/batches/{id}` endpoint to retrieve a batch's data.