### PR TITLE
SW-2602 Add time zones to database schema

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -159,7 +159,12 @@ class TerrawareGenerator : KotlinGenerator() {
             ForcedType()
                 .withIncludeExpression("(?i:.*_ur[li])")
                 .withConverter("com.terraformation.backend.db.UriConverter")
-                .withUserType("java.net.URI"))
+                .withUserType("java.net.URI"),
+            ForcedType()
+                .withIncludeExpression("time_zone")
+                .withConverter("com.terraformation.backend.db.TimeZoneConverter")
+                .withUserType("java.time.ZoneId"),
+        )
 
     ENUM_TABLES.forEach { (schemaName, tables) ->
       tables

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
@@ -1,0 +1,16 @@
+package com.terraformation.backend.db
+
+import java.time.ZoneId
+import org.jooq.impl.AbstractConverter
+
+/**
+ * Converts text values from the database to and from ZoneId objects. This is for type safety, so we
+ * don't treat arbitrary string values as zone IDs.
+ *
+ * This is referenced in generated database classes.
+ */
+class TimeZoneConverter :
+    AbstractConverter<String, ZoneId>(String::class.java, ZoneId::class.java) {
+  override fun from(databaseObject: String?): ZoneId? = databaseObject?.let { ZoneId.of(it) }
+  override fun to(userObject: ZoneId?): String? = userObject?.id
+}

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.db
 
+import java.time.DateTimeException
 import java.time.ZoneId
 import org.jooq.impl.AbstractConverter
 
@@ -11,6 +12,13 @@ import org.jooq.impl.AbstractConverter
  */
 class TimeZoneConverter :
     AbstractConverter<String, ZoneId>(String::class.java, ZoneId::class.java) {
+  /**
+   * Converts a time zone name to a ZoneId.
+   *
+   * @throws DateTimeException The zone name wasn't found in the list of zones recognized by the
+   * java.time package.
+   */
   override fun from(databaseObject: String?): ZoneId? = databaseObject?.let { ZoneId.of(it) }
+
   override fun to(userObject: ZoneId?): String? = userObject?.id
 }

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.tables.records.TimeZonesRecord
+import com.terraformation.backend.db.default_schema.tables.references.TIME_ZONES
+import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
+import javax.annotation.PostConstruct
+import javax.inject.Named
+import org.jooq.DSLContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Ensures that the `time_zones` table has all the time zone names recognized by the Java standard
+ * library. Java uses the IANA tz database.
+ */
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@Named
+class TimeZonePopulator(private val dslContext: DSLContext) {
+  private val log = perClassLogger()
+
+  @PostConstruct
+  fun populateTimeZonesTable() {
+    val existingValues =
+        dslContext
+            .select(TIME_ZONES.TIME_ZONE)
+            .from(TIME_ZONES)
+            .fetchSet(TIME_ZONES.TIME_ZONE.asNonNullable())
+    val desiredValues = ZoneId.getAvailableZoneIds().toSet()
+
+    val valuesToInsert = desiredValues.minus(existingValues)
+    val valuesToDelete = existingValues.minus(desiredValues)
+
+    if (valuesToInsert.isNotEmpty()) {
+      val timeZonesInserted =
+          dslContext
+              .insertInto(TIME_ZONES, TIME_ZONES.TIME_ZONE)
+              .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
+              .onConflictDoNothing()
+              .execute()
+      log.info("Inserted $timeZonesInserted new time zones")
+    }
+
+    if (valuesToDelete.isNotEmpty()) {
+      val timeZonesDeleted =
+          dslContext
+              .deleteFrom(TIME_ZONES)
+              .where(TIME_ZONES.TIME_ZONE.`in`(valuesToDelete))
+              .execute()
+
+      log.info("Deleted $timeZonesDeleted time zones")
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -25,9 +25,6 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
 
     val timeZonesDeleted =
         dslContext.deleteFrom(TIME_ZONES).where(TIME_ZONES.TIME_ZONE.notIn(validZoneIds)).execute()
-    if (timeZonesDeleted > 0) {
-      log.info("Deleted $timeZonesDeleted time zones")
-    }
 
     val existingValues =
         dslContext
@@ -37,15 +34,17 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
 
     val valuesToInsert = validZoneIds.minus(existingValues)
 
-    if (valuesToInsert.isNotEmpty()) {
-      val timeZonesInserted =
+    val timeZonesInserted =
+        if (valuesToInsert.isNotEmpty()) {
           dslContext
               .insertInto(TIME_ZONES, TIME_ZONES.TIME_ZONE)
               .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
               .onConflictDoNothing()
               .execute()
+        } else {
+          0
+        }
 
-      log.info("Inserted $timeZonesInserted new time zones")
-    }
+    log.info("Inserted $timeZonesInserted and deleted $timeZonesDeleted time zones")
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -38,6 +38,7 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
               .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
               .onConflictDoNothing()
               .execute()
+
       log.info("Inserted $timeZonesInserted new time zones")
     }
 

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -131,6 +131,8 @@ COMMENT ON TABLE test_clock IS 'User-adjustable clock for test environments. Not
 COMMENT ON COLUMN test_clock.fake_time IS 'What time the server should believe it was at the time the row was written.';
 COMMENT ON COLUMN test_clock.real_time IS 'What time it was in the real world when the row was written.';
 
+COMMENT ON TABLE time_zones IS '(Enum) Valid time zone names. This is populated with the list of names from the IANA time zone database.';
+
 COMMENT ON TABLE thumbnails IS 'Information about scaled-down versions of photos.';
 
 COMMENT ON TABLE timeseries IS 'Properties of a series of values collected from a device. Each device metric is represented as a timeseries.';

--- a/src/main/resources/db/migration/V165__TimeZones.sql
+++ b/src/main/resources/db/migration/V165__TimeZones.sql
@@ -1,0 +1,12 @@
+CREATE TABLE time_zones (
+    time_zone TEXT PRIMARY KEY
+);
+
+ALTER TABLE facilities
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE organizations
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE tracking.planting_sites
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE users
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -93,6 +93,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlotsRow
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration
@@ -434,7 +435,7 @@ abstract class DatabaseTest {
       lastName: String? = "Last",
       type: UserType = UserType.Individual,
       emailNotificationsEnabled: Boolean = false,
-      timeZone: String? = null,
+      timeZone: ZoneId? = null,
   ) {
     with(USERS) {
       dslContext

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.PhotosDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.ThumbnailsDao
+import com.terraformation.backend.db.default_schema.tables.daos.TimeZonesDao
 import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
@@ -259,6 +260,7 @@ abstract class DatabaseTest {
   protected val storageLocationsDao: StorageLocationsDao by lazyDao()
   protected val thumbnailsDao: ThumbnailsDao by lazyDao()
   protected val timeseriesDao: TimeseriesDao by lazyDao()
+  protected val timeZonesDao: TimeZonesDao by lazyDao()
   protected val uploadProblemsDao: UploadProblemsDao by lazyDao()
   protected val uploadsDao: UploadsDao by lazyDao()
   protected val usersDao: UsersDao by lazyDao()
@@ -432,6 +434,7 @@ abstract class DatabaseTest {
       lastName: String? = "Last",
       type: UserType = UserType.Individual,
       emailNotificationsEnabled: Boolean = false,
+      timeZone: String? = null,
   ) {
     with(USERS) {
       dslContext
@@ -444,6 +447,7 @@ abstract class DatabaseTest {
           .set(FIRST_NAME, firstName)
           .set(LAST_NAME, lastName)
           .set(MODIFIED_TIME, Instant.EPOCH)
+          .set(TIME_ZONE, timeZone)
           .set(USER_TYPE_ID, type)
           .execute()
     }

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -175,6 +175,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "timeseries" to setOf(ALL, DEVICE),
                   "timeseries_types" to setOf(ALL, DEVICE),
                   "timeseries_values" to setOf(ALL, DEVICE),
+                  "time_zones" to setOf(ALL),
                   "uploads" to setOf(ALL, CUSTOMER),
                   "upload_problems" to setOf(ALL, CUSTOMER),
                   "upload_problem_types" to setOf(ALL, CUSTOMER),

--- a/src/test/kotlin/com/terraformation/backend/db/TimeZonePopulatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/TimeZonePopulatorTest.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class TimeZonePopulatorTest : DatabaseTest() {
+  private val populator by lazy { TimeZonePopulator(dslContext) }
+
+  private val userId = UserId(1000)
+
+  private val invalidTimeZone = "Bogus/Nowhere"
+  private val validTimeZone = "America/New_York"
+
+  @Test
+  fun `inserts time zones that are not already in the database`() {
+    // A time zone that is extremely unlikely to be removed from the tz database
+    populator.populateTimeZonesTable()
+
+    assertEquals(
+        TimeZonesRow(validTimeZone),
+        timeZonesDao.fetchOneByTimeZone(validTimeZone),
+        "Time zone should have been inserted")
+  }
+
+  @Test
+  fun `deletes time zones that are no longer in the Java time zones list`() {
+    timeZonesDao.insert(TimeZonesRow(invalidTimeZone))
+
+    insertUser(userId, timeZone = invalidTimeZone)
+
+    populator.populateTimeZonesTable()
+
+    assertNull(
+        timeZonesDao.fetchOneByTimeZone(invalidTimeZone), "Time zone should have been deleted")
+    assertNull(
+        usersDao.fetchOneById(userId)!!.timeZone,
+        "User time zone should have been set to null by foreign key constraint")
+  }
+
+  @Test
+  fun `leaves existing valid time zone names alone rather than deleting and inserting them`() {
+    timeZonesDao.insert(TimeZonesRow(validTimeZone))
+
+    insertUser(userId, timeZone = validTimeZone)
+
+    populator.populateTimeZonesTable()
+
+    assertEquals(
+        TimeZonesRow(validTimeZone),
+        timeZonesDao.fetchOneByTimeZone(validTimeZone),
+        "Time zone should still be present")
+    assertEquals(
+        validTimeZone,
+        usersDao.fetchOneById(userId)?.timeZone,
+        "User should still have time zone (it wasn't set to null by the foreign key constraint)")
+  }
+}


### PR DESCRIPTION
Create a new table to hold the list of valid time zone names, and add code to
keep it in sync with the Java standard library's list of time zones (which is
taken from the IANA time zone database).

No API changes here, just database changes.