### PR TITLE
SW-2217 Switch from Java 11 HTTP client to Ktor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
 
   runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.2")
 
+  testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
   testImplementation("io.mockk:mockk:1.13.2")
   testImplementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
   testImplementation("org.junit.jupiter:junit-jupiter-api:$jUnitVersion")

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -1,13 +1,9 @@
 package com.terraformation.backend.util
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import freemarker.template.Template
 import java.io.StringWriter
 import java.math.BigDecimal
 import java.net.URI
-import java.net.http.HttpResponse
-import java.net.http.HttpResponse.BodyHandler
-import java.util.function.Supplier
 import org.jooq.Field
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
@@ -66,53 +62,3 @@ fun URI.appendPath(additionalPath: String): URI {
 fun <T> Sequence<T>.onChunk(chunkSize: Int, func: (List<T>) -> Unit): Sequence<T> {
   return chunked(chunkSize).onEach { func(it) }.flatten()
 }
-
-/**
- * Returns a handler that deserializes a JSON HTTP response to a particular class. This can be
- * passed to [java.net.http.HttpClient.send].
- *
- * The handler actually returns a [Supplier] that returns the deserialized value. The value isn't
- * deserialized until [Supplier.get] is called. That allows callers to first check whether the HTTP
- * request succeeded.
- *
- * Usage example:
- * ```
- * val response = httpClient.send(httpRequest, objectMapper.bodyHandler(SomeClass::class.java)
- * if (HttpStatus.resolve(response.statusCode())?.is2xxSuccessful == true) {
- *   val payload = response.body().get()
- * }
- * ```
- */
-fun <T> ObjectMapper.bodyHandler(responseClass: Class<T>): BodyHandler<Supplier<T>> {
-  return BodyHandler {
-    HttpResponse.BodySubscribers.mapping(HttpResponse.BodySubscribers.ofByteArray()) {
-      Supplier<T> {
-        if (responseClass == Unit::class.java) {
-          @Suppress("UNCHECKED_CAST")
-          Unit as T
-        } else {
-          readValue(it, responseClass)
-        }
-      }
-    }
-  }
-}
-
-/**
- * Returns a handler that deserializes a JSON HTTP response to a particular class. This can be
- * passed to [java.net.http.HttpClient.send].
- *
- * The handler actually returns a [Supplier] that returns the deserialized value. The value isn't
- * deserialized until [Supplier.get] is called. That allows callers to first check whether the HTTP
- * request succeeded.
- *
- * Usage example:
- * ```
- * val response = httpClient.send(httpRequest, objectMapper.bodyHandler<SomeClass>()
- * if (HttpStatus.resolve(response.statusCode())?.is2xxSuccessful == true) {
- *   val payload = response.body().get()
- * }
- * ```
- */
-inline fun <reified T> ObjectMapper.bodyHandler(): BodyHandler<Supplier<T>> =
-    bodyHandler(T::class.java)

--- a/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/HttpClientConfig.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.java.Java
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -21,13 +22,13 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class HttpClientConfig {
   @Bean
-  fun httpClient(): java.net.http.HttpClient {
-    return java.net.http.HttpClient.newHttpClient()
+  fun ktorEngine(): HttpClientEngine {
+    return Java.create()
   }
 
   @Bean
-  fun ktorHttpClient(objectMapper: ObjectMapper): HttpClient {
-    return HttpClient(Java) {
+  fun httpClient(engine: HttpClientEngine, objectMapper: ObjectMapper): HttpClient {
+    return HttpClient(engine) {
       defaultRequest { contentType(ContentType.Application.Json) }
 
       // By default, treat non-2xx responses as errors. This can be overridden per request.

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -116,7 +116,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             dslContext,
             mockk(),
             mockk(),
-            objectMapper,
             organizationStore,
             ParentStore(dslContext),
             PermissionStore(dslContext),

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.customer
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.config.TerrawareServerConfig
@@ -79,7 +78,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             dslContext,
             mockk(),
             mockk(),
-            jacksonObjectMapper(),
             organizationStore,
             parentStore,
             PermissionStore(dslContext),

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -155,7 +155,6 @@ internal class PermissionTest : DatabaseTest() {
             mockk(),
             mockk(),
             mockk(),
-            mockk(),
             parentStore,
             permissionStore,
             mockk(),


### PR DESCRIPTION
Update the code that makes requests to Balena and Keycloak to use the Ktor HTTP
client instead of the Java 11 one. Remove the helper functions we used to use to
make the Java 11 client's API less cumbersome.

No change in functionality or behavior here.