### PR TITLE
Add missing valdation rule for negative quantities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -259,10 +259,17 @@ data class AccessionModel(
   }
 
   private fun validateV2() {
+    assertRemainingQuantityNotNegative()
     assertRemainingQuantityNotRemoved()
     assertNoQuantityTypeChangeWithoutSubsetInfo()
     assertNoWithdrawalsWithoutQuantity(latestObservedQuantity ?: remaining)
     viabilityTests.forEach { it.validateV2() }
+  }
+
+  private fun assertRemainingQuantityNotNegative() {
+    if (remaining != null && remaining.quantity.signum() == -1) {
+      throw IllegalArgumentException("Remaining quantity may not be negative")
+    }
   }
 
   private fun assertRemainingQuantityNotRemoved() {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
@@ -50,6 +50,16 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   }
 
   @Test
+  fun `remaining quantity may not be negative`() {
+    assertThrows<IllegalArgumentException>("negative seeds") {
+      accession().copy(isManualState = true, remaining = seeds(-1))
+    }
+    assertThrows<IllegalArgumentException>("negative weight") {
+      accession().copy(isManualState = true, remaining = grams(-1))
+    }
+  }
+
+  @Test
   fun `total quantity must be greater than zero`() {
     assertThrows<IllegalArgumentException>("zero seeds") {
       accession(processingMethod = ProcessingMethod.Count, total = seeds(0))


### PR DESCRIPTION
In v1, we had a validation rule to ensure that the user-supplied total accession
quantity wasn't negative or zero.

In v2, we want to allow the user-supplied remaining quantity to be zero, but it
should never be negative. Add a validation check in the `AccessionModel`
constructor to ensure we can never have a model with a negative remaining quantity.