### PR TITLE
SW-1939 Remove implicit species creation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.species
 
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.species.db.SpeciesChecker
@@ -14,20 +13,6 @@ class SpeciesService(
     private val speciesChecker: SpeciesChecker,
     private val speciesStore: SpeciesStore,
 ) {
-  /** Returns an existing species with a scientific name or creates it if it doesn't exist. */
-  fun getOrCreateSpecies(
-      organizationId: OrganizationId,
-      scientificName: String,
-      commonName: String? = null,
-  ): SpeciesId {
-    return speciesStore.fetchSpeciesIdByName(organizationId, scientificName)
-        ?: createSpecies(
-            SpeciesRow(
-                commonName = commonName,
-                organizationId = organizationId,
-                scientificName = scientificName))
-  }
-
   /** Creates a new species and checks it for potential problems. */
   fun createSpecies(row: SpeciesRow): SpeciesId {
     return dslContext.transactionResult { _ ->

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -35,18 +35,6 @@ class SpeciesStore(
 ) {
   private val log = perClassLogger()
 
-  fun fetchSpeciesIdByName(organizationId: OrganizationId, scientificName: String): SpeciesId? {
-    requirePermissions { readOrganization(organizationId) }
-
-    return dslContext
-        .select(SPECIES.ID)
-        .from(SPECIES)
-        .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
-        .and(SPECIES.SCIENTIFIC_NAME.eq(scientificName))
-        .and(SPECIES.DELETED_TIME.isNull)
-        .fetchOne(SPECIES.ID)
-  }
-
   fun fetchSpeciesById(speciesId: SpeciesId): SpeciesRow {
     requirePermissions { readSpecies(speciesId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -95,7 +95,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             GeolocationStore(dslContext, clock),
             ViabilityTestStore(dslContext),
             parentStore,
-            mockk(),
             WithdrawalStore(dslContext, clock, mockk(), parentStore),
             clock,
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -38,8 +38,6 @@ import com.terraformation.backend.file.UploadService
 import com.terraformation.backend.file.UploadStore
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
-import com.terraformation.backend.species.SpeciesService
-import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import io.mockk.CapturingSlot
 import io.mockk.Runs
@@ -78,7 +76,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         GeolocationStore(dslContext, clock),
         ViabilityTestStore(dslContext),
         parentStore,
-        speciesService,
         WithdrawalStore(dslContext, clock, messages, parentStore),
         clock,
         messages,
@@ -107,10 +104,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   private val messages: Messages = Messages()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val scheduler: JobScheduler = mockk()
-  private val speciesChecker: SpeciesChecker = mockk()
-  private val speciesService: SpeciesService by lazy {
-    SpeciesService(dslContext, speciesChecker, speciesStore)
-  }
   private val speciesStore: SpeciesStore by lazy {
     SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
   }
@@ -126,7 +119,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     val userId = user.userId
 
-    every { speciesChecker.checkSpecies(any()) } just Runs
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadAccession(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -86,7 +86,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
             clock,
             mockk(),
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -126,24 +126,6 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `create without isManualState uses caller-supplied species name`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
-    val oldSpeciesName = "Old species"
-    val newSpeciesName = "New species"
-    insertSpecies(oldSpeciesId, oldSpeciesName)
-    insertSpecies(newSpeciesId, newSpeciesName)
-
-    val initial =
-        store.create(
-            AccessionModel(
-                facilityId = facilityId, species = newSpeciesName, speciesId = oldSpeciesId))
-
-    assertEquals(newSpeciesId, initial.speciesId, "Species ID")
-    assertEquals(newSpeciesName, initial.species, "Species name")
-  }
-
-  @Test
   fun `create with isManualState uses caller-supplied species ID`() {
     val oldSpeciesId = SpeciesId(1)
     val newSpeciesId = SpeciesId(2)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -225,7 +225,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val commonName = "Test Common Name"
     insertSpecies(speciesId, scientificName = oldScientificName, commonName = commonName)
 
-    val initial = store.create(AccessionModel(facilityId = facilityId, species = oldScientificName))
+    val initial = store.create(AccessionModel(facilityId = facilityId, speciesId = speciesId))
 
     speciesDao.update(speciesDao.fetchOneById(speciesId)!!.copy(scientificName = newScientificName))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
@@ -63,23 +63,6 @@ internal class AccessionStoreManualStateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update without isManualState uses caller-supplied species name`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
-    val oldSpeciesName = "Old species"
-    val newSpeciesName = "New species"
-    insertSpecies(oldSpeciesId, oldSpeciesName)
-    insertSpecies(newSpeciesId, newSpeciesName)
-
-    val initial = store.create(AccessionModel(facilityId = facilityId, species = oldSpeciesName))
-    val updated =
-        store.updateAndFetch(initial.copy(species = newSpeciesName, speciesId = oldSpeciesId))
-
-    assertEquals(newSpeciesId, updated.speciesId, "Species ID")
-    assertEquals(newSpeciesName, updated.species, "Species scientific name")
-  }
-
-  @Test
   fun `update with isManualState uses caller-supplied species ID`() {
     val oldSpeciesId = SpeciesId(1)
     val newSpeciesId = SpeciesId(2)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -23,12 +23,7 @@ import com.terraformation.backend.seedbank.db.WithdrawalStore
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.seeds
-import com.terraformation.backend.species.SpeciesService
-import com.terraformation.backend.species.db.SpeciesChecker
-import com.terraformation.backend.species.db.SpeciesStore
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import java.time.Clock
 import java.time.Duration
@@ -62,14 +57,8 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   protected fun init() {
     parentStore = ParentStore(dslContext)
 
-    val speciesStore = SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
-    val speciesChecker: SpeciesChecker = mockk()
-
     every { clock.instant() } returns Instant.EPOCH
     every { clock.zone } returns ZoneOffset.UTC
-
-    every { speciesChecker.checkSpecies(any()) } just Runs
-    every { speciesChecker.recheckSpecies(any(), any()) } just Runs
 
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(organizationId) } returns true
@@ -93,7 +82,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             GeolocationStore(dslContext, clock),
             ViabilityTestStore(dslContext),
             parentStore,
-            SpeciesService(dslContext, speciesChecker, speciesStore),
             WithdrawalStore(dslContext, clock, messages, parentStore),
             clock,
             messages,

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.species
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
@@ -43,37 +42,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateSpecies(any()) } returns true
 
     insertSiteData()
-  }
-
-  @Test
-  fun `getOrCreateSpecies returns existing species ID for organization`() {
-    val speciesId = SpeciesId(1)
-    val scientificName = "test"
-
-    insertSpecies(speciesId, scientificName = scientificName)
-
-    assertEquals(speciesId, service.getOrCreateSpecies(organizationId, scientificName))
-  }
-
-  @Test
-  fun `getOrCreateSpecies creates new species if it does not exist in organization`() {
-    val otherOrgId = OrganizationId(2)
-    val otherOrgSpeciesId = SpeciesId(10)
-    val scientificName = "test"
-
-    insertOrganization(otherOrgId.value)
-    insertSpecies(
-        otherOrgSpeciesId.value,
-        scientificName = scientificName,
-        organizationId = otherOrgId.value,
-    )
-
-    val speciesId = service.getOrCreateSpecies(organizationId, scientificName)
-
-    assertNotNull(speciesId, "Should have created species")
-    assertNotEquals(otherOrgSpeciesId, speciesId, "Should not use species ID from other org")
-
-    verify { speciesChecker.checkSpecies(speciesId) }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -356,10 +356,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     assertThrows<OrganizationNotFoundException> { store.countSpecies(organizationId) }
 
-    assertThrows<OrganizationNotFoundException> {
-      store.fetchSpeciesIdByName(organizationId, scientificName)
-    }
-
     assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
 
     assertThrows<OrganizationNotFoundException> { store.findAllSpecies(organizationId) }


### PR DESCRIPTION
In the v1 accessions API, clients could pass in a species name as part of the
accession data and the system would automatically add the species to the
organization's species list if it didn't already exist. In v2, clients have to
pass in the ID of an existing species.

Remove the code that supported species auto-creation.