### PR TITLE
SW-1939 Remove viability test remaining quantity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TEST_RESULTS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
-import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.ViabilityTestResultModel
 import javax.annotation.ManagedBean
@@ -101,7 +100,6 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
           endDate = record[END_DATE],
           id = record[ID]!!,
           notes = record[NOTES],
-          remaining = SeedQuantityModel.of(record[REMAINING_QUANTITY], record[REMAINING_UNITS_ID]),
           seedsCompromised = record[SEEDS_COMPROMISED],
           seedsEmpty = record[SEEDS_EMPTY],
           seedsFilled = record[SEEDS_FILLED],
@@ -160,9 +158,6 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
               .set(ACCESSION_ID, accessionId)
               .set(END_DATE, calculatedTest.endDate)
               .set(NOTES, calculatedTest.notes)
-              .set(REMAINING_GRAMS, calculatedTest.remaining?.grams)
-              .set(REMAINING_QUANTITY, calculatedTest.remaining?.quantity)
-              .set(REMAINING_UNITS_ID, calculatedTest.remaining?.units)
               .set(SEED_TYPE_ID, calculatedTest.seedType)
               .set(SEEDS_COMPROMISED, calculatedTest.seedsCompromised)
               .set(SEEDS_EMPTY, calculatedTest.seedsEmpty)
@@ -230,9 +225,6 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
                     .update(VIABILITY_TESTS)
                     .set(END_DATE, desiredTest.endDate)
                     .set(NOTES, desiredTest.notes)
