### PR TITLE
SW-1603 Detect collision of suggested species name

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -113,6 +113,9 @@ class OrganizationNotFoundException(val organizationId: OrganizationId) :
 class PhotoNotFoundException(val photoId: PhotoId) :
     EntityNotFoundException("Photo $photoId not found")
 
+class ScientificNameExistsException(val name: String?) :
+    DuplicateEntityException("Scientific name $name already exists")
+
 class ScientificNameNotFoundException(val name: String) :
     EntityNotFoundException("Scientific name $name not found")
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -366,18 +366,18 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `acceptProblemSuggestion throws ScientificNameExistsException on name collision`() {
+  fun `acceptProblemSuggestion throws exception if suggested scientific name is already in use`() {
     store.createSpecies(
-        SpeciesRow(organizationId = organizationId, scientificName = "Species name"))
-    val badSpeciesId =
+        SpeciesRow(organizationId = organizationId, scientificName = "Correct name"))
+    val speciesIdWithOutdatedName =
         store.createSpecies(
-            SpeciesRow(organizationId = organizationId, scientificName = "Bad name"))
+            SpeciesRow(organizationId = organizationId, scientificName = "Outdated name"))
     val problemsRow =
         SpeciesProblemsRow(
             createdTime = Instant.EPOCH,
             fieldId = SpeciesProblemField.ScientificName,
-            speciesId = badSpeciesId,
-            suggestedValue = "Species name",
+            speciesId = speciesIdWithOutdatedName,
+            suggestedValue = "Correct name",
             typeId = SpeciesProblemType.NameIsSynonym)
     speciesProblemsDao.insert(problemsRow)
 


### PR DESCRIPTION
If species 1 and 2 exist, and species 2 has an incorrect name (misspelled or
synonym) that should be changed to the same name as species 1, return HTTP 409
(Conflict) with a descriptive error message rather than an internal server error
when the user tries to accept the suggested edit.

Eventually we'll most likely want to add logic to merge the two species, but
until then, we should at least show a meaningful error message.