### PR TITLE
SW-1939 Remove accession-level viability calculations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -119,14 +119,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
         aliasField("geolocation", "geolocations_coordinates"),
         idWrapperField("id", "ID", ACCESSIONS.ID) { AccessionId(it) },
         textField("landowner", "Landowner", ACCESSIONS.COLLECTION_SITE_LANDOWNER),
-        integerField(
-            "latestViabilityPercent",
-            "Most recent % viability",
-            ACCESSIONS.LATEST_VIABILITY_PERCENT),
-        dateField(
-            "latestViabilityTestDate",
-            "Most recent viability test result date",
-            ACCESSIONS.LATEST_GERMINATION_RECORDING_DATE),
         dateField("nurseryStartDate", "Nursery start date", ACCESSIONS.NURSERY_START_DATE),
         textField("plantId", "Plant ID", ACCESSIONS.FOUNDER_ID),
         integerField(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -171,8 +171,6 @@ class AccessionStore(
                   record[LATEST_OBSERVED_UNITS_ID],
               ),
           latestObservedTime = record[LATEST_OBSERVED_TIME],
-          latestViabilityPercent = record[LATEST_VIABILITY_PERCENT],
-          latestViabilityTestDate = record[LATEST_GERMINATION_RECORDING_DATE],
           numberOfTrees = record[TREES_COLLECTED_FROM],
           nurseryStartDate = record[NURSERY_START_DATE],
           photoFilenames = record[photoFilenamesField],
@@ -286,10 +284,6 @@ class AccessionStore(
                         .set(FIELD_NOTES, accession.fieldNotes)
                         .set(FOUNDER_ID, accession.founderId)
                         .set(IS_MANUAL_STATE, if (accession.isManualState) true else null)
-                        .set(
-                            LATEST_GERMINATION_RECORDING_DATE,
-                            accession.calculateLatestViabilityRecordingDate())
-                        .set(LATEST_VIABILITY_PERCENT, accession.calculateLatestViabilityPercent())
                         .set(MODIFIED_BY, currentUser().userId)
                         .set(MODIFIED_TIME, clock.instant())
                         .set(NUMBER, accessionNumber)
@@ -312,7 +306,7 @@ class AccessionStore(
                         .set(TOTAL_GRAMS, accession.total?.grams)
                         .set(TOTAL_QUANTITY, accession.total?.quantity)
                         .set(TOTAL_UNITS_ID, accession.total?.units)
-                        .set(TOTAL_VIABILITY_PERCENT, accession.calculateTotalViabilityPercent())
+                        .set(TOTAL_VIABILITY_PERCENT, accession.totalViabilityPercent)
                         .set(TREES_COLLECTED_FROM, accession.numberOfTrees)
                         .returning(ID)
                         .fetchOne()
@@ -475,11 +469,9 @@ class AccessionStore(
                 .set(FIELD_NOTES, accession.fieldNotes)
                 .set(FOUNDER_ID, accession.founderId)
                 .set(IS_MANUAL_STATE, if (accession.isManualState) true else null)
-                .set(LATEST_GERMINATION_RECORDING_DATE, accession.latestViabilityTestDate)
                 .set(LATEST_OBSERVED_QUANTITY, accession.latestObservedQuantity?.quantity)
                 .set(LATEST_OBSERVED_TIME, accession.latestObservedTime)
                 .set(LATEST_OBSERVED_UNITS_ID, accession.latestObservedQuantity?.units)
-                .set(LATEST_VIABILITY_PERCENT, accession.latestViabilityPercent)
                 .set(MODIFIED_BY, currentUser().userId)
                 .set(MODIFIED_TIME, clock.instant())
                 .set(NURSERY_START_DATE, accession.nurseryStartDate)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -113,10 +113,6 @@ data class ViabilityTestModel(
         withdrawnByUserId == other.withdrawnByUserId
   }
 
-  fun calculateLatestRecordingDate(): LocalDate? {
-    return testResults?.maxOfOrNull { it.recordingDate }
-  }
-
   private fun calculateTotalSeedsGerminated(): Int? {
     return testResults?.sumOf { it.seedsGerminated }
   }

--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.species
 
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.species.db.SpeciesChecker
@@ -14,20 +13,6 @@ class SpeciesService(
     private val speciesChecker: SpeciesChecker,
     private val speciesStore: SpeciesStore,
 ) {
-  /** Returns an existing species with a scientific name or creates it if it doesn't exist. */
-  fun getOrCreateSpecies(
-      organizationId: OrganizationId,
-      scientificName: String,
-      commonName: String? = null,
-  ): SpeciesId {
-    return speciesStore.fetchSpeciesIdByName(organizationId, scientificName)
-        ?: createSpecies(
-            SpeciesRow(
-                commonName = commonName,
-                organizationId = organizationId,
-                scientificName = scientificName))
-  }
-
   /** Creates a new species and checks it for potential problems. */
   fun createSpecies(row: SpeciesRow): SpeciesId {
     return dslContext.transactionResult { _ ->

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -35,18 +35,6 @@ class SpeciesStore(
 ) {
   private val log = perClassLogger()
 
-  fun fetchSpeciesIdByName(organizationId: OrganizationId, scientificName: String): SpeciesId? {
-    requirePermissions { readOrganization(organizationId) }
-
-    return dslContext
-        .select(SPECIES.ID)
-        .from(SPECIES)
-        .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
-        .and(SPECIES.SCIENTIFIC_NAME.eq(scientificName))
-        .and(SPECIES.DELETED_TIME.isNull)
-        .fetchOne(SPECIES.ID)
-  }
-
   fun fetchSpeciesById(speciesId: SpeciesId): SpeciesRow {
     requirePermissions { readSpecies(speciesId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -95,7 +95,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             GeolocationStore(dslContext, clock),
             ViabilityTestStore(dslContext),
             parentStore,
-            mockk(),
             WithdrawalStore(dslContext, clock, mockk(), parentStore),
             clock,
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -38,8 +38,6 @@ import com.terraformation.backend.file.UploadService
 import com.terraformation.backend.file.UploadStore
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
-import com.terraformation.backend.species.SpeciesService
-import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import io.mockk.CapturingSlot
 import io.mockk.Runs
@@ -78,7 +76,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         GeolocationStore(dslContext, clock),
         ViabilityTestStore(dslContext),
         parentStore,
-        speciesService,
         WithdrawalStore(dslContext, clock, messages, parentStore),
         clock,
         messages,
@@ -107,10 +104,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   private val messages: Messages = Messages()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val scheduler: JobScheduler = mockk()
-  private val speciesChecker: SpeciesChecker = mockk()
-  private val speciesService: SpeciesService by lazy {
-    SpeciesService(dslContext, speciesChecker, speciesStore)
-  }
   private val speciesStore: SpeciesStore by lazy {
     SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
   }
@@ -126,7 +119,6 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     val userId = user.userId
 
-    every { speciesChecker.checkSpecies(any()) } just Runs
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadAccession(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -86,7 +86,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
             clock,
             mockk(),
             mockk(),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -126,24 +126,6 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `create without isManualState uses caller-supplied species name`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
-    val oldSpeciesName = "Old species"
-    val newSpeciesName = "New species"
-    insertSpecies(oldSpeciesId, oldSpeciesName)
-    insertSpecies(newSpeciesId, newSpeciesName)
-
-    val initial =
-        store.create(
-            AccessionModel(
-                facilityId = facilityId, species = newSpeciesName, speciesId = oldSpeciesId))
-
-    assertEquals(newSpeciesId, initial.speciesId, "Species ID")
-    assertEquals(newSpeciesName, initial.species, "Species name")
-  }
-
-  @Test
   fun `create with isManualState uses caller-supplied species ID`() {
     val oldSpeciesId = SpeciesId(1)
     val newSpeciesId = SpeciesId(2)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -225,7 +225,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val commonName = "Test Common Name"
     insertSpecies(speciesId, scientificName = oldScientificName, commonName = commonName)
 
-    val initial = store.create(AccessionModel(facilityId = facilityId, species = oldScientificName))
+    val initial = store.create(AccessionModel(facilityId = facilityId, speciesId = speciesId))
 
     speciesDao.update(speciesDao.fetchOneById(speciesId)!!.copy(scientificName = newScientificName))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
@@ -63,23 +63,6 @@ internal class AccessionStoreManualStateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update without isManualState uses caller-supplied species name`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
-    val oldSpeciesName = "Old species"
-    val newSpeciesName = "New species"
-    insertSpecies(oldSpeciesId, oldSpeciesName)
-    insertSpecies(newSpeciesId, newSpeciesName)
-
-    val initial = store.create(AccessionModel(facilityId = facilityId, species = oldSpeciesName))
-    val updated =
-        store.updateAndFetch(initial.copy(species = newSpeciesName, speciesId = oldSpeciesId))
-
-    assertEquals(newSpeciesId, updated.speciesId, "Species ID")
-    assertEquals(newSpeciesName, updated.species, "Species scientific name")
-  }
-
-  @Test
   fun `update with isManualState uses caller-supplied species ID`() {
     val oldSpeciesId = SpeciesId(1)
     val newSpeciesId = SpeciesId(2)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -23,12 +23,7 @@ import com.terraformation.backend.seedbank.db.WithdrawalStore
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.seeds
-import com.terraformation.backend.species.SpeciesService
-import com.terraformation.backend.species.db.SpeciesChecker
-import com.terraformation.backend.species.db.SpeciesStore
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import java.time.Clock
 import java.time.Duration
@@ -62,14 +57,8 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   protected fun init() {
     parentStore = ParentStore(dslContext)
 
-    val speciesStore = SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
-    val speciesChecker: SpeciesChecker = mockk()
-
     every { clock.instant() } returns Instant.EPOCH
     every { clock.zone } returns ZoneOffset.UTC
-
-    every { speciesChecker.checkSpecies(any()) } just Runs
-    every { speciesChecker.recheckSpecies(any(), any()) } just Runs
 
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(organizationId) } returns true
@@ -93,7 +82,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             GeolocationStore(dslContext, clock),
             ViabilityTestStore(dslContext),
             parentStore,
-            SpeciesService(dslContext, speciesChecker, speciesStore),
             WithdrawalStore(dslContext, clock, messages, parentStore),
             clock,
             messages,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
@@ -56,12 +56,8 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
             )),
         updatedTests)
 
-    val updatedRow = accessionsDao.fetchOneById(AccessionId(1))
-    assertNull(updatedRow?.totalViabilityPercent, "totalViabilityPercent")
-    assertNull(updatedRow?.latestViabilityPercent, "latestViabilityPercent")
-    assertNull(updatedRow?.latestGerminationRecordingDate, "latestGerminationRecordingDate")
-
     val updatedAccession = store.fetchOneById(AccessionId(1))
+    assertNull(updatedAccession.totalViabilityPercent, "Total viability percent should not be set")
     assertNull(
         updatedAccession.viabilityTests.first().testResults,
         "Empty list of viability test results should be null in model")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
@@ -24,28 +24,6 @@ import org.junit.jupiter.api.assertThrows
 
 internal class AccessionModelViabilityTest : AccessionModelTest() {
   @Test
-  fun `test without seeds sown is ignored`() {
-    val model =
-        accession(
-            total = seeds(10),
-            viabilityTests =
-                listOf(
-                    viabilityTest(
-                        testResults =
-                            listOf(
-                                viabilityTestResult(
-                                    recordingDate = january(2), seedsGerminated = 1),
-                            ),
-                    ),
-                ),
-        )
-
-    assertNull(model.calculateLatestViabilityRecordingDate(), "Latest viability test date")
-    assertNull(model.calculateLatestViabilityPercent(), "Latest viability percent")
-    assertNull(model.calculateTotalViabilityPercent(), "Total viability percent")
-  }
-
-  @Test
   fun `viability percent is not auto-populated on v2 accessions when test results are added`() {
     val model =
         accession()

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.species
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
@@ -43,37 +42,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateSpecies(any()) } returns true
 
     insertSiteData()
-  }
-
-  @Test
-  fun `getOrCreateSpecies returns existing species ID for organization`() {
-    val speciesId = SpeciesId(1)
-    val scientificName = "test"
-
-    insertSpecies(speciesId, scientificName = scientificName)
-
-    assertEquals(speciesId, service.getOrCreateSpecies(organizationId, scientificName))
-  }
-
-  @Test
-  fun `getOrCreateSpecies creates new species if it does not exist in organization`() {
-    val otherOrgId = OrganizationId(2)
-    val otherOrgSpeciesId = SpeciesId(10)
-    val scientificName = "test"
-
-    insertOrganization(otherOrgId.value)
-    insertSpecies(
-        otherOrgSpeciesId.value,
-        scientificName = scientificName,
-        organizationId = otherOrgId.value,
-    )
-
-    val speciesId = service.getOrCreateSpecies(organizationId, scientificName)
-
-    assertNotNull(speciesId, "Should have created species")
-    assertNotEquals(otherOrgSpeciesId, speciesId, "Should not use species ID from other org")
-
-    verify { speciesChecker.checkSpecies(speciesId) }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -356,10 +356,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     assertThrows<OrganizationNotFoundException> { store.countSpecies(organizationId) }
 
-    assertThrows<OrganizationNotFoundException> {
-      store.fetchSpeciesIdByName(organizationId, scientificName)
-    }
-
     assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
 
     assertThrows<OrganizationNotFoundException> { store.findAllSpecies(organizationId) }


### PR DESCRIPTION
In v1, we calculated an overall viability percentage by aggregating the results of
all the viability tests, but in v2 the viability percentage is user-selectable.
Remove the code that calculates the v1 values, and the `AccessionModel` fields
that held the v1-only values.