### PR TITLE
Add imports for JUnit assertion methods

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -61,6 +61,7 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
             "Total quantity withdrawn",
             BATCH_SUMMARIES.TOTAL_QUANTITY_WITHDRAWN,
             nullable = false),
+        integerField("version", "Batch version", BATCH_SUMMARIES.VERSION, nullable = false),
     )
   }
 

--- a/src/main/resources/db/migration/V149__NurseryBatchSummariesVersion.sql
+++ b/src/main/resources/db/migration/V149__NurseryBatchSummariesVersion.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW nursery.batch_summaries AS
+    SELECT id,
+           organization_id,
+           facility_id,
+           species_id,
+           batch_number,
+           added_date,
+           ready_quantity,
+           not_ready_quantity,
+           germinating_quantity,
+           ready_quantity + not_ready_quantity AS total_quantity,
+           ready_by_date,
+           notes,
+           accession_id,
+           COALESCE(
+                   (SELECT SUM(bw.ready_quantity_withdrawn + bw.not_ready_quantity_withdrawn)
+                    FROM nursery.batch_withdrawals bw
+                    WHERE b.id = bw.batch_id),
+                   0)                          AS total_quantity_withdrawn,
+           version
+    FROM nursery.batches b;

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 
 /**
  * ObjectMapper configured to pretty print. This is lazily instantiated since ObjectMappers aren't
@@ -27,7 +27,7 @@ private val prettyPrintingObjectMapper: ObjectMapper by lazy {
  */
 fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
   if (expected != actual) {
-    Assertions.assertEquals(
+    assertEquals(
         prettyPrintingObjectMapper.writeValueAsString(expected),
         prettyPrintingObjectMapper.writeValueAsString(actual),
         message)

--- a/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientTest.kt
@@ -14,8 +14,9 @@ import java.time.Instant
 import kotlin.random.Random
 import org.junit.AssumptionViolatedException
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -118,7 +119,7 @@ internal class LiveBalenaClientTest {
 
   @Test
   fun `getDeviceEnvironmentVar returns null if variable not set`() {
-    Assertions.assertNull(client.getDeviceEnvironmentVar(deviceId, "nonexistent"))
+    assertNull(client.getDeviceEnvironmentVar(deviceId, "nonexistent"))
   }
 
   @Test
@@ -160,7 +161,7 @@ internal class LiveBalenaClientTest {
   fun `listModifiedDevices includes newly-created devices`() {
     val devices = client.listModifiedDevices(Instant.EPOCH)
 
-    Assertions.assertTrue(devices.any { it.id == deviceId }, "Contains device created by test")
+    assertTrue(devices.any { it.id == deviceId }, "Contains device created by test")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -85,7 +85,8 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           germinatingQuantity = 1,
           notReadyQuantity = 2,
           readyQuantity = 4,
-          speciesId = speciesId1)
+          speciesId = speciesId1,
+      )
       insertBatch(
           addedDate = LocalDate.of(2022, 9, 2),
           facilityId = facilityId,
@@ -93,6 +94,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           notReadyQuantity = 16,
           readyQuantity = 32,
           speciesId = speciesId1,
+          version = 2,
       )
       insertBatch(
           BatchesRow(readyByDate = LocalDate.of(2022, 10, 2)),
@@ -246,6 +248,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("facility_name"),
                   prefix.resolve("readyByDate"),
                   prefix.resolve("addedDate"),
+                  prefix.resolve("version"),
               ),
               FieldNode(prefix.resolve("species_id"), listOf("$speciesId1")))
 
@@ -262,6 +265,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalQuantityWithdrawn" to "${1024 + 2048}",
                       "facility_name" to "Nursery",
                       "addedDate" to "2021-03-04",
+                      "version" to "1",
                   ),
                   mapOf(
                       "id" to "2",
@@ -273,6 +277,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalQuantityWithdrawn" to "${8192 + 16384 + 65536 + 131072}",
                       "facility_name" to "Nursery",
                       "addedDate" to "2022-09-02",
+                      "version" to "2",
                   ),
                   mapOf(
                       "id" to "3",
@@ -285,6 +290,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "facility_name" to "Other Nursery",
                       "readyByDate" to "2022-10-02",
                       "addedDate" to "2022-09-03",
+                      "version" to "1",
                   ),
               ),
               null),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
@@ -16,7 +16,9 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -38,10 +40,9 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
                 ),
         )
 
-    Assertions.assertNull(
-        model.calculateLatestViabilityRecordingDate(), "Latest viability test date")
-    Assertions.assertNull(model.calculateLatestViabilityPercent(), "Latest viability percent")
-    Assertions.assertNull(model.calculateTotalViabilityPercent(), "Total viability percent")
+    assertNull(model.calculateLatestViabilityRecordingDate(), "Latest viability test date")
+    assertNull(model.calculateLatestViabilityPercent(), "Latest viability percent")
+    assertNull(model.calculateTotalViabilityPercent(), "Total viability percent")
   }
 
   @Test
@@ -58,7 +59,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
                             viabilityTestResult(recordingDate = january(2), seedsGerminated = 4))),
                 clock)
 
-    Assertions.assertNull(model.totalViabilityPercent)
+    assertNull(model.totalViabilityPercent)
   }
 
   @Test
@@ -69,7 +70,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .copy(isManualState = true, remaining = seeds(50), totalViabilityPercent = percent)
             .withCalculatedValues(clock)
 
-    Assertions.assertEquals(percent, model.totalViabilityPercent)
+    assertEquals(percent, model.totalViabilityPercent)
   }
 
   @Test
@@ -87,7 +88,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
                             viabilityTestResult(recordingDate = january(2), seedsGerminated = 5))),
                 clock)
 
