### PR TITLE
SW-2225 Ignore fractional remaining seeds after withdrawal

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/SeedQuantity.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/SeedQuantity.kt
@@ -100,12 +100,20 @@ data class SeedQuantityModel(val quantity: BigDecimal, val units: SeedQuantityUn
     return SeedQuantityModel(quantity + other.toUnits(units).quantity, units)
   }
 
+  operator fun times(other: Int): SeedQuantityModel {
+    return SeedQuantityModel(quantity.times(other.toBigDecimal()).stripTrailingZeros(), units)
+  }
+
   override fun compareTo(other: SeedQuantityModel): Int {
     return if (units == other.units) {
       quantity.compareTo(other.quantity)
     } else {
       units.toGrams(quantity).compareTo(other.units.toGrams(other.quantity))
     }
+  }
+
+  fun abs(): SeedQuantityModel {
+    return SeedQuantityModel(quantity.abs(), units)
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/SeedQuantityModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/SeedQuantityModelTest.kt
@@ -102,4 +102,17 @@ internal class SeedQuantityModelTest {
     val expected = SeedQuantityModel(BigDecimal(13), SeedQuantityUnits.Seeds)
     assertEquals(expected, converted)
   }
+
+  @Test
+  fun `times strips trailing fractional zeros`() {
+    val original = SeedQuantityModel(BigDecimal("0.05"), SeedQuantityUnits.Grams)
+    val multiplied = original * 4
+
+    assertEquals(2, original.quantity.scale(), "Original scale")
+    assertEquals(1, multiplied.quantity.scale(), "Multiplied scale")
+    assertEquals(
+        SeedQuantityModel(BigDecimal("0.2"), SeedQuantityUnits.Grams),
+        multiplied,
+        "Multiplication result")
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -104,6 +104,35 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
                   withdrawals = listOf(existingWithdrawalForTest, otherExistingWithdrawal)))
       assertEquals(existingWithdrawalForTest.id, withdrawals[0].id, "Withdrawal ID")
     }
+
+    @Test
+    fun `withdrawal of estimated seed count rounds fractional remaining weight to zero`() {
+      val accession =
+          accession(remaining = grams(11), subsetCount = 10000, subsetWeight = grams(3))
+              .withCalculatedValues(clock)
+
+      val afterWithdrawal =
+          accession.addWithdrawal(
+              withdrawal(seeds(accession.estimatedSeedCount!!), id = null), clock)
+
+      assertEquals(grams(0), afterWithdrawal.remaining)
+      assertEquals(AccessionState.UsedUp, afterWithdrawal.state)
+    }
+
+    @Test
+    fun `withdrawal of estimated seed count rounds negative fractional remaining weight to zero`() {
+      val accession =
+          accession(remaining = grams(8), subsetCount = 1, subsetWeight = grams(3))
+              .withCalculatedValues(clock)
+
+      assertEquals(3, accession.estimatedSeedCount)
+      val afterWithdrawal =
+          accession.addWithdrawal(
+              withdrawal(seeds(accession.estimatedSeedCount!!), id = null), clock)
+
+      assertEquals(grams(0), afterWithdrawal.remaining)
+      assertEquals(AccessionState.UsedUp, afterWithdrawal.state)
+    }
   }
 
   @Nested


### PR DESCRIPTION
When the user creates a nursery transfer or a viability test, the withdrawal
quantity is always denominated in seeds even if the accession is weight-based.
We estimate the withdrawal weight using the subset count and weight, and
subtract that estimated weight from the accession's remaining weight.

This is normally fine, but when the user is trying to withdraw all the
remaining seeds from the accession, the withdrawal ends up either failing (if
the estimated weight ended up being slightly greater than the accession's
remaining weight) or leaving the accession active even though there are no more
seeds in reality (if the estimated weight was slightly less than the
accession's remaining weight).

Add logic to handle this case: if the most recent withdrawal from a
weight-based accession is count-based, and the remaining weight would be less
than the estimated weight of one seed (positive or negative), round the
accession's remaining quantity to zero.