### PR TITLE
Capitalize words of database-generated enums

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -62,7 +62,10 @@ class TerrawareGenerator : KotlinGenerator() {
           val id = rs.getInt(1)
           val name = rs.getString(2)
           if (name != null) {
-            val capitalizedName = name.replace(Regex("[-/ ]"), "").capitalize()
+            // Capitalize each word of multi-word values and concatenate them without spaces or
+            // punctuation.
+            val capitalizedName =
+                name.split(Regex("[-,/ ]")).joinToString("") { word -> word.capitalize() }
             val properties =
                 (listOf("\"$name\"") +
                         table.additionalColumns.mapIndexed { i, columnInfo ->

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -113,7 +113,7 @@ class AppNotificationService(
             "${event.organizationId}.")
 
     insert(
-        NotificationType.UserAddedtoOrganization,
+        NotificationType.UserAddedToOrganization,
         user.userId,
         null,
         message,
@@ -130,7 +130,7 @@ class AppNotificationService(
 
     insertFacilityNotifications(
         event.accessionId,
-        NotificationType.AccessionScheduledtoEndDrying,
+        NotificationType.AccessionScheduledToEndDrying,
         message,
         accessionUrl,
     )

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -176,7 +176,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         listOf(
             NotificationsRow(
                 id = NotificationId(1),
-                notificationTypeId = NotificationType.UserAddedtoOrganization,
+                notificationTypeId = NotificationType.UserAddedToOrganization,
                 userId = otherUserId,
                 organizationId = null,
                 title = "organization title",
@@ -208,7 +208,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         listOf(
             NotificationsRow(
                 id = NotificationId(1),
-                notificationTypeId = NotificationType.AccessionScheduledtoEndDrying,
+                notificationTypeId = NotificationType.AccessionScheduledToEndDrying,
                 userId = user.userId,
                 organizationId = organizationId,
                 title = "accession title",

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -47,7 +47,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
   ): CreateNotificationModel {
     val orgId: OrganizationId? = if (globalNotification) null else organizationId
     return CreateNotificationModel(
-        NotificationType.UserAddedtoOrganization,
+        NotificationType.UserAddedToOrganization,
         userId,
         orgId,
         "the quick brown fox",


### PR DESCRIPTION
Make enum values prettier when they contain words that start with lower-case
letters.

This only affects the symbols that are used in the code, not the display names
that are exposed to clients via the API.