### PR TITLE
Support gibberish time zones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -1,0 +1,16 @@
+import java.util.*
+
+/**
+ * Converts an English string to gibberish for localization testing:
+ * 1. Reverse the order of words
+ * 2. Replace each word with the base64 encoding of its UTF-8 representation, minus padding
+ *
+ * Note that this function does not preserve placeholder tokens.
+ */
+fun String.toGibberish(): String {
+  val encoder = Base64.getEncoder()
+
+  return split(' ').asReversed().joinToString(" ") { word ->
+    encoder.encodeToString(word.toByteArray()).trimEnd('=')
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
@@ -12,6 +12,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 import org.apache.commons.text.similarity.LevenshteinDistance
+import toGibberish
 
 /**
  * Generates a list of time zones with localized names for use by clients and other parts of the
@@ -229,12 +230,20 @@ class TimeZones(private val messages: Messages, private val objectMapper: Object
     val calendars = CLDR.get(locale).Calendars
     val city = calendars.timeZoneInfo(zoneId.id).city().name()
 
-    return if (zoneId in getTimeZonesWithMultipleCities(locale)) {
-      // Multiple non-alias zones map to the same English name, so include the city to disambiguate.
-      messages.timeZoneWithCity(nameWithoutCity, city)
+    val fullName =
+        if (zoneId in getTimeZonesWithMultipleCities(locale)) {
+          // Multiple non-alias zones map to the same English name, so include the city to
+          // disambiguate.
+          messages.timeZoneWithCity(nameWithoutCity, city)
+        } else {
+          // There's only one example city for this English zone name, so no need to include it.
+          nameWithoutCity
+        }
+
+    return if (locale == Locales.GIBBERISH) {
+      fullName.toGibberish()
     } else {
-      // There's only one example city for this English zone name, so no need to include it.
-      nameWithoutCity
+      fullName
     }
   }
 


### PR DESCRIPTION
If the locale is `gx, make `/api/v1/i18n/timeZones` return gibberish time zone
names for localization testing.