### PR TITLE
SW-1845 Stop fetching accessions by number in tests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -70,6 +70,11 @@ data class BatchWithdrawalPayload(
 data class NurseryWithdrawalPayload(
     val batchWithdrawals: List<BatchWithdrawalPayload>,
     val destination: String? = null,
+    @Schema(
+        description =
+            "If purpose is \"Nursery Transfer\", the ID of the facility to which the seedlings " +
+                "were transferred.")
+    val destinationFacilityId: FacilityId? = null,
     val facilityId: FacilityId,
     val id: WithdrawalId,
     val purpose: WithdrawalPurpose,
@@ -81,6 +86,7 @@ data class NurseryWithdrawalPayload(
   ) : this(
       model.batchWithdrawals.map { BatchWithdrawalPayload(it) },
       model.destination,
+      model.destinationFacilityId,
       model.facilityId,
       model.id,
       model.purpose,
@@ -92,6 +98,12 @@ data class NurseryWithdrawalPayload(
 data class CreateNurseryWithdrawalRequestPayload(
     @ArraySchema(minItems = 1) val batchWithdrawals: List<BatchWithdrawalPayload>,
     val destination: String? = null,
+    @Schema(
+        description =
+            "If purpose is \"Nursery Transfer\", the ID of the facility to transfer to. Must be " +
+                "in the same organization as the originating facility. Not allowed for purposes " +
+                "other than \"Nursery Transfer\".")
+    val destinationFacilityId: FacilityId? = null,
     val facilityId: FacilityId,
     val purpose: WithdrawalPurpose,
     val reason: String? = null,
@@ -101,6 +113,7 @@ data class CreateNurseryWithdrawalRequestPayload(
       NewWithdrawalModel(
           batchWithdrawals = batchWithdrawals.map { it.toModel() },
           destination = destination,
+          destinationFacilityId = destinationFacilityId,
           facilityId = facilityId,
           id = null,
           purpose = purpose,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.nursery.model.SpeciesSummary
+import com.terraformation.backend.nursery.model.WithdrawalModel
 import com.terraformation.backend.nursery.model.toModel
 import java.time.Clock
 import java.time.LocalDate
@@ -290,10 +291,6 @@ class BatchStore(
    * different species.
    */
   fun withdraw(withdrawal: NewWithdrawalModel): ExistingWithdrawalModel {
-    if (withdrawal.purpose == WithdrawalPurpose.NurseryTransfer) {
-      throw IllegalArgumentException("Nursery transfers are not implemented yet")
-    }
-
     withdrawal.batchWithdrawals.forEach { batchWithdrawal ->
       requirePermissions { updateBatch(batchWithdrawal.batchId) }
 
@@ -306,6 +303,22 @@ class BatchStore(
         withdrawal.batchWithdrawals.size) {
       throw IllegalArgumentException(
           "Cannot withdraw from the same batch more than once in a single withdrawal")
+    }
+
+    if (withdrawal.purpose == WithdrawalPurpose.NurseryTransfer) {
+      if (withdrawal.destinationFacilityId == null) {
+        throw IllegalArgumentException("Nursery transfer must include destination facility ID")
+      }
+
+      requirePermissions { createBatch(withdrawal.destinationFacilityId) }
+
+      if (parentStore.getOrganizationId(withdrawal.facilityId) !=
+          parentStore.getOrganizationId(withdrawal.destinationFacilityId)) {
+        throw CrossOrganizationNurseryTransferNotAllowedException(
+            withdrawal.facilityId, withdrawal.destinationFacilityId)
+      }
+    } else if (withdrawal.destinationFacilityId != null) {
+      throw IllegalArgumentException("Only nursery transfers may include destination facility ID")
     }
 
     return dslContext.transactionResult { _ ->
@@ -326,6 +339,8 @@ class BatchStore(
       withdrawalsDao.insert(withdrawalsRow)
       val withdrawalId = withdrawalsRow.id!!
 
+      val destinationBatchIds: Map<BatchId, BatchId> = createDestinationBatches(withdrawal)
+
       val batchWithdrawalsRows =
           withdrawal.batchWithdrawals
               // Sort by batch ID to avoid deadlocks if two clients withdraw from the same set of
@@ -336,6 +351,7 @@ class BatchStore(
                 val batchWithdrawalsRow =
                     BatchWithdrawalsRow(
                         batchId = batchId,
+                        destinationBatchId = destinationBatchIds[batchId],
                         withdrawalId = withdrawalId,
                         germinatingQuantityWithdrawn = batchWithdrawal.germinatingQuantityWithdrawn,
                         notReadyQuantityWithdrawn = batchWithdrawal.notReadyQuantityWithdrawn,
@@ -425,6 +441,49 @@ class BatchStore(
 
       withdrawalsRow.toModel(batchWithdrawalsRows)
     }
+  }
+
+  /**
+   * For nursery transfer withdrawals, creates a batch at the destination facility for each species
+   * being withdrawn.
+   *
+   * @return A map of the originating batch IDs to the newly-created batch IDs. This is an N:1
+   * mapping: if you withdraw from two batches of the same species, only one new batch will be
+   * created at the destination facility.
+   */
+  private fun createDestinationBatches(withdrawal: WithdrawalModel<*>): Map<BatchId, BatchId> {
+    if (withdrawal.purpose != WithdrawalPurpose.NurseryTransfer) {
+      return emptyMap()
+    }
+
+    // We want to create a new batch for each species, rather than one for each originating
+    // batch, so we need to look up the species ID of the originating bach of each batch withdrawal
+    // in order to aggregate the per-species quantities.
+    val batchWithdrawalsBySpeciesId =
+        withdrawal.batchWithdrawals.groupBy { batchesDao.fetchOneById(it.batchId)?.speciesId }
+
+    return batchWithdrawalsBySpeciesId
+        .flatMap { (speciesId, batchWithdrawals) ->
+          val germinatingQuantity = batchWithdrawals.sumOf { it.germinatingQuantityWithdrawn }
+          val notReadyQuantity = batchWithdrawals.sumOf { it.notReadyQuantityWithdrawn }
+          val readyQuantity = batchWithdrawals.sumOf { it.readyQuantityWithdrawn }
+
+          val newBatch =
+              create(
+                  BatchesRow(
+                      addedDate = withdrawal.withdrawnDate,
+                      facilityId = withdrawal.destinationFacilityId,
+                      germinatingQuantity = germinatingQuantity,
+                      notReadyQuantity = notReadyQuantity,
+                      readyQuantity = readyQuantity,
+                      speciesId = speciesId))
+
+          // Return a List<Pair<BatchId, BatchId>> mapping the originating batch IDs to the
+          // newly-created one. The List will get flattened by flatMap and then turned into
+          // Map<BatchId, BatchId>.
+          batchWithdrawals.map { it.batchId to newBatch.id!! }
+        }
+        .toMap()
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EntityStaleException
+import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.BatchId
 
 class BatchNotFoundException(val batchId: BatchId) :
@@ -12,3 +14,11 @@ class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
 
 class BatchInventoryInsufficientException(val batchId: BatchId) :
     IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")
+
+class CrossOrganizationNurseryTransferNotAllowedException(
+    val facilityId: FacilityId,
+    val destinationFacilityId: FacilityId
+) :
+    MismatchedStateException(
+        "Cannot transfer from $facilityId to $destinationFacilityId because they are in " +
+            "different organizations")

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -2,14 +2,17 @@ package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
+import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import io.mockk.every
@@ -17,6 +20,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
@@ -28,6 +32,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   private val species1Batch1Id = BatchId(11)
   private val species1Batch2Id = BatchId(12)
   private val species2Batch1Id = BatchId(21)
+
+  private val destinationFacilityId = FacilityId(3)
 
   @BeforeEach
   fun insertInitialBatches() {
@@ -374,8 +380,227 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   }
 
   @Test
-  fun `throws exception if you try to create a nursery transfer withdrawal`() {
-    assertThrows<IllegalArgumentException> {
+  fun `nursery transfer creates a new batch for each species`() {
+    val species1Batch1 = batchesDao.fetchOneById(species1Batch1Id)!!
+    val species1Batch2 = batchesDao.fetchOneById(species1Batch2Id)!!
+    val species2Batch1 = batchesDao.fetchOneById(species2Batch1Id)!!
+
+    insertFacility(destinationFacilityId, type = FacilityType.Nursery)
+
+    val withdrawalTime = clock.instant().plusSeconds(1000)
+    every { clock.instant() } returns withdrawalTime
+
+    val withdrawal =
+        store.withdraw(
+            NewWithdrawalModel(
+                destinationFacilityId = destinationFacilityId,
+                facilityId = facilityId,
+                id = null,
+                purpose = WithdrawalPurpose.NurseryTransfer,
+                reason = "Reason",
+                withdrawnDate = LocalDate.of(2022, 10, 1),
+                batchWithdrawals =
+                    listOf(
+                        BatchWithdrawalModel(
+                            batchId = species1Batch1Id,
+                            germinatingQuantityWithdrawn = 1,
+                            notReadyQuantityWithdrawn = 2,
+                            readyQuantityWithdrawn = 3),
+                        BatchWithdrawalModel(
+                            batchId = species1Batch2Id,
+                            germinatingQuantityWithdrawn = 4,
+                            notReadyQuantityWithdrawn = 5,
+                            readyQuantityWithdrawn = 6),
+                        BatchWithdrawalModel(
+                            batchId = species2Batch1Id,
+                            germinatingQuantityWithdrawn = 10,
+                            notReadyQuantityWithdrawn = 11,
+                            readyQuantityWithdrawn = 12))))
+
+    // The order the new batches get created is undefined, so either new batch ID/number could
+    // be for either species. Need to load them to figure out which is which.
+    val newBatches = batchesDao.fetchByFacilityId(destinationFacilityId)
+    val newSpecies1Batch =
+        newBatches.firstOrNull { it.speciesId == speciesId }
+            ?: fail("No new batch created for species $speciesId")
+    val newSpecies2Batch =
+        newBatches.firstOrNull { it.speciesId == speciesId2 }
+            ?: fail("No new batch created for species $speciesId2")
+
+    assertAll(
+        {
+          assertEquals(
+              listOf(
+                  species1Batch1.copy(
+                      germinatingQuantity = 10 - 1,
+                      notReadyQuantity = 20 - 2,
+                      readyQuantity = 30 - 3,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species1Batch2.copy(
+                      germinatingQuantity = 40 - 4,
+                      notReadyQuantity = 50 - 5,
+                      readyQuantity = 60 - 6,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+                  species2Batch1.copy(
+                      germinatingQuantity = 70 - 10,
+                      notReadyQuantity = 80 - 11,
+                      readyQuantity = 90 - 12,
+                      modifiedTime = withdrawalTime,
+                      version = 2,
+                  ),
+              ),
+              batchesDao.fetchByFacilityId(facilityId).sortedBy { it.germinatingQuantity!! },
+              "Should have deducted withdrawn quantities from batches")
+        },
+        {
+          val newBatch =
+              BatchesRow(
+                  addedDate = LocalDate.of(2022, 10, 1),
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime,
+                  facilityId = destinationFacilityId,
+                  latestObservedTime = withdrawalTime,
+                  modifiedBy = user.userId,
+                  modifiedTime = withdrawalTime,
+                  organizationId = organizationId,
+                  version = 1)
+
+          assertEquals(
+              listOf(
+                  newBatch.copy(
+                      batchNumber = newSpecies1Batch.batchNumber!!,
+                      id = newSpecies1Batch.id!!,
+                      germinatingQuantity = 1 + 4,
+                      notReadyQuantity = 2 + 5,
+                      readyQuantity = 3 + 6,
+                      latestObservedGerminatingQuantity = 1 + 4,
+                      latestObservedNotReadyQuantity = 2 + 5,
+                      latestObservedReadyQuantity = 3 + 6,
+                      speciesId = speciesId,
+                  ),
+                  newBatch.copy(
+                      id = newSpecies2Batch.id!!,
+                      batchNumber = newSpecies2Batch.batchNumber!!,
+                      germinatingQuantity = 10,
+                      notReadyQuantity = 11,
+                      readyQuantity = 12,
+                      latestObservedGerminatingQuantity = 10,
+                      latestObservedNotReadyQuantity = 11,
+                      latestObservedReadyQuantity = 12,
+                      speciesId = speciesId2,
+                  ),
+              ),
+              batchesDao.fetchByFacilityId(destinationFacilityId).sortedBy {
+                it.germinatingQuantity
+              },
+              "Should have created new batches")
+        },
+        {
+          assertEquals(
+              listOf(
+                  BatchWithdrawalsRow(
+                      batchId = species1Batch1Id,
+                      destinationBatchId = newSpecies1Batch.id,
+                      germinatingQuantityWithdrawn = 1,
+                      notReadyQuantityWithdrawn = 2,
+                      readyQuantityWithdrawn = 3,
+                      withdrawalId = withdrawal.id),
+                  BatchWithdrawalsRow(
+                      batchId = species1Batch2Id,
+                      destinationBatchId = newSpecies1Batch.id,
+                      germinatingQuantityWithdrawn = 4,
+                      notReadyQuantityWithdrawn = 5,
+                      readyQuantityWithdrawn = 6,
+                      withdrawalId = withdrawal.id),
+                  BatchWithdrawalsRow(
+                      batchId = species2Batch1Id,
+                      destinationBatchId = newSpecies2Batch.id,
+                      germinatingQuantityWithdrawn = 10,
+                      notReadyQuantityWithdrawn = 11,
+                      readyQuantityWithdrawn = 12,
+                      withdrawalId = withdrawal.id),
+              ),
+              batchWithdrawalsDao.findAll().sortedBy { it.germinatingQuantityWithdrawn },
+              "Should have created batch withdrawals")
+        },
+        {
+          val destinationBatchHistoryRow =
+              BatchQuantityHistoryRow(
+                  historyTypeId = BatchQuantityHistoryType.Observed,
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime)
+          val originBatchHistoryRow =
+              BatchQuantityHistoryRow(
+                  historyTypeId = BatchQuantityHistoryType.Computed,
+                  createdBy = user.userId,
+                  createdTime = withdrawalTime,
+                  withdrawalId = withdrawal.id)
+
+          assertEquals(
+              listOf(
+                  destinationBatchHistoryRow.copy(
+                      batchId = newSpecies1Batch.id!!,
+                      germinatingQuantity = 1 + 4,
+                      notReadyQuantity = 2 + 5,
+                      readyQuantity = 3 + 6),
+                  originBatchHistoryRow.copy(
+                      batchId = species1Batch1Id,
+                      germinatingQuantity = 10 - 1,
+                      notReadyQuantity = 20 - 2,
+                      readyQuantity = 30 - 3),
+                  destinationBatchHistoryRow.copy(
+                      batchId = newSpecies2Batch.id!!,
+                      germinatingQuantity = 10,
+                      notReadyQuantity = 11,
+                      readyQuantity = 12),
+                  originBatchHistoryRow.copy(
+                      batchId = species1Batch2Id,
+                      germinatingQuantity = 40 - 4,
+                      notReadyQuantity = 50 - 5,
+                      readyQuantity = 60 - 6),
+                  originBatchHistoryRow.copy(
+                      batchId = species2Batch1Id,
+                      germinatingQuantity = 70 - 10,
+                      notReadyQuantity = 80 - 11,
+                      readyQuantity = 90 - 12)),
+              batchQuantityHistoryDao
+                  .findAll()
+                  .map { it.copy(id = null) }
+                  .sortedBy { it.germinatingQuantity!! },
+              "Should have inserted quantity history rows")
+        },
+        {
+          assertEquals(
+              listOf(
+                  WithdrawalsRow(
+                      id = withdrawal.id,
+                      facilityId = facilityId,
+                      purposeId = WithdrawalPurpose.NurseryTransfer,
+                      withdrawnDate = LocalDate.of(2022, 10, 1),
+                      createdBy = user.userId,
+                      createdTime = withdrawalTime,
+                      modifiedBy = user.userId,
+                      modifiedTime = withdrawalTime,
+                      destinationFacilityId = destinationFacilityId,
+                      reason = "Reason")),
+              nurseryWithdrawalsDao.findAll(),
+              "Should have inserted withdrawals row")
+        })
+  }
+
+  @Test
+  fun `throws exception if destination facility is in a different organization`() {
+    val otherOrganizationId = OrganizationId(2)
+    val otherOrgFacilityId = FacilityId(3)
+
+    insertOrganization(otherOrganizationId)
+    insertFacility(otherOrgFacilityId, otherOrganizationId, type = FacilityType.Nursery)
+
+    assertThrows<CrossOrganizationNurseryTransferNotAllowedException> {
       store.withdraw(
           NewWithdrawalModel(
               batchWithdrawals =
@@ -383,8 +608,34 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       BatchWithdrawalModel(
                           batchId = species1Batch1Id,
                           germinatingQuantityWithdrawn = 1,
-                          notReadyQuantityWithdrawn = 1,
-                          readyQuantityWithdrawn = 1)),
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0)),
+              destinationFacilityId = otherOrgFacilityId,
+              facilityId = facilityId,
+              id = null,
+              purpose = WithdrawalPurpose.NurseryTransfer,
+              withdrawnDate = LocalDate.EPOCH))
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to create batches at destination facility`() {
+    insertFacility(destinationFacilityId, type = FacilityType.Nursery)
+
+    every { user.canCreateBatch(destinationFacilityId) } returns false
+    every { user.canReadFacility(destinationFacilityId) } returns true
+
+    assertThrows<AccessDeniedException> {
+      store.withdraw(
+          NewWithdrawalModel(
+              batchWithdrawals =
+                  listOf(
+                      BatchWithdrawalModel(
+                          batchId = species1Batch1Id,
+                          germinatingQuantityWithdrawn = 1,
+                          notReadyQuantityWithdrawn = 0,
+                          readyQuantityWithdrawn = 0)),
+              destinationFacilityId = destinationFacilityId,
               facilityId = facilityId,
               id = null,
               purpose = WithdrawalPurpose.NurseryTransfer,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -26,6 +26,7 @@ import java.time.Instant
 import java.time.LocalDate
 import kotlin.reflect.full.declaredMemberProperties
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
@@ -62,11 +63,16 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
   @Test
   fun `create deals with collisions in accession numbers`() {
-    store.create(AccessionModel(facilityId = facilityId))
+    val model1 = store.create(AccessionModel(facilityId = facilityId))
     dslContext.alterSequence(ACCESSION_NUMBER_SEQ).restartWith(197001010000000000).execute()
-    store.create(AccessionModel(facilityId = facilityId))
+    val model2 = store.create(AccessionModel(facilityId = facilityId))
 
-    assertNotNull(accessionsDao.fetchOneByNumber(accessionNumbers[1]))
+    assertNotNull(model1.accessionNumber, "First accession should have a number")
+    assertNotNull(model2.accessionNumber, "Second accession should have a number")
+    assertNotEquals(
+        model1.accessionNumber,
+        model2.accessionNumber,
+        "Accession numbers should be unique within facility")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -45,8 +45,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     // Second time should reuse them
     val secondAccession = store.create(payload)
 
-    val initialRow = accessionsDao.fetchOneByNumber(accessionNumbers[0])!!
-    val secondRow = accessionsDao.fetchOneByNumber(accessionNumbers[1])!!
+    val initialRow = accessionsDao.fetchOneById(initialAccession.id!!)!!
+    val secondRow = accessionsDao.fetchOneById(secondAccession.id!!)!!
 
     assertNotEquals(initialRow.number, secondRow.number, "Accession numbers")
     assertEquals(initialRow.speciesId, secondRow.speciesId, "Species")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -119,7 +119,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `can filter on computed fields whose raw values are being queried`() {
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("XYZ")!!.copy(stateId = AccessionState.Withdrawn))
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.Withdrawn))
 
     val fields = listOf(accessionNumberField, stateField)
     val searchNode = FieldNode(activeField, listOf("Inactive"))
@@ -137,7 +137,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `exact search on text fields is case-insensitive`() {
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(storageNotes = "Some Matching Notes"))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(storageNotes = "Some Matching Notes"))
 
     val fields = listOf(accessionNumberField)
     val searchNode =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -20,11 +20,11 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   fun `sorts enum fields by display name rather than ID`() {
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("ABCDEFG")!!
+            .fetchOneById(AccessionId(1001))!!
             .copy(targetStorageCondition = StorageCondition.Freezer))
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("XYZ")!!
+            .fetchOneById(AccessionId(1000))!!
             .copy(targetStorageCondition = StorageCondition.Refrigerator))
 
     val fields = listOf(targetStorageConditionField)
@@ -53,7 +53,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   @Test
   fun `uses enum display name when it differs from Kotlin name`() {
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(stateId = AccessionState.InStorage))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(stateId = AccessionState.InStorage))
 
     val searchNode = FieldNode(stateField, listOf("In Storage"))
     val fields = listOf(stateField)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -20,7 +20,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
   @Test
   fun `renders null values as null, not as a string`() {
-    accessionsDao.update(accessionsDao.fetchOneByNumber("XYZ")!!.copy(speciesId = null))
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(speciesId = null))
     val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
     assertEquals(listOf("Other Dogwood", null), values)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
@@ -10,8 +11,9 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
   @Test
   fun `fuzzy search on text fields is case-insensitive`() {
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(storageNotes = "Some Matching Notes"))
-    accessionsDao.update(accessionsDao.fetchOneByNumber("XYZ")!!.copy(storageNotes = "Not It"))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(storageNotes = "Some Matching Notes"))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(storageNotes = "Not It"))
 
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(storageNotesField, listOf("matc"), SearchFilterType.Fuzzy)
@@ -27,8 +29,9 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
   @Test
   fun `fuzzy search on text fields handles single-character search values`() {
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(storageNotes = "Some Matching Notes"))
-    accessionsDao.update(accessionsDao.fetchOneByNumber("XYZ")!!.copy(storageNotes = "Not It"))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(storageNotes = "Some Matching Notes"))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(storageNotes = "Not It"))
 
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(storageNotesField, listOf("G"), SearchFilterType.Fuzzy)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceGramsSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceGramsSearchTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.search.FieldNode
@@ -15,7 +16,7 @@ internal class SearchServiceGramsSearchTest : SearchServiceTest() {
   fun `can specify weight units when searching by grams`() {
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("ABCDEFG")!!
+            .fetchOneById(AccessionId(1001))!!
             .copy(
                 processingMethodId = ProcessingMethod.Weight,
                 totalGrams = BigDecimal(1000),
@@ -41,7 +42,7 @@ internal class SearchServiceGramsSearchTest : SearchServiceTest() {
   fun `searching on grams field defaults to grams if no units explicitly specified`() {
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("ABCDEFG")!!
+            .fetchOneById(AccessionId(1001))!!
             .copy(
                 processingMethodId = ProcessingMethod.Weight,
                 totalGrams = BigDecimal(1000),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
@@ -13,7 +14,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
   fun `search leaves out null values`() {
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("ABCDEFG")!!
+            .fetchOneById(AccessionId(1001))!!
             .copy(targetStorageCondition = StorageCondition.Freezer))
 
     val fields = listOf(targetStorageConditionField)
@@ -39,11 +40,11 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
     insertAccession(number = "MISSING")
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("ABCDEFG")!!
+            .fetchOneById(AccessionId(1001))!!
             .copy(targetStorageCondition = StorageCondition.Freezer))
     accessionsDao.update(
         accessionsDao
-            .fetchOneByNumber("XYZ")!!
+            .fetchOneById(AccessionId(1000))!!
             .copy(targetStorageCondition = StorageCondition.Refrigerator))
 
     val fields = listOf(targetStorageConditionField)
@@ -69,8 +70,9 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
   fun `can do fuzzy search for null values`() {
     insertAccession(number = "MISSING")
     accessionsDao.update(
-        accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(storageNotes = "some matching notes"))
-    accessionsDao.update(accessionsDao.fetchOneByNumber("XYZ")!!.copy(storageNotes = "not it"))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(storageNotes = "some matching notes"))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(storageNotes = "not it"))
 
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(storageNotesField, listOf("matching", null), SearchFilterType.Fuzzy)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
@@ -10,7 +11,8 @@ import org.junit.jupiter.api.assertThrows
 internal class SearchServiceRangeSearchTest : SearchServiceTest() {
   @Test
   fun `can do range search on integer field`() {
-    accessionsDao.update(accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
     val fields = listOf(treesCollectedFromField)
     val searchNode = FieldNode(treesCollectedFromField, listOf("2", "3000"), SearchFilterType.Range)
 
@@ -28,7 +30,8 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
   @Test
   fun `can do range search on integer field with no minimum`() {
-    accessionsDao.update(accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
     val fields = listOf(treesCollectedFromField)
     val searchNode = FieldNode(treesCollectedFromField, listOf(null, "3"), SearchFilterType.Range)
 
@@ -44,7 +47,8 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
   @Test
   fun `can do range search on integer field with no maximum`() {
-    accessionsDao.update(accessionsDao.fetchOneByNumber("ABCDEFG")!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
     val fields = listOf(treesCollectedFromField)
     val searchNode = FieldNode(treesCollectedFromField, listOf("2", null), SearchFilterType.Range)
 


### PR DESCRIPTION
In preparation for removing the requirement that accession numbers be globally
unique, update various tests that use accession numbers as unique lookup keys.

No application behavior change here. Replaces `AccessionsDao.fetchOneByNumber`
calls with `AccessionsDao.fetchOneById`.