### PR TITLE
SW-1048 Remove automations endpoints from facilities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -1,12 +1,13 @@
 package com.terraformation.backend.api
 
 import com.terraformation.backend.auth.KeycloakInfo
-import com.terraformation.backend.customer.api.AutomationPayload
 import com.terraformation.backend.customer.api.GetUserPreferencesResponsePayload
-import com.terraformation.backend.customer.api.ModifyAutomationRequestPayload
 import com.terraformation.backend.customer.api.UpdateUserPreferencesRequestPayload
+import com.terraformation.backend.device.api.AutomationPayload
+import com.terraformation.backend.device.api.CreateAutomationRequestPayload
 import com.terraformation.backend.device.api.CreateDeviceRequestPayload
 import com.terraformation.backend.device.api.DeviceConfig
+import com.terraformation.backend.device.api.UpdateAutomationRequestPayload
 import com.terraformation.backend.device.api.UpdateDeviceRequestPayload
 import com.terraformation.backend.search.api.SearchResponsePayload
 import io.swagger.v3.oas.annotations.media.Schema
@@ -96,11 +97,12 @@ class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomiser 
   private fun removeAdditionalProperties(openApi: OpenAPI) {
     val fieldsToModify =
         listOf(
-            AutomationPayload::class.swaggerSchemaName to "configuration",
+            AutomationPayload::class.swaggerSchemaName to "settings",
+            CreateAutomationRequestPayload::class.swaggerSchemaName to "settings",
             CreateDeviceRequestPayload::class.swaggerSchemaName to "settings",
             DeviceConfig::class.swaggerSchemaName to "settings",
             GetUserPreferencesResponsePayload::class.swaggerSchemaName to "preferences",
-            ModifyAutomationRequestPayload::class.swaggerSchemaName to "configuration",
+            UpdateAutomationRequestPayload::class.swaggerSchemaName to "settings",
             UpdateDeviceRequestPayload::class.swaggerSchemaName to "settings",
             UpdateUserPreferencesRequestPayload::class.swaggerSchemaName to "preferences",
         )

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -1,22 +1,16 @@
 package com.terraformation.backend.customer.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.customer.db.AutomationStore
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
-import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.AutomationNotFoundException
-import com.terraformation.backend.db.default_schema.AutomationId
-import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -27,13 +21,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import javax.ws.rs.BadRequestException
 import javax.ws.rs.InternalServerErrorException
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.Response
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -46,7 +38,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/facility", "/api/v1/facilities")
 class FacilitiesController(
-    private val automationStore: AutomationStore,
     private val facilityStore: FacilityStore,
     private val publisher: ApplicationEventPublisher,
 ) {
@@ -91,104 +82,6 @@ class FacilitiesController(
 
     facilityStore.update(
         facility.copy(name = payload.name, description = payload.description?.ifEmpty { null }))
-
-    return SimpleSuccessResponsePayload()
-  }
-
-  @ApiResponse(responseCode = "200", description = "Success")
-  @ApiResponse404("The facility does not exist or is not accessible.")
-  @GetMapping("/{facilityId}/automations")
-  @Operation(summary = "Lists a facility's automations.")
-  fun listAutomations(@PathVariable facilityId: FacilityId): ListAutomationsResponsePayload {
-    val automations = automationStore.fetchByFacilityId(facilityId)
-
-    return ListAutomationsResponsePayload(automations.map { AutomationPayload(it) })
-  }
-
-  @ApiResponse(responseCode = "200", description = "Success")
-  @ApiResponse404("The facility does not exist or is not accessible.")
-  @PostMapping("/{facilityId}/automations")
-  @Operation(summary = "Creates a new automation at a facility.")
-  fun createAutomation(
-      @PathVariable facilityId: FacilityId,
-      @RequestBody payload: ModifyAutomationRequestPayload
-  ): CreateAutomationResponsePayload {
-    val automationId =
-        automationStore.create(
-            description = payload.description,
-            deviceId = payload.deviceId,
-            facilityId = facilityId,
-            lowerThreshold = payload.lowerThreshold,
-            name = payload.name,
-            settings = payload.settings,
-            timeseriesName = payload.timeseriesName,
-            type = payload.type,
-            upperThreshold = payload.upperThreshold,
-            verbosity = payload.verbosity,
-        )
-
-    return CreateAutomationResponsePayload(automationId)
-  }
-
-  @ApiResponse(responseCode = "200", description = "Success")
-  @ApiResponse404
-  @GetMapping("/{facilityId}/automations/{automationId}")
-  @Operation(summary = "Gets information about a single automation.")
-  fun getAutomation(
-      @PathVariable facilityId: FacilityId,
-      @PathVariable automationId: AutomationId
-  ): GetAutomationResponsePayload {
-    val model = automationStore.fetchOneById(automationId)
-    if (model.facilityId != facilityId) {
-      throw AutomationNotFoundException(automationId)
-    }
-
-    return GetAutomationResponsePayload(AutomationPayload(model))
-  }
-
-  @ApiResponseSimpleSuccess
-  @ApiResponse404
-  @PutMapping("/{facilityId}/automations/{automationId}")
-  @Operation(summary = "Updates an existing automation.")
-  fun updateAutomation(
-      @PathVariable facilityId: FacilityId,
-      @PathVariable automationId: AutomationId,
-      @RequestBody payload: ModifyAutomationRequestPayload
-  ): SimpleSuccessResponsePayload {
-    val model = automationStore.fetchOneById(automationId)
-    if (model.facilityId != facilityId) {
-      throw AutomationNotFoundException(automationId)
-    }
-
-    automationStore.update(
-        model.copy(
-            description = payload.description,
-            deviceId = payload.deviceId,
-            name = payload.name,
-            lowerThreshold = payload.lowerThreshold,
-            settings = payload.settings,
-            timeseriesName = payload.timeseriesName,
-            type = payload.type,
-            upperThreshold = payload.upperThreshold,
-            verbosity = payload.verbosity,
-        ))
-
-    return SimpleSuccessResponsePayload()
-  }
-
-  @ApiResponseSimpleSuccess
-  @ApiResponse404
-  @DeleteMapping("/{facilityId}/automations/{automationId}")
-  @Operation(summary = "Deletes an automation from a facility.")
-  fun deleteAutomation(
-      @PathVariable facilityId: FacilityId,
-      @PathVariable automationId: AutomationId
-  ): SimpleSuccessResponsePayload {
-    if (facilityId != automationStore.fetchOneById(automationId).facilityId) {
-      throw AutomationNotFoundException(automationId)
-    }
-
-    automationStore.delete(automationId)
 
     return SimpleSuccessResponsePayload()
   }
@@ -251,61 +144,6 @@ class FacilitiesController(
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class AutomationPayload(
-    val id: AutomationId,
-    val facilityId: FacilityId,
-    @Schema(
-        description = "Short human-readable name of this automation.",
-    )
-    val name: String,
-    @Schema(description = "Human-readable description of this automation.")
-    val description: String?,
-    @Schema(description = "Client-defined configuration data for this automation.")
-    val configuration: Map<String, Any?>?,
-) {
-  constructor(
-      model: AutomationModel
-  ) : this(
-      model.id,
-      model.facilityId,
-      model.name,
-      model.description,
-      model.backwardCompatibleConfiguration())
-}
-
-private const val DEVICE_ID_KEY = "monitorDeviceId"
-private const val LOWER_THRESHOLD_KEY = "lowerThreshold"
-private const val TIMESERIES_NAME_KEY = "monitorTimeseriesName"
-private const val TYPE_KEY = "type"
-private const val UPPER_THRESHOLD_KEY = "upperThreshold"
-private const val VERBOSITY_KEY = "verbosity"
-
-private val backwardCompatibilityKeys =
-    setOf(
-        DEVICE_ID_KEY,
-        LOWER_THRESHOLD_KEY,
-        TIMESERIES_NAME_KEY,
-        TYPE_KEY,
-        UPPER_THRESHOLD_KEY,
-        VERBOSITY_KEY,
-    )
-
-private fun AutomationModel.backwardCompatibleConfiguration(): Map<String, Any?> {
-  val generatedSettings =
-      listOfNotNull(
-              TYPE_KEY to type,
-              VERBOSITY_KEY to verbosity,
-              deviceId?.let { DEVICE_ID_KEY to it.value },
-              timeseriesName?.let { TIMESERIES_NAME_KEY to it },
-              lowerThreshold?.let { LOWER_THRESHOLD_KEY to it },
-              upperThreshold?.let { UPPER_THRESHOLD_KEY to it },
-          )
-          .toMap()
-
-  return settings?.plus(generatedSettings) ?: generatedSettings
-}
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class FacilityPayload(
     val connectionState: FacilityConnectionState,
     val createdTime: Instant,
@@ -327,29 +165,6 @@ data class FacilityPayload(
       model.type)
 }
 
-data class ModifyAutomationRequestPayload(
-    val name: String,
-    val description: String?,
-    val configuration: Map<String, Any?>?,
-) {
-  val deviceId: DeviceId?
-    get() = configuration?.get(DEVICE_ID_KEY)?.toString()?.let { DeviceId(it) }
-  val lowerThreshold: Double?
-    get() = configuration?.get(LOWER_THRESHOLD_KEY)?.toString()?.toDouble()
-  val settings: Map<String, Any?>?
-    get() = configuration?.filterKeys { it !in backwardCompatibilityKeys }?.ifEmpty { null }
-  val timeseriesName: String?
-    get() = configuration?.get(TIMESERIES_NAME_KEY)?.toString()
-  val type: String
-    get() = configuration?.get(TYPE_KEY)?.toString() ?: throw BadRequestException("Missing type")
-  val upperThreshold: Double?
-    get() = configuration?.get(UPPER_THRESHOLD_KEY)?.toString()?.toDouble()
-  val verbosity: Int
-    get() = configuration?.get(VERBOSITY_KEY)?.toString()?.toInt() ?: 0
-}
-
-data class CreateAutomationResponsePayload(val id: AutomationId) : SuccessResponsePayload
-
 data class CreateFacilityRequestPayload(
     val description: String?,
     @Schema(description = "Which organization this facility belongs to.")
@@ -360,12 +175,7 @@ data class CreateFacilityRequestPayload(
 
 data class CreateFacilityResponsePayload(val id: FacilityId) : SuccessResponsePayload
 
-data class GetAutomationResponsePayload(val automation: AutomationPayload) : SuccessResponsePayload
-
 data class GetFacilityResponse(val facility: FacilityPayload) : SuccessResponsePayload
-
-data class ListAutomationsResponsePayload(val automations: List<AutomationPayload>) :
-    SuccessResponsePayload
 
 data class ListFacilitiesResponse(val facilities: List<FacilityPayload>) : SuccessResponsePayload
 


### PR DESCRIPTION
The device manager has been updated to use `/api/v1/automations` to get information
about automations; we no longer need the older endpoints under `/api/v1/facilities`,
nor the backward-compatibility code that constructed their payloads.