### PR TITLE
SW-2786 Make Messages text localizable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -1,0 +1,16 @@
+import java.util.*
+
+/**
+ * Converts an English string to gibberish for localization testing:
+ * 1. Reverse the order of words
+ * 2. Replace each word with the base64 encoding of its UTF-8 representation, minus padding
+ *
+ * Note that this function does not preserve placeholder tokens.
+ */
+fun String.toGibberish(): String {
+  val encoder = Base64.getEncoder()
+
+  return split(' ').asReversed().joinToString(" ") { word ->
+    encoder.encodeToString(word.toByteArray()).trimEnd('=')
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -159,7 +159,7 @@ class Messages {
       getMessage("historyAccessionQuantityUpdated", seedQuantity(newQuantity))
 
   fun historyAccessionStateChanged(newState: AccessionState) =
-      getMessage("historyAccessionStateChanged", newState.displayName)
+      getMessage("historyAccessionStateChanged", newState.getDisplayName(currentLocale()))
 
   fun historyAccessionWithdrawal(
       quantity: SeedQuantityModel?,

--- a/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
@@ -12,6 +12,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 import org.apache.commons.text.similarity.LevenshteinDistance
+import toGibberish
 
 /**
  * Generates a list of time zones with localized names for use by clients and other parts of the
@@ -229,12 +230,20 @@ class TimeZones(private val messages: Messages, private val objectMapper: Object
     val calendars = CLDR.get(locale).Calendars
     val city = calendars.timeZoneInfo(zoneId.id).city().name()
 
-    return if (zoneId in getTimeZonesWithMultipleCities(locale)) {
-      // Multiple non-alias zones map to the same English name, so include the city to disambiguate.
-      messages.timeZoneWithCity(nameWithoutCity, city)
+    val fullName =
+        if (zoneId in getTimeZonesWithMultipleCities(locale)) {
+          // Multiple non-alias zones map to the same English name, so include the city to
+          // disambiguate.
+          messages.timeZoneWithCity(nameWithoutCity, city)
+        } else {
+          // There's only one example city for this English zone name, so no need to include it.
+          nameWithoutCity
+        }
+
+    return if (locale == Locales.GIBBERISH) {
+      fullName.toGibberish()
     } else {
-      // There's only one example city for this English zone name, so no need to include it.
-      nameWithoutCity
+      fullName
     }
   }
 

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -1,0 +1,88 @@
+csvBadHeader=Incorrect column headings
+csvRequiredFieldMissing=Missing required field
+csvDateMalformed=Date must be in YYYY-MM-DD format
+csvWrongFieldCount=Expected row to have {0} fields, not {1}
+csvScientificNameMissing=Missing scientific name
+csvScientificNameInvalidChar=Scientific name has invalid character \"{0}\"
+csvScientificNameTooShort=Scientific name must be at least 2 words
+csvScientificNameTooLong=Scientific name must be no more than 4 words
+accessionCsvCollectionSourceInvalid=Collection source must be one of: {0}
+accessionCsvCountryInvalid=Country must be a valid two-letter ISO country code or a recognized country name
+accessionCsvNumberDuplicate=Accession number already used on line {0}
+accessionCsvNumberExists=Accession number already exists
+accessionCsvNumberOfPlantsInvalid=Number of plants must be 1 or more
+accessionCsvQuantityInvalid=Quantity must be a number greater than 0
+accessionCsvQuantityUnitsInvalid=Quantity units must be one of: {0}
+accessionCsvStatusInvalid=Status must be one of: {0}
+batchCsvQuantityInvalid=Quantity must be a whole number 0 or greater
+speciesCsvScientificNameExists=Scientific name already exists
+speciesCsvFamilyMultipleWords=Family must be a single word
+speciesCsvFamilyInvalidChar=Family has invalid character \"{0}\"
+speciesCsvEndangeredInvalid=Endangered value must be \"yes\" or \"no\"
+speciesCsvRareInvalid=Rare value must be \"yes\" or \"no\"
+speciesCsvGrowthFormInvalid=Growth form must be one of: {0}
+speciesCsvSeedStorageBehaviorInvalid=Seed storage behavior must be one of: {0}
+
+# In-app notifications
+userAddedToOrganizationNotificationTitle=You've been added to a new organization!
+userAddedToOrganizationNotificationBody=You are now a member of {0}. Welcome!
+
+accessionDryingEndNotificationTitle=An accession has dried
+accessionDryingEndNotificationBody={0} has finished drying.
+
+nurserySeedlingBatchReadyNotificationTitle={0} has reached its scheduled ready by date.
+nurserySeedlingBatchReadyNotificationBody={0} (located in {1}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
+
+facilityIdleTitle=Device manager cannot be detected.
+facilityIdleBody=Device manager is disconnected. Please check on it.
+
+lowPowerWarningTitle=Low power warning for {0}
+lowPowerWarningBody=The relative state of charge of the solar power system is at {0}%.
+
+sensorBoundsAlertTitle={0} is out of range.
+sensorBoundsAlertDefaultBody={0} on {1} is {2}, which is out of threshold.
+sensorBoundsAlertHumidityBody={0} has been or is at {1}% RH for the past 5 minutes, which is out of threshold. Please check on it.
+sensorBoundsAlertTemperatureBody={0} has been or is at {1}°C for the past 5 minutes, which is out of threshold. Please check on it."
+
+unknownAutomationTriggeredTitle={0} triggered at {1}
+unknownAutomationTriggeredBody=Please check on it.
+
+deviceUnresponsiveTitle={0} cannot be detected.
+deviceUnresponsiveBody={0} cannot be detected. Please check on it.
+
+# Accession history line items. There are separate strings for different purposes because the
+# purpose might require changes to other words in the string (e.g., if the language is gendered).
+historyAccessionQuantityUpdated=updated the quantity to {0}
+historyAccessionCreated=created accession
+historyAccessionStateChanged=updated the status to {0}
+historyAccessionQuantityWithdrawnForNursery=withdrew {0} for nursery
+historyAccessionQuantityWithdrawnForOther=withdrew {0} for other
+historyAccessionQuantityWithdrawnForOutPlanting=withdrew {0} for outplanting
+historyAccessionQuantityWithdrawnForViabilityTesting=withdrew {0} for viability testing
+historyAccessionQuantityWithdrawn=withdrew {0}
+historyAccessionWithdrawnForNursery=withdrew seeds for nursery
+historyAccessionWithdrawnForOther=withdrew seeds for other
+historyAccessionWithdrawnForOutPlanting=withdrew seeds for outplanting
+historyAccessionWithdrawnForViabilityTesting=withdrew seeds for viability testing
+historyAccessionWithdrawn=withdrew seeds
+
+# Items in the time zones menu that have example cities, e.g., "Pacific - Los Angeles"
+timeZoneWithCity={0} - {1}
+
+# Seed quantities. The handling of plurals will need to be revisited when we add a language that
+# doesn't have the same pluralization rules as English.
+seedQuantitySeedsSingular={0} seed
+seedQuantitySeedsPlural={0} seeds
+seedQuantityGramsSingular={0} gram
+seedQuantityGramsPlural={0} grams
+seedQuantityKilogramsSingular={0} kilogram
+seedQuantityKilogramsPlural={0} kilograms
+seedQuantityMilligramsSingular={0} milligram
+seedQuantityMilligramsPlural={0} milligrams
+seedQuantityOuncesSingular={0} ounce
+seedQuantityOuncesPlural={0} ounces
+seedQuantityPoundsSingular={0} pound
+seedQuantityPoundsPlural={0} pounds
+
+# Delimiter between list items. Note that this has a space at the end.
+listDelimiter=, 


### PR DESCRIPTION
The `Messages` class is where we render human-readable text on the server side.
The intent was always that it'd be updated to return text in the user's language.

Move the English strings into a properties file and look them up based on the
current locale. The strings should be the same as before since we only have an
English properties file.

In addition, render the numeric parts of seed quantities using the number
formatter for the user's locale. This doesn't currently support the number
formatting rules for the gibberish locale; it just uses the built-in formatting
rules from the Java standard library.