### PR TITLE
SW-2361 Allow super admins to move planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -134,6 +134,7 @@ data class DeviceManagerUser(
   override fun canImportGlobalSpeciesData(): Boolean = false
   override fun canListNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
+  override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
   override fun canReadBatch(batchId: BatchId): Boolean = false
   override fun canReadDelivery(deliveryId: DeliveryId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -213,6 +213,9 @@ data class IndividualUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId) =
       isManagerOrHigher(organizationId)
 
+  override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId) =
+      canUpdatePlantingSite(plantingSiteId) && isSuperAdmin()
+
   override fun canReadAccession(accessionId: AccessionId) =
       isMember(parentStore.getFacilityId(accessionId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -296,6 +296,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun movePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId) {
+    if (!user.canMovePlantingSiteToAnyOrg(plantingSiteId)) {
+      readPlantingSite(plantingSiteId)
+      throw AccessDeniedException("No permission to move planting site $plantingSiteId")
+    }
+  }
+
   fun readAccession(accessionId: AccessionId) {
     if (!user.canReadAccession(accessionId)) {
       throw AccessionNotFoundException(accessionId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -132,6 +132,7 @@ class SystemUser(
   override fun canListFacilities(organizationId: OrganizationId): Boolean = true
   override fun canListNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
+  override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
   override fun canReadBatch(batchId: BatchId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -97,6 +97,7 @@ interface TerrawareUser : Principal {
   fun canListFacilities(organizationId: OrganizationId): Boolean
   fun canListNotifications(organizationId: OrganizationId?): Boolean
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
+  fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean
   fun canReadAccession(accessionId: AccessionId): Boolean
   fun canReadAutomation(automationId: AutomationId): Boolean
   fun canReadBatch(batchId: BatchId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.tracking.DeliveryId
@@ -52,6 +53,7 @@ data class PlantingSiteModel(
     val description: String?,
     val id: PlantingSiteId,
     val name: String,
+    val organizationId: OrganizationId,
     val plantingZones: List<PlantingZoneModel>,
 ) {
   constructor(
@@ -63,6 +65,7 @@ data class PlantingSiteModel(
       record[PLANTING_SITES.DESCRIPTION],
       record[PLANTING_SITES.ID]!!,
       record[PLANTING_SITES.NAME]!!,
+      record[PLANTING_SITES.ORGANIZATION_ID]!!,
       plantingZonesMultiset?.let { record[it] } ?: emptyList())
 
   fun equals(other: Any?, tolerance: Double): Boolean {

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -51,6 +51,12 @@
 
 <h3>Planting Sites</h3>
 
+<ol>
+    <li th:value="${site.id}" th:each="site : ${plantingSites}">
+        <a th:href="|${prefix}/plantingSite/${site.id}|" th:text="${site.name}">Site Name</a>
+    </li>
+</ol>
+
 <form method="POST" enctype="multipart/form-data" th:action="|${prefix}/createPlantingSite|"
       th:if="${canCreatePlantingSite}">
     <h4>Create Planting Site</h4>

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -35,7 +35,8 @@
     <input type="submit" value="Update"/>
 </form>
 
-<form method="POST" th:action="|${prefix}/movePlantingSite|" th:if="${canMovePlantingSiteToAnyOrg}">
+<form method="POST" th:action="|${prefix}/movePlantingSite|" th:if="${canMovePlantingSiteToAnyOrg}"
+      id="moveForm">
     <h3>Move to New Organization</h3>
 
     <p>
@@ -75,5 +76,15 @@
     </ul>
 </th:block>
 
+<script th:if="${canMovePlantingSiteToAnyOrg}">
+    document.getElementById('moveForm').addEventListener('submit', event => {
+        const orgSelect = document.getElementById('organizationId');
+        const orgName = orgSelect.options[orgSelect.selectedIndex].text;
+
+        if (!confirm(`Are you sure you want to move the planting site to ${orgName}?`)) {
+            event.preventDefault();
+        }
+    });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -1,0 +1,79 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="/admin/header :: head"/>
+<style>
+    table.bordered, table.bordered tr th, table.bordered tr td {
+        border: 1px solid black;
+    }
+
+    table.bordered td, table.bordered th {
+        padding: .25em;
+    }
+
+    label::before {
+        content: '';
+        display: block;
+    }
+</style>
+<body>
+
+<span th:include="/admin/header :: top"/>
+
+<a th:href="|${prefix}/|">Home</a> -
+<a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>
+
+<h2 th:text="|Planting Site ${site.name} (${site.id})|">Planting Site Name (123)</h2>
+
+<form method="POST" th:action="|${prefix}/updatePlantingSite|" th:if="${canUpdatePlantingSite}">
+    <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+    <label for="siteName">Name</label>
+    <input type="text" id="siteName" name="siteName" th:value="${site.name}" minlength="1"
+           required/>
+    <label for="description">Description</label>
+    <input type="text" id="description" name="description" th:value="${site.description}"/>
+    <br/>
+    <input type="submit" value="Update"/>
+</form>
+
+<form method="POST" th:action="|${prefix}/movePlantingSite|" th:if="${canMovePlantingSiteToAnyOrg}">
+    <h3>Move to New Organization</h3>
+
+    <p>
+        <strong>WARNING!</strong> If you move a planting site, you will no longer be able to view it
+        unless you are a member of the organization you're moving it to. Make sure you're done
+        checking it for errors before you move it.
+    </p>
+
+    <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+    <label for="organizationId">Organization</label>
+    <select id="organizationId" name="organizationId">
+        <option th:each="org : ${allOrganizations}" th:value="${org.id}"
+                th:text="|${org.name} (${org.id})|"
+                th:selected="${org.id == organization.id}">
+            My Org (123)
+        </option>
+    </select>
+    <input type="submit" value="Move"/>
+</form>
+
+<th:div th:if="!${canUpdatePlantingSite}">
+    Description:
+    <th:block th:text="${site.description}"/>
+</th:div>
+
+<th:block th:if="!${site.plantingZones.isEmpty()}">
+    <h3 th:text="|Planting Zones (${numPlantingZones}) and Plots (${numPlots})|">Planting Zones (1)
+        and Plots (2)</h3>
+
+    <ul>
+        <li th:each="zone : ${site.plantingZones}">
+            <th:block th:text="${zone.name}">Zone Name</th:block>
+            <ul th:if="!${zone.plots.isEmpty()}">
+                <li th:each="plot : ${zone.plots}" th:text="${plot.fullName}">Plot Name</li>
+            </ul>
+        </li>
+    </ul>
+</th:block>
+
+</body>
+</html>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -395,6 +395,19 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun movePlantingSite() {
+    assertThrows<PlantingSiteNotFoundException> {
+      requirements.movePlantingSiteToAnyOrg(plantingSiteId)
+    }
+
+    grant { user.canReadPlantingSite(plantingSiteId) }
+    assertThrows<AccessDeniedException> { requirements.movePlantingSiteToAnyOrg(plantingSiteId) }
+
+    grant { user.canMovePlantingSiteToAnyOrg(plantingSiteId) }
+    requirements.movePlantingSiteToAnyOrg(plantingSiteId)
+  }
+
+  @Test
   fun readAccession() {
     assertThrows<AccessionNotFoundException> { requirements.readAccession(accessionId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -403,6 +403,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
     grant { user.canReadPlantingSite(plantingSiteId) }
     assertThrows<AccessDeniedException> { requirements.movePlantingSiteToAnyOrg(plantingSiteId) }
 
+    grant { user.canUpdatePlantingSite(plantingSiteId) }
+    assertThrows<AccessDeniedException> { requirements.movePlantingSiteToAnyOrg(plantingSiteId) }
+
     grant { user.canMovePlantingSiteToAnyOrg(plantingSiteId) }
     requirements.movePlantingSiteToAnyOrg(plantingSiteId)
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -898,6 +898,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSiteIds.toTypedArray(),
         createDelivery = true,
+        movePlantingSiteToAnyOrg = true,
         readPlantingSite = true,
         updatePlantingSite = true,
     )
@@ -936,7 +937,17 @@ internal class PermissionTest : DatabaseTest() {
   fun `super admin user has elevated privileges`() {
     usersDao.update(usersDao.fetchOneById(userId)!!.copy(userTypeId = UserType.SuperAdmin))
 
+    givenRole(org1Id, Role.ADMIN)
+
     val permissions = PermissionsTracker()
+
+    permissions.expect(
+        *plantingSiteIds.forOrg1(),
+        createDelivery = true,
+        movePlantingSiteToAnyOrg = true,
+        readPlantingSite = true,
+        updatePlantingSite = true,
+    )
 
     permissions.expect(
         createDeviceManager = true,
@@ -1379,6 +1390,7 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg plantingSiteIds: PlantingSiteId,
         createDelivery: Boolean = false,
+        movePlantingSiteToAnyOrg: Boolean = false,
         readPlantingSite: Boolean = false,
         updatePlantingSite: Boolean = false,
     ) {
@@ -1387,6 +1399,10 @@ internal class PermissionTest : DatabaseTest() {
             createDelivery,
             user.canCreateDelivery(plantingSiteId),
             "Can create delivery at planting site $plantingSiteId")
+        assertEquals(
+            movePlantingSiteToAnyOrg,
+            user.canMovePlantingSiteToAnyOrg(plantingSiteId),
+            "Can move planting site $plantingSiteId")
         assertEquals(
             readPlantingSite,
             user.canReadPlantingSite(plantingSiteId),


### PR DESCRIPTION
To support a workflow where a Terraformation employee creates a new planting site
using a shapefile, verifies it in the web app, then transfers it to the correct
organization, update the admin UI to allow moving planting sites to new
organizations.

This requires the ability to select a planting site in the admin UI; previously
it was only possible to create new sites, not view them.