### PR TITLE
SW-2179 Treat empty Mapbox token as absent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
@@ -24,7 +24,7 @@ class MapboxService(
 ) {
   private val log = perClassLogger()
 
-  val enabled: Boolean = config.mapbox.apiToken != null
+  val enabled: Boolean = config.mapbox.apiToken?.isNotBlank() == true
 
   /**
    * The Mapbox username of the account that owns the configured API token. Some Mapbox APIs require


### PR DESCRIPTION
If your environment includes an empty `TERRAWARE_MAPBOX_API_TOKEN` environment
variable, the server shouldn't try to use that empty value to make Mapbox API
calls.