### PR TITLE
SW-1939 Remove accession v2->v1 conversion code

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -94,19 +94,6 @@ data class ViabilityTestModel(
     }
   }
 
-  fun toV1Compatible(): ViabilityTestModel {
-    val newSubstrate =
-        when (substrate) {
-          ViabilityTestSubstrate.Agar,
-          ViabilityTestSubstrate.NurseryMedia,
-          ViabilityTestSubstrate.Other,
-          ViabilityTestSubstrate.Paper -> substrate
-          else -> null
-        }
-
-    return copy(substrate = newSubstrate)
-  }
-
   fun toV2Compatible(): ViabilityTestModel {
     val newSubstrate: ViabilityTestSubstrate? =
         if (testType == ViabilityTestType.Lab) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -158,25 +158,6 @@ data class WithdrawalModel(
     }
   }
 
-  fun toV1Compatible(
-      remaining: SeedQuantityModel?,
-      subsetWeight: SeedQuantityModel?,
-      subsetCount: Int?
-  ): WithdrawalModel {
-    val estimatedQuantity =
-        calculateEstimatedQuantity()
-            ?: throw IllegalStateException("Cannot calculate withdrawal quantity")
-
-    return if (remaining?.units == SeedQuantityUnits.Seeds &&
-        estimatedQuantity.units != SeedQuantityUnits.Seeds) {
-      copy(
-          withdrawn = estimatedQuantity.toUnits(SeedQuantityUnits.Seeds, subsetWeight, subsetCount))
-    } else {
-      // Withdrawn can be in seeds or weight for weight-based accessions
-      this
-    }
-  }
-
   fun toV2Compatible(): WithdrawalModel {
     val notesWithStaffResponsible =
         when {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
@@ -53,7 +53,6 @@ internal class AccessionStoreCheckInTest : AccessionStoreTest() {
     val updated = store.checkIn(initial.id!!)
 
     assertEquals(AccessionState.AwaitingProcessing, updated.state, "v2 state")
-    assertEquals(AccessionState.Pending, updated.toV1Compatible(clock).state, "v1 state")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -190,33 +190,4 @@ internal class ViabilityTestModelTest {
       assertEquals(ViabilityTestSubstrate.Other, v2Model.substrate)
     }
   }
-
-  @Nested
-  inner class V2ToV1Conversion {
-    @Test
-    fun `substrate is removed if it did not exist in v1`() {
-      val v2Model =
-          ViabilityTestModel(
-              seedsTested = 1,
-              substrate = ViabilityTestSubstrate.Moss,
-              testType = ViabilityTestType.Nursery,
-          )
-
-      val v1Model = v2Model.toV1Compatible()
-      assertNull(v1Model.substrate)
-    }
-
-    @Test
-    fun `substrate is preserved if it existed in v1`() {
-      val v2Model =
-          ViabilityTestModel(
-              seedsTested = 1,
-              substrate = ViabilityTestSubstrate.Agar,
-              testType = ViabilityTestType.Lab,
-          )
-
-      val v1Model = v2Model.toV1Compatible()
-      assertEquals(ViabilityTestSubstrate.Agar, v1Model.substrate)
-    }
-  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelConversionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelConversionsTest.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class AccessionModelConversionsTest : AccessionModelTest() {
@@ -96,62 +95,5 @@ internal class AccessionModelConversionsTest : AccessionModelTest() {
         )
 
     assertJsonEquals(expected, initial.toV2Compatible(tomorrowClock))
-  }
-
-  @Test
-  fun `V2 to V1 viability percent is overwritten with computed value`() {
-    val expectedPercent = 40
-    val v2Model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(500))
-            .withCalculatedValues(clock)
-            .addViabilityTest(
-                viabilityTest(
-                    seedsTested = 100,
-                    testResults =
-                        listOf(
-                            viabilityTestResult(
-                                recordingDate = january(2), seedsGerminated = expectedPercent))),
-                clock)
-    Assertions.assertNull(v2Model.totalViabilityPercent)
-
-    val v1Model = v2Model.toV1Compatible(clock)
-    Assertions.assertEquals(40, v1Model.totalViabilityPercent)
-  }
-
-  @Test
-  fun `V2 to V1 backdated viability tests with more seeds than initial quantity`() {
-    val initialV2Model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(2))
-            .withCalculatedValues(yesterdayClock)
-    val v2Model =
-        initialV2Model
-            .copy(latestObservedQuantityCalculated = false, remaining = seeds(1))
-            .withCalculatedValues(clock, initialV2Model)
-            // In v2, this is valid because it is dated yesterday and we have an observed quantity
-            // from today that overrides what would otherwise be a negative seeds remaining value.
-            .addViabilityTest(viabilityTest(seedsTested = 3, startDate = yesterday), clock)
-
-    val v1Model = v2Model.toV1Compatible(clock)
-    Assertions.assertEquals(seeds(1), v1Model.viabilityTests.getOrNull(0)?.remaining)
-  }
-
-  @Test
-  fun `V2 to V1 backdated withdrawals with more seeds than initial quantity`() {
-    val initialV2Model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(2))
-            .withCalculatedValues(yesterdayClock)
-    val v2Model =
-        initialV2Model
-            .copy(latestObservedQuantityCalculated = false, remaining = seeds(1))
-            .withCalculatedValues(clock, initialV2Model)
-            // In v2, this is valid because it is yesterday and we have an observed quantity from
-            // today that overrides what would otherwise be a negative seeds remaining value.
-            .addWithdrawal(withdrawal(seeds(3), date = yesterday, id = null), clock)
-
-    val v1Model = v2Model.toV1Compatible(clock)
-    Assertions.assertEquals(seeds(1), v1Model.withdrawals.getOrNull(0)?.remaining)
   }
 }


### PR DESCRIPTION
With the removal of the v1 API endpoints, there is no longer any way for a client
to ask the server to convert a v2-style accession to v1-style. Remove the
conversion code and its associated tests.

The v1->v2 conversion code is unaffected here; we'll continue to need it until all
existing accessions have been converted to v2.