### PR TITLE
SW-2228 Support uploading photos of nursery withdrawals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -24,7 +24,9 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.WITHDRAWALS
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -70,6 +72,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getFacilityId(viabilityTestId: ViabilityTestId): FacilityId? =
       fetchFieldById(viabilityTestId, VIABILITY_TESTS.ID, VIABILITY_TESTS.accessions.FACILITY_ID)
+
+  fun getFacilityId(withdrawalId: WithdrawalId): FacilityId? =
+      fetchFieldById(withdrawalId, WITHDRAWALS.ID, WITHDRAWALS.FACILITY_ID)
 
   fun getOrganizationId(deviceManagerId: DeviceManagerId): OrganizationId? =
       fetchFieldById(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -119,6 +120,7 @@ data class DeviceManagerUser(
   override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = false
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = false
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = false
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = false
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
   override fun canDeleteBatch(batchId: BatchId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
@@ -139,6 +141,7 @@ data class DeviceManagerUser(
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canReadUpload(uploadId: UploadId): Boolean = false
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = false
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = false
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -166,6 +167,9 @@ data class IndividualUser(
   override fun canCreateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))
 
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId) =
+      isMember(parentStore.getFacilityId(withdrawalId))
+
   override fun canDeleteAccession(accessionId: AccessionId) =
       isManagerOrHigher(parentStore.getFacilityId(accessionId))
 
@@ -256,6 +260,9 @@ data class IndividualUser(
 
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId) =
       isMember(parentStore.getFacilityId(viabilityTestId))
+
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId) =
+      isMember(parentStore.getFacilityId(withdrawalId))
 
   override fun canRegenerateAllDeviceManagerTokens() = isSuperAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -24,11 +24,13 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
@@ -188,6 +190,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canCreateTimeseries(deviceId)) {
       readDevice(deviceId)
       throw AccessDeniedException("No permission to create timeseries on device $deviceId")
+    }
+  }
+
+  fun createWithdrawalPhoto(withdrawalId: WithdrawalId) {
+    if (!user.canCreateWithdrawalPhoto(withdrawalId)) {
+      readWithdrawal(withdrawalId)
+      throw AccessDeniedException("No permission to create photo on withdrawal $withdrawalId")
     }
   }
 
