### PR TITLE
SW-1946 Add total withdrawals to batch search table

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -98,7 +98,8 @@ val ID_WRAPPERS =
     mapOf(
         "nursery" to
             listOf(
-                IdWrapper("BatchId", listOf("batches\\.id", ".*\\.batch_id")),
+                IdWrapper(
+                    "BatchId", listOf("batches\\.id", "batch_summaries\\.id", ".*\\.batch_id")),
                 IdWrapper("BatchQuantityHistoryId", listOf("batch_quantity_history\\.id")),
                 IdWrapper(
                     "WithdrawalId",

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
-import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.search.FacilityIdScope
@@ -25,7 +25,7 @@ class FacilitiesTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           accessions.asMultiValueSublist("accessions", FACILITIES.ID.eq(ACCESSIONS.FACILITY_ID)),
-          batches.asMultiValueSublist("batches", FACILITIES.ID.eq(BATCHES.FACILITY_ID)),
+          batches.asMultiValueSublist("batches", FACILITIES.ID.eq(BATCH_SUMMARIES.FACILITY_ID)),
           organizations.asSingleValueSublist(
               "organization", FACILITIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           storageLocations.asMultiValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
-import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.OrganizationIdScope
@@ -28,7 +28,8 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          batches.asMultiValueSublist("batches", ORGANIZATIONS.ID.eq(BATCHES.ORGANIZATION_ID)),
+          batches.asMultiValueSublist(
+              "batches", ORGANIZATIONS.ID.eq(BATCH_SUMMARIES.ORGANIZATION_ID)),
           countries.asSingleValueSublist(
               "country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE), isRequired = false),
           countrySubdivisions.asSingleValueSublist(

--- a/src/main/resources/db/migration/V141__NurseryBatchSummaries.sql
+++ b/src/main/resources/db/migration/V141__NurseryBatchSummaries.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE VIEW nursery.batch_summaries AS
+    SELECT id,
+           organization_id,
+           facility_id,
+           species_id,
+           batch_number,
+           added_date,
+           ready_quantity,
+           not_ready_quantity,
+           germinating_quantity,
+           ready_quantity + not_ready_quantity AS total_quantity,
+           ready_by_date,
+           notes,
+           accession_id,
+           COALESCE(
+                   (SELECT SUM(bw.ready_quantity_withdrawn + bw.not_ready_quantity_withdrawn)
+                    FROM nursery.batch_withdrawals bw
+                    WHERE b.id = bw.batch_id),
+                   0)                          AS total_quantity_withdrawn
+    FROM nursery.batches b;

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -7,6 +7,8 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFieldPrefix
@@ -18,13 +20,16 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
+  override val tablesToResetSequences = listOf(BATCHES)
 
   private val clock: Clock = mockk()
   private val searchService: SearchService by lazy { SearchService(dslContext) }
@@ -41,143 +46,249 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
     insertFacility(facilityId, name = "Nursery", type = FacilityType.Nursery)
   }
 
-  @Test
-  fun `summary tables return correct totals`() {
-    val organizationId2 = OrganizationId(2)
-    val speciesId1 = SpeciesId(1)
-    val speciesId2 = SpeciesId(2)
-    val org2SpeciesId = SpeciesId(3)
-    val facilityId2 = FacilityId(200)
-    val org2FacilityId = FacilityId(300)
+  @Nested
+  inner class SummaryTables {
+    private val organizationId2 = OrganizationId(2)
+    private val speciesId1 = SpeciesId(1)
+    private val speciesId2 = SpeciesId(2)
+    private val org2SpeciesId = SpeciesId(3)
+    private val facilityId2 = FacilityId(200)
+    private val org2FacilityId = FacilityId(300)
 
-    insertOrganization(organizationId2)
-    insertOrganizationUser(user.userId, organizationId2, Role.CONTRIBUTOR)
+    @BeforeEach
+    fun insertBatches() {
+      insertOrganization(organizationId2)
+      insertOrganizationUser(user.userId, organizationId2, Role.CONTRIBUTOR)
 
-    insertFacility(facilityId2, name = "Other Nursery", type = FacilityType.Nursery)
-    insertFacility(
-        org2FacilityId,
-        name = "Other Org Nursery",
-        organizationId = organizationId2,
-        type = FacilityType.Nursery)
+      insertFacility(facilityId2, name = "Other Nursery", type = FacilityType.Nursery)
+      insertFacility(
+          org2FacilityId,
+          name = "Other Org Nursery",
+          organizationId = organizationId2,
+          type = FacilityType.Nursery)
 
-    insertSpecies(speciesId1)
-    insertSpecies(speciesId2)
-    insertSpecies(org2SpeciesId, organizationId = organizationId2)
+      insertSpecies(speciesId1)
+      insertSpecies(speciesId2)
+      insertSpecies(org2SpeciesId, organizationId = organizationId2)
 
-    every { user.facilityRoles } returns
-        mapOf(
-            facilityId to Role.MANAGER,
-            facilityId2 to Role.MANAGER,
-            org2FacilityId to Role.CONTRIBUTOR)
-    every { user.organizationRoles } returns
-        mapOf(organizationId to Role.MANAGER, organizationId2 to Role.CONTRIBUTOR)
+      every { user.facilityRoles } returns
+          mapOf(
+              facilityId to Role.MANAGER,
+              facilityId2 to Role.MANAGER,
+              org2FacilityId to Role.CONTRIBUTOR)
+      every { user.organizationRoles } returns
+          mapOf(organizationId to Role.MANAGER, organizationId2 to Role.CONTRIBUTOR)
 
-    insertBatch(
-        facilityId = facilityId,
-        germinatingQuantity = 1,
-        notReadyQuantity = 2,
-        readyQuantity = 4,
-        speciesId = speciesId1)
-    insertBatch(
-        facilityId = facilityId,
-        germinatingQuantity = 8,
-        notReadyQuantity = 16,
-        readyQuantity = 32,
-        speciesId = speciesId1,
-    )
-    insertBatch(
-        facilityId = facilityId2,
-        germinatingQuantity = 64,
-        notReadyQuantity = 128,
-        readyQuantity = 256,
-        speciesId = speciesId1,
-    )
-    insertBatch(
-        facilityId = facilityId,
-        germinatingQuantity = 512,
-        notReadyQuantity = 1024,
-        readyQuantity = 2048,
-        speciesId = speciesId2,
-    )
-    insertBatch(
-        organizationId = organizationId2,
-        facilityId = org2FacilityId,
-        germinatingQuantity = 4096,
-        notReadyQuantity = 8192,
-        readyQuantity = 16384,
-        speciesId = org2SpeciesId,
-    )
+      insertBatch(
+          addedDate = LocalDate.of(2021, 3, 4),
+          facilityId = facilityId,
+          germinatingQuantity = 1,
+          notReadyQuantity = 2,
+          readyQuantity = 4,
+          speciesId = speciesId1)
+      insertBatch(
+          addedDate = LocalDate.of(2022, 9, 2),
+          facilityId = facilityId,
+          germinatingQuantity = 8,
+          notReadyQuantity = 16,
+          readyQuantity = 32,
+          speciesId = speciesId1,
+      )
+      insertBatch(
+          BatchesRow(readyByDate = LocalDate.of(2022, 10, 2)),
+          addedDate = LocalDate.of(2022, 9, 3),
+          facilityId = facilityId2,
+          germinatingQuantity = 64,
+          notReadyQuantity = 128,
+          readyQuantity = 256,
+          speciesId = speciesId1,
+      )
+      insertBatch(
+          addedDate = LocalDate.of(2022, 9, 4),
+          facilityId = facilityId,
+          germinatingQuantity = 512,
+          notReadyQuantity = 1024,
+          readyQuantity = 2048,
+          speciesId = speciesId2,
+      )
+      insertBatch(
+          addedDate = LocalDate.of(2022, 11, 15),
+          organizationId = organizationId2,
+          facilityId = org2FacilityId,
+          germinatingQuantity = 4096,
+          notReadyQuantity = 8192,
+          readyQuantity = 16384,
+          speciesId = org2SpeciesId,
+      )
+    }
 
-    val prefix = SearchFieldPrefix(root = searchTables.inventories)
-    val results =
-        searchService.search(
-            prefix,
-            listOf(
-                prefix.resolve("species_id"),
-                prefix.resolve("germinatingQuantity"),
-                prefix.resolve("notReadyQuantity"),
-                prefix.resolve("readyQuantity"),
-                prefix.resolve("totalQuantity"),
-                prefix.resolve("facilityInventories.facility_id"),
-                prefix.resolve("facilityInventories.facility_name"),
-                prefix.resolve("facilityInventories.germinatingQuantity"),
-                prefix.resolve("facilityInventories.notReadyQuantity"),
-                prefix.resolve("facilityInventories.readyQuantity"),
-                prefix.resolve("facilityInventories.totalQuantity"),
-            ),
-            FieldNode(prefix.resolve("organization_id"), listOf("$organizationId")),
-            listOf(
-                SearchSortField(prefix.resolve("species_id")),
-                SearchSortField(prefix.resolve("facilityInventories.facility_id")),
-            ))
+    @Test
+    fun `inventory tables return correct totals`() {
+      val prefix = SearchFieldPrefix(root = searchTables.inventories)
+      val results =
+          searchService.search(
+              prefix,
+              listOf(
+                  prefix.resolve("species_id"),
+                  prefix.resolve("germinatingQuantity"),
+                  prefix.resolve("notReadyQuantity"),
+                  prefix.resolve("readyQuantity"),
+                  prefix.resolve("totalQuantity"),
+                  prefix.resolve("facilityInventories.facility_id"),
+                  prefix.resolve("facilityInventories.facility_name"),
+                  prefix.resolve("facilityInventories.germinatingQuantity"),
+                  prefix.resolve("facilityInventories.notReadyQuantity"),
+                  prefix.resolve("facilityInventories.readyQuantity"),
+                  prefix.resolve("facilityInventories.totalQuantity"),
+              ),
+              FieldNode(prefix.resolve("organization_id"), listOf("$organizationId")),
+              listOf(
+                  SearchSortField(prefix.resolve("species_id")),
+                  SearchSortField(prefix.resolve("facilityInventories.facility_id")),
+              ))
 
-    assertEquals(
-        SearchResults(
-            listOf(
-                mapOf(
-                    "species_id" to "1",
-                    "germinatingQuantity" to "${1 + 8 + 64}",
-                    "notReadyQuantity" to "${2 + 16 + 128}",
-                    "readyQuantity" to "${4 + 32 + 256}",
-                    "totalQuantity" to "${2 + 4 + 16 + 32 + 128 + 256}",
-                    "facilityInventories" to
-                        listOf(
-                            mapOf(
-                                "facility_id" to "$facilityId",
-                                "facility_name" to "Nursery",
-                                "germinatingQuantity" to "${1 + 8}",
-                                "notReadyQuantity" to "${2 + 16}",
-                                "readyQuantity" to "${4 + 32}",
-                                "totalQuantity" to "${2 + 4 + 16 + 32}",
-                            ),
-                            mapOf(
-                                "facility_id" to "$facilityId2",
-                                "facility_name" to "Other Nursery",
-                                "germinatingQuantity" to "64",
-                                "notReadyQuantity" to "128",
-                                "readyQuantity" to "256",
-                                "totalQuantity" to "${128 + 256}",
-                            ),
-                        )),
-                mapOf(
-                    "species_id" to "2",
-                    "germinatingQuantity" to "512",
-                    "notReadyQuantity" to "1024",
-                    "readyQuantity" to "2048",
-                    "totalQuantity" to "${1024 + 2048}",
-                    "facilityInventories" to
-                        listOf(
-                            mapOf(
-                                "facility_id" to "$facilityId",
-                                "facility_name" to "Nursery",
-                                "germinatingQuantity" to "512",
-                                "notReadyQuantity" to "1024",
-                                "readyQuantity" to "2048",
-                                "totalQuantity" to "${1024 + 2048}",
-                            ),
-                        )),
-            ),
-            null),
-        results)
+      assertEquals(
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "species_id" to "1",
+                      "germinatingQuantity" to "${1 + 8 + 64}",
+                      "notReadyQuantity" to "${2 + 16 + 128}",
+                      "readyQuantity" to "${4 + 32 + 256}",
+                      "totalQuantity" to "${2 + 4 + 16 + 32 + 128 + 256}",
+                      "facilityInventories" to
+                          listOf(
+                              mapOf(
+                                  "facility_id" to "$facilityId",
+                                  "facility_name" to "Nursery",
+                                  "germinatingQuantity" to "${1 + 8}",
+                                  "notReadyQuantity" to "${2 + 16}",
+                                  "readyQuantity" to "${4 + 32}",
+                                  "totalQuantity" to "${2 + 4 + 16 + 32}",
+                              ),
+                              mapOf(
+                                  "facility_id" to "$facilityId2",
+                                  "facility_name" to "Other Nursery",
+                                  "germinatingQuantity" to "64",
+                                  "notReadyQuantity" to "128",
+                                  "readyQuantity" to "256",
+                                  "totalQuantity" to "${128 + 256}",
+                              ),
+                          )),
+                  mapOf(
+                      "species_id" to "2",
+                      "germinatingQuantity" to "512",
+                      "notReadyQuantity" to "1024",
+                      "readyQuantity" to "2048",
+                      "totalQuantity" to "${1024 + 2048}",
+                      "facilityInventories" to
+                          listOf(
+                              mapOf(
+                                  "facility_id" to "$facilityId",
+                                  "facility_name" to "Nursery",
+                                  "germinatingQuantity" to "512",
+                                  "notReadyQuantity" to "1024",
+                                  "readyQuantity" to "2048",
+                                  "totalQuantity" to "${1024 + 2048}",
+                              ),
+                          )),
+              ),
+              null),
+          results)
+    }
+
+    @Test
+    fun `batches table returns correct totals`() {
+      val withdrawalId1 = insertWithdrawal()
+      val withdrawalId2 = insertWithdrawal()
+
+      insertBatchWithdrawal(
+          withdrawalId = withdrawalId1,
+          batchId = 1,
+          germinatingQuantityWithdrawn = 512,
+          notReadyQuantityWithdrawn = 1024,
+          readyQuantityWithdrawn = 2048,
+      )
+      insertBatchWithdrawal(
+          withdrawalId = withdrawalId1,
+          batchId = 2,
+          germinatingQuantityWithdrawn = 4096,
+          notReadyQuantityWithdrawn = 8192,
+          readyQuantityWithdrawn = 16384,
+      )
+      insertBatchWithdrawal(
+          withdrawalId = withdrawalId2,
+          batchId = 2,
+          germinatingQuantityWithdrawn = 32768,
+          notReadyQuantityWithdrawn = 65536,
+          readyQuantityWithdrawn = 131072,
+      )
+      insertBatchWithdrawal(
+          withdrawalId = withdrawalId2,
+          batchId = 4, // different species in same withdrawal; shouldn't be included in total
+          germinatingQuantityWithdrawn = 262144,
+          notReadyQuantityWithdrawn = 524288,
+          readyQuantityWithdrawn = 1048576,
+      )
+
+      val prefix = SearchFieldPrefix(root = searchTables.batches)
+      val results =
+          searchService.search(
+              prefix,
+              listOf(
+                  prefix.resolve("id"),
+                  prefix.resolve("batchNumber"),
+                  prefix.resolve("germinatingQuantity"),
+                  prefix.resolve("notReadyQuantity"),
+                  prefix.resolve("readyQuantity"),
+                  prefix.resolve("totalQuantity"),
+                  prefix.resolve("totalQuantityWithdrawn"),
+                  prefix.resolve("facility_name"),
+                  prefix.resolve("readyByDate"),
+                  prefix.resolve("addedDate"),
+              ),
+              FieldNode(prefix.resolve("species_id"), listOf("$speciesId1")))
+
+      assertEquals(
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "id" to "1",
+                      "batchNumber" to "1",
+                      "germinatingQuantity" to "1",
+                      "notReadyQuantity" to "2",
+                      "readyQuantity" to "4",
+                      "totalQuantity" to "${2 + 4}",
+                      "totalQuantityWithdrawn" to "${1024 + 2048}",
+                      "facility_name" to "Nursery",
+                      "addedDate" to "2021-03-04",
+                  ),
+                  mapOf(
+                      "id" to "2",
+                      "batchNumber" to "2",
+                      "germinatingQuantity" to "8",
+                      "notReadyQuantity" to "16",
+                      "readyQuantity" to "32",
+                      "totalQuantity" to "${16 + 32}",
+                      "totalQuantityWithdrawn" to "${8192 + 16384 + 65536 + 131072}",
+                      "facility_name" to "Nursery",
+                      "addedDate" to "2022-09-02",
+                  ),
+                  mapOf(
+                      "id" to "3",
+                      "batchNumber" to "3",
+                      "germinatingQuantity" to "64",
+                      "notReadyQuantity" to "128",
+                      "readyQuantity" to "256",
+                      "totalQuantity" to "${128 + 256}",
+                      "totalQuantityWithdrawn" to "0",
+                      "facility_name" to "Other Nursery",
+                      "readyByDate" to "2022-10-02",
+                      "addedDate" to "2022-09-03",
+                  ),
+              ),
+              null),
+          results)
+    }
   }
 }


### PR DESCRIPTION
Allow clients to include the total quantity withdrawn as a search field when
searching for seedling batches. This is needed for the list of batches on the
Inventory Details page in the nursery UI.