### PR TITLE
Fix incorrect OpenAPI schema for search payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -78,7 +78,7 @@ data class SearchSortOrderElement(
             DiscriminatorMapping(value = "and", schema = AndNodePayload::class),
             DiscriminatorMapping(value = "field", schema = FieldNodePayload::class),
             DiscriminatorMapping(value = "not", schema = NotNodePayload::class),
-            DiscriminatorMapping(value = "or", schema = NotNodePayload::class),
+            DiscriminatorMapping(value = "or", schema = OrNodePayload::class),
         ])
 interface SearchNodePayload {
   fun toSearchNode(prefix: SearchFieldPrefix): SearchNode
@@ -90,7 +90,12 @@ interface SearchNodePayload {
         "Search criterion that matches results that meet any of a set of other search criteria. " +
             "That is, if the list of children is x, y, and z, this will require x OR y OR z.")
 data class OrNodePayload(
-    @ArraySchema(minItems = 1) @NotEmpty val children: List<SearchNodePayload>
+    @ArraySchema(
+        minItems = 1,
+        arraySchema =
+            Schema(description = "List of criteria at least one of which must be satisfied"))
+    @NotEmpty
+    val children: List<SearchNodePayload>
 ) : SearchNodePayload {
   override fun toSearchNode(prefix: SearchFieldPrefix): SearchNode {
     return OrNode(children.map { it.toSearchNode(prefix) })
@@ -103,7 +108,11 @@ data class OrNodePayload(
         "Search criterion that matches results that meet all of a set of other search criteria. " +
             "That is, if the list of children is x, y, and z, this will require x AND y AND z.")
 data class AndNodePayload(
-    @ArraySchema(minItems = 1) @NotEmpty val children: List<SearchNodePayload>
+    @ArraySchema(
+        minItems = 1,
+        arraySchema = Schema(description = "List of criteria all of which must be satisfied"))
+    @NotEmpty
+    val children: List<SearchNodePayload>
 ) : SearchNodePayload {
   override fun toSearchNode(prefix: SearchFieldPrefix): SearchNode {
     return AndNode(children.map { it.toSearchNode(prefix) })


### PR DESCRIPTION
The OpenAPI schema for search criteria was incorrect in two respects:

1. It incorrectly mapped the `or` operation to the payload for the `not`
   operation.
2. The payload for the `or` operation didn't include the `children` property.

The second item is due to a bug in the OpenAPI schema generator, which is
triggered when two payload classes in the same type hierarchy have an array
property of the same name with identical `@ArraySchema` annotations. Work around
it by making the annotations non-identical.

This didn't affect the web app thanks to the fact that its build process
overwrites the search payload definitions to avoid code generator bugs related to
circular references. But we should still generate correct schema definitions.