### PR TITLE
SW-1488 Use property accessors for jOOQ implicit joins

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -76,7 +76,7 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(deviceManagerId: DeviceManagerId): OrganizationId? =
       fetchFieldById(
-          deviceManagerId, DEVICE_MANAGERS.ID, DEVICE_MANAGERS.facilities().ORGANIZATION_ID)
+          deviceManagerId, DEVICE_MANAGERS.ID, DEVICE_MANAGERS.facilities.ORGANIZATION_ID)
 
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.ORGANIZATION_ID)
@@ -88,11 +88,11 @@ class ParentStore(private val dslContext: DSLContext) {
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)
 
   fun getOrganizationId(accessionId: AccessionId): OrganizationId? {
-    return fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.facilities().ORGANIZATION_ID)
+    return fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.facilities.ORGANIZATION_ID)
   }
 
   fun getFacilityConnectionState(deviceId: DeviceId): FacilityConnectionState {
-    return fetchFieldById(deviceId, DEVICES.ID, DEVICES.facilities().CONNECTION_STATE_ID)
+    return fetchFieldById(deviceId, DEVICES.ID, DEVICES.facilities.CONNECTION_STATE_ID)
         ?: throw DeviceNotFoundException(deviceId)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -182,7 +182,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
 
   override fun conditionForScope(scope: SearchScope): Condition {
     return when (scope) {
-      is OrganizationIdScope -> ACCESSIONS.facilities().ORGANIZATION_ID.eq(scope.organizationId)
+      is OrganizationIdScope -> ACCESSIONS.facilities.ORGANIZATION_ID.eq(scope.organizationId)
       is FacilityIdScope -> ACCESSIONS.FACILITY_ID.eq(scope.facilityId)
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -117,11 +117,11 @@ class AccessionStore(
         dslContext
             .select(
                 ACCESSIONS.asterisk(),
-                ACCESSIONS.species().COMMON_NAME,
-                ACCESSIONS.species().SCIENTIFIC_NAME,
+                ACCESSIONS.species.COMMON_NAME,
+                ACCESSIONS.species.SCIENTIFIC_NAME,
                 ACCESSIONS.STATE_ID,
-                ACCESSIONS.storageLocations().NAME,
-                ACCESSIONS.storageLocations().CONDITION_ID,
+                ACCESSIONS.storageLocations.NAME,
+                ACCESSIONS.storageLocations.CONDITION_ID,
                 ACCESSIONS.TARGET_STORAGE_CONDITION,
                 ACCESSIONS.PROCESSING_METHOD_ID,
                 ACCESSIONS.PROCESSING_STAFF_RESPONSIBLE,
@@ -186,12 +186,12 @@ class AccessionStore(
           remaining = SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
           source = record[DATA_SOURCE_ID],
           sourcePlantOrigin = record[SOURCE_PLANT_ORIGIN_ID],
-          species = record[species().SCIENTIFIC_NAME],
-          speciesCommonName = record[species().COMMON_NAME],
+          species = record[species.SCIENTIFIC_NAME],
+          speciesCommonName = record[species.COMMON_NAME],
           speciesId = record[SPECIES_ID],
           state = record[STATE_ID]!!,
-          storageCondition = record[storageLocations().CONDITION_ID],
-          storageLocation = record[storageLocations().NAME],
+          storageCondition = record[storageLocations.CONDITION_ID],
+          storageLocation = record[storageLocations.NAME],
           storageNotes = record[STORAGE_NOTES],
           storagePackets = record[STORAGE_PACKETS],
           storageStaffResponsible = record[STORAGE_STAFF_RESPONSIBLE],
@@ -863,7 +863,7 @@ class AccessionStore(
   /** Returns the number of accessions that are currently in an active state. */
   fun countActive(organizationId: OrganizationId): Int {
     requirePermissions { readOrganization(organizationId) }
-    val condition = ACCESSIONS.facilities().ORGANIZATION_ID.eq(organizationId)
+    val condition = ACCESSIONS.facilities.ORGANIZATION_ID.eq(organizationId)
     return countActive(condition)
   }
 
@@ -876,7 +876,7 @@ class AccessionStore(
   fun countByState(organizationId: OrganizationId): Map<AccessionState, Int> {
     requirePermissions { readOrganization(organizationId) }
 
-    return countByState(ACCESSIONS.facilities().ORGANIZATION_ID.eq(organizationId))
+    return countByState(ACCESSIONS.facilities.ORGANIZATION_ID.eq(organizationId))
   }
 
   fun fetchDryingEndDue(
@@ -945,7 +945,7 @@ class AccessionStore(
     return getSummaryStatistics(
         DSL.select(ACCESSIONS.ID)
             .from(ACCESSIONS)
-            .where(ACCESSIONS.facilities().ORGANIZATION_ID.eq(organizationId))
+            .where(ACCESSIONS.facilities.ORGANIZATION_ID.eq(organizationId))
             .and(ACCESSIONS.STATE_ID.`in`(AccessionState.activeValues)))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -172,7 +172,7 @@ class PhotoRepository(
     dslContext
         .selectDistinct(ACCESSION_PHOTOS.ACCESSION_ID)
         .from(ACCESSION_PHOTOS)
-        .where(ACCESSION_PHOTOS.accessions().facilities().ORGANIZATION_ID.eq(event.organizationId))
+        .where(ACCESSION_PHOTOS.accessions.facilities.ORGANIZATION_ID.eq(event.organizationId))
         .fetch(ACCESSION_PHOTOS.ACCESSION_ID)
         .filterNotNull()
         .forEach { deleteAllPhotos(it) }


### PR DESCRIPTION
The Kotlin code generator in jOOQ 3.17 added a new way to do implicit joins.
Previously, implicit joins were done using method calls. But now they can also
be done using property references.

It only saves two characters, but may as well use the more compact syntax.