### PR TITLE
SW-1415 Replace obsolete withdrawal purposes

### DIFF
--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -201,12 +201,7 @@ VALUES (1, 'Nursery Transfer'), -- ID 1 is used in a check constraint; don't cha
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO seedbank.withdrawal_purposes (id, name)
-VALUES (1, 'Propagation'),
-       (2, 'Outreach or Education'),
-       (3, 'Research'),
-       (4, 'Broadcast'),
-       (5, 'Share with Another Site'),
-       (6, 'Other'),
+VALUES (6, 'Other'),
        (7, 'Viability Testing'),
        (8, 'Out-planting'),
        (9, 'Nursery')

--- a/src/main/resources/db/migration/V156__SeedbankWithdrawalPurposes.sql
+++ b/src/main/resources/db/migration/V156__SeedbankWithdrawalPurposes.sql
@@ -1,0 +1,24 @@
+UPDATE seedbank.withdrawals
+SET purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Out-planting')
+WHERE purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Propagation');
+
+UPDATE seedbank.withdrawals
+SET purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Other')
+WHERE purpose_id IN (SELECT id
+                     FROM seedbank.withdrawal_purposes
+                     WHERE name IN (
+                                    'Outreach or Education',
+                                    'Research',
+                                    'Broadcast',
+                                    'Share with Another Site'
+                         ));
+
+DELETE
+FROM seedbank.withdrawal_purposes
+WHERE name IN (
+               'Propagation',
+               'Outreach or Education',
+               'Research',
+               'Broadcast',
+               'Share with Another Site'
+    );


### PR DESCRIPTION
Migrate existing seedbank withdrawals to use the currently-supported set of
withdrawal purposes and remove the old unsupported ones from the data model.