### PR TITLE
SW-1967 Add endpoint to withdraw from seedling batches

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -99,7 +99,12 @@ val ID_WRAPPERS =
         "nursery" to
             listOf(
                 IdWrapper(
-                    "BatchId", listOf("batches\\.id", "batch_summaries\\.id", ".*\\.batch_id")),
+                    "BatchId",
+                    listOf(
+                        "batches\\.id",
+                        "batch_summaries\\.id",
+                        "batch_withdrawals\\.destination_batch_id",
+                        ".*\\.batch_id")),
                 IdWrapper("BatchQuantityHistoryId", listOf("batch_quantity_history\\.id")),
                 IdWrapper(
                     "WithdrawalId",

--- a/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -118,7 +118,12 @@ val ID_WRAPPERS =
                     "DeviceId", listOf("devices\\.id", "devices\\.parent_id", ".*\\.device_id")),
                 IdWrapper("DeviceManagerId", listOf("device_managers\\.id")),
                 IdWrapper("DeviceTemplateId", listOf("device_templates\\.id")),
-                IdWrapper("FacilityId", listOf("facilities\\.id", ".*\\.facility_id")),
+                IdWrapper(
+                    "FacilityId",
+                    listOf(
+                        "facilities\\.id",
+                        "nursery\\.withdrawals\\.destination_facility_id",
+                        ".*\\.facility_id")),
                 IdWrapper("GbifNameId", listOf("gbif_names\\.id", ".*\\.gbif_name_id")),
                 IdWrapper(
                     "GbifTaxonId",

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -118,6 +118,7 @@ data class DeviceManagerUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
+  override fun canDeleteBatch(batchId: BatchId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
   override fun canDeleteSelf(): Boolean = false
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -208,6 +208,10 @@ data class IndividualUser(
     return canUpdateAutomation(automationId)
   }
 
+  override fun canDeleteBatch(batchId: BatchId): Boolean {
+    return canUpdateBatch(batchId)
+  }
+
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean {
     val role = organizationRoles[organizationId]
     return role == Role.OWNER

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -195,6 +195,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deleteBatch(batchId: BatchId) {
+    if (!user.canDeleteBatch(batchId)) {
+      readBatch(batchId)
+      throw AccessDeniedException("No permission to delete seedling batch $batchId")
+    }
+  }
+
   fun deleteOrganization(organizationId: OrganizationId) {
     if (!user.canDeleteOrganization(organizationId)) {
       readOrganization(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -114,6 +114,7 @@ class SystemUser(
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
+  override fun canDeleteBatch(batchId: BatchId): Boolean = true
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
   override fun canDeleteSelf(): Boolean = false
   override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -79,6 +79,7 @@ interface TerrawareUser : Principal {
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
   fun canDeleteAccession(accessionId: AccessionId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
+  fun canDeleteBatch(batchId: BatchId): Boolean
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean
   fun canDeleteSelf(): Boolean
   fun canDeleteSpecies(speciesId: SpeciesId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.Nulls
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse412
 import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -20,6 +21,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.validation.constraints.Min
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -45,6 +47,12 @@ class BatchesController(
   fun createBatch(@RequestBody payload: CreateBatchRequestPayload): BatchResponsePayload {
     val insertedRow = batchStore.create(payload.toRow())
     return BatchResponsePayload(BatchPayload(insertedRow))
+  }
+
+  @DeleteMapping("/{id}")
+  fun deleteBatch(@PathVariable("id") id: BatchId): SimpleSuccessResponsePayload {
+    batchStore.delete(id)
+    return SimpleSuccessResponsePayload()
   }
 
   @ApiResponse404

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import javax.validation.constraints.Min
 import org.springframework.web.bind.annotation.PostMapping
@@ -43,7 +44,7 @@ class WithdrawalsController(
 
 data class BatchWithdrawalPayload(
     val batchId: BatchId,
-    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val germinatingQuantityWithdrawn: Int,
+    @Schema(defaultValue = "0") @Min(0) val germinatingQuantityWithdrawn: Int? = null,
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val notReadyQuantityWithdrawn: Int,
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantityWithdrawn: Int,
 ) {
@@ -59,7 +60,7 @@ data class BatchWithdrawalPayload(
   fun toModel() =
       BatchWithdrawalModel(
           batchId = batchId,
-          germinatingQuantityWithdrawn = germinatingQuantityWithdrawn,
+          germinatingQuantityWithdrawn = germinatingQuantityWithdrawn ?: 0,
           notReadyQuantityWithdrawn = notReadyQuantityWithdrawn,
           readyQuantityWithdrawn = readyQuantityWithdrawn,
       )

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -1,0 +1,114 @@
+package com.terraformation.backend.nursery.api
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.model.BatchWithdrawalModel
+import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
+import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import java.time.LocalDate
+import javax.validation.constraints.Min
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@NurseryEndpoint
+@RequestMapping("/api/v1/nursery/withdrawals")
+@RestController
+class WithdrawalsController(
+    val batchStore: BatchStore,
+) {
+  @PostMapping
+  fun createBatchWithdrawal(
+      @RequestBody payload: CreateNurseryWithdrawalRequestPayload
+  ): CreateNurseryWithdrawalResponsePayload {
+    val model = batchStore.withdraw(payload.toModel())
+    val batchModels = model.batchWithdrawals.map { batchStore.fetchOneById(it.batchId) }
+
+    return CreateNurseryWithdrawalResponsePayload(
+        batchModels.map { BatchPayload(it) },
+        NurseryWithdrawalPayload(model),
+    )
+  }
+}
+
+data class BatchWithdrawalPayload(
+    val batchId: BatchId,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val germinatingQuantityWithdrawn: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val notReadyQuantityWithdrawn: Int,
+    @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantityWithdrawn: Int,
+) {
+  constructor(
+      model: BatchWithdrawalModel
+  ) : this(
+      batchId = model.batchId,
+      germinatingQuantityWithdrawn = model.germinatingQuantityWithdrawn,
+      notReadyQuantityWithdrawn = model.notReadyQuantityWithdrawn,
+      readyQuantityWithdrawn = model.readyQuantityWithdrawn,
+  )
+
+  fun toModel() =
+      BatchWithdrawalModel(
+          batchId = batchId,
+          germinatingQuantityWithdrawn = germinatingQuantityWithdrawn,
+          notReadyQuantityWithdrawn = notReadyQuantityWithdrawn,
+          readyQuantityWithdrawn = readyQuantityWithdrawn,
+      )
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class NurseryWithdrawalPayload(
+    val batchWithdrawals: List<BatchWithdrawalPayload>,
+    val destination: String? = null,
+    val facilityId: FacilityId,
+    val id: WithdrawalId,
+    val purpose: WithdrawalPurpose,
+    val reason: String?,
+    val withdrawnDate: LocalDate,
+) {
+  constructor(
+      model: ExistingWithdrawalModel
+  ) : this(
+      model.batchWithdrawals.map { BatchWithdrawalPayload(it) },
+      model.destination,
+      model.facilityId,
+      model.id,
+      model.purpose,
+      model.reason,
+      model.withdrawnDate,
+  )
+}
+
+data class CreateNurseryWithdrawalRequestPayload(
+    @ArraySchema(minItems = 1) val batchWithdrawals: List<BatchWithdrawalPayload>,
+    val destination: String? = null,
+    val facilityId: FacilityId,
+    val purpose: WithdrawalPurpose,
+    val reason: String? = null,
+    val withdrawnDate: LocalDate,
+) {
+  fun toModel() =
+      NewWithdrawalModel(
+          batchWithdrawals = batchWithdrawals.map { it.toModel() },
+          destination = destination,
+          facilityId = facilityId,
+          id = null,
+          purpose = purpose,
+          reason = reason,
+          withdrawnDate = withdrawnDate,
+      )
+}
+
+data class CreateNurseryWithdrawalResponsePayload(
+    val batches: List<BatchPayload>,
+    val withdrawal: NurseryWithdrawalPayload
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -302,6 +302,12 @@ class BatchStore(
       }
     }
 
+    if (withdrawal.batchWithdrawals.map { it.batchId }.distinct().size <
+        withdrawal.batchWithdrawals.size) {
+      throw IllegalArgumentException(
+          "Cannot withdraw from the same batch more than once in a single withdrawal")
+    }
+
     return dslContext.transactionResult { _ ->
       val withdrawalsRow =
           WithdrawalsRow(

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -9,3 +9,6 @@ class BatchNotFoundException(val batchId: BatchId) :
 
 class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
     EntityStaleException("Seedling batch $batchId version $requestedVersion out of date")
+
+class BatchInventoryInsufficientException(val batchId: BatchId) :
+    IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.nursery.model
+
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import java.time.LocalDate
+
+/**
+ * The number of seedlings of each type that came from a single batch as part of a withdrawal. There
+ * can be more than one of these per withdrawal.
+ */
+data class BatchWithdrawalModel(
+    val batchId: BatchId,
+    val destinationBatchId: BatchId? = null,
+    val germinatingQuantityWithdrawn: Int,
+    val notReadyQuantityWithdrawn: Int,
+    val readyQuantityWithdrawn: Int,
+) {
+  init {
+    if (germinatingQuantityWithdrawn < 0 ||
+        notReadyQuantityWithdrawn < 0 ||
+        readyQuantityWithdrawn < 0) {
+      throw IllegalArgumentException("Withdrawal quantities may not be negative")
+    }
+  }
+}
+
+/**
+ * Information about a withdrawal as a whole.
+ *
+ * @param ID This class can represent a withdrawal we loaded from the database (in which case [ID]
+ * will be non-nullable) or a new withdrawal we want to insert (in which case [ID] will be a
+ * null-only type). Use [ExistingWithdrawalModel] and [NewWithdrawalModel] rather than specifying a
+ * type parameter at usage sites.
+ */
+data class WithdrawalModel<ID : WithdrawalId?>(
+    val batchWithdrawals: List<BatchWithdrawalModel>,
+    val destination: String? = null,
+    val destinationFacilityId: FacilityId? = null,
+    val facilityId: FacilityId,
+    val id: ID,
+    val purpose: WithdrawalPurpose,
+    val reason: String? = null,
+    val withdrawnDate: LocalDate,
+) {
+  init {
+    if (batchWithdrawals.isEmpty()) {
+      throw IllegalArgumentException("Withdrawals must come from at least one batch")
+    }
+  }
+}
+
+/** A withdrawal that hasn't been inserted into the database yet. */
+typealias NewWithdrawalModel = WithdrawalModel<Nothing?>
+
+/** A withdrawal that was loaded from the database. */
+typealias ExistingWithdrawalModel = WithdrawalModel<WithdrawalId>
+
+fun BatchWithdrawalsRow.toModel(): BatchWithdrawalModel =
+    BatchWithdrawalModel(
+        batchId = batchId!!,
+        destinationBatchId = destinationBatchId,
+        germinatingQuantityWithdrawn = germinatingQuantityWithdrawn!!,
+        notReadyQuantityWithdrawn = notReadyQuantityWithdrawn!!,
+        readyQuantityWithdrawn = readyQuantityWithdrawn!!,
+    )
+
+fun WithdrawalsRow.toModel(batchWithdrawals: List<BatchWithdrawalsRow>): ExistingWithdrawalModel =
+    ExistingWithdrawalModel(
+        batchWithdrawals = batchWithdrawals.map { it.toModel() },
+        destination = destination,
+        destinationFacilityId = destinationFacilityId,
+        facilityId = facilityId!!,
+        id = id!!,
+        purpose = purposeId!!,
+        reason = reason,
+        withdrawnDate = withdrawnDate!!,
+    )

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -201,7 +201,7 @@ COMMENT ON TABLE nursery.batch_quantity_history_types IS '(Enum) Types of operat
 
 COMMENT ON TABLE nursery.batch_withdrawals IS 'Number of seedlings withdrawn from each originating batch as part of a withdrawal.';
 COMMENT ON COLUMN nursery.batch_withdrawals.batch_id IS 'The batch from which the seedlings were withdrawn, also referred to as the originating batch.';
-COMMENT ON COLUMN nursery.batch_withdrawals.destination_batch_id IS 'If the withdrawal was a nursery transfer, the batch that was created as a result. A withdrawal can have more than one originating batch; if they are of the same species, only one destination batch will be created and there will be multiple rows with the same `destination_batch_id`.';
+COMMENT ON COLUMN nursery.batch_withdrawals.destination_batch_id IS 'If the withdrawal was a nursery transfer, the batch that was created as a result. A withdrawal can have more than one originating batch; if they are of the same species, only one destination batch will be created and there will be multiple rows with the same `destination_batch_id`. May be null if the batch was subsequently deleted.';
 COMMENT ON COLUMN nursery.batch_withdrawals.germinating_quantity_withdrawn IS 'Number of germinating seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
 COMMENT ON COLUMN nursery.batch_withdrawals.not_ready_quantity_withdrawn IS 'Number of not-ready-for-planting seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
 COMMENT ON COLUMN nursery.batch_withdrawals.ready_quantity_withdrawn IS 'Number of ready-for-planting seedlings that were withdrawn from this batch. This is not necessarily the total number of seedlings in the withdrawal as a whole since a withdrawal can come from multiple batches.';
@@ -236,7 +236,7 @@ COMMENT ON TABLE nursery.withdrawals IS 'Top-level information about a withdrawa
 COMMENT ON COLUMN nursery.withdrawals.created_by IS 'Which user created the withdrawal.';
 COMMENT ON COLUMN nursery.withdrawals.created_time IS 'When the withdrawal was created.';
 COMMENT ON COLUMN nursery.withdrawals.destination IS 'User-supplied freeform text describing where the seedlings went.';
-COMMENT ON COLUMN nursery.withdrawals.destination_facility_id IS 'If the withdrawal was a nursery transfer, the facility where the seedlings were sent.';
+COMMENT ON COLUMN nursery.withdrawals.destination_facility_id IS 'If the withdrawal was a nursery transfer, the facility where the seedlings were sent. May be null if the facility was subsequently deleted.';
 COMMENT ON COLUMN nursery.withdrawals.facility_id IS 'Nursery from which the seedlings were withdrawn.';
 COMMENT ON COLUMN nursery.withdrawals.modified_by IS 'Which user most recently modified the withdrawal.';
 COMMENT ON COLUMN nursery.withdrawals.modified_time IS 'When the withdrawal was most recently modified.';

--- a/src/main/resources/db/migration/V142__NurseryBatchDeletion.sql
+++ b/src/main/resources/db/migration/V142__NurseryBatchDeletion.sql
@@ -1,0 +1,42 @@
+CREATE INDEX ON nursery.batch_withdrawals (destination_batch_id);
+
+ALTER TABLE nursery.batch_withdrawals
+    ADD CONSTRAINT batch_withdrawals_destination_batch_id_fkey_tmp
+        FOREIGN KEY (destination_batch_id)
+            REFERENCES nursery.batches (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.batches
+    ADD CONSTRAINT batches_accession_id_fkey_tmp
+        FOREIGN KEY (accession_id)
+            REFERENCES seedbank.accessions (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.withdrawals
+    ADD CONSTRAINT withdrawals_destination_only_for_transfers
+        CHECK (destination_facility_id IS NULL OR purpose_id = 1);
+
+ALTER TABLE nursery.withdrawals
+    ADD CONSTRAINT withdrawals_destination_facility_id_fkey_tmp
+        FOREIGN KEY (destination_facility_id)
+            REFERENCES facilities (id)
+            ON DELETE SET NULL;
+
+ALTER TABLE nursery.batch_withdrawals
+    DROP CONSTRAINT batch_withdrawals_destination_batch_id_fkey;
+ALTER TABLE nursery.batches
+    DROP CONSTRAINT batches_accession_id_fkey;
+ALTER TABLE nursery.withdrawals
+    DROP CONSTRAINT withdrawals_check;
+ALTER TABLE nursery.withdrawals
+    DROP CONSTRAINT withdrawals_destination_facility_id_fkey;
+
+ALTER TABLE nursery.batch_withdrawals
+    RENAME CONSTRAINT batch_withdrawals_destination_batch_id_fkey_tmp
+        TO batch_withdrawals_destination_batch_id_fkey;
+ALTER TABLE nursery.batches
+    RENAME CONSTRAINT batches_accession_id_fkey_tmp
+        TO batches_accession_id_fkey;
+ALTER TABLE nursery.withdrawals
+    RENAME CONSTRAINT withdrawals_destination_facility_id_fkey_tmp
+        TO withdrawals_destination_facility_id_fkey;

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -234,6 +234,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun deleteBatch() {
+    assertThrows<BatchNotFoundException> { requirements.deleteBatch(batchId) }
+
+    grant { user.canReadBatch(batchId) }
+    assertThrows<AccessDeniedException> { requirements.deleteBatch(batchId) }
+
+    grant { user.canDeleteBatch(batchId) }
+    requirements.deleteBatch(batchId)
+  }
+
+  @Test
   fun deleteOrganization() {
     assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -293,6 +293,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -432,6 +433,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -511,6 +513,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -584,6 +587,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -736,6 +740,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *batchIds.forOrg1(),
+        deleteBatch = true,
         readBatch = true,
         updateBatch = true,
     )
@@ -1167,10 +1172,12 @@ internal class PermissionTest : DatabaseTest() {
 
     fun expect(
         vararg batchIds: BatchId,
+        deleteBatch: Boolean = false,
         readBatch: Boolean = false,
         updateBatch: Boolean = false,
     ) {
       batchIds.forEach { batchId ->
+        assertEquals(deleteBatch, user.canDeleteBatch(batchId), "Can delete batch $batchId")
         assertEquals(readBatch, user.canReadBatch(batchId), "Can read batch $batchId")
         assertEquals(updateBatch, user.canUpdateBatch(batchId), "Can update batch $batchId")
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -661,6 +661,7 @@ abstract class DatabaseTest {
   fun insertBatchWithdrawal(
       row: BatchWithdrawalsRow = BatchWithdrawalsRow(),
       batchId: Any = row.batchId ?: throw IllegalArgumentException("Missing batch ID"),
+      destinationBatchId: Any? = row.destinationBatchId,
       germinatingQuantityWithdrawn: Int = row.germinatingQuantityWithdrawn ?: 0,
       notReadyQuantityWithdrawn: Int = row.notReadyQuantityWithdrawn ?: 0,
       readyQuantityWithdrawn: Int = row.readyQuantityWithdrawn ?: 0,
@@ -670,6 +671,7 @@ abstract class DatabaseTest {
     val rowWithDefaults =
         row.copy(
             batchId = batchId.toIdWrapper { BatchId(it) },
+            destinationBatchId = destinationBatchId?.toIdWrapper { BatchId(it) },
             germinatingQuantityWithdrawn = germinatingQuantityWithdrawn,
             notReadyQuantityWithdrawn = notReadyQuantityWithdrawn,
             readyQuantityWithdrawn = readyQuantityWithdrawn,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -1,0 +1,158 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.nursery.model.SpeciesSummary
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
+  @BeforeEach
+  fun grantDeletePermission() {
+    every { user.canDeleteBatch(any()) } returns true
+  }
+
+  @Test
+  fun `deletes history`() {
+    val batchId = insertBatch(speciesId = speciesId)
+    batchQuantityHistoryDao.insert(
+        BatchQuantityHistoryRow(
+            batchId = batchId,
+            historyTypeId = BatchQuantityHistoryType.Observed,
+            createdBy = user.userId,
+            createdTime = clock.instant(),
+            germinatingQuantity = 1,
+            notReadyQuantity = 2,
+            readyQuantity = 3))
+
+    store.delete(batchId)
+
+    assertEquals(emptyList<BatchesRow>(), batchesDao.findAll(), "Batches")
+    assertEquals(emptyList<BatchQuantityHistoryRow>(), batchQuantityHistoryDao.findAll(), "History")
+  }
+
+  @Test
+  fun `only deletes withdrawals that did not reference other batches`() {
+    val batchIdToDelete = insertBatch(speciesId = speciesId)
+    val remainingBatchId = insertBatch(speciesId = speciesId)
+    val singleBatchWithdrawlId = insertWithdrawal()
+    val multipleBatchWithdrawalId = insertWithdrawal()
+
+    insertBatchWithdrawal(batchId = batchIdToDelete, withdrawalId = singleBatchWithdrawlId)
+    insertBatchWithdrawal(batchId = batchIdToDelete, withdrawalId = multipleBatchWithdrawalId)
+    insertBatchWithdrawal(batchId = remainingBatchId, withdrawalId = multipleBatchWithdrawalId)
+
+    val deleteTime = clock.instant().plusSeconds(60)
+    every { clock.instant() } returns deleteTime
+
+    val expectedBatchWithdrawals = batchWithdrawalsDao.fetchByBatchId(remainingBatchId)
+    val expectedWithdrawals =
+        listOf(
+            nurseryWithdrawalsDao
+                .fetchOneById(multipleBatchWithdrawalId)!!
+                .copy(modifiedTime = deleteTime))
+
+    store.delete(batchIdToDelete)
+
+    assertEquals(
+        expectedWithdrawals,
+        nurseryWithdrawalsDao.findAll(),
+        "Withdrawal from multiple batches should not be deleted")
+    assertEquals(
+        expectedBatchWithdrawals,
+        batchWithdrawalsDao.findAll(),
+        "Batch withdrawals from other batches should not be deleted")
+  }
+
+  @Test
+  fun `removes association with destination batch of transfer withdrawal`() {
+    val sourceBatchId = insertBatch(speciesId = speciesId)
+    val destinationBatchId = insertBatch(speciesId = speciesId)
+    val withdrawalId = insertWithdrawal()
+
+    insertBatchWithdrawal(
+        BatchWithdrawalsRow(
+            batchId = sourceBatchId,
+            destinationBatchId = destinationBatchId,
+            withdrawalId = withdrawalId))
+
+    val expectedBatchWithdrawals =
+        batchWithdrawalsDao.findAll().map { it.copy(destinationBatchId = null) }
+
+    store.delete(destinationBatchId)
+
+    assertEquals(expectedBatchWithdrawals, batchWithdrawalsDao.findAll())
+  }
+
+  // In the current implementation, the summary is not actually "updated" (it is a query across the
+  // underlying data that aggregates the results, so there's nothing to update) but that's an
+  // implementation detail, not part of the API contract.
+  @Test
+  fun `species summary is updated to reflect deleted batch`() {
+    val batchId =
+        insertBatch(
+            speciesId = speciesId, germinatingQuantity = 1, notReadyQuantity = 2, readyQuantity = 3)
+    val withdrawalId = insertWithdrawal(purpose = WithdrawalPurpose.Dead)
+
+    // This batch is not deleted
+    insertBatch(
+        speciesId = speciesId,
+        germinatingQuantity = 100,
+        notReadyQuantity = 200,
+        readyQuantity = 300)
+
+    insertBatchWithdrawal(
+        batchId = batchId,
+        withdrawalId = withdrawalId,
+        germinatingQuantityWithdrawn = 10,
+        readyQuantityWithdrawn = 20,
+        notReadyQuantityWithdrawn = 30)
+
+    val summaryBeforeDelete =
+        SpeciesSummary(
+            germinatingQuantity = 101,
+            notReadyQuantity = 202,
+            readyQuantity = 303,
+            lossRate = 9,
+            nurseries = listOf(FacilitiesRow(id = facilityId, name = "Nursery")),
+            speciesId = speciesId,
+            totalDead = 50,
+            totalQuantity = 505,
+            totalWithdrawn = 50)
+    assertEquals(
+        summaryBeforeDelete, store.getSpeciesSummary(speciesId), "Summary before deleting batch")
+
+    store.delete(batchId)
+
+    assertEquals(
+        SpeciesSummary(
+            germinatingQuantity = 100,
+            notReadyQuantity = 200,
+            readyQuantity = 300,
+            lossRate = 0,
+            nurseries = summaryBeforeDelete.nurseries,
+            speciesId = speciesId,
+            totalDead = 0,
+            totalQuantity = 500,
+            totalWithdrawn = 0),
+        store.getSpeciesSummary(speciesId),
+        "Summary after deleting batch")
+  }
+
+  @Test
+  fun `throws exception if user has no permission to delete batch`() {
+    every { user.canDeleteBatch(any()) } returns false
+
+    val batchId = insertBatch(speciesId = speciesId)
+
+    assertThrows<AccessDeniedException> { store.delete(batchId) }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -29,10 +29,12 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
     BatchStore(
         batchesDao,
         batchQuantityHistoryDao,
+        batchWithdrawalsDao,
         clock,
         dslContext,
         IdentifierGenerator(clock, dslContext),
         ParentStore(dslContext),
+        nurseryWithdrawalsDao,
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -1,0 +1,375 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
+import com.terraformation.backend.nursery.model.BatchWithdrawalModel
+import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import io.mockk.every
+import java.time.Instant
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class BatchStoreWithdrawTest : BatchStoreTest() {
+  private val speciesId2 = SpeciesId(2)
+  private val species1Batch1Id = BatchId(1)
+  private val species1Batch2Id = BatchId(2)
+  private val species2Batch1Id = BatchId(3)
+
+  @BeforeEach
+  fun insertInitialBatches() {
+    insertSpecies(speciesId2)
+    insertBatch(
+        id = species1Batch1Id,
+        speciesId = speciesId,
+        germinatingQuantity = 10,
+        notReadyQuantity = 20,
+        readyQuantity = 30)
+    insertBatch(
+        id = species1Batch2Id,
+        speciesId = speciesId,
+        germinatingQuantity = 40,
+        notReadyQuantity = 50,
+        readyQuantity = 60)
+    insertBatch(
+        id = species2Batch1Id,
+        speciesId = speciesId2,
+        germinatingQuantity = 70,
+        notReadyQuantity = 80,
+        readyQuantity = 90)
+  }
+
+  @Test
+  fun `can withdraw from multiple batches`() {
+    val species1Batch1 = batchesDao.fetchOneById(species1Batch1Id)!!
+    val species1Batch2 = batchesDao.fetchOneById(species1Batch2Id)!!
+    val species2Batch1 = batchesDao.fetchOneById(species2Batch1Id)!!
+
+    val withdrawalTime = clock.instant().plusSeconds(1000)
+    every { clock.instant() } returns withdrawalTime
+
+    val withdrawal =
+        store.withdraw(
+            NewWithdrawalModel(
+                facilityId = facilityId,
+                id = null,
+                purpose = WithdrawalPurpose.Other,
+                withdrawnDate = LocalDate.of(2022, 10, 1),
+                destination = "Destination",
+                reason = "Reason",
+                batchWithdrawals =
+                    listOf(
+                        BatchWithdrawalModel(
+                            batchId = species1Batch1Id,
+                            germinatingQuantityWithdrawn = 1,
+                            notReadyQuantityWithdrawn = 2,
+                            readyQuantityWithdrawn = 3),
+                        BatchWithdrawalModel(
+                            batchId = species1Batch2Id,
+                            germinatingQuantityWithdrawn = 4,
+                            notReadyQuantityWithdrawn = 5,
+                            readyQuantityWithdrawn = 6),
+                        BatchWithdrawalModel(
+                            batchId = species2Batch1Id,
+                            germinatingQuantityWithdrawn = 7,
+                            notReadyQuantityWithdrawn = 8,
+                            readyQuantityWithdrawn = 9))))
+
+    assertAll(
+        {
+          assertEquals(
+              listOf(
+                  species1Batch1.copy(
+                      germinatingQuantity = 9,
+                      notReadyQuantity = 18,
+                      readyQuantity = 27,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species1Batch2.copy(
+                      germinatingQuantity = 36,
+                      notReadyQuantity = 45,
+                      readyQuantity = 54,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species2Batch1.copy(
+                      germinatingQuantity = 63,
+                      notReadyQuantity = 72,
+                      readyQuantity = 81,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+              ),
+              batchesDao.findAll().sortedBy { it.germinatingQuantity!! },
+              "Should have deducted withdrawn quantities from batches")
+        },
+        {
+          assertEquals(
+              listOf(
+                  BatchQuantityHistoryRow(
+                      batchId = species1Batch1Id,
+                      historyTypeId = BatchQuantityHistoryType.Computed,
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      germinatingQuantity = 9,
+                      notReadyQuantity = 18,
+                      readyQuantity = 27,
+                      withdrawalId = withdrawal.id),
+                  BatchQuantityHistoryRow(
+                      batchId = species1Batch2Id,
+                      historyTypeId = BatchQuantityHistoryType.Computed,
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      germinatingQuantity = 36,
+                      notReadyQuantity = 45,
+                      readyQuantity = 54,
+                      withdrawalId = withdrawal.id),
+                  BatchQuantityHistoryRow(
+                      batchId = species2Batch1Id,
+                      historyTypeId = BatchQuantityHistoryType.Computed,
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      germinatingQuantity = 63,
+                      notReadyQuantity = 72,
+                      readyQuantity = 81,
+                      withdrawalId = withdrawal.id)),
+              batchQuantityHistoryDao
+                  .findAll()
+                  .map { it.copy(id = null) }
+                  .sortedBy { it.germinatingQuantity!! },
+              "Should have inserted quantity history rows")
+        },
+        {
+          assertEquals(
+              listOf(
+                  WithdrawalsRow(
+                      id = withdrawal.id,
+                      facilityId = facilityId,
+                      purposeId = WithdrawalPurpose.Other,
+                      withdrawnDate = LocalDate.of(2022, 10, 1),
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      modifiedBy = user.userId,
+                      modifiedTime = withdrawalTime,
+                      destination = "Destination",
+                      reason = "Reason")),
+              nurseryWithdrawalsDao.findAll(),
+              "Should have inserted withdrawals row")
+        })
+  }
+
+  @Test
+  fun `does not update batch quantities if withdrawal date is earlier than latest observation`() {
+    val species1Batch1 =
+        batchesDao
+            .fetchOneById(species1Batch1Id)!!
+            .copy(latestObservedTime = Instant.EPOCH.plus(3, ChronoUnit.DAYS))
+
+    batchesDao.update(species1Batch1)
+
+    val withdrawalTime = Instant.EPOCH.plus(4, ChronoUnit.DAYS)
+    every { clock.instant() } returns withdrawalTime
+
+    val withdrawal =
+        store.withdraw(
+            NewWithdrawalModel(
+                facilityId = facilityId,
+                id = null,
+                purpose = WithdrawalPurpose.Other,
+                withdrawnDate = LocalDate.EPOCH,
+                batchWithdrawals =
+                    listOf(
+                        BatchWithdrawalModel(
+                            batchId = species1Batch1Id,
+                            germinatingQuantityWithdrawn = 100000,
+                            notReadyQuantityWithdrawn = 2,
+                            readyQuantityWithdrawn = 3))))
+
+    assertAll(
+        {
+          assertEquals(
+              species1Batch1.copy(version = 2, modifiedTime = withdrawalTime),
+              batchesDao.fetchOneById(species1Batch1Id),
+              "Should not have deducted withdrawn quantities from batch")
+        },
+        {
+          assertEquals(
+              emptyList<BatchQuantityHistoryRow>(),
+              batchQuantityHistoryDao.findAll(),
+              "Should not have inserted quantity history row")
+        },
+        {
+          assertEquals(
+              listOf(
+                  WithdrawalsRow(
+                      id = withdrawal.id,
+                      facilityId = facilityId,
+                      purposeId = WithdrawalPurpose.Other,
+                      withdrawnDate = LocalDate.EPOCH,
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      modifiedBy = user.userId,
+                      modifiedTime = withdrawalTime)),
+              nurseryWithdrawalsDao.findAll(),
+              "Should have inserted withdrawals row")
+        },
+        {
+          assertEquals(
+              listOf(
+                  BatchWithdrawalsRow(
+                      batchId = species1Batch1Id,
+                      withdrawalId = withdrawal.id,
+                      germinatingQuantityWithdrawn = 100000,
+                      notReadyQuantityWithdrawn = 2,
+                      readyQuantityWithdrawn = 3)),
+              batchWithdrawalsDao.findAll(),
+              "Should have inserted batch withdrawals row")
+        },
+    )
+  }
+
+  // In the current implementation, the summary is not actually "updated" (it is a query across the
+  // underlying data that aggregates the results, so there's nothing to update) but that's an
+  // implementation detail, not part of the API contract.
+  @Test
+  fun `updates species summary to reflect withdrawn quantities`() {
+    val initialSummary = store.getSpeciesSummary(speciesId)
+
+    store.withdraw(
+        NewWithdrawalModel(
+            facilityId = facilityId,
+            id = null,
+            purpose = WithdrawalPurpose.Dead,
+            withdrawnDate = LocalDate.EPOCH,
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(
+                        batchId = species1Batch1Id,
+                        germinatingQuantityWithdrawn = 1,
+                        notReadyQuantityWithdrawn = 2,
+                        readyQuantityWithdrawn = 3))))
+
+    assertEquals(
+        initialSummary.copy(
+            germinatingQuantity = initialSummary.germinatingQuantity - 1,
+            notReadyQuantity = initialSummary.notReadyQuantity - 2,
+            readyQuantity = initialSummary.readyQuantity - 3,
+            lossRate = (5 * 100 / initialSummary.totalQuantity).toInt(),
+            totalDead = 5,
+            totalQuantity = initialSummary.totalQuantity - 5,
+            totalWithdrawn = 5,
+        ),
+        store.getSpeciesSummary(speciesId))
+  }
+
+  @Test
+  fun `throws exception if a batch has insufficient seedlings remaining`() {
+    assertThrows<BatchInventoryInsufficientException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.Dead,
+              withdrawnDate = LocalDate.EPOCH,
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1000,
+                          notReadyQuantityWithdrawn = 2000,
+                          readyQuantityWithdrawn = 3000))))
+    }
+  }
+
+  @Test
+  fun `throws exception if user has no permission to update a batch`() {
+    every { user.canUpdateBatch(species1Batch2Id) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 1,
+                          readyQuantityWithdrawn = 1),
+                      BatchWithdrawalModel(
+                          batchId = species1Batch2Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 1,
+                          readyQuantityWithdrawn = 1),
+                  ),
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.Dead,
+              withdrawnDate = LocalDate.EPOCH))
+    }
+  }
+
+  @Test
+  fun `throws exception if any batches are not from requested facility ID`() {
+    val otherFacilityId = FacilityId(2)
+    insertFacility(otherFacilityId, type = FacilityType.Nursery)
+
+    val otherFacilityBatchId =
+        insertBatch(
+            id = 100, facilityId = otherFacilityId, speciesId = speciesId, germinatingQuantity = 1)
+
+    assertThrows<IllegalArgumentException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 1,
+                          readyQuantityWithdrawn = 1),
+                      BatchWithdrawalModel(
+                          batchId = otherFacilityBatchId,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0),
+                  ),
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.Dead,
+              withdrawnDate = LocalDate.EPOCH))
+    }
+  }
+
+  @Test
+  fun `throws exception if you try to create a nursery transfer withdrawal`() {
+    assertThrows<IllegalArgumentException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 1,
+                          readyQuantityWithdrawn = 1)),
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.NurseryTransfer,
+              withdrawnDate = LocalDate.EPOCH))
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -25,9 +25,9 @@ import org.springframework.security.access.AccessDeniedException
 
 internal class BatchStoreWithdrawTest : BatchStoreTest() {
   private val speciesId2 = SpeciesId(2)
-  private val species1Batch1Id = BatchId(1)
-  private val species1Batch2Id = BatchId(2)
-  private val species2Batch1Id = BatchId(3)
+  private val species1Batch1Id = BatchId(11)
+  private val species1Batch2Id = BatchId(12)
+  private val species2Batch1Id = BatchId(21)
 
   @BeforeEach
   fun insertInitialBatches() {
@@ -118,35 +118,30 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
               "Should have deducted withdrawn quantities from batches")
         },
         {
+          val newHistoryRow =
+              BatchQuantityHistoryRow(
+                  historyTypeId = BatchQuantityHistoryType.Computed,
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime,
+                  withdrawalId = withdrawal.id)
+
           assertEquals(
               listOf(
-                  BatchQuantityHistoryRow(
+                  newHistoryRow.copy(
                       batchId = species1Batch1Id,
-                      historyTypeId = BatchQuantityHistoryType.Computed,
-                      createdBy = user.userId,
-                      createdTime = withdrawalTime,
                       germinatingQuantity = 9,
                       notReadyQuantity = 18,
-                      readyQuantity = 27,
-                      withdrawalId = withdrawal.id),
-                  BatchQuantityHistoryRow(
+                      readyQuantity = 27),
+                  newHistoryRow.copy(
                       batchId = species1Batch2Id,
-                      historyTypeId = BatchQuantityHistoryType.Computed,
-                      createdBy = user.userId,
-                      createdTime = withdrawalTime,
                       germinatingQuantity = 36,
                       notReadyQuantity = 45,
-                      readyQuantity = 54,
-                      withdrawalId = withdrawal.id),
-                  BatchQuantityHistoryRow(
+                      readyQuantity = 54),
+                  newHistoryRow.copy(
                       batchId = species2Batch1Id,
-                      historyTypeId = BatchQuantityHistoryType.Computed,
-                      createdBy = user.userId,
-                      createdTime = withdrawalTime,
                       germinatingQuantity = 63,
                       notReadyQuantity = 72,
-                      readyQuantity = 81,
-                      withdrawalId = withdrawal.id)),
+                      readyQuantity = 81)),
               batchQuantityHistoryDao
                   .findAll()
                   .map { it.copy(id = null) }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -272,6 +272,30 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   }
 
   @Test
+  fun `throws exception if trying to withdraw from the same batch twice in one withdrawal`() {
+    assertThrows<IllegalArgumentException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.Dead,
+              withdrawnDate = LocalDate.EPOCH,
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 0,
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 1),
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 0,
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 1))))
+    }
+  }
+
+  @Test
   fun `throws exception if a batch has insufficient seedlings remaining`() {
     assertThrows<BatchInventoryInsufficientException> {
       store.withdraw(


### PR DESCRIPTION
`POST /api/v1/nursery/withdrawals` will withdraw from one or more batches at a
facility. If the withdrawal date is on or after the date (in UTC time zone) the
user most recently edited the batch's remaining quantities, the withdrawal
quantities will be subtracted from the batch.

Withdrawals that change batches' quantities will cause quantity history records
to be created. There is currently no API to query the history of a batch.

This initial version does not support nursery transfer withdrawals; those will
come in a followup revision.