### PR TITLE
SW-2636 Use seed bank time zone in accession history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -425,6 +425,10 @@ class FacilityStore(
     return facility.copy(nextNotificationTime = nextNotificationTime)
   }
 
+  fun getClock(facilityId: FacilityId): Clock {
+    return clock.withZone(fetchEffectiveTimeZone(fetchOneById(facilityId)))
+  }
+
   fun fetchEffectiveTimeZone(facility: FacilityModel): ZoneId {
     return fetchEffectiveTimeZone(facility.timeZone, facility.organizationId)
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -39,6 +39,8 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import java.time.ZoneId
+import java.time.ZoneOffset
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -126,6 +128,14 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getDeviceManagerId(userId: UserId): DeviceManagerId? =
       fetchFieldById(userId, DEVICE_MANAGERS.USER_ID, DEVICE_MANAGERS.ID)
+
+  fun getEffectiveTimeZone(accessionId: AccessionId): ZoneId =
+      fetchFieldById(
+          accessionId,
+          ACCESSIONS.ID,
+          DSL.coalesce(
+              ACCESSIONS.facilities.TIME_ZONE, ACCESSIONS.facilities.organizations.TIME_ZONE))
+          ?: ZoneOffset.UTC
 
   fun exists(deviceManagerId: DeviceManagerId): Boolean =
       fetchFieldById(deviceManagerId, DEVICE_MANAGERS.ID, DSL.one()) != null

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -24,7 +24,6 @@ import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import java.math.BigDecimal
-import java.time.Clock
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.Record1
@@ -35,7 +34,6 @@ import org.jooq.impl.DSL
 class AccessionService(
     private val accessionStore: AccessionStore,
     private val batchStore: BatchStore,
-    private val clock: Clock,
     private val dslContext: DSLContext,
     private val parentStore: ParentStore,
     private val photoRepository: PhotoRepository,
@@ -60,7 +58,7 @@ class AccessionService(
     val accessionId =
         withdrawal.accessionId ?: throw IllegalArgumentException("Accession ID must be non-null")
 
-    return updateAccession(accessionId) { it.addWithdrawal(withdrawal, clock) }
+    return updateAccession(accessionId) { it.addWithdrawal(withdrawal) }
   }
 
   fun updateWithdrawal(
@@ -68,11 +66,11 @@ class AccessionService(
       withdrawalId: WithdrawalId,
       modify: (WithdrawalModel) -> WithdrawalModel
   ): AccessionModel {
-    return updateAccession(accessionId) { it.updateWithdrawal(withdrawalId, clock, modify) }
+    return updateAccession(accessionId) { it.updateWithdrawal(withdrawalId, modify) }
   }
 
   fun deleteWithdrawal(accessionId: AccessionId, withdrawalId: WithdrawalId): AccessionModel {
-    return updateAccession(accessionId) { it.deleteWithdrawal(withdrawalId, clock) }
+    return updateAccession(accessionId) { it.deleteWithdrawal(withdrawalId) }
   }
 
   /**
@@ -140,11 +138,7 @@ class AccessionService(
     val accessionId =
         viabilityTest.accessionId ?: throw IllegalArgumentException("Accession ID must be non-null")
 
-    // We create withdrawals for viability tests. If the new test doesn't have a start date, the
-    // withdrawal's date will default to today. We need "today" to be in the seed bank's time zone.
-    val facilityClock = clock.withZone(parentStore.getEffectiveTimeZone(accessionId))
-
-    return updateAccession(accessionId) { it.addViabilityTest(viabilityTest, facilityClock) }
+    return updateAccession(accessionId) { it.addViabilityTest(viabilityTest) }
   }
 
   fun updateViabilityTest(
@@ -152,14 +146,14 @@ class AccessionService(
       viabilityTestId: ViabilityTestId,
       modify: (ViabilityTestModel) -> ViabilityTestModel
   ): AccessionModel {
-    return updateAccession(accessionId) { it.updateViabilityTest(viabilityTestId, clock, modify) }
+    return updateAccession(accessionId) { it.updateViabilityTest(viabilityTestId, modify) }
   }
 
   fun deleteViabilityTest(
       accessionId: AccessionId,
       viabilityTestId: ViabilityTestId
   ): AccessionModel {
-    return updateAccession(accessionId) { it.deleteViabilityTest(viabilityTestId, clock) }
+    return updateAccession(accessionId) { it.deleteViabilityTest(viabilityTestId) }
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -140,7 +140,11 @@ class AccessionService(
     val accessionId =
         viabilityTest.accessionId ?: throw IllegalArgumentException("Accession ID must be non-null")
 
-    return updateAccession(accessionId) { it.addViabilityTest(viabilityTest, clock) }
+    // We create withdrawals for viability tests. If the new test doesn't have a start date, the
+    // withdrawal's date will default to today. We need "today" to be in the seed bank's time zone.
+    val facilityClock = clock.withZone(parentStore.getEffectiveTimeZone(accessionId))
+
+    return updateAccession(accessionId) { it.addViabilityTest(viabilityTest, facilityClock) }
   }
 
   fun updateViabilityTest(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
@@ -24,6 +24,9 @@ data class AccessionHistoryModel(
     /**
      * The effective date of the event. For example, if the event is a withdrawal, this would be the
      * withdrawal date entered by the user (which might not be the same day as [createdTime].)
+     *
+     * If the event's date was entered by the user, this is the user-entered date. If it is based on
+     * a timestamp, this date is in the seed bank's time zone.
      */
     val date: LocalDate,
     val description: String,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.util.compareNullsFirst
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneOffset
+import java.time.ZoneId
 import org.jooq.Record
 
 data class WithdrawalModel(
@@ -125,8 +125,8 @@ data class WithdrawalModel(
     }
   }
 
-  fun isAfter(instant: Instant): Boolean {
-    val instantDate = LocalDate.ofInstant(instant, ZoneOffset.UTC)
+  fun isAfter(instant: Instant, timeZone: ZoneId): Boolean {
+    val instantDate = LocalDate.ofInstant(instant, timeZone)
     return when {
       date < instantDate -> false
       date > instantDate -> true

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -206,7 +206,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertUser(otherUserId)
     insertOrganizationUser()
 
-    val accessionModel = accessionStore.create(AccessionModel(facilityId = facilityId))
+    val accessionModel =
+        accessionStore.create(AccessionModel(clock = clock, facilityId = facilityId))
     assertNotNull(accessionModel)
 
     service.on(AccessionDryingEndEvent(accessionModel.accessionNumber!!, accessionModel.id!!))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -55,7 +55,6 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
     AccessionService(
         accessionStore,
         batchStore,
-        clock,
         dslContext,
         parentStore,
         photoRepository,
@@ -108,6 +107,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
     private val withdrawalId = WithdrawalId(1)
     private val accessionWithOneWithdrawal =
         AccessionModel(
+            clock = clock,
             id = accessionId,
             facilityId = FacilityId(1),
             latestObservedQuantity = seeds(15),
@@ -172,7 +172,8 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `createViabilityTest uses facility time zone to determine default withdrawal date`() {
       val earlierZoneThanUtc = ZoneId.of("America/New_York")
-      every { parentStore.getEffectiveTimeZone(accessionId) } returns earlierZoneThanUtc
+      every { accessionStore.fetchOneById(accessionId) } returns
+          accessionWithOneWithdrawal.copy(clock = clock.withZone(earlierZoneThanUtc))
 
       val viabilityTest =
           ViabilityTestModel(accessionId = accessionId, testType = ViabilityTestType.Lab)
@@ -224,6 +225,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
 
     private val accession =
         AccessionModel(
+            clock = clock,
             id = accessionId,
             facilityId = seedBankFacilityId,
             latestObservedQuantity = seeds(10),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
+import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
@@ -20,6 +21,7 @@ import com.terraformation.backend.search.table.SearchTables
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.PhotoRepository
 import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import io.mockk.CapturingSlot
 import io.mockk.Runs
@@ -30,6 +32,7 @@ import io.mockk.slot
 import io.mockk.verify
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -164,6 +167,18 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
       assertNotNull(exceptionThrown, "Expected exception to be thrown")
       assertEquals(
           "Withdrawal quantity can't be more than remaining quantity", exceptionThrown?.message)
+    }
+
+    @Test
+    fun `createViabilityTest uses facility time zone to determine default withdrawal date`() {
+      val earlierZoneThanUtc = ZoneId.of("America/New_York")
+      every { parentStore.getEffectiveTimeZone(accessionId) } returns earlierZoneThanUtc
+
+      val viabilityTest =
+          ViabilityTestModel(accessionId = accessionId, testType = ViabilityTestType.Lab)
+      val updatedAccession = service.createViabilityTest(viabilityTest)
+
+      assertEquals(LocalDate.EPOCH.minusDays(1), updatedAccession.withdrawals[0].date)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -1,7 +1,9 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertJsonEquals
+import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
@@ -83,12 +85,23 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     )
   }
   private val clock: Clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+  private val facilityStore: FacilityStore by lazy {
+    FacilityStore(
+        clock,
+        mockk(),
+        dslContext,
+        TestEventPublisher(),
+        facilitiesDao,
+        organizationsDao,
+        storageLocationsDao)
+  }
   private val fileStore: FileStore = mockk()
   private val importer: AccessionImporter by lazy {
     AccessionImporter(
         accessionStore,
         countriesDao,
         dslContext,
+        facilityStore,
         fileStore,
         messages,
         parentStore,
@@ -122,6 +135,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateAccession(any()) } returns true
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadAccession(any()) } returns true
+    every { user.canReadFacility(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
     every { user.canReadSpecies(any()) } returns true
     every { user.canReadUpload(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.BagId
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
-import com.terraformation.backend.seedbank.model.AccessionModel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -12,7 +11,7 @@ import org.junit.jupiter.api.Test
 internal class AccessionStoreBagTest : AccessionStoreTest() {
   @Test
   fun `bag numbers are not shared between accessions`() {
-    val payload = AccessionModel(bagNumbers = setOf("bag 1", "bag 2"), facilityId = facilityId)
+    val payload = accessionModel(bagNumbers = setOf("bag 1", "bag 2"))
     store.create(payload)
     store.create(payload)
 
@@ -24,8 +23,7 @@ internal class AccessionStoreBagTest : AccessionStoreTest() {
 
   @Test
   fun `bags are inserted and deleted as needed`() {
-    val initial =
-        store.create(AccessionModel(bagNumbers = setOf("bag 1", "bag 2"), facilityId = facilityId))
+    val initial = store.create(accessionModel(bagNumbers = setOf("bag 1", "bag 2")))
     val initialBags = bagsDao.fetchByAccessionId(AccessionId(1))
 
     // Insertion order is not defined by the API, so don't assume bag ID 1 is "bag 1".

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
-import com.terraformation.backend.seedbank.model.AccessionModel
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,7 +11,7 @@ import org.junit.jupiter.api.Test
 internal class AccessionStoreCheckInTest : AccessionStoreTest() {
   @Test
   fun `checkIn of v2 accession transitions state to AwaitingProcessing`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     val updated = store.checkIn(initial.id!!)
 
     assertEquals(AccessionState.AwaitingProcessing, updated.state, "Accession state")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.fail
 internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   @Test
   fun `existing rows are used for free-text fields that live in reference tables`() {
-    val payload = AccessionModel(facilityId = facilityId, species = "test species")
+    val payload = accessionModel(species = "test species")
 
     // First time inserts the reference table rows
     val initialAccession = store.create(payload)
@@ -55,10 +55,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `update removes existing collectors if needed`() {
-    val initial =
-        store.create(
-            AccessionModel(
-                collectors = listOf("primary", "second1", "second2"), facilityId = facilityId))
+    val initial = store.create(accessionModel(collectors = listOf("primary", "second1", "second2")))
 
     store.update(initial.copy(collectors = listOf("second1")))
 
@@ -133,8 +130,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     insertSpecies(1)
     insertStorageLocation(1, name = storageLocationName)
 
-    val initial =
-        store.create(AccessionModel(facilityId = facilityId, source = DataSource.SeedCollectorApp))
+    val initial = store.create(accessionModel(source = DataSource.SeedCollectorApp))
     val stored = store.updateAndFetch(update.applyToModel(initial))
 
     accessionModelProperties
@@ -188,14 +184,14 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     insertSpecies(1)
     insertStorageLocation(1, name = storageLocationName)
 
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     val accessionId = initial.id!!
 
     val updated =
         update
             .applyToModel(initial)
-            .addViabilityTest(viabilityTest.toModel(accessionId), clock)
-            .addWithdrawal(withdrawal.toModel(accessionId), clock)
+            .addViabilityTest(viabilityTest.toModel(accessionId))
+            .addWithdrawal(withdrawal.toModel(accessionId))
     store.update(updated)
 
     store.delete(accessionId)
@@ -225,7 +221,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val commonName = "Test Common Name"
     insertSpecies(speciesId, scientificName = oldScientificName, commonName = commonName)
 
-    val initial = store.create(AccessionModel(facilityId = facilityId, speciesId = speciesId))
+    val initial = store.create(accessionModel(speciesId = speciesId))
 
     speciesDao.update(speciesDao.fetchOneById(speciesId)!!.copy(scientificName = newScientificName))
 
@@ -237,7 +233,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `dryRun does not persist changes`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId, species = "Initial Species"))
+    val initial = store.create(accessionModel(species = "Initial Species"))
     store.dryRun(initial.copy(species = "Modified Species"))
     val fetched = store.fetchOneById(initial.id!!)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistory
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
 import com.terraformation.backend.seedbank.model.AccessionHistoryModel
 import com.terraformation.backend.seedbank.model.AccessionHistoryType
-import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
@@ -29,8 +28,7 @@ import org.junit.jupiter.api.Test
 internal class AccessionStoreHistoryTest : AccessionStoreTest() {
   @Test
   fun `update creates quantity history row if remaining quantity is edited`() {
-    val initial =
-        store.create(AccessionModel(facilityId = facilityId, state = AccessionState.Processing))
+    val initial = store.create(accessionModel(state = AccessionState.Processing))
 
     store.update(initial.copy(latestObservedQuantityCalculated = false, remaining = seeds(10)))
 
@@ -50,9 +48,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
   @Test
   fun `update does not create quantity history row if remaining quantity is not edited`() {
     val initial =
-        store.create(
-            AccessionModel(
-                facilityId = facilityId, remaining = seeds(10), state = AccessionState.Processing))
+        store.create(accessionModel(remaining = seeds(10), state = AccessionState.Processing))
     val initialHistory = accessionQuantityHistoryDao.findAll()
 
     store.update(initial.copy(latestObservedQuantityCalculated = false, remaining = seeds(10)))
@@ -94,7 +90,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     clock.instant = createTime
     every { user.userId } returns createUserId
 
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     clock.instant = checkInTime
     every { user.userId } returns checkInUserId
@@ -231,7 +227,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
 
   @Test
   fun `state history row is inserted at creation time`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     val historyRecords =
         dslContext
             .selectFrom(ACCESSION_STATE_HISTORY)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreLocationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreLocationTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.seedbank.GeolocationId
 import com.terraformation.backend.db.seedbank.StorageCondition
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.tables.pojos.StorageLocationsRow
-import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.Geolocation
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,8 +17,7 @@ internal class AccessionStoreLocationTest : AccessionStoreTest() {
   fun `geolocations are inserted and deleted as needed`() {
     val initial =
         store.create(
-            AccessionModel(
-                facilityId = facilityId,
+            accessionModel(
                 geolocations =
                     setOf(
                         Geolocation(BigDecimal(1), BigDecimal(2), BigDecimal(100)),
@@ -72,7 +70,7 @@ internal class AccessionStoreLocationTest : AccessionStoreTest() {
             modifiedTime = clock.instant(),
             name = locationName))
 
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     store.update(initial.copy(storageLocation = locationName))
 
     assertEquals(
@@ -87,7 +85,7 @@ internal class AccessionStoreLocationTest : AccessionStoreTest() {
   @Test
   fun `unknown storage locations are rejected`() {
     assertThrows<IllegalArgumentException> {
-      val initial = store.create(AccessionModel(facilityId = facilityId))
+      val initial = store.create(accessionModel())
       store.update(initial.copy(storageLocation = "bogus"))
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
@@ -2,15 +2,13 @@ package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.seedbank.AccessionState
-import com.terraformation.backend.seedbank.model.AccessionModel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class AccessionStoreManualStateTest : AccessionStoreTest() {
   @Test
   fun `update allows state to be modified if isManualState flag is set`() {
-    val initial =
-        store.create(AccessionModel(facilityId = facilityId, state = AccessionState.Processing))
+    val initial = store.create(accessionModel(state = AccessionState.Processing))
 
     val updated = store.updateAndFetch(initial.copy(state = AccessionState.Drying))
 
@@ -19,9 +17,7 @@ internal class AccessionStoreManualStateTest : AccessionStoreTest() {
 
   @Test
   fun `update allows state to be changed from Awaiting Check-In if isManualState flag is set`() {
-    val initial =
-        store.create(
-            AccessionModel(facilityId = facilityId, state = AccessionState.AwaitingCheckIn))
+    val initial = store.create(accessionModel(state = AccessionState.AwaitingCheckIn))
 
     val updated = store.updateAndFetch(initial.copy(state = AccessionState.Drying))
 
@@ -35,7 +31,7 @@ internal class AccessionStoreManualStateTest : AccessionStoreTest() {
     insertSpecies(oldSpeciesId, "Old species")
     insertSpecies(newSpeciesId, "New species")
 
-    val initial = store.create(AccessionModel(facilityId = facilityId, speciesId = oldSpeciesId))
+    val initial = store.create(accessionModel(speciesId = oldSpeciesId))
     val updated =
         store.updateAndFetch(initial.copy(species = "Implicit species", speciesId = newSpeciesId))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.seedbank.model.AccessionModel
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -22,8 +21,8 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
 
   @Test
   fun `can create accessions with different facility IDs`() {
-    val accessionInMainFacility = store.create(AccessionModel(facilityId = facilityId))
-    val accessionInOtherFacility = store.create(AccessionModel(facilityId = otherFacilityId))
+    val accessionInMainFacility = store.create(accessionModel())
+    val accessionInOtherFacility = store.create(accessionModel(facilityId = otherFacilityId))
 
     assertNotEquals(
         accessionInMainFacility.accessionNumber,
@@ -41,7 +40,7 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
     insertFacility(anotherFacilityId)
 
     every { user.canUpdateAccession(any()) } returns true
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     store.update(initial.copy(facilityId = anotherFacilityId))
 
@@ -59,7 +58,7 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
     insertFacility(facilityIdInAnotherOrg, anotherOrgId)
 
     every { user.canUpdateAccession(any()) } returns true
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     assertThrows<FacilityNotFoundException> {
       store.update(initial.copy(facilityId = facilityIdInAnotherOrg))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
-import com.terraformation.backend.seedbank.model.AccessionModel
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -14,7 +13,7 @@ import org.springframework.security.access.AccessDeniedException
 internal class AccessionStorePermissionTest : AccessionStoreTest() {
   @Test
   fun `fetchOneById throws exception if user does not have permission`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     assertNotNull(initial, "Should have created accession successfully")
 
     every { user.canReadAccession(any()) } returns false
@@ -25,7 +24,7 @@ internal class AccessionStorePermissionTest : AccessionStoreTest() {
   @Test
   fun `update does not write to database if user does not have permission`() {
     every { user.canUpdateAccession(any()) } returns false
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     assertThrows<AccessDeniedException> { store.update(initial.copy(numberOfTrees = 1)) }
 
@@ -36,7 +35,7 @@ internal class AccessionStorePermissionTest : AccessionStoreTest() {
 
   @Test
   fun `fetchHistory throws exception if user does not have permission`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     every { user.canReadAccession(any()) } returns false
 
@@ -46,7 +45,7 @@ internal class AccessionStorePermissionTest : AccessionStoreTest() {
   @Test
   fun `delete throws exception if user does not have permission`() {
     every { user.canDeleteAccession(any()) } returns false
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
 
     assertThrows<AccessDeniedException> { store.delete(initial.id!!) }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePhotoTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePhotoTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.default_schema.tables.pojos.PhotosRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
-import com.terraformation.backend.seedbank.model.AccessionModel
 import java.net.URI
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -13,7 +12,7 @@ import org.springframework.http.MediaType
 internal class AccessionStorePhotoTest : AccessionStoreTest() {
   @Test
   fun `photo filenames are returned`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     val photosRow =
         PhotosRow(
             fileName = "photo.jpg",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreStateTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
-import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.seeds
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -14,8 +13,7 @@ import org.junit.jupiter.api.assertThrows
 internal class AccessionStoreStateTest : AccessionStoreTest() {
   @Test
   fun `update does not allow state to be changed back to Awaiting Check-In`() {
-    val initial =
-        store.create(AccessionModel(facilityId = facilityId, state = AccessionState.Processing))
+    val initial = store.create(accessionModel(state = AccessionState.Processing))
 
     val updated = store.updateAndFetch(initial.copy(state = AccessionState.AwaitingCheckIn))
 
@@ -24,8 +22,7 @@ internal class AccessionStoreStateTest : AccessionStoreTest() {
 
   @Test
   fun `update throws exception if caller tries to manually change to a v1-only state`() {
-    val initial =
-        store.create(AccessionModel(facilityId = facilityId, state = AccessionState.Processing))
+    val initial = store.create(accessionModel(state = AccessionState.Processing))
 
     assertThrows<IllegalArgumentException> {
       store.update(initial.copy(state = AccessionState.Dried))
@@ -34,10 +31,7 @@ internal class AccessionStoreStateTest : AccessionStoreTest() {
 
   @Test
   fun `state changes cause history entries to be inserted`() {
-    val initial =
-        store.create(
-            AccessionModel(
-                facilityId = facilityId, remaining = seeds(10), state = AccessionState.Drying))
+    val initial = store.create(accessionModel(remaining = seeds(10), state = AccessionState.Drying))
     store.update(initial.copy(state = AccessionState.InStorage))
     val fetched = store.fetchOneById(initial.id!!)
 
@@ -64,7 +58,7 @@ internal class AccessionStoreStateTest : AccessionStoreTest() {
 
   @Test
   fun `absence of deviceInfo causes source to be set to Web`() {
-    val initial = store.create(AccessionModel(facilityId = facilityId))
+    val initial = store.create(accessionModel())
     assertEquals(DataSource.Web, initial.source)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -6,7 +6,11 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.seedbank.AccessionState
+import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
@@ -22,9 +26,13 @@ import com.terraformation.backend.seedbank.db.GeolocationStore
 import com.terraformation.backend.seedbank.db.ViabilityTestStore
 import com.terraformation.backend.seedbank.db.WithdrawalStore
 import com.terraformation.backend.seedbank.model.AccessionModel
+import com.terraformation.backend.seedbank.model.Geolocation
+import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
+import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
 import io.mockk.every
+import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import org.jooq.Record
@@ -93,14 +101,11 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
               ViabilityTestModel(
                   seedsTested = 5,
                   startDate = LocalDate.of(2021, 4, 1),
-                  testType = ViabilityTestType.Lab),
-              clock)
+                  testType = ViabilityTestType.Lab))
         }
   }
 
-  protected fun create(
-      model: AccessionModel = AccessionModel(facilityId = facilityId)
-  ): AccessionModel {
+  protected fun create(model: AccessionModel = accessionModel()): AccessionModel {
     return store.create(model)
   }
 
@@ -140,4 +145,34 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
     clock.instant = desiredTime
     return this
   }
+
+  /** AccessionModel constructor wrapper that supplies defaults for required properties. */
+  protected fun accessionModel(
+      bagNumbers: Set<String> = emptySet(),
+      clock: Clock = this.clock,
+      collectors: List<String> = emptyList(),
+      facilityId: FacilityId = this.facilityId,
+      geolocations: Set<Geolocation> = emptySet(),
+      processingNotes: String? = null,
+      remaining: SeedQuantityModel? = null,
+      source: DataSource? = null,
+      species: String? = null,
+      speciesId: SpeciesId? = null,
+      state: AccessionState? = null,
+      withdrawals: List<WithdrawalModel> = emptyList(),
+  ): AccessionModel =
+      AccessionModel(
+          bagNumbers = bagNumbers,
+          clock = clock,
+          collectors = collectors,
+          facilityId = facilityId,
+          geolocations = geolocations,
+          processingNotes = processingNotes,
+          remaining = remaining,
+          source = source,
+          species = species,
+          speciesId = speciesId,
+          state = state,
+          withdrawals = withdrawals,
+      )
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
@@ -37,8 +37,7 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
         .andUpdate {
           it.addViabilityTest(
               ViabilityTestModel(
-                  seedsTested = 1, startDate = startDate, testType = ViabilityTestType.Lab),
-              clock)
+                  seedsTested = 1, startDate = startDate, testType = ViabilityTestType.Lab))
         }
 
     val updatedTests = viabilityTestsDao.fetchByAccessionId(AccessionId(1))
@@ -68,7 +67,7 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
             .andAdvanceClock(Duration.ofSeconds(1))
             .andUpdate {
               it.addViabilityTest(
-                  ViabilityTestModel(seedsTested = 1, testType = ViabilityTestType.Lab), clock)
+                  ViabilityTestModel(seedsTested = 1, testType = ViabilityTestType.Lab))
             }
 
     val desired =
@@ -110,7 +109,7 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
             .andAdvanceClock(Duration.ofSeconds(1))
             .andUpdate {
               it.addViabilityTest(
-                  ViabilityTestModel(seedsTested = 50, testType = ViabilityTestType.Lab), clock)
+                  ViabilityTestModel(seedsTested = 50, testType = ViabilityTestType.Lab))
             }
 
     assertEquals(Instant.EPOCH, initial.latestObservedTime, "Latest observed time")
@@ -120,9 +119,7 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
         "Accession remaining quantity before update")
 
     val desired =
-        initial.updateViabilityTest(initial.viabilityTests[0].id!!, clock) {
-          it.copy(seedsTested = 80)
-        }
+        initial.updateViabilityTest(initial.viabilityTests[0].id!!) { it.copy(seedsTested = 80) }
     val updated = store.updateAndFetch(desired)
 
     assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreWithdrawalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreWithdrawalTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
-import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
@@ -16,12 +15,7 @@ import org.junit.jupiter.api.Test
 internal class AccessionStoreWithdrawalTest : AccessionStoreTest() {
   @Test
   fun `update forces state to Used Up if no seeds remaining`() {
-    val initial =
-        store.create(
-            AccessionModel(
-                facilityId = facilityId,
-                state = AccessionState.Processing,
-            ))
+    val initial = store.create(accessionModel(state = AccessionState.Processing))
 
     val withQuantity = store.updateAndFetch(initial.copy(remaining = seeds(1)))
     val updated =
@@ -45,8 +39,7 @@ internal class AccessionStoreWithdrawalTest : AccessionStoreTest() {
                   WithdrawalModel(
                       date = LocalDate.EPOCH,
                       purpose = WithdrawalPurpose.Other,
-                      withdrawn = seeds(10)),
-                  clock)
+                      withdrawn = seeds(10)))
             }
 
     assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -53,6 +53,7 @@ internal abstract class AccessionModelTest {
     return AccessionModel(
         id = AccessionId(1L),
         accessionNumber = "dummy",
+        clock = clock,
         createdTime = clock.instant(),
         dryingEndDate = dryingEndDate,
         latestObservedQuantity = latestObservedQuantity,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -39,7 +39,6 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
     AccessionService(
         accessionStore,
         mockk(),
-        clock,
         dslContext,
         mockk(),
         mockk(),


### PR DESCRIPTION
The accession history entries for state changes and quantity updates calculate the
effective date based on the (UTC) timestamp when the change happened. Previously,
the date was calculated in UTC. Use the seed bank's time zone instead.

The dates of history entries for withdrawals and viability tests aren't calculated
from timestamps, so they don't require any changes.