### PR TITLE
SW-1990 Allow editing collected and received dates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -834,10 +834,6 @@ data class AccessionModel(
   fun withCalculatedValues(clock: Clock, existing: AccessionModel = this): AccessionModel {
     val newProcessingStartDate =
         processingStartDate ?: existing.processingStartDate ?: calculateProcessingStartDate(clock)
-    val newCollectedDate =
-        if (existing.source == DataSource.Web) collectedDate else existing.collectedDate
-    val newReceivedDate =
-        if (existing.source == DataSource.Web) receivedDate else existing.receivedDate
     val newRemaining = calculateRemaining(clock, existing)
     val newWithdrawals = calculateWithdrawals(clock, existing)
     val newViabilityPercent =
@@ -851,7 +847,6 @@ data class AccessionModel(
     val cutTests = newViabilityTests.filter { it.testType == ViabilityTestType.Cut }
 
     return copy(
-        collectedDate = newCollectedDate,
         cutTestSeedsCompromised = cutTests.mapNotNull { it.seedsCompromised }.orNull()?.sum(),
         cutTestSeedsEmpty = cutTests.mapNotNull { it.seedsEmpty }.orNull()?.sum(),
         cutTestSeedsFilled = cutTests.mapNotNull { it.seedsFilled }.orNull()?.sum(),
@@ -863,7 +858,6 @@ data class AccessionModel(
         latestViabilityTestDate = calculateLatestViabilityRecordingDate(),
         latestObservedQuantityCalculated = true,
         processingStartDate = newProcessingStartDate,
-        receivedDate = newReceivedDate,
         remaining = newRemaining,
         state = newState,
         totalViabilityPercent = newViabilityPercent,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.seedbank.CollectionSource
+import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.SourcePlantOrigin
 import com.terraformation.backend.db.seedbank.StorageCondition
@@ -164,7 +165,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             modifiedTime = clock.instant(),
             name = storageLocationName))
 
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial =
+        store.create(AccessionModel(facilityId = facilityId, source = DataSource.SeedCollectorApp))
     val stored = store.updateAndFetch(update.toModel(initial.id!!))
 
     accessionModelProperties


### PR DESCRIPTION
In v1, we didn't allow users to edit the collected or received dates of accessions
that were created by the seed collector mobile app, but now we want those dates to
be editable.