### PR TITLE
SW-1951 Fix CSV upload job scheduling

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.species.db.SpeciesStore
 import java.io.InputStream
 import java.time.LocalDate
 import javax.annotation.ManagedBean
+import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.annotation.Lazy
@@ -36,7 +37,7 @@ class BatchImporter(
     fileStore: FileStore,
     private val messages: Messages,
     private val parentStore: ParentStore,
-    @Lazy scheduler: JobScheduler,
+    @Lazy private val scheduler: JobScheduler,
     private val speciesStore: SpeciesStore,
     uploadProblemsDao: UploadProblemsDao,
     uploadsDao: UploadsDao,
@@ -47,7 +48,6 @@ class BatchImporter(
     CsvImporter(
         dslContext,
         fileStore,
-        scheduler,
         uploadProblemsDao,
         uploadsDao,
         uploadService,
@@ -123,4 +123,10 @@ class BatchImporter(
             speciesId = speciesId,
         ))
   }
+
+  override fun enqueueValidateCsv(uploadId: UploadId): JobId =
+      scheduler.enqueue<BatchImporter> { validateCsv(uploadId) }
+
+  override fun enqueueImportCsv(uploadId: UploadId, overwriteExisting: Boolean): JobId =
+      scheduler.enqueue<BatchImporter> { importCsv(uploadId, overwriteExisting) }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -29,6 +29,7 @@ import java.io.InputStream
 import java.math.BigDecimal
 import java.time.LocalDate
 import javax.annotation.ManagedBean
+import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.annotation.Lazy
@@ -41,7 +42,7 @@ class AccessionImporter(
     fileStore: FileStore,
     private val messages: Messages,
     private val parentStore: ParentStore,
-    @Lazy scheduler: JobScheduler,
+    @Lazy private val scheduler: JobScheduler,
     private val speciesStore: SpeciesStore,
     uploadProblemsDao: UploadProblemsDao,
     uploadsDao: UploadsDao,
@@ -52,7 +53,6 @@ class AccessionImporter(
     CsvImporter(
         dslContext,
         fileStore,
-        scheduler,
         uploadProblemsDao,
         uploadsDao,
         uploadService,
@@ -215,4 +215,10 @@ class AccessionImporter(
           ))
     }
   }
+
+  override fun enqueueValidateCsv(uploadId: UploadId): JobId =
+      scheduler.enqueue<AccessionImporter> { validateCsv(uploadId) }
+
+  override fun enqueueImportCsv(uploadId: UploadId, overwriteExisting: Boolean): JobId =
+      scheduler.enqueue<AccessionImporter> { importCsv(uploadId, overwriteExisting) }
 }


### PR DESCRIPTION
Commit 508c1f9f refactored the CSV upload code to extract common logic into a
superclass. Unfortunately, the refactor caused JobRunr to be unable to detect
which importer was enqueuing the asynchronous jobs to validate and import the
files.

Fix it by enqueuing the jobs explicitly from each subclass.