### PR TITLE
SW-1939 Remove unused accession summary calculation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -836,20 +836,6 @@ class AccessionStore(
     }
   }
 
-  /** Returns the number of accessions that are currently in an active state. */
-  fun countActive(facilityId: FacilityId): Int {
-    requirePermissions { readFacility(facilityId) }
-    val condition = ACCESSIONS.FACILITY_ID.eq(facilityId)
-    return countActive(condition)
-  }
-
-  /** Returns the number of accessions that are currently in an active state. */
-  fun countActive(organizationId: OrganizationId): Int {
-    requirePermissions { readOrganization(organizationId) }
-    val condition = ACCESSIONS.facilities.ORGANIZATION_ID.eq(organizationId)
-    return countActive(condition)
-  }
-
   fun countByState(facilityId: FacilityId): Map<AccessionState, Int> {
     requirePermissions { readFacility(facilityId) }
 
@@ -876,19 +862,6 @@ class AccessionStore(
           .fetch { it[NUMBER]!! to it[ID]!! }
           .toMap()
     }
-  }
-
-  private fun countActive(condition: Condition): Int {
-    val query =
-        dslContext
-            .select(DSL.count())
-            .from(ACCESSIONS)
-            .where(condition)
-            .and(ACCESSIONS.STATE_ID.`in`(AccessionState.activeValues))
-
-    log.debug("Active accessions query ${query.getSQL(ParamType.INLINED)}")
-
-    return log.debugWithTiming("Active accessions query") { query.fetchOne()?.value1() ?: 0 }
   }
 
   private fun countByState(condition: Condition): Map<AccessionState, Int> {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
@@ -36,13 +36,6 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `countActive only counts accessions from the requested facility`() {
-    store.create(AccessionModel(facilityId = facilityId))
-    assertEquals(1, store.countActive(facilityId))
-    assertEquals(0, store.countActive(otherFacilityId))
-  }
-
-  @Test
   fun `update writes new facility id if it belongs to the same organization as previous facility`() {
     val anotherFacilityId = FacilityId(5000)
     insertFacility(anotherFacilityId)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
@@ -52,20 +52,6 @@ internal class AccessionStorePermissionTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `rejects count active accessions by facility when user cannot read facility`() {
-    every { user.canReadFacility(any()) } returns false
-
-    assertThrows<FacilityNotFoundException> { store.countActive(facilityId) }
-  }
-
-  @Test
-  fun `rejects count active accessions by organization when user cannot read organization`() {
-    every { user.canReadOrganization(any()) } returns false
-
-    assertThrows<OrganizationNotFoundException> { store.countActive(organizationId) }
-  }
-
-  @Test
   fun `countByState throws exception when no permission to read facility`() {
     every { user.canReadFacility(facilityId) } returns false
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
-import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import java.math.BigDecimal
 import org.jooq.impl.DSL
@@ -16,18 +15,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class AccessionStoreSummaryTest : AccessionStoreTest() {
-  @Test
-  fun `counts active accessions by facility`() {
-    store.create(AccessionModel(facilityId = facilityId))
-    assertEquals(1, store.countActive(facilityId))
-  }
-
-  @Test
-  fun `counts active accessions by organization`() {
-    store.create(AccessionModel(facilityId = facilityId))
-    assertEquals(1, store.countActive(organizationId))
-  }
-
   @Test
   fun countByState() {
     val otherOrganizationId = OrganizationId(2)


### PR DESCRIPTION
In the older version of the web app, we used to show the total number of active
accessions in a facility or organization, but now we break the counts down by
status. Remove the code that calculated the old total. It was only referenced by
tests; the endpoint that used to call it was removed in a previous change.