### PR TITLE
SW-1845 Revamp accession and batch number generation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
@@ -2,46 +2,68 @@ package com.terraformation.backend.db
 
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.IDENTIFIER_SEQUENCES
-import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.db.AccessionStore
 import java.time.Clock
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
+/**
+ * Generates user-facing identifiers. These are used in places where we need a unique value to
+ * identify a resource but it's not acceptable to display the underlying integer ID from the
+ * database, e.g., accession numbers.
+ *
+ * Identifiers are mostly-fixed-length numeric values of the form YYYYMMDDXXX where XXX is a numeric
+ * suffix of three or more digits that starts at 000 for the first identifier created on a
+ * particular date. The desired behavior is for the suffix to represent the order in which entries
+ * were added to the system, so ideally we want to avoid gaps or out-of-order values, though it's
+ * fine for that to be best-effort.
+ *
+ * In most cases, there should be fewer than 1000 items created by an organization on a given day,
+ * so the identifiers will all be the same length, but if an organization creates a big burst of
+ * data all at once, we let the identifiers grow by a digit. That is, the identifier after
+ * 20221025999 is 202210251000 (999 -> 1000).
+ *
+ * The implementation uses a database table that holds the next value for each organization. The
+ * values follow the same pattern as the identifiers, but the suffix is always 10 digits; it is
+ * rendered as a 3-or-more-digit value. Doing it that way means the SQL query that allocates the
+ * next value doesn't have to be aware of the "grow the identifier if the suffix overflows 3 digits"
+ * logic; it just adds 1 to the previous value. To take the above example, the value in the database
+ * would go from 202210250000000999 to 202210250000001000.
+ *
+ * If the date part of the sequence value doesn't match the current date, the value is reset to the
+ * zero suffix for the current date. That is, if the database says the next value is
+ * 202210310000000036 but it is now November 1, the value will be bumped to 202211010000000000 and
+ * the next identifier (with the suffix collapsed to 3 digits) will be 20221101000.
+ *
+ * Note that although this class is guaranteed to only ever return a given value once for a given
+ * organization ID, it is possible for the generated identifiers to collide with user-supplied
+ * identifiers. To guard against that, [AccessionStore.create] will retry a few times if it gets an
+ * identifier that's already in use.
+ */
 @ManagedBean
 class IdentifierGenerator(
     private val clock: Clock,
     private val dslContext: DSLContext,
 ) {
-  private val log = perClassLogger()
-
   /**
-   * Returns the next unused user-facing identifier. This is used in places where we need a unique
-   * value to identify a resource but it's not acceptable to display the underlying integer ID from
-   * the database, e.g., accession numbers.
+   * Generates a new identifier for an organization.
    *
-   * Identifiers are of the form YYYYMMDDXXX where XXX is a numeric suffix of three or more digits
-   * that starts at 000 for the first identifier created on a particular date. The desired behavior
-   * is for the suffix to represent the order in which entries were added to the system, so ideally
-   * we want to avoid gaps or out-of-order values, though it's fine for that to be best-effort.
-   *
-   * The implementation uses a database sequence. The sequence's values follow the same pattern as
-   * the identifiers, but the suffix is always 10 digits; it is rendered as a 3-or-more-digit value
-   * by this method.
-   *
-   * If the date part of the sequence value doesn't match the current date, this method resets the
-   * sequence to the zero suffix for the current date.
-   *
-   * Note that there is a bit of a race condition if multiple terraware-server instances happen to
-   * allocate their first identifier of a given day at the same time; they might both reset the
-   * sequence. To guard against that, [AccessionStore.create] will retry a few times if it gets a
-   * unique constraint violation on the accession number.
+   * @param timeZone Time zone to use to determine the current date.
    */
-  fun generateIdentifier(organizationId: OrganizationId): String {
+  fun generateIdentifier(
+      organizationId: OrganizationId,
+      timeZone: ZoneId = ZoneOffset.UTC,
+  ): String {
     val suffixMultiplier = 10000000000L
-    val todayAsLong = LocalDate.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE).toLong()
+    val todayAsLong =
+        LocalDate.ofInstant(clock.instant(), timeZone)
+            .format(DateTimeFormatter.BASIC_ISO_DATE) // "20221031"
+            .toLong()
     val firstValueForToday = todayAsLong * suffixMultiplier
 
     val sequenceValue =
@@ -51,28 +73,13 @@ class IdentifierGenerator(
               .set(ORGANIZATION_ID, organizationId)
               .set(NEXT_VALUE, firstValueForToday)
               .onDuplicateKeyUpdate()
-              .set(NEXT_VALUE, NEXT_VALUE.plus(1))
+              .set(NEXT_VALUE, DSL.greatest(NEXT_VALUE.plus(1), DSL.value(firstValueForToday)))
               .returning(NEXT_VALUE)
               .fetchOne(NEXT_VALUE)!!
         }
 
     val datePart = sequenceValue / suffixMultiplier
     val suffixPart = sequenceValue.rem(suffixMultiplier)
-
-    if (todayAsLong != datePart) {
-      log.info("Resetting identifier to $firstValueForToday for organization $organizationId")
-
-      with(IDENTIFIER_SEQUENCES) {
-        dslContext
-            .update(IDENTIFIER_SEQUENCES)
-            .set(NEXT_VALUE, firstValueForToday)
-            .where(ORGANIZATION_ID.eq(organizationId))
-            .and(NEXT_VALUE.lt(firstValueForToday))
-            .execute()
-      }
-
-      return generateIdentifier(organizationId)
-    }
 
     return "%08d%03d".format(datePart, suffixPart)
   }

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -76,7 +76,9 @@ class BatchStore(
     val facilityId =
         row.facilityId ?: throw IllegalArgumentException("Facility ID must be non-null")
     val facilityType = parentStore.getFacilityType(facilityId)
-    val organizationId = parentStore.getOrganizationId(facilityId)
+    val organizationId =
+        parentStore.getOrganizationId(facilityId)
+            ?: throw IllegalArgumentException("Facility not found")
     val speciesId = row.speciesId ?: throw IllegalArgumentException("Species ID must be non-null")
     val now = clock.instant()
     val userId = currentUser().userId
@@ -93,7 +95,7 @@ class BatchStore(
 
     val rowWithDefaults =
         row.copy(
-            batchNumber = identifierGenerator.generateIdentifier(),
+            batchNumber = identifierGenerator.generateIdentifier(organizationId),
             createdBy = userId,
             createdTime = now,
             modifiedBy = userId,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -89,6 +89,8 @@ COMMENT ON TABLE seedbank.geolocations IS 'Locations where seeds were collected.
 
 COMMENT ON TABLE growth_forms IS '(Enum) What physical form a particular species takes. For example, "Tree" or "Shrub."';
 
+COMMENT ON TABLE identifier_sequences IS 'Current state for generating user-facing identifiers (accession number, etc.) for each organization.';
+
 COMMENT ON TABLE notification_criticalities IS '(Enum) Criticality information of notifications in the application.';
 COMMENT ON TABLE notification_types IS '(Enum) Types of notifications in the application.';
 COMMENT ON TABLE notifications IS 'Notifications for application users.';

--- a/src/main/resources/db/migration/V144__IdentifierSequences.sql
+++ b/src/main/resources/db/migration/V144__IdentifierSequences.sql
@@ -1,0 +1,12 @@
+CREATE TABLE identifier_sequences (
+    organization_id BIGINT PRIMARY KEY REFERENCES organizations ON DELETE CASCADE,
+    next_value      BIGINT NOT NULL DEFAULT 1
+);
+
+DROP SEQUENCE seedbank.accession_number_seq;
+
+-- Accession numbers should not need to be globally unique.
+ALTER TABLE seedbank.accessions
+    ADD CONSTRAINT accession_number_facility_unique UNIQUE (number, facility_id);
+ALTER TABLE seedbank.accessions
+    DROP CONSTRAINT accession_number_unique;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -80,7 +80,6 @@ import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration
 import org.jooq.DSLContext
 import org.jooq.Record
-import org.jooq.Sequence
 import org.jooq.Table
 import org.jooq.impl.DAOImpl
 import org.jooq.impl.DSL
@@ -122,9 +121,8 @@ import org.testcontainers.utility.DockerImageName
  * helper method.
  * - Sequences, including the ones used to generate auto-increment primary keys, are normally not
  * reset when transactions are rolled back. But it is useful to have a predictable set of IDs to
- * compare against. So subclasses can override the [sequencesToReset] value with a list of sequences
- * to reset before each test method. Or, often more convenient, they can override
- * [tablesToResetSequences] with a list of tables whose primary key sequences should be reset.
+ * compare against. So subclasses can override [tablesToResetSequences] with a list of tables whose
+ * primary key sequences should be reset before each test method.
  */
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -137,13 +135,6 @@ abstract class DatabaseTest {
   @Autowired lateinit var dslContext: DSLContext
 
   /**
-   * List of sequences to reset before each test method. Test classes can use this to get
-   * predictable IDs when inserting new data.
-   */
-  protected val sequencesToReset: List<Sequence<out Number>>
-    get() = emptyList()
-
-  /**
    * List of tables from which sequences are to be reset before each test method. Sequences used
    * here belong to the primary key in the table.
    */
@@ -154,11 +145,6 @@ abstract class DatabaseTest {
   // marked as final so they can be referenced in constructor-initialized properties in subclasses.
   protected final val organizationId: OrganizationId = OrganizationId(1)
   protected final val facilityId: FacilityId = FacilityId(100)
-
-  @BeforeEach
-  fun resetSequences() {
-    sequencesToReset.forEach { sequence -> dslContext.alterSequence(sequence).restart().execute() }
-  }
 
   @BeforeEach
   fun resetSequencesForTables() {

--- a/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
@@ -1,0 +1,41 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class IdentifierGeneratorTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock: Clock = mockk()
+
+  private val generator: IdentifierGenerator by lazy { IdentifierGenerator(clock, dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    every { clock.instant() } returns Instant.EPOCH
+    every { clock.zone } returns ZoneOffset.UTC
+
+    insertUser()
+    insertOrganization()
+  }
+
+  @Test
+  fun `identifiers are allocated per organization`() {
+    val otherOrganizationId = OrganizationId(2)
+    insertOrganization(otherOrganizationId)
+
+    val org1Identifier = generator.generateIdentifier(organizationId)
+    val org2Identifier = generator.generateIdentifier(otherOrganizationId)
+
+    assertEquals(org1Identifier, org2Identifier)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,5 +38,39 @@ internal class IdentifierGeneratorTest : DatabaseTest(), RunsAsUser {
     val org2Identifier = generator.generateIdentifier(otherOrganizationId)
 
     assertEquals(org1Identifier, org2Identifier)
+  }
+
+  @Test
+  fun `generateIdentifier honors time zone`() {
+    every { clock.instant() } returns
+        ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC).toInstant()
+
+    val identifierInUtc = generator.generateIdentifier(organizationId, ZoneOffset.UTC)
+    val identifierInLaterZone = generator.generateIdentifier(organizationId, ZoneOffset.ofHours(1))
+
+    assertEquals(
+        "19991231", identifierInUtc.substring(0..7), "Date part of identifier in earlier time zone")
+    assertEquals(
+        "20000101",
+        identifierInLaterZone.substring(0..7),
+        "Date part of identifier in later time zone")
+  }
+
+  @Test
+  fun `switching time zones does not cause identifiers to run backwards`() {
+    every { clock.instant() } returns
+        ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC).toInstant()
+
+    val identifierInLaterZone = generator.generateIdentifier(organizationId, ZoneOffset.ofHours(1))
+    val identifierInUtc = generator.generateIdentifier(organizationId, ZoneOffset.UTC)
+
+    assertEquals(
+        "20000101",
+        identifierInLaterZone.substring(0..7),
+        "Date part of identifier in later time zone")
+    assertEquals(
+        "20000101",
+        identifierInUtc.substring(0..7),
+        "Date part of identifier in earlier time zone after later one has already been generated")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -150,6 +150,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "gbif_taxa" to setOf(SPECIES),
                   "gbif_vernacular_names" to setOf(SPECIES),
                   "growth_forms" to setOf(ALL, SEEDBANK),
+                  "identifier_sequences" to setOf(ALL, SEEDBANK, NURSERY),
                   "notification_criticalities" to setOf(ALL, CUSTOMER),
                   "notification_types" to setOf(ALL, CUSTOMER),
                   "notifications" to setOf(ALL, CUSTOMER),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.IDENTIFIER_SEQUENCES
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryId
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
@@ -12,7 +13,6 @@ import com.terraformation.backend.db.seedbank.CollectionSource
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.SourcePlantOrigin
-import com.terraformation.backend.db.seedbank.sequences.ACCESSION_NUMBER_SEQ
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionQuantityHistoryRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
@@ -48,7 +48,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             dataSourceId = DataSource.Web,
             modifiedBy = user.userId,
             modifiedTime = clock.instant(),
-            number = accessionNumbers[0],
+            number = "19700101000",
             stateId = AccessionState.AwaitingCheckIn),
         accessionsDao.fetchOneById(AccessionId(1)))
   }
@@ -64,7 +64,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   @Test
   fun `create deals with collisions in accession numbers`() {
     val model1 = store.create(AccessionModel(facilityId = facilityId))
-    dslContext.alterSequence(ACCESSION_NUMBER_SEQ).restartWith(197001010000000000).execute()
+    dslContext.deleteFrom(IDENTIFIER_SEQUENCES).execute()
     val model2 = store.create(AccessionModel(facilityId = facilityId))
 
     assertNotNull(model1.accessionNumber, "First accession should have a number")
@@ -79,16 +79,9 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   fun `create gives up if it can't generate an unused accession number`() {
     repeat(10) { store.create(AccessionModel(facilityId = facilityId)) }
 
-    dslContext.alterSequence(ACCESSION_NUMBER_SEQ).restartWith(197001010000000000).execute()
+    dslContext.deleteFrom(IDENTIFIER_SEQUENCES).execute()
 
     assertThrows<DuplicateKeyException> { store.create(AccessionModel(facilityId = facilityId)) }
-  }
-
-  @Test
-  fun `create adds digit to accession number suffix if it exceeds 3 digits`() {
-    dslContext.alterSequence(ACCESSION_NUMBER_SEQ).restartWith(197001010000001000).execute()
-    val inserted = store.create(AccessionModel(facilityId = facilityId))
-    assertEquals(inserted.accessionNumber, "197001011000")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.seedbank.ProcessingMethod
-import com.terraformation.backend.db.seedbank.sequences.ACCESSION_NUMBER_SEQ
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
 import com.terraformation.backend.db.seedbank.tables.references.BAGS
@@ -40,15 +39,11 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import org.jooq.Record
-import org.jooq.Sequence
 import org.jooq.Table
 import org.junit.jupiter.api.BeforeEach
 
 internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   override val user: IndividualUser = mockUser()
-
-  override val sequencesToReset: List<Sequence<Long>>
-    get() = listOf(ACCESSION_NUMBER_SEQ)
 
   override val tablesToResetSequences: List<Table<out Record>>
     get() =
@@ -60,18 +55,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             VIABILITY_TESTS,
             SPECIES,
             WITHDRAWALS)
-
-  protected val accessionNumbers =
-      listOf(
-          "19700101000",
-          "19700101001",
-          "19700101002",
-          "19700101003",
-          "19700101004",
-          "19700101005",
-          "19700101006",
-          "19700101007",
-      )
 
   protected val clock: Clock = mockk()
 


### PR DESCRIPTION
Previously, accession numbers were globally unique, which was fine because we were
generating them on the server side. But now we allow users to upload CSV files
with their own arbitrary accession numbers, and we don't want one organization to
be able to make an accession number unavailable to another one.

Change the database constraint so that accession numbers are only required to be
unique per facility, and change the number generation so that we generate numbers
per organization rather than globally. Note the difference between the constraint
(per-facility uniqueness) and the default (per-organization uniqueness) -- we
think the latter is a good idea, but if people are uploading their own inventory
spreadsheets, they might use the same numbering scheme at two seed banks and we
don't want to bomb out on the CSV upload.