### PR TITLE
SW-2228 Refactor PhotoRepository

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
@@ -1,0 +1,133 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.default_schema.tables.daos.PhotosDao
+import com.terraformation.backend.db.default_schema.tables.pojos.PhotosRow
+import com.terraformation.backend.db.default_schema.tables.references.PHOTOS
+import com.terraformation.backend.file.model.PhotoMetadata
+import com.terraformation.backend.log.perClassLogger
+import java.io.IOException
+import java.io.InputStream
+import java.net.URI
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.NoSuchFileException
+import java.time.Clock
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+
+/**
+ * Manages storage of photos including metadata. In this implementation, image files are stored on
+ * the filesystem and metadata in the database.
+ */
+@ManagedBean
+class PhotoService(
+    private val dslContext: DSLContext,
+    private val clock: Clock,
+    private val fileStore: FileStore,
+    private val photosDao: PhotosDao,
+    private val thumbnailStore: ThumbnailStore,
+) {
+  private val log = perClassLogger()
+
+  @Throws(IOException::class)
+  fun storePhoto(
+      category: String,
+      data: InputStream,
+      size: Long,
+      metadata: PhotoMetadata,
+      insertChildRows: (PhotoId) -> Unit
+  ): PhotoId {
+    val photoUrl = fileStore.newUrl(clock.instant(), category, metadata.contentType)
+
+    try {
+      fileStore.write(photoUrl, data)
+
+      val photosRow =
+          PhotosRow(
+              contentType = metadata.contentType,
+              createdTime = clock.instant(),
+              createdBy = currentUser().userId,
+              fileName = metadata.filename,
+              modifiedBy = currentUser().userId,
+              modifiedTime = clock.instant(),
+              size = size,
+              storageUrl = photoUrl,
+          )
+
+      dslContext.transaction { _ ->
+        photosDao.insert(photosRow)
+        insertChildRows(photosRow.id!!)
+      }
+
+      return photosRow.id!!
+    } catch (e: FileAlreadyExistsException) {
+      // Don't delete the existing file
+      throw e
+    } catch (e: Exception) {
+      try {
+        fileStore.delete(photoUrl)
+      } catch (ignore: NoSuchFileException) {
+        // Swallow this; file is already deleted
+      }
+      throw e
+    }
+  }
+
+  @Throws(IOException::class)
+  fun readPhoto(
+      photoId: PhotoId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null,
+  ): SizedInputStream {
+    return if (maxWidth != null || maxHeight != null) {
+      thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight)
+    } else {
+      fileStore.read(fetchUrl(photoId))
+    }
+  }
+
+  /** Returns the photo's size in bytes. */
+  @Throws(IOException::class)
+  fun getPhotoFileSize(photoId: PhotoId): Long {
+    val photoUrl = fetchUrl(photoId)
+    return fileStore.size(photoUrl)
+  }
+
+  /**
+   * Deletes a photo and its thumbnails.
+   *
+   * @param deleteChildRows Deletes any rows from child tables that refer to the photos table. This
+   * is called in a transaction before the photos table row is deleted.
+   */
+  fun deletePhoto(photoId: PhotoId, deleteChildRows: () -> Unit) {
+    val storageUrl = fetchUrl(photoId)
+    thumbnailStore.deleteThumbnails(photoId)
+
+    try {
+      fileStore.delete(storageUrl)
+    } catch (e: NoSuchFileException) {
+      log.warn("Photo file $storageUrl was already deleted from file store")
+    }
+
+    dslContext.transaction { _ ->
+      deleteChildRows()
+      photosDao.deleteById(photoId)
+    }
+  }
+
+  /**
+   * Returns the storage URL of an existing photo.
+   *
+   * @throws PhotoNotFoundException There was no record of the photo.
+   */
+  private fun fetchUrl(photoId: PhotoId): URI {
+    return dslContext
+        .select(PHOTOS.STORAGE_URL)
+        .from(PHOTOS)
+        .where(PHOTOS.ID.eq(photoId))
+        .fetchOne(PHOTOS.STORAGE_URL)
+        ?: throw PhotoNotFoundException(photoId)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/file/model/PhotoMetadata.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/model/PhotoMetadata.kt
@@ -1,4 +1,4 @@
-package com.terraformation.backend.seedbank.model
+package com.terraformation.backend.file.model
 
 data class PhotoMetadata(
     val filename: String,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
@@ -13,9 +13,9 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.db.PhotoRepository
-import com.terraformation.backend.seedbank.model.PhotoMetadata
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Encoding

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -1,48 +1,30 @@
 package com.terraformation.backend.seedbank.db
 
-import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.PhotoId
-import com.terraformation.backend.db.default_schema.tables.daos.PhotosDao
-import com.terraformation.backend.db.default_schema.tables.pojos.PhotosRow
 import com.terraformation.backend.db.default_schema.tables.references.PHOTOS
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_PHOTOS
-import com.terraformation.backend.file.FileStore
+import com.terraformation.backend.file.PhotoService
 import com.terraformation.backend.file.SizedInputStream
-import com.terraformation.backend.file.ThumbnailStore
+import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.seedbank.model.PhotoMetadata
 import java.io.IOException
 import java.io.InputStream
-import java.net.URI
-import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
-import java.time.Clock
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 
-/**
- * Manages storage of photos including metadata. In this implementation, image files are stored on
- * the filesystem and metadata in the database.
- *
- * Each accession's photos are in a subdirectory whose path includes the facility ID and the
- * accession number (not the numeric accession ID). The configuration setting
- * [TerrawareServerConfig.photoIntermediateDepth] controls the depth of that subdirectory path.
- */
+/** Manages storage of accession photos. */
 @ManagedBean
 class PhotoRepository(
     private val accessionPhotosDao: AccessionPhotosDao,
     private val dslContext: DSLContext,
-    private val clock: Clock,
-    private val fileStore: FileStore,
-    private val photosDao: PhotosDao,
-    private val thumbnailStore: ThumbnailStore,
+    private val photoService: PhotoService,
 ) {
   private val log = perClassLogger()
 
@@ -50,47 +32,13 @@ class PhotoRepository(
   fun storePhoto(accessionId: AccessionId, data: InputStream, size: Long, metadata: PhotoMetadata) {
     requirePermissions { updateAccession(accessionId) }
 
-    val photoUrl = fileStore.newUrl(clock.instant(), "accession", metadata.contentType)
+    val photoId =
+        photoService.storePhoto("accession", data, size, metadata) { photoId ->
+          accessionPhotosDao.insert(
+              AccessionPhotosRow(accessionId = accessionId, photoId = photoId))
+        }
 
-    try {
-      fileStore.write(photoUrl, data)
-
-      dslContext.transaction { _ ->
-        val photosRow =
-            PhotosRow(
-                contentType = metadata.contentType,
-                createdTime = clock.instant(),
-                createdBy = currentUser().userId,
-                fileName = metadata.filename,
-                modifiedBy = currentUser().userId,
-                modifiedTime = clock.instant(),
-                size = size,
-                storageUrl = photoUrl,
-            )
-
-        photosDao.insert(photosRow)
-
-        val accessionPhotosRow =
-            AccessionPhotosRow(
-                accessionId = accessionId,
-                photoId = photosRow.id,
-            )
-
-        accessionPhotosDao.insert(accessionPhotosRow)
-      }
-
-      log.info("Stored $photoUrl for accession $accessionId")
-    } catch (e: FileAlreadyExistsException) {
-      // Don't delete the existing file
-      throw e
-    } catch (e: Exception) {
-      try {
-        fileStore.delete(photoUrl)
-      } catch (ignore: NoSuchFileException) {
-        // Swallow this; file is already deleted
-      }
-      throw e
-    }
+    log.info("Stored photo $photoId for accession $accessionId")
   }
 
   @Throws(IOException::class)
@@ -102,11 +50,7 @@ class PhotoRepository(
   ): SizedInputStream {
     requirePermissions { readAccession(accessionId) }
 
-    return if (maxWidth != null || maxHeight != null) {
-      thumbnailStore.getThumbnailData(fetchPhotoId(accessionId, filename), maxWidth, maxHeight)
-    } else {
-      fileStore.read(fetchUrl(accessionId, filename))
-    }
+    return photoService.readPhoto(fetchPhotoId(accessionId, filename), maxWidth, maxHeight)
   }
 
   /** Returns the photo's size in bytes. */
@@ -114,8 +58,7 @@ class PhotoRepository(
   fun getPhotoFileSize(accessionId: AccessionId, filename: String): Long {
     requirePermissions { readAccession(accessionId) }
 
-    val photoUrl = fetchUrl(accessionId, filename)
-    return fileStore.size(photoUrl)
+    return photoService.getPhotoFileSize(fetchPhotoId(accessionId, filename))
   }
 
   /** Returns a list of metadata for an accession's photos. */
@@ -142,27 +85,15 @@ class PhotoRepository(
     requirePermissions { updateAccession(accessionId) }
 
     dslContext
-        .select(ACCESSION_PHOTOS.PHOTO_ID, PHOTOS.STORAGE_URL)
+        .select(ACCESSION_PHOTOS.PHOTO_ID)
         .from(ACCESSION_PHOTOS)
         .join(PHOTOS)
         .on(ACCESSION_PHOTOS.PHOTO_ID.eq(PHOTOS.ID))
         .where(ACCESSION_PHOTOS.ACCESSION_ID.eq(accessionId))
-        .fetch()
-        .forEach { (photoId, storageUrl) ->
-          if (photoId != null && storageUrl != null) {
-            thumbnailStore.deleteThumbnails(photoId)
-
-            try {
-              fileStore.delete(storageUrl)
-            } catch (e: NoSuchFileException) {
-              log.warn("Photo file $storageUrl was already deleted from file store")
-            }
-
-            dslContext.transaction { _ ->
-              accessionPhotosDao.deleteById(photoId)
-              photosDao.deleteById(photoId)
-            }
-          }
+        .fetch(ACCESSION_PHOTOS.PHOTO_ID)
+        .filterNotNull()
+        .forEach { photoId ->
+          photoService.deletePhoto(photoId) { accessionPhotosDao.deleteById(photoId) }
         }
   }
 
@@ -176,23 +107,6 @@ class PhotoRepository(
         .fetch(ACCESSION_PHOTOS.ACCESSION_ID)
         .filterNotNull()
         .forEach { deleteAllPhotos(it) }
-  }
-
-  /**
-   * Returns the storage URL of an existing photo.
-   *
-   * @throws NoSuchFileException There was no record of the photo.
-   */
-  private fun fetchUrl(accessionId: AccessionId, filename: String): URI {
-    return dslContext
-        .select(PHOTOS.STORAGE_URL)
-        .from(PHOTOS)
-        .join(ACCESSION_PHOTOS)
-        .on(PHOTOS.ID.eq(ACCESSION_PHOTOS.PHOTO_ID))
-        .where(ACCESSION_PHOTOS.ACCESSION_ID.eq(accessionId))
-        .and(PHOTOS.FILE_NAME.eq(filename))
-        .fetchOne(PHOTOS.STORAGE_URL)
-        ?: throw NoSuchFileException(filename)
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -15,10 +15,11 @@ import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.LocalFileStore
 import com.terraformation.backend.file.PathGenerator
+import com.terraformation.backend.file.PhotoService
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
+import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.mockUser
-import com.terraformation.backend.seedbank.model.PhotoMetadata
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -59,6 +60,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private val config: TerrawareServerConfig = mockk()
   private lateinit var fileStore: FileStore
   private lateinit var pathGenerator: PathGenerator
+  private lateinit var photoService: PhotoService
   private val random: Random = mockk()
   private lateinit var repository: PhotoRepository
   private val thumbnailStore: ThumbnailStore = mockk()
@@ -109,8 +111,8 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     every { user.canReadAccession(any()) } returns true
     every { user.canUpdateAccession(any()) } returns true
 
-    repository =
-        PhotoRepository(accessionPhotosDao, dslContext, clock, fileStore, photosDao, thumbnailStore)
+    photoService = PhotoService(dslContext, clock, fileStore, photosDao, thumbnailStore)
+    repository = PhotoRepository(accessionPhotosDao, dslContext, photoService)
 
     insertSiteData()
     insertAccession(id = accessionId, number = accessionNumber)


### PR DESCRIPTION
In preparation for adding photos of nursery withdrawals, extract all the logic
from `PhotoRepository` that isn't specific to accession photos into a new
`PhotoService` class.

No change in functionality here; the existing test cases in `PhotoRepositoryTest`
continue to pass.