### PR TITLE
SW-1939 Remove v1-only accession states from API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -767,7 +767,7 @@ class AccessionStore(
       dslContext
           .select(ID, NUMBER)
           .from(ACCESSIONS)
-          .where(STATE_ID.`in`(AccessionState.Drying, AccessionState.Dried))
+          .where(STATE_ID.eq(AccessionState.Drying))
           .and(DRYING_END_DATE.le(LocalDate.ofInstant(until.toInstant(), clock.zone)))
           .and(DRYING_END_DATE.gt(LocalDate.ofInstant(after.toInstant(), clock.zone)))
           .fetch { it[NUMBER]!! to it[ID]!! }
@@ -793,7 +793,9 @@ class AccessionStore(
 
     // The query results won't include states with no accessions, but we want to return the full
     // list with counts of 0.
-    return AccessionState.activeValues.associateWith { totals[it] ?: 0 }
+    return AccessionState.activeValues
+        .filter { it.isV2Compatible }
+        .associateWith { totals[it] ?: 0 }
   }
 
   fun getSummaryStatistics(facilityId: FacilityId): AccessionSummaryStatistics {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionQuantityHistoryRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
+import com.terraformation.backend.seedbank.api.AccessionStateV2
 import com.terraformation.backend.seedbank.api.CreateAccessionRequestPayloadV2
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.Geolocation
@@ -207,7 +208,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             receivedDate = today,
             source = DataSource.FileImport,
             speciesId = SpeciesId(1),
-            state = AccessionState.AwaitingProcessing,
+            state = AccessionStateV2.AwaitingProcessing,
             storageLocation = "Location 1",
         )
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.CollectionSource
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
@@ -15,6 +14,7 @@ import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.seedbank.tables.records.AccessionStateHistoryRecord
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
+import com.terraformation.backend.seedbank.api.AccessionStateV2
 import com.terraformation.backend.seedbank.api.CreateViabilityTestRequestPayload
 import com.terraformation.backend.seedbank.api.CreateWithdrawalRequestPayload
 import com.terraformation.backend.seedbank.api.UpdateAccessionRequestPayloadV2
@@ -98,7 +98,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             receivedDate = today,
             remainingQuantity = kilograms(15),
             speciesId = SpeciesId(1),
-            state = AccessionState.Drying,
+            state = AccessionStateV2.Drying,
             storageLocation = storageLocationName,
             subsetCount = 5,
             subsetWeight = grams(9),
@@ -171,7 +171,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             receivedDate = today,
             remainingQuantity = seeds(100),
             speciesId = SpeciesId(1),
-            state = AccessionState.InStorage,
+            state = AccessionStateV2.InStorage,
             storageLocation = storageLocationName,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -29,26 +29,19 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
             facilityId to
                 mapOf(
                     AccessionState.AwaitingProcessing to 2,
-                    AccessionState.Dried to 1,
                     AccessionState.Drying to 2,
                     AccessionState.InStorage to 3,
-                    AccessionState.Nursery to 1,
-                    AccessionState.Pending to 4,
-                    AccessionState.Processed to 1,
                     AccessionState.UsedUp to 2,
-                    AccessionState.Withdrawn to 1,
                 ),
             otherOrgFacilityId to
                 mapOf(
                     AccessionState.InStorage to 1,
-                    AccessionState.Withdrawn to 1,
+                    AccessionState.UsedUp to 1,
                 ),
             sameOrgFacilityId to
                 mapOf(
-                    AccessionState.Dried to 1,
-                    AccessionState.Processed to 2,
                     AccessionState.Processing to 2,
-                    AccessionState.Withdrawn to 1,
+                    AccessionState.UsedUp to 1,
                 ),
         )
 
@@ -62,11 +55,8 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
         mapOf(
             AccessionState.AwaitingCheckIn to 0,
             AccessionState.AwaitingProcessing to 2,
-            AccessionState.Dried to 1,
             AccessionState.Drying to 2,
             AccessionState.InStorage to 3,
-            AccessionState.Pending to 4,
-            AccessionState.Processed to 1,
             AccessionState.Processing to 0,
         ),
         store.countByState(facilityId),
@@ -76,11 +66,8 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
         mapOf(
             AccessionState.AwaitingCheckIn to 0,
             AccessionState.AwaitingProcessing to 2,
-            AccessionState.Dried to 2,
             AccessionState.Drying to 2,
             AccessionState.InStorage to 3,
-            AccessionState.Pending to 4,
-            AccessionState.Processed to 3,
             AccessionState.Processing to 2,
         ),
         store.countByState(organizationId),
@@ -110,7 +97,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
                 processingMethodId = ProcessingMethod.Count,
                 remainingQuantity = BigDecimal(2),
                 remainingUnitsId = SeedQuantityUnits.Seeds,
-                stateId = AccessionState.Processed,
+                stateId = AccessionState.Drying,
             ),
             // Wrong facility
             AccessionsRow(
@@ -134,7 +121,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
                 processingMethodId = ProcessingMethod.Count,
                 remainingQuantity = BigDecimal(16),
                 remainingUnitsId = SeedQuantityUnits.Seeds,
-                stateId = AccessionState.Withdrawn,
+                stateId = AccessionState.UsedUp,
             ),
             // Weight-based accession
             AccessionsRow(
@@ -197,7 +184,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
                 remainingGrams = BigDecimal(2000),
                 remainingQuantity = BigDecimal(2),
                 remainingUnitsId = SeedQuantityUnits.Kilograms,
-                stateId = AccessionState.Processed,
+                stateId = AccessionState.Drying,
                 subsetCount = 1,
                 subsetWeightGrams = BigDecimal(1000),
             ),
