### PR TITLE
Add missing OpenAPI response declarations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -48,6 +48,11 @@ annotation class ApiResponseSimpleError(val responseCode: String)
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
+@ApiResponse(responseCode = "200")
+annotation class ApiResponse200(val description: String = "The requested operation succeeded.")
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
 @ApiResponseSimpleError(responseCode = "404")
 annotation class ApiResponse404(val description: String = "The requested resource was not found.")
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -102,6 +102,7 @@ class OrganizationsController(
   }
 
   @ApiResponse409(description = "The organization has other members and cannot be deleted.")
+  @ApiResponseSimpleSuccess
   @Operation(
       summary = "Deletes an existing organization.",
       description =

--- a/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/TimeseriesController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.device.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse413
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.DeviceManagerAppEndpoint
@@ -76,12 +77,10 @@ class TimeseriesController(
     return ListTimeseriesResponsePayload(timeseries)
   }
 
-  @ApiResponse(
-      responseCode = "200",
-      description =
-          "Successfully processed the request. Note that this status will be returned even if " +
-              "the server was unable to record some of the values. In that case, the failed " +
-              "values will be returned in the response payload.")
+  @ApiResponse200(
+      "Successfully processed the request. Note that this status will be returned even if the " +
+          "server was unable to record some of the values. In that case, the failed values will " +
+          "be returned in the response payload.")
   @ApiResponse(
       responseCode = "202",
       description =

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.nursery.api
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
+import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponse412
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
@@ -86,6 +87,7 @@ class BatchesController(
     return getBatch(id)
   }
 
+  @ApiResponse200
   @ApiResponse404
   @ApiResponse412
   @PutMapping("/{id}/quantities")

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -118,12 +118,9 @@ class SpeciesController(
     return SimpleSuccessResponsePayload()
   }
 
-  @ApiResponses(
-      ApiResponse(responseCode = "200", description = "Species deleted."),
-      ApiResponse(
-          responseCode = "409",
-          description = "Cannot delete the species because it is currently in use."))
   @ApiResponse404
+  @ApiResponse409("Cannot delete the species because it is currently in use.")
+  @ApiResponseSimpleSuccess("Species deleted.")
   @DeleteMapping("/{speciesId}")
   @Operation(
       summary = "Deletes an existing species.",

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.api
 
+import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
@@ -20,7 +21,7 @@ class MapboxController(
     private val config: TerrawareServerConfig,
     private val mapboxService: MapboxService,
 ) {
-  @ApiResponse(responseCode = "200")
+  @ApiResponse200
   @ApiResponse404(description = "The server is not configured to return Mapbox tokens.")
   @ApiResponse(
       responseCode = "503",

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -1,0 +1,75 @@
+package com.terraformation.backend.api
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.lang.reflect.Method
+import java.util.stream.Stream
+import kotlin.streams.asStream
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.annotation.MergedAnnotations
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Verifies that all our controller methods have the expected set of annotations to generate a good
+ * OpenAPI schema document.
+ */
+class OpenApiAnnotationTest {
+  @MethodSource("findAllEndpointMethods")
+  @ParameterizedTest(name = "{0}")
+  fun `all endpoints declare their success responses`(
+      @Suppress("UNUSED_PARAMETER") name: String,
+      method: Method
+  ) {
+    val responseCodes =
+        MergedAnnotations.from(method)
+            .stream(ApiResponse::class.java)
+            .map { it.getString("responseCode").toInt() }
+            .toList()
+
+    assertTrue(
+        responseCodes.isEmpty() || responseCodes.any { it in 200..299 },
+        "No response declared for HTTP 2xx response code")
+  }
+
+  companion object {
+    @JvmStatic
+    private val controllerMethodAnnotations =
+        setOf(
+            DeleteMapping::class,
+            GetMapping::class,
+            PatchMapping::class,
+            PostMapping::class,
+            PutMapping::class,
+            RequestMapping::class,
+        )
+
+    @JvmStatic
+    fun findAllEndpointMethods(): Stream<Arguments> {
+      val scanner = ClassPathScanningCandidateComponentProvider(false)
+      scanner.addIncludeFilter(AnnotationTypeFilter(RestController::class.java))
+      val controllerClasses = scanner.findCandidateComponents("com.terraformation.backend")
+
+      return controllerClasses
+          .asSequence()
+          .mapNotNull { it.beanClassName }
+          .mapNotNull { Class.forName(it) }
+          .flatMap { clazz ->
+            clazz.declaredMethods.filter { method: Method ->
+              method.annotations.any { it.annotationClass in controllerMethodAnnotations }
+            }
+          }
+          .map { method -> Arguments.of("${method.declaringClass.name}.${method.name}", method) }
+          .asStream()
+    }
+  }
+}


### PR DESCRIPTION
Several endpoints were missing the necessary annotations to include their HTTP 2xx
response payloads in the generated OpenAPI schema. Add the missing annotations and
add a test that scans all the controller methods and ensures they either
explicitly declare a 2xx response or don't declare any responses at all (in which
case OpenAPI includes HTTP 200 by default).