### PR TITLE
SW-2225 Clean up inconsistent accession quantities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/QuantityRepairer.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/QuantityRepairer.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.db
 
+import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
@@ -12,6 +13,7 @@ import java.time.Clock
 import javax.annotation.ManagedBean
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
 
@@ -23,6 +25,8 @@ import org.springframework.context.event.EventListener
  *
  * This class can be deleted after it has run in production.
  */
+// HACK: Disable for "gradle generateOpenApiDocs"
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
 @ManagedBean
 class QuantityRepairer(
     private val accessionStore: AccessionStore,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/QuantityRepairer.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/QuantityRepairer.kt
@@ -1,0 +1,127 @@
+package com.terraformation.backend.seedbank.db
+
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.db.seedbank.SeedQuantityUnits
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
+import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
+import com.terraformation.backend.log.perClassLogger
+import java.math.BigDecimal
+import java.time.Clock
+import javax.annotation.ManagedBean
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+
+/**
+ * Cleans up after a bug in the v1 accession code that caused withdrawals to be inserted into the
+ * database even when the withdrawal ultimately failed, which then triggered a bug in the v1-to-v2
+ * migration that caused subsequent withdrawals to have negative estimated weights to be calculated
+ * for weight-based accessions with count-based withdrawals.
+ *
+ * This class can be deleted after it has run in production.
+ */
+@ManagedBean
+class QuantityRepairer(
+    private val accessionStore: AccessionStore,
+    private val clock: Clock,
+    private val dslContext: DSLContext,
+    private val systemUser: SystemUser,
+) {
+  private val log = perClassLogger()
+
+  @EventListener
+  fun on(@Suppress("UNUSED_PARAMETER") event: ApplicationStartedEvent) {
+    systemUser.run {
+      log.info("Scanning for accessions with inconsistent withdrawal quantities")
+
+      var accessionId: AccessionId? = AccessionId(0)
+
+      while (accessionId != null) {
+        dslContext.transaction { _ ->
+          accessionId =
+              dslContext
+                  .select(ACCESSIONS.ID)
+                  .from(ACCESSIONS)
+                  .whereExists(
+                      DSL.selectOne()
+                          .from(WITHDRAWALS)
+                          .where(WITHDRAWALS.ESTIMATED_WEIGHT_QUANTITY.lt(BigDecimal.ZERO))
+                          .and(WITHDRAWALS.ACCESSION_ID.eq(ACCESSIONS.ID)))
+                  .and(ACCESSIONS.ID.gt(accessionId))
+                  .and(ACCESSIONS.REMAINING_UNITS_ID.ne(SeedQuantityUnits.Seeds))
+                  .orderBy(ACCESSIONS.ID)
+                  .limit(1)
+                  .forUpdate()
+                  .skipLocked()
+                  .fetchOne(ACCESSIONS.ID)
+
+          if (accessionId != null) {
+            try {
+              val accession = accessionStore.fetchOneById(accessionId!!)
+
+              // Get rid of withdrawals more recent than the latest observed time that don't have
+              // corresponding quantity history entries, where "corresponding" means "created within
+              // a few seconds of the withdrawal."
+              val quantityHistoryTimes =
+                  dslContext
+                      .select(ACCESSION_QUANTITY_HISTORY.CREATED_TIME)
+                      .from(ACCESSION_QUANTITY_HISTORY)
+                      .where(ACCESSION_QUANTITY_HISTORY.ACCESSION_ID.eq(accessionId))
+                      .fetch(ACCESSION_QUANTITY_HISTORY.CREATED_TIME)
+                      .filterNotNull()
+              val withdrawalsToRetain =
+                  accession.withdrawals.filter { withdrawal ->
+                    val startTime = withdrawal.createdTime!!
+                    val endTime = startTime.plusSeconds(3L)
+                    val isBeforeLatestObservation =
+                        !withdrawal.isAfter(accession.latestObservedTime!!)
+                    val hasHistoryEntry =
+                        quantityHistoryTimes.any { it >= startTime && it < endTime }
+
+                    isBeforeLatestObservation || hasHistoryEntry
+                  }
+
+              if (withdrawalsToRetain != accession.withdrawals) {
+                log.info("Accession $accessionId had withdrawals without quantity history entries")
+              }
+
+              val observedQuantityToKeepExistingRemainingQuantity =
+                  withdrawalsToRetain
+                      .filter { it.isAfter(accession.latestObservedTime!!) }
+                      .map {
+                        it.withdrawn!!.toUnits(
+                            SeedQuantityUnits.Milligrams,
+                            accession.subsetWeightQuantity,
+                            accession.subsetCount)
+                      }
+                      .fold(accession.remaining!!.toUnits(SeedQuantityUnits.Milligrams)) {
+                          subtotal,
+                          withdrawn ->
+                        subtotal + withdrawn
+                      }
+                      .toUnits(accession.remaining.units)
+
+              val adjustedAccession =
+                  accession
+                      .copy(
+                          latestObservedQuantity = observedQuantityToKeepExistingRemainingQuantity,
+                          latestObservedQuantityCalculated = true,
+                          withdrawals = withdrawalsToRetain)
+                      .withCalculatedValues(clock)
+
+              accessionStore.update(adjustedAccession)
+            } catch (e: Exception) {
+              log.error("Unable to recalculate quantity for accession $accessionId: ${e.message}")
+              // Proceed to the next accession
+            }
+          }
+        }
+      }
+
+      log.debug("Done scanning for inconsistent remaining quantities")
+    }
+  }
+}

--- a/src/main/resources/db/migration/V158__WithdrawalPurposeFix.sql
+++ b/src/main/resources/db/migration/V158__WithdrawalPurposeFix.sql
@@ -1,0 +1,15 @@
+-- A bug allowed creating seed withdrawals that had viability test IDs without the withdrawal
+-- purpose being set to "Viability Testing". Fix up the existing withdrawals and add a constraint
+-- to prevent it from happening again.
+
+-- Purpose 7 is Viability Testing (can't look it up dynamically in the check constraint).
+
+UPDATE seedbank.withdrawals
+SET purpose_id = 7
+WHERE purpose_id IS NULL
+  AND viability_test_id IS NOT NULL;
+
+ALTER TABLE seedbank.withdrawals
+    ADD CONSTRAINT withdrawals_test_id_requires_purpose
+        CHECK ((viability_test_id IS NULL AND (purpose_id IS NULL OR purpose_id <> 7)) OR
+               (viability_test_id IS NOT NULL AND purpose_id IS NOT NULL AND purpose_id = 7));


### PR DESCRIPTION
Thanks to a combination of bugs in the v1 accession code and problems with the
v1->v2 migration, a handful of accessions ended up with withdrawals whose
quantities add up to more than the latest observed quantity. It's thus impossible
to do anything with the accessions because the quantity recalculation logic always
catches the problem and bails out.

Fix up the existing accessions in three ways:

* Set the correct withdrawal purpose for viability test withdrawals and add a
  database constraint to make sure it's always properly set going forward.
* Remove withdrawals that were created after the most recent quantity observation
  but don't have associated quantity history entries. These are all duplicates
  of withdrawals that _do_ have history entries, and they are causing withdrawal
  quantities to be double-counted.
* Make sure the above doesn't cause the remaining quantities (which users have
  already seen) to change suddenly, by calculating a latest observed quantity
  that causes the withdrawals to add up to the currently-displayed remaining
  quantity. (An alternative would have been to set the latest observed quantity
  to the current quantity, but that'd cause a behavior difference if a user
  edited an existing withdrawal's quantity.)

Once the cleanup has run, its class can be removed from the code base.