### PR TITLE
SW-1971 Add endpoint to transfer seeds to nursery

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -20,5 +20,5 @@ class CrossOrganizationNurseryTransferNotAllowedException(
     val destinationFacilityId: FacilityId
 ) :
     MismatchedStateException(
-        "Cannot transfer from $facilityId to $destinationFacilityId because they are in " +
-            "different organizations")
+        "Cannot transfer from facility $facilityId to facility $destinationFacilityId because " +
+            "they are in different organizations")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.seedbank.api
+
+import com.fasterxml.jackson.annotation.JsonSetter
+import com.fasterxml.jackson.annotation.Nulls
+import com.terraformation.backend.api.SeedBankAppEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.nursery.api.BatchPayload
+import com.terraformation.backend.seedbank.AccessionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import javax.validation.constraints.Min
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v2/seedbank/accessions/{accessionId}/transfers")
+@RestController
+@SeedBankAppEndpoint
+class TransfersController(
+    private val accessionService: AccessionService,
+) {
+  @Operation(summary = "Transfers seeds to a nursery.")
+  @PostMapping("/nursery")
+  fun createNurseryTransferWithdrawal(
+      @PathVariable("accessionId") accessionId: AccessionId,
+      @RequestBody payload: CreateNurseryTransferRequestPayload
+  ): CreateNurseryTransferResponsePayload {
+    val (accession, batch) =
+        accessionService.createNurseryTransfer(
+            accessionId, payload.toBatchesRow(), payload.withdrawnByUserId)
+    return CreateNurseryTransferResponsePayload(AccessionPayloadV2(accession), BatchPayload(batch))
+  }
+}
+
+data class CreateNurseryTransferRequestPayload(
+    val date: LocalDate,
+    val destinationFacilityId: FacilityId,
+    @JsonSetter(nulls = Nulls.FAIL)
+    @Min(0) //
+    val germinatingQuantity: Int,
+    val notes: String? = null,
+    @JsonSetter(nulls = Nulls.FAIL)
+    @Min(0) //
+    val notReadyQuantity: Int,
+    val readyByDate: LocalDate? = null,
+    @JsonSetter(nulls = Nulls.FAIL)
+    @Min(0) //
+    val readyQuantity: Int,
+    @Schema(
+        description =
+            "ID of the user who withdrew the seeds. Default is the current user's ID. If " +
+                "non-null, the current user must have permission to read the referenced user's " +
+                "membership details in the organization.")
+    val withdrawnByUserId: UserId? = null,
+) {
+  fun toBatchesRow(): BatchesRow =
+      BatchesRow(
+          addedDate = date,
+          facilityId = destinationFacilityId,
+          germinatingQuantity = germinatingQuantity,
+          notes = notes,
+          notReadyQuantity = notReadyQuantity,
+          readyByDate = readyByDate,
+          readyQuantity = readyQuantity,
+      )
+}
+
+data class CreateNurseryTransferResponsePayload(
+    @Schema(description = "Updated accession that includes a withdrawal for the nursery transfer.")
+    val accession: AccessionPayloadV2,
+    @Schema(description = "Details of ewly-created seedling batch.") val batch: BatchPayload,
+) : SuccessResponsePayload


### PR DESCRIPTION
`POST /api/v2/seedbank/accessions/{id}/transfers/nursery` will withdraw seeds from
an accession and create a new seedling batch.