### PR TITLE
SW-2003 Use ArbitraryJsonObject for automation settings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
@@ -38,7 +38,7 @@ class AutomationStore(
       verbosity: Int = 0,
       lowerThreshold: Double? = null,
       upperThreshold: Double? = null,
-      settings: Map<String, Any?>? = null,
+      settings: JSONB? = null,
   ): AutomationId {
     requirePermissions { createAutomation(facilityId) }
 
@@ -53,7 +53,7 @@ class AutomationStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = name,
-            settings = settings?.toJsonb(),
+            settings = settings,
             timeseriesName = timeseriesName,
             type = type,
             upperThreshold = upperThreshold,
@@ -115,7 +115,7 @@ class AutomationStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = model.name,
-            settings = model.settings?.toJsonb(),
+            settings = model.settings,
             timeseriesName = model.timeseriesName,
             type = model.type,
             upperThreshold = model.upperThreshold,
@@ -130,6 +130,4 @@ class AutomationStore(
 
     automationsDao.deleteById(automationId)
   }
-
-  private fun Map<String, Any?>.toJsonb() = JSONB.jsonb(objectMapper.writeValueAsString(this))
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.pojos.AutomationsRow
 import java.time.Instant
+import org.jooq.JSONB
 
 data class AutomationModel(
     val createdTime: Instant,
@@ -17,7 +18,7 @@ data class AutomationModel(
     val lowerThreshold: Double?,
     val modifiedTime: Instant,
     val name: String,
-    val settings: Map<String, Any?>?,
+    val settings: JSONB?,
     val timeseriesName: String?,
     val type: String,
     val upperThreshold: Double?,

--- a/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.device.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ArbitraryJsonObject
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -135,7 +136,7 @@ data class AutomationPayload(
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
     @Schema(description = "Client-defined configuration data for this automation.")
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 ) {
   constructor(
       model: AutomationModel
@@ -163,7 +164,7 @@ data class CreateAutomationRequestPayload(
     val verbosity: Int?,
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 )
 
 data class UpdateAutomationRequestPayload(
@@ -175,7 +176,7 @@ data class UpdateAutomationRequestPayload(
     val verbosity: Int?,
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 ) {
   fun toModel(existing: AutomationModel): AutomationModel {
     return existing.copy(


### PR DESCRIPTION
In preparation for changing the JSON deserialization settings to treat empty
strings as null values, update the automation payloads' settings fields to use
`ArbitraryJsonObject` instead of `Map<String, Any?>`.

Client-visible behavior remains the same as before.