### PR TITLE
SW-2239 Use consistent CRS for planting sites

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,6 +132,7 @@ dependencies {
   runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.2")
 
   testImplementation("io.mockk:mockk:1.13.2")
+  testImplementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-api:$jUnitVersion")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.search.field
 
+import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.asGeoJson
+import com.terraformation.backend.db.transformSrid
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
@@ -24,7 +26,8 @@ class GeometryField(
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = emptySet()
 
-  override val databaseField: Field<String?> = geometryField.asGeoJson()
+  override val databaseField: Field<String?> =
+      geometryField.transformSrid(SRID.LONG_LAT).asGeoJson()
 
   override fun getCondition(fieldNode: FieldNode): Condition {
     throw IllegalArgumentException("Filters not supported for geometry fields")

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.PlotId
-import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import org.jooq.Field
 import org.jooq.Record
@@ -14,14 +13,31 @@ data class PlotModel(
     val id: PlotId,
     val fullName: String,
     val name: String,
-)
+) {
+  fun equals(other: Any?, tolerance: Double): Boolean {
+    return other is PlotModel &&
+        id == other.id &&
+        fullName == other.fullName &&
+        name == other.name &&
+        boundary.equalsExact(other.boundary, tolerance)
+  }
+}
 
 data class PlantingZoneModel(
     val boundary: Geometry,
     val id: PlantingZoneId,
     val name: String,
     val plots: List<PlotModel>,
-)
+) {
+  fun equals(other: Any?, tolerance: Double): Boolean {
+    return other is PlantingZoneModel &&
+        id == other.id &&
+        name == other.name &&
+        plots.size == other.plots.size &&
+        plots.zip(other.plots).all { it.first.equals(it.second, tolerance) } &&
+        boundary.equalsExact(other.boundary, tolerance)
+  }
+}
 
 data class PlantingSiteModel(
     val boundary: Geometry?,
@@ -31,17 +47,26 @@ data class PlantingSiteModel(
     val plantingZones: List<PlantingZoneModel>,
 ) {
   constructor(
-      row: PlantingSitesRow,
-      plantingZones: List<PlantingZoneModel>
-  ) : this(row.boundary, row.description, row.id!!, row.name!!, plantingZones)
-
-  constructor(
       record: Record,
+      plantingSitesBoundaryField: Field<Geometry?>,
       plantingZonesMultiset: Field<List<PlantingZoneModel>>? = null
   ) : this(
-      record[PLANTING_SITES.BOUNDARY],
+      record[plantingSitesBoundaryField],
       record[PLANTING_SITES.DESCRIPTION],
       record[PLANTING_SITES.ID]!!,
       record[PLANTING_SITES.NAME]!!,
       plantingZonesMultiset?.let { record[it] } ?: emptyList())
+
+  fun equals(other: Any?, tolerance: Double): Boolean {
+    return other is PlantingSiteModel &&
+        description == other.description &&
+        id == other.id &&
+        name == other.name &&
+        plantingZones.size == other.plantingZones.size &&
+        plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) } &&
+        (boundary == null && other.boundary == null ||
+            boundary != null &&
+                other.boundary != null &&
+                boundary.equalsExact(other.boundary, tolerance))
+  }
 }

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -201,12 +201,7 @@ VALUES (1, 'Nursery Transfer'), -- ID 1 is used in a check constraint; don't cha
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO seedbank.withdrawal_purposes (id, name)
-VALUES (1, 'Propagation'),
-       (2, 'Outreach or Education'),
-       (3, 'Research'),
-       (4, 'Broadcast'),
-       (5, 'Share with Another Site'),
-       (6, 'Other'),
+VALUES (6, 'Other'),
        (7, 'Viability Testing'),
        (8, 'Out-planting'),
        (9, 'Nursery')

--- a/src/main/resources/db/migration/V156__SeedbankWithdrawalPurposes.sql
+++ b/src/main/resources/db/migration/V156__SeedbankWithdrawalPurposes.sql
@@ -1,0 +1,24 @@
+UPDATE seedbank.withdrawals
+SET purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Out-planting')
+WHERE purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Propagation');
+
+UPDATE seedbank.withdrawals
+SET purpose_id = (SELECT id FROM seedbank.withdrawal_purposes WHERE name = 'Other')
+WHERE purpose_id IN (SELECT id
+                     FROM seedbank.withdrawal_purposes
+                     WHERE name IN (
+                                    'Outreach or Education',
+                                    'Research',
+                                    'Broadcast',
+                                    'Share with Another Site'
+                         ));
+
+DELETE
+FROM seedbank.withdrawal_purposes
+WHERE name IN (
+               'Propagation',
+               'Outreach or Education',
+               'Research',
+               'Broadcast',
+               'Share with Another Site'
+    );

