### PR TITLE
SW-1968 Implement nursery transfer withdrawals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -70,6 +70,11 @@ data class BatchWithdrawalPayload(
 data class NurseryWithdrawalPayload(
     val batchWithdrawals: List<BatchWithdrawalPayload>,
     val destination: String? = null,
+    @Schema(
+        description =
+            "If purpose is \"Nursery Transfer\", the ID of the facility to which the seedlings " +
+                "were transferred.")
+    val destinationFacilityId: FacilityId? = null,
     val facilityId: FacilityId,
     val id: WithdrawalId,
     val purpose: WithdrawalPurpose,
@@ -81,6 +86,7 @@ data class NurseryWithdrawalPayload(
   ) : this(
       model.batchWithdrawals.map { BatchWithdrawalPayload(it) },
       model.destination,
+      model.destinationFacilityId,
       model.facilityId,
       model.id,
       model.purpose,
@@ -92,6 +98,12 @@ data class NurseryWithdrawalPayload(
 data class CreateNurseryWithdrawalRequestPayload(
     @ArraySchema(minItems = 1) val batchWithdrawals: List<BatchWithdrawalPayload>,
     val destination: String? = null,
+    @Schema(
+        description =
+            "If purpose is \"Nursery Transfer\", the ID of the facility to transfer to. Must be " +
+                "in the same organization as the originating facility. Not allowed for purposes " +
+                "other than \"Nursery Transfer\".")
+    val destinationFacilityId: FacilityId? = null,
     val facilityId: FacilityId,
     val purpose: WithdrawalPurpose,
     val reason: String? = null,
@@ -101,6 +113,7 @@ data class CreateNurseryWithdrawalRequestPayload(
       NewWithdrawalModel(
           batchWithdrawals = batchWithdrawals.map { it.toModel() },
           destination = destination,
+          destinationFacilityId = destinationFacilityId,
           facilityId = facilityId,
           id = null,
           purpose = purpose,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.nursery.model.SpeciesSummary
+import com.terraformation.backend.nursery.model.WithdrawalModel
 import com.terraformation.backend.nursery.model.toModel
 import java.time.Clock
 import java.time.LocalDate
@@ -290,10 +291,6 @@ class BatchStore(
    * different species.
    */
   fun withdraw(withdrawal: NewWithdrawalModel): ExistingWithdrawalModel {
-    if (withdrawal.purpose == WithdrawalPurpose.NurseryTransfer) {
-      throw IllegalArgumentException("Nursery transfers are not implemented yet")
-    }
-
     withdrawal.batchWithdrawals.forEach { batchWithdrawal ->
       requirePermissions { updateBatch(batchWithdrawal.batchId) }
 
@@ -306,6 +303,22 @@ class BatchStore(
         withdrawal.batchWithdrawals.size) {
       throw IllegalArgumentException(
           "Cannot withdraw from the same batch more than once in a single withdrawal")
+    }
+
+    if (withdrawal.purpose == WithdrawalPurpose.NurseryTransfer) {
+      if (withdrawal.destinationFacilityId == null) {
+        throw IllegalArgumentException("Nursery transfer must include destination facility ID")
+      }
+
+      requirePermissions { createBatch(withdrawal.destinationFacilityId) }
+
+      if (parentStore.getOrganizationId(withdrawal.facilityId) !=
+          parentStore.getOrganizationId(withdrawal.destinationFacilityId)) {
+        throw CrossOrganizationNurseryTransferNotAllowedException(
+            withdrawal.facilityId, withdrawal.destinationFacilityId)
+      }
+    } else if (withdrawal.destinationFacilityId != null) {
+      throw IllegalArgumentException("Only nursery transfers may include destination facility ID")
     }
 
     return dslContext.transactionResult { _ ->
@@ -326,6 +339,8 @@ class BatchStore(
       withdrawalsDao.insert(withdrawalsRow)
       val withdrawalId = withdrawalsRow.id!!
 
+      val destinationBatchIds: Map<BatchId, BatchId> = createDestinationBatches(withdrawal)
+
       val batchWithdrawalsRows =
           withdrawal.batchWithdrawals
               // Sort by batch ID to avoid deadlocks if two clients withdraw from the same set of
@@ -336,6 +351,7 @@ class BatchStore(
                 val batchWithdrawalsRow =
                     BatchWithdrawalsRow(
                         batchId = batchId,
+                        destinationBatchId = destinationBatchIds[batchId],
                         withdrawalId = withdrawalId,
                         germinatingQuantityWithdrawn = batchWithdrawal.germinatingQuantityWithdrawn,
                         notReadyQuantityWithdrawn = batchWithdrawal.notReadyQuantityWithdrawn,
@@ -425,6 +441,49 @@ class BatchStore(
 
       withdrawalsRow.toModel(batchWithdrawalsRows)
     }
+  }
+
+  /**
+   * For nursery transfer withdrawals, creates a batch at the destination facility for each species
+   * being withdrawn.
+   *
+   * @return A map of the originating batch IDs to the newly-created batch IDs. This is an N:1
+   * mapping: if you withdraw from two batches of the same species, only one new batch will be
+   * created at the destination facility.
+   */
+  private fun createDestinationBatches(withdrawal: WithdrawalModel<*>): Map<BatchId, BatchId> {
+    if (withdrawal.purpose != WithdrawalPurpose.NurseryTransfer) {
+      return emptyMap()
+    }
+
+    // We want to create a new batch for each species, rather than one for each originating
+    // batch, so we need to look up the species ID of the originating bach of each batch withdrawal
+    // in order to aggregate the per-species quantities.
+    val batchWithdrawalsBySpeciesId =
+        withdrawal.batchWithdrawals.groupBy { batchesDao.fetchOneById(it.batchId)?.speciesId }
+
+    return batchWithdrawalsBySpeciesId
+        .flatMap { (speciesId, batchWithdrawals) ->
+          val germinatingQuantity = batchWithdrawals.sumOf { it.germinatingQuantityWithdrawn }
+          val notReadyQuantity = batchWithdrawals.sumOf { it.notReadyQuantityWithdrawn }
+          val readyQuantity = batchWithdrawals.sumOf { it.readyQuantityWithdrawn }
+
+          val newBatch =
+              create(
+                  BatchesRow(
+                      addedDate = withdrawal.withdrawnDate,
+                      facilityId = withdrawal.destinationFacilityId,
+                      germinatingQuantity = germinatingQuantity,
+                      notReadyQuantity = notReadyQuantity,
+                      readyQuantity = readyQuantity,
+                      speciesId = speciesId))
+
+          // Return a List<Pair<BatchId, BatchId>> mapping the originating batch IDs to the
+          // newly-created one. The List will get flattened by flatMap and then turned into
+          // Map<BatchId, BatchId>.
+          batchWithdrawals.map { it.batchId to newBatch.id!! }
+        }
+        .toMap()
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EntityStaleException
+import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.BatchId
 
 class BatchNotFoundException(val batchId: BatchId) :
@@ -12,3 +14,11 @@ class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
 
 class BatchInventoryInsufficientException(val batchId: BatchId) :
     IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")
+
+class CrossOrganizationNurseryTransferNotAllowedException(
+    val facilityId: FacilityId,
+    val destinationFacilityId: FacilityId
+) :
+    MismatchedStateException(
+        "Cannot transfer from $facilityId to $destinationFacilityId because they are in " +
+            "different organizations")

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -2,14 +2,17 @@ package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
+import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import io.mockk.every
@@ -17,6 +20,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
@@ -28,6 +32,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   private val species1Batch1Id = BatchId(11)
   private val species1Batch2Id = BatchId(12)
   private val species2Batch1Id = BatchId(21)
+
+  private val destinationFacilityId = FacilityId(3)
 
   @BeforeEach
   fun insertInitialBatches() {
@@ -374,8 +380,227 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   }
 
   @Test
-  fun `throws exception if you try to create a nursery transfer withdrawal`() {
-    assertThrows<IllegalArgumentException> {
+  fun `nursery transfer creates a new batch for each species`() {
+    val species1Batch1 = batchesDao.fetchOneById(species1Batch1Id)!!
+    val species1Batch2 = batchesDao.fetchOneById(species1Batch2Id)!!
+    val species2Batch1 = batchesDao.fetchOneById(species2Batch1Id)!!
+
+    insertFacility(destinationFacilityId, type = FacilityType.Nursery)
+
+    val withdrawalTime = clock.instant().plusSeconds(1000)
+    every { clock.instant() } returns withdrawalTime
+
+    val withdrawal =
+        store.withdraw(
+            NewWithdrawalModel(
+                destinationFacilityId = destinationFacilityId,
+                facilityId = facilityId,
+                id = null,
+                purpose = WithdrawalPurpose.NurseryTransfer,
+                reason = "Reason",
+                withdrawnDate = LocalDate.of(2022, 10, 1),
+                batchWithdrawals =
+                    listOf(
+                        BatchWithdrawalModel(
+                            batchId = species1Batch1Id,
+                            germinatingQuantityWithdrawn = 1,
+                            notReadyQuantityWithdrawn = 2,
+                            readyQuantityWithdrawn = 3),
+                        BatchWithdrawalModel(
+                            batchId = species1Batch2Id,
+                            germinatingQuantityWithdrawn = 4,
+                            notReadyQuantityWithdrawn = 5,
+                            readyQuantityWithdrawn = 6),
+                        BatchWithdrawalModel(
+                            batchId = species2Batch1Id,
+                            germinatingQuantityWithdrawn = 10,
+                            notReadyQuantityWithdrawn = 11,
+                            readyQuantityWithdrawn = 12))))
+
+    // The order the new batches get created is undefined, so either new batch ID/number could
+    // be for either species. Need to load them to figure out which is which.
+    val newBatches = batchesDao.fetchByFacilityId(destinationFacilityId)
+    val newSpecies1Batch =
+        newBatches.firstOrNull { it.speciesId == speciesId }
+            ?: fail("No new batch created for species $speciesId")
+    val newSpecies2Batch =
+        newBatches.firstOrNull { it.speciesId == speciesId2 }
+            ?: fail("No new batch created for species $speciesId2")
+
+    assertAll(
+        {
+          assertEquals(
+              listOf(
+                  species1Batch1.copy(
+                      germinatingQuantity = 10 - 1,
+                      notReadyQuantity = 20 - 2,
+                      readyQuantity = 30 - 3,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species1Batch2.copy(
+                      germinatingQuantity = 40 - 4,
+                      notReadyQuantity = 50 - 5,
+                      readyQuantity = 60 - 6,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species2Batch1.copy(
+                      germinatingQuantity = 70 - 10,
+                      notReadyQuantity = 80 - 11,
+                      readyQuantity = 90 - 12,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+              ),
+              batchesDao.fetchByFacilityId(facilityId).sortedBy { it.germinatingQuantity!! },
+              "Should have deducted withdrawn quantities from batches")
+        },
+        {
+          val newBatch =
+              BatchesRow(
+                  addedDate = LocalDate.of(2022, 10, 1),
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime,
+                  facilityId = destinationFacilityId,
+                  latestObservedTime = withdrawalTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = withdrawalTime,
+                  organizationId = organizationId,
+                  version = 1)
+
+          assertEquals(
+              listOf(
+                  newBatch.copy(
+                      batchNumber = newSpecies1Batch.batchNumber!!,
+                      id = newSpecies1Batch.id!!,
+                      germinatingQuantity = 1 + 4,
+                      notReadyQuantity = 2 + 5,
+                      readyQuantity = 3 + 6,
+                      latestObservedGerminatingQuantity = 1 + 4,
+                      latestObservedNotReadyQuantity = 2 + 5,
+                      latestObservedReadyQuantity = 3 + 6,
+                      speciesId = speciesId,
+                  ),
+                  newBatch.copy(
+                      id = newSpecies2Batch.id!!,
+                      batchNumber = newSpecies2Batch.batchNumber!!,
+                      germinatingQuantity = 10,
+                      notReadyQuantity = 11,
+                      readyQuantity = 12,
+                      latestObservedGerminatingQuantity = 10,
+                      latestObservedNotReadyQuantity = 11,
+                      latestObservedReadyQuantity = 12,
+                      speciesId = speciesId2,
+                  ),
+              ),
+              batchesDao.fetchByFacilityId(destinationFacilityId).sortedBy {
+                it.germinatingQuantity
+              },
+              "Should have created new batches")
+        },
+        {
+          assertEquals(
+              listOf(
+                  BatchWithdrawalsRow(
+                      batchId = species1Batch1Id,
+                      destinationBatchId = newSpecies1Batch.id,
+                      germinatingQuantityWithdrawn = 1,
+                      notReadyQuantityWithdrawn = 2,
+                      readyQuantityWithdrawn = 3,
+                      withdrawalId = withdrawal.id),
+                  BatchWithdrawalsRow(
+                      batchId = species1Batch2Id,
+                      destinationBatchId = newSpecies1Batch.id,
+                      germinatingQuantityWithdrawn = 4,
+                      notReadyQuantityWithdrawn = 5,
+                      readyQuantityWithdrawn = 6,
+                      withdrawalId = withdrawal.id),
+                  BatchWithdrawalsRow(
+                      batchId = species2Batch1Id,
+                      destinationBatchId = newSpecies2Batch.id,
+                      germinatingQuantityWithdrawn = 10,
+                      notReadyQuantityWithdrawn = 11,
+                      readyQuantityWithdrawn = 12,
+                      withdrawalId = withdrawal.id),
+              ),
+              batchWithdrawalsDao.findAll().sortedBy { it.germinatingQuantityWithdrawn },
+              "Should have created batch withdrawals")
+        },
+        {
+          val destinationBatchHistoryRow =
+              BatchQuantityHistoryRow(
+                  historyTypeId = BatchQuantityHistoryType.Observed,
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime)
+          val originBatchHistoryRow =
+              BatchQuantityHistoryRow(
+                  historyTypeId = BatchQuantityHistoryType.Computed,
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime,
+                  withdrawalId = withdrawal.id)
+
+          assertEquals(
+              listOf(
+                  destinationBatchHistoryRow.copy(
+                      batchId = newSpecies1Batch.id!!,
+                      germinatingQuantity = 1 + 4,
+                      notReadyQuantity = 2 + 5,
+                      readyQuantity = 3 + 6),
+                  originBatchHistoryRow.copy(
+                      batchId = species1Batch1Id,
+                      germinatingQuantity = 10 - 1,
+                      notReadyQuantity = 20 - 2,
+                      readyQuantity = 30 - 3),
+                  destinationBatchHistoryRow.copy(
+                      batchId = newSpecies2Batch.id!!,
+                      germinatingQuantity = 10,
+                      notReadyQuantity = 11,
+                      readyQuantity = 12),
+                  originBatchHistoryRow.copy(
+                      batchId = species1Batch2Id,
+                      germinatingQuantity = 40 - 4,
+                      notReadyQuantity = 50 - 5,
+                      readyQuantity = 60 - 6),
+                  originBatchHistoryRow.copy(
+                      batchId = species2Batch1Id,
+                      germinatingQuantity = 70 - 10,
+                      notReadyQuantity = 80 - 11,
+                      readyQuantity = 90 - 12)),
+              batchQuantityHistoryDao
+                  .findAll()
+                  .map { it.copy(id = null) }
+                  .sortedBy { it.germinatingQuantity!! },
+              "Should have inserted quantity history rows")
+        },
+        {
+          assertEquals(
+              listOf(
+                  WithdrawalsRow(
+                      id = withdrawal.id,
+                      facilityId = facilityId,
+                      purposeId = WithdrawalPurpose.NurseryTransfer,
+                      withdrawnDate = LocalDate.of(2022, 10, 1),
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      modifiedBy = user.userId,
+                      modifiedTime = withdrawalTime,
+                      destinationFacilityId = destinationFacilityId,
+                      reason = "Reason")),
+              nurseryWithdrawalsDao.findAll(),
+              "Should have inserted withdrawals row")
+        })
+  }
+
+  @Test
+  fun `throws exception if destination facility is in a different organization`() {
+    val otherOrganizationId = OrganizationId(2)
+    val otherOrgFacilityId = FacilityId(3)
+
+    insertOrganization(otherOrganizationId)
+    insertFacility(otherOrgFacilityId, otherOrganizationId, type = FacilityType.Nursery)
+
+    assertThrows<CrossOrganizationNurseryTransferNotAllowedException> {
       store.withdraw(
           NewWithdrawalModel(
               batchWithdrawals =
@@ -383,8 +608,34 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       BatchWithdrawalModel(
                           batchId = species1Batch1Id,
                           germinatingQuantityWithdrawn = 1,
-                          notReadyQuantityWithdrawn = 1,
-                          readyQuantityWithdrawn = 1)),
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0)),
+              destinationFacilityId = otherOrgFacilityId,
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.NurseryTransfer,
+              withdrawnDate = LocalDate.EPOCH))
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to create batches at destination facility`() {
+    insertFacility(destinationFacilityId, type = FacilityType.Nursery)
+
+    every { user.canCreateBatch(destinationFacilityId) } returns false
+    every { user.canReadFacility(destinationFacilityId) } returns true
+
+    assertThrows<AccessDeniedException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0)),
+              destinationFacilityId = destinationFacilityId,
               facilityId = facilityId,
               id = null,
               purpose = WithdrawalPurpose.NurseryTransfer,


### PR DESCRIPTION
Add support for the `Nursery Transfer` withdrawal purpose, which will cause the
system to create new batches at a destination nursery facility.