### PR TITLE
SW-2006 Restart JobRunr after database recovery

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.daily
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.log.perClassLogger
+import java.sql.SQLException
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.annotation.ManagedBean
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+import javax.sql.DataSource
+import org.jobrunr.server.BackgroundJobServer
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Restarts JobRunr's background job processing thread after database problems. JobRunr shuts down
+ * when it can't talk to the database to avoid spewing errors to the log, but it doesn't come back
+ * up when the database becomes available again. We want the server to recover from transient
+ * database problems.
+ */
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@ManagedBean
+class JobRunrRecoveryThread(
+    private val backgroundJobServer: BackgroundJobServer,
+    private val dataSource: DataSource,
+) : Thread() {
+  companion object {
+    /** How often to check whether JobRunr's background thread has stopped. */
+    private val JOBRUNR_DOWN_POLL_INTERVAL = Duration.ofSeconds(1)!!
+
+    /**
+     * How often to check whether the database has become available again after JobRunr's background
+     * thread has stopped.
+     */
+    private val DB_RECOVERY_POLL_INTERVAL = Duration.ofSeconds(10)!!
+  }
+
+  private val shutdownLatch = CountDownLatch(1)
+
+  private val log = perClassLogger()
+
+  @PostConstruct
+  fun startThread() {
+    isDaemon = true
+    start()
+  }
+
+  @PreDestroy
+  fun stopThread() {
+    shutdownLatch.countDown()
+  }
+
+  override fun run() {
+    try {
+      while (!shutdownLatch.await(JOBRUNR_DOWN_POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS)) {
+        if (!backgroundJobServer.isRunning) {
+          log.warn("JobRunr background thread is not running! Waiting for database to come back")
+
+          while (!backgroundJobServer.isRunning &&
+              !shutdownLatch.await(DB_RECOVERY_POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS)) {
+            try {
+              // The connection pool does health checks, so if the database is unavailable, it won't
+              // give us a connection and this will throw an exception.
+              dataSource.connection.close()
+
+              log.info("Database has recovered; restarting JobRunr")
+              backgroundJobServer.start()
+            } catch (e: SQLException) {
+              // Nothing to do but wait a bit and try again.
+            }
+          }
+        }
+      }
+    } catch (e: Exception) {
+      log.error("JobRunr recovery thread aborting due to unexpected error", e)
+    }
+  }
+}


### PR DESCRIPTION
If there's a database problem, JobRunr shuts down its background worker thread to
cut down on log spew. But it doesn't restart the thread when the database comes
back. This causes the server's health check to report unhealthy status even though
request handling is working fine.

Add a watchdog thread to start JobRunr back up again after the database becomes
available.