### PR TITLE
SW-1986 Generate shorter accession/batch numbers

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.IdentifierType
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -95,7 +96,8 @@ class BatchStore(
 
     val rowWithDefaults =
         row.copy(
-            batchNumber = identifierGenerator.generateIdentifier(organizationId),
+            batchNumber =
+                identifierGenerator.generateIdentifier(organizationId, IdentifierType.BATCH),
             createdBy = userId,
             createdTime = now,
             modifiedBy = userId,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.IdentifierType
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -244,7 +245,8 @@ class AccessionStore(
 
     while (attemptsRemaining-- > 0) {
       val accessionNumber =
-          accession.accessionNumber ?: identifierGenerator.generateIdentifier(organizationId)
+          accession.accessionNumber
+              ?: identifierGenerator.generateIdentifier(organizationId, IdentifierType.ACCESSION)
 
       try {
         val accessionId =

--- a/src/main/resources/db/migration/V145__IdentifierSequencesPerPrefix.sql
+++ b/src/main/resources/db/migration/V145__IdentifierSequencesPerPrefix.sql
@@ -1,0 +1,8 @@
+DROP TABLE identifier_sequences;
+
+CREATE TABLE identifier_sequences (
+    organization_id BIGINT NOT NULL REFERENCES organizations,
+    prefix TEXT NOT NULL,
+    next_value BIGINT NOT NULL,
+    PRIMARY KEY (organization_id, prefix)
+);

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -33,7 +33,7 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
     val expectedBatch =
         BatchesRow(
             addedDate = LocalDate.of(2022, 1, 2),
-            batchNumber = "19700101000",
+            batchNumber = "70-2-001",
             createdBy = user.userId,
             createdTime = clock.instant(),
             facilityId = facilityId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -230,7 +230,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
                 isManualState = true,
                 modifiedBy = user.userId,
                 modifiedTime = Instant.EPOCH,
-                number = "19700101000",
+                number = "70-1-001",
                 remainingGrams = BigDecimal(101),
                 remainingQuantity = BigDecimal(101),
                 remainingUnitsId = SeedQuantityUnits.Grams,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -48,7 +48,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             dataSourceId = DataSource.Web,
             modifiedBy = user.userId,
             modifiedTime = clock.instant(),
-            number = "19700101000",
+            number = "70-1-001",
             stateId = AccessionState.AwaitingCheckIn),
         accessionsDao.fetchOneById(AccessionId(1)))
   }


### PR DESCRIPTION
After getting feedback about the previous accession/batch numbering scheme,
we want to change two things: make the identifiers shorter and allow people
to visually differentiate between accession numbers and batch numbers.

This new format is 3 characters shorter and treats accessions and batches
as separate sequential number spaces: an accession number in the old format
looked like `20221012888` and in the new scheme it would be `22-1-888` where
the `1` indicates that it's an accession number.