### PR TITLE
Add missing descriptions to OpenAPI schema fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -308,7 +309,11 @@ data class OrganizationPayload(
     val countrySubdivisionCode: String?,
     val createdTime: Instant,
     val description: String?,
-    @Schema(description = "This organization's facilities. Only included if depth is \"Facility\".")
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "This organization's facilities. Only included if depth is \"Facility\"."))
     val facilities: List<FacilityPayload>?,
     val id: OrganizationId,
     val name: String,

--- a/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.device.model.TimeseriesModel
 import com.terraformation.backend.device.model.TimeseriesValueModel
 import com.terraformation.backend.log.perClassLogger
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
@@ -251,7 +252,9 @@ data class TimeseriesValuesErrorPayload(
     val deviceId: DeviceId,
     @Schema(description = "Name of timeseries as specified in the failing request.")
     val timeseriesName: String,
-    @Schema(description = "Values that the server was not able to successfully record.")
+    @ArraySchema(
+        arraySchema =
+            Schema(description = "Values that the server was not able to successfully record."))
     val values: List<TimeseriesValuePayload>,
     @Schema(
         description = "Human-readable details about the failure.",
@@ -300,10 +303,12 @@ data class RecordTimeseriesValuesRequestPayload(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Results of a request to record timeseries values.")
 data class RecordTimeseriesValuesResponsePayload(
-    @Schema(
-        description =
-            "List of values that the server failed to record. Will not be included if all the " +
-                "values were recorded successfully.")
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "List of values that the server failed to record. Will not be included if " +
+                        "all the values were recorded successfully."))
     val failures: List<TimeseriesValuesErrorPayload>?,
     override val status: SuccessOrError,
     val error: ErrorDetails?
@@ -374,7 +379,8 @@ data class GetTimeseriesHistoryRequestPayload(
             "Number of values to return. The time range is divided into this many equal " +
                 "intervals, and a value is returned from each interval if available.")
     val count: Int,
-    @Schema(description = "Timeseries to query. May be from different devices.")
+    @ArraySchema(
+        arraySchema = Schema(description = "Timeseries to query. May be from different devices."))
     @field:Size(max = 100)
     val timeseries: List<TimeseriesIdPayload>,
 )

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.api.writeNext
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
@@ -134,16 +135,21 @@ data class SearchRequestPayload(
         example = "facilities.accessions")
     val prefix: String? = null,
     @NotEmpty
-    @Schema(
-        description =
-            "List of fields to return. Field names should be relative to the prefix. They may " +
-                "navigate the data hierarchy using '.' or '_' as delimiters.",
-        example = """["processingStartDate","viabilityTests.seedsTested","facility_name"]""")
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "List of fields to return. Field names should be relative to the prefix. " +
+                        "They may navigate the data hierarchy using '.' or '_' as delimiters.",
+                example =
+                    """["processingStartDate","viabilityTests.seedsTested","facility_name"]"""))
     override val fields: List<String>,
-    @Schema(
-        description =
-            "How to sort the search results. This controls both the order of the top-level " +
-                "results and the order of any lists of child objects.")
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "How to sort the search results. This controls both the order of the " +
+                        "top-level results and the order of any lists of child objects."))
     override val sortOrder: List<SearchSortOrderElement>? = null,
     @Schema(
         description =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.Geolocation
 import com.terraformation.backend.util.orNull
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Clock
@@ -115,7 +116,7 @@ data class AccessionPayloadV2(
     val collectionSiteName: String? = null,
     val collectionSiteNotes: String? = null,
     val collectionSource: CollectionSource? = null,
-    @Schema(description = "Names of the people who collected the seeds.")
+    @ArraySchema(arraySchema = Schema(description = "Names of the people who collected the seeds."))
     val collectors: List<String>?,
     val dryingEndDate: LocalDate?,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
@@ -51,7 +51,7 @@ class SummaryController(
       @RequestParam("facilityId", required = false)
       @Schema(description = "If set, return summary on that specific seedbank.")
       facilityId: FacilityId?
-  ): SummaryResponse {
+  ): SummaryResponsePayload {
     return when {
       facilityId != null && organizationId == null -> getSummary(facilityId)
       facilityId == null && organizationId != null -> getSummary(organizationId)
@@ -81,10 +81,10 @@ class SummaryController(
         summary.accessions, summary.species, SeedCountSummaryPayload(summary))
   }
 
-  private fun getSummary(facilityId: FacilityId): SummaryResponse {
+  private fun getSummary(facilityId: FacilityId): SummaryResponsePayload {
     val stats = accessionStore.getSummaryStatistics(facilityId)
 
-    return SummaryResponse(
+    return SummaryResponsePayload(
         activeAccessions = stats.accessions,
         species = stats.species,
         accessionsByState = accessionStore.countByState(facilityId),
@@ -92,10 +92,10 @@ class SummaryController(
     )
   }
 
-  private fun getSummary(organizationId: OrganizationId): SummaryResponse {
+  private fun getSummary(organizationId: OrganizationId): SummaryResponsePayload {
     val stats = accessionStore.getSummaryStatistics(organizationId)
 
-    return SummaryResponse(
+    return SummaryResponsePayload(
         activeAccessions = stats.accessions,
         species = stats.species,
         accessionsByState = accessionStore.countByState(organizationId),
@@ -105,7 +105,7 @@ class SummaryController(
 }
 
 @Schema(description = "Summary of important statistics about the seed bank for the Summary page.")
-data class SummaryResponse(
+data class SummaryResponsePayload(
     val activeAccessions: Int,
     val species: Int,
     @Schema(description = "Number of accessions in each state.")

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -75,5 +75,6 @@ data class CreateNurseryTransferRequestPayload(
 data class CreateNurseryTransferResponsePayload(
     @Schema(description = "Updated accession that includes a withdrawal for the nursery transfer.")
     val accession: AccessionPayloadV2,
-    @Schema(description = "Details of ewly-created seedling batch.") val batch: BatchPayload,
+    @Schema(description = "Details of newly-created seedling batch.") //
+    val batch: BatchPayload,
 ) : SuccessResponsePayload


### PR DESCRIPTION
Our OpenAPI customization class has code to work around a limitation of the
Swagger core library's annotation processing that causes it to throw away payload
field descriptions if the fields are references to other payload classes.
Previously, the workaround required keeping an explicit list of all the payload
classes that needed to be fixed up. The list was, inevitably, out of date and
missing several classes that ought to have been included.

Switch to a classpath-scanning approach where we probe the code base using
reflection and find all the payload classes. This is slower but it's a one-time
operation that only happens the first time someone requests the OpenAPI schema
from a server instance.

In addition, we were using the wrong annotations on some of the payload fields
whose values are collections; fix those.