### PR TITLE
SW-1842 Only do fuzzy matching if there are no exact matches

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -45,18 +45,29 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
   }
 
   @Test
-  fun `fuzzy search on text fields tries exact matching first`() {
+  fun `fuzzy search on text fields limits results to exact matches if any exist`() {
     accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "22-1-100"))
     accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "22-1-101"))
 
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(accessionNumberField, listOf("22-1-100"), SearchFilterType.Fuzzy)
 
-    val result = searchAccessions(facilityId, fields, searchNode)
+    assertEquals(
+        SearchResults(
+            listOf(mapOf("id" to "1000", "accessionNumber" to "22-1-100")), cursor = null),
+        searchAccessions(facilityId, fields, searchNode),
+        "Search for value with an exact match")
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1000", "accessionNumber" to "22-1-100")), cursor = null)
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "22-1-102"))
 
-    assertEquals(expected, result)
+    assertEquals(
+        SearchResults(
+            listOf(
+                mapOf("id" to "1001", "accessionNumber" to "22-1-101"),
+                mapOf("id" to "1000", "accessionNumber" to "22-1-102"),
+            ),
+            null),
+        searchAccessions(facilityId, fields, searchNode),
+        "Search for value without an exact match")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -43,4 +43,20 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
 
     assertEquals(expected, result)
   }
+
+  @Test
+  fun `fuzzy search on text fields tries exact matching first`() {
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "22-1-100"))
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "22-1-101"))
+
+    val fields = listOf(accessionNumberField)
+    val searchNode = FieldNode(accessionNumberField, listOf("22-1-100"), SearchFilterType.Fuzzy)
+
+    val result = searchAccessions(facilityId, fields, searchNode)
+
+    val expected =
+        SearchResults(listOf(mapOf("id" to "1000", "accessionNumber" to "22-1-100")), cursor = null)
+
+    assertEquals(expected, result)
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -75,14 +75,13 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
         accessionsDao.fetchOneById(AccessionId(1000))!!.copy(storageNotes = "not it"))
 
     val fields = listOf(accessionNumberField)
-    val searchNode = FieldNode(storageNotesField, listOf("matching", null), SearchFilterType.Fuzzy)
+    val searchNode = FieldNode(storageNotesField, listOf(null), SearchFilterType.Fuzzy)
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 mapOf("id" to "1", "accessionNumber" to "MISSING"),
             ),
             cursor = null)


### PR DESCRIPTION
We want users to be able to type nonexistent accession numbers into the accession
list UI and get back close matches. But we also want users to be able to paste
exact accession numbers into the same search field and not have the results
cluttered with accessions they didn't search for.

Try to thread this needle by making the fuzzy search code start off by trying an
exact search. If that finds matches, then we're probably in the "user entered an
exact value" situation; return those results. Otherwise do the fuzzy search and
return approximate matches.

This change means there is no way for a user to do a fuzzy search for a value that
also happens to be an exact match; we believe that will still be an improvement
over the current behavior.