### PR TITLE
Use scheduled withdrawal date as observation time

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -13,6 +13,8 @@ import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.OffsetTime
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DynamicTest
@@ -48,16 +50,27 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
               total = grams(100),
               withdrawals =
                   listOf(
-                      withdrawal(remaining = grams(95), createdTime = Instant.ofEpochSecond(1)),
-                      withdrawal(remaining = grams(89), createdTime = Instant.ofEpochSecond(2)),
-                      withdrawal(remaining = grams(91), createdTime = Instant.ofEpochSecond(3)),
+                      withdrawal(
+                          remaining = grams(95),
+                          date = january(3),
+                          createdTime = Instant.ofEpochSecond(1)),
+                      withdrawal(
+                          remaining = grams(89),
+                          date = january(3),
+                          createdTime = Instant.ofEpochSecond(2)),
+                      withdrawal(
+                          remaining = grams(91),
+                          date = january(3),
+                          createdTime = Instant.ofEpochSecond(3)),
                   ))
 
       assertAll(
           { assertEquals(grams(89), accession.calculateLatestObservedQuantity(clock), "Quantity") },
           {
             assertEquals(
-                Instant.ofEpochSecond(3), accession.calculateLatestObservedTime(clock), "Time")
+                january(3).atTime(OffsetTime.of(0, 0, 3, 0, ZoneOffset.UTC)).toInstant(),
+                accession.calculateLatestObservedTime(clock),
+                "Time")
           })
     }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelConversionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelConversionsTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.model.accession
 
 import com.terraformation.backend.assertJsonEquals
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -95,5 +96,53 @@ internal class AccessionModelConversionsTest : AccessionModelTest() {
         )
 
     assertJsonEquals(expected, initial.toV2Compatible(tomorrowClock))
+  }
+
+  @Test
+  fun `V1 to V2 weight-based accession with scheduled withdrawals`() {
+    val initial =
+        AccessionModel(
+            checkedInTime = yesterdayInstant,
+            id = AccessionId(175),
+            processingMethod = ProcessingMethod.Weight,
+            remaining = grams(5),
+            state = AccessionState.InStorage,
+            subsetCount = 10,
+            subsetWeightQuantity = grams(2),
+            total = grams(50),
+            withdrawals =
+                listOf(
+                    WithdrawalModel(
+                        date = today,
+                        remaining = grams(10),
+                        withdrawn = seeds(12),
+                        id = WithdrawalId(95),
+                        accessionId = AccessionId(175),
+                        purpose = WithdrawalPurpose.ViabilityTesting,
+                        createdTime = yesterdayInstant,
+                        viabilityTestId = ViabilityTestId(37),
+                    ),
+                    WithdrawalModel(
+                        date = tomorrow,
+                        remaining = grams(5),
+                        withdrawn = grams(5),
+                        id = WithdrawalId(96),
+                        accessionId = AccessionId(175),
+                        purpose = WithdrawalPurpose.Other,
+                        createdTime = yesterdayInstant,
+                    ),
+                ),
+            viabilityTests =
+                listOf(
+                    ViabilityTestModel(
+                        startDate = today,
+                        remaining = grams(10),
+                        seedsTested = 12,
+                        id = ViabilityTestId(37),
+                        accessionId = AccessionId(175),
+                        testType = ViabilityTestType.Nursery,
+                    )))
+
+    initial.toV2Compatible(yesterdayClock)
   }
 }


### PR DESCRIPTION
In v1, we allowed withdrawals to be scheduled for future dates, and if the
accessions were weight-based, the user had to enter the (expected) remaining
weight ahead of time. These withdrawals had dates that were later than their
creation times, which was causing the v1->v2 conversion to calculate incorrect
(or even negative) remaining quantities on these accessions.

This fix is only relevant for v1->v2 conversion of existing accessions, but
without it, some of the accessions in the production environment can't be
correctly migrated to v2.