### PR TITLE
SW-2606 Add timeZone fields to user APIs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.MapSchema
 import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityScheme
+import java.time.ZoneId
 import javax.inject.Named
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
@@ -41,6 +43,11 @@ class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomiser 
     GeoJsonOpenApiSchema.configureJtsSchemas(config)
 
     config.replaceWithSchema(ArbitraryJsonObject::class.java, ObjectSchema())
+    config.replaceWithSchema(
+        ZoneId::class.java,
+        StringSchema()
+            .description("Time zone name in IANA tz database format")
+            .example("America/New_York"))
   }
 
   override fun customise(openApi: OpenAPI) {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.ZoneId
 import javax.servlet.http.HttpSession
 import javax.ws.rs.ForbiddenException
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -37,7 +38,8 @@ class UsersController(private val userStore: UserStore) {
               user.email,
               user.emailNotificationsEnabled,
               user.firstName,
-              user.lastName))
+              user.lastName,
+              user.timeZone))
     } else {
       throw ForbiddenException("Only ordinary users can request their information")
     }
@@ -53,7 +55,9 @@ class UsersController(private val userStore: UserStore) {
               emailNotificationsEnabled = payload.emailNotificationsEnabled
                       ?: user.emailNotificationsEnabled,
               firstName = payload.firstName,
-              lastName = payload.lastName)
+              lastName = payload.lastName,
+              timeZone = payload.timeZone,
+          )
       userStore.updateUser(model)
       return SimpleSuccessResponsePayload()
     } else {
@@ -110,6 +114,7 @@ data class UserProfilePayload(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    val timeZone: ZoneId?,
 )
 
 data class GetUserResponsePayload(val user: UserProfilePayload) : SuccessResponsePayload
@@ -124,6 +129,7 @@ data class UpdateUserRequestPayload(
     val emailNotificationsEnabled: Boolean? = null,
     val firstName: String,
     val lastName: String,
+    val timeZone: ZoneId?,
 )
 
 @JsonInclude(JsonInclude.Include.ALWAYS)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -219,7 +219,8 @@ class UserStore(
           usersRow.copy(
               emailNotificationsEnabled = model.emailNotificationsEnabled,
               firstName = model.firstName,
-              lastName = model.lastName))
+              lastName = model.lastName,
+              timeZone = model.timeZone))
 
       try {
         val keycloakUser = usersResource.get(usersRow.authId)
@@ -502,6 +503,7 @@ class UserStore(
             ?: throw IllegalArgumentException("Email notifications enabled should never be null"),
         usersRow.firstName,
         usersRow.lastName,
+        usersRow.timeZone,
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),
         parentStore,
         permissionStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -22,6 +22,8 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
+import java.time.ZoneOffset
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
@@ -41,6 +43,8 @@ data class DeviceManagerUser(
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
 ) : TerrawareUser, UserDetails {
+  override val timeZone: ZoneId
+    get() = ZoneOffset.UTC
   override val userType: UserType
     get() = UserType.DeviceManager
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
@@ -65,6 +66,7 @@ data class IndividualUser(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    override val timeZone: ZoneId?,
     override val userType: UserType,
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -21,6 +21,8 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import java.time.ZoneId
+import java.time.ZoneOffset
 import javax.inject.Named
 import org.springframework.context.annotation.Lazy
 
@@ -57,6 +59,9 @@ class SystemUser(
      */
     private const val USERNAME = "system"
   }
+
+  override val timeZone: ZoneId
+    get() = ZoneOffset.UTC
 
   override val userId: UserId by lazy {
     usersDao.fetchOneByEmail(USERNAME)?.id

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.security.Principal
+import java.time.ZoneId
 
 /**
  * An entity on whose behalf the system can do work.
@@ -31,6 +32,7 @@ import java.security.Principal
 interface TerrawareUser : Principal {
   val userId: UserId
   val userType: UserType
+  val timeZone: ZoneId?
 
   /**
    * The user's Keycloak ID, if any. Null if this is an internal pseudo-user or if this user has

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -148,11 +148,15 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchByAuthId returns existing user without touching Keycloak`() {
-    insertUser(authId = authId)
+    val timeZone = insertTimeZone()
+    insertUser(authId = authId, firstName = "f", lastName = "l", timeZone = timeZone)
 
     val actual = userStore.fetchByAuthId(authId) as IndividualUser
 
-    assertEquals(authId, actual.authId)
+    assertEquals(authId, actual.authId, "Auth ID")
+    assertEquals("f", actual.firstName, "First name")
+    assertEquals("l", actual.lastName, "Last name")
+    assertEquals(timeZone, actual.timeZone, "Time zone")
   }
 
   @Test
@@ -348,6 +352,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   fun `updateUser updates profile information`() {
     val newFirstName = "Testy"
     val newLastName = "McTestalot"
+    val newTimeZone = insertTimeZone()
 
     insertUser(authId = userRepresentation.id, email = userRepresentation.email)
 
@@ -364,7 +369,8 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
             email = "newemail@x.com",
             firstName = newFirstName,
             lastName = newLastName,
-            emailNotificationsEnabled = true)
+            emailNotificationsEnabled = true,
+            timeZone = newTimeZone)
     userStore.updateUser(modelWithEdits)
 
     val updatedModel = userStore.fetchOneById(model.userId) as IndividualUser
@@ -372,6 +378,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(oldEmail, updatedModel.email, "Email (DB)")
     assertEquals(newFirstName, updatedModel.firstName, "First name (DB)")
     assertEquals(newLastName, updatedModel.lastName, "Last name (DB)")
+    assertEquals(newTimeZone, updatedModel.timeZone, "Time zone (DB)")
     assertTrue(updatedModel.emailNotificationsEnabled, "Email notifications enabled (DB)")
 
     val updatedRepresentation = representationSlot.captured

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -38,6 +38,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
+import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -862,6 +863,12 @@ abstract class DatabaseTest {
     plantingsDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!
+  }
+
+  fun insertTimeZone(timeZone: Any = ZoneId.of("Pacific/Honolulu")): ZoneId {
+    val zoneId = if (timeZone is ZoneId) timeZone else ZoneId.of("$timeZone")
+    timeZonesDao.insert(TimeZonesRow(zoneId))
+    return zoneId
   }
 
   class DockerPostgresDataSourceInitializer :


### PR DESCRIPTION
Add `timeZone` fields to the payloads of the `/api/v1/users` endpoints to get and
set per-user time zones.