### PR TITLE
Add test fixture for Clock

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/TestClock.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestClock.kt
@@ -1,0 +1,18 @@
+package com.terraformation.backend
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/** Mutable clock for tests. Its time can be set on the fly; otherwise it acts as a fixed clock. */
+class TestClock(
+    var instant: Instant = Instant.EPOCH,
+    private val zone: ZoneId = ZoneOffset.UTC,
+) : Clock() {
+  override fun instant(): Instant = instant
+
+  override fun withZone(zone: ZoneId): Clock = TestClock(instant, zone)
+
+  override fun getZone(): ZoneId = zone
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.config.TerrawareServerConfig
@@ -49,10 +50,8 @@ import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import com.terraformation.backend.seedbank.model.AccessionModel
 import io.mockk.every
 import io.mockk.mockk
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
-import java.time.ZoneOffset
 import org.jooq.Record
 import org.jooq.Table
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -71,7 +70,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   private val otherUserId = UserId(100)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val messages: Messages = mockk()
   private val realmResource: RealmResource = mockk()
 
@@ -139,8 +138,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             messages,
             webAppUrls)
 
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
     every { messages.userAddedToOrganizationNotification(any()) } returns
         NotificationMessage("organization title", "organization body")
     every { messages.accessionDryingEndNotification(any()) } returns

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.config.TerrawareServerConfig
@@ -28,7 +29,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 import org.jobrunr.jobs.JobId
@@ -52,7 +52,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Autowired private lateinit var config: TerrawareServerConfig
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private lateinit var organizationStore: OrganizationStore
   private lateinit var parentStore: ParentStore
   private val publisher = TestEventPublisher()
