### PR TITLE
SW-1939 Remove v1 model validation logic

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -40,12 +40,7 @@ data class ViabilityTestModel(
     val withdrawnByName: String? = null,
     val withdrawnByUserId: UserId? = null,
 ) {
-  fun validateV1() {
-    assertNotMixingCutAndGerminationResults()
-    assertValidSeedCounts()
-  }
-
-  fun validateV2() {
+  fun validate() {
     val isLab = testType == ViabilityTestType.Lab
     val isNursery = testType == ViabilityTestType.Nursery
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -23,7 +23,7 @@ internal class ViabilityTestModelTest {
                           recordingDate = LocalDate.EPOCH, seedsGerminated = 1)),
               testType = ViabilityTestType.Cut)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -38,7 +38,7 @@ internal class ViabilityTestModelTest {
                     ViabilityTestModel(seedsEmpty = 1, testType = testType),
                     ViabilityTestModel(seedsFilled = 1, testType = testType))
                 .forEach { model ->
-                  assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+                  assertThrows<IllegalArgumentException>("$model") { model.validate() }
                 }
           }
     }
@@ -49,7 +49,7 @@ internal class ViabilityTestModelTest {
           ViabilityTestModel(
               substrate = ViabilityTestSubstrate.Moss, testType = ViabilityTestType.Lab)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class ViabilityTestModelTest {
           ViabilityTestModel(
               substrate = ViabilityTestSubstrate.Agar, testType = ViabilityTestType.Nursery)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -71,7 +71,7 @@ internal class ViabilityTestModelTest {
               seedsTested = 2,
               testType = ViabilityTestType.Cut)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -86,7 +86,7 @@ internal class ViabilityTestModelTest {
               ViabilityTestModel(seedsTested = -1, testType = ViabilityTestType.Lab),
           )
           .forEach { model ->
-            assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+            assertThrows<IllegalArgumentException>("$model") { model.validate() }
           }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.model.accession
 
-import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.ViabilityTestSubstrate
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.seedbank.grams
@@ -12,17 +11,6 @@ import org.junit.jupiter.api.assertThrows
 
 internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
-  fun `cannot withdraw more seeds than exist in the accession`() {
-    assertThrows<IllegalArgumentException> {
-      accession(
-          processingMethod = ProcessingMethod.Count,
-          total = seeds(1),
-          viabilityTests = listOf(viabilityTest(seedsTested = 1)),
-          withdrawals = listOf(withdrawal(withdrawn = seeds(1), date = tomorrow)))
-    }
-  }
-
-  @Test
   fun `cannot add withdrawal with more seeds than exist in the accession`() {
     val accession =
         accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
@@ -33,45 +21,12 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   }
 
   @Test
-  fun `cannot specify negative seeds remaining for weight-based accessions`() {
-    assertThrows<IllegalArgumentException>("Viability tests") {
-      accession(
-          processingMethod = ProcessingMethod.Weight,
-          total = grams(1),
-          viabilityTests = listOf(viabilityTest(seedsTested = 1, remaining = grams(-1))))
-    }
-
-    assertThrows<IllegalArgumentException>("withdrawals") {
-      accession(
-          processingMethod = ProcessingMethod.Weight,
-          total = grams(1),
-          withdrawals = listOf(withdrawal(withdrawn = grams(1), remaining = grams(-1))))
-    }
-  }
-
-  @Test
   fun `remaining quantity may not be negative`() {
     assertThrows<IllegalArgumentException>("negative seeds") {
       accession().copy(isManualState = true, remaining = seeds(-1))
     }
     assertThrows<IllegalArgumentException>("negative weight") {
       accession().copy(isManualState = true, remaining = grams(-1))
-    }
-  }
-
-  @Test
-  fun `total quantity must be greater than zero`() {
-    assertThrows<IllegalArgumentException>("zero seeds") {
-      accession(processingMethod = ProcessingMethod.Count, total = seeds(0))
-    }
-    assertThrows<IllegalArgumentException>("zero weight") {
-      accession(processingMethod = ProcessingMethod.Weight, total = grams(0))
-    }
-    assertThrows<IllegalArgumentException>("negative seeds") {
-      accession(processingMethod = ProcessingMethod.Count, total = seeds(-1))
-    }
-    assertThrows<IllegalArgumentException>("negative weight") {
-      accession(processingMethod = ProcessingMethod.Weight, total = grams(-1))
     }
   }
 


### PR DESCRIPTION
Since there are no more v1 accessions, there is no more need to validate them.

This change continues to check the `isManualState` flag to control whether or not
the v2 validation logic is executed. That's to support some unit tests that
haven't been converted to v2 yet and would fail the v2 validation checks. A
subsequent change will update those tests and remove the `isManualState` check.

Most of the tests of v1-only validation logic were removed in PR #728.