### PR TITLE
Add missing response payload to OpenAPI spec

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -163,6 +163,7 @@ class WithdrawalsController(
     return ResponseEntity(resource, headers, HttpStatus.OK)
   }
 
+  @ApiResponse(responseCode = "200")
   @ApiResponse404("The withdrawal does not exist.")
   @GetMapping("/{withdrawalId}/photos")
   @Operation(summary = "Lists all the photos of a withdrawal.")


### PR DESCRIPTION
The generated OpenAPI docs didn't include the response payload for `GET
/api/v1/nursery/withdrawals/{withdrawalId}/photos` because the annotation was
missing on the controller method.