### PR TITLE
Reduce boilerplate in PermissionRequirementsTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -195,153 +195,120 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun addOrganizationUser() {
-    allow { addOrganizationUser(organizationId) } ifUser { canAddOrganizationUser(organizationId) }
-  }
+  fun addOrganizationUser() =
+      allow { addOrganizationUser(organizationId) } ifUser
+          {
+            canAddOrganizationUser(organizationId)
+          }
 
   @Test
-  fun createAccession() {
-    allow { createAccession(facilityId) } ifUser { canCreateAccession(facilityId) }
-  }
+  fun createAccession() =
+      allow { createAccession(facilityId) } ifUser { canCreateAccession(facilityId) }
 
   @Test
-  fun createApiKey() {
-    allow { createApiKey(organizationId) } ifUser { canCreateApiKey(organizationId) }
-  }
+  fun createApiKey() =
+      allow { createApiKey(organizationId) } ifUser { canCreateApiKey(organizationId) }
 
   @Test
-  fun createAutomation() {
-    allow { createAutomation(facilityId) } ifUser { canCreateAutomation(facilityId) }
-  }
+  fun createAutomation() =
+      allow { createAutomation(facilityId) } ifUser { canCreateAutomation(facilityId) }
+
+  @Test fun createBatch() = allow { createBatch(facilityId) } ifUser { canCreateBatch(facilityId) }
 
   @Test
-  fun createBatch() {
-    allow { createBatch(facilityId) } ifUser { canCreateBatch(facilityId) }
-  }
+  fun createDelivery() =
+      allow { createDelivery(plantingSiteId) } ifUser { canCreateDelivery(plantingSiteId) }
 
   @Test
-  fun createDelivery() {
-    allow { createDelivery(plantingSiteId) } ifUser { canCreateDelivery(plantingSiteId) }
-  }
+  fun createDevice() = allow { createDevice(facilityId) } ifUser { canCreateDevice(facilityId) }
 
   @Test
-  fun createDevice() {
-    allow { createDevice(facilityId) } ifUser { canCreateDevice(facilityId) }
-  }
+  fun createDeviceManager() = allow { createDeviceManager() } ifUser { canCreateDeviceManager() }
 
   @Test
-  fun createDeviceManager() {
-    allow { createDeviceManager() } ifUser { canCreateDeviceManager() }
-  }
+  fun createFacility() =
+      allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
 
   @Test
-  fun createFacility() {
-    allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
-  }
+  fun createNotification() =
+      allow { createNotification(notificationUserId, organizationId) } ifUser
+          {
+            canCreateNotification(notificationUserId, organizationId)
+          }
 
   @Test
-  fun createNotification() {
-    allow { createNotification(notificationUserId, organizationId) } ifUser
-        {
-          canCreateNotification(notificationUserId, organizationId)
-        }
-  }
+  fun createPlantingSite() =
+      allow { createPlantingSite(organizationId) } ifUser { canCreatePlantingSite(organizationId) }
 
   @Test
-  fun createPlantingSite() {
-    allow { createPlantingSite(organizationId) } ifUser { canCreatePlantingSite(organizationId) }
-  }
+  fun createSpecies() =
+      allow { createSpecies(organizationId) } ifUser { canCreateSpecies(organizationId) }
 
   @Test
-  fun createSpecies() {
-    allow { createSpecies(organizationId) } ifUser { canCreateSpecies(organizationId) }
-  }
+  fun createStorageLocation() =
+      allow { createStorageLocation(facilityId) } ifUser { canCreateStorageLocation(facilityId) }
 
   @Test
-  fun createStorageLocation() {
-    allow { createStorageLocation(facilityId) } ifUser { canCreateStorageLocation(facilityId) }
-  }
+  fun createTimeseries() =
+      allow { createTimeseries(deviceId) } ifUser { canCreateTimeseries(deviceId) }
 
   @Test
-  fun createTimeseries() {
-    allow { createTimeseries(deviceId) } ifUser { canCreateTimeseries(deviceId) }
-  }
+  fun createWithdrawalPhoto() =
+      allow { createWithdrawalPhoto(withdrawalId) } ifUser
+          {
+            canCreateWithdrawalPhoto(withdrawalId)
+          }
 
   @Test
-  fun createWithdrawalPhoto() {
-    allow { createWithdrawalPhoto(withdrawalId) } ifUser { canCreateWithdrawalPhoto(withdrawalId) }
-  }
+  fun deleteAccession() =
+      allow { deleteAccession(accessionId) } ifUser { canDeleteAccession(accessionId) }
 
   @Test
-  fun deleteAccession() {
-    allow { deleteAccession(accessionId) } ifUser { canDeleteAccession(accessionId) }
-  }
+  fun deleteAutomation() =
+      allow { deleteAutomation(automationId) } ifUser { canDeleteAutomation(automationId) }
+
+  @Test fun deleteBatch() = allow { deleteBatch(batchId) } ifUser { canDeleteBatch(batchId) }
 
   @Test
-  fun deleteAutomation() {
-    allow { deleteAutomation(automationId) } ifUser { canDeleteAutomation(automationId) }
-  }
+  fun deleteOrganization() =
+      allow { deleteOrganization(organizationId) } ifUser { canDeleteOrganization(organizationId) }
+
+  @Test fun deleteSelf() = allow { deleteSelf() } ifUser { canDeleteSelf() }
 
   @Test
-  fun deleteBatch() {
-    allow { deleteBatch(batchId) } ifUser { canDeleteBatch(batchId) }
-  }
+  fun deleteSpecies() = allow { deleteSpecies(speciesId) } ifUser { canDeleteSpecies(speciesId) }
 
   @Test
-  fun deleteOrganization() {
-    allow { deleteOrganization(organizationId) } ifUser { canDeleteOrganization(organizationId) }
-  }
+  fun deleteStorageLocation() =
+      allow { deleteStorageLocation(storageLocationId) } ifUser
+          {
+            canDeleteStorageLocation(storageLocationId)
+          }
+
+  @Test fun deleteUpload() = allow { deleteUpload(uploadId) } ifUser { canDeleteUpload(uploadId) }
 
   @Test
-  fun deleteSelf() {
-    allow { deleteSelf() } ifUser { canDeleteSelf() }
-  }
+  fun importGlobalSpeciesData() =
+      allow { importGlobalSpeciesData() } ifUser { canImportGlobalSpeciesData() }
 
   @Test
