### PR TITLE
SW-1966 Add endpoint to update batch quantities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -53,6 +53,13 @@ annotation class ApiResponse409(val description: String = "The request would cau
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
+@ApiResponseSimpleError(responseCode = "412")
+annotation class ApiResponse412(
+    val description: String = "The requested resource has a newer version and was not updated."
+)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
 @ApiResponseSimpleError(responseCode = "413")
 annotation class ApiResponse413(val description: String = "The request was too large.")
 

--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import com.opencsv.CSVWriter
 import com.terraformation.backend.db.DuplicateEntityException
 import com.terraformation.backend.db.EntityNotFoundException
+import com.terraformation.backend.db.EntityStaleException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.OperationInProgressException
 import java.io.ByteArrayOutputStream
@@ -56,6 +57,11 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
       request: WebRequest
   ): ResponseEntity<*> {
     return simpleErrorResponse(ex.message, HttpStatus.NOT_FOUND, request)
+  }
+
+  @ExceptionHandler
+  fun handleEntityStaleException(ex: EntityStaleException, request: WebRequest): ResponseEntity<*> {
+    return simpleErrorResponse(ex.message, HttpStatus.PRECONDITION_FAILED, request)
   }
 
   @ExceptionHandler

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -144,6 +144,7 @@ data class DeviceManagerUser(
   override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
   override fun canUpdateAppVersions(): Boolean = false
+  override fun canUpdateBatch(batchId: BatchId): Boolean = false
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false
   override fun canUpdateDeviceTemplates(): Boolean = false
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -379,6 +379,11 @@ data class IndividualUser(
     return canUpdateFacility(facilityId)
   }
 
+  override fun canUpdateBatch(batchId: BatchId): Boolean {
+    // All users in the organization have read/write access to batches.
+    return canReadBatch(batchId)
+  }
+
   override fun canUpdateDevice(deviceId: DeviceId): Boolean {
     val facilityId = parentStore.getFacilityId(deviceId) ?: return false
     return canUpdateFacility(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -412,6 +412,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateBatch(batchId: BatchId) {
+    if (!user.canUpdateBatch(batchId)) {
+      readBatch(batchId)
+      throw AccessDeniedException("No permission to update seedling batch $batchId")
+    }
+  }
+
   fun updateDevice(deviceId: DeviceId) {
     if (!user.canUpdateDevice(deviceId)) {
       readDevice(deviceId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -151,6 +151,7 @@ class SystemUser(
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
   override fun canUpdateAppVersions(): Boolean = true
   override fun canUpdateAutomation(automationId: AutomationId): Boolean = true
+  override fun canUpdateBatch(batchId: BatchId): Boolean = true
   override fun canUpdateDevice(deviceId: DeviceId): Boolean = true
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canUpdateDeviceTemplates(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -113,6 +113,7 @@ interface TerrawareUser : Principal {
   fun canUpdateAccession(accessionId: AccessionId): Boolean
   fun canUpdateAppVersions(): Boolean
   fun canUpdateAutomation(automationId: AutomationId): Boolean
+  fun canUpdateBatch(batchId: BatchId): Boolean
   fun canUpdateDevice(deviceId: DeviceId): Boolean
   fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canUpdateDeviceTemplates(): Boolean

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -29,6 +29,18 @@ abstract class EntityNotFoundException(message: String) : RuntimeException(messa
 }
 
 /**
+ * Thrown when the system detects that the client has a stale copy of some piece of data but is
+ * attempting to update the data.
+ *
+ * Subclasses of this are mapped to HTTP 412 Precondition Failed if they are thrown by a controller
+ * method.
+ */
+abstract class EntityStaleException(message: String) : RuntimeException(message) {
+  override val message: String
+    get() = super.message!!
+}
+
+/**
  * Thrown when the system detects a duplicate piece of data that needs to be unique.
  *
  * Subclasses of this are mapped to HTTP 409 Conflict if they are thrown by a controller method.

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -1,11 +1,16 @@
 package com.terraformation.backend.nursery.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponse412
 import com.terraformation.backend.api.NurseryEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.nursery.db.BatchStore
@@ -13,9 +18,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import javax.validation.constraints.Min
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -26,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController
 class BatchesController(
     private val batchStore: BatchStore,
 ) {
+  @ApiResponse404
   @GetMapping("/{id}")
   fun getBatch(@PathVariable("id") id: BatchId): BatchResponsePayload {
     val row = batchStore.fetchOneById(id)
@@ -36,6 +44,24 @@ class BatchesController(
   fun createBatch(@RequestBody payload: CreateBatchRequestPayload): BatchResponsePayload {
     val insertedRow = batchStore.create(payload.toRow())
     return BatchResponsePayload(BatchPayload(insertedRow))
+  }
+
+  @ApiResponse404
+  @ApiResponse412
+  @PutMapping("/{id}/quantities")
+  fun updateBatchQuantities(
+      @PathVariable("id") id: BatchId,
+      @RequestBody payload: UpdateBatchQuantitiesRequestPayload
+  ): BatchResponsePayload {
+    batchStore.updateQuantities(
+        batchId = id,
+        version = payload.version,
+        germinating = payload.germinatingQuantity,
+        notReady = payload.notReadyQuantity,
+        ready = payload.readyQuantity,
+        historyType = BatchQuantityHistoryType.Observed)
+
+    return getBatch(id)
   }
 }
 
@@ -86,12 +112,12 @@ data class BatchPayload(
 data class CreateBatchRequestPayload(
     val addedDate: LocalDate,
     val facilityId: FacilityId,
-    val germinatingQuantity: Int,
     val notes: String? = null,
-    val notReadyQuantity: Int,
     val readyByDate: LocalDate? = null,
-    val readyQuantity: Int,
     val speciesId: SpeciesId,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val germinatingQuantity: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val notReadyQuantity: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantity: Int,
 ) {
   fun toRow() =
       BatchesRow(
@@ -105,5 +131,12 @@ data class CreateBatchRequestPayload(
           speciesId = speciesId,
       )
 }
+
+data class UpdateBatchQuantitiesRequestPayload(
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val germinatingQuantity: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val notReadyQuantity: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantity: Int,
+    @JsonSetter(nulls = Nulls.FAIL) val version: Int,
+)
 
 data class BatchResponsePayload(val batch: BatchPayload) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -1,7 +1,11 @@
 package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.db.EntityNotFoundException
+import com.terraformation.backend.db.EntityStaleException
 import com.terraformation.backend.db.nursery.BatchId
 
 class BatchNotFoundException(val batchId: BatchId) :
     EntityNotFoundException("Seedling batch $batchId not found")
+
+class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
+    EntityStaleException("Seedling batch $batchId version $requestedVersion out of date")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -561,6 +561,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun updateBatch() {
+    assertThrows<BatchNotFoundException> { requirements.updateBatch(batchId) }
+
+    grant { user.canReadBatch(batchId) }
+    assertThrows<AccessDeniedException> { requirements.updateBatch(batchId) }
+
+    grant { user.canUpdateBatch(batchId) }
+    requirements.updateBatch(batchId)
+  }
+
+  @Test
   fun updateDevice() {
     assertThrows<DeviceNotFoundException> { requirements.updateDevice(deviceId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -294,6 +294,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *batchIds.forOrg1(),
         readBatch = true,
+        updateBatch = true,
     )
 
     permissions.expect(
@@ -432,6 +433,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *batchIds.forOrg1(),
         readBatch = true,
+        updateBatch = true,
     )
 
     permissions.expect(
@@ -510,6 +512,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *batchIds.forOrg1(),
         readBatch = true,
+        updateBatch = true,
     )
 
     permissions.expect(
@@ -582,6 +585,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *batchIds.forOrg1(),
         readBatch = true,
+        updateBatch = true,
     )
 
     permissions.expect(
@@ -733,6 +737,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *batchIds.forOrg1(),
         readBatch = true,
+        updateBatch = true,
     )
 
     permissions.expect(
@@ -1163,9 +1168,11 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg batchIds: BatchId,
         readBatch: Boolean = false,
+        updateBatch: Boolean = false,
     ) {
       batchIds.forEach { batchId ->
         assertEquals(readBatch, user.canReadBatch(batchId), "Can read batch $batchId")
+        assertEquals(updateBatch, user.canUpdateBatch(batchId), "Can update batch $batchId")
 
         uncheckedBatches.remove(batchId)
       }


### PR DESCRIPTION
`PUT /api/v1/nursery/batches/{id}/quantities` will update the seedling quantities
of an existing batch.

This endpoint introduces a new pattern to the API: optimistic locking using
versions. This will help us manage data consistency when multiple users are
working with the same batch. The client must pass in a version number and the
version number must match the current version of the batch. If the versions
don't match, it means some other client updated the batch already, and the
server returns HTTP 412.

Example flow to demonstrate how it works:

1. Batch 123 has a version number of 9
2. Client A: `GET /api/v1/nursery/batches/123` (returns version 9)
3. Client B: `GET /api/v1/nursery/batches/123` (returns version 9)
4. Client A: `PUT /api/v1/nursery/batches/123/quantities` with version=9
   (succeeds and returns updated batch with version 10)
5. Client B: `PUT /api/v1/nursery/batches/123/quantities` with version=9
   (fails with HTTP 412)
6. Client B: `GET /api/v1/nursery/batches/123` (returns version 10)
7. Client B: `PUT /api/v1/nursery/batches/123/quantities` with version=10
   (succeeds and returns updated batch with version 11)