### PR TITLE
SW-2606 Add timeZone fields to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.MapSchema
 import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.security.SecurityScheme
+import java.time.ZoneId
 import javax.inject.Named
 import kotlin.reflect.KClass
 import kotlin.reflect.full.declaredMemberProperties
@@ -41,6 +43,11 @@ class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomiser 
     GeoJsonOpenApiSchema.configureJtsSchemas(config)
 
     config.replaceWithSchema(ArbitraryJsonObject::class.java, ObjectSchema())
+    config.replaceWithSchema(
+        ZoneId::class.java,
+        StringSchema()
+            .description("Time zone name in IANA tz database format")
+            .example("America/New_York"))
   }
 
   override fun customise(openApi: OpenAPI) {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import java.time.Instant
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.ws.rs.InternalServerErrorException
 import javax.ws.rs.WebApplicationException
@@ -67,7 +68,12 @@ class FacilitiesController(
   ): CreateFacilityResponsePayload {
     val model =
         facilityStore.create(
-            payload.organizationId, payload.type, payload.name, payload.description)
+            description = payload.description,
+            name = payload.name,
+            organizationId = payload.organizationId,
+            timeZone = payload.timeZone,
+            type = payload.type,
+        )
 
     return CreateFacilityResponsePayload(model.id)
   }
@@ -81,7 +87,10 @@ class FacilitiesController(
     val facility = facilityStore.fetchOneById(facilityId)
 
     facilityStore.update(
-        facility.copy(name = payload.name, description = payload.description?.ifEmpty { null }))
+        facility.copy(
+            name = payload.name,
+            description = payload.description?.ifEmpty { null },
+            timeZone = payload.timeZone))
 
     return SimpleSuccessResponsePayload()
   }
@@ -151,6 +160,7 @@ data class FacilityPayload(
     val id: FacilityId,
     val name: String,
     val organizationId: OrganizationId,
+    val timeZone: ZoneId?,
     val type: FacilityType,
 ) {
   constructor(
@@ -162,7 +172,9 @@ data class FacilityPayload(
       model.id,
       model.name,
       model.organizationId,
-      model.type)
+      model.timeZone,
+      model.type,
+  )
 }
 
 data class CreateFacilityRequestPayload(
@@ -170,6 +182,7 @@ data class CreateFacilityRequestPayload(
     @Schema(description = "Which organization this facility belongs to.")
     val organizationId: OrganizationId,
     val name: String,
+    val timeZone: ZoneId?,
     val type: FacilityType,
 )
 
@@ -185,4 +198,8 @@ data class SendFacilityAlertRequestPayload(
     val body: String
 )
 
-data class UpdateFacilityRequestPayload(val description: String?, val name: String)
+data class UpdateFacilityRequestPayload(
+    val description: String?,
+    val name: String,
+    val timeZone: ZoneId?,
+)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.validation.Valid
 import javax.validation.constraints.NotEmpty
@@ -251,6 +252,7 @@ data class CreateOrganizationRequestPayload(
     val countrySubdivisionCode: String?,
     val description: String?,
     @field:NotEmpty val name: String,
+    val timeZone: ZoneId?,
 ) {
   fun toRow(): OrganizationsRow {
     return OrganizationsRow(
@@ -258,6 +260,7 @@ data class CreateOrganizationRequestPayload(
         countrySubdivisionCode = countrySubdivisionCode,
         description = description,
         name = name,
+        timeZone = timeZone,
     )
   }
 }
@@ -280,6 +283,7 @@ data class UpdateOrganizationRequestPayload(
     val countrySubdivisionCode: String?,
     val description: String?,
     @field:NotEmpty val name: String,
+    val timeZone: ZoneId?,
 ) {
   fun toRow(): OrganizationsRow {
     return OrganizationsRow(
@@ -287,6 +291,7 @@ data class UpdateOrganizationRequestPayload(
         countrySubdivisionCode = countrySubdivisionCode,
         description = description,
         name = name,
+        timeZone = timeZone,
     )
   }
 }
@@ -322,6 +327,7 @@ data class OrganizationPayload(
         description = "The current user's role in the organization.",
     )
     val role: Role,
+    val timeZone: ZoneId?,
     @Schema(
         description = "The total number of users in the organization, including the current user.")
     val totalUsers: Int,
@@ -338,6 +344,7 @@ data class OrganizationPayload(
       model.id,
       model.name,
       role,
+      model.timeZone,
       model.totalUsers,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.ZoneId
 import javax.servlet.http.HttpSession
 import javax.ws.rs.ForbiddenException
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -37,7 +38,8 @@ class UsersController(private val userStore: UserStore) {
               user.email,
               user.emailNotificationsEnabled,
               user.firstName,
-              user.lastName))
+              user.lastName,
+              user.timeZone))
     } else {
       throw ForbiddenException("Only ordinary users can request their information")
     }
