### PR TITLE
Generate gibberish translations of English messages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,9 +78,6 @@ jobs:
     - name: Compile tests
       run: ./gradlew testClasses
 
-    - name: "DEBUG: List generated properties files"
-      run: ls -l build/resources/main/i18n
-
     - name: Run tests
       run: ./gradlew test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,9 @@ jobs:
     - name: Compile tests
       run: ./gradlew testClasses
 
+    - name: "DEBUG: List generated properties files"
+      run: ls -l build/resources/main/i18n
+
     - name: Run tests
       run: ./gradlew test
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,10 +170,13 @@ val generateVersionFile = tasks.register<VersionFileTask>("generateVersionFile")
 val generatePostgresDockerConfig =
     tasks.register<PostgresDockerConfigTask>("generatePostgresDockerConfig")
 
+val renderGibberishTask =
+    tasks.register<com.terraformation.gradle.RenderGibberishTask>("renderGibberish")
 val renderMjmlTask = tasks.register<com.terraformation.gradle.RenderMjmlTask>("renderMjml")
 
 tasks {
   processResources {
+    dependsOn(renderGibberishTask)
     dependsOn(renderMjmlTask)
     exclude("**/*.mjml")
   }

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
@@ -1,0 +1,108 @@
+package com.terraformation.gradle
+
+import com.github.gradle.node.util.ProjectApiHelper
+import com.github.gradle.node.yarn.task.YarnInstallTask
+import java.io.File
+import java.nio.file.Files
+import java.util.*
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileType
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.IgnoreEmptyDirectories
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.ChangeType
+import org.gradle.work.FileChange
+import org.gradle.work.InputChanges
+
+/** Translates English messages into gibberish for localization testing. */
+abstract class RenderGibberishTask : DefaultTask() {
+  @get:IgnoreEmptyDirectories
+  @get:InputFiles
+  @get:SkipWhenEmpty
+  val propertiesFiles =
+      project.files(
+          project.fileTree("src/main/resources/i18n") {
+            include("**/*.properties")
+            exclude("**/*_*.properties")
+          })
+
+  @get:OutputDirectory val outputDir = project.buildDir.resolve("resources/main/i18n")
+
+  @get:Internal val projectHelper = ProjectApiHelper.newInstance(project)
+
+  @get:Inject abstract val objects: ObjectFactory
+
+  init {
+    group = "build"
+    description = "Renders gibberish strings."
+    dependsOn(YarnInstallTask.NAME)
+  }
+
+  @TaskAction
+  fun exec(changes: InputChanges) {
+    changes.getFileChanges(propertiesFiles).forEach { change ->
+      if (change.fileType != FileType.DIRECTORY) {
+        val targetFile = getTargetFile(change)
+
+        if (change.changeType == ChangeType.REMOVED) {
+          targetFile.delete()
+        } else {
+          renderGibberish(change.file, targetFile)
+        }
+      }
+    }
+  }
+
+  private fun renderGibberish(englishFile: File, targetFile: File) {
+    Files.createDirectories(targetFile.toPath().parent)
+
+    val englishProperties = Properties()
+    val gibberishProperties = Properties()
+
+    englishFile.reader().use { englishProperties.load(it) }
+
+    englishProperties.forEach { name, english ->
+      gibberishProperties[name] =
+          "$english".split(' ').asReversed().joinToString(" ") { word ->
+            if (word.startsWith('{')) {
+              word
+            } else {
+              val bytes = word.toByteArray()
+              Base64.getEncoder().encodeToString(bytes).trimEnd('=')
+            }
+          }
+    }
+
+    targetFile.writer().use { gibberishProperties.store(it, null) }
+  }
+
+  /**
+   * Returns the target path for the given properties file in the gibberish locale. The upper levels
+   * of directory structure are a little different in the src and build directories; we want the
+   * following mapping:
+   *
+   * `src/main/resources/templates/i18n/a/b.properties` ->
+   * `build/resources/main/templates/i18n/a/b_gx.properties`
+   */
+  private fun getTargetFile(change: FileChange): File {
+    val extension = "properties"
+
+    if (change.file.extension != extension) {
+      throw IllegalArgumentException("File ${change.file} is not a properties file")
+    }
+
+    val targetFilename = change.file.nameWithoutExtension + "_gx.$extension"
+
+    val targetRelativeToResourcesDir =
+        change.file.parentFile
+            .resolve(targetFilename)
+            .relativeTo(project.projectDir.resolve("src/main/resources"))
+
+    return project.buildDir.resolve("resources/main").resolve(targetRelativeToResourcesDir)
+  }
+}


### PR DESCRIPTION
Add a build step that reads the default-locale properties files from
`src/main/resources/i18n` and produces gibberish versions of them.

For now, `src/main/resources/i18n/Messages.properties` is the only message
bundle; it is transformed to `build/resources/main/i18n/Messages_gx.properties`.

This causes the `Messages` class to support the gibberish locale.