### PR TITLE
SW-1405 Remove collectionNotes accession search field

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -77,7 +77,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             "ageYears", "Age (years)", ACCESSIONS.COLLECTED_DATE, AgeField.YearGranularity, clock),
         aliasField("bagNumber", "bags_number"),
         dateField("collectedDate", "Collected on", ACCESSIONS.COLLECTED_DATE),
-        textField("collectionNotes", "Notes (collection)", ACCESSIONS.COLLECTION_SITE_NOTES),
         textField("collectionSiteCity", "Collection site city", ACCESSIONS.COLLECTION_SITE_CITY),
         textField(
             "collectionSiteCountryCode",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -860,7 +860,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "ageMonths" to "15",
                     "ageYears" to "1",
                     "collectedDate" to "2019-03-02",
-                    "collectionNotes" to "siteNotes",
                     "collectionSiteCity" to "city",
                     "collectionSiteCountryCode" to "UG",
                     "collectionSiteCountrySubdivision" to "subdivision",


### PR DESCRIPTION
This was a backward-compatibility alias for `collectionSiteNotes`. The client has
been updated to use the new name, so the old one is no longer needed.