### PR TITLE
Replace ManagedBean with Named

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ExistingAdminRoleInterceptor.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ExistingAdminRoleInterceptor.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.api
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.HandlerInterceptor
  * admin requirement can be disabled using the [TerrawareServerConfig.allowAdminUiForNonAdmins]
  * configuration option.
  */
-@ManagedBean
+@Named
 class ExistingAdminRoleInterceptor(private val config: TerrawareServerConfig) : HandlerInterceptor {
   override fun preHandle(
       request: HttpServletRequest,

--- a/src/main/kotlin/com/terraformation/backend/api/OctetStreamJsonConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OctetStreamJsonConverter.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.api
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.http.HttpInputMessage
 import org.springframework.http.HttpOutputMessage
 import org.springframework.http.MediaType
@@ -19,7 +19,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
  * To prevent this converter from unintentionally converting objects that should really be treated
  * as binary data, it only works if the target class is annotated with [JsonDeserialize].
  */
-@ManagedBean
+@Named
 class OctetStreamJsonConverter(private val objectMapper: ObjectMapper) : HttpMessageConverter<Any> {
   override fun canRead(clazz: Class<*>, mediaType: MediaType?): Boolean {
     return mediaType == MediaType.APPLICATION_OCTET_STREAM &&

--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityScheme
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
  * - Descriptions from annotations are added to model fields that are references to other model
  * classes.
  */
-@ManagedBean
+@Named
 class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomiser {
   @Autowired(required = false) var dslContext: DSLContext? = null
 

--- a/src/main/kotlin/com/terraformation/backend/auth/KeycloakInfo.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/KeycloakInfo.kt
@@ -1,10 +1,10 @@
 package com.terraformation.backend.auth
 
 import java.net.URI
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.keycloak.adapters.springboot.KeycloakSpringBootProperties
 
-@ManagedBean
+@Named
 class KeycloakInfo(keycloakProperties: KeycloakSpringBootProperties) {
   /**
    * Client ID the server uses to authenticate users with Keycloak. This is included in redirect

--- a/src/main/kotlin/com/terraformation/backend/config/Base64ToByteArrayConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/Base64ToByteArrayConverter.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.config
 
 import java.util.Base64
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding
 import org.springframework.core.convert.converter.Converter
 
@@ -11,7 +11,7 @@ import org.springframework.core.convert.converter.Converter
  * (encryption keys, etc.)
  */
 @ConfigurationPropertiesBinding
-@ManagedBean
+@Named
 class Base64ToByteArrayConverter : Converter<String, ByteArray> {
   private val decoder = Base64.getDecoder()!!
 

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -25,11 +25,11 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
 import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import java.net.URI
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 
-@ManagedBean
+@Named
 class AppNotificationService(
     private val automationStore: AutomationStore,
     private val deviceStore: DeviceStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
@@ -3,13 +3,13 @@ package com.terraformation.backend.customer
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.event.FacilityIdleEvent
 import com.terraformation.backend.customer.model.SystemUser
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jobrunr.jobs.annotations.Job
 import org.jobrunr.spring.annotations.Recurring
 import org.springframework.context.ApplicationEventPublisher
 
 /** Facility-related business logic that needs to interact with multiple services. */
-@ManagedBean
+@Named
 class FacilityService(
     private val facilityStore: FacilityStore,
     private val publisher: ApplicationEventPublisher,

--- a/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/OrganizationService.kt
@@ -13,7 +13,7 @@ import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.log.perClassLogger
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.ApplicationEventPublisher
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 
 /** Organization-related business logic that needs to interact with multiple services. */
-@ManagedBean
+@Named
 class OrganizationService(
     private val dslContext: DSLContext,
     private val organizationStore: OrganizationStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTask.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATI
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
 import java.time.temporal.ChronoUnit
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.event.EventListener
@@ -15,7 +15,7 @@ import org.springframework.context.event.EventListener
     TerrawareServerConfig.NOTIFICATIONS_CLEANUP_ENABLED_PROPERTY,
     havingValue = "true",
     matchIfMissing = true)
-@ManagedBean
+@Named
 class NotificationsCleanupTask(
     private val clock: Clock,
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AppVersionStore.kt
@@ -4,10 +4,10 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.tables.daos.AppVersionsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.AppVersionsRow
 import com.terraformation.backend.db.default_schema.tables.references.APP_VERSIONS
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
-@ManagedBean
+@Named
 class AppVersionStore(
     private val appVersionsDao: AppVersionsDao,
     private val dslContext: DSLContext

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
@@ -14,11 +14,11 @@ import com.terraformation.backend.db.default_schema.tables.pojos.AutomationsRow
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.JSONB
 
-@ManagedBean
+@Named
 class AutomationStore(
     private val automationsDao: AutomationsDao,
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -22,13 +22,13 @@ import com.terraformation.backend.db.seedbank.tables.pojos.StorageLocationsRow
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.security.access.AccessDeniedException
 
 /** Permission-aware accessors for facility information. */
-@ManagedBean
+@Named
 class FacilityStore(
     private val clock: Clock,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
@@ -11,12 +11,12 @@ import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.context.event.EventListener
 
-@ManagedBean
+@Named
 class NotificationStore(
     private val dslContext: DSLContext,
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -27,14 +27,14 @@ import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DuplicateKeyException
 
-@ManagedBean
+@Named
 class OrganizationStore(
     private val clock: Clock,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -39,7 +39,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
@@ -54,7 +54,7 @@ import org.jooq.impl.DSL
  * number of dependencies in [IndividualUser], and also gives us a clean place to introduce caching
  * if parent ID lookups in permission checks become a performance bottleneck.
  */
-@ManagedBean
+@Named
 class ParentStore(private val dslContext: DSLContext) {
   fun getFacilityId(accessionId: AccessionId): FacilityId? =
       fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.FACILITY_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
 /**
@@ -17,7 +17,7 @@ import org.jooq.DSLContext
  * If you want to read the current user's roles, you will usually want to use the properties on
  * [IndividualUser] instead of the `fetch` methods on this class.
  */
-@ManagedBean
+@Named
 class PermissionStore(private val dslContext: DSLContext) {
   /**
    * Returns a user's role in each facility under the organizations they're in. The roles are

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.time.Instant
 import java.util.Base64
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 import kotlin.random.Random
@@ -64,7 +64,7 @@ import org.springframework.web.context.support.ServletRequestHandledEvent
  *
  * Spring Security calls this class to look up users when it is authenticating requests.
  */
-@ManagedBean
+@Named
 class UserStore(
     private val clock: Clock,
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -21,7 +21,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.context.annotation.Lazy
 
 /**
@@ -42,7 +42,7 @@ import org.springframework.context.annotation.Lazy
  * There is no way for a client to authenticate as the system user; the application code has to
  * explicitly switch to this user identity, typically by calling this class's [run] method.
  */
-@ManagedBean
+@Named
 class SystemUser(
     // This class is instantiated as a dependency when we're generating docs, and thus don't have a
     // database to connect to. In that case we will never actually need to query the system user's

--- a/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
@@ -9,8 +9,8 @@ import com.terraformation.backend.time.ClockAdvancedEvent
 import com.terraformation.backend.time.ClockResetEvent
 import java.time.Clock
 import java.time.Instant
-import javax.annotation.ManagedBean
 import javax.inject.Inject
+import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -28,7 +28,7 @@ import org.springframework.dao.DuplicateKeyException
  * values that are themselves published as events, allowing tasks to depend on other tasks.
  */
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
-@ManagedBean
+@Named
 class DailyTaskRunner(
     private val clock: Clock,
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -6,9 +6,9 @@ import java.sql.SQLException
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import javax.annotation.ManagedBean
 import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
+import javax.inject.Named
 import javax.sql.DataSource
 import org.jobrunr.server.BackgroundJobServer
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -20,7 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
  * database problems.
  */
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
-@ManagedBean
+@Named
 class JobRunrRecoveryThread(
     private val backgroundJobServer: BackgroundJobServer,
     private val dataSource: DataSource,

--- a/src/main/kotlin/com/terraformation/backend/db/GeometryModule.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryModule.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.db
 
 import com.fasterxml.jackson.databind.module.SimpleModule
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryCollection
 import org.locationtech.jts.geom.LineString
@@ -12,7 +12,7 @@ import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 
 /** Serializer module to parse and render JTS [Geometry] objects as GeoJSON. */
-@ManagedBean
+@Named
 class GeometryModule : SimpleModule("GeometryModule") {
   init {
     val deserializer = GeometryDeserializer()

--- a/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/IdentifierGenerator.kt
@@ -7,7 +7,7 @@ import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
 /**
@@ -38,7 +38,7 @@ import org.jooq.DSLContext
  * identifiers. To guard against that, [AccessionStore.create] will retry a few times if it gets an
  * identifier that's already in use.
  */
-@ManagedBean
+@Named
 class IdentifierGenerator(
     private val clock: Clock,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/db/LockService.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/LockService.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.db
 
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 
@@ -13,7 +13,7 @@ import org.jooq.impl.DSL
  * [PostgreSQL advisory locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)
  * which are lightweight and can participate in transactions.
  */
-@ManagedBean
+@Named
 class LockService(private val dslContext: DSLContext) {
   /**
    * Acquires an exclusive lock on the given key. The lock is held until the current transaction is

--- a/src/main/kotlin/com/terraformation/backend/device/AutomationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/AutomationService.kt
@@ -7,10 +7,10 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.device.event.SensorBoundsAlertTriggeredEvent
 import com.terraformation.backend.device.event.UnknownAutomationTriggeredEvent
 import com.terraformation.backend.log.perClassLogger
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.context.ApplicationEventPublisher
 
-@ManagedBean
+@Named
 class AutomationService(
     private val automationStore: AutomationStore,
     private val eventPublisher: ApplicationEventPublisher,

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceManagerService.kt
@@ -15,11 +15,11 @@ import com.terraformation.backend.db.default_schema.tables.references.DEVICE_MAN
 import com.terraformation.backend.device.balena.BalenaClient
 import com.terraformation.backend.device.db.DeviceManagerStore
 import com.terraformation.backend.log.perClassLogger
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.security.access.AccessDeniedException
 
-@ManagedBean
+@Named
 class DeviceManagerService(
     private val balenaClient: BalenaClient,
     private val deviceManagerStore: DeviceManagerStore,

--- a/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/DeviceService.kt
@@ -13,11 +13,11 @@ import com.terraformation.backend.device.event.DeviceUnresponsiveEvent
 import com.terraformation.backend.log.perClassLogger
 import java.time.Duration
 import java.time.Instant
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.ApplicationEventPublisher
 
-@ManagedBean
+@Named
 class DeviceService(
     private val automationStore: AutomationStore,
     private val deviceStore: DeviceStore,

--- a/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
@@ -8,13 +8,13 @@ import com.terraformation.backend.device.db.DeviceManagerStore
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
 import java.time.Instant
-import javax.annotation.ManagedBean
 import javax.inject.Inject
+import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class BalenaPoller(
     private val balenaClient: BalenaClient,
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
@@ -15,7 +15,7 @@ import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.function.Supplier
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.ws.rs.core.MediaType
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpStatus
@@ -25,7 +25,7 @@ import org.springframework.http.HttpStatus
  * configuration.
  */
 @ConditionalOnProperty(TerrawareServerConfig.BALENA_ENABLED_PROPERTY, havingValue = "true")
-@ManagedBean
+@Named
 class LiveBalenaClient(
     private val config: TerrawareServerConfig,
     private val httpClient: HttpClient,

--- a/src/main/kotlin/com/terraformation/backend/device/balena/StubBalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/StubBalenaClient.kt
@@ -5,12 +5,12 @@ import com.terraformation.backend.db.default_schema.BalenaDeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.log.perClassLogger
 import java.time.Instant
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 @ConditionalOnProperty(
     TerrawareServerConfig.BALENA_ENABLED_PROPERTY, havingValue = "false", matchIfMissing = true)
-@ManagedBean
+@Named
 class StubBalenaClient : BalenaClient {
   private val log = perClassLogger()
 

--- a/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/db/DeviceManagerStore.kt
@@ -11,12 +11,12 @@ import com.terraformation.backend.db.default_schema.tables.pojos.DeviceManagersR
 import com.terraformation.backend.db.default_schema.tables.references.DEVICE_MANAGERS
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.conf.ParamType
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class DeviceManagerStore(
     private val clock: Clock,
     private val deviceManagersDao: DeviceManagersDao,

--- a/src/main/kotlin/com/terraformation/backend/device/db/DeviceStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/db/DeviceStore.kt
@@ -7,10 +7,10 @@ import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.daos.DevicesDao
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
-import javax.annotation.ManagedBean
+import javax.inject.Named
 
 /** Permission-aware database operations for device configuration data. */
-@ManagedBean
+@Named
 class DeviceStore(private val devicesDao: DevicesDao) {
   fun fetchOneById(deviceId: DeviceId): DevicesRow {
     requirePermissions { readDevice(deviceId) }

--- a/src/main/kotlin/com/terraformation/backend/device/db/TimeseriesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/db/TimeseriesStore.kt
@@ -16,7 +16,7 @@ import java.math.RoundingMode
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import kotlin.math.ceil
 import kotlin.math.roundToLong
 import org.jooq.DSLContext
@@ -24,7 +24,7 @@ import org.jooq.Record3
 import org.jooq.Select
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class TimeseriesStore(private val clock: Clock, private val dslContext: DSLContext) {
   /** Subquery to retrieve the latest value when querying the TIMESERIES table. */
   private val latestValueMultiset =

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -33,10 +33,10 @@ import com.terraformation.backend.nursery.daily.NurseryDateNotificationTask
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
 import com.terraformation.backend.seedbank.daily.DateNotificationTask
 import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.springframework.context.event.EventListener
 
-@ManagedBean
+@Named
 class EmailNotificationService(
     private val automationStore: AutomationStore,
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/email/EmailSender.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailSender.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.email
 
 import com.terraformation.backend.config.TerrawareServerConfig
 import java.io.ByteArrayOutputStream
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.mail.Message
 import javax.mail.internet.MimeMessage
 import org.springframework.mail.javamail.JavaMailSender
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.sesv2.model.RawMessage
  *
  * This is a facade for [JavaMailSender] or the AWS SES client, depending on which one is selected.
  */
-@ManagedBean
+@Named
 class EmailSender(
     private val config: TerrawareServerConfig,
     private val javaMailSender: JavaMailSender,

--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -14,7 +14,7 @@ import freemarker.template.Configuration
 import freemarker.template.TemplateNotFoundException
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.mail.internet.InternetAddress
 import org.apache.commons.validator.routines.EmailValidator
 import org.springframework.mail.javamail.MimeMessageHelper
@@ -27,7 +27,7 @@ import org.springframework.mail.javamail.MimeMessageHelper
  *
  * This class does not interact with any email services; that's done in [EmailSender].
  */
-@ManagedBean
+@Named
 class EmailService(
     private val config: TerrawareServerConfig,
     private val freeMarkerConfig: Configuration,

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -9,14 +9,14 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import java.net.URI
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import javax.ws.rs.core.UriBuilder
 
 /**
  * Constructs URLs for specific locations in the web app. These are used in things like notification
  * email messages that need to include direct links to specific areas of the app.
  */
-@ManagedBean
+@Named
 class WebAppUrls(private val config: TerrawareServerConfig) {
   fun fullOrganizationHome(organizationId: OrganizationId): URI {
     return UriBuilder.fromUri(config.webAppUrl)

--- a/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
@@ -8,8 +8,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.Instant
-import javax.annotation.ManagedBean
 import javax.annotation.Priority
+import javax.inject.Named
 import kotlin.io.path.Path
 import kotlin.io.path.deleteExisting
 import kotlin.io.path.deleteIfExists
@@ -30,7 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
  * `/storage/foo/bar`.
  */
 @ConditionalOnProperty("terraware.photo-dir", havingValue = "")
-@ManagedBean
+@Named
 @Priority(2) // If both S3 and filesystem storage are configured, prefer S3.
 class LocalFileStore(
     private val config: TerrawareServerConfig,

--- a/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PathGenerator.kt
@@ -4,7 +4,7 @@ import java.nio.file.Path
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import kotlin.io.path.Path
 import kotlin.random.Random
 import org.apache.tika.mime.MimeTypes
@@ -23,7 +23,7 @@ import org.apache.tika.mime.MimeTypes
  * - `.ext` is a file extension based on the file's MIME type, or `.bin` if the file's type doesn't
  * have a standard file extension. For example, for JPEG files, the extension is `.jpg`.
  */
-@ManagedBean
+@Named
 class PathGenerator(private val random: Random = Random.Default) {
   private val yearFormatter = dateTimeFormatter("yyyy")
   private val monthFormatter = dateTimeFormatter("MM")

--- a/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PhotoService.kt
@@ -14,14 +14,14 @@ import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
 /**
  * Manages storage of photos including metadata. In this implementation, image files are stored on
  * the filesystem and metadata in the database.
  */
-@ManagedBean
+@Named
 class PhotoService(
     private val dslContext: DSLContext,
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
@@ -9,8 +9,8 @@ import java.nio.file.FileSystemException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.time.Instant
-import javax.annotation.ManagedBean
 import javax.annotation.Priority
+import javax.inject.Named
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.relativeTo
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 import software.amazon.awssdk.services.s3.model.UploadPartRequest
 
 @ConditionalOnProperty("terraware.s3BucketName", havingValue = "")
-@ManagedBean
+@Named
 @Priority(1) // If both S3 and filesystem storage are configured, prefer S3.
 class S3FileStore(config: TerrawareServerConfig, private val pathGenerator: PathGenerator) :
     FileStore {

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -15,8 +15,8 @@ import java.net.URI
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.time.Clock
-import javax.annotation.ManagedBean
 import javax.imageio.ImageIO
+import javax.inject.Named
 import kotlin.io.path.Path
 import kotlin.io.path.nameWithoutExtension
 import net.coobird.thumbnailator.Thumbnails
@@ -25,7 +25,7 @@ import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.http.MediaType
 
-@ManagedBean
+@Named
 class ThumbnailStore(
     private val clock: Clock,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UploadService.kt
@@ -18,11 +18,11 @@ import java.io.InputStream
 import java.nio.file.NoSuchFileException
 import java.time.Duration
 import java.time.InstantSource
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 
-@ManagedBean
+@Named
 class UploadService(
     private val clock: InstantSource,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/file/UploadStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UploadStore.kt
@@ -12,10 +12,10 @@ import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOAD_PROBLEMS
 import com.terraformation.backend.file.model.UploadModel
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
-@ManagedBean
+@Named
 class UploadStore(
     private val dslContext: DSLContext,
     private val uploadProblemsDao: UploadProblemsDao,

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -13,7 +13,7 @@ import com.terraformation.backend.util.equalsIgnoreScale
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import javax.annotation.ManagedBean
+import javax.inject.Named
 
 /** Helper class to encapsulate notification message semantics */
 data class NotificationMessage(val title: String, val body: String)
@@ -23,7 +23,7 @@ data class NotificationMessage(val title: String, val body: String)
  * should live here rather than inline in the rest of the application. This will make it easier to
  * localize the messages into languages other than English in future versions.
  */
-@ManagedBean
+@Named
 class Messages {
   fun csvBadHeader() = "Incorrect column headings"
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
@@ -9,10 +9,10 @@ import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.tracking.db.DeliveryStore
 import java.time.LocalDate
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
-@ManagedBean
+@Named
 class BatchService(
     private val batchStore: BatchStore,
     private val deliveryStore: DeliveryStore,

--- a/src/main/kotlin/com/terraformation/backend/nursery/daily/NurseryDateNotificationTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/daily/NurseryDateNotificationTask.kt
@@ -8,14 +8,14 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.db.BatchStore
 import java.time.Instant
 import java.time.temporal.TemporalAccessor
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
-@ManagedBean
+@Named
 class NurseryDateNotificationTask(
     private val batchStore: BatchStore,
     private val dailyTaskRunner: DailyTaskRunner,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -24,13 +24,13 @@ import com.terraformation.backend.importer.CsvValidator
 import com.terraformation.backend.species.db.SpeciesStore
 import java.io.InputStream
 import java.time.LocalDate
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.annotation.Lazy
 
-@ManagedBean
+@Named
 class BatchImporter(
     private val batchStore: BatchStore,
     dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -42,13 +42,13 @@ import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.TemporalAccessor
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.UpdateSetFirstStep
 import org.jooq.UpdateSetMoreStep
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class BatchStore(
     private val batchesDao: BatchesDao,
     private val batchQuantityHistoryDao: BatchQuantityHistoryDao,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -13,11 +13,11 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.log.perClassLogger
 import java.io.InputStream
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 
-@ManagedBean
+@Named
 class WithdrawalPhotoService(
     private val dslContext: DSLContext,
     private val photoService: PhotoService,

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -3,7 +3,7 @@ package com.terraformation.backend.search
 import com.terraformation.backend.log.debugWithTiming
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.search.field.SearchField
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Record
@@ -23,7 +23,7 @@ import org.jooq.impl.DSL
  * opposed to issuing a series of smaller queries and assembling their results in the application.
  * This maximizes the database's flexibility to optimize the query.
  */
-@ManagedBean
+@Named
 class SearchService(private val dslContext: DSLContext) {
   private val log = perClassLogger()
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.search.SearchTable
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 
 /**
  * Manages the hierarchy of [SearchTable]s.
@@ -20,7 +20,7 @@ import javax.annotation.ManagedBean
  * instance of this class, and there's no practical way to get an instance of this class that isn't
  * successfully initialized.
  */
-@ManagedBean
+@Named
 class SearchTables(clock: Clock) {
   val accessionCollectors = AccessionCollectorsTable(this)
   val accessions = AccessionsTable(this, clock)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -25,13 +25,13 @@ import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import java.math.BigDecimal
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Record1
 import org.jooq.Select
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class AccessionService(
     private val accessionStore: AccessionStore,
     private val batchStore: BatchStore,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/daily/DateNotificationTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/daily/DateNotificationTask.kt
@@ -9,14 +9,14 @@ import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import java.time.Instant
 import java.time.temporal.TemporalAccessor
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
-@ManagedBean
+@Named
 class DateNotificationTask(
     private val accessionStore: AccessionStore,
     private val dailyTaskRunner: DailyTaskRunner,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -28,13 +28,13 @@ import com.terraformation.backend.species.db.SpeciesStore
 import java.io.InputStream
 import java.math.BigDecimal
 import java.time.LocalDate
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.annotation.Lazy
 
-@ManagedBean
+@Named
 class AccessionImporter(
     private val accessionStore: AccessionStore,
     private val countriesDao: CountriesDao,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -44,7 +44,7 @@ import java.time.Clock
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.TemporalAccessor
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -55,7 +55,7 @@ import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL
 import org.springframework.dao.DuplicateKeyException
 
-@ManagedBean
+@Named
 class AccessionStore(
     private val dslContext: DSLContext,
     private val bagStore: BagStore,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/BagStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/BagStore.kt
@@ -3,12 +3,12 @@ package com.terraformation.backend.seedbank.db
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.BAGS
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class BagStore(private val dslContext: DSLContext) {
   fun bagNumbersMultiset(idField: Field<AccessionId?> = ACCESSIONS.ID): Field<Set<String>> {
     return DSL.multiset(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/GeolocationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/GeolocationStore.kt
@@ -6,12 +6,12 @@ import com.terraformation.backend.db.seedbank.tables.references.GEOLOCATIONS
 import com.terraformation.backend.seedbank.model.Geolocation
 import java.math.BigDecimal
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class GeolocationStore(private val dslContext: DSLContext, private val clock: Clock) {
   fun geolocationsMultiset(idField: Field<AccessionId?> = ACCESSIONS.ID): Field<Set<Geolocation>> {
     return DSL.multiset(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -15,12 +15,12 @@ import com.terraformation.backend.log.perClassLogger
 import java.io.IOException
 import java.io.InputStream
 import java.nio.file.NoSuchFileException
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener
 
 /** Manages storage of accession photos. */
-@ManagedBean
+@Named
 class PhotoRepository(
     private val accessionPhotosDao: AccessionPhotosDao,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/StorageLocationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/StorageLocationStore.kt
@@ -4,10 +4,10 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
-@ManagedBean
+@Named
 class StorageLocationStore(private val dslContext: DSLContext) {
   fun fetchStorageConditionsByLocationName(facilityId: FacilityId): Map<String, StorageCondition> {
     return if (currentUser().canReadFacility(facilityId)) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -12,13 +12,13 @@ import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TEST_R
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.ViabilityTestResultModel
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class ViabilityTestStore(private val dslContext: DSLContext) {
   fun fetchOneById(viabilityTestId: ViabilityTestId): ViabilityTestModel {
     requirePermissions { readViabilityTest(viabilityTestId) }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
@@ -19,12 +19,12 @@ import com.terraformation.backend.seedbank.model.AccessionHistoryType
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class WithdrawalStore(
     private val dslContext: DSLContext,
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -4,10 +4,10 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 
-@ManagedBean
+@Named
 class SpeciesService(
     private val dslContext: DSLContext,
     private val speciesChecker: SpeciesChecker,

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
@@ -24,7 +24,7 @@ import java.io.FileNotFoundException
 import java.io.InputStream
 import java.net.URI
 import java.util.zip.ZipFile
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL
@@ -60,7 +60,7 @@ import org.jooq.impl.DSL
  * - [GBIF_NAME_WORDS]: individual words from all the names in [GBIF_NAMES], folded to lower case,
  * to support fast searching of word prefixes in typeaheads.
  */
-@ManagedBean
+@Named
 class GbifImporter(
     private val config: TerrawareServerConfig,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -14,11 +14,11 @@ import com.terraformation.backend.db.likeFuzzy
 import com.terraformation.backend.db.similarity
 import com.terraformation.backend.species.model.GbifTaxonModel
 import com.terraformation.backend.species.model.GbifVernacularNameModel
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class GbifStore(private val dslContext: DSLContext) {
   /**
    * Returns the species names whose words begin with a list of prefixes.

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesChecker.kt
@@ -3,9 +3,9 @@ package com.terraformation.backend.species.db
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
-import javax.annotation.ManagedBean
+import javax.inject.Named
 
-@ManagedBean
+@Named
 class SpeciesChecker(
     private val gbifStore: GbifStore,
     private val speciesStore: SpeciesStore,

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -19,14 +19,14 @@ import com.terraformation.backend.file.UploadStore
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.importer.CsvImporter
 import java.io.InputStream
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.apache.commons.lang3.BooleanUtils
 import org.jobrunr.jobs.JobId
 import org.jobrunr.scheduling.JobScheduler
 import org.jooq.DSLContext
 import org.springframework.context.annotation.Lazy
 
-@ManagedBean
+@Named
 class SpeciesImporter(
     dslContext: DSLContext,
     fileStore: FileStore,

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -20,13 +20,13 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PR
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.SpeciesService
 import java.time.Clock
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
-@ManagedBean
+@Named
 class SpeciesStore(
     private val clock: Clock,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/time/DatabaseBackedClock.kt
+++ b/src/main/kotlin/com/terraformation/backend/time/DatabaseBackedClock.kt
@@ -10,9 +10,9 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Timer
-import javax.annotation.ManagedBean
 import javax.annotation.PreDestroy
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.concurrent.timer
 import org.jooq.DSLContext
 import org.springframework.boot.context.event.ApplicationStartedEvent
@@ -50,7 +50,7 @@ import org.springframework.core.annotation.Order
  * base real time again. This effectively undoes the passage of time since step 1.
  * 5. Start the server. The clock will appear to have advanced by only a few seconds.
  */
-@ManagedBean
+@Named
 class DatabaseBackedClock
 private constructor(
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/DeliveryStore.kt
@@ -22,11 +22,11 @@ import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.model.DeliveryModel
 import com.terraformation.backend.tracking.model.PlantingModel
 import java.time.InstantSource
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 
-@ManagedBean
+@Named
 class DeliveryStore(
     private val clock: InstantSource,
     private val deliveriesDao: DeliveriesDao,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -15,13 +15,13 @@ import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.ShapefileFeature
 import java.time.InstantSource
 import java.util.EnumSet
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
 
-@ManagedBean
+@Named
 class PlantingSiteImporter(
     private val clock: InstantSource,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -16,12 +16,12 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.tracking.model.PlotModel
 import java.time.InstantSource
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.locationtech.jts.geom.MultiPolygon
 
-@ManagedBean
+@Named
 class PlantingSiteStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,

--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
@@ -13,10 +13,10 @@ import java.net.URL
 import java.time.Instant
 import java.time.InstantSource
 import java.time.temporal.ChronoUnit
-import javax.annotation.ManagedBean
+import javax.inject.Named
 import kotlinx.coroutines.runBlocking
 
-@ManagedBean
+@Named
 class MapboxService(
     private val clock: InstantSource,
     private val config: TerrawareServerConfig,


### PR DESCRIPTION
The `@ManagedBean` annotation is deprecated in Jakarta EE 9, which we'll be using
when we upgrade to the next major Spring version. Replace it with `@Named` which
is supported in both the current and upcoming versions.

This is a global search-and-replace, no manual edits.