### PR TITLE
SW-215 Switch to maintained fork of jOOQ Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,16 @@ plugins {
 }
 
 buildscript {
+  // Force the jOOQ codegen plugin to use the same jOOQ version we use in the application code.
+  val jooqVersion: String by project
+  configurations.classpath {
+    resolutionStrategy {
+      setForcedModules(
+          "org.jooq:jooq-codegen:$jooqVersion",
+      )
+    }
+  }
+
   // The MJML -> HTML translator for email messages is a Node.js utility. This plugin is a
   // dependency of buildSrc, but we need it here as well so we can configure it.
   apply(plugin = "com.github.node-gradle.node")
@@ -67,7 +77,6 @@ dependencies {
   val springDocVersion: String by project
 
   jooqCodegen("org.postgresql:postgresql:$postgresJdbcVersion")
-  jooqCodegen("org.jooq:jooq-codegen:$jooqVersion")
 
   // Build autocomplete metadata for our config settings in application.yaml. This
   // requires kapt which slows the build down significantly, so is commented out.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,19 +36,6 @@ plugins {
 }
 
 buildscript {
-  // Force the jOOQ codegen plugin to use the same jOOQ version we use in the application code.
-  val jooqVersion: String by project
-  configurations.classpath {
-    resolutionStrategy {
-      setForcedModules(
-          // https://github.com/revolut-engineering/jooq-plugin/pull/17
-          "com.github.docker-java:docker-java-transport-okhttp:3.2.12",
-          "org.jooq:jooq:$jooqVersion",
-          "org.jooq:jooq-codegen:$jooqVersion",
-      )
-    }
-  }
-
   // The MJML -> HTML translator for email messages is a Node.js utility. This plugin is a
   // dependency of buildSrc, but we need it here as well so we can configure it.
   apply(plugin = "com.github.node-gradle.node")
@@ -80,6 +67,7 @@ dependencies {
   val springDocVersion: String by project
 
   jooqCodegen("org.postgresql:postgresql:$postgresJdbcVersion")
+  jooqCodegen("org.jooq:jooq-codegen:$jooqVersion")
 
   // Build autocomplete metadata for our config settings in application.yaml. This
   // requires kapt which slows the build down significantly, so is commented out.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
   // Uncomment the kapt line in the dependencies block if you enable this.
   // kotlin("kapt")
 
-  id("com.revolut.jooq-docker") version "0.3.7"
+  id("dev.monosoul.jooq-docker") version "1.3.17"
   id("com.diffplug.spotless") version "6.4.2"
   id("org.springframework.boot") version "2.7.6"
   id("io.spring.dependency-management") version "1.1.0"
@@ -79,7 +79,7 @@ dependencies {
   val postgresJdbcVersion: String by project
   val springDocVersion: String by project
 
-  jdbc("org.postgresql:postgresql:$postgresJdbcVersion")
+  jooqCodegen("org.postgresql:postgresql:$postgresJdbcVersion")
 
   // Build autocomplete metadata for our config settings in application.yaml. This
   // requires kapt which slows the build down significantly, so is commented out.
@@ -180,12 +180,11 @@ tasks {
   }
 
   generateJooqClasses {
-    basePackageName = "com.terraformation.backend.db"
-    excludeFlywayTable = true
-    schemas = arrayOf("public", "nursery", "seedbank", "tracking")
-    outputSchemaToDefault = setOf("public")
+    basePackageName.set("com.terraformation.backend.db")
+    schemas.set(listOf("public", "nursery", "seedbank", "tracking"))
+    outputSchemaToDefault.add("public")
 
-    customizeGenerator {
+    usingJavaConfig {
       val generator = com.terraformation.backend.jooq.TerrawareGenerator()
       val pluralStrategy = com.terraformation.backend.jooq.PluralPojoStrategy()
 
@@ -195,7 +194,7 @@ tasks {
         withName("org.jooq.meta.postgres.PostgresDatabase")
         withIncludes(".*")
         withExcludes(generator.excludes())
-        withForcedTypes(generator.forcedTypes(basePackageName))
+        withForcedTypes(generator.forcedTypes(basePackageName.get()))
         withEmbeddables(generator.embeddables())
         // Fix compiler warnings for PostGIS functions; see https://github.com/jOOQ/jOOQ/issues/8587
         withTableValuedFunctions(false)
@@ -213,21 +212,19 @@ tasks {
       }
     }
 
-    flywayProperties =
-        mapOf(
-            "flyway.placeholders.jsonColumnType" to "JSONB",
-            "flyway.placeholders.uuidColumnType" to "UUID",
-        )
+    flywayProperties.put("flyway.placeholders.jsonColumnType", "JSONB")
+    flywayProperties.put("flyway.placeholders.uuidColumnType", "UUID")
   }
 }
 
 jooq {
-  image {
-    val postgresDockerRepository: String by project
-    val postgresDockerTag: String by project
+  withContainer {
+    image {
+      val postgresDockerRepository: String by project
+      val postgresDockerTag: String by project
 
-    repository = postgresDockerRepository
-    tag = postgresDockerTag
+      name = "$postgresDockerRepository:$postgresDockerTag"
+    }
   }
 }
 


### PR DESCRIPTION
We're using a Gradle plugin that automatically fires up PostgreSQL in a Docker
container to run our migrations so jOOQ can look at the resulting schema for code
generation. But the plugin seems to have been abandoned; I submitted a simple pull
request over a year ago to fix a compatibility problem and it hasn't been merged
or rejected yet.

Someone forked the project and has been actively maintaining it, and their version
doesn't have the problem my PR was meant to fix. Switch to the fork and update the
build config to account for some minor naming changes the fork's maintainer has
made.