### PR TITLE
SW-2230 Add count fields for planting zones and plots

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -171,7 +171,12 @@ val ID_WRAPPERS =
             ),
         "tracking" to
             listOf(
-                IdWrapper("PlantingSiteId", listOf("planting_sites\\.id", ".*\\.planting_site_id")),
+                IdWrapper(
+                    "PlantingSiteId",
+                    listOf(
+                        "planting_sites\\.id",
+                        "planting_site_summaries\\.id",
+                        ".*\\.planting_site_id")),
                 IdWrapper("PlantingZoneId", listOf("planting_zones\\.id", ".*\\.planting_zone_id")),
                 IdWrapper("PlotId", listOf("plots\\.id", ".*\\.plot_id")),
             ),

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.OrganizationIdScope
 import com.terraformation.backend.search.SearchScope
@@ -44,7 +44,7 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
           organizationUsers.asMultiValueSublist(
               "members", ORGANIZATIONS.ID.eq(ORGANIZATION_USERS.ORGANIZATION_ID)),
           plantingSites.asMultiValueSublist(
-              "plantingSites", ORGANIZATIONS.ID.eq(PLANTING_SITES.ORGANIZATION_ID)),
+              "plantingSites", ORGANIZATIONS.ID.eq(PLANTING_SITE_SUMMARIES.ORGANIZATION_ID)),
           species.asMultiValueSublist("species", ORGANIZATIONS.ID.eq(SPECIES.ORGANIZATION_ID)),
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.tracking.PlantingSiteId
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.OrganizationIdScope
@@ -13,55 +13,67 @@ import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
 import org.jooq.Condition
+import org.jooq.OrderField
 import org.jooq.Record
 import org.jooq.TableField
 import org.jooq.impl.DSL
 
 class PlantingSitesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = PLANTING_SITES.ID
+    get() = PLANTING_SITE_SUMMARIES.ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
           organizations.asSingleValueSublist(
-              "organization", PLANTING_SITES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
+              "organization", PLANTING_SITE_SUMMARIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           plantingZones.asMultiValueSublist(
-              "plantingZones", PLANTING_SITES.ID.eq(PLANTING_ZONES.PLANTING_SITE_ID)),
+              "plantingZones", PLANTING_SITE_SUMMARIES.ID.eq(PLANTING_ZONES.PLANTING_SITE_ID)),
       )
     }
   }
 
   override val fields: List<SearchField> =
       listOf(
-          geometryField("boundary", "Planting site boundary", PLANTING_SITES.BOUNDARY),
+          geometryField("boundary", "Planting site boundary", PLANTING_SITE_SUMMARIES.BOUNDARY),
           timestampField(
               "createdTime",
               "Planting site created time",
-              PLANTING_SITES.CREATED_TIME,
+              PLANTING_SITE_SUMMARIES.CREATED_TIME,
               nullable = false),
-          textField("description", "Planting site description", PLANTING_SITES.DESCRIPTION),
-          idWrapperField("id", "Planting site ID", PLANTING_SITES.ID) { PlantingSiteId(it) },
+          textField(
+              "description", "Planting site description", PLANTING_SITE_SUMMARIES.DESCRIPTION),
+          idWrapperField("id", "Planting site ID", PLANTING_SITE_SUMMARIES.ID) {
+            PlantingSiteId(it)
+          },
           timestampField(
               "modifiedTime",
               "Planting site modified time",
-              PLANTING_SITES.MODIFIED_TIME,
+              PLANTING_SITE_SUMMARIES.MODIFIED_TIME,
               nullable = false),
-          textField("name", "Planting site name", PLANTING_SITES.NAME, nullable = false),
+          textField("name", "Planting site name", PLANTING_SITE_SUMMARIES.NAME, nullable = false),
+          longField(
+              "numPlantingZones",
+              "Planting site number of planting zones",
+              PLANTING_SITE_SUMMARIES.NUM_PLANTING_ZONES),
+          longField("numPlots", "Planting site number of plots", PLANTING_SITE_SUMMARIES.NUM_PLOTS),
       )
 
   override fun conditionForVisibility(): Condition {
-    return PLANTING_SITES.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
+    return PLANTING_SITE_SUMMARIES.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
   }
 
   override fun conditionForScope(scope: SearchScope): Condition {
     return when (scope) {
-      is OrganizationIdScope -> PLANTING_SITES.ORGANIZATION_ID.eq(scope.organizationId)
+      is OrganizationIdScope -> PLANTING_SITE_SUMMARIES.ORGANIZATION_ID.eq(scope.organizationId)
       is FacilityIdScope ->
-          PLANTING_SITES.ORGANIZATION_ID.eq(
+          PLANTING_SITE_SUMMARIES.ORGANIZATION_ID.eq(
               DSL.select(FACILITIES.ORGANIZATION_ID)
                   .from(FACILITIES)
                   .where(FACILITIES.ID.eq(scope.facilityId)))
     }
   }
+
+  override val defaultOrderFields: List<OrderField<*>>
+    get() = listOf(PLANTING_SITE_SUMMARIES.ID)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.tracking.PlantingZoneId
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLOTS
 import com.terraformation.backend.search.FacilityIdScope
@@ -25,7 +25,7 @@ class PlantingZonesTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           plantingSites.asSingleValueSublist(
-              "plantingSite", PLANTING_ZONES.PLANTING_SITE_ID.eq(PLANTING_SITES.ID)),
+              "plantingSite", PLANTING_ZONES.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID)),
           plots.asMultiValueSublist("plots", PLANTING_ZONES.ID.eq(PLOTS.PLANTING_ZONE_ID)),
       )
     }