@@ -363,6 +372,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readViabilityTest(viabilityTestId: ViabilityTestId) {
     if (!user.canReadViabilityTest(viabilityTestId)) {
       throw ViabilityTestNotFoundException(viabilityTestId)
+    }
+  }
+
+  fun readWithdrawal(withdrawalId: WithdrawalId) {
+    if (!user.canReadWithdrawal(withdrawalId)) {
+      throw WithdrawalNotFoundException(withdrawalId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -114,6 +115,7 @@ class SystemUser(
   override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
   override fun canCreateStorageLocation(facilityId: FacilityId): Boolean = true
   override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
+  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = true
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
   override fun canDeleteBatch(batchId: BatchId): Boolean = true
@@ -143,6 +145,7 @@ class SystemUser(
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
   override fun canReadUpload(uploadId: UploadId): Boolean = true
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = true
+  override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = true
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
@@ -79,6 +80,7 @@ interface TerrawareUser : Principal {
   fun canCreateSpecies(organizationId: OrganizationId): Boolean
   fun canCreateStorageLocation(facilityId: FacilityId): Boolean
   fun canCreateTimeseries(deviceId: DeviceId): Boolean
+  fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean
   fun canDeleteAccession(accessionId: AccessionId): Boolean
   fun canDeleteAutomation(automationId: AutomationId): Boolean
   fun canDeleteBatch(batchId: BatchId): Boolean
@@ -107,6 +109,7 @@ interface TerrawareUser : Principal {
   fun canReadTimeseries(deviceId: DeviceId): Boolean
   fun canReadUpload(uploadId: UploadId): Boolean
   fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean
+  fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean
   fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -3,30 +3,54 @@ package com.terraformation.backend.nursery.api
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
+import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_OPERATION_DESCRIPTION
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.PhotoId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.db.WithdrawalPhotoService
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.LocalDate
 import javax.validation.constraints.Min
+import javax.ws.rs.NotSupportedException
+import javax.ws.rs.QueryParam
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @NurseryEndpoint
 @RequestMapping("/api/v1/nursery/withdrawals")
 @RestController
 class WithdrawalsController(
     val batchStore: BatchStore,
+    val withdrawalPhotoService: WithdrawalPhotoService,
 ) {
   @PostMapping
   fun createBatchWithdrawal(
@@ -39,6 +63,76 @@ class WithdrawalsController(
         batchModels.map { BatchPayload(it) },
         NurseryWithdrawalPayload(model),
     )
+  }
+
+  @Operation(summary = "Creates a new photo of a seedling batch withdrawal.")
+  @PostMapping("/{withdrawalId}/photos")
+  @io.swagger.v3.oas.annotations.parameters.RequestBody(
+      content =
+          [Content(encoding = [Encoding(name = "file", contentType = MediaType.IMAGE_JPEG_VALUE)])])
+  fun uploadWithdrawalPhoto(
+      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @RequestPart("file") file: MultipartFile,
+  ): CreateNurseryWithdrawalPhotoResponsePayload {
+    val contentType = file.contentType?.substringBefore(';')
+    if (contentType == null || contentType != MediaType.IMAGE_JPEG_VALUE) {
+      throw NotSupportedException("Photos must be of type image/jpeg")
+    }
+
+    val filename = file.originalFilename ?: "photo.jpg"
+
+    val photoId =
+        withdrawalPhotoService.storePhoto(
+            withdrawalId,
+            file.inputStream,
+            file.size,
+            PhotoMetadata(filename, contentType, file.size))
+
+    return CreateNurseryWithdrawalPhotoResponsePayload(photoId)
+  }
+
+  @ApiResponse(
+      responseCode = "200",
+      description = "The photo was successfully retrieved.",
+      content =
+          [
+              Content(
+                  schema = Schema(type = "string", format = "binary"),
+                  mediaType = MediaType.IMAGE_JPEG_VALUE)])
+  @ApiResponse404("The withdrawal does not exist, or does not have a photo with the requested ID.")
+  @GetMapping("/{withdrawalId}/photos/{photoId}", produces = [MediaType.IMAGE_JPEG_VALUE])
+  @Operation(
+      summary = "Retrieves a specific photo from a withdrawal.",
+      description = PHOTO_OPERATION_DESCRIPTION)
+  @ResponseBody
+  fun getWithdrawalPhoto(
+      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+      @PathVariable("photoId") photoId: PhotoId,
+      @QueryParam("maxWidth")
+      @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
+      maxWidth: Int? = null,
+      @QueryParam("maxHeight")
+      @Schema(description = PHOTO_MAXHEIGHT_DESCRIPTION)
+      maxHeight: Int? = null,
+  ): ResponseEntity<InputStreamResource> {
+    val headers = HttpHeaders()
+
+    val inputStream = withdrawalPhotoService.readPhoto(withdrawalId, photoId, maxWidth, maxHeight)
+    headers.contentLength = inputStream.size
+
+    val resource = InputStreamResource(inputStream)
+    return ResponseEntity(resource, headers, HttpStatus.OK)
+  }
+
+  @ApiResponse404("The withdrawal does not exist.")
+  @GetMapping("/{withdrawalId}/photos")
+  @Operation(summary = "Lists all the photos of a withdrawal.")
+  fun listWithdrawalPhotos(
+      @PathVariable("withdrawalId") withdrawalId: WithdrawalId,
+  ): ListWithdrawalPhotosResponsePayload {
+    val photoIds = withdrawalPhotoService.listPhotos(withdrawalId)
+
+    return ListWithdrawalPhotosResponsePayload(photoIds.map { NurseryWithdrawalPhotoPayload(it) })
   }
 }
 
@@ -127,3 +221,10 @@ data class CreateNurseryWithdrawalResponsePayload(
     val batches: List<BatchPayload>,
     val withdrawal: NurseryWithdrawalPayload
 ) : SuccessResponsePayload
+
+data class CreateNurseryWithdrawalPhotoResponsePayload(val id: PhotoId) : SuccessResponsePayload
+
+data class NurseryWithdrawalPhotoPayload(val id: PhotoId)
+
+data class ListWithdrawalPhotosResponsePayload(val photos: List<NurseryWithdrawalPhotoPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.EntityStaleException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 
 class BatchNotFoundException(val batchId: BatchId) :
     EntityNotFoundException("Seedling batch $batchId not found")
@@ -22,3 +23,6 @@ class CrossOrganizationNurseryTransferNotAllowedException(
     MismatchedStateException(
         "Cannot transfer from facility $facilityId to facility $destinationFacilityId because " +
             "they are in different organizations")
+
+class WithdrawalNotFoundException(val withdrawalId: WithdrawalId) :
+    EntityNotFoundException("Withdrawal $withdrawalId not found")

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -1,0 +1,94 @@
+package com.terraformation.backend.nursery.db
+
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.tables.daos.WithdrawalPhotosDao
+import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
+import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_PHOTOS
+import com.terraformation.backend.file.PhotoService
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.model.PhotoMetadata
+import com.terraformation.backend.log.perClassLogger
+import java.io.InputStream
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
+
+@ManagedBean
+class WithdrawalPhotoService(
+    private val dslContext: DSLContext,
+    private val photoService: PhotoService,
+    private val withdrawalPhotosDao: WithdrawalPhotosDao,
+) {
+  private val log = perClassLogger()
+
+  fun storePhoto(
+      withdrawalId: WithdrawalId,
+      data: InputStream,
+      size: Long,
+      metadata: PhotoMetadata
+  ): PhotoId {
+    requirePermissions { createWithdrawalPhoto(withdrawalId) }
+
+    val photoId =
+        photoService.storePhoto("withdrawal", data, size, metadata) { photoId ->
+          withdrawalPhotosDao.insert(
+              WithdrawalPhotosRow(photoId = photoId, withdrawalId = withdrawalId))
+        }
+
+    log.info("Stored photo $photoId for withdrawal $withdrawalId")
+
+    return photoId
+  }
+
+  fun readPhoto(
+      withdrawalId: WithdrawalId,
+      photoId: PhotoId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null
+  ): SizedInputStream {
+    val storedWithdrawalId =
+        dslContext
+            .select(WITHDRAWAL_PHOTOS.WITHDRAWAL_ID)
+            .from(WITHDRAWAL_PHOTOS)
+            .where(WITHDRAWAL_PHOTOS.PHOTO_ID.eq(photoId))
+            .fetchOne(WITHDRAWAL_PHOTOS.WITHDRAWAL_ID)
+    if (withdrawalId != storedWithdrawalId) {
+      throw PhotoNotFoundException(photoId)
+    }
+
+    requirePermissions { readWithdrawal(withdrawalId) }
+
+    return photoService.readPhoto(photoId, maxWidth, maxHeight)
+  }
+
+  fun listPhotos(withdrawalId: WithdrawalId): List<PhotoId> {
+    requirePermissions { readWithdrawal(withdrawalId) }
+
+    return dslContext
+        .select(WITHDRAWAL_PHOTOS.PHOTO_ID)
+        .from(WITHDRAWAL_PHOTOS)
+        .where(WITHDRAWAL_PHOTOS.WITHDRAWAL_ID.eq(withdrawalId))
+        .fetch(WITHDRAWAL_PHOTOS.PHOTO_ID)
+        .filterNotNull()
+  }
+
+  /** Deletes all the photos from all the withdrawals owned by an organization. */
+  @EventListener
+  fun on(event: OrganizationDeletionStartedEvent) {
+    with(WITHDRAWAL_PHOTOS) {
+      dslContext
+          .select(PHOTO_ID)
+          .from(WITHDRAWAL_PHOTOS)
+          .where(withdrawals.withdrawalsFacilityIdFkey.ORGANIZATION_ID.eq(event.organizationId))
+          .fetch(PHOTO_ID)
+          .filterNotNull()
+          .forEach { photoId ->
+            photoService.deletePhoto(photoId) { withdrawalPhotosDao.deleteById(photoId) }
+          }
+    }
+  }
+}

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -225,6 +225,8 @@ COMMENT ON COLUMN nursery.batches.ready_quantity IS 'Number of ready-for-plantin
 COMMENT ON COLUMN nursery.batches.species_id IS 'Species of the batch''s plants. Must be under the same organization as the facility ID (enforced in application code).';
 COMMENT ON COLUMN nursery.batches.version IS 'Increases by 1 each time the batch is modified. Used to detect when clients have stale data about batches.';
 
+COMMENT ON TABLE nursery.withdrawal_photos IS 'Linking table between `withdrawals` and `photos`.';
+
 COMMENT ON TABLE nursery.withdrawal_purposes IS '(Enum) Reasons that someone can withdraw seedlings from a nursery.';
 
 COMMENT ON TABLE nursery.withdrawals IS 'Top-level information about a withdrawal from a nursery. Does not contain withdrawal quantities; those are in the `batch_withdrawals` table.';

--- a/src/main/resources/db/migration/V155__NurseryWithdrawalPhotos.sql
+++ b/src/main/resources/db/migration/V155__NurseryWithdrawalPhotos.sql
@@ -1,0 +1,9 @@
+-- No cascading deletes on these foreign keys because deleting photos requires deleting files from
+-- the file store.
+CREATE TABLE nursery.withdrawal_photos
+(
+    photo_id      BIGINT PRIMARY KEY REFERENCES photos,
+    withdrawal_id BIGINT NOT NULL REFERENCES nursery.withdrawals
+);
+
+CREATE INDEX ON nursery.withdrawal_photos (withdrawal_id);

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -23,11 +23,13 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
+import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
@@ -71,6 +73,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val uploadId = UploadId(1)
   private val userId = UserId(1)
   private val viabilityTestId = ViabilityTestId(1)
+  private val withdrawalId = WithdrawalId(1)
 
   /**
    * Grants permission to perform a particular operation. This is a simple wrapper around a MockK
@@ -223,6 +226,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canCreateTimeseries(deviceId) }
     requirements.createTimeseries(deviceId)
+  }
+
+  @Test
+  fun createWithdrawalPhoto() {
+    assertThrows<WithdrawalNotFoundException> { requirements.createWithdrawalPhoto(withdrawalId) }
+
+    grant { user.canReadWithdrawal(withdrawalId) }
+    assertThrows<AccessDeniedException> { requirements.createWithdrawalPhoto(withdrawalId) }
+
+    grant { user.canCreateWithdrawalPhoto(withdrawalId) }
+    requirements.createWithdrawalPhoto(withdrawalId)
   }
 
   @Test
@@ -482,6 +496,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canReadViabilityTest(viabilityTestId) }
     requirements.readViabilityTest(viabilityTestId)
+  }
+
+  @Test
+  fun readWithdrawal() {
+    assertThrows<WithdrawalNotFoundException> { requirements.readWithdrawal(withdrawalId) }
+
+    grant { user.canReadWithdrawal(withdrawalId) }
+    requirements.readWithdrawal(withdrawalId)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -52,6 +52,7 @@ import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.daos.BatchQuantityHistoryDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchWithdrawalsDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchesDao
+import com.terraformation.backend.db.nursery.tables.daos.WithdrawalPhotosDao
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
@@ -254,6 +255,7 @@ abstract class DatabaseTest {
   protected val usersDao: UsersDao by lazyDao()
   protected val viabilityTestResultsDao: ViabilityTestResultsDao by lazyDao()
   protected val viabilityTestsDao: ViabilityTestsDao by lazyDao()
+  protected val withdrawalPhotosDao: WithdrawalPhotosDao by lazyDao()
   protected val withdrawalsDao: WithdrawalsDao by lazyDao()
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -129,8 +129,9 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "batch_quantity_history" to setOf(ALL, NURSERY),
                   "batch_quantity_history_types" to setOf(ALL, NURSERY),
                   "batch_withdrawals" to setOf(ALL, NURSERY),
-                  "withdrawals" to setOf(ALL, NURSERY),
+                  "withdrawal_photos" to setOf(ALL, NURSERY),
                   "withdrawal_purposes" to setOf(ALL, NURSERY),
+                  "withdrawals" to setOf(ALL, NURSERY),
               ),
           "public" to
               mapOf(

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -1,0 +1,164 @@
+package com.terraformation.backend.nursery.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
+import com.terraformation.backend.file.FileStore
+import com.terraformation.backend.file.PhotoService
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailStore
+import com.terraformation.backend.file.model.PhotoMetadata
+import com.terraformation.backend.mockUser
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.net.URI
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val fileStore: FileStore = mockk()
+  private val thumbnailStore: ThumbnailStore = mockk()
+  private val photoService: PhotoService by lazy {
+    PhotoService(
+        dslContext,
+        Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+        fileStore,
+        photosDao,
+        thumbnailStore)
+  }
+  private val service: WithdrawalPhotoService by lazy {
+    WithdrawalPhotoService(dslContext, photoService, withdrawalPhotosDao)
+  }
+
+  private val metadata = PhotoMetadata("filename", "contentType", 123L)
+  private val withdrawalId: WithdrawalId by lazy { insertWithdrawal() }
+  private var storageUrlCount = 0
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertFacility(type = FacilityType.Nursery)
+
+    every { fileStore.delete(any()) } just Runs
+    every { fileStore.newUrl(any(), any(), any()) } answers { URI("${++storageUrlCount}") }
+    every { fileStore.write(any(), any()) } just Runs
+    every { thumbnailStore.deleteThumbnails(any()) } just Runs
+    every { user.canCreateWithdrawalPhoto(any()) } returns true
+    every { user.canReadWithdrawal(any()) } returns true
+  }
+
+  @Test
+  fun `storePhoto associates photo with withdrawal`() {
+    val photoId = storePhoto()
+
+    assertEquals(listOf(WithdrawalPhotosRow(photoId, withdrawalId)), withdrawalPhotosDao.findAll())
+  }
+
+  @Test
+  fun `readPhoto returns photo data`() {
+    val content = Random.nextBytes(10)
+    val photoId = storePhoto(content = content)
+
+    every { fileStore.read(URI("1")) } returns SizedInputStream(content.inputStream(), 10L)
+
+    val inputStream = service.readPhoto(withdrawalId, photoId)
+    assertArrayEquals(content, inputStream.readAllBytes(), "File content")
+  }
+
+  @Test
+  fun `readPhoto returns thumbnail data`() {
+    val content = Random.nextBytes(10)
+    val photoId = storePhoto()
+    val maxWidth = 10
+    val maxHeight = 20
+
+    every { thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight) } returns
+        SizedInputStream(content.inputStream(), 10L)
+
+    val inputStream = service.readPhoto(withdrawalId, photoId, maxWidth, maxHeight)
+    assertArrayEquals(content, inputStream.readAllBytes(), "Thumbnail content")
+  }
+
+  @Test
+  fun `readPhoto throws exception if photo is on a different withdrawal`() {
+    val otherWithdrawalId = insertWithdrawal()
+    val photoId = storePhoto()
+
+    assertThrows<PhotoNotFoundException> { service.readPhoto(otherWithdrawalId, photoId) }
+  }
+
+  @Test
+  fun `readPhoto throws exception if no permission to read withdrawal`() {
+    val photoId = storePhoto()
+
+    every { user.canReadWithdrawal(any()) } returns false
+
+    assertThrows<WithdrawalNotFoundException> { service.readPhoto(withdrawalId, photoId) }
+  }
+
+  @Test
+  fun `listPhotos returns list of withdrawal photo IDs for correct withdrawal`() {
+    val photoIds = setOf(storePhoto(), storePhoto())
+    val otherWithdrawalId = insertWithdrawal()
+    storePhoto(otherWithdrawalId)
+
+    assertEquals(photoIds, service.listPhotos(withdrawalId).toSet())
+  }
+
+  @Test
+  fun `listPhotos throws exception if no permission to read withdrawal`() {
+    every { user.canReadWithdrawal(any()) } returns false
+
+    assertThrows<WithdrawalNotFoundException> { service.listPhotos(withdrawalId) }
+  }
+
+  @Test
+  fun `handler for OrganizationDeletionStartedEvent deletes photos for all withdrawals in organization`() {
+    val facilityId2 = FacilityId(2)
+    val otherOrganizationId = OrganizationId(2)
+    val otherOrgFacilityId = FacilityId(3)
+    insertOrganization(otherOrganizationId)
+    insertFacility(facilityId2, type = FacilityType.Nursery)
+    insertFacility(otherOrgFacilityId, otherOrganizationId, type = FacilityType.Nursery)
+    val facility2WithdrawalId = insertWithdrawal(facilityId = facilityId2)
+    val otherOrgWithdrawalId = insertWithdrawal(facilityId = otherOrgFacilityId)
+
+    storePhoto()
+    storePhoto()
+    storePhoto(facility2WithdrawalId)
+    val otherOrgPhotoId = storePhoto(otherOrgWithdrawalId)
+
+    service.on(OrganizationDeletionStartedEvent(organizationId))
+
+    assertEquals(listOf(otherOrgPhotoId), photosDao.findAll().map { it.id }, "Remaining photo IDs")
+    assertEquals(
+        listOf(WithdrawalPhotosRow(photoId = otherOrgPhotoId, withdrawalId = otherOrgWithdrawalId)),
+        withdrawalPhotosDao.findAll(),
+        "Remaining withdrawal photos")
+  }
+
+  private fun storePhoto(
+      withdrawalId: WithdrawalId = this.withdrawalId,
+      content: ByteArray = ByteArray(0)
+  ): PhotoId {
+    return service.storePhoto(withdrawalId, content.inputStream(), content.size.toLong(), metadata)
+  }
+}


### PR DESCRIPTION
Add endpoints to upload, fetch, and list photos of nursery withdrawals:

`POST /api/v1/nursery/withdrawals/{withdrawalId}/photos` uploads a photo,
which is expected to be in a file upload form field called `file`, same as
the existing accession photo upload endpoint. Unlike the accession photo
upload API, though, this endpoint returns a photo ID rather than relying on
the client-supplied filename.

`GET /api/v1/nursery/withdrawals/{withdrawalId}/photos` returns a list of
the photos for the withdrawal. Currently, this is just their photo IDs,
though it's structured to allow for additional data to be added later.

`GET /api/v1/nursery/withdrawals/{withdrawalId}/photos/{photoId}` fetches
a photo. Like the accession photo download endpoint, you can pass optional
`maxWidth` and/or `maxHeight` query string parameters to generate a thumbnail
of the requested dimensions.

Currently, only JPEG photos are accepted; support for additional file formats
will be added in a later change.