### PR TITLE
Fix failing BatchStore test

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchEstimatedReadyTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchEstimatedReadyTest.kt
@@ -33,6 +33,6 @@ internal class BatchStoreFetchEstimatedReadyTest : BatchStoreTest() {
             LocalDateTime.of(2022, 11, 1, 0, 0).atZone(ZoneId.systemDefault()),
             LocalDateTime.of(2022, 11, 6, 0, 0).atZone(ZoneId.systemDefault()))
 
-    assertEquals(expected, actual)
+    assertEquals(expected.toSet(), actual.toSet())
   }
 }


### PR DESCRIPTION
The test was assuming the results of a database query would be returned in a
specific order, but the function under test does not guarantee ordering.

Update the test to ignore what order the results are in.