-  fun deleteSpecies() {
-    allow { deleteSpecies(speciesId) } ifUser { canDeleteSpecies(speciesId) }
-  }
+  fun listAutomations() =
+      allow { listAutomations(facilityId) } ifUser { canListAutomations(facilityId) }
 
   @Test
-  fun deleteStorageLocation() {
-    allow { deleteStorageLocation(storageLocationId) } ifUser
-        {
-          canDeleteStorageLocation(storageLocationId)
-        }
-  }
+  fun listGlobalNotifications() =
+      allow { listNotifications(null) } ifUser { canListNotifications(null) }
 
   @Test
-  fun deleteUpload() {
-    allow { deleteUpload(uploadId) } ifUser { canDeleteUpload(uploadId) }
-  }
+  fun listOrganizationNotifications() =
+      allow { listNotifications(organizationId) } ifUser { canListNotifications(organizationId) }
 
   @Test
-  fun importGlobalSpeciesData() {
-    allow { importGlobalSpeciesData() } ifUser { canImportGlobalSpeciesData() }
-  }
-
-  @Test
-  fun listAutomations() {
-    allow { listAutomations(facilityId) } ifUser { canListAutomations(facilityId) }
-  }
-
-  @Test
-  fun listGlobalNotifications() {
-    allow { listNotifications(null) } ifUser { canListNotifications(null) }
-  }
-
-  @Test
-  fun listOrganizationNotifications() {
-    allow { listNotifications(organizationId) } ifUser { canListNotifications(organizationId) }
-  }
-
-  @Test
-  fun listOrganizationUsers() {
-    allow { listOrganizationUsers(organizationId) } ifUser
-        {
-          canListOrganizationUsers(organizationId)
-        }
-  }
+  fun listOrganizationUsers() =
+      allow { listOrganizationUsers(organizationId) } ifUser
+          {
+            canListOrganizationUsers(organizationId)
+          }
 
   @Test
   fun movePlantingSite() {
@@ -359,50 +326,23 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.movePlantingSiteToAnyOrg(plantingSiteId)
   }
 
-  @Test
-  fun readAccession() {
-    testRead { readAccession(accessionId) }
-  }
+  @Test fun readAccession() = testRead { readAccession(accessionId) }
 
-  @Test
-  fun readAutomation() {
-    testRead { readAutomation(automationId) }
-  }
+  @Test fun readAutomation() = testRead { readAutomation(automationId) }
 
-  @Test
-  fun readBatch() {
-    testRead { readBatch(batchId) }
-  }
+  @Test fun readBatch() = testRead { readBatch(batchId) }
 
-  @Test
-  fun readDelivery() {
-    testRead { readDelivery(deliveryId) }
-  }
+  @Test fun readDelivery() = testRead { readDelivery(deliveryId) }
 
-  @Test
-  fun readDevice() {
-    testRead { readDevice(deviceId) }
-  }
+  @Test fun readDevice() = testRead { readDevice(deviceId) }
 
-  @Test
-  fun readDeviceManager() {
-    testRead { readDeviceManager(deviceManagerId) }
-  }
+  @Test fun readDeviceManager() = testRead { readDeviceManager(deviceManagerId) }
 
-  @Test
-  fun readFacility() {
-    testRead { readFacility(facilityId) }
-  }
+  @Test fun readFacility() = testRead { readFacility(facilityId) }
 
-  @Test
-  fun readNotification() {
-    testRead { readNotification(notificationId) }
-  }
+  @Test fun readNotification() = testRead { readNotification(notificationId) }
 
-  @Test
-  fun readOrganization() {
-    testRead { readOrganization(organizationId) }
-  }
+  @Test fun readOrganization() = testRead { readOrganization(organizationId) }
 
   @Test
   fun readOrganizationUser() {
@@ -419,45 +359,23 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.readOrganizationUser(organizationId, userId)
   }
 
-  @Test
-  fun readPlanting() {
-    testRead { readPlanting(plantingId) }
-  }
+  @Test fun readPlanting() = testRead { readPlanting(plantingId) }
+
+  @Test fun readPlantingSite() = testRead { readPlantingSite(plantingSiteId) }
+
+  @Test fun readSpecies() = testRead { readSpecies(speciesId) }
+
+  @Test fun readStorageLocation() = testRead { readStorageLocation(storageLocationId) }
+
+  @Test fun readUpload() = testRead { readUpload(uploadId) }
+
+  @Test fun readViabilityTest() = testRead { readViabilityTest(viabilityTestId) }
+
+  @Test fun readWithdrawal() = testRead { readWithdrawal(withdrawalId) }
 
   @Test
-  fun readPlantingSite() {
-    testRead { readPlantingSite(plantingSiteId) }
-  }
-
-  @Test
-  fun readSpecies() {
-    testRead { readSpecies(speciesId) }
-  }
-
-  @Test
-  fun readStorageLocation() {
-    testRead { readStorageLocation(storageLocationId) }
-  }
-
-  @Test
-  fun readUpload() {
-    testRead { readUpload(uploadId) }
-  }
-
-  @Test
-  fun readViabilityTest() {
-    testRead { readViabilityTest(viabilityTestId) }
-  }
-
-  @Test
-  fun readWithdrawal() {
-    testRead { readWithdrawal(withdrawalId) }
-  }
-
-  @Test
-  fun regenerateAllDeviceManagerTokens() {
-    allow { regenerateAllDeviceManagerTokens() } ifUser { canRegenerateAllDeviceManagerTokens() }
-  }
+  fun regenerateAllDeviceManagerTokens() =
+      allow { regenerateAllDeviceManagerTokens() } ifUser { canRegenerateAllDeviceManagerTokens() }
 
   @Test
   fun removeOrganizationUser() {
@@ -474,10 +392,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.removeOrganizationUser(organizationId, userId)
   }
 
-  @Test
-  fun sendAlert() {
-    allow { sendAlert(facilityId) } ifUser { canSendAlert(facilityId) }
-  }
+  @Test fun sendAlert() = allow { sendAlert(facilityId) } ifUser { canSendAlert(facilityId) }
 
   @Test
   fun setOrganizationUserRole() {
@@ -487,111 +402,83 @@ internal class PermissionRequirementsTest : RunsAsUser {
         }
   }
 
-  @Test
-  fun setTestClock() {
-    allow { setTestClock() } ifUser { canSetTestClock() }
-  }
+  @Test fun setTestClock() = allow { setTestClock() } ifUser { canSetTestClock() }
 
   @Test