-                    .set(REMAINING_GRAMS, desiredTest.remaining?.grams)
-                    .set(REMAINING_QUANTITY, desiredTest.remaining?.quantity)
-                    .set(REMAINING_UNITS_ID, desiredTest.remaining?.units)
                     .set(SEED_TYPE_ID, desiredTest.seedType)
                     .set(SEEDS_COMPROMISED, desiredTest.seedsCompromised)
                     .set(SEEDS_EMPTY, desiredTest.seedsEmpty)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -259,10 +259,17 @@ data class AccessionModel(
   }
 
   private fun validateV2() {
+    assertRemainingQuantityNotNegative()
     assertRemainingQuantityNotRemoved()
     assertNoQuantityTypeChangeWithoutSubsetInfo()
     assertNoWithdrawalsWithoutQuantity(latestObservedQuantity ?: remaining)
     viabilityTests.forEach { it.validateV2() }
+  }
+
+  private fun assertRemainingQuantityNotNegative() {
+    if (remaining != null && remaining.quantity.signum() == -1) {
+      throw IllegalArgumentException("Remaining quantity may not be negative")
+    }
   }
 
   private fun assertRemainingQuantityNotRemoved() {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -425,19 +425,13 @@ data class AccessionModel(
               } else {
                 null
               }
-          val remaining =
-              if (!isManualState) {
-                test.remaining
-              } else {
-                null
-              }
 
           WithdrawalModel(
               createdTime = existingWithdrawal?.createdTime,
               date = test.startDate ?: existingWithdrawal?.date ?: LocalDate.now(clock),
               id = existingWithdrawal?.id,
               purpose = WithdrawalPurpose.ViabilityTesting,
-              remaining = remaining,
+              remaining = null,
               staffResponsible = test.staffResponsible,
               viabilityTest = test,
               viabilityTestId = test.id,
@@ -481,9 +475,7 @@ data class AccessionModel(
                         "Withdrawal quantity can't be more than remaining quantity")
                   }
 
-                  withdrawal.copy(
-                      remaining = currentRemaining,
-                      viabilityTest = withdrawal.viabilityTest?.copy(remaining = currentRemaining))
+                  withdrawal.copy(remaining = currentRemaining)
                 } else {
                   if (withdrawal.remaining != null) {
                     currentRemaining = withdrawal.remaining
@@ -503,10 +495,7 @@ data class AccessionModel(
                   .sortedWith { a, b -> a.compareByTime(b) }
                   .map { withdrawal ->
                     withdrawal.withdrawn?.let { withdrawn -> currentRemaining -= withdrawn }
-                    withdrawal.copy(
-                        remaining = currentRemaining,
-                        viabilityTest =
-                            withdrawal.viabilityTest?.copy(remaining = currentRemaining))
+                    withdrawal.copy(remaining = currentRemaining)
                   }
             }
             ProcessingMethod.Weight -> {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -23,7 +23,6 @@ data class ViabilityTestModel(
     val endDate: LocalDate? = null,
     val id: ViabilityTestId? = null,
     val notes: String? = null,
-    val remaining: SeedQuantityModel? = null,
     val seedsCompromised: Int? = null,
     val seedsEmpty: Int? = null,
     val seedsFilled: Int? = null,
@@ -92,7 +91,6 @@ data class ViabilityTestModel(
   fun fieldsEqual(other: ViabilityTestModel): Boolean {
     return endDate == other.endDate &&
         notes == other.notes &&
-        remaining.equalsIgnoreScale(other.remaining) &&
         seedsCompromised == other.seedsCompromised &&
         seedsEmpty == other.seedsEmpty &&
         seedsFilled == other.seedsFilled &&

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -40,12 +40,7 @@ data class ViabilityTestModel(
     val withdrawnByName: String? = null,
     val withdrawnByUserId: UserId? = null,
 ) {
-  fun validateV1() {
-    assertNotMixingCutAndGerminationResults()
-    assertValidSeedCounts()
-  }
-
-  fun validateV2() {
+  fun validate() {
     val isLab = testType == ViabilityTestType.Lab
     val isNursery = testType == ViabilityTestType.Nursery
 

--- a/src/main/resources/db/migration/V150__DropViabilityTestsRemaining.sql
+++ b/src/main/resources/db/migration/V150__DropViabilityTestsRemaining.sql
@@ -1,0 +1,3 @@
+ALTER TABLE seedbank.viability_tests DROP COLUMN remaining_grams;
+ALTER TABLE seedbank.viability_tests DROP COLUMN remaining_quantity;
+ALTER TABLE seedbank.viability_tests DROP COLUMN remaining_units_id;

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -28,7 +28,6 @@ import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestType
@@ -38,7 +37,6 @@ import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATION
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import io.mockk.every
 import io.mockk.mockk
-import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -172,8 +170,6 @@ internal class PermissionTest : DatabaseTest() {
               accessionId = AccessionId(facilityId.value),
               id = ViabilityTestId(facilityId.value),
               seedsSown = 1,
-              remainingQuantity = BigDecimal.ONE,
-              remainingUnitsId = SeedQuantityUnits.Seeds,
               testType = ViabilityTestType.Lab))
 
       insertBatch(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
@@ -16,7 +15,6 @@ import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.db.StorageLocationStore
 import io.mockk.every
 import io.mockk.mockk
-import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
@@ -62,11 +60,7 @@ internal class ValuesControllerTest : DatabaseTest(), RunsAsUser {
         AccessionCollectorsRow(org2AccessionId, 0, "o2c0"),
     )
 
-    val viabilityTestsRow =
-        ViabilityTestsRow(
-            testType = ViabilityTestType.Lab,
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds)
+    val viabilityTestsRow = ViabilityTestsRow(testType = ViabilityTestType.Lab)
     val org1Test = viabilityTestsRow.copy(accessionId = org1AccessionId, notes = "o1")
     val org2Test = viabilityTestsRow.copy(accessionId = org2AccessionId, notes = "o2")
     viabilityTestsDao.insert(org1Test, org2Test)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -342,11 +342,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   fun `accepts new viability testing withdrawals with test IDs`() {
     viabilityTestsDao.insert(
         ViabilityTestsRow(
-            id = viabilityTestId,
-            accessionId = accessionId,
-            testType = ViabilityTestType.Lab,
-            remainingQuantity = BigDecimal(10),
-            remainingUnitsId = SeedQuantityUnits.Grams))
+            id = viabilityTestId, accessionId = accessionId, testType = ViabilityTestType.Lab))
 
     val desired =
         WithdrawalModel(
@@ -386,11 +382,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   fun `does not allow modifying test IDs on existing viability testing withdrawals`() {
     viabilityTestsDao.insert(
         ViabilityTestsRow(
-            id = viabilityTestId,
-            accessionId = accessionId,
-            testType = ViabilityTestType.Lab,
-            remainingQuantity = BigDecimal(10),
-            remainingUnitsId = SeedQuantityUnits.Grams))
+            id = viabilityTestId, accessionId = accessionId, testType = ViabilityTestType.Lab))
 
     val initial =
         WithdrawalModel(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
@@ -48,8 +48,6 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
             ViabilityTestsRow(
                 accessionId = AccessionId(1),
                 id = ViabilityTestId(1),
-                remainingQuantity = BigDecimal(100),
-                remainingUnitsId = SeedQuantityUnits.Seeds,
                 seedsSown = 1,
                 startDate = startDate,
                 testType = ViabilityTestType.Lab,
@@ -99,14 +97,12 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
                 treatmentId = ViabilityTestTreatment.Scarify,
                 substrateId = ViabilityTestSubstrate.Paper,
                 notes = "notes",
-                seedsSown = 5,
-                remainingQuantity = BigDecimal(95),
-                remainingUnitsId = SeedQuantityUnits.Seeds)),
+                seedsSown = 5)),
         updatedTests)
   }
 
   @Test
-  fun `change to viability test quantity is propagated to withdrawal and accession`() {
+  fun `change to viability test quantity is propagated to withdrawal and accession when weight-based`() {
     val initial =
         create()
             .andUpdate {
@@ -127,10 +123,6 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
         grams<SeedQuantityModel>(75),
         initial.withdrawals[0].remaining,
         "Withdrawal quantities remaining before update")
-    assertEquals(
-        grams<SeedQuantityModel>(75),
-        initial.viabilityTests[0].remaining,
-        "Test remaining quantity before update")
 
     val desired =
         initial.updateViabilityTest(initial.viabilityTests[0].id!!, clock) {
@@ -146,10 +138,6 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
         grams<SeedQuantityModel>(60),
         updated.withdrawals[0].remaining,
         "Withdrawal quantities remaining after update")
-    assertEquals(
-        grams<SeedQuantityModel>(60),
-        updated.viabilityTests[0].remaining,
-        "Test remaining quantity after update")
   }
 
   @Test
@@ -363,8 +351,8 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update computes remaining quantity on viability tests for count-based accessions`() {
-    val initial =
+  fun `update computes remaining quantity for count-based accessions`() {
+    val accession =
         create()
             .andUpdate { it.copy(remaining = seeds(100)) }
             .andUpdate {
@@ -375,9 +363,6 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
             }
 
     assertEquals(
-        seeds<SeedQuantityModel>(90),
-        initial.viabilityTests[0].remaining,
-        "Quantity remaining on test")
-    assertEquals(seeds<SeedQuantityModel>(90), initial.remaining, "Quantity remaining on accession")
+        seeds<SeedQuantityModel>(90), accession.remaining, "Quantity remaining on accession")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/ViabilityTestModelTest.kt
@@ -23,7 +23,7 @@ internal class ViabilityTestModelTest {
                           recordingDate = LocalDate.EPOCH, seedsGerminated = 1)),
               testType = ViabilityTestType.Cut)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -38,7 +38,7 @@ internal class ViabilityTestModelTest {
                     ViabilityTestModel(seedsEmpty = 1, testType = testType),
                     ViabilityTestModel(seedsFilled = 1, testType = testType))
                 .forEach { model ->
-                  assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+                  assertThrows<IllegalArgumentException>("$model") { model.validate() }
                 }
           }
     }
@@ -49,7 +49,7 @@ internal class ViabilityTestModelTest {
           ViabilityTestModel(
               substrate = ViabilityTestSubstrate.Moss, testType = ViabilityTestType.Lab)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class ViabilityTestModelTest {
           ViabilityTestModel(
               substrate = ViabilityTestSubstrate.Agar, testType = ViabilityTestType.Nursery)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -71,7 +71,7 @@ internal class ViabilityTestModelTest {
               seedsTested = 2,
               testType = ViabilityTestType.Cut)
 
-      assertThrows<IllegalArgumentException> { model.validateV2() }
+      assertThrows<IllegalArgumentException> { model.validate() }
     }
 
     @Test
@@ -86,7 +86,7 @@ internal class ViabilityTestModelTest {
               ViabilityTestModel(seedsTested = -1, testType = ViabilityTestType.Lab),
           )
           .forEach { model ->
-            assertThrows<IllegalArgumentException>("$model") { model.validateV2() }
+            assertThrows<IllegalArgumentException>("$model") { model.validate() }
           }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -82,7 +82,6 @@ internal abstract class AccessionModelTest {
       startDate: LocalDate? = january(1),
       seedsTested: Int? = null,
       testResults: List<ViabilityTestResultModel>? = null,
-      remaining: SeedQuantityModel? = null,
       substrate: ViabilityTestSubstrate? = null,
       withdrawnByUserId: UserId? = null,
       seedsCompromised: Int? = null,
@@ -92,7 +91,6 @@ internal abstract class AccessionModelTest {
     return ViabilityTestModel(
         accessionId = AccessionId(1),
         id = nextViabilityTestId(),
-        remaining = remaining,
         seedsCompromised = seedsCompromised,
         seedsEmpty = seedsEmpty,
         seedsFilled = seedsFilled,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
@@ -50,6 +50,16 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   }
 
   @Test
+  fun `remaining quantity may not be negative`() {
+    assertThrows<IllegalArgumentException>("negative seeds") {
+      accession().copy(isManualState = true, remaining = seeds(-1))
+    }
+    assertThrows<IllegalArgumentException>("negative weight") {
+      accession().copy(isManualState = true, remaining = grams(-1))
+    }
+  }
+
+  @Test
   fun `total quantity must be greater than zero`() {
     assertThrows<IllegalArgumentException>("zero seeds") {
       accession(processingMethod = ProcessingMethod.Count, total = seeds(0))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.model.accession
 
-import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.ViabilityTestSubstrate
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.seedbank.grams
@@ -12,17 +11,6 @@ import org.junit.jupiter.api.assertThrows
 
 internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
-  fun `cannot withdraw more seeds than exist in the accession`() {
-    assertThrows<IllegalArgumentException> {
-      accession(
-          processingMethod = ProcessingMethod.Count,
-          total = seeds(1),
-          viabilityTests = listOf(viabilityTest(seedsTested = 1)),
-          withdrawals = listOf(withdrawal(withdrawn = seeds(1), date = tomorrow)))
-    }
-  }
-
-  @Test
   fun `cannot add withdrawal with more seeds than exist in the accession`() {
     val accession =
         accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
@@ -33,45 +21,12 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   }
 
   @Test
-  fun `cannot specify negative seeds remaining for weight-based accessions`() {
-    assertThrows<IllegalArgumentException>("Viability tests") {
-      accession(
-          processingMethod = ProcessingMethod.Weight,
-          total = grams(1),
-          viabilityTests = listOf(viabilityTest(seedsTested = 1, remaining = grams(-1))))
-    }
-
-    assertThrows<IllegalArgumentException>("withdrawals") {
-      accession(
-          processingMethod = ProcessingMethod.Weight,
-          total = grams(1),
-          withdrawals = listOf(withdrawal(withdrawn = grams(1), remaining = grams(-1))))
-    }
-  }
-
-  @Test
   fun `remaining quantity may not be negative`() {
     assertThrows<IllegalArgumentException>("negative seeds") {
       accession().copy(isManualState = true, remaining = seeds(-1))
     }
     assertThrows<IllegalArgumentException>("negative weight") {
       accession().copy(isManualState = true, remaining = grams(-1))
-    }
-  }
-
-  @Test
-  fun `total quantity must be greater than zero`() {
-    assertThrows<IllegalArgumentException>("zero seeds") {
-      accession(processingMethod = ProcessingMethod.Count, total = seeds(0))
-    }
-    assertThrows<IllegalArgumentException>("zero weight") {
-      accession(processingMethod = ProcessingMethod.Weight, total = grams(0))
-    }
-    assertThrows<IllegalArgumentException>("negative seeds") {
-      accession(processingMethod = ProcessingMethod.Count, total = seeds(-1))
-    }
-    assertThrows<IllegalArgumentException>("negative weight") {
-      accession(processingMethod = ProcessingMethod.Weight, total = grams(-1))
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
@@ -11,7 +10,6 @@ import com.terraformation.backend.search.NoConditionNode
 import com.terraformation.backend.search.SearchDirection
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
-import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -73,24 +71,9 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   @Test
   fun `can search on enum in child table`() {
     viabilityTestsDao.insert(
-        ViabilityTestsRow(
-            accessionId = AccessionId(1000),
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
-            testType = ViabilityTestType.Lab,
-        ),
-        ViabilityTestsRow(
-            accessionId = AccessionId(1000),
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
-            testType = ViabilityTestType.Nursery,
-        ),
-        ViabilityTestsRow(
-            accessionId = AccessionId(1001),
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
-            testType = ViabilityTestType.Lab,
-        ),
+        ViabilityTestsRow(accessionId = AccessionId(1000), testType = ViabilityTestType.Lab),
+        ViabilityTestsRow(accessionId = AccessionId(1000), testType = ViabilityTestType.Nursery),
+        ViabilityTestsRow(accessionId = AccessionId(1001), testType = ViabilityTestType.Lab),
     )
 
     val fields = listOf(viabilityTestsTypeField)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -17,7 +16,6 @@ import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
 import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.OrganizationIdScope
 import io.mockk.every
-import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -157,8 +155,6 @@ internal class SearchServiceFetchAllValuesTest : SearchServiceTest() {
               id = testId,
               accessionId = accessionId,
               testType = ViabilityTestType.Lab,
-              remainingQuantity = BigDecimal.ONE,
-              remainingUnitsId = SeedQuantityUnits.Grams,
               seedsSown = id))
       viabilityTestResultsDao.insert(
           ViabilityTestResultsRow(
@@ -213,15 +209,11 @@ internal class SearchServiceFetchAllValuesTest : SearchServiceTest() {
             accessionId = accessionId,
             id = viabilityTestId,
             notes = "notes",
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
             testType = ViabilityTestType.Lab),
         ViabilityTestsRow(
             accessionId = otherAccessionId,
             id = otherViabilityTestId,
             notes = "otherNotes",
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
             testType = ViabilityTestType.Nursery))
     viabilityTestResultsDao.insert(
         ViabilityTestResultsRow(
@@ -283,15 +275,11 @@ internal class SearchServiceFetchAllValuesTest : SearchServiceTest() {
             accessionId = accessionId,
             id = viabilityTestId,
             notes = "notes",
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
             testType = ViabilityTestType.Lab),
         ViabilityTestsRow(
             accessionId = otherAccessionId,
             id = otherViabilityTestId,
             notes = "otherNotes",
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
             testType = ViabilityTestType.Nursery))
     viabilityTestResultsDao.insert(
         ViabilityTestResultsRow(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
@@ -18,7 +17,6 @@ import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
-import java.math.BigDecimal
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -50,8 +48,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val viabilityTestResultsRow =
         ViabilityTestsRow(
             accessionId = AccessionId(1000),
-            remainingQuantity = BigDecimal.TEN,
-            remainingUnitsId = SeedQuantityUnits.Grams,
             seedsSown = 15,
             testType = ViabilityTestType.Lab,
             totalPercentGerminated = 100,
@@ -418,11 +414,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     viabilityTestsDao.insert(
         ViabilityTestsRow(
-            accessionId = AccessionId(1000),
-            testType = ViabilityTestType.Nursery,
-            seedsSown = 1,
-            remainingQuantity = BigDecimal.TEN,
-            remainingUnitsId = SeedQuantityUnits.Grams))
+            accessionId = AccessionId(1000), testType = ViabilityTestType.Nursery, seedsSown = 1))
 
     val result =
         searchAccessions(
@@ -842,8 +834,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val cutTestRow =
         ViabilityTestsRow(
             accessionId = AccessionId(1000),
-            remainingQuantity = BigDecimal.ONE,
-            remainingUnitsId = SeedQuantityUnits.Seeds,
             seedsCompromised = 1,
             seedsEmpty = 2,
             seedsFilled = 3,
@@ -1103,11 +1093,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val viabilityTestResultsRow =
         ViabilityTestsRow(
-            accessionId = AccessionId(1001),
-            testType = ViabilityTestType.Lab,
-            seedsSown = 50,
-            remainingQuantity = BigDecimal(30),
-            remainingUnitsId = SeedQuantityUnits.Pounds)
+            accessionId = AccessionId(1001), testType = ViabilityTestType.Lab, seedsSown = 50)
 
     viabilityTestsDao.insert(viabilityTestResultsRow)
     viabilityTestResultsDao.insert(


### PR DESCRIPTION
In v1, we required users to enter the remaining quantity when they were
creating a viability test for a weight-based accession. Since it was user input,
we had to persist it to the database.

In v2, we require subset weight/count to be specified for weight-based accessions
in order to create viability tests, so we're always able to compute the remaining
quantity.

Drop the database columns and model field that held the v1-style value.