### PR TITLE
SW-2105 Add CRUD endpoints for planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -32,6 +32,11 @@ annotation class CustomerEndpoint
 annotation class SearchEndpoint
 
 @Retention(AnnotationRetention.RUNTIME)
+@Tag(name = "Tracking")
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class TrackingEndpoint
+
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
 @ApiResponse(
     content =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -1,0 +1,130 @@
+package com.terraformation.backend.tracking.api
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.PlotId
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.PlantingZoneModel
+import com.terraformation.backend.tracking.model.PlotModel
+import io.swagger.v3.oas.annotations.media.Schema
+import org.locationtech.jts.geom.Geometry
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/tracking/sites")
+@RestController
+@TrackingEndpoint
+class PlantingSitesController(
+    private val plantingSiteStore: PlantingSiteStore,
+) {
+  @GetMapping
+  fun listPlantingSites(
+      @RequestParam //
+      organizationId: OrganizationId,
+      @RequestParam(required = false)
+      @Schema(
+          description = "If true, include planting zones and plots for each site.",
+          defaultValue = "false")
+      full: Boolean?
+  ): ListPlantingSitesResponsePayload {
+    val models = plantingSiteStore.fetchSitesByOrganizationId(organizationId, full == true)
+    val payloads = models.map { PlantingSitePayload(it) }
+    return ListPlantingSitesResponsePayload(payloads)
+  }
+
+  @GetMapping("/{id}")
+  fun getPlantingSite(
+      @PathVariable("id") id: PlantingSiteId,
+  ): GetPlantingSiteResponsePayload {
+    val model = plantingSiteStore.fetchSiteById(id)
+    return GetPlantingSiteResponsePayload(PlantingSitePayload(model))
+  }
+
+  @PostMapping
+  fun createPlantingSite(
+      @RequestBody payload: CreatePlantingSiteRequestPayload
+  ): CreatePlantingSiteResponsePayload {
+    val model =
+        plantingSiteStore.createPlantingSite(
+            payload.organizationId, payload.name, payload.description)
+    return CreatePlantingSiteResponsePayload(model.id)
+  }
+
+  @PutMapping("/{id}")
+  fun updatePlantingSite(
+      @PathVariable("id") id: PlantingSiteId,
+      @RequestBody payload: UpdatePlantingSiteRequestPayload
+  ): SimpleSuccessResponsePayload {
+    plantingSiteStore.updatePlantingSite(id, payload.name, payload.description)
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class PlotPayload(
+    val boundary: Geometry,
+    val fullName: String,
+    val id: PlotId,
+    val name: String,
+) {
+  constructor(model: PlotModel) : this(model.boundary, model.fullName, model.id, model.name)
+}
+
+data class PlantingZonePayload(
+    val boundary: Geometry,
+    val id: PlantingZoneId,
+    val name: String,
+    val plots: List<PlotPayload>,
+) {
+  constructor(
+      model: PlantingZoneModel
+  ) : this(model.boundary, model.id, model.name, model.plots.map { PlotPayload(it) })
+}
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+data class PlantingSitePayload(
+    val boundary: Geometry?,
+    val description: String?,
+    val id: PlantingSiteId,
+    val name: String,
+    val plantingZones: List<PlantingZonePayload>?,
+) {
+  constructor(
+      model: PlantingSiteModel
+  ) : this(
+      model.boundary,
+      model.description,
+      model.id,
+      model.name,
+      model.plantingZones.map { PlantingZonePayload(it) },
+  )
+}
+
+data class CreatePlantingSiteRequestPayload(
+    val description: String? = null,
+    val name: String,
+    val organizationId: OrganizationId,
+)
+
+data class CreatePlantingSiteResponsePayload(val id: PlantingSiteId) : SuccessResponsePayload
+
+data class GetPlantingSiteResponsePayload(val site: PlantingSitePayload) : SuccessResponsePayload
+
+data class ListPlantingSitesResponsePayload(val sites: List<PlantingSitePayload>) :
+    SuccessResponsePayload
+
+data class UpdatePlantingSiteRequestPayload(
+    val description: String? = null,
+    val name: String,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1,0 +1,150 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
+import com.terraformation.backend.db.tracking.tables.references.PLOTS
+import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.PlantingZoneModel
+import com.terraformation.backend.tracking.model.PlotModel
+import java.time.InstantSource
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.impl.DSL
+import org.locationtech.jts.geom.Geometry
+
+@ManagedBean
+class PlantingSiteStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+    private val plantingSitesDao: PlantingSitesDao,
+) {
+  private val plotsBoundaryField = geometryField(PLOTS.BOUNDARY)
+  private val plantingZonesBoundaryField = geometryField(PLANTING_ZONES.BOUNDARY)
+  private val plantingSitesBoundaryField = geometryField(PLANTING_SITES.BOUNDARY)
+
+  private val plotsMultiset =
+      DSL.multiset(
+              DSL.select(PLOTS.ID, PLOTS.FULL_NAME, PLOTS.NAME, plotsBoundaryField)
+                  .from(PLOTS)
+                  .where(PLANTING_ZONES.ID.eq(PLOTS.PLANTING_ZONE_ID)))
+          .convertFrom { result ->
+            result.map { record ->
+              PlotModel(
+                  record[plotsBoundaryField]!!,
+                  record[PLOTS.ID]!!,
+                  record[PLOTS.FULL_NAME]!!,
+                  record[PLOTS.NAME]!!)
+            }
+          }
+
+  private val plantingZonesMultiset =
+      DSL.multiset(
+              DSL.select(
+                      PLANTING_ZONES.ID,
+                      PLANTING_ZONES.NAME,
+                      plantingZonesBoundaryField,
+                      plotsMultiset)
+                  .from(PLANTING_ZONES)
+                  .where(PLANTING_SITES.ID.eq(PLANTING_ZONES.PLANTING_SITE_ID)))
+          .convertFrom { result ->
+            result.map { record ->
+              PlantingZoneModel(
+                  record[plantingZonesBoundaryField]!!,
+                  record[PLANTING_ZONES.ID]!!,
+                  record[PLANTING_ZONES.NAME]!!,
+                  record[plotsMultiset] ?: emptyList(),
+              )
+            }
+          }
+
+  fun fetchSiteById(plantingSiteId: PlantingSiteId): PlantingSiteModel {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext
+        .select(
+            PLANTING_SITES.ID,
+            PLANTING_SITES.DESCRIPTION,
+            PLANTING_SITES.NAME,
+            plantingSitesBoundaryField,
+            plantingZonesMultiset)
+        .from(PLANTING_SITES)
+        .where(PLANTING_SITES.ID.eq(plantingSiteId))
+        .fetchOne { record ->
+          PlantingSiteModel(
+              record[plantingSitesBoundaryField],
+              record[PLANTING_SITES.DESCRIPTION],
+              record[PLANTING_SITES.ID]!!,
+              record[PLANTING_SITES.NAME]!!,
+              record[plantingZonesMultiset] ?: emptyList())
+        }
+        ?: throw PlantingSiteNotFoundException(plantingSiteId)
+  }
+
+  fun fetchSitesByOrganizationId(
+      organizationId: OrganizationId,
+      includeZones: Boolean = false
+  ): List<PlantingSiteModel> {
+    requirePermissions { readOrganization(organizationId) }
+
+    val zonesField = if (includeZones) plantingZonesMultiset else null
+
+    return dslContext
+        .select(PLANTING_SITES.asterisk(), zonesField)
+        .from(PLANTING_SITES)
+        .where(PLANTING_SITES.ORGANIZATION_ID.eq(organizationId))
+        .fetch { PlantingSiteModel(it, zonesField) }
+  }
+
+  fun createPlantingSite(
+      organizationId: OrganizationId,
+      name: String,
+      description: String?,
+  ): PlantingSiteModel {
+    requirePermissions { createPlantingSite(organizationId) }
+
+    val now = clock.instant()
+    val plantingSitesRow =
+        PlantingSitesRow(
+            createdBy = currentUser().userId,
+            createdTime = now,
+            description = description,
+            modifiedBy = currentUser().userId,
+            modifiedTime = now,
+            name = name,
+            organizationId = organizationId,
+        )
+
+    plantingSitesDao.insert(plantingSitesRow)
+
+    return PlantingSiteModel(plantingSitesRow, emptyList())
+  }
+
+  fun updatePlantingSite(plantingSiteId: PlantingSiteId, name: String, description: String?) {
+    requirePermissions { updatePlantingSite(plantingSiteId) }
+
+    with(PLANTING_SITES) {
+      dslContext
+          .update(PLANTING_SITES)
+          .set(DESCRIPTION, description)
+          .set(MODIFIED_BY, currentUser().userId)
+          .set(MODIFIED_TIME, clock.instant())
+          .set(NAME, name)
+          .where(ID.eq(plantingSiteId))
+          .execute()
+    }
+  }
+
+  /**
+   * Wraps a [Geometry] field for use in a multiset query. Workaround for
+   * https://github.com/jOOQ/jOOQ/issues/14195.
+   */
+  private fun geometryField(field: Field<Geometry?>): Field<Geometry?> =
+      DSL.field("substring(ST_AsEWKB(?)::text, 3)", Geometry::class.java, field)
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -27,7 +27,6 @@ class PlantingSiteStore(
 ) {
   private val plotsBoundaryField = geometryField(PLOTS.BOUNDARY)
   private val plantingZonesBoundaryField = geometryField(PLANTING_ZONES.BOUNDARY)
-  private val plantingSitesBoundaryField = geometryField(PLANTING_SITES.BOUNDARY)
 
   private val plotsMultiset =
       DSL.multiset(
@@ -68,22 +67,10 @@ class PlantingSiteStore(
     requirePermissions { readPlantingSite(plantingSiteId) }
 
     return dslContext
-        .select(
-            PLANTING_SITES.ID,
-            PLANTING_SITES.DESCRIPTION,
-            PLANTING_SITES.NAME,
-            plantingSitesBoundaryField,
-            plantingZonesMultiset)
+        .select(PLANTING_SITES.asterisk(), plantingZonesMultiset)
         .from(PLANTING_SITES)
         .where(PLANTING_SITES.ID.eq(plantingSiteId))
-        .fetchOne { record ->
-          PlantingSiteModel(
-              record[plantingSitesBoundaryField],
-              record[PLANTING_SITES.DESCRIPTION],
-              record[PLANTING_SITES.ID]!!,
-              record[PLANTING_SITES.NAME]!!,
-              record[plantingZonesMultiset] ?: emptyList())
-        }
+        .fetchOne { record -> PlantingSiteModel(record, plantingZonesMultiset) }
         ?: throw PlantingSiteNotFoundException(plantingSiteId)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
@@ -15,9 +16,7 @@ import com.terraformation.backend.tracking.model.PlotModel
 import java.time.InstantSource
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
-import org.jooq.Field
 import org.jooq.impl.DSL
-import org.locationtech.jts.geom.Geometry
 
 @ManagedBean
 class PlantingSiteStore(
@@ -25,8 +24,8 @@ class PlantingSiteStore(
     private val dslContext: DSLContext,
     private val plantingSitesDao: PlantingSitesDao,
 ) {
-  private val plotsBoundaryField = geometryField(PLOTS.BOUNDARY)
-  private val plantingZonesBoundaryField = geometryField(PLANTING_ZONES.BOUNDARY)
+  private val plotsBoundaryField = PLOTS.BOUNDARY.forMultiset()
+  private val plantingZonesBoundaryField = PLANTING_ZONES.BOUNDARY.forMultiset()
 
   private val plotsMultiset =
       DSL.multiset(
@@ -127,11 +126,4 @@ class PlantingSiteStore(
           .execute()
     }
   }
-
-  /**
-   * Wraps a [Geometry] field for use in a multiset query. Workaround for
-   * https://github.com/jOOQ/jOOQ/issues/14195.
-   */
-  private fun geometryField(field: Field<Geometry?>): Field<Geometry?> =
-      DSL.field("substring(ST_AsEWKB(?)::text, 3)", Geometry::class.java, field)
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -5,8 +5,6 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.PlotId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
-import com.terraformation.backend.db.tracking.tables.references.PLOTS
 import org.jooq.Field
 import org.jooq.Record
 import org.locationtech.jts.geom.Geometry
@@ -16,33 +14,14 @@ data class PlotModel(
     val id: PlotId,
     val fullName: String,
     val name: String,
-) {
-  constructor(
-      record: Record,
-  ) : this(
-      record[PLOTS.BOUNDARY]!!,
-      record[PLOTS.ID]!!,
-      record[PLOTS.FULL_NAME]!!,
-      record[PLOTS.NAME]!!,
-  )
-}
+)
 
 data class PlantingZoneModel(
     val boundary: Geometry,
     val id: PlantingZoneId,
     val name: String,
     val plots: List<PlotModel>,
-) {
-  constructor(
-      record: Record,
-      plotsMultiset: Field<List<PlotModel>>
-  ) : this(
-      record[PLANTING_ZONES.BOUNDARY]!!,
-      record[PLANTING_ZONES.ID]!!,
-      record[PLANTING_ZONES.NAME]!!,
-      record[plotsMultiset]!!,
-  )
-}
+)
 
 data class PlantingSiteModel(
     val boundary: Geometry?,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -1,0 +1,68 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.PlotId
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
+import com.terraformation.backend.db.tracking.tables.references.PLOTS
+import org.jooq.Field
+import org.jooq.Record
+import org.locationtech.jts.geom.Geometry
+
+data class PlotModel(
+    val boundary: Geometry,
+    val id: PlotId,
+    val fullName: String,
+    val name: String,
+) {
+  constructor(
+      record: Record,
+  ) : this(
+      record[PLOTS.BOUNDARY]!!,
+      record[PLOTS.ID]!!,
+      record[PLOTS.FULL_NAME]!!,
+      record[PLOTS.NAME]!!,
+  )
+}
+
+data class PlantingZoneModel(
+    val boundary: Geometry,
+    val id: PlantingZoneId,
+    val name: String,
+    val plots: List<PlotModel>,
+) {
+  constructor(
+      record: Record,
+      plotsMultiset: Field<List<PlotModel>>
+  ) : this(
+      record[PLANTING_ZONES.BOUNDARY]!!,
+      record[PLANTING_ZONES.ID]!!,
+      record[PLANTING_ZONES.NAME]!!,
+      record[plotsMultiset]!!,
+  )
+}
+
+data class PlantingSiteModel(
+    val boundary: Geometry?,
+    val description: String?,
+    val id: PlantingSiteId,
+    val name: String,
+    val plantingZones: List<PlantingZoneModel>,
+) {
+  constructor(
+      row: PlantingSitesRow,
+      plantingZones: List<PlantingZoneModel>
+  ) : this(row.boundary, row.description, row.id!!, row.name!!, plantingZones)
+
+  constructor(
+      record: Record,
+      plantingZonesMultiset: Field<List<PlantingZoneModel>>? = null
+  ) : this(
+      record[PLANTING_SITES.BOUNDARY],
+      record[PLANTING_SITES.DESCRIPTION],
+      record[PLANTING_SITES.ID]!!,
+      record[PLANTING_SITES.NAME]!!,
+      plantingZonesMultiset?.let { record[it] } ?: emptyList())
+}

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.db.SRID
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.locationtech.jts.geom.CoordinateXY
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
 
 /**
  * ObjectMapper configured to pretty print. This is lazily instantiated since ObjectMappers aren't
@@ -32,4 +36,19 @@ fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
         prettyPrintingObjectMapper.writeValueAsString(actual),
         message)
   }
+}
+
+/** Creates a simple triangular MultiPolygon. */
+fun multiPolygon(scale: Double): MultiPolygon {
+  val geometryFactory = GeometryFactory()
+  return geometryFactory
+      .createMultiPolygon(
+          arrayOf(
+              geometryFactory.createPolygon(
+                  arrayOf(
+                      CoordinateXY(0.0, 0.0),
+                      CoordinateXY(scale, 0.0),
+                      CoordinateXY(scale, scale),
+                      CoordinateXY(0.0, 0.0)))))
+      .also { it.srid = SRID.SPHERICAL_MERCATOR }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -753,7 +753,7 @@ abstract class DatabaseTest {
           row.plantingZoneId ?: throw IllegalArgumentException("Missing planting zone ID"),
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
-      name: String = row.name ?: id?.let { "$id" } ?: "${nextPlantingSiteNumber++}",
+      name: String = row.name ?: id?.let { "$id" } ?: "${nextPlotNumber++}",
       fullName: String = "Z1-$name",
   ): PlotId {
     val rowWithDefaults =

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -4,12 +4,12 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLOTS
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.search.NoConditionNode
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchResults
@@ -24,10 +24,7 @@ import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.locationtech.jts.geom.CoordinateXY
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryFactory
-import org.locationtech.jts.geom.MultiPolygon
 
 class TrackingSearchTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -145,20 +142,5 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         .fetchOne()!!
         .get(0)!!
         .toString()
-  }
-
-  /** Creates a simple triangular MultiPolygon. */
-  private fun multiPolygon(scale: Double): MultiPolygon {
-    val geometryFactory = GeometryFactory()
-    return geometryFactory
-        .createMultiPolygon(
-            arrayOf(
-                geometryFactory.createPolygon(
-                    arrayOf(
-                        CoordinateXY(0.0, 0.0),
-                        CoordinateXY(scale, 0.0),
-                        CoordinateXY(scale, scale),
-                        CoordinateXY(0.0, 0.0)))))
-        .also { it.srid = SRID.SPHERICAL_MERCATOR }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -1,0 +1,151 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
+import com.terraformation.backend.db.tracking.tables.references.PLOTS
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.PlantingZoneModel
+import com.terraformation.backend.tracking.model.PlotModel
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+import java.time.InstantSource
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+  override val tablesToResetSequences = listOf(PLANTING_SITES, PLANTING_ZONES, PLOTS)
+
+  private val clock: InstantSource = mockk()
+  private val store: PlantingSiteStore by lazy {
+    PlantingSiteStore(clock, dslContext, plantingSitesDao)
+  }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+
+    every { clock.instant() } returns Instant.EPOCH
+    every { user.canCreatePlantingSite(any()) } returns true
+    every { user.canReadPlantingSite(any()) } returns true
+    every { user.canReadOrganization(any()) } returns true
+    every { user.canUpdatePlantingSite(any()) } returns true
+  }
+
+  @Test
+  fun `fetchSiteById returns planting zone and plot models`() {
+    val plantingSiteId = insertPlantingSite(boundary = multiPolygon(3.0))
+    val plantingZoneId =
+        insertPlantingZone(boundary = multiPolygon(2.0), plantingSiteId = plantingSiteId)
+    val plotId = insertPlot(boundary = multiPolygon(1.0), plantingZoneId = plantingZoneId)
+
+    val expected =
+        PlantingSiteModel(
+            boundary = multiPolygon(3.0),
+            description = null,
+            id = plantingSiteId,
+            name = "Site 1",
+            plantingZones =
+                listOf(
+                    PlantingZoneModel(
+                        boundary = multiPolygon(2.0),
+                        id = plantingZoneId,
+                        name = "Z1",
+                        plots =
+                            listOf(
+                                PlotModel(
+                                    boundary = multiPolygon(1.0),
+                                    id = plotId,
+                                    fullName = "Z1-1",
+                                    name = "1")))))
+
+    val actual = store.fetchSiteById(plantingSiteId)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `fetchSiteById throws exception if no permission to read planting site`() {
+    val plantingSiteId = insertPlantingSite()
+
+    every { user.canReadPlantingSite(any()) } returns false
+
+    assertThrows<PlantingSiteNotFoundException> { store.fetchSiteById(plantingSiteId) }
+  }
+
+  @Test
+  fun `createPlantingSite inserts new site`() {
+    val model = store.createPlantingSite(organizationId, "name", "description")
+
+    assertEquals(
+        listOf(
+            PlantingSitesRow(
+                id = model.id,
+                organizationId = organizationId,
+                name = "name",
+                description = "description",
+                createdBy = user.userId,
+                createdTime = Instant.EPOCH,
+                modifiedBy = user.userId,
+                modifiedTime = Instant.EPOCH,
+            )),
+        plantingSitesDao.findAll(),
+        "Planting sites")
+
+    assertEquals(emptyList<PlantingZonesRow>(), plantingZonesDao.findAll(), "Planting zones")
+  }
+
+  @Test
+  fun `createPlantingSite throws exception if no permission`() {
+    every { user.canCreatePlantingSite(any()) } returns false
+
+    assertThrows<AccessDeniedException> { store.createPlantingSite(organizationId, "name", null) }
+  }
+
+  @Test
+  fun `updatePlantingSite updates values`() {
+    val initialModel = store.createPlantingSite(organizationId, "initial name", null)
+
+    val now = Instant.ofEpochSecond(1000)
+    every { clock.instant() } returns now
+
+    store.updatePlantingSite(initialModel.id, "new name", "new description")
+
+    assertEquals(
+        listOf(
+            PlantingSitesRow(
+                id = initialModel.id,
+                organizationId = organizationId,
+                name = "new name",
+                description = "new description",
+                createdBy = user.userId,
+                createdTime = Instant.EPOCH,
+                modifiedBy = user.userId,
+                modifiedTime = now,
+            )),
+        plantingSitesDao.findAll(),
+        "Planting sites")
+  }
+
+  @Test
+  fun `updatePlantingSite throws exception if no permission`() {
+    val plantingSiteId = insertPlantingSite()
+
+    every { user.canUpdatePlantingSite(any()) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.updatePlantingSite(plantingSiteId, "new name", "new description")
+    }
+  }
+}


### PR DESCRIPTION
Allow clients to read and write planting site information. Client-created planting
sites may not include planting zones or plots, and clients can't edit planting zones
or plots that were created via shapefile upload.

The planting site boundary is always returned from the GET endpoints for planting
sites created via shapefile upload. The list of planting zones and plots is always
included when querying a single planting site, but may be turned on or off when
listing the planting sites for an organization.

All the information available via the GET endpoints here is also available using
the search API, but the dedicated endpoints may be more convenient.