@@ -227,10 +214,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
             AccessionsRow(
                 facilityId = facilityId,
                 processingMethodId = ProcessingMethod.Weight,
-                remainingGrams = BigDecimal(16),
-                remainingQuantity = BigDecimal(16),
+                remainingGrams = BigDecimal.ZERO,
+                remainingQuantity = BigDecimal.ZERO,
                 remainingUnitsId = SeedQuantityUnits.Grams,
-                stateId = AccessionState.Withdrawn,
+                stateId = AccessionState.UsedUp,
                 subsetCount = 10,
                 subsetWeightGrams = BigDecimal(10),
             ),
@@ -321,7 +308,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
                 remainingGrams = BigDecimal(1),
                 remainingQuantity = BigDecimal(1),
                 remainingUnitsId = SeedQuantityUnits.Grams,
-                stateId = AccessionState.Processed,
+                stateId = AccessionState.Drying,
                 subsetCount = 10,
             ),
             // Subset weight/count present
@@ -406,31 +393,31 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
             // No species ID
             AccessionsRow(
                 facilityId = facilityId,
-                stateId = AccessionState.Pending,
+                stateId = AccessionState.AwaitingProcessing,
             ),
             // Species in org
             AccessionsRow(
                 facilityId = facilityId,
                 speciesId = speciesId,
-                stateId = AccessionState.Pending,
+                stateId = AccessionState.AwaitingProcessing,
             ),
             // Second accession with same species at different facility
             AccessionsRow(
                 facilityId = sameOrgFacilityId,
                 speciesId = speciesId,
-                stateId = AccessionState.Pending,
+                stateId = AccessionState.AwaitingProcessing,
             ),
             // Second species at different facility
             AccessionsRow(
                 facilityId = sameOrgFacilityId,
                 speciesId = sameOrgSpeciesId,
-                stateId = AccessionState.Pending,
+                stateId = AccessionState.AwaitingProcessing,
             ),
             // Third species, but it is in a different organization
             AccessionsRow(
                 facilityId = otherOrgFacilityId,
                 speciesId = otherOrgSpeciesId,
-                stateId = AccessionState.Pending,
+                stateId = AccessionState.AwaitingProcessing,
             ),
         )
         .forEach { insertAccession(it) }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
@@ -21,7 +21,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
   @Test
   fun `can search for exact ages`() {
     listOf(1100L, 1101L, 1102L).forEach { id ->
-      insertAccession(id = id, stateId = AccessionState.Processed)
+      insertAccession(id = id, stateId = AccessionState.Drying)
     }
 
     setCollectedDates(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -119,7 +119,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `can filter on computed fields whose raw values are being queried`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.Withdrawn))
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.UsedUp))
 
     val fields = listOf(accessionNumberField, stateField)
     val searchNode = FieldNode(activeField, listOf("Inactive"))
@@ -128,7 +128,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Withdrawn")),
+            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Used Up")),
             cursor = null)
 
     assertEquals(expected, result)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
@@ -50,9 +49,6 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
 
   @Test
   fun `uses enum display name when it differs from Kotlin name`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(stateId = AccessionState.InStorage))
-
     val searchNode = FieldNode(stateField, listOf("In Storage"))
     val fields = listOf(stateField)
 
@@ -61,7 +57,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "state" to "In Storage"),
+                mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "In Storage"),
             ),
             cursor = null)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -62,7 +62,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
             rootPrefix,
             stateField,
             FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy))
-    assertEquals(listOf("Processed", "Processing"), values)
+    assertEquals(listOf("In Storage", "Processing"), values)
   }
 
   @Test
@@ -83,7 +83,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   @Test
   fun `can filter on computed column value`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.Withdrawn))
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.UsedUp))
     val values =
         searchService.fetchValues(
             rootPrefix, activeField, FieldNode(activeField, listOf("Inactive")))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -789,7 +789,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                 "accessions" to
                                     listOf(
                                         mapOf("active" to "Active", "state" to "Processing"),
-                                        mapOf("active" to "Active", "state" to "Processed"),
+                                        mapOf("active" to "Active", "state" to "In Storage"),
                                     ))))),
             cursor = null)
 
@@ -882,7 +882,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "siteLocation" to "siteName",
                     "source" to "Seed Collector App",
                     "speciesName" to "Kousa Dogwood",
-                    "state" to "Processed",
+                    "state" to "In Storage",
                     "treesCollectedFrom" to "1",
                     "viabilityTests" to
                         listOf(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -133,7 +133,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
     insertAccession(
         AccessionsRow(
             number = "XYZ",
-            stateId = AccessionState.Processed,
+            stateId = AccessionState.InStorage,
             collectedDate = LocalDate.of(2019, 3, 2),
             collectionSiteCity = "city",
             collectionSiteCountryCode = "UG",


### PR DESCRIPTION
Stop treating v1-only accession states as valid values in the accessions API.

We can't delete the v1-only states from the `accession_states` table because
they are referenced in `accession_state_history` and those historical records
are still valid. But we no longer want them to be available as possible values
for the current state of an accession.