### PR TITLE
SW-2634 Allow advancing test clock by minutes or hours

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -619,10 +619,29 @@ class AdminController(
   }
 
   @PostMapping("/advanceTestClock")
-  fun advanceTestClock(@RequestParam days: Long, redirectAttributes: RedirectAttributes): String {
-    clock.advance(Duration.ofDays(days))
-    val daysWord = if (days == 1L) "day" else "days"
-    redirectAttributes.successMessage = "Clock advanced by $days $daysWord."
+  fun advanceTestClock(
+      @RequestParam quantity: Long,
+      @RequestParam units: String,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    val duration =
+        when (units) {
+          "M" -> Duration.ofMinutes(quantity)
+          "H" -> Duration.ofHours(quantity)
+          "D" -> Duration.ofDays(quantity)
+          else -> Duration.parse("PT$quantity$units")
+        }
+    val prettyDuration =
+        when (units) {
+          "M" -> if (quantity == 1L) "1 minute" else "$quantity minutes"
+          "H" -> if (quantity == 1L) "1 hour" else "$quantity hours"
+          "D" -> if (quantity == 1L) "1 day" else "$quantity days"
+          else -> "$duration"
+        }
+
+    clock.advance(duration)
+
+    redirectAttributes.successMessage = "Clock advanced by $prettyDuration."
     return testClock()
   }
 

--- a/src/main/resources/templates/admin/testClock.html
+++ b/src/main/resources/templates/admin/testClock.html
@@ -18,8 +18,13 @@
 <p>
 <form method="POST" th:action="|${prefix}/advanceTestClock|">
     Advance clock by
-    <input name="days" size="2" maxlength="2" type="text" value="1"/>
-    day(s):
+    <input name="quantity" size="2" maxlength="2" type="text" value="1"/>
+    <select name="units">
+        <option value="D">days</option>
+        <option value="H">hours</option>
+        <option value="M">minutes</option>
+    </select>
+    :
     <input type="submit" value="Do It!"/>
 </form>
 


### PR DESCRIPTION
When testing time zone support, it is useful to be able to advance the test clock
by increments of less than one day so as to trigger notifications in some time
zones but not others.

Add a units selector to the admin UI's test clock page.