### PR TITLE
SW-2043 Log request and response payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
@@ -1,0 +1,95 @@
+package com.terraformation.backend.auth
+
+import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.log.perClassLogger
+import io.ktor.http.ContentType
+import io.ktor.http.charset
+import java.nio.charset.StandardCharsets
+import javax.servlet.DispatcherType
+import javax.servlet.Filter
+import javax.servlet.FilterChain
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import javax.ws.rs.core.MediaType
+import kotlin.math.min
+import org.slf4j.MDC
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+/**
+ * Logs request and response bodies from users whose lowercase email addresses match a regular
+ * expression. This filter should come after [TerrawareUserFilter] so that [CurrentUserHolder] is
+ * initialized.
+ *
+ * Only JSON and HTML form payloads are logged, and only the first 10000 bytes of long payloads are
+ * logged. Requests from device manager users are never logged.
+ *
+ * Payloads are logged using [MDC] rather than included in the message text so that they show up as
+ * discrete values in structured logs without requiring extra parsing.
+ */
+class RequestResponseLoggingFilter(private val requestLogEmailRegex: Regex) : Filter {
+  /** Log up to this many bytes of each payload. */
+  private val maxPayloadSize = 10000
+
+  private val log = perClassLogger()
+
+  private val loggableContentTypes =
+      listOf(MediaType.APPLICATION_JSON, MediaType.APPLICATION_FORM_URLENCODED)
+
+  override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+    val user = CurrentUserHolder.getCurrentUser()
+    if (log.isDebugEnabled &&
+        user is IndividualUser &&
+        user.email.lowercase().matches(requestLogEmailRegex) &&
+        request is HttpServletRequest &&
+        response is HttpServletResponse &&
+        request.dispatcherType != DispatcherType.ASYNC) {
+      val wrappedRequest = ContentCachingRequestWrapper(request, maxPayloadSize)
+      val wrappedResponse = ContentCachingResponseWrapper(response)
+
+      try {
+        chain.doFilter(wrappedRequest, wrappedResponse)
+      } finally {
+        val oldMdc = MDC.getCopyOfContextMap()
+        try {
+          mdcPut("request", payload(wrappedRequest.contentType, wrappedRequest.contentAsByteArray))
+          mdcPut(
+              "response", payload(wrappedResponse.contentType, wrappedResponse.contentAsByteArray))
+          mdcPut("email", user.email)
+          mdcPut("method", wrappedRequest.method)
+          mdcPut("uri", wrappedRequest.requestURI)
+
+          log.debug("Request")
+        } finally {
+          oldMdc?.let { MDC.setContextMap(it) } ?: MDC.clear()
+          wrappedResponse.copyBodyToResponse()
+        }
+      }
+    } else {
+      chain.doFilter(request, response)
+    }
+  }
+
+  private fun mdcPut(key: String, value: String?) {
+    if (value != null) {
+      MDC.put(key, value)
+    }
+  }
+
+  /** Returns the string representation of the payload if the payload is loggable. */
+  private fun payload(contentType: String?, bytes: ByteArray): String? {
+    val parsedContentType = contentType?.let { ContentType.parse(it) } ?: return null
+
+    return if (bytes.isNotEmpty() && loggableContentTypes.any { parsedContentType.match(it) }) {
+      String(
+          bytes,
+          0,
+          min(bytes.size, maxPayloadSize),
+          parsedContentType.charset() ?: StandardCharsets.UTF_8)
+    } else {
+      null
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -113,8 +113,8 @@ class SecurityConfig(private val config: TerrawareServerConfig, private val user
 
       // Add a request filter that logs request and response payloads for users whose email
       // addresses match a configured regex.
-      config.requestLogEmailRegex?.let {
-        addFilterAfter<TerrawareUserFilter>(RequestResponseLoggingFilter(it))
+      if (config.requestLog.emailRegex != null) {
+        addFilterAfter<TerrawareUserFilter>(RequestResponseLoggingFilter(config.requestLog))
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -80,12 +80,6 @@ class TerrawareServerConfig(
      */
     val allowAdminUiForNonAdmins: Boolean = false,
 
-    /**
-     * Log request and response bodies from users whose email addresses match this regular
-     * expression. Used for troubleshooting.
-     */
-    val requestLogEmailRegex: Regex? = null,
-
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 
@@ -113,6 +107,9 @@ class TerrawareServerConfig(
 
     /** Configures notifications processing. */
     val notifications: NotificationsConfig = NotificationsConfig(),
+
+    /** Configures detailed request logging. */
+    val requestLog: RequestLogConfig = RequestLogConfig(),
 ) {
   @ConstructorBinding
   class DailyTasksConfig(
@@ -266,6 +263,22 @@ class TerrawareServerConfig(
        * enabled.
        */
       @DefaultValue("30") val retentionDays: Long = 30,
+  )
+
+  @ConstructorBinding
+  class RequestLogConfig(
+      /**
+       * Log request and response bodies from users whose email addresses match this regular
+       * expression. Used for troubleshooting.
+       */
+      val emailRegex: Regex? = null,
+
+      /**
+       * Exclude requests whose paths match this regex from detailed logging. This regex needs to
+       * match the whole path, not a substring. For example, it should be `/api/v1/abc/def` rather
+       * than `abc/def`. Query string parameters are not included in the match.
+       */
+      val excludeRegex: Regex? = null,
   )
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -80,6 +80,12 @@ class TerrawareServerConfig(
      */
     val allowAdminUiForNonAdmins: Boolean = false,
 
+    /**
+     * Log request and response bodies from users whose email addresses match this regular
+     * expression. Used for troubleshooting.
+     */
+    val requestLogEmailRegex: Regex? = null,
+
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -12,7 +12,8 @@ terraware:
     always-send-to-override-address: true
     subject-prefix: "[DEV]"
   # Log all request and response bodies in dev environments.
-  request-log-email-regex: ".*"
+  request-log:
+    email-regex: ".*"
 
 keycloak:
   resource: "dev-terraware-server"

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -1,3 +1,7 @@
+# Default settings if no Spring profile is specified. In production, we always specify a profile,
+# so this is effectively the default settings file for dev environments. You can override any of
+# these settings locally by creating a file application-dev.yaml (it is already in .gitignore).
+
 terraware:
   # By default, the frontend dev service listens on HTTP port 3000.
   web-app-url: "http://localhost:3000/"
@@ -7,6 +11,8 @@ terraware:
   email:
     always-send-to-override-address: true
     subject-prefix: "[DEV]"
+  # Log all request and response bodies in dev environments.
+  request-log-email-regex: ".*"
 
 keycloak:
   resource: "dev-terraware-server"
@@ -30,3 +36,15 @@ logging:
   level:
     com.terraformation: DEBUG
     org.springdoc: DEBUG
+  pattern:
+    # This is the default Spring Boot console log format, but with the MDC values (%X) in between
+    # the log message and the exception stacktrace.
+    console: >-
+      %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}
+      %clr(%5p)
+      %clr(${PID:- }){magenta}
+      %clr(---){faint}
+      %clr([%15.15t]){faint}
+      %clr(%-40.40logger{39}){cyan}
+      %clr(:){faint}
+      %m%replace( %X){'^ $',''}%n%wEx


### PR DESCRIPTION
To make it easier to troubleshoot problems we discover during QA testing, add the
ability to log request and response bodies for a subset of users.