### PR TITLE
Use a Consistent Postgis Version

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Download Docker images
       run: |
-        docker pull postgis/postgis:12-3.1
+        docker pull postgis/postgis:13-3.0
         docker pull schemaspy/schemaspy:6.1.0
 
     - name: Compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Download dependencies
       run: |
-        docker pull postgres:12
+        docker pull postgres:13
         ./gradlew downloadDependencies yarn
 
     - name: Generate jOOQ classes

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out
 .idea
 openapi.yaml
 .env
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ out
 .idea
 openapi.yaml
 .env
-*.DS_Store
+.DS_Store

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ version: "3.8"
 
 services:
   postgres:
-    image: "postgis/postgis:13-3.1"
+    image: "postgis/postgis:13-3.0"
     environment:
       POSTGRES_DB: "terraware"
       POSTGRES_PASSWORD: "terraware"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ springDocVersion=1.6.11
 # container using this image. If you change this, make sure you also change DatabaseTest.kt.
 
 postgresDockerRepository=postgis/postgis
-postgresDockerTag=12-3.1
+postgresDockerTag=13-3.0


### PR DESCRIPTION
The postgis version specified for tests and github is inconsistent.
It should be `postgis:13-3.0` to match what is used for staging/prod
deployment in RDS. Also add `.DS_Store` files to `.gitignore`.