### PR TITLE
SW-2179 Add endpoint to get Mapbox API token

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -267,7 +267,6 @@ ij_kotlin_method_parameters_right_paren_on_new_line = true
 ij_kotlin_method_parameters_wrap = on_every_item
 ij_kotlin_name_count_to_use_star_import = 99999
 ij_kotlin_name_count_to_use_star_import_for_members = 99999
-ij_kotlin_packages_to_use_import_on_demand = io.ktor.**
 ij_kotlin_parameter_annotation_wrap = off
 ij_kotlin_space_after_comma = true
 ij_kotlin_space_after_extend_colon = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
   val jtsVersion: String by project
   val jUnitVersion: String by project
   val keycloakVersion: String by project
+  val ktorVersion: String by project
   val postgresJdbcVersion: String by project
   val springDocVersion: String by project
 
@@ -99,6 +100,9 @@ dependencies {
   implementation("commons-fileupload:commons-fileupload:1.4")
   implementation("commons-validator:commons-validator:1.7")
   implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.4.1")
+  implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+  implementation("io.ktor:ktor-client-java:$ktorVersion")
+  implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
   implementation("io.swagger.core.v3:swagger-annotations:2.2.6")
   implementation("javax.inject:javax.inject:1")
   implementation("net.coobird:thumbnailator:0.4.18")

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@ jUnitVersion=5.9.1
 keycloakVersion=19.0.1
 kotlinVersion=1.7.10
 ktfmtVersion=0.41
+ktorVersion=2.1.3
 postgresJdbcVersion=42.5.0
 springDocVersion=1.6.12
 

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -102,6 +102,9 @@ class TerrawareServerConfig(
     /** Configures how the server interacts with the Balena cloud service to manage sensor kits. */
     val balena: BalenaConfig = BalenaConfig(),
 
+    /** Configures how the server interacts with the Mapbox service. */
+    val mapbox: MapboxConfig = MapboxConfig(),
+
     /** Configures notifications processing. */
     val notifications: NotificationsConfig = NotificationsConfig(),
 ) {
@@ -242,6 +245,13 @@ class TerrawareServerConfig(
       const val BALENA_API_URL = "https://api.balena-cloud.com"
     }
   }
+
+  @ConstructorBinding
+  class MapboxConfig(
+      val apiToken: String? = null,
+      /** How long temporary Mapbox API tokens should last. */
+      @DefaultValue("30") val temporaryTokenExpirationMinutes: Long = 30,
+  )
 
   @ConstructorBinding
   class NotificationsConfig(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.tracking.api
+
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.tracking.mapbox.MapboxRequestFailedException
+import com.terraformation.backend.tracking.mapbox.MapboxService
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import javax.ws.rs.NotFoundException
+import javax.ws.rs.ServiceUnavailableException
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/tracking/mapbox")
+@RestController
+@TrackingEndpoint
+class MapboxController(
+    private val config: TerrawareServerConfig,
+    private val mapboxService: MapboxService,
+) {
+  @ApiResponse(responseCode = "200")
+  @ApiResponse404(description = "The server is not configured to return Mapbox tokens.")
+  @ApiResponse(
+      responseCode = "503",
+      description = "The server is temporarily unable to generate a new Mapbox token.")
+  @GetMapping("/token")
+  fun getMapboxToken(): GetMapboxTokenResponsePayload {
+    val token =
+        if (mapboxService.enabled) {
+          try {
+            mapboxService.generateTemporaryToken()
+          } catch (e: MapboxRequestFailedException) {
+            throw ServiceUnavailableException("Temporarily unable to generate Mapbox tokens.")
+          }
+        } else {
+          throw NotFoundException("The server is not configured to return Mapbox tokens.")
+        }
+
+    return GetMapboxTokenResponsePayload(token)
+  }
+}
+
+data class GetMapboxTokenResponsePayload(val token: String) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/Exceptions.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.tracking.mapbox
+
+import io.ktor.http.HttpStatusCode
+
+abstract class MapboxException(message: String) : RuntimeException(message)
+
+class MapboxNotConfiguredException() :
+    MapboxException("Server is not configured to make requests to Mapbox")
+
+class MapboxRequestFailedException(message: String) : MapboxException(message) {
+  constructor(statusCode: HttpStatusCode) : this("Request failed with HTTP status $statusCode")
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
@@ -1,0 +1,90 @@
+package com.terraformation.backend.tracking.mapbox
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.log.perClassLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import java.net.URL
+import java.time.Instant
+import java.time.InstantSource
+import java.time.temporal.ChronoUnit
+import javax.annotation.ManagedBean
+import kotlinx.coroutines.runBlocking
+
+@ManagedBean
+class MapboxService(
+    private val clock: InstantSource,
+    private val config: TerrawareServerConfig,
+    private val httpClient: HttpClient,
+) {
+  private val log = perClassLogger()
+
+  val enabled: Boolean = config.mapbox.apiToken != null
+
+  /**
+   * The Mapbox username of the account that owns the configured API token. Some Mapbox APIs require
+   * the username to be included explicitly in the request.
+   *
+   * We fetch this lazily the first time it's accessed by requesting information about our access
+   * token, which includes the username.
+   */
+  val username: String by lazy {
+    runBlocking {
+      try {
+        val response: RetrieveTokenResponsePayload = httpClient.get(mapboxUrl("tokens/v2")).body()
+        response.token.user
+      } catch (e: ClientRequestException) {
+        log.error("HTTP ${e.response.status} when fetching Mapbox token information")
+        log.info("Mapbox error response payload: ${e.response.bodyAsText()}")
+        throw MapboxRequestFailedException(e.response.status)
+      }
+    }
+  }
+
+  /** Generates a temporary API token. */
+  fun generateTemporaryToken(): String {
+    if (!enabled) {
+      throw MapboxNotConfiguredException()
+    }
+
+    val url = mapboxUrl("tokens/v2/$username")
+
+    val expirationTime =
+        clock.instant().plus(config.mapbox.temporaryTokenExpirationMinutes, ChronoUnit.MINUTES)
+    val requestPayload =
+        TemporaryTokenRequestPayload(
+            expires = expirationTime, scopes = listOf("styles:tiles", "styles:read", "fonts:read"))
+
+    return runBlocking {
+      try {
+        val responsePayload: TemporaryTokenResponsePayload =
+            httpClient.post(url) { setBody(requestPayload) }.body()
+
+        responsePayload.token
+      } catch (e: ClientRequestException) {
+        log.error("Mapbox token request failed with HTTP ${e.response.status}")
+        log.info("Mapbox error response payload: ${e.response.bodyAsText()}")
+        throw MapboxRequestFailedException(e.response.status)
+      }
+    }
+  }
+
+  private fun mapboxUrl(endpoint: String): URL =
+      URL("https://api.mapbox.com/$endpoint?accss_token=${config.mapbox.apiToken}")
+
+  data class TemporaryTokenRequestPayload(
+      val expires: Instant,
+      val scopes: List<String>,
+  )
+
+  data class TemporaryTokenResponsePayload(val token: String)
+
+  data class RetrieveTokenResponsePayload(val code: String, val token: Token) {
+    data class Token(val user: String)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
@@ -33,7 +33,7 @@ class MapboxService(
    * We fetch this lazily the first time it's accessed by requesting information about our access
    * token, which includes the username.
    */
-  val username: String by lazy {
+  private val username: String by lazy {
     runBlocking {
       try {
         val response: RetrieveTokenResponsePayload = httpClient.get(mapboxUrl("tokens/v2")).body()
@@ -75,7 +75,7 @@ class MapboxService(
   }
 
   private fun mapboxUrl(endpoint: String): URL =
-      URL("https://api.mapbox.com/$endpoint?accss_token=${config.mapbox.apiToken}")
+      URL("https://api.mapbox.com/$endpoint?access_token=${config.mapbox.apiToken}")
 
   data class TemporaryTokenRequestPayload(
       val expires: Instant,

--- a/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
@@ -1,6 +1,13 @@
 package com.terraformation.backend.util
 
-import java.net.http.HttpClient
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.java.Java
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.jackson.JacksonConverter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -14,7 +21,21 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class HttpClientConfig {
   @Bean
-  fun httpClient(): HttpClient {
-    return HttpClient.newHttpClient()
+  fun httpClient(): java.net.http.HttpClient {
+    return java.net.http.HttpClient.newHttpClient()
+  }
+
+  @Bean
+  fun ktorHttpClient(objectMapper: ObjectMapper): HttpClient {
+    return HttpClient(Java) {
+      defaultRequest { contentType(ContentType.Application.Json) }
+
+      // By default, treat non-2xx responses as errors. This can be overridden per request.
+      expectSuccess = true
+
+      install(ContentNegotiation) {
+        register(ContentType.Application.Json, JacksonConverter(objectMapper))
+      }
+    }
   }
 }


### PR DESCRIPTION
The `GET /api/v1/tracking/mapbox/token` endpoint will return a temporary Mapbox
API token that has permission to read map data.

It requires the server to be configured with a Mapbox API token that has the
`token:write` scope, e.g., in an `application.yaml` file:

```
terraware:
  mapbox:
    api-token: "YOUR_MAPBOX_API_TOKEN"
```

The implementation introduces the Ktor HTTP client library to the code base.
It is a Kotlin-native HTTP client that is a lot more convenient to use than the
Java 11 standard library HTTP client we've used previously. Existing code that
uses the Java client is left untouched here; it can be converted later.