### PR TITLE
SW-1939 Remove v1 support from AccessionModel tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
-import com.terraformation.backend.db.seedbank.ProcessingMethod
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestResultId
@@ -12,7 +11,6 @@ import com.terraformation.backend.db.seedbank.ViabilityTestSubstrate
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
-import com.terraformation.backend.seedbank.grams
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
@@ -43,29 +41,31 @@ internal abstract class AccessionModelTest {
   protected fun accession(
       viabilityTests: List<ViabilityTestModel> = emptyList(),
       dryingEndDate: LocalDate? = null,
-      subsetCount: Int? = null,
+      latestObservedQuantity: SeedQuantityModel? = null,
+      latestObservedTime: Instant? = null,
+      remaining: SeedQuantityModel? = null,
       state: AccessionState = defaultState,
       storageLocation: String? = null,
       storagePackets: Int? = null,
+      subsetCount: Int? = null,
       subsetWeight: SeedQuantityModel? = null,
-      total: SeedQuantityModel? = null,
       withdrawals: List<WithdrawalModel> = emptyList(),
-      processingMethod: ProcessingMethod? =
-          total?.let { if (it.grams != null) ProcessingMethod.Weight else ProcessingMethod.Count },
   ): AccessionModel {
     return AccessionModel(
         id = AccessionId(1L),
         accessionNumber = "dummy",
         createdTime = clock.instant(),
         dryingEndDate = dryingEndDate,
-        processingMethod = processingMethod,
+        isManualState = true,
+        latestObservedQuantity = latestObservedQuantity,
+        latestObservedTime = latestObservedTime,
+        remaining = remaining,
         source = DataSource.Web,
         state = state,
         storageLocation = storageLocation,
         storagePackets = storagePackets,
         subsetCount = subsetCount,
         subsetWeightQuantity = subsetWeight,
-        total = total,
         viabilityTests = viabilityTests,
         withdrawals = withdrawals,
     )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelValidationRulesTest.kt
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.assertThrows
 internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `cannot add withdrawal with more seeds than exist in the accession`() {
-    val accession =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val accession = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
       accession.addWithdrawal(WithdrawalModel(date = today, withdrawn = seeds(11)), tomorrowClock)
@@ -22,17 +21,13 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `remaining quantity may not be negative`() {
-    assertThrows<IllegalArgumentException>("negative seeds") {
-      accession().copy(isManualState = true, remaining = seeds(-1))
-    }
-    assertThrows<IllegalArgumentException>("negative weight") {
-      accession().copy(isManualState = true, remaining = grams(-1))
-    }
+    assertThrows<IllegalArgumentException>("negative seeds") { accession(remaining = seeds(-1)) }
+    assertThrows<IllegalArgumentException>("negative weight") { accession(remaining = grams(-1)) }
   }
 
   @Test
   fun `cannot withdraw seeds if remaining quantity is not set`() {
-    val initial = accession().copy(isManualState = true)
+    val initial = accession()
 
     assertThrows<IllegalArgumentException> {
       initial.copy(withdrawals = listOf(withdrawal(withdrawn = seeds(1))))
@@ -41,8 +36,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `cannot withdraw more seeds than most recent observed quantity`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
       initial
@@ -54,12 +48,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `cannot withdraw more weight than most recent observed seed count`() {
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                subsetCount = 2,
-                subsetWeightQuantity = grams(2),
-                remaining = seeds(10))
+        accession(subsetCount = 2, subsetWeight = grams(2), remaining = seeds(10))
             .withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
@@ -71,8 +60,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `cannot remove remaining quantity once it has been set`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(1)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(1)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> { initial.copy(remaining = null) }
   }
@@ -80,8 +68,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `cannot change remaining quantity from seeds to weight without subset info if withdrawals exist`() {
     val initial =
-        accession()
-            .copy(isManualState = true, remaining = seeds(10))
+        accession(remaining = seeds(10))
             .withCalculatedValues(clock)
             .copy(withdrawals = listOf(withdrawal(seeds(1))))
             .withCalculatedValues(clock)
@@ -92,8 +79,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `cannot change remaining quantity from weight to seeds without subset info if withdrawals exist`() {
     val initial =
-        accession()
-            .copy(isManualState = true, remaining = grams(10))
+        accession(remaining = grams(10))
             .withCalculatedValues(clock)
             .copy(withdrawals = listOf(withdrawal(grams(1))))
             .withCalculatedValues(clock)
@@ -103,16 +89,14 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `can change remaining quantity from seeds to weight without subset info if no withdrawals exist`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertDoesNotThrow { initial.copy(remaining = grams(1)) }
   }
 
   @Test
   fun `can change remaining quantity from weight to seeds without subset info if no withdrawals exist`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = grams(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = grams(10)).withCalculatedValues(clock)
 
     assertDoesNotThrow { initial.copy(remaining = seeds(1)) }
   }
@@ -120,12 +104,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `can change remaining quantity from seeds to weight if subset info exists`() {
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                subsetCount = 1,
-                subsetWeightQuantity = grams(1),
-                remaining = seeds(10))
+        accession(subsetCount = 1, subsetWeight = grams(1), remaining = seeds(10))
             .withCalculatedValues(clock)
             .copy(withdrawals = listOf(withdrawal(seeds(1))))
             .withCalculatedValues(clock)
@@ -136,12 +115,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `can change remaining quantity from weight to seeds if subset info exists`() {
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                subsetCount = 1,
-                subsetWeightQuantity = grams(1),
-                remaining = grams(10))
+        accession(subsetCount = 1, subsetWeight = grams(1), remaining = grams(10))
             .withCalculatedValues(clock)
             .copy(withdrawals = listOf(withdrawal(grams(1))))
             .withCalculatedValues(clock)
@@ -151,8 +125,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `cannot create viability test on weight-based accession without subset data`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = grams(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = grams(10)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
       initial.addViabilityTest(viabilityTest(seedsTested = 1, startDate = null), tomorrowClock)
@@ -161,8 +134,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `cannot add viability test with more seeds sown than remaining quantity`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
       initial.addViabilityTest(viabilityTest(seedsTested = 11, startDate = null), tomorrowClock)
@@ -171,8 +143,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `can add viability test with more seeds sown than remaining quantity if it is older than the latest observed quantity`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertDoesNotThrow {
       initial.addViabilityTest(
@@ -183,12 +154,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `can add viability test with fewer seeds sown than estimated seed count by weight`() {
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                subsetCount = 2,
-                subsetWeightQuantity = grams(2),
-                remaining = grams(10))
+        accession(subsetCount = 2, subsetWeight = grams(2), remaining = grams(10))
             .withCalculatedValues(clock)
 
     assertDoesNotThrow { initial.addViabilityTest(viabilityTest(seedsTested = 9), tomorrowClock) }
@@ -197,12 +163,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
   @Test
   fun `cannot add new viability test with more seeds sown than estimated seed count by weight`() {
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                subsetCount = 2,
-                subsetWeightQuantity = grams(2),
-                remaining = grams(10))
+        accession(subsetCount = 2, subsetWeight = grams(2), remaining = grams(10))
             .withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
@@ -212,8 +173,7 @@ internal class AccessionModelValidationRulesTest : AccessionModelTest() {
 
   @Test
   fun `cannot add new viability test with substrate that is not valid for test type`() {
-    val initial =
-        accession().copy(isManualState = true, remaining = seeds(10)).withCalculatedValues(clock)
+    val initial = accession(remaining = seeds(10)).withCalculatedValues(clock)
 
     assertThrows<IllegalArgumentException> {
       initial.addViabilityTest(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelViabilityTest.kt
@@ -23,8 +23,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   @Test
   fun `viability percent is not auto-populated on v2 accessions when test results are added`() {
     val model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(50))
+        accession(remaining = seeds(50))
             .withCalculatedValues(clock)
             .addViabilityTest(
                 viabilityTest(
@@ -41,8 +40,8 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   fun `viability percent is not cleared on v2 accessions without tests`() {
     val percent = 77
     val model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(50), totalViabilityPercent = percent)
+        accession(remaining = seeds(50))
+            .copy(totalViabilityPercent = percent)
             .withCalculatedValues(clock)
 
     assertEquals(percent, model.totalViabilityPercent)
@@ -52,8 +51,8 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   fun `viability percent is not overwritten on v2 accessions when test results are added`() {
     val percent = 16
     val model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(50), totalViabilityPercent = percent)
+        accession(remaining = seeds(50))
+            .copy(totalViabilityPercent = percent)
             .withCalculatedValues(clock)
             .addViabilityTest(
                 viabilityTest(
@@ -70,8 +69,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   fun `viability test withdrawnByUserId is propagated to new withdrawals`() {
     val withdrawnByUserId = UserId(1234)
     val model =
-        accession()
-            .copy(isManualState = true, remaining = seeds(10))
+        accession(remaining = seeds(10))
             .withCalculatedValues(clock)
             .addViabilityTest(
                 viabilityTest(seedsTested = 1, withdrawnByUserId = withdrawnByUserId), clock)
@@ -88,9 +86,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
     val viabilityTestId = viabilityTest.id!!
 
     val model =
-        accession()
-            .copy(
-                isManualState = true,
+        accession(
                 remaining = seeds(10),
                 viabilityTests = listOf(viabilityTest),
                 withdrawals =
@@ -114,9 +110,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
     val viabilityTestId = viabilityTest.id!!
 
     val model =
-        accession()
-            .copy(
-                isManualState = true,
+        accession(
                 remaining = seeds(10),
                 viabilityTests = listOf(viabilityTest),
                 withdrawals =
@@ -134,8 +128,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   fun `change to seeds tested causes withdrawal and accession remaining seeds to update`() {
     val initialTest = viabilityTest(seedsTested = 1, startDate = null)
     val initial =
-        accession()
-            .copy(isManualState = true, remaining = seeds(100))
+        accession(remaining = seeds(100))
             .withCalculatedValues(clock)
             .addViabilityTest(initialTest, clock)
 
@@ -151,12 +144,7 @@ internal class AccessionModelViabilityTest : AccessionModelTest() {
   fun `change to seeds tested causes withdrawal and accession remaining weights to update`() {
     val initialTest = viabilityTest(seedsTested = 2, startDate = null)
     val initial =
-        accession()
-            .copy(
-                isManualState = true,
-                remaining = grams(100),
-                subsetCount = 2,
-                subsetWeightQuantity = grams(1))
+        accession(remaining = grams(100), subsetCount = 2, subsetWeight = grams(1))
             .withCalculatedValues(yesterdayClock)
             .addViabilityTest(initialTest, clock)
 


### PR DESCRIPTION
Most of the tests for `AccessionModel` use a helper method to construct a model
object. Previously, the method returned a v1 model and the tests had to explicitly
copy it to convert it to v2. Update the helper to return a v2 model, and remove
a few test methods that aren't meaningful with v2 models.