### PR TITLE
SW-2019 Populate estimated quantities at creation time

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -231,6 +231,12 @@ class AccessionStore(
         } else {
           null
         }
+    val estimatedWeight =
+        if (accession.remaining?.units != SeedQuantityUnits.Seeds) {
+          accession.remaining
+        } else {
+          null
+        }
 
     requirePermissions {
       createAccession(facilityId)
@@ -279,6 +285,12 @@ class AccessionStore(
                         .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
                         .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)
                         .set(DATA_SOURCE_ID, accession.source ?: DataSource.Web)
+                        .set(
+                            EST_SEED_COUNT,
+                            accession.calculateEstimatedSeedCount(accession.remaining))
+                        .set(EST_WEIGHT_GRAMS, estimatedWeight?.grams)
+                        .set(EST_WEIGHT_QUANTITY, estimatedWeight?.quantity)
+                        .set(EST_WEIGHT_UNITS_ID, estimatedWeight?.units)
                         .set(FACILITY_ID, facilityId)
                         .set(FIELD_NOTES, accession.fieldNotes)
                         .set(FOUNDER_ID, accession.founderId)

--- a/src/main/resources/db/migration/V147__BackfillEstimatedQuantity.sql
+++ b/src/main/resources/db/migration/V147__BackfillEstimatedQuantity.sql
@@ -1,0 +1,12 @@
+UPDATE seedbank.accessions
+SET est_weight_grams = remaining_grams,
+    est_weight_quantity = remaining_quantity,
+    est_weight_units_id = remaining_units_id
+WHERE est_weight_grams IS NULL
+  AND remaining_grams IS NOT NULL;
+
+UPDATE seedbank.accessions
+SET est_seed_count = remaining_quantity
+WHERE est_seed_count IS NULL
+  AND remaining_quantity IS NOT NULL
+  AND remaining_units_id = (SELECT id FROM seedbank.seed_quantity_units WHERE name = 'Seeds');

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
@@ -187,7 +188,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         speciesDao.findAll(),
         "Imported species")
 
-    assertEquals(
+    assertJsonEquals(
         listOf(
             AccessionsRow(
                 checkedInTime = Instant.EPOCH,
@@ -202,6 +203,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
                 createdBy = user.userId,
                 createdTime = Instant.EPOCH,
                 dataSourceId = DataSource.FileImport,
+                estSeedCount = 100,
                 facilityId = facilityId,
                 founderId = "PlantID",
                 id = AccessionId(1),
@@ -225,20 +227,23 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
                 createdBy = user.userId,
                 createdTime = Instant.EPOCH,
                 dataSourceId = DataSource.FileImport,
+                estWeightGrams = BigDecimal(101000),
+                estWeightQuantity = BigDecimal(101),
+                estWeightUnitsId = SeedQuantityUnits.Kilograms,
                 facilityId = facilityId,
                 id = AccessionId(2),
                 isManualState = true,
                 modifiedBy = user.userId,
                 modifiedTime = Instant.EPOCH,
                 number = "70-1-001",
-                remainingGrams = BigDecimal(101),
+                remainingGrams = BigDecimal(101000),
                 remainingQuantity = BigDecimal(101),
-                remainingUnitsId = SeedQuantityUnits.Grams,
+                remainingUnitsId = SeedQuantityUnits.Kilograms,
                 speciesId = SpeciesId(1),
                 stateId = AccessionState.InStorage,
-                totalGrams = BigDecimal(101),
+                totalGrams = BigDecimal(101000),
                 totalQuantity = BigDecimal(101),
-                totalUnitsId = SeedQuantityUnits.Grams,
+                totalUnitsId = SeedQuantityUnits.Kilograms,
             ),
         ),
         accessionsDao.findAll().sortedBy { it.id!!.value },

--- a/src/test/resources/seedbank/accession/HappyPath.csv
+++ b/src/test/resources/seedbank/accession/HappyPath.csv
@@ -31,4 +31,4 @@ Please choose from the following list or an error will occur during upload:
 12345,New species var. new,New common name,100,Seeds,Drying,2022-03-04,New site name,New landowner,"City name",Hawaii,US,"Site description
 with multiple
 lines","Collector,Name",Reintroduced,5,PlantID
-,New species var. new,Updated common name,101,Grams,In Storage,2022-03-05,,,,,UG,,,Wild (In Situ),,
+,New species var. new,Updated common name,101,Kilograms,In Storage,2022-03-05,,,,,UG,,,Wild (In Situ),,


### PR DESCRIPTION
In cases where an accession's quantity was known at creation time, e.g., when
importing from a CSV file, we weren't populating the estimated count/weight.
This was a holdover from the v1 world where quantity could only be set as a
processing step after the accession was initially created.

Start populating the missing values, and update the CSV importer test to
verify the desired behavior. Backfill the values where they're currently missing.