### PR TITLE
SW-1163 Remove Update and Delete Permission from Contributor

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -365,9 +365,15 @@ data class IndividualUser(
   }
 
   override fun canUpdateAccession(accessionId: AccessionId): Boolean {
-    // All users in a project can write all accessions in the project's facilities, so this
-    // is the same as the read permission check.
-    return canReadAccession(accessionId)
+    // Updating accession is allowed only for Role.MANAGER and higher.
+    // The user must also have read permissions for the accession.
+    val facilityId = parentStore.getFacilityId(accessionId)
+    return when (facilityRoles[facilityId]) {
+      Role.OWNER,
+      Role.ADMIN,
+      Role.MANAGER -> true
+      else -> false
+    } && canReadAccession(accessionId)
   }
 
   override fun canUpdateAppVersions(): Boolean {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -366,14 +366,13 @@ data class IndividualUser(
 
   override fun canUpdateAccession(accessionId: AccessionId): Boolean {
     // Updating accession is allowed only for Role.MANAGER and higher.
-    // The user must also have read permissions for the accession.
     val facilityId = parentStore.getFacilityId(accessionId)
     return when (facilityRoles[facilityId]) {
       Role.OWNER,
       Role.ADMIN,
       Role.MANAGER -> true
       else -> false
-    } && canReadAccession(accessionId)
+    }
   }
 
   override fun canUpdateAppVersions(): Boolean {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -520,7 +520,7 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
-  fun `contributors have access to data associated with their organizations, but cannot update or delete accessions`() {
+  fun `contributors have full read and limited write access to data associated with their organizations`() {
     givenRole(org1Id, Role.CONTRIBUTOR)
 
     val permissions = PermissionsTracker()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -520,7 +520,7 @@ internal class PermissionTest : DatabaseTest() {
   }
 
   @Test
-  fun `contributors have access to data associated with their organizations`() {
+  fun `contributors have access to data associated with their organizations, but cannot update or delete accessions`() {
     givenRole(org1Id, Role.CONTRIBUTOR)
 
     val permissions = PermissionsTracker()
@@ -543,8 +543,8 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *accessionIds.forOrg1(),
         readAccession = true,
-        updateAccession = true,
-        deleteAccession = true,
+        updateAccession = false,
+        deleteAccession = false,
     )
 
     permissions.expect(


### PR DESCRIPTION
- Modify the canUpdateAccession method to deny for Contributor
- Note that canDeleteAccession is the same as canUpdateAccession
- Modify PermissionTest to reflect new permissions