### PR TITLE
SW-1842 Exact-then-fuzzy logic for search summaries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
@@ -4,20 +4,16 @@ import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.search.SearchFieldPrefix
-import com.terraformation.backend.search.SearchNode
-import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.api.HasSearchNode
 import com.terraformation.backend.search.api.SearchNodePayload
 import com.terraformation.backend.search.table.SearchTables
+import com.terraformation.backend.seedbank.AccessionService
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
-import org.jooq.Record1
-import org.jooq.Select
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -29,12 +25,11 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/seedbank/summary")
 @SeedBankAppEndpoint
 class SummaryController(
+    private val accessionService: AccessionService,
     private val accessionStore: AccessionStore,
-    private val searchService: SearchService,
     tables: SearchTables,
 ) {
   private val accessionsPrefix = SearchFieldPrefix(tables.accessions)
-  private val accessionIdField = accessionsPrefix.resolve("id")
 
   @GetMapping
   @Operation(
@@ -59,38 +54,14 @@ class SummaryController(
 
   @Operation(
       summary =
-          "Get summary statistics about the accessions that match a specified set of " +
-              "search criteria.")
+          "Get summary statistics about accessions that match a specified set of search criteria.")
   @PostMapping
   fun summarizeAccessionSearch(
       @RequestBody payload: SummarizeAccessionSearchRequestPayload
   ): SummarizeAccessionSearchResponsePayload {
-    val originalCriteria = payload.toSearchNode(accessionsPrefix)
+    val stats = accessionService.getSearchSummaryStatistics(payload.toSearchNode(accessionsPrefix))
 
-    // If there are fuzzy search criteria, first see if we get results by treating them as exact
-    // matches. This mirrors the behavior of SearchService.search(), such that the summary data
-    // will be consistent with the search results.
-    val exactCriteria = originalCriteria.toExactSearch()
-    val exactSummary = querySummary(exactCriteria)
-
-    val summary =
-        if (exactSummary.isNonZero() || exactCriteria == originalCriteria) {
-          exactSummary
-        } else {
-          querySummary(originalCriteria)
-        }
-
-    return SummarizeAccessionSearchResponsePayload(summary)
-  }
-
-  private fun querySummary(criteria: SearchNode): AccessionSummaryStatistics {
-    @Suppress("UNCHECKED_CAST")
-    val query =
-        searchService
-            .buildQuery(accessionsPrefix, listOf(accessionIdField), criteria)
-            .toSelectQuery() as Select<Record1<AccessionId?>>
-
-    return accessionStore.getSummaryStatistics(query)
+    return SummarizeAccessionSearchResponsePayload(stats)
   }
 
   private fun getSummary(facilityId: FacilityId): SummaryResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
@@ -24,4 +24,14 @@ data class AccessionSummaryStatistics(
       totalSeedsRemaining = subtotalBySeedCount.toLong() + subtotalByWeightEstimate.toLong(),
       unknownQuantityAccessions = unknownQuantityAccessions.toInt(),
   )
+
+  /** Returns true if any of the fields have nonzero values. */
+  fun isNonZero(): Boolean {
+    return accessions != 0 ||
+        species != 0 ||
+        subtotalBySeedCount != 0L ||
+        subtotalByWeightEstimate != 0L ||
+        totalSeedsRemaining != 0L ||
+        unknownQuantityAccessions != 0
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
+import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.PhotoRepository
 import com.terraformation.backend.seedbank.model.AccessionModel
@@ -58,7 +59,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
         parentStore,
         photoRepository,
         mockk(),
-        mockk(),
+        SearchTables(clock),
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -50,7 +50,16 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
   private val photoRepository: PhotoRepository = mockk()
 
   private val service: AccessionService by lazy {
-    AccessionService(accessionStore, batchStore, clock, dslContext, parentStore, photoRepository)
+    AccessionService(
+        accessionStore,
+        batchStore,
+        clock,
+        dslContext,
+        parentStore,
+        photoRepository,
+        mockk(),
+        mockk(),
+    )
   }
 
   private val accessionId = AccessionId(1)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -1,0 +1,112 @@
+package com.terraformation.backend.seedbank.search
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.Role
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.db.seedbank.SeedQuantityUnits
+import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchFieldPrefix
+import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchService
+import com.terraformation.backend.search.table.SearchTables
+import com.terraformation.backend.seedbank.AccessionService
+import com.terraformation.backend.seedbank.db.AccessionStore
+import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.Clock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val accessionStore: AccessionStore by lazy {
+    AccessionStore(dslContext, mockk(), mockk(), mockk(), mockk(), mockk(), clock, mockk(), mockk())
+  }
+  private val clock: Clock = mockk()
+  private val searchService: SearchService by lazy { SearchService(dslContext) }
+  private val searchTables: SearchTables by lazy { SearchTables(clock) }
+
+  private val service: AccessionService by lazy {
+    AccessionService(
+        accessionStore,
+        mockk(),
+        clock,
+        dslContext,
+        mockk(),
+        mockk(),
+        searchService,
+        searchTables,
+    )
+  }
+
+  @BeforeEach
+  fun setUp() {
+    insertSiteData()
+    insertOrganizationUser()
+
+    every { user.facilityRoles } returns mapOf(facilityId to Role.CONTRIBUTOR)
+  }
+
+  @Test
+  fun `returns exact-match statistics for fuzzy searches if there are exact matches`() {
+    val speciesId1 = insertSpecies(1)
+    val speciesId2 = insertSpecies(2)
+    insertAccession(
+        AccessionsRow(
+            id = AccessionId(1),
+            number = "22-1-001",
+            remainingQuantity = BigDecimal.TEN,
+            remainingUnitsId = SeedQuantityUnits.Seeds,
+            speciesId = speciesId1))
+    insertAccession(
+        AccessionsRow(
+            id = AccessionId(2),
+            number = "22-1-002",
+            remainingQuantity = BigDecimal.ONE,
+            remainingUnitsId = SeedQuantityUnits.Kilograms,
+            speciesId = speciesId2))
+
+    val accessionNumberField =
+        SearchFieldPrefix(root = searchTables.accessions).resolve("accessionNumber")
+    val criteriaWithExactMatch =
+        FieldNode(accessionNumberField, listOf("22-1-001"), SearchFilterType.Fuzzy)
+    val criteriaWithoutExactMatch =
+        FieldNode(accessionNumberField, listOf("22-1-000"), SearchFilterType.Fuzzy)
+
+    assertAll(
+        {
+          assertEquals(
+              AccessionSummaryStatistics(
+                  accessions = 1,
+                  species = 1,
+                  subtotalBySeedCount = 10L,
+                  subtotalByWeightEstimate = 0L,
+                  totalSeedsRemaining = 10L,
+                  unknownQuantityAccessions = 0),
+              service.getSearchSummaryStatistics(criteriaWithExactMatch),
+              "Statistics for fuzzy search that has an exact match")
+        },
+        {
+          assertEquals(
+              AccessionSummaryStatistics(
+                  accessions = 2,
+                  species = 2,
+                  subtotalBySeedCount = 10L,
+                  subtotalByWeightEstimate = 0L,
+                  totalSeedsRemaining = 10L,
+                  unknownQuantityAccessions = 1),
+              service.getSearchSummaryStatistics(criteriaWithoutExactMatch),
+              "Statistics for fuzzy search that does not have an exact match")
+        },
+    )
+  }
+}


### PR DESCRIPTION
Commit ee97dd57 updated the search code so that if you do a fuzzy search, it first
looks for exact matches and returns those if there are any. This had the desired
effect of letting people type exact accession numbers into the accession search
UI, but the summary statistics were still based on the fuzzy matches.

Update the summary endpoint so it uses the same "try an exact search first, and
fall back to fuzzy if that doesn't return results" logic so the summary stats will
match the detailed search results.