### PR TITLE
SW-1885 Add readyByDate to nursery withdrawals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -32,7 +32,7 @@ class WithdrawalsController(
   fun createBatchWithdrawal(
       @RequestBody payload: CreateNurseryWithdrawalRequestPayload
   ): CreateNurseryWithdrawalResponsePayload {
-    val model = batchStore.withdraw(payload.toModel())
+    val model = batchStore.withdraw(payload.toModel(), payload.readyByDate)
     val batchModels = model.batchWithdrawals.map { batchStore.fetchOneById(it.batchId) }
 
     return CreateNurseryWithdrawalResponsePayload(
@@ -104,6 +104,11 @@ data class CreateNurseryWithdrawalRequestPayload(
     val facilityId: FacilityId,
     val notes: String? = null,
     val purpose: WithdrawalPurpose,
+    @Schema(
+        description =
+            "If purpose is \"Nursery Transfer\", the estimated ready-by date to use for the " +
+                "batches that are created at the other nursery.")
+    val readyByDate: LocalDate? = null,
     val withdrawnDate: LocalDate,
 ) {
   fun toModel() =

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -385,6 +385,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
 
     insertFacility(destinationFacilityId, type = FacilityType.Nursery)
 
+    val newReadyByDate = LocalDate.of(2000, 1, 2)
     val withdrawalTime = clock.instant().plusSeconds(1000)
     every { clock.instant() } returns withdrawalTime
 
@@ -413,7 +414,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                             batchId = species2Batch1Id,
                             germinatingQuantityWithdrawn = 10,
                             notReadyQuantityWithdrawn = 11,
-                            readyQuantityWithdrawn = 12))))
+                            readyQuantityWithdrawn = 12))),
+            newReadyByDate)
 
     // The order the new batches get created is undefined, so either new batch ID/number could
     // be for either species. Need to load them to figure out which is which.
@@ -465,6 +467,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                   modifiedBy = user.userId,
                   modifiedTime = withdrawalTime,
                   organizationId = organizationId,
+                  readyByDate = newReadyByDate,
                   version = 1)
 
           assertEquals(


### PR DESCRIPTION
When doing a nursery transfer, the user needs to be able to set the estimated
ready-by date on the newly-created batches, but there wasn't a way to pass it in.