@@ -87,7 +87,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
         OrganizationService(
             dslContext, organizationStore, publisher, scheduler, SystemUser(usersDao), userStore)
 
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateFacility(any()) } returns true
     every { user.canCreateStorageLocation(any()) } returns true
     every { user.canDeleteOrganization(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTaskTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTaskTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.daily
 
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
@@ -7,7 +8,6 @@ import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.UserId
 import io.mockk.every
 import io.mockk.mockk
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,15 +16,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class NotificationsCleanupTaskTest : DatabaseTest() {
-  private val clock: Clock = mockk()
   private val config: TerrawareServerConfig = mockk()
   private val now = Instant.parse("2021-01-01T00:00:00Z")
+  private val clock = TestClock(now)
 
   private lateinit var notificationsCleanupTask: NotificationsCleanupTask
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns now
     every { config.notifications.retentionDays } returns 1
 
     notificationsCleanupTask = NotificationsCleanupTask(clock, config, dslContext)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -9,9 +10,6 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,7 +17,7 @@ import org.junit.jupiter.api.Test
 internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val objectMapper = jacksonObjectMapper()
   private val store: AutomationStore by lazy {
     AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext))
@@ -29,7 +27,6 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canListAutomations(any()) } returns true
     every { user.canReadDevice(any()) } returns true
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.event.UserDeletionStartedEvent
 import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.customer.model.NotificationModel
@@ -16,9 +17,7 @@ import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATI
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
 import java.net.URI
-import java.time.Clock
 import java.time.Instant
 import org.jooq.Record
 import org.jooq.Table
@@ -37,7 +36,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(NOTIFICATIONS, ORGANIZATIONS)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private lateinit var permissionStore: PermissionStore
   private lateinit var store: NotificationStore
 
@@ -73,7 +72,6 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     permissionStore = PermissionStore(dslContext)
     store = NotificationStore(dslContext, clock)
-    every { clock.instant() } returns Instant.EPOCH
 
     every { user.canReadOrganization(any()) } returns true
     every { user.canCreateNotification(any(), any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
@@ -24,8 +25,6 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import org.jooq.JSONB
@@ -43,7 +42,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(ORGANIZATIONS)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private lateinit var permissionStore: PermissionStore
   private val publisher = TestEventPublisher()
   private lateinit var store: OrganizationStore
@@ -80,8 +79,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     permissionStore = PermissionStore(dslContext)
     store = OrganizationStore(clock, dslContext, organizationsDao, publisher)
-
-    every { clock.instant() } returns Instant.EPOCH
 
     every { user.canReadOrganization(any()) } returns true
     every { user.canUpdateOrganization(any()) } returns true
@@ -252,7 +249,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `update populates organization details`() {
     val newTime = clock.instant().plusSeconds(1000)
-    every { clock.instant() } returns newTime
+    clock.instant = newTime
 
     val newUserId = UserId(101)
     insertUser(newUserId)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.config.TerrawareServerConfig
@@ -60,7 +61,7 @@ import org.springframework.security.access.AccessDeniedException
  * [InMemoryKeycloakUsersResource].
  */
 internal class UserStoreTest : DatabaseTest(), RunsAsUser {
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val config: TerrawareServerConfig = mockk()
   private val objectMapper = jacksonObjectMapper()
   private val publisher = TestEventPublisher()
@@ -100,8 +101,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
     every { config.keycloak } returns keycloakConfig
     every { realmResource.users() } returns usersResource
 

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.device
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.AutomationStore
 import com.terraformation.backend.customer.db.FacilityStore
@@ -21,8 +22,6 @@ import com.terraformation.backend.device.db.DeviceStore
 import com.terraformation.backend.device.event.DeviceUnresponsiveEvent
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import org.jooq.JSONB
@@ -38,7 +37,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences = listOf(DEVICES)
   override val user: TerrawareUser = mockUser()
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val objectMapper = jacksonObjectMapper()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
@@ -117,7 +116,6 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateAutomation(any()) } returns true
     every { user.canCreateDevice(any()) } returns true
     every { user.canDeleteAutomation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.device.balena
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -13,7 +14,6 @@ import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.Clock
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -23,7 +23,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val balenaClient: BalenaClient = mockk()
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
 
   private val poller: BalenaPoller by lazy {
     BalenaPoller(
@@ -36,7 +36,6 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { balenaClient.listModifiedDevices(any()) } returns emptyList()
 
     insertSiteData()
@@ -112,7 +111,7 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
 
     val existingRow = insertDeviceManager(456, balenaId = device.id, facilityId = 100)
 
-    every { clock.instant() } returns Instant.ofEpochSecond(200)
+    clock.instant = Instant.ofEpochSecond(200)
     every { balenaClient.listModifiedDevices(any()) } returns listOf(device)
 
     poller.updateBalenaDevices()

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.device.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.DeviceManagerNotFoundException
@@ -11,8 +12,6 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceManagersRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Instant
 import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -26,7 +25,7 @@ import org.springframework.security.access.AccessDeniedException
 internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val store: DeviceManagerStore by lazy {
     DeviceManagerStore(clock, deviceManagersDao, dslContext)
   }
@@ -35,7 +34,6 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateDeviceManager() } returns true
     every { user.canReadDeviceManager(any()) } returns true
     every { user.canReadFacility(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/file/PhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/PhotoServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -23,7 +24,6 @@ import java.net.URI
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.time.Clock
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import kotlin.io.path.Path
@@ -42,7 +42,7 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.MediaType
 
 class PhotoServiceTest : DatabaseTest(), RunsAsUser {
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val config: TerrawareServerConfig = mockk()
   private lateinit var fileStore: FileStore
   private lateinit var pathGenerator: PathGenerator
@@ -65,7 +65,7 @@ class PhotoServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     tempDir = Files.createTempDirectory(javaClass.simpleName)
 
-    every { clock.instant() } returns uploadedTime
+    clock.instant = uploadedTime
     every { config.photoDir } returns tempDir
     every { config.photoIntermediateDepth } returns 3
 

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
@@ -23,7 +24,6 @@ import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.net.URI
 import java.nio.file.NoSuchFileException
-import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
@@ -36,7 +36,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
   override val tablesToResetSequences = listOf(UPLOADS)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val fileStore: FileStore = mockk()
   private val uploadStore: UploadStore by lazy {
     UploadStore(dslContext, uploadProblemsDao, uploadsDao)
@@ -50,7 +50,6 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canReadUpload(any()) } returns true
     every { user.canUpdateUpload(any()) } returns true
     every { user.canDeleteUpload(any()) } returns true
@@ -144,7 +143,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
     val recentStorageUrl = URI.create("file:///recent")
     val now = Instant.EPOCH + Duration.ofDays(30)
 
-    every { clock.instant() } returns now
+    clock.instant = now
     every { fileStore.delete(twoWeekOldStorageUrl) } just Runs
     every { fileStore.delete(weekOldStorageUrl) } just Runs
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
@@ -12,9 +13,6 @@ import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.tracking.db.DeliveryStore
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -24,7 +22,7 @@ import org.junit.jupiter.api.assertThrows
 internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val service: BatchService by lazy {
     val parentStore = ParentStore(dslContext)
     BatchService(
@@ -47,7 +45,6 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateDelivery(any()) } returns true
     every { user.canReadBatch(any()) } returns true
     every { user.canUpdateBatch(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.DatabaseTest
@@ -21,11 +22,7 @@ import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.SearchSortField
 import com.terraformation.backend.search.table.SearchTables
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -35,15 +32,12 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
   override val tablesToResetSequences = listOf(BATCHES)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val searchService: SearchService by lazy { SearchService(dslContext) }
   private val searchTables: SearchTables by lazy { SearchTables(clock) }
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
-
     insertUser()
     insertOrganization(organizationId)
     insertOrganizationUser(user.userId, organizationId, Role.MANAGER)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
@@ -31,7 +32,6 @@ import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -49,7 +49,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(BATCHES, SPECIES, UPLOAD_PROBLEMS)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val fileStore: FileStore = mockk()
   private val scheduler: JobScheduler = mockk()
   private val uploadService: UploadService = mockk()
@@ -97,7 +97,6 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     val userId = user.userId
 
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateBatch(any()) } returns true
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadFacility(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -51,7 +51,7 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
     insertBatchWithdrawal(batchId = remainingBatchId, withdrawalId = multipleBatchWithdrawalId)
 
     val deleteTime = clock.instant().plusSeconds(60)
-    every { clock.instant() } returns deleteTime
+    clock.instant = deleteTime
 
     val expectedBatchWithdrawals = batchWithdrawalsDao.fetchByBatchId(remainingBatchId)
     val expectedWithdrawals =

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
@@ -12,11 +13,7 @@ import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HI
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.junit.jupiter.api.BeforeEach
 
 internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
@@ -24,7 +21,7 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
 
   override val tablesToResetSequences = listOf(BATCHES, BATCH_QUANTITY_HISTORY)
 
-  protected val clock: Clock = mockk()
+  protected val clock = TestClock()
   protected val store: BatchStore by lazy {
     BatchStore(
         batchesDao,
@@ -47,8 +44,6 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
     insertFacility(name = "Nursery", type = FacilityType.Nursery)
     insertSpecies(speciesId)
 
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
     every { user.canCreateBatch(any()) } returns true
     every { user.canReadBatch(any()) } returns true
     every { user.canReadSpecies(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.nursery.db.batchStore
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.nursery.db.BatchStaleException
-import io.mockk.every
 import java.time.Instant
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -23,7 +22,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
         readyQuantity = 1,
         speciesId = speciesId)
 
-    every { clock.instant() } returns updateTime
+    clock.instant = updateTime
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.nursery.db.BatchStaleException
-import io.mockk.every
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +19,7 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
   fun setUpTestBatch() {
     insertBatch(id = batchId, readyQuantity = 1, speciesId = speciesId)
 
-    every { clock.instant() } returns updateTime
+    clock.instant = updateTime
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -65,7 +65,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
     val species2Batch1 = batchesDao.fetchOneById(species2Batch1Id)!!
 
     val withdrawalTime = clock.instant().plusSeconds(1000)
-    every { clock.instant() } returns withdrawalTime
+    clock.instant = withdrawalTime
 
     val withdrawal =
         store.withdraw(
@@ -181,7 +181,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
     batchesDao.update(species1Batch1)
 
     val withdrawalTime = Instant.EPOCH.plus(4, ChronoUnit.DAYS)
-    every { clock.instant() } returns withdrawalTime
+    clock.instant = withdrawalTime
 
     val withdrawal =
         store.withdraw(
@@ -387,7 +387,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
 
     val newReadyByDate = LocalDate.of(2000, 1, 2)
     val withdrawalTime = clock.instant().plusSeconds(1000)
-    every { clock.instant() } returns withdrawalTime
+    clock.instant = withdrawalTime
 
     val withdrawal =
         store.withdraw(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -27,10 +28,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -45,7 +44,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
 
   private val accessionStore: AccessionStore = mockk()
   private val batchStore: BatchStore = mockk()
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val parentStore: ParentStore = mockk()
   private val photoRepository: PhotoRepository = mockk()
 
@@ -67,8 +66,6 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     every { accessionStore.delete(any()) } just Runs
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
     every { photoRepository.deleteAllPhotos(any()) } just Runs
     every { user.canDeleteAccession(any()) } returns true
     every { user.canReadAccession(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/api/ValuesControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.api
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -14,9 +15,6 @@ import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.db.StorageLocationStore
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,7 +22,7 @@ import org.junit.jupiter.api.Test
 internal class ValuesControllerTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val controller: ValuesController by lazy {
     ValuesController(
         SearchTables(clock), StorageLocationStore(dslContext), SearchService(dslContext))
@@ -32,8 +30,6 @@ internal class ValuesControllerTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
-
     insertSiteData()
 
     insertOrganizationUser(user.userId, organizationId)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
@@ -32,7 +33,6 @@ import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.time.Clock
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import kotlin.io.path.Path
@@ -51,7 +51,6 @@ import org.springframework.security.access.AccessDeniedException
 
 class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private lateinit var accessionStore: AccessionStore
-  private val clock: Clock = mockk()
   private val config: TerrawareServerConfig = mockk()
   private lateinit var fileStore: FileStore
   private lateinit var pathGenerator: PathGenerator
@@ -72,6 +71,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private val filename = "test-photo.jpg"
   private val uploadedTime = ZonedDateTime.of(2021, 2, 3, 4, 5, 6, 0, ZoneOffset.UTC).toInstant()
   private val metadata = PhotoMetadata(filename, contentType, 1L)
+  private val clock = TestClock(uploadedTime)
 
   @BeforeEach
   fun setUp() {
@@ -90,7 +90,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
     tempDir = Files.createTempDirectory(javaClass.simpleName)
 
-    every { clock.instant() } returns uploadedTime
     every { config.photoDir } returns tempDir
     every { config.photoIntermediateDepth } returns 3
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
@@ -25,9 +26,7 @@ import com.terraformation.backend.seedbank.milligrams
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
 import io.mockk.every
-import io.mockk.mockk
 import java.math.BigDecimal
-import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import org.jooq.Record
@@ -42,7 +41,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var store: WithdrawalStore
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
 
   private val accessionId = AccessionId(9999)
   private val viabilityTestId = ViabilityTestId(9998)
@@ -54,7 +53,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   fun setup() {
     store = WithdrawalStore(dslContext, clock, Messages(), ParentStore(dslContext))
 
-    every { clock.instant() } returns Instant.ofEpochSecond(1000)
+    clock.instant = Instant.ofEpochSecond(1000)
     every { user.canReadAccession(any()) } returns true
     every { user.canReadOrganization(organizationId) } returns true
     every { user.canReadOrganizationUser(organizationId, any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
 import com.terraformation.backend.seedbank.model.AccessionModel
-import io.mockk.every
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -42,10 +41,10 @@ internal class AccessionStoreCheckInTest : AccessionStoreTest() {
     val accessionId = create().id!!
     val checkInTime = Instant.ofEpochSecond(10)
 
-    every { clock.instant() } returns checkInTime
+    clock.instant = checkInTime
     store.checkIn(accessionId)
 
-    every { clock.instant() } returns Instant.ofEpochSecond(30)
+    clock.instant = Instant.ofEpochSecond(30)
     store.checkIn(accessionId)
 
     val updatedRow = accessionsDao.fetchOneById(accessionId)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -91,24 +91,24 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     insertUser(firstWithdrawerUserId, firstName = "First", lastName = "Withdrawer")
     insertUser(viabilityTesterUserId, firstName = "Viability", lastName = "Tester")
 
-    every { clock.instant() } returns createTime
+    clock.instant = createTime
     every { user.userId } returns createUserId
 
     val initial = store.create(AccessionModel(facilityId = facilityId))
 
-    every { clock.instant() } returns checkInTime
+    clock.instant = checkInTime
     every { user.userId } returns checkInUserId
 
     store.checkIn(initial.id!!)
 
-    every { clock.instant() } returns processTime
+    clock.instant = processTime
     every { user.userId } returns processUserId
 
     val withSeedQuantity =
         store.updateAndFetch(
             initial.copy(remaining = seeds(100), state = AccessionState.Processing))
 
-    every { clock.instant() } returns firstWithdrawalTime
+    clock.instant = firstWithdrawalTime
 
     val withFirstWithdrawal =
         store.updateAndFetch(
@@ -121,7 +121,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
                             withdrawn = seeds(1),
                             withdrawnByUserId = firstWithdrawerUserId))))
 
-    every { clock.instant() } returns secondWithdrawalTime
+    clock.instant = secondWithdrawalTime
 
     val withSecondWithdrawal =
         store.updateAndFetch(
@@ -134,7 +134,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
                             testType = ViabilityTestType.Lab,
                             withdrawnByUserId = viabilityTesterUserId))))
 
-    every { clock.instant() } returns backdatedWithdrawalTime
+    clock.instant = backdatedWithdrawalTime
 
     store.updateAndFetch(
         withSecondWithdrawal.copy(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
@@ -24,12 +25,8 @@ import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.seeds
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.jooq.Record
 import org.jooq.Table
 import org.junit.jupiter.api.BeforeEach
@@ -48,7 +45,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             SPECIES,
             WITHDRAWALS)
 
-  protected val clock: Clock = mockk()
+  protected val clock = TestClock()
 
   protected lateinit var store: AccessionStore
   protected lateinit var parentStore: ParentStore
@@ -56,9 +53,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   protected fun init() {
     parentStore = ParentStore(dslContext)
-
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
 
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(organizationId) } returns true
@@ -143,7 +137,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
    */
   protected fun AccessionModel.andAdvanceClock(duration: Duration): AccessionModel {
     val desiredTime = clock.instant() + duration
-    every { clock.instant() } returns desiredTime
+    clock.instant = desiredTime
     return this
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -19,7 +20,6 @@ import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
-import java.time.Clock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,7 +31,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
   private val accessionStore: AccessionStore by lazy {
     AccessionStore(dslContext, mockk(), mockk(), mockk(), mockk(), mockk(), clock, mockk(), mockk())
   }
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val searchService: SearchService by lazy { SearchService(dslContext) }
   private val searchTables: SearchTables by lazy { SearchTables(clock) }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -29,11 +30,8 @@ import com.terraformation.backend.search.SearchSortField
 import com.terraformation.backend.search.field.AliasField
 import com.terraformation.backend.search.table.SearchTables
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.jooq.Record
 import org.jooq.Table
 import org.junit.jupiter.api.BeforeEach
@@ -49,7 +47,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected val checkedTime = Instant.parse(checkedTimeString)
   protected val searchScopes = listOf(OrganizationIdScope(organizationId))
 
-  protected val clock: Clock = mockk()
+  protected val clock = TestClock()
 
   protected val tables = SearchTables(clock)
   protected val accessionsTable = tables.accessions
@@ -78,8 +76,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected fun init() {
     searchService = SearchService(dslContext)
 
-    every { clock.instant() } returns Instant.parse("2020-06-15T00:00:00.00Z")
-    every { clock.zone } returns ZoneOffset.UTC
+    clock.instant = Instant.parse("2020-06-15T00:00:00.00Z")
     every { user.organizationRoles } returns mapOf(organizationId to Role.MANAGER)
     every { user.facilityRoles } returns mapOf(facilityId to Role.MANAGER)
 

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.species
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -13,14 +14,12 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.Clock
-import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   override val user: TerrawareUser = mockUser()
 
   private val speciesStore: SpeciesStore by lazy {
@@ -33,7 +32,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { speciesChecker.checkSpecies(any()) } just Runs
     every { speciesChecker.recheckSpecies(any(), any()) } just Runs
     every { user.canCreateSpecies(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.species.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -17,8 +18,6 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblems
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -30,7 +29,7 @@ import org.springframework.dao.DuplicateKeyException
 import org.springframework.security.access.AccessDeniedException
 
 internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   override val user: TerrawareUser = mockUser()
 
   private lateinit var store: SpeciesStore
@@ -38,8 +37,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     store = SpeciesStore(clock, dslContext, speciesDao, speciesProblemsDao)
-
-    every { clock.instant() } returns Instant.EPOCH
 
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
@@ -141,7 +138,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         )
 
     val newInstant = Instant.ofEpochSecond(500)
-    every { clock.instant() } returns newInstant
+    clock.instant = newInstant
 
     val reusedSpeciesId = store.createSpecies(editedRow)
 
@@ -194,7 +191,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val bogusUserId = UserId(10000)
 
     val newInstant = Instant.ofEpochSecond(500)
-    every { clock.instant() } returns newInstant
+    clock.instant = newInstant
 
     val update =
         SpeciesRow(

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.model.Role
 import com.terraformation.backend.db.DatabaseTest
@@ -18,10 +19,6 @@ import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
 import io.mockk.every
-import io.mockk.mockk
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -32,15 +29,12 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
   override val tablesToResetSequences = listOf(PLANTING_SITES, PLANTING_ZONES, PLOTS)
 
-  private val clock: Clock = mockk()
+  private val clock = TestClock()
   private val searchService: SearchService by lazy { SearchService(dslContext) }
   private val searchTables: SearchTables by lazy { SearchTables(clock) }
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
-    every { clock.zone } returns ZoneOffset.UTC
-
     insertUser()
     insertOrganization()
     insertOrganizationUser()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -17,9 +18,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.model.DeliveryModel
 import com.terraformation.backend.tracking.model.PlantingModel
 import io.mockk.every
-import io.mockk.mockk
 import java.time.Instant
-import java.time.InstantSource
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -31,7 +30,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
   override val tablesToResetSequences = listOf(DELIVERIES, PLANTINGS)
 
-  private val clock: InstantSource = mockk()
+  private val clock = TestClock()
   private val store: DeliveryStore by lazy {
     DeliveryStore(clock, deliveriesDao, dslContext, ParentStore(dslContext), plantingsDao)
   }
@@ -45,7 +44,6 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreateDelivery(any()) } returns true
     every { user.canReadDelivery(any()) } returns true
     every { user.canReadPlanting(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -14,9 +15,7 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.PlantingSiteImporter.ValidationOption
 import com.terraformation.backend.tracking.model.Shapefile
 import io.mockk.every
-import io.mockk.mockk
 import java.time.Instant
-import java.time.InstantSource
 import kotlin.io.path.Path
 import org.jooq.Record
 import org.jooq.Table
@@ -34,7 +33,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(PLANTING_SITES, PLANTING_ZONES, PLOTS)
 
-  private val clock: InstantSource = mockk()
+  private val clock = TestClock()
   private val importer: PlantingSiteImporter by lazy {
     PlantingSiteImporter(clock, dslContext, plantingSitesDao, plantingZonesDao, plotsDao)
   }
@@ -43,7 +42,6 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    every { clock.instant() } returns Instant.EPOCH
     every { user.canCreatePlantingSite(any()) } returns true
 
     insertUser()


### PR DESCRIPTION
We've been using MockK to stub out `Clock` objects for testing. That works fine
when the application code just reads scalar values from the clock, but we're
shortly going to start calling `Clock.withZone()` in some places and that's
more awkward to stub out with MockK.

Replace the MockK stubs with a dedicated test class.

Most of the edits here are mechanical:

* Replace `val clock: Clock = mockk()` with `val clock = TestClock()`.
* Delete `every { clock.instant() } returns Instant.EPOCH` and
  `every { clock.zone } returns ZoneOffset.UTC` because they are the defaults.
* Replace `every { clock.instant() } returns` with `clock.instant =` for tests
  that need to change the clock on the fly.

In a few places, manual tweaking was required, e.g., passing an `Instant` to
the constructor in tests that don't use `Instant.EPOCH`.