### PR TITLE
Use Accept-Language header to determine locale

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
@@ -1,0 +1,24 @@
+package com.terraformation.backend.api
+
+import com.terraformation.backend.i18n.Locales
+import java.util.*
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver
+
+@Configuration
+class LocaleConfig {
+  /**
+   * Make Spring's request handlers look at the HTTP Accept-Language header to set the locale for
+   * the current thread.
+   */
+  @Bean
+  fun localeResolver(): AcceptHeaderLocaleResolver {
+    val resolver = AcceptHeaderLocaleResolver()
+
+    resolver.defaultLocale = Locale.ENGLISH
+    resolver.supportedLocales = Locales.supported
+
+    return resolver
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.i18n
+
+import java.util.Locale
+import org.springframework.context.i18n.LocaleContextHolder
+
+object Locales {
+  val GIBBERISH = Locale.forLanguageTag("gx")
+
+  val supported =
+      listOf(
+          Locale.ENGLISH,
+          GIBBERISH,
+      )
+}
+
+/**
+ * Returns the currently-active locale. This currently uses Spring's locale context, which gets
+ * populated with the current locale based on the Accept-Language header of the incoming request.
+ */
+fun currentLocale(): Locale = LocaleContextHolder.getLocale()

--- a/src/main/kotlin/com/terraformation/backend/i18n/api/TimeZonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/api/TimeZonesController.kt
@@ -3,10 +3,10 @@ package com.terraformation.backend.i18n.api
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.i18n.TimeZones
+import com.terraformation.backend.i18n.currentLocale
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
 import java.util.Locale
-import org.springframework.util.StringUtils
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -20,12 +20,14 @@ class TimeZonesController(private val timeZones: TimeZones) {
   fun listTimeZoneNames(
       @RequestParam("locale")
       @Schema(
-          description = "Language code and optional country code suffix.",
-          defaultValue = "en_US",
-          example = "zh_CN")
+          description =
+              "Language code and optional country code suffix. If not specified, the preferred " +
+                  "locale from the Accept-Language header is used if supported; otherwise US " +
+                  "English is the default.",
+          example = "zh-CN")
       localeName: String?
   ): ListTimeZoneNamesResponsePayload {
-    val locale = localeName?.let { StringUtils.parseLocaleString(it) } ?: Locale.US
+    val locale = localeName?.let { Locale.forLanguageTag(it) } ?: currentLocale()
     val payloads = timeZones.getTimeZoneNames(locale).map { TimeZonePayload(it.key, it.value) }
     return ListTimeZoneNamesResponsePayload(payloads)
   }


### PR DESCRIPTION
Configure Spring's web framework so it sets the current locale based on the value
of the `Accept-Language` header.

Use that header to determine the default locale for `/api/v1/i18n/timeZones`.