@@ -53,7 +55,9 @@ class UsersController(private val userStore: UserStore) {
               emailNotificationsEnabled = payload.emailNotificationsEnabled
                       ?: user.emailNotificationsEnabled,
               firstName = payload.firstName,
-              lastName = payload.lastName)
+              lastName = payload.lastName,
+              timeZone = payload.timeZone,
+          )
       userStore.updateUser(model)
       return SimpleSuccessResponsePayload()
     } else {
@@ -110,6 +114,7 @@ data class UserProfilePayload(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    val timeZone: ZoneId?,
 )
 
 data class GetUserResponsePayload(val user: UserProfilePayload) : SuccessResponsePayload
@@ -124,6 +129,7 @@ data class UpdateUserRequestPayload(
     val emailNotificationsEnabled: Boolean? = null,
     val firstName: String,
     val lastName: String,
+    val timeZone: ZoneId?,
 )
 
 @JsonInclude(JsonInclude.Include.ALWAYS)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.seedbank.tables.pojos.StorageLocationsRow
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.log.perClassLogger
 import java.time.Clock
+import java.time.ZoneId
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
@@ -84,6 +85,7 @@ class FacilityStore(
       description: String? = null,
       maxIdleMinutes: Int = DEFAULT_MAX_IDLE_MINUTES,
       createStorageLocations: Boolean = true,
+      timeZone: ZoneId? = null,
   ): FacilityModel {
     requirePermissions { createFacility(organizationId) }
 
@@ -98,6 +100,7 @@ class FacilityStore(
             modifiedTime = clock.instant(),
             name = name,
             organizationId = organizationId,
+            timeZone = timeZone,
             typeId = type,
         )
 
@@ -136,7 +139,7 @@ class FacilityStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = model.name,
-            typeId = model.type))
+            timeZone = model.timeZone))
   }
 
   fun fetchStorageLocations(facilityId: FacilityId): List<StorageLocationsRow> {

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -120,6 +120,7 @@ class OrganizationStore(
             modifiedBy = currentUser().userId,
             modifiedTime = clock.instant(),
             name = row.name,
+            timeZone = row.timeZone,
         )
 
     organizationsDao.insert(fullRow)
@@ -156,6 +157,7 @@ class OrganizationStore(
           .set(MODIFIED_BY, currentUser().userId)
           .set(MODIFIED_TIME, clock.instant())
           .set(NAME, row.name)
+          .set(TIME_ZONE, row.timeZone)
           .where(ID.eq(organizationId))
           .execute()
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -219,7 +219,8 @@ class UserStore(
           usersRow.copy(
               emailNotificationsEnabled = model.emailNotificationsEnabled,
               firstName = model.firstName,
-              lastName = model.lastName))
+              lastName = model.lastName,
+              timeZone = model.timeZone))
 
       try {
         val keycloakUser = usersResource.get(usersRow.authId)
@@ -502,6 +503,7 @@ class UserStore(
             ?: throw IllegalArgumentException("Email notifications enabled should never be null"),
         usersRow.firstName,
         usersRow.lastName,
+        usersRow.timeZone,
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),
         parentStore,
         permissionStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -22,6 +22,8 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
+import java.time.ZoneOffset
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
@@ -41,6 +43,8 @@ data class DeviceManagerUser(
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
 ) : TerrawareUser, UserDetails {
+  override val timeZone: ZoneId
+    get() = ZoneOffset.UTC
   override val userType: UserType
     get() = UserType.DeviceManager
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import java.time.Instant
+import java.time.ZoneId
 import org.jooq.Record
 
 data class FacilityModel(
@@ -21,6 +22,7 @@ data class FacilityModel(
     val type: FacilityType,
     val lastTimeseriesTime: Instant?,
     val maxIdleMinutes: Int,
+    val timeZone: ZoneId? = null,
 ) {
   constructor(
       record: Record
@@ -38,7 +40,9 @@ data class FacilityModel(
       record[FACILITIES.TYPE_ID] ?: throw IllegalArgumentException("Type is required"),
       record[FACILITIES.LAST_TIMESERIES_TIME],
       record[FACILITIES.MAX_IDLE_MINUTES]
-          ?: throw IllegalArgumentException("Max idle minutes is required"))
+          ?: throw IllegalArgumentException("Max idle minutes is required"),
+      record[FACILITIES.TIME_ZONE],
+  )
 
   /**
    * The device template category that holds the list of default devices to create when a sensor kit
@@ -66,5 +70,7 @@ fun FacilitiesRow.toModel(): FacilityModel {
       organizationId ?: throw IllegalArgumentException("Organization is required"),
       typeId ?: throw IllegalArgumentException("Type is required"),
       lastTimeseriesTime,
-      maxIdleMinutes ?: throw IllegalArgumentException("Max idle minutes is required"))
+      maxIdleMinutes ?: throw IllegalArgumentException("Max idle minutes is required"),
+      timeZone,
+  )
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
+import java.time.ZoneId
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
@@ -65,6 +66,7 @@ data class IndividualUser(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    override val timeZone: ZoneId?,
     override val userType: UserType,
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import java.time.Instant
+import java.time.ZoneId
 import org.jooq.Field
 import org.jooq.Record
 
@@ -18,6 +19,7 @@ data class OrganizationModel(
     val disabledTime: Instant? = null,
     val facilities: List<FacilityModel>? = null,
     val totalUsers: Int,
+    val timeZone: ZoneId? = null,
 ) {
   constructor(
       record: Record,
@@ -34,6 +36,7 @@ data class OrganizationModel(
       disabledTime = record[ORGANIZATIONS.DISABLED_TIME],
       facilities = record[facilitiesMultiset],
       totalUsers = record[totalUsersSubquery],
+      timeZone = record[ORGANIZATIONS.TIME_ZONE],
   )
 }
 
@@ -47,4 +50,5 @@ fun OrganizationsRow.toModel(totalUsers: Int): OrganizationModel =
         createdTime = createdTime ?: throw IllegalArgumentException("Created time is required"),
         disabledTime = disabledTime,
         totalUsers = totalUsers,
+        timeZone = timeZone,
     )

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -21,6 +21,8 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import java.time.ZoneId
+import java.time.ZoneOffset
 import javax.inject.Named
 import org.springframework.context.annotation.Lazy
 
@@ -57,6 +59,9 @@ class SystemUser(
      */
     private const val USERNAME = "system"
   }
+
+  override val timeZone: ZoneId
+    get() = ZoneOffset.UTC
 
   override val userId: UserId by lazy {
     usersDao.fetchOneByEmail(USERNAME)?.id

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.security.Principal
+import java.time.ZoneId
 
 /**
  * An entity on whose behalf the system can do work.
@@ -31,6 +32,7 @@ import java.security.Principal
 interface TerrawareUser : Principal {
   val userId: UserId
   val userType: UserType
+  val timeZone: ZoneId?
 
   /**
    * The user's Keycloak ID, if any. Null if this is an internal pseudo-user or if this user has

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -18,10 +18,12 @@ import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.search.field.TextField
 import com.terraformation.backend.search.field.TimestampField
 import com.terraformation.backend.search.field.UpperCaseTextField
+import com.terraformation.backend.search.field.ZoneIdField
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.OrderField
@@ -308,4 +310,11 @@ abstract class SearchTable {
       databaseField: Field<String?>,
       nullable: Boolean = true
   ) = UpperCaseTextField(fieldName, displayName, databaseField, this, nullable)
+
+  fun zoneIdField(
+      fieldName: String,
+      displayName: String,
+      databaseField: TableField<*, ZoneId?>,
+      nullable: Boolean = true
+  ) = ZoneIdField(fieldName, displayName, databaseField, this, nullable)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
@@ -1,0 +1,42 @@
+package com.terraformation.backend.search.field
+
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchTable
+import java.time.ZoneId
+import java.util.*
+import org.jooq.Condition
+import org.jooq.Record
+import org.jooq.TableField
+import org.jooq.impl.DSL
+
+/** Search field for columns that hold time zone identifiers. */
+class ZoneIdField(
+    override val fieldName: String,
+    override val displayName: String,
+    override val databaseField: TableField<*, ZoneId?>,
+    override val table: SearchTable,
+    override val nullable: Boolean = true
+) : SingleColumnSearchField<ZoneId>() {
+  private val validZoneNames = ZoneId.getAvailableZoneIds()
+
+  override val supportedFilterTypes: Set<SearchFilterType>
+    get() = EnumSet.of(SearchFilterType.Exact)
+  override val possibleValues = validZoneNames.toList()
+
+  override fun getCondition(fieldNode: FieldNode): Condition {
+    if (fieldNode.type != SearchFilterType.Exact) {
+      throw IllegalArgumentException("$fieldName only supports exact searches")
+    }
+
+    val zoneIds =
+        fieldNode.values.filter { it != null && it in validZoneNames }.map { ZoneId.of(it) }
+
+    return DSL.or(
+        listOfNotNull(
+            if (zoneIds.isNotEmpty()) databaseField.`in`(zoneIds) else null,
+            if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+  }
+
+  override fun computeValue(record: Record) = record[databaseField]?.id
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -49,6 +49,7 @@ class FacilitiesTable(tables: SearchTables) : SearchTable() {
           textField("description", "Facility description", FACILITIES.DESCRIPTION),
           idWrapperField("id", "Facility ID", FACILITIES.ID) { FacilityId(it) },
           textField("name", "Facility name", FACILITIES.NAME, nullable = false),
+          zoneIdField("timeZone", "Facility time zone", FACILITIES.TIME_ZONE),
           enumField("type", "Facility type", FACILITIES.TYPE_ID, nullable = false),
       )
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -67,6 +67,7 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
               nullable = false),
           idWrapperField("id", "Organization ID", ORGANIZATIONS.ID) { OrganizationId(it) },
           textField("name", "Organization name", ORGANIZATIONS.NAME, nullable = false),
+          zoneIdField("timeZone", "Organization time zone", ORGANIZATIONS.TIME_ZONE),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -64,6 +64,7 @@ class PlantingSitesTable(tables: SearchTables) : SearchTable() {
               "Planting site number of planting zones",
               PLANTING_SITE_SUMMARIES.NUM_PLANTING_ZONES),
           longField("numPlots", "Planting site number of plots", PLANTING_SITE_SUMMARIES.NUM_PLOTS),
+          zoneIdField("timeZone", "Planting site time zone", PLANTING_SITE_SUMMARIES.TIME_ZONE),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -32,6 +32,7 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
         idWrapperField("id", "User ID", USERS.ID) { UserId(it) },
         timestampField("lastActivityTime", "User last activity time", USERS.LAST_ACTIVITY_TIME),
         textField("lastName", "User last name", USERS.LAST_NAME),
+        zoneIdField("timeZone", "User time zone", USERS.TIME_ZONE),
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.tracking.model.PlotModel
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.ZoneId
 import org.locationtech.jts.geom.MultiPolygon
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -58,7 +59,7 @@ class PlantingSitesController(
   ): CreatePlantingSiteResponsePayload {
     val model =
         plantingSiteStore.createPlantingSite(
-            payload.organizationId, payload.name, payload.description)
+            payload.organizationId, payload.name, payload.description, payload.timeZone)
     return CreatePlantingSiteResponsePayload(model.id)
   }
 
@@ -67,7 +68,7 @@ class PlantingSitesController(
       @PathVariable("id") id: PlantingSiteId,
       @RequestBody payload: UpdatePlantingSiteRequestPayload
   ): SimpleSuccessResponsePayload {
-    plantingSiteStore.updatePlantingSite(id, payload.name, payload.description)
+    plantingSiteStore.updatePlantingSite(id, payload.name, payload.description, payload.timeZone)
     return SimpleSuccessResponsePayload()
   }
 }
@@ -99,6 +100,7 @@ data class PlantingSitePayload(
     val id: PlantingSiteId,
     val name: String,
     val plantingZones: List<PlantingZonePayload>?,
+    val timeZone: ZoneId?,
 ) {
   constructor(
       model: PlantingSiteModel
@@ -108,6 +110,7 @@ data class PlantingSitePayload(
       model.id,
       model.name,
       model.plantingZones.map { PlantingZonePayload(it) },
+      model.timeZone,
   )
 }
 
@@ -115,6 +118,7 @@ data class CreatePlantingSiteRequestPayload(
     val description: String? = null,
     val name: String,
     val organizationId: OrganizationId,
+    val timeZone: ZoneId?,
 )
 
 data class CreatePlantingSiteResponsePayload(val id: PlantingSiteId) : SuccessResponsePayload
@@ -127,4 +131,5 @@ data class ListPlantingSitesResponsePayload(val sites: List<PlantingSitePayload>
 data class UpdatePlantingSiteRequestPayload(
     val description: String? = null,
     val name: String,
+    val timeZone: ZoneId?,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.tracking.model.PlotModel
 import java.time.InstantSource
+import java.time.ZoneId
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
@@ -105,6 +106,7 @@ class PlantingSiteStore(
       organizationId: OrganizationId,
       name: String,
       description: String?,
+      timeZone: ZoneId?,
   ): PlantingSiteModel {
     requirePermissions { createPlantingSite(organizationId) }
 
@@ -118,6 +120,7 @@ class PlantingSiteStore(
             modifiedTime = now,
             name = name,
             organizationId = organizationId,
+            timeZone = timeZone,
         )
 
     plantingSitesDao.insert(plantingSitesRow)
@@ -125,7 +128,12 @@ class PlantingSiteStore(
     return fetchSiteById(plantingSitesRow.id!!)
   }
 
-  fun updatePlantingSite(plantingSiteId: PlantingSiteId, name: String, description: String?) {
+  fun updatePlantingSite(
+      plantingSiteId: PlantingSiteId,
+      name: String,
+      description: String?,
+      timeZone: ZoneId? = null,
+  ) {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
     with(PLANTING_SITES) {
@@ -135,6 +143,7 @@ class PlantingSiteStore(
           .set(MODIFIED_BY, currentUser().userId)
           .set(MODIFIED_TIME, clock.instant())
           .set(NAME, name)
+          .set(TIME_ZONE, timeZone)
           .where(ID.eq(plantingSiteId))
           .execute()
     }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.tracking.PlotId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import java.time.ZoneId
 import org.jooq.Field
 import org.jooq.Record
 import org.locationtech.jts.geom.Geometry
@@ -55,6 +56,7 @@ data class PlantingSiteModel(
     val name: String,
     val organizationId: OrganizationId,
     val plantingZones: List<PlantingZoneModel>,
+    val timeZone: ZoneId? = null,
 ) {
   constructor(
       record: Record,
@@ -66,13 +68,16 @@ data class PlantingSiteModel(
       record[PLANTING_SITES.ID]!!,
       record[PLANTING_SITES.NAME]!!,
       record[PLANTING_SITES.ORGANIZATION_ID]!!,
-      plantingZonesMultiset?.let { record[it] } ?: emptyList())
+      plantingZonesMultiset?.let { record[it] } ?: emptyList(),
+      record[PLANTING_SITES.TIME_ZONE],
+  )
 
   fun equals(other: Any?, tolerance: Double): Boolean {
     return other is PlantingSiteModel &&
         description == other.description &&
         id == other.id &&
         name == other.name &&
+        timeZone == other.timeZone &&
         plantingZones.size == other.plantingZones.size &&
         plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) } &&
         (boundary == null && other.boundary == null ||

--- a/src/main/resources/db/migration/V166__PlantingSiteSummariesTimeZone.sql
+++ b/src/main/resources/db/migration/V166__PlantingSiteSummariesTimeZone.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE VIEW tracking.planting_site_summaries AS
+SELECT id,
+       organization_id,
+       name,
+       description,
+       boundary,
+       created_by,
+       created_time,
+       modified_by,
+       modified_time,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+        WHERE ps.id = pz.planting_site_id) AS num_planting_zones,
+       (SELECT COUNT(*)
+        FROM tracking.planting_zones pz
+                 JOIN tracking.plots p ON pz.id = p.planting_zone_id
+        WHERE ps.id = pz.planting_site_id) AS num_plots,
+       time_zone
+FROM tracking.planting_sites ps;

--- a/src/test/kotlin/com/terraformation/backend/MockUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/MockUser.kt
@@ -7,8 +7,10 @@ import com.terraformation.backend.db.default_schema.UserType
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
+import java.time.ZoneId
 
 fun mockUser(userId: UserId = UserId(2)): IndividualUser {
+  val timeZone = ZoneId.of("Pacific/Honolulu")
   val user: IndividualUser = mockk(relaxed = true)
 
   every { user.userId } returns userId
@@ -17,6 +19,7 @@ fun mockUser(userId: UserId = UserId(2)): IndividualUser {
   every { user.firstName } returns "First"
   every { user.lastName } returns "Last"
   every { user.fullName } returns "First Last"
+  every { user.timeZone } returns timeZone
   every { user.userType } returns UserType.Individual
 
   val funcSlot = CapturingSlot<() -> Any>()

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -29,6 +29,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneId
 import org.jooq.JSONB
 import org.jooq.Record
 import org.jooq.Table
@@ -61,7 +62,9 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           modifiedTime = Instant.EPOCH,
           name = "Facility $facilityId",
           organizationId = organizationId,
-          type = FacilityType.SeedBank)
+          timeZone = null,
+          type = FacilityType.SeedBank,
+      )
   private val organizationModel =
       OrganizationModel(
           id = organizationId,
@@ -70,7 +73,11 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           countrySubdivisionCode = "US-HI",
           createdTime = Instant.EPOCH,
           facilities = listOf(facilityModel),
-          totalUsers = 0)
+          timeZone = null,
+          totalUsers = 0,
+      )
+
+  private lateinit var timeZone: ZoneId
 
   @BeforeEach
   fun setUp() {
@@ -97,6 +104,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
         countryCode = organizationModel.countryCode,
         countrySubdivisionCode = organizationModel.countrySubdivisionCode)
     insertFacility()
+    timeZone = insertTimeZone()
   }
 
   @Test
@@ -180,6 +188,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             countrySubdivisionCode = "US-HI",
             description = "Test description",
             name = "Test Org",
+            timeZone = timeZone,
         )
     val createdModel = store.createWithAdmin(row)
 
@@ -256,7 +265,9 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             id = organizationId,
             name = "New Name",
             description = "New Description",
-            countryCode = "ZA")
+            countryCode = "ZA",
+            timeZone = timeZone,
+        )
     val expected =
         updates.copy(
             createdBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -148,11 +148,15 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchByAuthId returns existing user without touching Keycloak`() {
-    insertUser(authId = authId)
+    val timeZone = insertTimeZone()
+    insertUser(authId = authId, firstName = "f", lastName = "l", timeZone = timeZone)
 
     val actual = userStore.fetchByAuthId(authId) as IndividualUser
 
-    assertEquals(authId, actual.authId)
+    assertEquals(authId, actual.authId, "Auth ID")
+    assertEquals("f", actual.firstName, "First name")
+    assertEquals("l", actual.lastName, "Last name")
+    assertEquals(timeZone, actual.timeZone, "Time zone")
   }
 
   @Test
@@ -348,6 +352,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   fun `updateUser updates profile information`() {
     val newFirstName = "Testy"
     val newLastName = "McTestalot"
+    val newTimeZone = insertTimeZone()
 
     insertUser(authId = userRepresentation.id, email = userRepresentation.email)
 
@@ -364,7 +369,8 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
             email = "newemail@x.com",
             firstName = newFirstName,
             lastName = newLastName,
-            emailNotificationsEnabled = true)
+            emailNotificationsEnabled = true,
+            timeZone = newTimeZone)
     userStore.updateUser(modelWithEdits)
 
     val updatedModel = userStore.fetchOneById(model.userId) as IndividualUser
@@ -372,6 +378,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(oldEmail, updatedModel.email, "Email (DB)")
     assertEquals(newFirstName, updatedModel.firstName, "First name (DB)")
     assertEquals(newLastName, updatedModel.lastName, "Last name (DB)")
+    assertEquals(newTimeZone, updatedModel.timeZone, "Time zone (DB)")
     assertTrue(updatedModel.emailNotificationsEnabled, "Email notifications enabled (DB)")
 
     val updatedRepresentation = representationSlot.captured

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -711,6 +711,7 @@ abstract class DatabaseTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: id?.let { "Site $id" } ?: "Site ${nextPlantingSiteNumber++}",
+      timeZone: ZoneId? = row.timeZone,
   ): PlantingSiteId {
     val rowWithDefaults =
         row.copy(
@@ -722,6 +723,7 @@ abstract class DatabaseTest {
             modifiedTime = modifiedTime,
             name = name,
             organizationId = organizationId.toIdWrapper { OrganizationId(it) },
+            timeZone = timeZone,
         )
 
     plantingSitesDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -38,6 +38,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
+import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -862,6 +863,12 @@ abstract class DatabaseTest {
     plantingsDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!
+  }
+
+  fun insertTimeZone(timeZone: Any = ZoneId.of("Pacific/Honolulu")): ZoneId {
+    val zoneId = if (timeZone is ZoneId) timeZone else ZoneId.of("$timeZone")
+    timeZonesDao.insert(TimeZonesRow(zoneId))
+    return zoneId
   }
 
   class DockerPostgresDataSourceInitializer :

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -831,6 +831,19 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
       }
     }
 
+    val orgTimeZone = "Asia/Tokyo"
+    val facilityTimeZone = "Africa/Nairobi"
+    val userTimeZone = "America/Santiago"
+
+    organizationsDao.update(
+        organizationsDao
+            .fetchOneById(organizationId)!!
+            .copy(timeZone = insertTimeZone(orgTimeZone)))
+    facilitiesDao.update(
+        facilitiesDao.fetchOneById(facilityId)!!.copy(timeZone = insertTimeZone(facilityTimeZone)))
+    usersDao.update(
+        usersDao.fetchOneById(user.userId)!!.copy(timeZone = insertTimeZone(userTimeZone)))
+
     val cutTestRow =
         ViabilityTestsRow(
             accessionId = AccessionId(1000),
@@ -947,6 +960,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 "description" to "Description 100",
                 "id" to "100",
                 "name" to "Facility 100",
+                "timeZone" to facilityTimeZone,
                 "type" to "Seed Bank",
             ))
 
@@ -962,7 +976,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     mapOf(
                         "createdTime" to "1970-01-01T00:00:00Z",
                         "roleName" to "Manager",
-                    )))
+                    )),
+            "timeZone" to userTimeZone,
+        )
 
     val expectedOrganizationUsers =
         listOf(
@@ -981,6 +997,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 "name" to "Organization 1",
                 "members" to expectedOrganizationUsers,
                 "species" to expectedSpecies,
+                "timeZone" to orgTimeZone,
             ))
 
     val result = searchService.search(prefix, fields, NoConditionNode())


### PR DESCRIPTION
Allow clients to query the time zones of organizations, facilities, planting
sites, and users.