### PR TITLE
SW-1845 Revamp accession and batch number generation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -76,7 +76,9 @@ class BatchStore(
     val facilityId =
         row.facilityId ?: throw IllegalArgumentException("Facility ID must be non-null")
     val facilityType = parentStore.getFacilityType(facilityId)
-    val organizationId = parentStore.getOrganizationId(facilityId)
+    val organizationId =
+        parentStore.getOrganizationId(facilityId)
+            ?: throw IllegalArgumentException("Facility not found")
     val speciesId = row.speciesId ?: throw IllegalArgumentException("Species ID must be non-null")
     val now = clock.instant()
     val userId = currentUser().userId
@@ -93,7 +95,7 @@ class BatchStore(
 
     val rowWithDefaults =
         row.copy(
-            batchNumber = identifierGenerator.generateIdentifier(),
+            batchNumber = identifierGenerator.generateIdentifier(organizationId),
             createdBy = userId,
             createdTime = now,
             modifiedBy = userId,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -89,6 +89,8 @@ COMMENT ON TABLE seedbank.geolocations IS 'Locations where seeds were collected.
 
 COMMENT ON TABLE growth_forms IS '(Enum) What physical form a particular species takes. For example, "Tree" or "Shrub."';
 
+COMMENT ON TABLE identifier_sequences IS 'Current state for generating user-facing identifiers (accession number, etc.) for each organization.';
+
 COMMENT ON TABLE notification_criticalities IS '(Enum) Criticality information of notifications in the application.';
 COMMENT ON TABLE notification_types IS '(Enum) Types of notifications in the application.';
 COMMENT ON TABLE notifications IS 'Notifications for application users.';

--- a/src/main/resources/db/migration/V143__IdentifierSequences.sql
+++ b/src/main/resources/db/migration/V143__IdentifierSequences.sql
@@ -1,0 +1,12 @@
+CREATE TABLE identifier_sequences (
+    organization_id BIGINT PRIMARY KEY REFERENCES organizations ON DELETE CASCADE,
+    next_value      BIGINT NOT NULL DEFAULT 1
+);
+
+DROP SEQUENCE seedbank.accession_number_seq;
+
+-- Accession numbers should not need to be globally unique.
+ALTER TABLE seedbank.accessions
+    ADD CONSTRAINT accession_number_facility_unique UNIQUE (number, facility_id);
+ALTER TABLE seedbank.accessions
+    DROP CONSTRAINT accession_number_unique;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -80,7 +80,6 @@ import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration
 import org.jooq.DSLContext
 import org.jooq.Record
-import org.jooq.Sequence
 import org.jooq.Table
 import org.jooq.impl.DAOImpl
 import org.jooq.impl.DSL
@@ -122,9 +121,8 @@ import org.testcontainers.utility.DockerImageName
  * helper method.
  * - Sequences, including the ones used to generate auto-increment primary keys, are normally not
  * reset when transactions are rolled back. But it is useful to have a predictable set of IDs to
- * compare against. So subclasses can override the [sequencesToReset] value with a list of sequences
- * to reset before each test method. Or, often more convenient, they can override
- * [tablesToResetSequences] with a list of tables whose primary key sequences should be reset.
+ * compare against. So subclasses can override [tablesToResetSequences] with a list of tables whose
+ * primary key sequences should be reset before each test method.
  */
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -137,13 +135,6 @@ abstract class DatabaseTest {
   @Autowired lateinit var dslContext: DSLContext
 
   /**
-   * List of sequences to reset before each test method. Test classes can use this to get
-   * predictable IDs when inserting new data.
-   */
-  protected val sequencesToReset: List<Sequence<out Number>>
-    get() = emptyList()
-
-  /**
    * List of tables from which sequences are to be reset before each test method. Sequences used
    * here belong to the primary key in the table.
    */
@@ -154,11 +145,6 @@ abstract class DatabaseTest {
   // marked as final so they can be referenced in constructor-initialized properties in subclasses.
   protected final val organizationId: OrganizationId = OrganizationId(1)
   protected final val facilityId: FacilityId = FacilityId(100)
-
-  @BeforeEach
-  fun resetSequences() {
-    sequencesToReset.forEach { sequence -> dslContext.alterSequence(sequence).restart().execute() }
-  }
 
   @BeforeEach
   fun resetSequencesForTables() {

--- a/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class IdentifierGeneratorTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock: Clock = mockk()
+
+  private val generator: IdentifierGenerator by lazy { IdentifierGenerator(clock, dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+    every { clock.zone } returns ZoneOffset.UTC
+
+    insertUser()
+    insertOrganization()
+  }
+
+  @Test
+  fun `identifiers start at 6 digits`() {
+    val identifier = generator.generateIdentifier(organizationId)
+
+    assertEquals(6, identifier.length, "Identifier length")
+  }
+
+  @Test
+  fun `identifiers are allocated per organization`() {
+    val otherOrganizationId = OrganizationId(2)
+    insertOrganization(otherOrganizationId)
+
+    val org1Identifier = generator.generateIdentifier(organizationId)
+    val org2Identifier = generator.generateIdentifier(otherOrganizationId)
+
+    assertEquals(org1Identifier, org2Identifier)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -150,6 +150,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "gbif_taxa" to setOf(SPECIES),
                   "gbif_vernacular_names" to setOf(SPECIES),
                   "growth_forms" to setOf(ALL, SEEDBANK),
+                  "identifier_sequences" to setOf(ALL, SEEDBANK, NURSERY),
                   "notification_criticalities" to setOf(ALL, CUSTOMER),
                   "notification_types" to setOf(ALL, CUSTOMER),
                   "notifications" to setOf(ALL, CUSTOMER),

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -33,7 +33,7 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
     val expectedBatch =
         BatchesRow(
             addedDate = LocalDate.of(2022, 1, 2),
-            batchNumber = "19700101000",
+            batchNumber = "100000",
             createdBy = user.userId,
             createdTime = clock.instant(),
             facilityId = facilityId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -230,7 +230,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
                 isManualState = true,
                 modifiedBy = user.userId,
                 modifiedTime = Instant.EPOCH,
-                number = "19700101000",
+                number = "100000",
                 remainingGrams = BigDecimal(101),
                 remainingQuantity = BigDecimal(101),
                 remainingUnitsId = SeedQuantityUnits.Grams,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.seedbank.ProcessingMethod
-import com.terraformation.backend.db.seedbank.sequences.ACCESSION_NUMBER_SEQ
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
 import com.terraformation.backend.db.seedbank.tables.references.BAGS
@@ -40,15 +39,11 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import org.jooq.Record
-import org.jooq.Sequence
 import org.jooq.Table
 import org.junit.jupiter.api.BeforeEach
 
 internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   override val user: IndividualUser = mockUser()
-
-  override val sequencesToReset: List<Sequence<Long>>
-    get() = listOf(ACCESSION_NUMBER_SEQ)
 
   override val tablesToResetSequences: List<Table<out Record>>
     get() =
@@ -60,18 +55,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             VIABILITY_TESTS,
             SPECIES,
             WITHDRAWALS)
-
-  protected val accessionNumbers =
-      listOf(
-          "19700101000",
-          "19700101001",
-          "19700101002",
-          "19700101003",
-          "19700101004",
-          "19700101005",
-          "19700101006",
-          "19700101007",
-      )
 
   protected val clock: Clock = mockk()
 


### PR DESCRIPTION
Previously, accession numbers were globally unique, which was fine because we were
generating them on the server side. But now we allow users to upload CSV files
with their own arbitrary accession numbers, and we don't want one organization to
be able to make an accession number unavailable to another one.

Change the database constraint so that accession numbers are only required to be
unique per facility.

In addition, the fact that we encoded dates into accession numbers sometimes
causes user confusion: those dates _usually_ match up with several other accession
dates such as the collection date, but not always. Although the date selection was
consistent on the server side, users didn't have a good way of learning how it
worked and made assumptions which then broke some of the time.

To address that, we now allocate these identifiers as simple incrementing numbers,
tracked separately per organization, starting with 100000 so they'll stay a
consistent width on screen for all but the very largest of organizations.

Seed accession and seedling batch numbers are allocated from the same place; we
will never generate an accession number that we've generated as a batch number for
the same organization or vice versa. However, if the user generates their own
accession numbers and uploads them in a CSV file, we don't enforce that the
numbers have to be unique across the organization, just unique within a particular
seed bank.