-  fun setWithdrawalUser() {
-    allow { setWithdrawalUser(accessionId) } ifUser { canSetWithdrawalUser(accessionId) }
-  }
+  fun setWithdrawalUser() =
+      allow { setWithdrawalUser(accessionId) } ifUser { canSetWithdrawalUser(accessionId) }
 
   @Test
-  fun triggerAutomation() {
-    allow { triggerAutomation(automationId) } ifUser { canTriggerAutomation(automationId) }
-  }
+  fun triggerAutomation() =
+      allow { triggerAutomation(automationId) } ifUser { canTriggerAutomation(automationId) }
 
   @Test
-  fun updateAccession() {
-    allow { updateAccession(accessionId) } ifUser { canUpdateAccession(accessionId) }
-  }
+  fun updateAccession() =
+      allow { updateAccession(accessionId) } ifUser { canUpdateAccession(accessionId) }
+
+  @Test fun updateAppVersions() = allow { updateAppVersions() } ifUser { canUpdateAppVersions() }
 
   @Test
-  fun updateAppVersions() {
-    allow { updateAppVersions() } ifUser { canUpdateAppVersions() }
-  }
+  fun updateAutomation() =
+      allow { updateAutomation(automationId) } ifUser { canUpdateAutomation(automationId) }
+
+  @Test fun updateBatch() = allow { updateBatch(batchId) } ifUser { canUpdateBatch(batchId) }
 
   @Test
-  fun updateAutomation() {
-    allow { updateAutomation(automationId) } ifUser { canUpdateAutomation(automationId) }
-  }
+  fun updateDelivery() =
+      allow { updateDelivery(deliveryId) } ifUser { canUpdateDelivery(deliveryId) }
+
+  @Test fun updateDevice() = allow { updateDevice(deviceId) } ifUser { canUpdateDevice(deviceId) }
 
   @Test
-  fun updateBatch() {
-    allow { updateBatch(batchId) } ifUser { canUpdateBatch(batchId) }
-  }
+  fun updateDeviceManager() =
+      allow { updateDeviceManager(deviceManagerId) } ifUser
+          {
+            canUpdateDeviceManager(deviceManagerId)
+          }
 
   @Test
-  fun updateDelivery() {
-    allow { updateDelivery(deliveryId) } ifUser { canUpdateDelivery(deliveryId) }
-  }
+  fun updateDeviceTemplates() =
+      allow { updateDeviceTemplates() } ifUser { canUpdateDeviceTemplates() }
 
   @Test
-  fun updateDevice() {
-    allow { updateDevice(deviceId) } ifUser { canUpdateDevice(deviceId) }
-  }
+  fun updateFacility() =
+      allow { updateFacility(facilityId) } ifUser { canUpdateFacility(facilityId) }
 
   @Test
-  fun updateDeviceManager() {
-    allow { updateDeviceManager(deviceManagerId) } ifUser
-        {
-          canUpdateDeviceManager(deviceManagerId)
-        }
-  }
+  fun updateGlobalNotifications() =
+      allow { updateNotifications(null) } ifUser { canUpdateNotifications(null) }
 
   @Test
-  fun updateDeviceTemplates() {
-    allow { updateDeviceTemplates() } ifUser { canUpdateDeviceTemplates() }
-  }
+  fun updateNotification() =
+      allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }
 
   @Test
-  fun updateFacility() {
-    allow { updateFacility(facilityId) } ifUser { canUpdateFacility(facilityId) }
-  }
+  fun updateOrganization() =
+      allow { updateOrganization(organizationId) } ifUser { canUpdateOrganization(organizationId) }
 
   @Test
-  fun updateGlobalNotifications() {
-    allow { updateNotifications(null) } ifUser { canUpdateNotifications(null) }
-  }
+  fun updateOrganizationNotifications() =
+      allow { updateNotifications(organizationId) } ifUser
+          {
+            canUpdateNotifications(organizationId)
+          }
 
   @Test
-  fun updateNotification() {
-    allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }
-  }
+  fun updatePlantingSite() =
+      allow { updatePlantingSite(plantingSiteId) } ifUser { canUpdatePlantingSite(plantingSiteId) }
 
   @Test
-  fun updateOrganization() {
-    allow { updateOrganization(organizationId) } ifUser { canUpdateOrganization(organizationId) }
-  }
+  fun updateSpecies() = allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
 
   @Test
-  fun updateOrganizationNotifications() {
-    allow { updateNotifications(organizationId) } ifUser { canUpdateNotifications(organizationId) }
-  }
+  fun updateStorageLocation() =
+      allow { updateStorageLocation(storageLocationId) } ifUser
+          {
+            canUpdateStorageLocation(storageLocationId)
+          }
 
-  @Test
-  fun updatePlantingSite() {
-    allow { updatePlantingSite(plantingSiteId) } ifUser { canUpdatePlantingSite(plantingSiteId) }
-  }
-
-  @Test
-  fun updateSpecies() {
-    allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
-  }
-
-  @Test
-  fun updateStorageLocation() {
-    allow { updateStorageLocation(storageLocationId) } ifUser
-        {
-          canUpdateStorageLocation(storageLocationId)
-        }
-  }
-
-  @Test
-  fun updateUpload() {
-    allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
-  }
+  @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
 
   // When adding new permission tests, put them in alphabetical order.
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AutomationNotFoundException
 import com.terraformation.backend.db.DeviceManagerNotFoundException
 import com.terraformation.backend.db.DeviceNotFoundException
