### PR TITLE
Fix timeseries.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,10 +73,10 @@ usually reasonable since it means you can run it like:
 ./timeseries.py --session SESSION_COOKIE_VALUE
 ```
 
-or, if you have an access token from Keycloak:
+or, if you have a refresh token from Keycloak:
 
 ```
-./timeseries.py --bearer ACCESS_TOKEN_VALUE
+./timeseries.py --refresh-token REFRESH_TOKEN_VALUE
 ```
 
 To simulate a device manager submitting new data periodically, you can run it in a loop

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -228,8 +228,13 @@ def add_terraware_args(parser: ArgumentParser):
 
 
 def client_from_args(args: Namespace) -> TerrawareClient:
+    refresh_token = args.refresh_token or os.getenv("TERRAWARE_REFRESH_TOKEN")
+
+    if not refresh_token and not args.session:
+        raise Exception("Must specify --refresh-token or --session")
+
     return TerrawareClient(
-        args.refresh_token or os.getenv("TERRAWARE_REFRESH_TOKEN"),
+        refresh_token,
         args.session,
         args.url,
     )

--- a/scripts/timeseries.py
+++ b/scripts/timeseries.py
@@ -214,13 +214,6 @@ def main():
 
     args = parser.parse_args()
 
-    if not args.bearer and not args.session:
-        print(
-            "Must specify either --bearer or --session to authenticate to server",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     client = client_from_args(args)
 
     if args.device:


### PR DESCRIPTION
Commit 16cf9a08 added support for passing offline refresh tokens to the various
scripts in the `scripts` directory, replacing the old support for bearer tokens.
But `timeseries.py` wasn't updated accordingly. It had an explicit check that
tested for the bearer token command-line argument, which caused it to bomb out.