@@ -51,7 +51,9 @@ class PlantingZonesTable(tables: SearchTables) : SearchTable() {
   override val inheritsVisibilityFrom: SearchTable = tables.plantingSites
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
-    return query.join(PLANTING_SITES).on(PLANTING_ZONES.PLANTING_SITE_ID.eq(PLANTING_SITES.ID))
+    return query
+        .join(PLANTING_SITE_SUMMARIES)
+        .on(PLANTING_ZONES.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID))
   }
 
   override fun conditionForScope(scope: SearchScope): Condition {

--- a/src/main/resources/db/migration/V154__PlantingSiteSummaries.sql
+++ b/src/main/resources/db/migration/V154__PlantingSiteSummaries.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE VIEW tracking.planting_site_summaries AS
+SELECT id,
+       organization_id,
+       name,
+       description,
+       boundary,
+       created_by,
+       created_time,
+       modified_by,
+       modified_time,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+        WHERE ps.id = pz.planting_site_id) AS num_planting_zones,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+                 JOIN tracking.plots p ON pz.id = p.planting_zone_id
+        WHERE ps.id = pz.planting_site_id) AS num_plots
+FROM tracking.planting_sites ps;

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -50,11 +50,13 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
   fun `can search for all fields`() {
     val plantingSiteGeometry = multiPolygon(3.0)
     val plantingZoneGeometry = multiPolygon(2.0)
-    val plotGeometry = multiPolygon(1.0)
+    val plotGeometry3 = multiPolygon(1.0)
+    val plotGeometry4 = multiPolygon(1.0)
     val plantingSiteId = insertPlantingSite(boundary = plantingSiteGeometry)
     val plantingZoneId =
         insertPlantingZone(boundary = plantingZoneGeometry, id = 2, plantingSiteId = plantingSiteId)
-    insertPlot(boundary = plotGeometry, id = 3, plantingZoneId = plantingZoneId)
+    insertPlot(boundary = plotGeometry3, id = 3, plantingZoneId = plantingZoneId)
+    insertPlot(boundary = plotGeometry4, id = 4, plantingZoneId = plantingZoneId)
 
     val expected =
         SearchResults(
@@ -65,6 +67,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                     "id" to "1",
                     "modifiedTime" to "1970-01-01T00:00:00Z",
                     "name" to "Site 1",
+                    "numPlantingZones" to "1",
+                    "numPlots" to "2",
                     "plantingZones" to
                         listOf(
                             mapOf(
@@ -76,12 +80,20 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                 "plots" to
                                     listOf(
                                         mapOf(
-                                            "boundary" to postgisRenderGeoJson(plotGeometry),
+                                            "boundary" to postgisRenderGeoJson(plotGeometry3),
                                             "createdTime" to "1970-01-01T00:00:00Z",
                                             "fullName" to "Z1-3",
                                             "id" to "3",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "3",
+                                        ),
+                                        mapOf(
+                                            "boundary" to postgisRenderGeoJson(plotGeometry4),
+                                            "createdTime" to "1970-01-01T00:00:00Z",
+                                            "fullName" to "Z1-4",
+                                            "id" to "4",
+                                            "modifiedTime" to "1970-01-01T00:00:00Z",
+                                            "name" to "4",
                                         )))))),
             null)
 
@@ -93,6 +105,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "id",
                 "modifiedTime",
                 "name",
+                "numPlantingZones",
+                "numPlots",
                 "plantingZones.boundary",
                 "plantingZones.createdTime",
                 "plantingZones.id",


### PR DESCRIPTION
The UI needs to show the number of planting zones and plots in each planting
site as searchable, sortable table fields. Expose the counts as numeric fields
in the search API.