### PR TITLE
SW-1962 More precise error message for withdrawals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -662,6 +662,12 @@ data class AccessionModel(
                         withdrawal.withdrawn.toUnits(
                             currentRemaining.units, subsetWeightQuantity, subsetCount)
                   }
+
+                  if (currentRemaining.quantity.signum() < 0) {
+                    throw IllegalArgumentException(
+                        "Withdrawal quantity can't be more than remaining quantity")
+                  }
+
                   withdrawal.copy(
                       remaining = currentRemaining,
                       viabilityTest = withdrawal.viabilityTest?.copy(remaining = currentRemaining))


### PR DESCRIPTION
If a withdrawal's quantity is larger than the accession's remaining quantity,
return the exact error message for that situation from the product requirements
rather than a less-precise one about negative quantities.