--- a/src/main/resources/db/migration/V157__PlantingSitesSrid.sql
+++ b/src/main/resources/db/migration/V157__PlantingSitesSrid.sql
@@ -1,0 +1,28 @@
+-- Store geometry values in whatever coordinate system was used in the source data (that is, retain
+-- the exact original values when importing); we will transform at read time.
+
+-- Need to recreate the view because we're changing the data type of one of its columns.
+DROP VIEW tracking.planting_site_summaries;
+
+ALTER TABLE tracking.planting_sites ALTER COLUMN boundary TYPE GEOMETRY(MULTIPOLYGON);
+ALTER TABLE tracking.planting_zones ALTER COLUMN boundary TYPE GEOMETRY(MULTIPOLYGON);
+ALTER TABLE tracking.plots ALTER COLUMN boundary TYPE GEOMETRY(MULTIPOLYGON);
+
+CREATE OR REPLACE VIEW tracking.planting_site_summaries AS
+SELECT id,
+       organization_id,
+       name,
+       description,
+       boundary,
+       created_by,
+       created_time,
+       modified_by,
+       modified_time,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+        WHERE ps.id = pz.planting_site_id) AS num_planting_zones,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+                 JOIN tracking.plots p ON pz.id = p.planting_zone_id
+        WHERE ps.id = pz.planting_site_id) AS num_plots
+FROM tracking.planting_sites ps;

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -50,5 +50,5 @@ fun multiPolygon(scale: Double): MultiPolygon {
                       CoordinateXY(scale, 0.0),
                       CoordinateXY(scale, scale),
                       CoordinateXY(0.0, 0.0)))))
-      .also { it.srid = SRID.SPHERICAL_MERCATOR }
+      .also { it.srid = SRID.LONG_LAT }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -16,10 +16,13 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Instant
 import java.time.InstantSource
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.locationtech.jts.geom.Geometry
 import org.springframework.security.access.AccessDeniedException
 
 internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
@@ -72,7 +75,57 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
     val actual = store.fetchSiteById(plantingSiteId)
 
-    assertEquals(expected, actual)
+    if (!expected.equals(actual, 0.00001)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Test
+  fun `fetchSiteById transforms coordinates to SRID 4326`() {
+    val crsFactory = CRS.getAuthorityFactory(true)
+    val crs3857 = crsFactory.createCoordinateReferenceSystem("EPSG:3857")
+    val crs4326 = crsFactory.createCoordinateReferenceSystem("EPSG:4326")
+    val transform4326To3857 = CRS.findMathTransform(crs4326, crs3857)
+    fun Geometry.to3857() = JTS.transform(this, transform4326To3857).also { it.srid = 3857 }
+
+    val siteBoundary4326 = multiPolygon(30.0)
+    val zoneBoundary4326 = multiPolygon(20.0)
+    val plotBoundary4326 = multiPolygon(10.0)
+
+    val siteBoundary3857 = siteBoundary4326.to3857()
+    val zoneBoundary3857 = zoneBoundary4326.to3857()
+    val plotBoundary3857 = plotBoundary4326.to3857()
+
+    val plantingSiteId = insertPlantingSite(boundary = siteBoundary3857)
+    val plantingZoneId =
+        insertPlantingZone(boundary = zoneBoundary3857, plantingSiteId = plantingSiteId)
+    val plotId = insertPlot(boundary = plotBoundary3857, plantingZoneId = plantingZoneId)
+
+    val expected =
+        PlantingSiteModel(
+            boundary = siteBoundary4326,
+            description = null,
+            id = plantingSiteId,
+            name = "Site 1",
+            plantingZones =
+                listOf(
+                    PlantingZoneModel(
+                        boundary = zoneBoundary4326,
+                        id = plantingZoneId,
+                        name = "Z1",
+                        plots =
+                            listOf(
+                                PlotModel(
+                                    boundary = plotBoundary4326,
+                                    id = plotId,
+                                    fullName = "Z1-1",
+                                    name = "1")))))
+
+    val actual = store.fetchSiteById(plantingSiteId)
+
+    if (!expected.equals(actual, 0.000001)) {
+      assertEquals(expected, actual)
+    }
   }
 
   @Test


### PR DESCRIPTION
The default coordinate reference system (CRS) for GeoJSON objects is EPSG:4326,
which uses degrees of latitude and longitude. ArcGIS uses a spherical Mercator
coordinate system (EPSG:3857) by default, and we were returning geometry values
in that system which isn't usually what clients need.

Make two changes to the way we handle coordinates:

* Store coordinates in whatever coordinate reference system was used in the
  shapefiles we're importing.
* At read time, transform to EPSG:4326. (In the future, we might allow the client
  to ask for a different CRS.)