### PR TITLE
Record correct reason when checking in v2 accession

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -99,61 +99,6 @@ private fun SourcePlantOrigin.toCollectionSource(): CollectionSource =
       SourcePlantOrigin.Wild -> CollectionSource.Wild
     }
 
-// Mark all fields as write-only in the schema
-@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
-data class CreateAccessionRequestPayload(
-    val bagNumbers: Set<String>? = null,
-    val collectedDate: LocalDate? = null,
-    val collectionSiteCity: String? = null,
-    val collectionSiteCountryCode: String? = null,
-    val collectionSiteCountrySubdivision: String? = null,
-    val collectionSiteLandowner: String? = null,
-    val collectionSiteName: String? = null,
-    val collectionSiteNotes: String? = null,
-    val collectionSource: CollectionSource? = null,
-    val collectors: List<String>? = null,
-    @Schema(deprecated = true, description = "Backward-compatibility alias for collectionSiteNotes")
-    val environmentalNotes: String? = null,
-    val facilityId: FacilityId,
-    val fieldNotes: String? = null,
-    val founderId: String? = null,
-    val geolocations: Set<Geolocation>? = null,
-    @Schema(
-        deprecated = true, description = "Backward-compatibility alias for collectionSiteLandowner")
-    val landowner: String? = null,
-    val numberOfTrees: Int? = null,
-    val receivedDate: LocalDate? = null,
-    @Schema(deprecated = true, description = "Backward-compatibility alias for collectionSiteName")
-    val siteLocation: String? = null,
-    val source: DataSource? = null,
-    val sourcePlantOrigin: SourcePlantOrigin? = null,
-    val species: String? = null,
-) {
-  fun toModel(): AccessionModel {
-    return AccessionModel(
-        bagNumbers = bagNumbers.orEmpty(),
-        collectedDate = collectedDate,
-        collectionSiteCity = collectionSiteCity,
-        collectionSiteCountryCode = collectionSiteCountryCode,
-        collectionSiteCountrySubdivision = collectionSiteCountrySubdivision,
-        collectionSiteLandowner = landowner ?: collectionSiteLandowner,
-        collectionSiteName = siteLocation ?: collectionSiteName,
-        collectionSiteNotes = environmentalNotes ?: collectionSiteNotes,
-        collectionSource = sourcePlantOrigin?.toCollectionSource() ?: collectionSource,
-        collectors = collectors.orEmpty(),
-        facilityId = facilityId,
-        fieldNotes = fieldNotes,
-        founderId = founderId,
-        geolocations = geolocations.orEmpty(),
-        numberOfTrees = numberOfTrees,
-        receivedDate = receivedDate,
-        source = source ?: DataSource.Web,
-        sourcePlantOrigin = sourcePlantOrigin,
-        species = species,
-    )
-  }
-}
-
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
 data class UpdateAccessionRequestPayload(
     val bagNumbers: Set<String>? = null,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -252,6 +252,8 @@ data class AccessionModel(
     val oldState = state ?: AccessionState.AwaitingProcessing
     val newState = newModel.state ?: AccessionState.AwaitingProcessing
     val alreadyCheckedIn = oldState != AccessionState.AwaitingCheckIn
+    val checkingIn =
+        oldState == AccessionState.AwaitingCheckIn && newState == AccessionState.AwaitingProcessing
     val revertingToAwaitingCheckIn =
         alreadyCheckedIn && newModel.state == AccessionState.AwaitingCheckIn
     val addingSeedsWhenUsedUp =
@@ -266,6 +268,7 @@ data class AccessionModel(
           revertingToAwaitingCheckIn -> oldState to "Cannot revert to Awaiting Check-In"
           changingToUsedUpWithoutWithdrawingAllSeeds ->
               oldState to "Cannot change to Used Up before withdrawing all seeds"
+          checkingIn -> newState to "Accession has been checked in"
           else -> newState to "Accession has been edited"
         }
 


### PR DESCRIPTION
In v1, checking an accession in created a state history entry with a reason of,
"Accession has been checked in." But that was lost in v2 and instead the message
was, "Accession has been edited."

Add a rule to the v2 state transition calculation, analogous to the one in the v1
code, that uses a different message in the specific case of the state changing
from Awaiting Check-In to Awaiting Processing, which is the transition that's
generated when you click the "Check In" button in the web app.