+import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -38,14 +39,30 @@ import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 /**
  * Tests the exception-throwing logic in [PermissionRequirements].
  *
- * The general form of the test methods here is
+ * For a read permission on a single object ID, where there should be an [EntityNotFoundException]
+ * if the user doesn't have the permission, you can call [testRead] and pass in an ID that is
+ * created by the [readableId] method.
+ *
+ * For a write permission on a single object ID, where there should be an [EntityNotFoundException]
+ * if the user doesn't have permission to read the object and an [AccessDeniedException] if they
+ * don't have write permission, the test will look like
+ * ```
+ * allow { methodUnderTest(objectId) } ifUser { canDoWhatever(objectId) }
+ * ```
+ *
+ * The general approach to these tests, which is implemented by [testRead] and [ifUser] for simple
+ * scenarios and explicitly in test methods for more complex scenarios, is
  *
  * 1. Assert the exception that's thrown if the exception-checking method is called when the user
  * has none of the relevant permissions at all
@@ -61,25 +78,48 @@ internal class PermissionRequirementsTest : RunsAsUser {
   override val user: TerrawareUser = mockk(relaxed = true)
   private val requirements = PermissionRequirements(user)
 
-  private val accessionId = AccessionId(1)
-  private val automationId = AutomationId(1)
-  private val batchId = BatchId(1)
-  private val deliveryId = DeliveryId(1)
-  private val deviceId = DeviceId(1)
-  private val deviceManagerId = DeviceManagerId(1)
-  private val facilityId = FacilityId(1)
+  /**
+   * List of callback functions that will test that an exception is thrown if the user doesn't have
+   * read permission on an object, then will grant permission. This is populated implicitly when a
+   * test method accesses one of the IDs that's lazy-created by [readableId].
+   */
+  private val readChecks = mutableListOf<(() -> Unit) -> Unit>()
+
+  // Lazy-instantiated object IDs with implicit testing of read permission handling. When you access
+  // one of these IDs for the first time, an entry is added to [readChecks].
+
+  private val accessionId: AccessionId by
+      readableId(AccessionNotFoundException::class) { canReadAccession(it) }
+  private val automationId: AutomationId by
+      readableId(AutomationNotFoundException::class) { canReadAutomation(it) }
+  private val batchId: BatchId by readableId(BatchNotFoundException::class) { canReadBatch(it) }
+  private val deliveryId: DeliveryId by
+      readableId(DeliveryNotFoundException::class) { canReadDelivery(it) }
+  private val deviceId: DeviceId by readableId(DeviceNotFoundException::class) { canReadDevice(it) }
+  private val deviceManagerId: DeviceManagerId by
+      readableId(DeviceManagerNotFoundException::class) { canReadDeviceManager(it) }
+  private val facilityId: FacilityId by
+      readableId(FacilityNotFoundException::class) { canReadFacility(it) }
   private val notificationUserId = UserId(2)
-  private val notificationId = NotificationId(1)
-  private val organizationId = OrganizationId(1)
-  private val plantingId = PlantingId(1)
-  private val plantingSiteId = PlantingSiteId(1)
+  private val notificationId: NotificationId by
+      readableId(NotificationNotFoundException::class) { canReadNotification(it) }
+  private val organizationId: OrganizationId by
+      readableId(OrganizationNotFoundException::class) { canReadOrganization(it) }
+  private val plantingId: PlantingId by
+      readableId(PlantingNotFoundException::class) { canReadPlanting(it) }
+  private val plantingSiteId: PlantingSiteId by
+      readableId(PlantingSiteNotFoundException::class) { canReadPlantingSite(it) }
   private val role = Role.CONTRIBUTOR
-  private val speciesId = SpeciesId(1)
-  private val storageLocationId = StorageLocationId(1)
-  private val uploadId = UploadId(1)
+  private val speciesId: SpeciesId by
+      readableId(SpeciesNotFoundException::class) { canReadSpecies(it) }
+  private val storageLocationId: StorageLocationId by
+      readableId(StorageLocationNotFoundException::class) { canReadStorageLocation(it) }
+  private val uploadId: UploadId by readableId(UploadNotFoundException::class) { canReadUpload(it) }
   private val userId = UserId(1)
