### PR TITLE
SW-1875 Add batch version to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -61,6 +61,7 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
             "Total quantity withdrawn",
             BATCH_SUMMARIES.TOTAL_QUANTITY_WITHDRAWN,
             nullable = false),
+        integerField("version", "Batch version", BATCH_SUMMARIES.VERSION, nullable = false),
     )
   }
 

--- a/src/main/resources/db/migration/V149__NurseryBatchSummariesVersion.sql
+++ b/src/main/resources/db/migration/V149__NurseryBatchSummariesVersion.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW nursery.batch_summaries AS
+    SELECT id,
+           organization_id,
+           facility_id,
+           species_id,
+           batch_number,
+           added_date,
+           ready_quantity,
+           not_ready_quantity,
+           germinating_quantity,
+           ready_quantity + not_ready_quantity AS total_quantity,
+           ready_by_date,
+           notes,
+           accession_id,
+           COALESCE(
+                   (SELECT SUM(bw.ready_quantity_withdrawn + bw.not_ready_quantity_withdrawn)
+                    FROM nursery.batch_withdrawals bw
+                    WHERE b.id = bw.batch_id),
+                   0)                          AS total_quantity_withdrawn,
+           version
+    FROM nursery.batches b;

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -85,7 +85,8 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           germinatingQuantity = 1,
           notReadyQuantity = 2,
           readyQuantity = 4,
-          speciesId = speciesId1)
+          speciesId = speciesId1,
+      )
       insertBatch(
           addedDate = LocalDate.of(2022, 9, 2),
           facilityId = facilityId,
@@ -93,6 +94,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           notReadyQuantity = 16,
           readyQuantity = 32,
           speciesId = speciesId1,
+          version = 2,
       )
       insertBatch(
           BatchesRow(readyByDate = LocalDate.of(2022, 10, 2)),
@@ -246,6 +248,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("facility_name"),
                   prefix.resolve("readyByDate"),
                   prefix.resolve("addedDate"),
+                  prefix.resolve("version"),
               ),
               FieldNode(prefix.resolve("species_id"), listOf("$speciesId1")))
 
@@ -262,6 +265,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalQuantityWithdrawn" to "${1024 + 2048}",
                       "facility_name" to "Nursery",
                       "addedDate" to "2021-03-04",
+                      "version" to "1",
                   ),
                   mapOf(
                       "id" to "2",
@@ -273,6 +277,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalQuantityWithdrawn" to "${8192 + 16384 + 65536 + 131072}",
                       "facility_name" to "Nursery",
                       "addedDate" to "2022-09-02",
+                      "version" to "2",
                   ),
                   mapOf(
                       "id" to "3",
@@ -285,6 +290,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "facility_name" to "Other Nursery",
                       "readyByDate" to "2022-10-02",
                       "addedDate" to "2022-09-03",
+                      "version" to "1",
                   ),
               ),
               null),


### PR DESCRIPTION
The search API was missing the seedling batch `version` field; add it.