### PR TITLE
Don't allow searches with no values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
@@ -102,6 +102,12 @@ data class FieldNode(
     val values: List<String?>,
     val type: SearchFilterType = SearchFilterType.Exact
 ) : SearchNode {
+  init {
+    if (values.isEmpty()) {
+      throw IllegalArgumentException("Search must include at least one value")
+    }
+  }
+
   override fun toCondition(): Condition {
     val conditions = field.searchField.getConditions(this)
     return when {

--- a/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
@@ -105,22 +105,22 @@ data class FieldNode(
   override fun toCondition(): Condition {
     val conditions = field.searchField.getConditions(this)
     return when {
-      type == SearchFilterType.Fuzzy && values.any { it == null } -> DSL.trueCondition()
+      isFuzzySearchForNull -> DSL.trueCondition()
       conditions.size == 1 -> conditions[0]
       else -> DSL.and(conditions)
     }
   }
 
   override fun referencedSublists(): Set<SublistField> {
-    return if (field.searchField is AliasField) {
-      field.searchField.targetPath.sublists.toSet()
-    } else {
-      field.sublists.toSet()
+    return when {
+      isFuzzySearchForNull -> emptySet()
+      field.searchField is AliasField -> field.searchField.targetPath.sublists.toSet()
+      else -> field.sublists.toSet()
     }
   }
 
   override fun toExactSearch(): FieldNode {
-    return if (type == SearchFilterType.Fuzzy && values.none { it == null }) {
+    return if (type == SearchFilterType.Fuzzy && !isFuzzySearchForNull) {
       FieldNode(field, values)
     } else {
       this
@@ -130,6 +130,9 @@ data class FieldNode(
   override fun toString(): String {
     return "FieldNode($field $type [${values.joinToString()}])"
   }
+
+  private val isFuzzySearchForNull: Boolean
+    get() = type == SearchFilterType.Fuzzy && values.any { it == null }
 }
 
 class NoConditionNode : SearchNode {

--- a/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
@@ -120,8 +120,8 @@ data class FieldNode(
   }
 
   override fun toExactSearch(): FieldNode {
-    return if (type == SearchFilterType.Fuzzy && !isFuzzySearchForNull) {
-      FieldNode(field, values)
+    return if (type == SearchFilterType.Fuzzy && values.any { it != null }) {
+      FieldNode(field, values.filterNotNull())
     } else {
       this
     }

--- a/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
@@ -104,7 +104,11 @@ data class FieldNode(
 ) : SearchNode {
   override fun toCondition(): Condition {
     val conditions = field.searchField.getConditions(this)
-    return if (conditions.size == 1) conditions[0] else DSL.and(conditions)
+    return when {
+      type == SearchFilterType.Fuzzy && values.any { it == null } -> DSL.trueCondition()
+      conditions.size == 1 -> conditions[0]
+      else -> DSL.and(conditions)
+    }
   }
 
   override fun referencedSublists(): Set<SublistField> {
@@ -116,7 +120,7 @@ data class FieldNode(
   }
 
   override fun toExactSearch(): FieldNode {
-    return if (type == SearchFilterType.Fuzzy) {
+    return if (type == SearchFilterType.Fuzzy && values.none { it == null }) {
       FieldNode(field, values)
     } else {
       this

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -74,4 +74,21 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
         searchAccessions(facilityId, fields, searchNode),
         "Search for value without an exact match")
   }
+
+  @Test
+  fun `fuzzy search for null and non-null values matches non-null exact values if any exist`() {
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
+
+    val fields = listOf(processingNotesField)
+    val searchNode = FieldNode(processingNotesField, listOf("Notes", null), SearchFilterType.Fuzzy)
+
+    assertEquals(
+        SearchResults(
+            listOf(
+                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
+            ),
+            null),
+        searchAccessions(facilityId, fields, searchNode))
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -60,7 +60,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
 
     val fields = listOf(processingNotesField)
     val searchNode =
-        FieldNode(processingNotesField, listOf("ignored", null), SearchFilterType.Fuzzy)
+        FieldNode(processingNotesField, listOf("non-matching value", null), SearchFilterType.Fuzzy)
 
     assertEquals(
         SearchResults(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -54,27 +54,21 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
   }
 
   @Test
-  fun `can do fuzzy search for null values`() {
-    insertAccession(number = "MISSING")
+  fun `fuzzy search treats null values as no-ops`() {
     accessionsDao.update(
-        accessionsDao
-            .fetchOneById(AccessionId(1001))!!
-            .copy(processingNotes = "some matching notes"))
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(processingNotes = "not it"))
+        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
 
-    val fields = listOf(accessionNumberField)
-    val searchNode = FieldNode(processingNotesField, listOf(null), SearchFilterType.Fuzzy)
+    val fields = listOf(processingNotesField)
+    val searchNode =
+        FieldNode(processingNotesField, listOf("ignored", null), SearchFilterType.Fuzzy)
 
-    val result = searchAccessions(facilityId, fields, searchNode)
-
-    val expected =
+    assertEquals(
         SearchResults(
             listOf(
-                mapOf("id" to "1", "accessionNumber" to "MISSING"),
+                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
+                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
             ),
-            cursor = null)
-
-    assertEquals(expected, result)
+            null),
+        searchAccessions(facilityId, fields, searchNode))
   }
 }


### PR DESCRIPTION
The list of search values for a `FieldNode` is annotated `@NotEmpty` in the API
payload class, but the implementation wasn't guarding against empty lists of
field values.