### PR TITLE
SW-1307 Improve performance of duplicate timeseries values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.db
+
+import org.jooq.Field
+
+/**
+ * Converts a jOOQ field with a nullable column type into a non-nullable one. Use this when the
+ * value is guaranteed to never be null (e.g., when querying a non-nullable database column without
+ * any left joins) to tell Kotlin's type system about the non-nullability.
+ *
+ * This is a no-op at runtime, and will likely be optimized out of existence by the JIT compiler.
+ */
+@Suppress("UNCHECKED_CAST") fun <T : Any> Field<T?>.asNonNullable() = this as Field<T>


### PR DESCRIPTION
If an incoming timeseries values request has a lot of entries that are already in
the database, detecting the duplicates is currently pretty slow and leads to
request timeouts. Check for duplicates explicitly by querying for all of the
timestamps at once rather than relying on individual INSERT queries failing.

For a request whose values are entirely duplicates, this will result in the
server doing a single SELECT query rather than a ton of failing INSERTs.