### PR TITLE
SW-1970 Add endpoint to delete seedling batches

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -99,7 +99,12 @@ val ID_WRAPPERS =
         "nursery" to
             listOf(
                 IdWrapper(
-                    "BatchId", listOf("batches\\.id", "batch_summaries\\.id", ".*\\.batch_id")),
+                    "BatchId",
+                    listOf(
+                        "batches\\.id",
+                        "batch_summaries\\.id",
+                        "batch_withdrawals\\.destination_batch_id",
+                        ".*\\.batch_id")),
                 IdWrapper("BatchQuantityHistoryId", listOf("batch_quantity_history\\.id")),
                 IdWrapper(
                     "WithdrawalId",

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -118,6 +118,7 @@ data class DeviceManagerUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
+  override fun canDeleteBatch(batchId: BatchId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
   override fun canDeleteSelf(): Boolean = false
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -208,6 +208,10 @@ data class IndividualUser(
     return canUpdateAutomation(automationId)
   }
 
+  override fun canDeleteBatch(batchId: BatchId): Boolean {
+    return canUpdateBatch(batchId)
+  }
+
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean {
     val role = organizationRoles[organizationId]
     return role == Role.OWNER

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -195,6 +195,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deleteBatch(batchId: BatchId) {
+    if (!user.canDeleteBatch(batchId)) {
+      readBatch(batchId)
+      throw AccessDeniedException("No permission to delete seedling batch $batchId")
+    }
+  }
+
   fun deleteOrganization(organizationId: OrganizationId) {
     if (!user.canDeleteOrganization(organizationId)) {
       readOrganization(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -114,6 +114,7 @@ class SystemUser(
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
+  override fun canDeleteBatch(batchId: BatchId): Boolean = true
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
   override fun canDeleteSelf(): Boolean = false
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -79,6 +79,7 @@ interface TerrawareUser : Principal {
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
   fun canDeleteAccession(accessionId: AccessionId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
+  fun canDeleteBatch(batchId: BatchId): Boolean
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean
   fun canDeleteSelf(): Boolean
   fun canDeleteSpecies(speciesId: SpeciesId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.Nulls
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse412
 import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -20,6 +21,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.validation.constraints.Min
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -45,6 +47,12 @@ class BatchesController(
   fun createBatch(@RequestBody payload: CreateBatchRequestPayload): BatchResponsePayload {
     val insertedRow = batchStore.create(payload.toRow())
     return BatchResponsePayload(BatchPayload(insertedRow))
+  }
+
+  @DeleteMapping("/{id}")
+  fun deleteBatch(@PathVariable("id") id: BatchId): SimpleSuccessResponsePayload {
+    batchStore.delete(id)
+    return SimpleSuccessResponsePayload()
   }
 
   @ApiResponse404

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -201,7 +201,7 @@ COMMENT ON TABLE nursery.batch_quantity_history_types IS '(Enum) Types of operat
 
 COMMENT ON TABLE nursery.batch_withdrawals IS 'Number of seedlings withdrawn from each originating batch as part of a withdrawal.';
 COMMENT ON COLUMN nursery.batch_withdrawals.batch_id IS 'The batch from which the seedlings were withdrawn, also referred to as the originating batch.';
-COMMENT ON COLUMN nursery.batch_withdrawals.destination_batch_id IS 'If the withdrawal was a nursery transfer, the batch that was created as a result. A withdrawal can have more than one originating batch; if they are of the same species, only one destination batch will be created and there will be multiple rows with the same `destination_batch_id`.';
+COMMENT ON COLUMN nursery.batch_withdrawals.destination_batch_id IS 'If the withdrawal was a nursery transfer, the batch that was created as a result. A withdrawal can have more than one originating batch; if they are of the same species, only one destination batch will be created and there will be multiple rows with the same `destination_batch_id`. May be null if the batch was subsequently deleted.';
 COMMENT ON COLUMN nursery.batch_withdrawals.germinating_quantity_withdrawn IS 'Number of germinating seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
 COMMENT ON COLUMN nursery.batch_withdrawals.not_ready_quantity_withdrawn IS 'Number of not-ready-for-planting seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
 COMMENT ON COLUMN nursery.batch_withdrawals.ready_quantity_withdrawn IS 'Number of ready-for-planting seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
@@ -236,7 +236,7 @@ COMMENT ON TABLE nursery.withdrawals IS 'Top-level information about a withdrawa
 COMMENT ON COLUMN nursery.withdrawals.created_by IS 'Which user created the withdrawal.';
 COMMENT ON COLUMN nursery.withdrawals.created_time IS 'When the withdrawal was created.';
 COMMENT ON COLUMN nursery.withdrawals.destination IS 'User-supplied freeform text describing where the seedlings went.';
-COMMENT ON COLUMN nursery.withdrawals.destination_facility_id IS 'If the withdrawal was a nursery transfer, the facility where the seedlings were sent.';
+COMMENT ON COLUMN nursery.withdrawals.destination_facility_id IS 'If the withdrawal was a nursery transfer, the facility where the seedlings were sent. May be null if the facility was subsequently deleted.';
 COMMENT ON COLUMN nursery.withdrawals.facility_id IS 'Nursery from which the seedlings were withdrawn.';
 COMMENT ON COLUMN nursery.withdrawals.modified_by IS 'Which user most recently modified the withdrawal.';
 COMMENT ON COLUMN nursery.withdrawals.modified_time IS 'When the withdrawal was most recently modified.';

--- a/src/main/resources/db/migration/V142__NurseryBatchDeletion.sql
+++ b/src/main/resources/db/migration/V142__NurseryBatchDeletion.sql
@@ -1,0 +1,42 @@
+CREATE INDEX ON nursery.batch_withdrawals (destination_batch_id);
+
+ALTER TABLE nursery.batch_withdrawals
+    ADD CONSTRAINT batch_withdrawals_destination_batch_id_fkey_tmp
+        FOREIGN KEY (destination_batch_id)
+            REFERENCES nursery.batches (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.batches
+    ADD CONSTRAINT batches_accession_id_fkey_tmp
+        FOREIGN KEY (accession_id)
+            REFERENCES seedbank.accessions (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.withdrawals
+    ADD CONSTRAINT withdrawals_destination_only_for_transfers
+        CHECK (destination_facility_id IS NULL OR purpose_id = 1);
+
+ALTER TABLE nursery.withdrawals
+    ADD CONSTRAINT withdrawals_destination_facility_id_fkey_tmp
+        FOREIGN KEY (destination_facility_id)
+            REFERENCES facilities (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.batch_withdrawals
+    DROP CONSTRAINT batch_withdrawals_destination_batch_id_fkey;
+ALTER TABLE nursery.batches
+    DROP CONSTRAINT batches_accession_id_fkey;
+ALTER TABLE nursery.withdrawals
+    DROP CONSTRAINT withdrawals_check;
+ALTER TABLE nursery.withdrawals
+    DROP CONSTRAINT withdrawals_destination_facility_id_fkey;
+
+ALTER TABLE nursery.batch_withdrawals
+    RENAME CONSTRAINT batch_withdrawals_destination_batch_id_fkey_tmp
+        TO batch_withdrawals_destination_batch_id_fkey;
+ALTER TABLE nursery.batches
+    RENAME CONSTRAINT batches_accession_id_fkey_tmp
+        TO batches_accession_id_fkey;
+ALTER TABLE nursery.withdrawals
+    RENAME CONSTRAINT withdrawals_destination_facility_id_fkey_tmp
+        TO withdrawals_destination_facility_id_fkey;

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -234,6 +234,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun deleteBatch() {
+    assertThrows<BatchNotFoundException> { requirements.deleteBatch(batchId) }
+
+    grant { user.canReadBatch(batchId) }
+    assertThrows<AccessDeniedException> { requirements.deleteBatch(batchId) }
+
+    grant { user.canDeleteBatch(batchId) }
+    requirements.deleteBatch(batchId)
+  }
+
+  @Test
   fun deleteOrganization() {
     assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -293,6 +293,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -432,6 +433,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -511,6 +513,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -584,6 +587,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -736,6 +740,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -1167,10 +1172,12 @@ internal class PermissionTest : DatabaseTest() {
 
     fun expect(
         vararg batchIds: BatchId,
+        deleteBatch: Boolean = false,
         readBatch: Boolean = false,
         updateBatch: Boolean = false,
     ) {
       batchIds.forEach { batchId ->
+        assertEquals(deleteBatch, user.canDeleteBatch(batchId), "Can delete batch $batchId")
         assertEquals(readBatch, user.canReadBatch(batchId), "Can read batch $batchId")
         assertEquals(updateBatch, user.canUpdateBatch(batchId), "Can update batch $batchId")
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -661,6 +661,7 @@ abstract class DatabaseTest {
   fun insertBatchWithdrawal(
       row: BatchWithdrawalsRow = BatchWithdrawalsRow(),
       batchId: Any = row.batchId ?: throw IllegalArgumentException("Missing batch ID"),
+      destinationBatchId: Any? = row.destinationBatchId,
       germinatingQuantityWithdrawn: Int = row.germinatingQuantityWithdrawn ?: 0,
       notReadyQuantityWithdrawn: Int = row.notReadyQuantityWithdrawn ?: 0,
       readyQuantityWithdrawn: Int = row.readyQuantityWithdrawn ?: 0,
@@ -670,6 +671,7 @@ abstract class DatabaseTest {
     val rowWithDefaults =
         row.copy(
             batchId = batchId.toIdWrapper { BatchId(it) },
+            destinationBatchId = destinationBatchId?.toIdWrapper { BatchId(it) },
             germinatingQuantityWithdrawn = germinatingQuantityWithdrawn,
             notReadyQuantityWithdrawn = notReadyQuantityWithdrawn,
             readyQuantityWithdrawn = readyQuantityWithdrawn,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -1,0 +1,158 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.nursery.model.SpeciesSummary
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
+  @BeforeEach
+  fun grantDeletePermission() {
+    every { user.canDeleteBatch(any()) } returns true
+  }
+
+  @Test
+  fun `deletes history`() {
+    val batchId = insertBatch(speciesId = speciesId)
+    batchQuantityHistoryDao.insert(
+        BatchQuantityHistoryRow(
+            batchId = batchId,
+            historyTypeId = BatchQuantityHistoryType.Observed,
+            createdBy = user.userId,
+            createdTime = clock.instant(),
+            germinatingQuantity = 1,
+            notReadyQuantity = 2,
+            readyQuantity = 3))
+
+    store.delete(batchId)
+
+    assertEquals(emptyList<BatchesRow>(), batchesDao.findAll(), "Batches")
+    assertEquals(emptyList<BatchQuantityHistoryRow>(), batchQuantityHistoryDao.findAll(), "History")
+  }
+
+  @Test
+  fun `only deletes withdrawals that did not reference other batches`() {
+    val batchIdToDelete = insertBatch(speciesId = speciesId)
+    val remainingBatchId = insertBatch(speciesId = speciesId)
+    val singleBatchWithdrawlId = insertWithdrawal()
+    val multipleBatchWithdrawalId = insertWithdrawal()
+
+    insertBatchWithdrawal(batchId = batchIdToDelete, withdrawalId = singleBatchWithdrawlId)
+    insertBatchWithdrawal(batchId = batchIdToDelete, withdrawalId = multipleBatchWithdrawalId)
+    insertBatchWithdrawal(batchId = remainingBatchId, withdrawalId = multipleBatchWithdrawalId)
+
+    val deleteTime = clock.instant().plusSeconds(60)
+    every { clock.instant() } returns deleteTime
+
+    val expectedBatchWithdrawals = batchWithdrawalsDao.fetchByBatchId(remainingBatchId)
+    val expectedWithdrawals =
+        listOf(
+            nurseryWithdrawalsDao
+                .fetchOneById(multipleBatchWithdrawalId)!!
+                .copy(modifiedTime = deleteTime))
+
+    store.delete(batchIdToDelete)
+
+    assertEquals(
+        expectedWithdrawals,
+        nurseryWithdrawalsDao.findAll(),
+        "Withdrawal from multiple batches should not be deleted")
+    assertEquals(
+        expectedBatchWithdrawals,
+        batchWithdrawalsDao.findAll(),
+        "Batch withdrawals from other batches should not be deleted")
+  }
+
+  @Test
+  fun `removes association with destination batch of transfer withdrawal`() {
+    val sourceBatchId = insertBatch(speciesId = speciesId)
+    val destinationBatchId = insertBatch(speciesId = speciesId)
+    val withdrawalId = insertWithdrawal()
+
+    insertBatchWithdrawal(
+        BatchWithdrawalsRow(
+            batchId = sourceBatchId,
+            destinationBatchId = destinationBatchId,
+            withdrawalId = withdrawalId))
+
+    val expectedBatchWithdrawals =
+        batchWithdrawalsDao.findAll().map { it.copy(destinationBatchId = null) }
+
+    store.delete(destinationBatchId)
+
+    assertEquals(expectedBatchWithdrawals, batchWithdrawalsDao.findAll())
+  }
+
+  // In the current implementation, the summary is not actually "updated" (it is a query across the
+  // underlying data that aggregates the results, so there's nothing to update) but that's an
+  // implementation detail, not part of the API contract.
+  @Test
+  fun `species summary is updated to reflect deleted batch`() {
+    val batchId =
+        insertBatch(
+            speciesId = speciesId, germinatingQuantity = 1, notReadyQuantity = 2, readyQuantity = 3)
+    val withdrawalId = insertWithdrawal(purpose = WithdrawalPurpose.Dead)
+
+    // This batch is not deleted
+    insertBatch(
+        speciesId = speciesId,
+        germinatingQuantity = 100,
+        notReadyQuantity = 200,
+        readyQuantity = 300)
+
+    insertBatchWithdrawal(
+        batchId = batchId,
+        withdrawalId = withdrawalId,
+        germinatingQuantityWithdrawn = 10,
+        readyQuantityWithdrawn = 20,
+        notReadyQuantityWithdrawn = 30)
+
+    val summaryBeforeDelete =
+        SpeciesSummary(
+            germinatingQuantity = 101,
+            notReadyQuantity = 202,
+            readyQuantity = 303,
+            lossRate = 9,
+            nurseries = listOf(FacilitiesRow(id = facilityId, name = "Nursery")),
+            speciesId = speciesId,
+            totalDead = 50,
+            totalQuantity = 505,
+            totalWithdrawn = 50)
+    assertEquals(
+        summaryBeforeDelete, store.getSpeciesSummary(speciesId), "Summary before deleting batch")
+
+    store.delete(batchId)
+
+    assertEquals(
+        SpeciesSummary(
+            germinatingQuantity = 100,
+            notReadyQuantity = 200,
+            readyQuantity = 300,
+            lossRate = 0,
+            nurseries = summaryBeforeDelete.nurseries,
+            speciesId = speciesId,
+            totalDead = 0,
+            totalQuantity = 500,
+            totalWithdrawn = 0),
+        store.getSpeciesSummary(speciesId),
+        "Summary after deleting batch")
+  }
+
+  @Test
+  fun `throws exception if user has no permission to delete batch`() {
+    every { user.canDeleteBatch(any()) } returns false
+
+    val batchId = insertBatch(speciesId = speciesId)
+
+    assertThrows<AccessDeniedException> { store.delete(batchId) }
+  }
+}


### PR DESCRIPTION
`DELETE /api/v1/nursery/batches/{id}` will delete a batch from the system.

The ability to delete a batch means we have to relax some of our constraints.
For example, it becomes possible for there to be a nursery transfer withdrawal
where the destination batch no longer exists; we still want the withdrawal to
exist on the originating side.