-    Assertions.assertEquals(percent, model.totalViabilityPercent)
+    assertEquals(percent, model.totalViabilityPercent)
   }
 
   @Test
@@ -100,7 +101,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .addViabilityTest(
                 viabilityTest(seedsTested = 1, withdrawnByUserId = withdrawnByUserId), clock)
 
-    Assertions.assertEquals(withdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
+    assertEquals(withdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
   }
 
   @Test
@@ -127,7 +128,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
               it.copy(withdrawnByUserId = newWithdrawnByUserId)
             }
 
-    Assertions.assertEquals(newWithdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
+    assertEquals(newWithdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
   }
 
   @Test
@@ -151,7 +152,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .withCalculatedValues(clock)
             .updateViabilityTest(viabilityTestId, clock) { it.copy(withdrawnByUserId = null) }
 
-    Assertions.assertEquals(withdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
+    assertEquals(withdrawnByUserId, model.withdrawals[0].withdrawnByUserId)
   }
 
   @Test
@@ -163,12 +164,12 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .withCalculatedValues(clock)
             .addViabilityTest(initialTest, clock)
 
-    Assertions.assertEquals(seeds(99), initial.remaining, "Initial quantity")
+    assertEquals(seeds(99), initial.remaining, "Initial quantity")
 
     val updated =
         initial.updateViabilityTest(initialTest.id!!, tomorrowClock) { it.copy(seedsTested = 25) }
 
-    Assertions.assertEquals(seeds(75), updated.remaining, "Updated quantity")
+    assertEquals(seeds(75), updated.remaining, "Updated quantity")
   }
 
   @Test
@@ -184,12 +185,12 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .withCalculatedValues(yesterdayClock)
             .addViabilityTest(initialTest, clock)
 
-    Assertions.assertEquals(grams(99), initial.remaining, "Initial quantity")
+    assertEquals(grams(99), initial.remaining, "Initial quantity")
 
     val updated =
         initial.updateViabilityTest(initialTest.id!!, tomorrowClock) { it.copy(seedsTested = 50) }
 
-    Assertions.assertEquals(grams(75), updated.remaining, "Updated quantity")
+    assertEquals(grams(75), updated.remaining, "Updated quantity")
   }
 
   @Test
@@ -208,9 +209,9 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             .addViabilityTest(
                 viabilityTest(ViabilityTestType.Cut, seedsFilled = 1, seedsTested = 1), clock)
 
-    Assertions.assertEquals(1, model.cutTestSeedsCompromised, "Compromised")
-    Assertions.assertEquals(2, model.cutTestSeedsEmpty, "Empty")
-    Assertions.assertEquals(4, model.cutTestSeedsFilled, "Filled")
+    assertEquals(1, model.cutTestSeedsCompromised, "Compromised")
+    assertEquals(2, model.cutTestSeedsEmpty, "Empty")
+    assertEquals(4, model.cutTestSeedsFilled, "Filled")
   }
 
   @Test
@@ -231,7 +232,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             testType = ViabilityTestType.Cut,
         )
 
-    Assertions.assertEquals(listOf(expectedTest), updated.viabilityTests)
+    assertEquals(listOf(expectedTest), updated.viabilityTests)
   }
 
   @Test
@@ -241,9 +242,8 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
     val updated =
         withCutTest.copy(cutTestSeedsEmpty = null).withCalculatedValues(clock, withCutTest)
 
-    Assertions.assertNotEquals(
-        emptyList<ViabilityTestModel>(), withCutTest.viabilityTests, "Before edit")
-    Assertions.assertEquals(emptyList<ViabilityTestModel>(), updated.viabilityTests, "After edit")
+    assertNotEquals(emptyList<ViabilityTestModel>(), withCutTest.viabilityTests, "Before edit")
+    assertEquals(emptyList<ViabilityTestModel>(), updated.viabilityTests, "After edit")
   }
 
   @Test
@@ -287,15 +287,15 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             viabilityTest = expectedViabilityTest,
             withdrawn = seeds(3))
 
-    Assertions.assertEquals(
+    assertEquals(
         listOf(expectedViabilityTest),
         updatedAccession.viabilityTests,
         "Existing viability test should be updated")
-    Assertions.assertEquals(
+    assertEquals(
         listOf(expectedWithdrawal),
         updatedAccession.withdrawals,
         "Existing withdrawal should be updated")
-    Assertions.assertEquals(seeds(7), updatedAccession.remaining, "Remaining quantity")
+    assertEquals(seeds(7), updatedAccession.remaining, "Remaining quantity")
   }
 
   @Test
@@ -334,7 +334,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             ),
             fixedClock(2))
 
-    Assertions.assertEquals(grams(95), withTest.remaining, "After test")
+    assertEquals(grams(95), withTest.remaining, "After test")
 
     val withWithdrawal =
         withTest.addWithdrawal(
@@ -345,6 +345,6 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
             ),
             fixedClock(3))
 
-    Assertions.assertEquals(grams(0), withWithdrawal.remaining, "After withdrawal")
+    assertEquals(grams(0), withWithdrawal.remaining, "After withdrawal")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.search.NoConditionNode
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
 import io.mockk.every
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class SearchServicePermissionTest : SearchServiceTest() {
@@ -29,7 +29,7 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
 
-    Assertions.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 
   @Test
@@ -44,6 +44,6 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
 
-    Assertions.assertEquals(expected, actual)
+    assertEquals(expected, actual)
   }
 }


### PR DESCRIPTION
In a few places in the test suite, we were using qualified names for the various
assertion methods rather than statically importing them. That is, we sometimes
had `Assertions.assertEquals` instead of `assertEquals`.