### PR TITLE
SW-2228 Add permissions for withdrawal photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -24,7 +24,9 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.WITHDRAWALS
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -70,6 +72,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getFacilityId(viabilityTestId: ViabilityTestId): FacilityId? =
       fetchFieldById(viabilityTestId, VIABILITY_TESTS.ID, VIABILITY_TESTS.accessions.FACILITY_ID)
+
+  fun getFacilityId(withdrawalId: WithdrawalId): FacilityId? =
+      fetchFieldById(withdrawalId, WITHDRAWALS.ID, WITHDRAWALS.FACILITY_ID)
 
   fun getOrganizationId(deviceManagerId: DeviceManagerId): OrganizationId? =
       fetchFieldById(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -119,6 +120,7 @@ data class DeviceManagerUser(
   override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = false
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = false
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
   override fun canDeleteBatch(batchId: BatchId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
@@ -139,6 +141,7 @@ data class DeviceManagerUser(
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = false
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = false
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -166,6 +167,9 @@ data class IndividualUser(
   override fun canCreateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))
 
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId) =
+      isMember(parentStore.getFacilityId(withdrawalId))
+
   override fun canDeleteAccession(accessionId: AccessionId) =
       isManagerOrHigher(parentStore.getFacilityId(accessionId))
 
@@ -256,6 +260,9 @@ data class IndividualUser(
 
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId) =
       isMember(parentStore.getFacilityId(viabilityTestId))
+
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId) =
+      isMember(parentStore.getFacilityId(withdrawalId))
 
   override fun canRegenerateAllDeviceManagerTokens() = isSuperAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -24,11 +24,13 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
@@ -188,6 +190,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canCreateTimeseries(deviceId)) {
       readDevice(deviceId)
       throw AccessDeniedException("No permission to create timeseries on device $deviceId")
+    }
+  }
+
+  fun createWithdrawalPhoto(withdrawalId: WithdrawalId) {
+    if (!user.canCreateWithdrawalPhoto(withdrawalId)) {
+      readWithdrawal(withdrawalId)
+      throw AccessDeniedException("No permission to create photo on withdrawal $withdrawalId")
     }
   }
 
@@ -363,6 +372,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readViabilityTest(viabilityTestId: ViabilityTestId) {
     if (!user.canReadViabilityTest(viabilityTestId)) {
       throw ViabilityTestNotFoundException(viabilityTestId)
+    }
+  }
+
+  fun readWithdrawal(withdrawalId: WithdrawalId) {
+    if (!user.canReadWithdrawal(withdrawalId)) {
+      throw WithdrawalNotFoundException(withdrawalId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -114,6 +115,7 @@ class SystemUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = true
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
   override fun canDeleteBatch(batchId: BatchId): Boolean = true
@@ -143,6 +145,7 @@ class SystemUser(
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
   override fun canReadUpload(uploadId: UploadId): Boolean = true
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = true
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = true
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -79,6 +80,7 @@ interface TerrawareUser : Principal {
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
+  fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean
   fun canDeleteAccession(accessionId: AccessionId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
   fun canDeleteBatch(batchId: BatchId): Boolean
@@ -107,6 +109,7 @@ interface TerrawareUser : Principal {
   fun canReadTimeseries(deviceId: DeviceId): Boolean
   fun canReadUpload(uploadId: UploadId): Boolean
   fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean
+  fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean
   fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.EntityStaleException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 
 class BatchNotFoundException(val batchId: BatchId) :
     EntityNotFoundException("Seedling batch $batchId not found")
@@ -22,3 +23,6 @@ class CrossOrganizationNurseryTransferNotAllowedException(
     MismatchedStateException(
         "Cannot transfer from facility $facilityId to facility $destinationFacilityId because " +
             "they are in different organizations")
+
+class WithdrawalNotFoundException(val withdrawalId: WithdrawalId) :
+    EntityNotFoundException("Withdrawal $withdrawalId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -23,11 +23,13 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
@@ -71,6 +73,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val uploadId = UploadId(1)
   private val userId = UserId(1)
   private val viabilityTestId = ViabilityTestId(1)
+  private val withdrawalId = WithdrawalId(1)
 
   /**
    * Grants permission to perform a particular operation. This is a simple wrapper around a MockK
@@ -223,6 +226,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canCreateTimeseries(deviceId) }
     requirements.createTimeseries(deviceId)
+  }
+
+  @Test
+  fun createWithdrawalPhoto() {
+    assertThrows<WithdrawalNotFoundException> { requirements.createWithdrawalPhoto(withdrawalId) }
+
+    grant { user.canReadWithdrawal(withdrawalId) }
+    assertThrows<AccessDeniedException> { requirements.createWithdrawalPhoto(withdrawalId) }
+
+    grant { user.canCreateWithdrawalPhoto(withdrawalId) }
+    requirements.createWithdrawalPhoto(withdrawalId)
   }
 
   @Test
@@ -482,6 +496,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canReadViabilityTest(viabilityTestId) }
     requirements.readViabilityTest(viabilityTestId)
+  }
+
+  @Test
+  fun readWithdrawal() {
+    assertThrows<WithdrawalNotFoundException> { requirements.readWithdrawal(withdrawalId) }
+
+    grant { user.canReadWithdrawal(withdrawalId) }
+    requirements.readWithdrawal(withdrawalId)
   }
 
   @Test


### PR DESCRIPTION
In preparation for adding API endpoints to upload and retrieve photos of nursery
withdrawals, add a couple new permission checks. Nothing actually uses these in
the application code yet.