### PR TITLE
SW-2771 Add locale to user details

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -164,6 +164,10 @@ class TerrawareGenerator : KotlinGenerator() {
                 .withIncludeExpression("time_zone")
                 .withConverter("com.terraformation.backend.db.TimeZoneConverter")
                 .withUserType("java.time.ZoneId"),
+            ForcedType()
+                .withIncludeExpression("locale")
+                .withConverter("com.terraformation.backend.db.LocaleConverter")
+                .withUserType("java.util.Locale"),
         )
 
     ENUM_TABLES.forEach { (schemaName, tables) ->

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
+import java.util.*
 import javax.servlet.http.HttpSession
 import javax.ws.rs.ForbiddenException
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -39,6 +40,7 @@ class UsersController(private val userStore: UserStore) {
               user.emailNotificationsEnabled,
               user.firstName,
               user.lastName,
+              user.locale?.toLanguageTag(),
               user.timeZone))
     } else {
       throw ForbiddenException("Only ordinary users can request their information")
@@ -56,6 +58,7 @@ class UsersController(private val userStore: UserStore) {
                       ?: user.emailNotificationsEnabled,
               firstName = payload.firstName,
               lastName = payload.lastName,
+              locale = payload.locale?.let { Locale.forLanguageTag(it) },
               timeZone = payload.timeZone,
           )
       userStore.updateUser(model)
@@ -114,6 +117,8 @@ data class UserProfilePayload(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    @Schema(description = "IETF locale code containing user's preferred language.", example = "en")
+    val locale: String?,
     val timeZone: ZoneId?,
 )
 
@@ -129,6 +134,8 @@ data class UpdateUserRequestPayload(
     val emailNotificationsEnabled: Boolean? = null,
     val firstName: String,
     val lastName: String,
+    @Schema(description = "IETF locale code containing user's preferred language.", example = "en")
+    val locale: String?,
     val timeZone: ZoneId?,
 )
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -220,6 +220,7 @@ class UserStore(
               emailNotificationsEnabled = model.emailNotificationsEnabled,
               firstName = model.firstName,
               lastName = model.lastName,
+              locale = model.locale,
               timeZone = model.timeZone))
 
       try {
@@ -502,6 +503,7 @@ class UserStore(
             ?: throw IllegalArgumentException("Email notifications enabled should never be null"),
         usersRow.firstName,
         usersRow.lastName,
+        usersRow.locale,
         usersRow.timeZone,
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),
         parentStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
+import java.util.*
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
@@ -66,6 +67,7 @@ data class IndividualUser(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    override val locale: Locale?,
     override val timeZone: ZoneId?,
     override val userType: UserType,
     private val parentStore: ParentStore,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.security.Principal
 import java.time.ZoneId
+import java.util.*
 
 /**
  * An entity on whose behalf the system can do work.
@@ -32,6 +33,8 @@ import java.time.ZoneId
 interface TerrawareUser : Principal {
   val userId: UserId
   val userType: UserType
+  val locale: Locale?
+    get() = Locale.ENGLISH
   val timeZone: ZoneId?
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/db/LocaleConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/LocaleConverter.kt
@@ -1,0 +1,23 @@
+package com.terraformation.backend.db
+
+import java.time.DateTimeException
+import java.util.Locale
+import org.jooq.impl.AbstractConverter
+
+/**
+ * Converts text values from the database to and from Locale objects.
+ *
+ * This is referenced in generated database classes.
+ */
+class LocaleConverter : AbstractConverter<String, Locale>(String::class.java, Locale::class.java) {
+  /**
+   * Converts a time zone name to a ZoneId.
+   *
+   * @throws DateTimeException The zone name wasn't found in the list of zones recognized by the
+   *   java.time package.
+   */
+  override fun from(databaseObject: String?): Locale? =
+      databaseObject?.let { Locale.forLanguageTag(it) }
+
+  override fun to(userObject: Locale?): String? = userObject?.toLanguageTag()
+}

--- a/src/main/kotlin/com/terraformation/backend/db/LocaleConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/LocaleConverter.kt
@@ -19,5 +19,5 @@ class LocaleConverter : AbstractConverter<String, Locale>(String::class.java, Lo
   override fun from(databaseObject: String?): Locale? =
       databaseObject?.let { Locale.forLanguageTag(it) }
 
-  override fun to(userObject: Locale?): String? = userObject?.toLanguageTag()
+  override fun to(locale: Locale?): String? = locale?.toLanguageTag()
 }

--- a/src/main/resources/db/migration/V168__UsersLocale.sql
+++ b/src/main/resources/db/migration/V168__UsersLocale.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN locale TEXT;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -38,6 +38,7 @@ import io.mockk.verify
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.Locale
 import org.jooq.JSONB
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -351,6 +352,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   fun `updateUser updates profile information`() {
     val newFirstName = "Testy"
     val newLastName = "McTestalot"
+    val newLocale = Locale("gx")
     val newTimeZone = insertTimeZone()
 
     insertUser(authId = userRepresentation.id, email = userRepresentation.email)
@@ -369,7 +371,9 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
             firstName = newFirstName,
             lastName = newLastName,
             emailNotificationsEnabled = true,
-            timeZone = newTimeZone)
+            locale = newLocale,
+            timeZone = newTimeZone,
+        )
     userStore.updateUser(modelWithEdits)
 
     val updatedModel = userStore.fetchOneById(model.userId) as IndividualUser
@@ -377,6 +381,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(oldEmail, updatedModel.email, "Email (DB)")
     assertEquals(newFirstName, updatedModel.firstName, "First name (DB)")
     assertEquals(newLastName, updatedModel.lastName, "Last name (DB)")
+    assertEquals(newLocale, updatedModel.locale, "Locale (DB)")
     assertEquals(newTimeZone, updatedModel.timeZone, "Time zone (DB)")
     assertTrue(updatedModel.emailNotificationsEnabled, "Email notifications enabled (DB)")
 


### PR DESCRIPTION
Update the `/api/v1/users` payloads to include a `locale` field.