### PR TITLE
SW-2003 Use ArbitraryJsonObject for device settings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceController.kt
@@ -1,10 +1,9 @@
 package com.terraformation.backend.device.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
+import com.terraformation.backend.api.ArbitraryJsonObject
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -18,7 +17,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Duration
 import java.time.Instant
-import org.jooq.JSONB
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -31,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController
 class DeviceController(
     private val deviceService: DeviceService,
     private val deviceStore: DeviceStore,
-    private val objectMapper: ObjectMapper,
 ) {
   @ApiResponse(responseCode = "200", description = "Successfully listed the facility's devices.")
   @ApiResponse404(
@@ -40,13 +37,13 @@ class DeviceController(
   @Operation(summary = "Lists the configurations of all the devices at a facility.")
   fun listFacilityDevices(@PathVariable facilityId: FacilityId): ListDeviceConfigsResponse {
     val devices = deviceStore.fetchByFacilityId(facilityId)
-    return ListDeviceConfigsResponse(devices.map { DeviceConfig(it, objectMapper) })
+    return ListDeviceConfigsResponse(devices.map { DeviceConfig(it) })
   }
 
   @ApiResponseSimpleSuccess
   @PostMapping("/api/v1/devices")
   fun createDevice(@RequestBody payload: CreateDeviceRequestPayload): CreateDeviceResponsePayload {
-    val devicesRow = payload.toRow(objectMapper)
+    val devicesRow = payload.toRow()
     val deviceId = deviceService.create(devicesRow)
     return CreateDeviceResponsePayload(deviceId)
   }
@@ -57,7 +54,7 @@ class DeviceController(
   @Operation(summary = "Gets the configuration of a single device.")
   fun getDevice(@PathVariable("id") deviceId: DeviceId): GetDeviceResponsePayload {
     val devicesRow = deviceStore.fetchOneById(deviceId)
-    return GetDeviceResponsePayload(DeviceConfig(devicesRow, objectMapper))
+    return GetDeviceResponsePayload(DeviceConfig(devicesRow))
   }
 
   @ApiResponse(responseCode = "200", description = "Device configuration updated.")
@@ -68,7 +65,7 @@ class DeviceController(
       @PathVariable("id") deviceId: DeviceId,
       @RequestBody payload: UpdateDeviceRequestPayload
   ): SimpleSuccessResponsePayload {
-    val devicesRow = payload.toRow(deviceId, objectMapper)
+    val devicesRow = payload.toRow(deviceId)
     deviceService.update(devicesRow)
     return SimpleSuccessResponsePayload()
   }
@@ -127,7 +124,7 @@ data class DeviceConfig(
         description =
             "Protocol- and device-specific custom settings. This is an arbitrary JSON object; " +
                 "the exact settings depend on the device type.")
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
     @Schema(
         description = "Level of diagnostic information to log.",
     )
@@ -136,8 +133,7 @@ data class DeviceConfig(
     val parentId: DeviceId?,
 ) {
   constructor(
-      row: DevicesRow,
-      objectMapper: ObjectMapper
+      row: DevicesRow
   ) : this(
       id = row.id!!,
       facilityId = row.facilityId!!,
@@ -148,35 +144,10 @@ data class DeviceConfig(
       protocol = row.protocol,
       address = row.address,
       port = row.port,
-      settings = row.settingsWithVerbosity(objectMapper),
+      settings = row.settings,
       verbosity = row.verbosity,
       parentId = row.parentId,
   )
-}
-
-/**
- * Settings key for the device's verbosity level, for backward compatibility.
- *
- * TODO: Remove this once the device manager uses the verbosity payload field.
- */
-private const val VERBOSITY_KEY = "diagnosticMode"
-
-private fun DevicesRow.settingsWithVerbosity(objectMapper: ObjectMapper): Map<String, Any?>? {
-  val settingsMap = settings?.let { objectMapper.readValue<Map<String, Any?>>(it.data()) }
-
-  return if (verbosity == null) {
-    settingsMap
-  } else {
-    val verbosityMap = mapOf(VERBOSITY_KEY to verbosity)
-
-    settingsMap?.plus(verbosityMap) ?: verbosityMap
-  }
-}
-
-private fun Map<String, Any?>.toJsonbWithoutVerbosity(objectMapper: ObjectMapper): JSONB? {
-  return minus(VERBOSITY_KEY)
-      .ifEmpty { null }
-      ?.let { JSONB.jsonb(objectMapper.writeValueAsString(it)) }
 }
 
 data class CreateDeviceRequestPayload(
@@ -210,7 +181,7 @@ data class CreateDeviceRequestPayload(
         description =
             "Protocol- and device-specific custom settings. This is an arbitrary JSON object; " +
                 "the exact settings depend on the device type.")
-    val settings: Map<String, Any?>? = null,
+    val settings: ArbitraryJsonObject? = null,
     @Schema(
         description = "Level of diagnostic information to log.",
     )
@@ -220,7 +191,7 @@ data class CreateDeviceRequestPayload(
             "ID of parent device such as a hub or gateway, if any. The parent device must exist.")
     val parentId: DeviceId? = null,
 ) {
-  fun toRow(objectMapper: ObjectMapper): DevicesRow {
+  fun toRow(): DevicesRow {
     return DevicesRow(
         id = null,
         facilityId = facilityId,
@@ -231,9 +202,9 @@ data class CreateDeviceRequestPayload(
         protocol = protocol,
         address = address,
         port = port,
-        verbosity = verbosity ?: settings?.get(VERBOSITY_KEY)?.toString()?.toInt(),
+        verbosity = verbosity,
         enabled = true,
-        settings = settings?.toJsonbWithoutVerbosity(objectMapper),
+        settings = settings,
         parentId = parentId,
     )
   }
@@ -268,7 +239,7 @@ data class UpdateDeviceRequestPayload(
         description =
             "Protocol- and device-specific custom settings. This is an arbitrary JSON object; " +
                 "the exact settings depend on the device type.")
-    val settings: Map<String, Any?>? = null,
+    val settings: ArbitraryJsonObject? = null,
     @Schema(
         description = "Level of diagnostic information to log.",
     )
@@ -278,7 +249,7 @@ data class UpdateDeviceRequestPayload(
             "ID of parent device such as a hub or gateway, if any. The parent device must exist.")
     val parentId: DeviceId? = null,
 ) {
-  fun toRow(deviceId: DeviceId, objectMapper: ObjectMapper): DevicesRow {
+  fun toRow(deviceId: DeviceId): DevicesRow {
     return DevicesRow(
         id = deviceId,
         facilityId = null,
@@ -289,9 +260,9 @@ data class UpdateDeviceRequestPayload(
         protocol = protocol,
         address = address,
         port = port,
-        verbosity = verbosity ?: settings?.get(VERBOSITY_KEY)?.toString()?.toInt(),
+        verbosity = verbosity,
         enabled = true,
-        settings = settings?.toJsonbWithoutVerbosity(objectMapper),
+        settings = settings,
         parentId = parentId,
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceTemplatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceTemplatesController.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.device.api
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import com.terraformation.backend.api.ArbitraryJsonObject
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.DeviceTemplateCategory
@@ -16,10 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @DeviceManagerAppEndpoint
 @RequestMapping("/api/v1/devices/templates")
 @RestController
-class DeviceTemplatesController(
-    private val deviceTemplatesDao: DeviceTemplatesDao,
-    private val objectMapper: ObjectMapper,
-) {
+class DeviceTemplatesController(private val deviceTemplatesDao: DeviceTemplatesDao) {
   @GetMapping
   fun listDeviceTemplates(
       @RequestParam category: DeviceTemplateCategory? = null
@@ -31,8 +27,7 @@ class DeviceTemplatesController(
           deviceTemplatesDao.findAll()
         }
 
-    val templatePayloads =
-        templates.map { DeviceTemplatePayload(it, objectMapper) }.sortedBy { it.name }
+    val templatePayloads = templates.map { DeviceTemplatePayload(it) }.sortedBy { it.name }
     return ListDeviceTemplatesResponsePayload(templatePayloads)
   }
 }
@@ -47,12 +42,11 @@ data class DeviceTemplatePayload(
     val protocol: String?,
     val address: String?,
     val port: Int?,
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
     val verbosity: Int?,
 ) {
   constructor(
-      row: DeviceTemplatesRow,
-      objectMapper: ObjectMapper
+      row: DeviceTemplatesRow
   ) : this(
       row.id!!,
       row.categoryId!!,
@@ -63,7 +57,7 @@ data class DeviceTemplatePayload(
       row.protocol,
       row.address,
       row.port,
-      row.settings?.let { objectMapper.readValue(it.data()) },
+      row.settings,
       row.verbosity)
 }
 


### PR DESCRIPTION
Device settings are arbitrary JSON objects defined by the device manager.
Previously, we were unpacking them because we needed to populate a setting for
backward compatibility with old device manager versions. Now that the device
managers in the field have been updated to not use that setting any more, we
can treat the settings as opaque values and there's no longer any need to
represent them as `Map` objects internally.

In addition to removing unnecessary logic, this is a prerequisite to changing
the JSON deserializer configuration to treat empty strings as null; in the
absence of this change, doing so would have prevented the device manager from
including empty strings as setting values, which would break the "device manager
can put whatever it wants in the settings" API contract.

This doesn't change the API schema, but it does change the behavior in that the
server no longer inserts a `diagnosticMode` value into the settings object.