### PR TITLE
Don't rely on result order in SpeciesImporterTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -557,7 +557,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
         )
 
     val actual = speciesDao.findAll()
-    assertEquals(expected, actual)
+    assertEquals(expected.toSet(), actual.toSet())
     assertStatus(UploadStatus.Completed)
   }
 


### PR DESCRIPTION
`SpeciesImporterTest` had an implicit assumption that unordered database query
results would be returned in a particular order. This caused the test to fail
sporadically.