### PR TITLE
SW-1939 Remove support for v1 cut test results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -95,13 +95,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
         textField("collectionSiteName", "Collection site name", ACCESSIONS.COLLECTION_SITE_NAME),
         textField("collectionSiteNotes", "Collection site notes", ACCESSIONS.COLLECTION_SITE_NOTES),
         enumField("collectionSource", "Collection source", ACCESSIONS.COLLECTION_SOURCE_ID),
-        integerField(
-            "cutTestSeedsCompromised",
-            "Number of seeds compromised",
-            ACCESSIONS.CUT_TEST_SEEDS_COMPROMISED),
-        integerField("cutTestSeedsEmpty", "Number of seeds empty", ACCESSIONS.CUT_TEST_SEEDS_EMPTY),
-        integerField(
-            "cutTestSeedsFilled", "Number of seeds filled", ACCESSIONS.CUT_TEST_SEEDS_FILLED),
         dateField("dryingEndDate", "Drying end date", ACCESSIONS.DRYING_END_DATE),
         dateField("dryingMoveDate", "Drying move date", ACCESSIONS.DRYING_MOVE_DATE),
         dateField("dryingStartDate", "Drying start date", ACCESSIONS.DRYING_START_DATE),

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -150,9 +150,6 @@ class AccessionStore(
           collectionSource = record[COLLECTION_SOURCE_ID],
           collectors = record[collectorsField],
           createdTime = record[CREATED_TIME],
-          cutTestSeedsCompromised = record[CUT_TEST_SEEDS_COMPROMISED],
-          cutTestSeedsEmpty = record[CUT_TEST_SEEDS_EMPTY],
-          cutTestSeedsFilled = record[CUT_TEST_SEEDS_FILLED],
           dryingEndDate = record[DRYING_END_DATE],
           dryingMoveDate = record[DRYING_MOVE_DATE],
           dryingStartDate = record[DRYING_START_DATE],
@@ -270,9 +267,6 @@ class AccessionStore(
                         .set(COLLECTION_SOURCE_ID, accession.collectionSource)
                         .set(CREATED_BY, currentUser().userId)
                         .set(CREATED_TIME, clock.instant())
-                        .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
-                        .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
-                        .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)
                         .set(DATA_SOURCE_ID, accession.source ?: DataSource.Web)
                         .set(
                             EST_SEED_COUNT,
@@ -455,9 +449,6 @@ class AccessionStore(
                 .set(COLLECTION_SITE_NAME, accession.collectionSiteName)
                 .set(COLLECTION_SITE_NOTES, accession.collectionSiteNotes)
                 .set(COLLECTION_SOURCE_ID, accession.collectionSource)
-                .set(CUT_TEST_SEEDS_COMPROMISED, accession.cutTestSeedsCompromised)
-                .set(CUT_TEST_SEEDS_EMPTY, accession.cutTestSeedsEmpty)
-                .set(CUT_TEST_SEEDS_FILLED, accession.cutTestSeedsFilled)
                 .set(DRYING_END_DATE, accession.dryingEndDate)
                 .set(DRYING_MOVE_DATE, accession.dryingMoveDate)
                 .set(DRYING_START_DATE, accession.dryingStartDate)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -42,9 +42,6 @@ internal abstract class AccessionModelTest {
 
   protected fun accession(
       viabilityTests: List<ViabilityTestModel> = emptyList(),
-      cutTestSeedsCompromised: Int? = null,
-      cutTestSeedsEmpty: Int? = null,
-      cutTestSeedsFilled: Int? = null,
       dryingEndDate: LocalDate? = null,
       dryingStartDate: LocalDate? = null,
       processingStartDate: LocalDate? = null,
@@ -63,9 +60,6 @@ internal abstract class AccessionModelTest {
         id = AccessionId(1L),
         accessionNumber = "dummy",
         createdTime = clock.instant(),
-        cutTestSeedsCompromised = cutTestSeedsCompromised,
-        cutTestSeedsEmpty = cutTestSeedsEmpty,
-        cutTestSeedsFilled = cutTestSeedsFilled,
         dryingEndDate = dryingEndDate,
         dryingStartDate = dryingStartDate,
         processingMethod = processingMethod,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
-import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.seedbank.grams
@@ -17,10 +16,8 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 internal class AccessionModelViabilityTest : AccessionModelTest() {
   @Test
@@ -169,120 +166,6 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
         initial.updateViabilityTest(initialTest.id!!, tomorrowClock) { it.copy(seedsTested = 50) }
 
     assertEquals(grams(75), updated.remaining, "Updated quantity")
-  }
-
-  @Test
-  fun `cut test results are reflected in v1 cut test fields`() {
-    val model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(10))
-            .addViabilityTest(
-                viabilityTest(
-                    ViabilityTestType.Cut,
-                    seedsCompromised = 1,
-                    seedsEmpty = 2,
-                    seedsFilled = 3,
-                    seedsTested = 6),
-                clock)
-            .addViabilityTest(
-                viabilityTest(ViabilityTestType.Cut, seedsFilled = 1, seedsTested = 1), clock)
-
-    assertEquals(1, model.cutTestSeedsCompromised, "Compromised")
-    assertEquals(2, model.cutTestSeedsEmpty, "Empty")
-    assertEquals(4, model.cutTestSeedsFilled, "Filled")
-  }
-
-  @Test
-  fun `new cut test is added if v1 cut test fields are newly populated`() {
-    val initial = accession(total = seeds(10))
-    val updated =
-        initial
-            .copy(cutTestSeedsCompromised = 1, cutTestSeedsEmpty = 2, cutTestSeedsFilled = 3)
-            .withCalculatedValues(clock, initial)
-
-    val expectedTest =
-        ViabilityTestModel(
-            remaining = seeds(4),
-            seedsCompromised = 1,
-            seedsEmpty = 2,
-            seedsFilled = 3,
-            seedsTested = 6,
-            testType = ViabilityTestType.Cut,
-        )
-
-    assertEquals(listOf(expectedTest), updated.viabilityTests)
-  }
-
-  @Test
-  fun `cut test is removed if v1 cut test fields are cleared`() {
-    val initial = accession(total = seeds(10)).withCalculatedValues(clock)
-    val withCutTest = initial.copy(cutTestSeedsEmpty = 1).withCalculatedValues(clock, initial)
-    val updated =
-        withCutTest.copy(cutTestSeedsEmpty = null).withCalculatedValues(clock, withCutTest)
-
-    assertNotEquals(emptyList<ViabilityTestModel>(), withCutTest.viabilityTests, "Before edit")
-    assertEquals(emptyList<ViabilityTestModel>(), updated.viabilityTests, "After edit")
-  }
-
-  @Test
-  fun `existing cut test is updated if v1 cut test fields are modified`() {
-    val initialViabilityTest =
-        ViabilityTestModel(
-            id = ViabilityTestId(1),
-            remaining = seeds(9),
-            seedsFilled = 1,
-            seedsTested = 1,
-            testType = ViabilityTestType.Cut)
-    val initialWithdrawal =
-        withdrawal(
-            remaining = seeds(9), viabilityTestId = initialViabilityTest.id, withdrawn = seeds(1))
-
-    val initialAccession =
-        accession(
-                cutTestSeedsFilled = 1,
-                total = seeds(10),
-                viabilityTests = listOf(initialViabilityTest),
-                withdrawals = listOf(initialWithdrawal))
-            .withCalculatedValues(clock)
-    val updatedAccession =
-        initialAccession
-            .copy(
-                cutTestSeedsCompromised = 1,
-                cutTestSeedsFilled = 2,
-                // v1 PUT requests won't include the cut test or its withdrawal since we filter
-                // them out of v1 GET responses.
-                viabilityTests = emptyList(),
-                withdrawals = emptyList())
-            .withCalculatedValues(clock, initialAccession)
-
-    val expectedViabilityTest =
-        initialViabilityTest.copy(
-            remaining = seeds(7), seedsCompromised = 1, seedsFilled = 2, seedsTested = 3)
-    val expectedWithdrawal =
-        initialWithdrawal.copy(
-            estimatedCount = 3,
-            remaining = seeds(7),
-            viabilityTest = expectedViabilityTest,
-            withdrawn = seeds(3))
-
-    assertEquals(
-        listOf(expectedViabilityTest),
-        updatedAccession.viabilityTests,
-        "Existing viability test should be updated")
-    assertEquals(
-        listOf(expectedWithdrawal),
-        updatedAccession.withdrawals,
-        "Existing withdrawal should be updated")
-    assertEquals(seeds(7), updatedAccession.remaining, "Remaining quantity")
-  }
-
-  @Test
-  fun `cut test on weight-based accession requires subset data`() {
-    val initial = accession(total = grams(10)).withCalculatedValues(clock)
-
-    assertThrows<IllegalArgumentException> {
-      initial.copy(cutTestSeedsFilled = 1).withCalculatedValues(clock, initial)
-    }
   }
 
   // SW-2026


### PR DESCRIPTION
In v1, the results of cut tests were accession-level values. In v2, cut tests are
represented as a kind of viability test that can exist alongside other tests.

Remove the accession-level fields from `AccessionModel` along with the code that
operated on them.