### PR TITLE
SW-2019 Backfill estimated accession weights

### DIFF
--- a/src/main/resources/db/migration/V146__BackfillEstimatedWeight.sql
+++ b/src/main/resources/db/migration/V146__BackfillEstimatedWeight.sql
@@ -1,0 +1,6 @@
+UPDATE seedbank.accessions
+SET est_weight_grams = remaining_grams,
+    est_weight_quantity = remaining_quantity,
+    est_weight_units_id = remaining_units_id
+WHERE est_weight_grams IS NULL
+  AND remaining_grams IS NOT NULL;


### PR DESCRIPTION
The v2 accessions code introduced an "estimated weight" value. This value is
calculated in both the v1 and v2 code paths, but we never backfilled it for
existing weight-based v1 accessions. These accessions are thus showing up without
estimated weights in the accession search UI.