### PR TITLE
SW-2297 Support PNG photo uploads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
@@ -84,7 +84,8 @@ class PhotoService(
     return if (maxWidth != null || maxHeight != null) {
       thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight)
     } else {
-      fileStore.read(fetchUrl(photoId))
+      val photosRow = photosDao.fetchOneById(photoId) ?: throw PhotoNotFoundException(photoId)
+      fileStore.read(photosRow.storageUrl!!).withContentType(photosRow.contentType)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/file/SizedInputStream.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/SizedInputStream.kt
@@ -2,10 +2,11 @@ package com.terraformation.backend.file
 
 import java.io.InputStream
 import java.io.OutputStream
+import org.springframework.http.MediaType
 
 /**
- * Input stream whose total size is known in advance. This delegates all methods to an underlying
- * stream but exposes a property for the total size of the stream.
+ * Input stream whose total size, and possibly content type, is known in advance. This delegates all
+ * methods to an underlying stream but exposes a property for the total size of the stream.
  *
  * This allows us to avoid extra round trips to external file storage services that already include
  * the file size as part of their "stream a file's contents" return values.
@@ -13,7 +14,11 @@ import java.io.OutputStream
  * [size] can differ from [available] since [available] returns the number of bytes that can be read
  * _without blocking_, and there might be additional content that requires blocking.
  */
-class SizedInputStream(private val stream: InputStream, val size: Long) : InputStream() {
+class SizedInputStream(
+    private val stream: InputStream,
+    val size: Long,
+    val contentType: MediaType? = null
+) : InputStream() {
   override fun available(): Int = stream.available()
   override fun close() = stream.close()
   override fun mark(readlimit: Int) = stream.mark(readlimit)
@@ -28,4 +33,9 @@ class SizedInputStream(private val stream: InputStream, val size: Long) : InputS
   override fun skip(n: Long): Long = stream.skip(n)
   override fun skipNBytes(n: Long) = stream.skipNBytes(n)
   override fun transferTo(out: OutputStream): Long = stream.transferTo(out)
+
+  fun withContentType(contentType: String?): SizedInputStream {
+    val mediaType = contentType?.let { MediaType.parseMediaType(it) }
+    return SizedInputStream(stream, size, mediaType)
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -86,7 +86,7 @@ class ThumbnailStore(
       val thumbUrl = thumbnailsRow.storageUrl!!
 
       try {
-        return fileStore.read(thumbUrl)
+        return fileStore.read(thumbUrl).withContentType(thumbnailsRow.contentType!!)
       } catch (e: NoSuchFileException) {
         log.warn("Found thumbnail $thumbUrl in database but file did not exist; regenerating it")
         thumbnailsDao.delete(thumbnailsRow)
@@ -168,7 +168,7 @@ class ThumbnailStore(
             "${resizedImage.height} bytes $size",
     )
 
-    return SizedInputStream(ByteArrayInputStream(buffer), size.toLong())
+    return SizedInputStream(ByteArrayInputStream(buffer), size.toLong(), MediaType.IMAGE_JPEG)
   }
 
   /** Compresses an image to a JPEG file in a memory buffer. */
@@ -199,6 +199,7 @@ class ThumbnailStore(
     return log.debugWithTiming(
         "Resizing image from ${originalImage.width} x ${originalImage.height} to $maxWidth x $maxHeight") {
           Thumbnails.of(originalImage)
+              .imageType(BufferedImage.TYPE_INT_RGB)
               .scalingMode(scalingMode)
               .size(maxWidth ?: Int.MAX_VALUE, maxHeight ?: Int.MAX_VALUE)
               .asBufferedImage()

--- a/src/test/kotlin/com/terraformation/backend/file/PhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/PhotoServiceTest.kt
@@ -168,6 +168,7 @@ class PhotoServiceTest : DatabaseTest(), RunsAsUser {
 
     val stream = photoService.readPhoto(photoId)
 
+    assertEquals(MediaType.parseMediaType(metadata.contentType), stream.contentType, "Content type")
     assertArrayEquals(photoData, stream.readAllBytes())
   }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
 
 internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -47,7 +48,7 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
     WithdrawalPhotoService(dslContext, photoService, withdrawalPhotosDao)
   }
 
-  private val metadata = PhotoMetadata("filename", "contentType", 123L)
+  private val metadata = PhotoMetadata("filename", MediaType.IMAGE_JPEG_VALUE, 123L)
   private val withdrawalId: WithdrawalId by lazy { insertWithdrawal() }
   private var storageUrlCount = 0
 


### PR DESCRIPTION
Add PNG as a supported image format for accession and nursery withdrawal photos.
Thumbnails are still always generated in JPEG format regardless of the format
of the original image.