-  private val viabilityTestId = ViabilityTestId(1)
-  private val withdrawalId = WithdrawalId(1)
+  private val viabilityTestId: ViabilityTestId by
+      readableId(ViabilityTestNotFoundException::class) { canReadViabilityTest(it) }
+  private val withdrawalId: WithdrawalId by
+      readableId(WithdrawalNotFoundException::class) { canReadWithdrawal(it) }
 
   /**
    * Grants permission to perform a particular operation. This is a simple wrapper around a MockK
@@ -90,308 +130,217 @@ internal class PermissionRequirementsTest : RunsAsUser {
     every(stubBlock) returns true
   }
 
+  /**
+   * Lazy initialization wrapper that returns an ID. Adds a function to [readChecks] that verifies
+   * that an exception of the correct class is thrown by the method under test if the user doesn't
+   * have permission to read the ID, then grants read permission.
+   */
+  private inline fun <reified T> readableId(
+      exceptionClass: KClass<out Exception>,
+      crossinline grantBlock: TerrawareUser.(T) -> Boolean
+  ): Lazy<T> = lazy {
+    val id =
+        T::class
+            .constructors
+            .first { it.parameters.size == 1 && it.parameters[0].type == typeOf<Long>() }
+            .call(1L)
+    readChecks.add { operation ->
+      Assertions.assertThrows(exceptionClass.java, operation)
+      grant { grantBlock.invoke(user, id) }
+    }
+    id
+  }
+
+  private infix fun (() -> Unit).ifUser(grantBlock: TerrawareUser.() -> Boolean) {
+    // Evaluate any lazy arguments, which will have the side effect of adding read checks; we
+    // don't care about the specific exception here since the read checks will test for them.
+    assertThrows<Exception>(this)
+
+    readChecks.forEach { check -> check(this) }
+
+    assertThrows<AccessDeniedException>(this)
+
+    grant { grantBlock.invoke(user) }
+    assertDoesNotThrow(this)
+  }
+
+  /**
+   * Returns a function that invokes the supplied lambda on the [requirements] object. This should
+   * almost always be followed by [ifUser], which will perform the actual testing.
+   *
+   * This is syntactic sugar for readability and brevity; the following two lines are equivalent:
+   * ```
+   * allow { foo() }
+   * { requirements.foo() }
+   * ```
+   */
+  private fun allow(func: PermissionRequirements.() -> Unit): () -> Unit {
+    return { func.invoke(requirements) }
+  }
+
+  /**
+   * Calls the supplied lambda on the [requirements] object, including any read checks that are
+   * required for any IDs that are referenced in the lambda.
+   */
+  private fun testRead(func: PermissionRequirements.() -> Unit) {
+    val funcWithReceiver = { func.invoke(requirements) }
+
+    // Evaluate any lazy arguments, which will have the side effect of adding read checks; we
+    // don't care about the specific exception here since the read checks will test for them.
+    assertThrows<Exception>(funcWithReceiver)
+
+    readChecks.forEach { check -> check(funcWithReceiver) }
+
+    assertDoesNotThrow(funcWithReceiver)
+  }
+
   @Test
   fun addOrganizationUser() {
-    assertThrows<OrganizationNotFoundException> { requirements.addOrganizationUser(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.addOrganizationUser(organizationId) }
-
-    grant { user.canAddOrganizationUser(organizationId) }
-    requirements.addOrganizationUser(organizationId)
+    allow { addOrganizationUser(organizationId) } ifUser { canAddOrganizationUser(organizationId) }
   }
 
   @Test
   fun createAccession() {
-    assertThrows<FacilityNotFoundException> { requirements.createAccession(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createAccession(facilityId) }
-
-    grant { user.canCreateAccession(facilityId) }
-    requirements.createAccession(facilityId)
+    allow { createAccession(facilityId) } ifUser { canCreateAccession(facilityId) }
   }
 
   @Test
   fun createApiKey() {
-    assertThrows<OrganizationNotFoundException> { requirements.createApiKey(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createApiKey(organizationId) }
-
-    grant { user.canCreateApiKey(organizationId) }
-    requirements.createApiKey(organizationId)
+    allow { createApiKey(organizationId) } ifUser { canCreateApiKey(organizationId) }
   }
 
   @Test
   fun createAutomation() {
-    assertThrows<FacilityNotFoundException> { requirements.createAutomation(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createAutomation(facilityId) }
-
-    grant { user.canCreateAutomation(facilityId) }
-    requirements.createAutomation(facilityId)
+    allow { createAutomation(facilityId) } ifUser { canCreateAutomation(facilityId) }
   }
 
   @Test
   fun createBatch() {
-    assertThrows<FacilityNotFoundException> { requirements.createBatch(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createBatch(facilityId) }
-
-    grant { user.canCreateBatch(facilityId) }
-    requirements.createBatch(facilityId)
+    allow { createBatch(facilityId) } ifUser { canCreateBatch(facilityId) }
   }
 
   @Test
   fun createDelivery() {
-    assertThrows<PlantingSiteNotFoundException> { requirements.createDelivery(plantingSiteId) }
-
-    grant { user.canReadPlantingSite(plantingSiteId) }
-    assertThrows<AccessDeniedException> { requirements.createDelivery(plantingSiteId) }
-
-    grant { user.canCreateDelivery(plantingSiteId) }
-    requirements.createDelivery(plantingSiteId)
+    allow { createDelivery(plantingSiteId) } ifUser { canCreateDelivery(plantingSiteId) }
   }
 
   @Test
   fun createDevice() {
-    assertThrows<FacilityNotFoundException> { requirements.createDevice(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createDevice(facilityId) }
-
-    grant { user.canCreateDevice(facilityId) }
-    requirements.createDevice(facilityId)
+    allow { createDevice(facilityId) } ifUser { canCreateDevice(facilityId) }
   }
 
   @Test
   fun createDeviceManager() {
-    assertThrows<AccessDeniedException> { requirements.createDeviceManager() }
-
-    grant { user.canCreateDeviceManager() }
-    requirements.createDeviceManager()
+    allow { createDeviceManager() } ifUser { canCreateDeviceManager() }
   }
 
   @Test
   fun createFacility() {
-    assertThrows<OrganizationNotFoundException> { requirements.createFacility(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createFacility(organizationId) }
-
-    grant { user.canCreateFacility(organizationId) }
-    requirements.createFacility(organizationId)
+    allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
   }
 
   @Test
   fun createNotification() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.createNotification(notificationUserId, organizationId)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> {
-      requirements.createNotification(notificationUserId, organizationId)
-    }
-
-    grant { user.canCreateNotification(notificationUserId, organizationId) }
-    requirements.createNotification(notificationUserId, organizationId)
+    allow { createNotification(notificationUserId, organizationId) } ifUser
+        {
+          canCreateNotification(notificationUserId, organizationId)
+        }
   }
 
   @Test
   fun createPlantingSite() {
-    assertThrows<OrganizationNotFoundException> { requirements.createPlantingSite(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createPlantingSite(organizationId) }
-
-    grant { user.canCreatePlantingSite(organizationId) }
-    requirements.createPlantingSite(organizationId)
+    allow { createPlantingSite(organizationId) } ifUser { canCreatePlantingSite(organizationId) }
   }
 
   @Test
   fun createSpecies() {
-    assertThrows<OrganizationNotFoundException> { requirements.createSpecies(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.createSpecies(organizationId) }
-
-    grant { user.canCreateSpecies(organizationId) }
-    requirements.createSpecies(organizationId)
+    allow { createSpecies(organizationId) } ifUser { canCreateSpecies(organizationId) }
   }
 
   @Test
   fun createStorageLocation() {
-    assertThrows<FacilityNotFoundException> { requirements.createStorageLocation(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.createStorageLocation(facilityId) }
-
-    grant { user.canCreateStorageLocation(facilityId) }
-    requirements.createStorageLocation(facilityId)
+    allow { createStorageLocation(facilityId) } ifUser { canCreateStorageLocation(facilityId) }
   }
 
   @Test
   fun createTimeseries() {
-    assertThrows<DeviceNotFoundException> { requirements.createTimeseries(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    assertThrows<AccessDeniedException> { requirements.createTimeseries(deviceId) }
-
-    grant { user.canCreateTimeseries(deviceId) }
-    requirements.createTimeseries(deviceId)
+    allow { createTimeseries(deviceId) } ifUser { canCreateTimeseries(deviceId) }
   }
 
   @Test
   fun createWithdrawalPhoto() {
-    assertThrows<WithdrawalNotFoundException> { requirements.createWithdrawalPhoto(withdrawalId) }
-
-    grant { user.canReadWithdrawal(withdrawalId) }
-    assertThrows<AccessDeniedException> { requirements.createWithdrawalPhoto(withdrawalId) }
-
-    grant { user.canCreateWithdrawalPhoto(withdrawalId) }
-    requirements.createWithdrawalPhoto(withdrawalId)
+    allow { createWithdrawalPhoto(withdrawalId) } ifUser { canCreateWithdrawalPhoto(withdrawalId) }
   }
 
   @Test
   fun deleteAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.deleteAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    assertThrows<AccessDeniedException> { requirements.deleteAccession(accessionId) }
-
-    grant { user.canDeleteAccession(accessionId) }
-    requirements.deleteAccession(accessionId)
+    allow { deleteAccession(accessionId) } ifUser { canDeleteAccession(accessionId) }
   }
 
   @Test
   fun deleteAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.deleteAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.deleteAutomation(automationId) }
-
-    grant { user.canDeleteAutomation(automationId) }
-    requirements.deleteAutomation(automationId)
+    allow { deleteAutomation(automationId) } ifUser { canDeleteAutomation(automationId) }
   }
 
   @Test
   fun deleteBatch() {
-    assertThrows<BatchNotFoundException> { requirements.deleteBatch(batchId) }
-
-    grant { user.canReadBatch(batchId) }
-    assertThrows<AccessDeniedException> { requirements.deleteBatch(batchId) }
-
-    grant { user.canDeleteBatch(batchId) }
-    requirements.deleteBatch(batchId)
+    allow { deleteBatch(batchId) } ifUser { canDeleteBatch(batchId) }
   }
 
   @Test
   fun deleteOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.deleteOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.deleteOrganization(organizationId) }
-
-    grant { user.canDeleteOrganization(organizationId) }
-    requirements.deleteOrganization(organizationId)
+    allow { deleteOrganization(organizationId) } ifUser { canDeleteOrganization(organizationId) }
   }
 
   @Test
   fun deleteSelf() {
-    assertThrows<AccessDeniedException> { requirements.deleteSelf() }
-
-    grant { user.canDeleteSelf() }
-    requirements.deleteSelf()
+    allow { deleteSelf() } ifUser { canDeleteSelf() }
   }
 
   @Test
   fun deleteSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.deleteSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    assertThrows<AccessDeniedException> { requirements.deleteSpecies(speciesId) }
-
-    grant { user.canDeleteSpecies(speciesId) }
-    requirements.deleteSpecies(speciesId)
+    allow { deleteSpecies(speciesId) } ifUser { canDeleteSpecies(speciesId) }
   }
 
   @Test
   fun deleteStorageLocation() {
-    assertThrows<StorageLocationNotFoundException> {
-      requirements.deleteStorageLocation(storageLocationId)
-    }
-
-    grant { user.canReadStorageLocation(storageLocationId) }
-    assertThrows<AccessDeniedException> { requirements.deleteStorageLocation(storageLocationId) }
-
-    grant { user.canDeleteStorageLocation(storageLocationId) }
-    requirements.deleteStorageLocation(storageLocationId)
+    allow { deleteStorageLocation(storageLocationId) } ifUser
+        {
+          canDeleteStorageLocation(storageLocationId)
+        }
   }
 
   @Test
   fun deleteUpload() {
-    assertThrows<UploadNotFoundException> { requirements.deleteUpload(uploadId) }
-
-    grant { user.canReadUpload(uploadId) }
-    assertThrows<AccessDeniedException> { requirements.deleteUpload(uploadId) }
-
-    grant { user.canDeleteUpload(uploadId) }
-    requirements.deleteUpload(uploadId)
+    allow { deleteUpload(uploadId) } ifUser { canDeleteUpload(uploadId) }
   }
 
   @Test
   fun importGlobalSpeciesData() {
-    assertThrows<AccessDeniedException> { requirements.importGlobalSpeciesData() }
-
-    grant { user.canImportGlobalSpeciesData() }
-    requirements.importGlobalSpeciesData()
+    allow { importGlobalSpeciesData() } ifUser { canImportGlobalSpeciesData() }
   }
 
   @Test
   fun listAutomations() {
-    assertThrows<FacilityNotFoundException> { requirements.listAutomations(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.listAutomations(facilityId) }
-
-    grant { user.canListAutomations(facilityId) }
-    requirements.listAutomations(facilityId)
+    allow { listAutomations(facilityId) } ifUser { canListAutomations(facilityId) }
   }
 
   @Test
   fun listGlobalNotifications() {
-    assertThrows<AccessDeniedException> { requirements.listNotifications(null) }
-
-    grant { user.canListNotifications(null) }
-    requirements.listNotifications(null)
+    allow { listNotifications(null) } ifUser { canListNotifications(null) }
   }
 
   @Test
   fun listOrganizationNotifications() {
-    assertThrows<OrganizationNotFoundException> { requirements.listNotifications(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.listNotifications(organizationId) }
-
-    grant { user.canListNotifications(organizationId) }
-    requirements.listNotifications(organizationId)
+    allow { listNotifications(organizationId) } ifUser { canListNotifications(organizationId) }
   }
 
   @Test
   fun listOrganizationUsers() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.listOrganizationUsers(organizationId)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.listOrganizationUsers(organizationId) }
-
-    grant { user.canListOrganizationUsers(organizationId) }
-    requirements.listOrganizationUsers(organizationId)
+    allow { listOrganizationUsers(organizationId) } ifUser
+        {
+          canListOrganizationUsers(organizationId)
+        }
   }
 
   @Test
@@ -412,74 +361,47 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun readAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.readAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    requirements.readAccession(accessionId)
+    testRead { readAccession(accessionId) }
   }
 
   @Test
   fun readAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.readAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    requirements.readAutomation(automationId)
+    testRead { readAutomation(automationId) }
   }
 
   @Test
   fun readBatch() {
-    assertThrows<BatchNotFoundException> { requirements.readBatch(batchId) }
-
-    grant { user.canReadBatch(batchId) }
-    requirements.readBatch(batchId)
+    testRead { readBatch(batchId) }
   }
 
   @Test
   fun readDelivery() {
-    assertThrows<DeliveryNotFoundException> { requirements.readDelivery(deliveryId) }
-
-    grant { user.canReadDelivery(deliveryId) }
-    requirements.readDelivery(deliveryId)
+    testRead { readDelivery(deliveryId) }
   }
 
   @Test
   fun readDevice() {
-    assertThrows<DeviceNotFoundException> { requirements.readDevice(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    requirements.readDevice(deviceId)
+    testRead { readDevice(deviceId) }
   }
 
   @Test
   fun readDeviceManager() {
-    assertThrows<DeviceManagerNotFoundException> { requirements.readDeviceManager(deviceManagerId) }
-
-    grant { user.canReadDeviceManager(deviceManagerId) }
-    requirements.readDeviceManager(deviceManagerId)
+    testRead { readDeviceManager(deviceManagerId) }
   }
 
   @Test
   fun readFacility() {
-    assertThrows<FacilityNotFoundException> { requirements.readFacility(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    requirements.readFacility(facilityId)
+    testRead { readFacility(facilityId) }
   }
 
   @Test
   fun readNotification() {
-    assertThrows<NotificationNotFoundException> { requirements.readNotification(notificationId) }
-
-    grant { user.canReadNotification(notificationId) }
-    requirements.readNotification(notificationId)
+    testRead { readNotification(notificationId) }
   }
 
   @Test
   fun readOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.readOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    requirements.readOrganization(organizationId)
+    testRead { readOrganization(organizationId) }
   }
 
   @Test
@@ -499,68 +421,42 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun readPlanting() {
-    assertThrows<PlantingNotFoundException> { requirements.readPlanting(plantingId) }
-
-    grant { user.canReadPlanting(plantingId) }
-    requirements.readPlanting(plantingId)
+    testRead { readPlanting(plantingId) }
   }
 
   @Test
   fun readPlantingSite() {
-    assertThrows<PlantingSiteNotFoundException> { requirements.readPlantingSite(plantingSiteId) }
-
-    grant { user.canReadPlantingSite(plantingSiteId) }
-    requirements.readPlantingSite(plantingSiteId)
+    testRead { readPlantingSite(plantingSiteId) }
   }
 
   @Test
   fun readSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.readSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    requirements.readSpecies(speciesId)
+    testRead { readSpecies(speciesId) }
   }
 
   @Test
   fun readStorageLocation() {
-    assertThrows<StorageLocationNotFoundException> {
-      requirements.readStorageLocation(storageLocationId)
-    }
-
-    grant { user.canReadStorageLocation(storageLocationId) }
-    requirements.readStorageLocation(storageLocationId)
+    testRead { readStorageLocation(storageLocationId) }
   }
 
   @Test
   fun readUpload() {
-    assertThrows<UploadNotFoundException> { requirements.readUpload(uploadId) }
-
-    grant { user.canReadUpload(uploadId) }
-    requirements.readUpload(uploadId)
+    testRead { readUpload(uploadId) }
   }
 
   @Test
   fun readViabilityTest() {
-    assertThrows<ViabilityTestNotFoundException> { requirements.readViabilityTest(viabilityTestId) }
-
-    grant { user.canReadViabilityTest(viabilityTestId) }
-    requirements.readViabilityTest(viabilityTestId)
+    testRead { readViabilityTest(viabilityTestId) }
   }
 
   @Test
   fun readWithdrawal() {
-    assertThrows<WithdrawalNotFoundException> { requirements.readWithdrawal(withdrawalId) }
-
-    grant { user.canReadWithdrawal(withdrawalId) }
-    requirements.readWithdrawal(withdrawalId)
+    testRead { readWithdrawal(withdrawalId) }
   }
 
   @Test
   fun regenerateAllDeviceManagerTokens() {
-    assertThrows<AccessDeniedException> { requirements.regenerateAllDeviceManagerTokens() }
-
-    grant { user.canRegenerateAllDeviceManagerTokens() }
-    requirements.regenerateAllDeviceManagerTokens()
+    allow { regenerateAllDeviceManagerTokens() } ifUser { canRegenerateAllDeviceManagerTokens() }
   }
 
   @Test
@@ -580,237 +476,121 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun sendAlert() {
-    assertThrows<FacilityNotFoundException> { requirements.sendAlert(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.sendAlert(facilityId) }
-
-    grant { user.canSendAlert(facilityId) }
-    requirements.sendAlert(facilityId)
+    allow { sendAlert(facilityId) } ifUser { canSendAlert(facilityId) }
   }
 
   @Test
   fun setOrganizationUserRole() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.setOrganizationUserRole(organizationId, role)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> {
-      requirements.setOrganizationUserRole(organizationId, role)
-    }
-
-    grant { user.canSetOrganizationUserRole(organizationId, role) }
-    requirements.setOrganizationUserRole(organizationId, role)
+    allow { setOrganizationUserRole(organizationId, role) } ifUser
+        {
+          canSetOrganizationUserRole(organizationId, role)
+        }
   }
 
   @Test
   fun setTestClock() {
-    assertThrows<AccessDeniedException> { requirements.setTestClock() }
-
-    grant { user.canSetTestClock() }
-    requirements.setTestClock()
+    allow { setTestClock() } ifUser { canSetTestClock() }
   }
 
   @Test
   fun setWithdrawalUser() {
-    assertThrows<AccessionNotFoundException> { requirements.setWithdrawalUser(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    assertThrows<AccessDeniedException> { requirements.setWithdrawalUser(accessionId) }
-
-    grant { user.canSetWithdrawalUser(accessionId) }
-    requirements.setWithdrawalUser(accessionId)
+    allow { setWithdrawalUser(accessionId) } ifUser { canSetWithdrawalUser(accessionId) }
   }
 
   @Test
   fun triggerAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.triggerAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.triggerAutomation(automationId) }
-
-    grant { user.canTriggerAutomation(automationId) }
-    requirements.triggerAutomation(automationId)
+    allow { triggerAutomation(automationId) } ifUser { canTriggerAutomation(automationId) }
   }
 
   @Test
   fun updateAccession() {
-    assertThrows<AccessionNotFoundException> { requirements.updateAccession(accessionId) }
-
-    grant { user.canReadAccession(accessionId) }
-    assertThrows<AccessDeniedException> { requirements.updateAccession(accessionId) }
-
-    grant { user.canUpdateAccession(accessionId) }
-    requirements.updateAccession(accessionId)
+    allow { updateAccession(accessionId) } ifUser { canUpdateAccession(accessionId) }
   }
 
   @Test
   fun updateAppVersions() {
-    assertThrows<AccessDeniedException> { requirements.updateAppVersions() }
-
-    grant { user.canUpdateAppVersions() }
-    requirements.updateAppVersions()
+    allow { updateAppVersions() } ifUser { canUpdateAppVersions() }
   }
 
   @Test
   fun updateAutomation() {
-    assertThrows<AutomationNotFoundException> { requirements.updateAutomation(automationId) }
-
-    grant { user.canReadAutomation(automationId) }
-    assertThrows<AccessDeniedException> { requirements.updateAutomation(automationId) }
-
-    grant { user.canUpdateAutomation(automationId) }
-    requirements.updateAutomation(automationId)
+    allow { updateAutomation(automationId) } ifUser { canUpdateAutomation(automationId) }
   }
 
   @Test
   fun updateBatch() {
-    assertThrows<BatchNotFoundException> { requirements.updateBatch(batchId) }
-
-    grant { user.canReadBatch(batchId) }
-    assertThrows<AccessDeniedException> { requirements.updateBatch(batchId) }
-
-    grant { user.canUpdateBatch(batchId) }
-    requirements.updateBatch(batchId)
+    allow { updateBatch(batchId) } ifUser { canUpdateBatch(batchId) }
   }
 
   @Test
   fun updateDelivery() {
-    assertThrows<DeliveryNotFoundException> { requirements.updateDelivery(deliveryId) }
-
-    grant { user.canReadDelivery(deliveryId) }
-    assertThrows<AccessDeniedException> { requirements.updateDelivery(deliveryId) }
-
-    grant { user.canUpdateDelivery(deliveryId) }
-    requirements.updateDelivery(deliveryId)
+    allow { updateDelivery(deliveryId) } ifUser { canUpdateDelivery(deliveryId) }
   }
 
   @Test
   fun updateDevice() {
-    assertThrows<DeviceNotFoundException> { requirements.updateDevice(deviceId) }
-
-    grant { user.canReadDevice(deviceId) }
-    assertThrows<AccessDeniedException> { requirements.updateDevice(deviceId) }
-
-    grant { user.canUpdateDevice(deviceId) }
-    requirements.updateDevice(deviceId)
+    allow { updateDevice(deviceId) } ifUser { canUpdateDevice(deviceId) }
   }
 
   @Test
   fun updateDeviceManager() {
-    assertThrows<DeviceManagerNotFoundException> {
-      requirements.updateDeviceManager(deviceManagerId)
-    }
-
-    grant { user.canReadDeviceManager(deviceManagerId) }
-    assertThrows<AccessDeniedException> { requirements.updateDeviceManager(deviceManagerId) }
-
-    grant { user.canUpdateDeviceManager(deviceManagerId) }
-    requirements.updateDeviceManager(deviceManagerId)
+    allow { updateDeviceManager(deviceManagerId) } ifUser
+        {
+          canUpdateDeviceManager(deviceManagerId)
+        }
   }
 
   @Test
   fun updateDeviceTemplates() {
-    assertThrows<AccessDeniedException> { requirements.updateDeviceTemplates() }
-
-    grant { user.canUpdateDeviceTemplates() }
-    requirements.updateDeviceTemplates()
+    allow { updateDeviceTemplates() } ifUser { canUpdateDeviceTemplates() }
   }
 
   @Test
   fun updateFacility() {
-    assertThrows<FacilityNotFoundException> { requirements.updateFacility(facilityId) }
-
-    grant { user.canReadFacility(facilityId) }
-    assertThrows<AccessDeniedException> { requirements.updateFacility(facilityId) }
-
-    grant { user.canUpdateFacility(facilityId) }
-    requirements.updateFacility(facilityId)
+    allow { updateFacility(facilityId) } ifUser { canUpdateFacility(facilityId) }
   }
 
   @Test
   fun updateGlobalNotifications() {
-    assertThrows<AccessDeniedException> { requirements.updateNotifications(null) }
-
-    grant { user.canUpdateNotifications(null) }
-    requirements.updateNotifications(null)
+    allow { updateNotifications(null) } ifUser { canUpdateNotifications(null) }
   }
 
   @Test
   fun updateNotification() {
-    assertThrows<NotificationNotFoundException> { requirements.updateNotification(notificationId) }
-
-    grant { user.canUpdateNotification(notificationId) }
-    requirements.updateNotification(notificationId)
+    allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }
   }
 
   @Test
   fun updateOrganization() {
-    assertThrows<OrganizationNotFoundException> { requirements.updateOrganization(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.updateOrganization(organizationId) }
-
-    grant { user.canUpdateOrganization(organizationId) }
-    requirements.updateOrganization(organizationId)
+    allow { updateOrganization(organizationId) } ifUser { canUpdateOrganization(organizationId) }
   }
 
   @Test
   fun updateOrganizationNotifications() {
-    assertThrows<OrganizationNotFoundException> { requirements.updateNotifications(organizationId) }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<AccessDeniedException> { requirements.updateNotifications(organizationId) }
-
-    grant { user.canUpdateNotifications(organizationId) }
-    requirements.updateNotifications(organizationId)
+    allow { updateNotifications(organizationId) } ifUser { canUpdateNotifications(organizationId) }
   }
 
   @Test
   fun updatePlantingSite() {
-    assertThrows<PlantingSiteNotFoundException> { requirements.updatePlantingSite(plantingSiteId) }
-
-    grant { user.canReadPlantingSite(plantingSiteId) }
-    assertThrows<AccessDeniedException> { requirements.updatePlantingSite(plantingSiteId) }
-
-    grant { user.canUpdatePlantingSite(plantingSiteId) }
-    requirements.updatePlantingSite(plantingSiteId)
+    allow { updatePlantingSite(plantingSiteId) } ifUser { canUpdatePlantingSite(plantingSiteId) }
   }
 
   @Test
   fun updateSpecies() {
-    assertThrows<SpeciesNotFoundException> { requirements.updateSpecies(speciesId) }
-
-    grant { user.canReadSpecies(speciesId) }
-    assertThrows<AccessDeniedException> { requirements.updateSpecies(speciesId) }
-
-    grant { user.canUpdateSpecies(speciesId) }
-    requirements.updateSpecies(speciesId)
+    allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
   }
 
   @Test
   fun updateStorageLocation() {
-    assertThrows<StorageLocationNotFoundException> {
-      requirements.updateStorageLocation(storageLocationId)
-    }
-
-    grant { user.canReadStorageLocation(storageLocationId) }
-    assertThrows<AccessDeniedException> { requirements.updateStorageLocation(storageLocationId) }
-
-    grant { user.canUpdateStorageLocation(storageLocationId) }
-    requirements.updateStorageLocation(storageLocationId)
+    allow { updateStorageLocation(storageLocationId) } ifUser
+        {
+          canUpdateStorageLocation(storageLocationId)
+        }
   }
 
   @Test
   fun updateUpload() {
-    assertThrows<UploadNotFoundException> { requirements.updateUpload(uploadId) }
-
-    grant { user.canReadUpload(uploadId) }
-    assertThrows<AccessDeniedException> { requirements.updateUpload(uploadId) }
-
-    grant { user.canUpdateUpload(uploadId) }
-    requirements.updateUpload(uploadId)
+    allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
   }
 
   // When adding new permission tests, put them in alphabetical order.


### PR DESCRIPTION
Nearly all the test cases in PermissionRequirementsTest check for behavior that
follows one of two patterns depending on whether they're checking a write
permission or a read permission. The only things that vary across the read
tests and across the write tests are

* The method under test
* The type of the ID of the permission's target
* The type of the exception that's thrown if the user doesn't have read access
  (this is always the same for a given ID type)
* The TerrawareUser method that controls whether or not the user has permission

Use lazy evaluation and extension methods to make a mini-DSL for these tests,
collapsing the vast majority of them to one-liners.