### PR TITLE
Simplify non-nullable jOOQ queries

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -159,7 +159,12 @@ class TerrawareGenerator : KotlinGenerator() {
             ForcedType()
                 .withIncludeExpression("(?i:.*_ur[li])")
                 .withConverter("com.terraformation.backend.db.UriConverter")
-                .withUserType("java.net.URI"))
+                .withUserType("java.net.URI"),
+            ForcedType()
+                .withIncludeExpression("time_zone")
+                .withConverter("com.terraformation.backend.db.TimeZoneConverter")
+                .withUserType("java.time.ZoneId"),
+        )
 
     ENUM_TABLES.forEach { (schemaName, tables) ->
       tables

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -314,8 +314,7 @@ class FacilityStore(
               .and(FACILITIES.IDLE_SINCE_TIME.isNull)
               .forUpdate()
               .skipLocked()
-              .fetch(FACILITIES.ID.asNonNullable())
-              .toSet()
+              .fetchSet(FACILITIES.ID.asNonNullable())
 
       if (facilityIds.isNotEmpty()) {
         log.info("Found newly idle facilities: $facilityIds")

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.customer.model.toModel
 import com.terraformation.backend.db.FacilityAlreadyConnectedException
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
@@ -313,8 +314,7 @@ class FacilityStore(
               .and(FACILITIES.IDLE_SINCE_TIME.isNull)
               .forUpdate()
               .skipLocked()
-              .fetch(FACILITIES.ID)
-              .filterNotNull()
+              .fetch(FACILITIES.ID.asNonNullable())
               .toSet()
 
       if (facilityIds.isNotEmpty()) {

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.CannotRemoveLastOwnerException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.UserAlreadyInOrganizationException
 import com.terraformation.backend.db.UserNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
@@ -218,8 +219,7 @@ class OrganizationStore(
         .select(ORGANIZATION_USERS.ORGANIZATION_ID)
         .from(ORGANIZATION_USERS)
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
-        .fetch(ORGANIZATION_USERS.ORGANIZATION_ID)
-        .filterNotNull()
+        .fetch(ORGANIZATION_USERS.ORGANIZATION_ID.asNonNullable())
         .filter { user.userId == userId || user.canListOrganizationUsers(it) }
   }
 
@@ -290,8 +290,7 @@ class OrganizationStore(
         .where(ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId))
         .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin))
         .and(optInCondition)
-        .fetch(USERS.EMAIL)
-        .filterNotNull()
+        .fetch(USERS.EMAIL.asNonNullable())
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
@@ -1,0 +1,16 @@
+package com.terraformation.backend.db
+
+import java.time.ZoneId
+import org.jooq.impl.AbstractConverter
+
+/**
+ * Converts text values from the database to and from ZoneId objects. This is for type safety, so we
+ * don't treat arbitrary string values as zone IDs.
+ *
+ * This is referenced in generated database classes.
+ */
+class TimeZoneConverter :
+    AbstractConverter<String, ZoneId>(String::class.java, ZoneId::class.java) {
+  override fun from(databaseObject: String?): ZoneId? = databaseObject?.let { ZoneId.of(it) }
+  override fun to(userObject: ZoneId?): String? = userObject?.id
+}

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZoneConverter.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.db
 
+import java.time.DateTimeException
 import java.time.ZoneId
 import org.jooq.impl.AbstractConverter
 
@@ -11,6 +12,13 @@ import org.jooq.impl.AbstractConverter
  */
 class TimeZoneConverter :
     AbstractConverter<String, ZoneId>(String::class.java, ZoneId::class.java) {
+  /**
+   * Converts a time zone name to a ZoneId.
+   *
+   * @throws DateTimeException The zone name wasn't found in the list of zones recognized by the
+   * java.time package.
+   */
   override fun from(databaseObject: String?): ZoneId? = databaseObject?.let { ZoneId.of(it) }
+
   override fun to(userObject: ZoneId?): String? = userObject?.id
 }

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.tables.records.TimeZonesRecord
+import com.terraformation.backend.db.default_schema.tables.references.TIME_ZONES
+import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
+import javax.annotation.PostConstruct
+import javax.inject.Named
+import org.jooq.DSLContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Ensures that the `time_zones` table has all the time zone names recognized by the Java standard
+ * library. Java uses the IANA tz database.
+ */
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@Named
+class TimeZonePopulator(private val dslContext: DSLContext) {
+  private val log = perClassLogger()
+
+  @PostConstruct
+  fun populateTimeZonesTable() {
+    val existingValues =
+        dslContext
+            .select(TIME_ZONES.TIME_ZONE)
+            .from(TIME_ZONES)
+            .fetchSet(TIME_ZONES.TIME_ZONE.asNonNullable())
+    val desiredValues = ZoneId.getAvailableZoneIds().toSet()
+
+    val valuesToInsert = desiredValues.minus(existingValues)
+    val valuesToDelete = existingValues.minus(desiredValues)
+
+    if (valuesToInsert.isNotEmpty()) {
+      val timeZonesInserted =
+          dslContext
+              .insertInto(TIME_ZONES, TIME_ZONES.TIME_ZONE)
+              .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
+              .onConflictDoNothing()
+              .execute()
+      log.info("Inserted $timeZonesInserted new time zones")
+    }
+
+    if (valuesToDelete.isNotEmpty()) {
+      val timeZonesDeleted =
+          dslContext
+              .deleteFrom(TIME_ZONES)
+              .where(TIME_ZONES.TIME_ZONE.`in`(valuesToDelete))
+              .execute()
+
+      log.info("Deleted $timeZonesDeleted time zones")
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -25,9 +25,6 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
 
     val timeZonesDeleted =
         dslContext.deleteFrom(TIME_ZONES).where(TIME_ZONES.TIME_ZONE.notIn(validZoneIds)).execute()
-    if (timeZonesDeleted > 0) {
-      log.info("Deleted $timeZonesDeleted time zones")
-    }
 
     val existingValues =
         dslContext
@@ -37,15 +34,17 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
 
     val valuesToInsert = validZoneIds.minus(existingValues)
 
-    if (valuesToInsert.isNotEmpty()) {
-      val timeZonesInserted =
+    val timeZonesInserted =
+        if (valuesToInsert.isNotEmpty()) {
           dslContext
               .insertInto(TIME_ZONES, TIME_ZONES.TIME_ZONE)
               .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
               .onConflictDoNothing()
               .execute()
+        } else {
+          0
+        }
 
-      log.info("Inserted $timeZonesInserted new time zones")
-    }
+    log.info("Inserted $timeZonesInserted and deleted $timeZonesDeleted time zones")
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -38,6 +38,7 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
               .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
               .onConflictDoNothing()
               .execute()
+
       log.info("Inserted $timeZonesInserted new time zones")
     }
 

--- a/src/main/kotlin/com/terraformation/backend/file/UploadStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/UploadStore.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.UploadNotAwaitingActionException
 import com.terraformation.backend.db.UploadNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadStatus
@@ -37,8 +38,7 @@ class UploadStore(
         .select(UPLOADS.ID)
         .from(UPLOADS)
         .where(UPLOADS.ORGANIZATION_ID.eq(organizationId))
-        .fetch(UPLOADS.ID)
-        .filterNotNull()
+        .fetch(UPLOADS.ID.asNonNullable())
         .filter { currentUser().canReadUpload(it) }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.nursery.db
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.PhotoId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.daos.WithdrawalPhotosDao
@@ -72,8 +73,7 @@ class WithdrawalPhotoService(
         .select(WITHDRAWAL_PHOTOS.PHOTO_ID)
         .from(WITHDRAWAL_PHOTOS)
         .where(WITHDRAWAL_PHOTOS.WITHDRAWAL_ID.eq(withdrawalId))
-        .fetch(WITHDRAWAL_PHOTOS.PHOTO_ID)
-        .filterNotNull()
+        .fetch(WITHDRAWAL_PHOTOS.PHOTO_ID.asNonNullable())
   }
 
   /** Deletes all the photos from all the withdrawals owned by an organization. */
@@ -84,8 +84,7 @@ class WithdrawalPhotoService(
           .select(PHOTO_ID)
           .from(WITHDRAWAL_PHOTOS)
           .where(withdrawals.withdrawalsFacilityIdFkey.ORGANIZATION_ID.eq(event.organizationId))
-          .fetch(PHOTO_ID)
-          .filterNotNull()
+          .fetch(PHOTO_ID.asNonNullable())
           .forEach { photoId ->
             photoService.deletePhoto(photoId) { withdrawalPhotosDao.deleteById(photoId) }
           }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -4,6 +4,7 @@ import com.opencsv.CSVReader
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UploadId
@@ -95,8 +96,7 @@ class AccessionImporter(
                   .from(ACCESSIONS)
                   .where(ACCESSIONS.FACILITY_ID.eq(uploadsRow.facilityId))
                   .and(ACCESSIONS.NUMBER.`in`(numbers))
-                  .fetch(ACCESSIONS.NUMBER)
-                  .filterNotNull()
+                  .fetch(ACCESSIONS.NUMBER.asNonNullable())
             })
     return validator
   }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -261,8 +261,7 @@ class AccessionStore(
                         .set(TOTAL_VIABILITY_PERCENT, accession.totalViabilityPercent)
                         .set(TREES_COLLECTED_FROM, accession.numberOfTrees)
                         .returning(ID)
-                        .fetchOne()
-                        ?.get(ID)!!
+                        .fetchOne(ID)!!
                   }
 
               if (accession.remaining != null) {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.tables.pojos.PhotosRow
 import com.terraformation.backend.db.default_schema.tables.references.PHOTOS
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -85,8 +86,7 @@ class PhotoRepository(
         .join(PHOTOS)
         .on(ACCESSION_PHOTOS.PHOTO_ID.eq(PHOTOS.ID))
         .where(ACCESSION_PHOTOS.ACCESSION_ID.eq(accessionId))
-        .fetch(ACCESSION_PHOTOS.PHOTO_ID)
-        .filterNotNull()
+        .fetch(ACCESSION_PHOTOS.PHOTO_ID.asNonNullable())
         .forEach { photoId ->
           photoService.deletePhoto(photoId) { accessionPhotosDao.deleteById(photoId) }
         }
@@ -99,8 +99,7 @@ class PhotoRepository(
         .selectDistinct(ACCESSION_PHOTOS.ACCESSION_ID)
         .from(ACCESSION_PHOTOS)
         .where(ACCESSION_PHOTOS.accessions.facilities.ORGANIZATION_ID.eq(event.organizationId))
-        .fetch(ACCESSION_PHOTOS.ACCESSION_ID)
-        .filterNotNull()
+        .fetch(ACCESSION_PHOTOS.ACCESSION_ID.asNonNullable())
         .forEach { deleteAllPhotos(it) }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/ViabilityTestStore.kt
@@ -171,8 +171,7 @@ class ViabilityTestStore(private val dslContext: DSLContext) {
               .set(TOTAL_SEEDS_GERMINATED, calculatedTest.totalSeedsGerminated)
               .set(TREATMENT_ID, calculatedTest.treatment)
               .returning(ID)
-              .fetchOne()
-              ?.get(ID)!!
+              .fetchOne(ID)!!
         }
 
     calculatedTest.testResults?.forEach { insertTestResult(testId, it) }

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -100,7 +100,6 @@ class GbifStore(private val dslContext: DSLContext) {
         .orderBy(firstWordSortPosition, GBIF_NAMES.NAME)
         .limit(maxResults)
         .fetchInto(GbifNamesRow::class.java)
-        .filterNotNull()
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.species.db
 import com.opencsv.CSVReader
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
@@ -69,8 +70,7 @@ class SpeciesImporter(
             .from(SPECIES)
             .where(SPECIES.ORGANIZATION_ID.eq(uploadsRow.organizationId))
             .and(SPECIES.DELETED_TIME.isNull)
-            .fetch(SPECIES.SCIENTIFIC_NAME)
-            .filterNotNull()
+            .fetch(SPECIES.SCIENTIFIC_NAME.asNonNullable())
             .toSet()
     val existingRenames =
         dslContext

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -70,8 +70,7 @@ class SpeciesImporter(
             .from(SPECIES)
             .where(SPECIES.ORGANIZATION_ID.eq(uploadsRow.organizationId))
             .and(SPECIES.DELETED_TIME.isNull)
-            .fetch(SPECIES.SCIENTIFIC_NAME.asNonNullable())
-            .toSet()
+            .fetchSet(SPECIES.SCIENTIFIC_NAME.asNonNullable())
     val existingRenames =
         dslContext
             .selectDistinct(SPECIES.INITIAL_SCIENTIFIC_NAME, SPECIES.SCIENTIFIC_NAME)

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.ScientificNameExistsException
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.SpeciesProblemHasNoSuggestionException
 import com.terraformation.backend.db.SpeciesProblemNotFoundException
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
@@ -82,8 +83,7 @@ class SpeciesStore(
         .where(SPECIES.CHECKED_TIME.isNull)
         .and(SPECIES.ORGANIZATION_ID.eq(organizationId))
         .and(SPECIES.DELETED_TIME.isNull)
-        .fetch(SPECIES.ID)
-        .filterNotNull()
+        .fetch(SPECIES.ID.asNonNullable())
   }
 
   /** Returns a list of problems for a particular species, if any. */

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -131,6 +131,8 @@ COMMENT ON TABLE test_clock IS 'User-adjustable clock for test environments. Not
 COMMENT ON COLUMN test_clock.fake_time IS 'What time the server should believe it was at the time the row was written.';
 COMMENT ON COLUMN test_clock.real_time IS 'What time it was in the real world when the row was written.';
 
+COMMENT ON TABLE time_zones IS '(Enum) Valid time zone names. This is populated with the list of names from the IANA time zone database.';
+
 COMMENT ON TABLE thumbnails IS 'Information about scaled-down versions of photos.';
 
 COMMENT ON TABLE timeseries IS 'Properties of a series of values collected from a device. Each device metric is represented as a timeseries.';

--- a/src/main/resources/db/migration/V165__TimeZones.sql
+++ b/src/main/resources/db/migration/V165__TimeZones.sql
@@ -1,0 +1,12 @@
+CREATE TABLE time_zones (
+    time_zone TEXT PRIMARY KEY
+);
+
+ALTER TABLE facilities
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE organizations
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE tracking.planting_sites
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;
+ALTER TABLE users
+    ADD COLUMN time_zone TEXT REFERENCES time_zones ON DELETE SET NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -93,6 +93,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlotsRow
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration
@@ -434,7 +435,7 @@ abstract class DatabaseTest {
       lastName: String? = "Last",
       type: UserType = UserType.Individual,
       emailNotificationsEnabled: Boolean = false,
-      timeZone: String? = null,
+      timeZone: ZoneId? = null,
   ) {
     with(USERS) {
       dslContext

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.PhotosDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.ThumbnailsDao
+import com.terraformation.backend.db.default_schema.tables.daos.TimeZonesDao
 import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
@@ -259,6 +260,7 @@ abstract class DatabaseTest {
   protected val storageLocationsDao: StorageLocationsDao by lazyDao()
   protected val thumbnailsDao: ThumbnailsDao by lazyDao()
   protected val timeseriesDao: TimeseriesDao by lazyDao()
+  protected val timeZonesDao: TimeZonesDao by lazyDao()
   protected val uploadProblemsDao: UploadProblemsDao by lazyDao()
   protected val uploadsDao: UploadsDao by lazyDao()
   protected val usersDao: UsersDao by lazyDao()
@@ -432,6 +434,7 @@ abstract class DatabaseTest {
       lastName: String? = "Last",
       type: UserType = UserType.Individual,
       emailNotificationsEnabled: Boolean = false,
+      timeZone: String? = null,
   ) {
     with(USERS) {
       dslContext
@@ -444,6 +447,7 @@ abstract class DatabaseTest {
           .set(FIRST_NAME, firstName)
           .set(LAST_NAME, lastName)
           .set(MODIFIED_TIME, Instant.EPOCH)
+          .set(TIME_ZONE, timeZone)
           .set(USER_TYPE_ID, type)
           .execute()
     }

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -175,6 +175,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "timeseries" to setOf(ALL, DEVICE),
                   "timeseries_types" to setOf(ALL, DEVICE),
                   "timeseries_values" to setOf(ALL, DEVICE),
+                  "time_zones" to setOf(ALL),
                   "uploads" to setOf(ALL, CUSTOMER),
                   "upload_problems" to setOf(ALL, CUSTOMER),
                   "upload_problem_types" to setOf(ALL, CUSTOMER),

--- a/src/test/kotlin/com/terraformation/backend/db/TimeZonePopulatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/TimeZonePopulatorTest.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.db
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class TimeZonePopulatorTest : DatabaseTest() {
+  private val populator by lazy { TimeZonePopulator(dslContext) }
+
+  private val userId = UserId(1000)
+
+  private val invalidTimeZone = "Bogus/Nowhere"
+  private val validTimeZone = "America/New_York"
+
+  @Test
+  fun `inserts time zones that are not already in the database`() {
+    // A time zone that is extremely unlikely to be removed from the tz database
+    populator.populateTimeZonesTable()
+
+    assertEquals(
+        TimeZonesRow(validTimeZone),
+        timeZonesDao.fetchOneByTimeZone(validTimeZone),
+        "Time zone should have been inserted")
+  }
+
+  @Test
+  fun `deletes time zones that are no longer in the Java time zones list`() {
+    timeZonesDao.insert(TimeZonesRow(invalidTimeZone))
+
+    insertUser(userId, timeZone = invalidTimeZone)
+
+    populator.populateTimeZonesTable()
+
+    assertNull(
+        timeZonesDao.fetchOneByTimeZone(invalidTimeZone), "Time zone should have been deleted")
+    assertNull(
+        usersDao.fetchOneById(userId)!!.timeZone,
+        "User time zone should have been set to null by foreign key constraint")
+  }
+
+  @Test
+  fun `leaves existing valid time zone names alone rather than deleting and inserting them`() {
+    timeZonesDao.insert(TimeZonesRow(validTimeZone))
+
+    insertUser(userId, timeZone = validTimeZone)
+
+    populator.populateTimeZonesTable()
+
+    assertEquals(
+        TimeZonesRow(validTimeZone),
+        timeZonesDao.fetchOneByTimeZone(validTimeZone),
+        "Time zone should still be present")
+    assertEquals(
+        validTimeZone,
+        usersDao.fetchOneById(userId)?.timeZone,
+        "User should still have time zone (it wasn't set to null by the foreign key constraint)")
+  }
+}


### PR DESCRIPTION
Use the new `asNonNullable()` extension function to remove `filterNotNull()` calls
on jOOQ queries that were only there to inform Kotlin that the results were
non-nullable. This is really just for conciseness; there will be a performance
gain from not having to copy the list, but it'll be miniscule.

In a couple places we were doing `fetch().get(FIELD)`; simplify those to
`fetchOne(FIELD)`.

No behavior change here.