### PR TITLE
Add permissions for planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -33,6 +33,8 @@ import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -80,6 +82,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.ORGANIZATION_ID)
+
+  fun getOrganizationId(plantingSiteId: PlantingSiteId): OrganizationId? =
+      fetchFieldById(plantingSiteId, PLANTING_SITES.ID, PLANTING_SITES.ORGANIZATION_ID)
 
   fun getOrganizationId(speciesId: SpeciesId): OrganizationId? =
       fetchFieldById(speciesId, SPECIES.ID, SPECIES.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -115,6 +116,7 @@ data class DeviceManagerUser(
   override fun canCreateBatch(facilityId: FacilityId): Boolean = false
   override fun canCreateDeviceManager(): Boolean = false
   override fun canCreateFacility(organizationId: OrganizationId): Boolean = false
+  override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = false
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
@@ -132,6 +134,7 @@ data class DeviceManagerUser(
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
+  override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
@@ -152,6 +155,7 @@ data class DeviceManagerUser(
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = false
+  override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = false
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canUpdateUpload(uploadId: UploadId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -178,6 +179,14 @@ data class IndividualUser(
         (organizationId in organizationRoles)
   }
 
+  override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean {
+    return when (organizationRoles[organizationId]) {
+      Role.OWNER,
+      Role.ADMIN -> true
+      else -> false
+    }
+  }
+
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean {
     return when (organizationRoles[organizationId]) {
       Role.OWNER,
@@ -306,6 +315,11 @@ data class IndividualUser(
     }
   }
 
+  override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean {
+    val organizationId = parentStore.getOrganizationId(plantingSiteId) ?: return false
+    return organizationId in organizationRoles
+  }
+
   override fun canReadSpecies(speciesId: SpeciesId): Boolean {
     // If this logic changes, make sure to also change code that bakes this rule into SQL queries
     // for efficiency. Example: SpeciesStore.fetchUncheckedSpeciesIds
@@ -430,6 +444,15 @@ data class IndividualUser(
       canListNotifications(organizationId)
 
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean {
+    return when (organizationRoles[organizationId]) {
+      Role.OWNER,
+      Role.ADMIN -> true
+      else -> false
+    }
+  }
+
+  override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean {
+    val organizationId = parentStore.getOrganizationId(plantingSiteId) ?: return false
     return when (organizationRoles[organizationId]) {
       Role.OWNER,
       Role.ADMIN -> true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -27,7 +27,9 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -156,6 +158,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     readOrganization(organizationId)
     if (!user.canCreateNotification(userId, organizationId)) {
       throw AccessDeniedException("No permission to create notification")
+    }
+  }
+
+  fun createPlantingSite(organizationId: OrganizationId) {
+    if (!user.canCreatePlantingSite(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to create planting sites in organization $organizationId")
     }
   }
 
@@ -320,6 +330,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readPlantingSite(plantingSiteId: PlantingSiteId) {
+    if (!user.canReadPlantingSite(plantingSiteId)) {
+      throw PlantingSiteNotFoundException(plantingSiteId)
+    }
+  }
+
   fun readSpecies(speciesId: SpeciesId) {
     if (!user.canReadSpecies(speciesId)) {
       throw SpeciesNotFoundException(speciesId)
@@ -473,6 +489,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateOrganization(organizationId)) {
       readOrganization(organizationId)
       throw AccessDeniedException("No permission to update organization $organizationId")
+    }
+  }
+
+  fun updatePlantingSite(plantingSiteId: PlantingSiteId) {
+    if (!user.canUpdatePlantingSite(plantingSiteId)) {
+      readPlantingSite(plantingSiteId)
+      throw AccessDeniedException("No permission to update planting site $plantingSiteId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import javax.annotation.ManagedBean
 import org.springframework.context.annotation.Lazy
 
@@ -109,6 +110,7 @@ class SystemUser(
       targetUserId: UserId,
       organizationId: OrganizationId
   ): Boolean = true
+  override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = true
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
@@ -135,6 +137,7 @@ class SystemUser(
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
+  override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
@@ -160,6 +163,7 @@ class SystemUser(
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
+  override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.security.Principal
 
 /**
@@ -74,6 +75,7 @@ interface TerrawareUser : Principal {
   fun canCreateDeviceManager(): Boolean
   fun canCreateFacility(organizationId: OrganizationId): Boolean
   fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean
+  fun canCreatePlantingSite(organizationId: OrganizationId): Boolean
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
@@ -99,6 +101,7 @@ interface TerrawareUser : Principal {
   fun canReadNotification(notificationId: NotificationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
+  fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canReadTimeseries(deviceId: DeviceId): Boolean
@@ -122,6 +125,7 @@ interface TerrawareUser : Principal {
   fun canUpdateNotification(notificationId: NotificationId): Boolean
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
+  fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
   fun canUpdateSpecies(speciesId: SpeciesId): Boolean
   fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -1,0 +1,7 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.db.EntityNotFoundException
+import com.terraformation.backend.db.tracking.PlantingSiteId
+
+class PlantingSiteNotFoundException(val plantingSiteId: PlantingSiteId) :
+    EntityNotFoundException("Planting site $plantingSiteId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -26,7 +26,9 @@ import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -62,6 +64,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val notificationUserId = UserId(2)
   private val notificationId = NotificationId(1)
   private val organizationId = OrganizationId(1)
+  private val plantingSiteId = PlantingSiteId(1)
   private val role = Role.CONTRIBUTOR
   private val speciesId = SpeciesId(1)
   private val storageLocationId = StorageLocationId(1)
@@ -176,6 +179,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canCreateNotification(notificationUserId, organizationId) }
     requirements.createNotification(notificationUserId, organizationId)
+  }
+
+  @Test
+  fun createPlantingSite() {
+    assertThrows<OrganizationNotFoundException> { requirements.createPlantingSite(organizationId) }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> { requirements.createPlantingSite(organizationId) }
+
+    grant { user.canCreatePlantingSite(organizationId) }
+    requirements.createPlantingSite(organizationId)
   }
 
   @Test
@@ -429,6 +443,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun readPlantingSite() {
+    assertThrows<PlantingSiteNotFoundException> { requirements.readPlantingSite(plantingSiteId) }
+
+    grant { user.canReadPlantingSite(plantingSiteId) }
+    requirements.readPlantingSite(plantingSiteId)
+  }
+
+  @Test
   fun readSpecies() {
     assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
 
@@ -661,6 +683,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canUpdateNotifications(organizationId) }
     requirements.updateNotifications(organizationId)
+  }
+
+  @Test
+  fun updatePlantingSite() {
+    assertThrows<PlantingSiteNotFoundException> { requirements.updatePlantingSite(plantingSiteId) }
+
+    grant { user.canReadPlantingSite(plantingSiteId) }
+    assertThrows<AccessDeniedException> { requirements.updatePlantingSite(plantingSiteId) }
+
+    grant { user.canUpdatePlantingSite(plantingSiteId) }
+    requirements.updatePlantingSite(plantingSiteId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -72,6 +72,7 @@ import com.terraformation.backend.db.seedbank.tables.daos.ViabilityTestsDao
 import com.terraformation.backend.db.seedbank.tables.daos.WithdrawalsDao
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
@@ -231,6 +232,7 @@ abstract class DatabaseTest {
   protected val organizationsDao: OrganizationsDao by lazyDao()
   protected val organizationUsersDao: OrganizationUsersDao by lazyDao()
   protected val photosDao: PhotosDao by lazyDao()
+  protected val plantingSitesDao: PlantingSitesDao by lazyDao()
   protected val speciesDao: SpeciesDao by lazyDao()
   protected val speciesProblemsDao: SpeciesProblemsDao by lazyDao()
   protected val storageLocationsDao: StorageLocationsDao by lazyDao()


### PR DESCRIPTION
Define permissions for access to planting site data. This follows the same
model as facilities: readable by everyone in the organization, modifiable by
admins and owners.