### PR TITLE
SW-2290 Upgrade aws-actions/configure-aws-credentials to use newer Node.js version 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
 
     - name: Configure AWS Credentials
       if: env.IS_CD == 'true'
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}


### PR DESCRIPTION
- this is to resolve the deprecated Node.js version 12 usage
- use version @v1-node16 (note that there are newer Node versions but this is the only available actions version at this point)
- see note on aws-actions github page https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning
- re: testing, having trouble running `act`, i recall now having tried this a few months back. it downloads a bunch of docker images and spins up a gradle daemon and waits, i need to look into this more later