### PR TITLE
Simplify OpenAPI customization

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/GeoJsonOpenApiSchema.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.ExternalDocumentation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springdoc.core.SpringDocUtils
 
 /**
  * Defines an OpenAPI schema for the GeoJSON renditions of the JTS geometry classes. These classes
@@ -13,8 +14,8 @@ import io.swagger.v3.oas.annotations.media.Schema
  *
  * This is invoked by [OpenApiConfig] which does some additional postprocessing on the schema.
  */
+@Suppress("unused")
 abstract class GeoJsonOpenApiSchema {
-  @Suppress("unused")
   internal enum class GeoJsonGeometryType {
     Point,
     LineString,
@@ -52,7 +53,6 @@ abstract class GeoJsonOpenApiSchema {
       type = "object")
   internal interface Geometry {
     val type: GeoJsonGeometryType
-    @Suppress("unused")
     val crs: CRS?
       get() = null
   }
@@ -189,4 +189,22 @@ abstract class GeoJsonOpenApiSchema {
                   url = "https://en.wikipedia.org/wiki/EPSG_Geodetic_Parameter_Dataset"))
       val name: String
   )
+
+  companion object {
+    fun configureJtsSchemas(config: SpringDocUtils) {
+      config.replaceWithClass(org.locationtech.jts.geom.Geometry::class.java, Geometry::class.java)
+      config.replaceWithClass(
+          org.locationtech.jts.geom.GeometryCollection::class.java, GeometryCollection::class.java)
+      config.replaceWithClass(
+          org.locationtech.jts.geom.LineString::class.java, LineString::class.java)
+      config.replaceWithClass(
+          org.locationtech.jts.geom.MultiLineString::class.java, MultiLineString::class.java)
+      config.replaceWithClass(
+          org.locationtech.jts.geom.MultiPoint::class.java, MultiPoint::class.java)
+      config.replaceWithClass(
+          org.locationtech.jts.geom.MultiPolygon::class.java, MultiPolygon::class.java)
+      config.replaceWithClass(org.locationtech.jts.geom.Point::class.java, Point::class.java)
+      config.replaceWithClass(org.locationtech.jts.geom.Polygon::class.java, Polygon::class.java)
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/AutomationStore.kt
@@ -38,7 +38,7 @@ class AutomationStore(
       verbosity: Int = 0,
       lowerThreshold: Double? = null,
       upperThreshold: Double? = null,
-      settings: Map<String, Any?>? = null,
+      settings: JSONB? = null,
   ): AutomationId {
     requirePermissions { createAutomation(facilityId) }
 
@@ -53,7 +53,7 @@ class AutomationStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = name,
-            settings = settings?.toJsonb(),
+            settings = settings,
             timeseriesName = timeseriesName,
             type = type,
             upperThreshold = upperThreshold,
@@ -115,7 +115,7 @@ class AutomationStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = model.name,
-            settings = model.settings?.toJsonb(),
+            settings = model.settings,
             timeseriesName = model.timeseriesName,
             type = model.type,
             upperThreshold = model.upperThreshold,
@@ -130,6 +130,4 @@ class AutomationStore(
 
     automationsDao.deleteById(automationId)
   }
-
-  private fun Map<String, Any?>.toJsonb() = JSONB.jsonb(objectMapper.writeValueAsString(this))
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/AutomationModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.pojos.AutomationsRow
 import java.time.Instant
+import org.jooq.JSONB
 
 data class AutomationModel(
     val createdTime: Instant,
@@ -17,7 +18,7 @@ data class AutomationModel(
     val lowerThreshold: Double?,
     val modifiedTime: Instant,
     val name: String,
-    val settings: Map<String, Any?>?,
+    val settings: JSONB?,
     val timeseriesName: String?,
     val type: String,
     val upperThreshold: Double?,

--- a/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.device.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ArbitraryJsonObject
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
@@ -135,7 +136,7 @@ data class AutomationPayload(
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
     @Schema(description = "Client-defined configuration data for this automation.")
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 ) {
   constructor(
       model: AutomationModel
@@ -163,7 +164,7 @@ data class CreateAutomationRequestPayload(
     val verbosity: Int?,
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 )
 
 data class UpdateAutomationRequestPayload(
@@ -175,7 +176,7 @@ data class UpdateAutomationRequestPayload(
     val verbosity: Int?,
     val lowerThreshold: Double?,
     val upperThreshold: Double?,
-    val settings: Map<String, Any?>?,
+    val settings: ArbitraryJsonObject?,
 ) {
   fun toModel(existing: AutomationModel): AutomationModel {
     return existing.copy(


### PR DESCRIPTION
Remove the explicit list of arbitrary-JSON-object payload fields whose
`additionalProperties` values need to be cleared, in favor of detecting them
dynamically during the scan of all the payload fields we're doing anyway.

Move the GeoJSON schema configuration to a helper function that lives alongside
the schema configuration classes.

There's no change in the intended behavior here, but this does fix the definitions
of a couple of payload fields that weren't being properly adjusted previously.