### PR TITLE
Implement gibberish number formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,6 +162,7 @@ tasks.register("downloadDependencies") {
 
 tasks.test {
   useJUnitPlatform()
+  systemProperty("java.locale.providers", "SPI,CLDR,COMPAT")
   testLogging { exceptionFormat = TestExceptionFormat.FULL }
 }
 
@@ -275,7 +276,7 @@ openApi {
   apiDocsUrl.set("http://localhost:$listenPort/v3/api-docs.yaml")
 
   // Use application-apidoc.yaml for application configuration.
-  bootRun.jvmArgs("-Dspring.profiles.active=apidoc")
+  bootRun.jvmArgs("-Djava.locale.providers=SPI,CLDR,COMPAT", "-Dspring.profiles.active=apidoc")
 
   outputDir.set(projectDir)
   outputFileName.set("openapi.yaml")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,4 +20,4 @@ COPY --chown=$USER_ID BOOT-INF/classes .
 EXPOSE 8080
 
 USER $USER_ID
-CMD ["java", "-cp", ".:lib/*", "com.terraformation.backend.ApplicationKt"]
+CMD ["java", "-Djava.locale.providers=SPI,CLDR,COMPAT", "-cp", ".:lib/*", "com.terraformation.backend.ApplicationKt"]

--- a/src/main/kotlin/com/terraformation/backend/Application.kt
+++ b/src/main/kotlin/com/terraformation/backend/Application.kt
@@ -49,5 +49,14 @@ class Application
 fun main(args: Array<String>) {
   // By default, jOOQ logs a noisy banner message at startup; disable that to keep the logs clean.
   System.setProperty("org.jooq.no-logo", "true")
+
+  // Make sure the system property to allow registering custom locale providers is set. Annoyingly,
+  // it is not possible to change this programmatically; it has to be a command-line argument.
+  val expectedProviders = "SPI,CLDR,COMPAT"
+  if (System.getProperty("java.locale.providers") != expectedProviders) {
+    throw RuntimeException(
+        "Please add -Djava.locale.providers=$expectedProviders to the JVM's command-line arguments.")
+  }
+
   SpringApplication.run(Application::class.java, *args)
 }

--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -1,3 +1,7 @@
+package com.terraformation.backend.i18n
+
+import java.text.DecimalFormatSymbols
+import java.text.spi.DecimalFormatSymbolsProvider
 import java.util.*
 
 /**
@@ -12,5 +16,21 @@ fun String.toGibberish(): String {
 
   return split(' ').asReversed().joinToString(" ") { word ->
     encoder.encodeToString(word.toByteArray()).trimEnd('=')
+  }
+}
+
+/**
+ * Customizes the number formatting in the gibberish locale to use different separator characters.
+ */
+class GibberishDecimalFormatSymbolsProvider : DecimalFormatSymbolsProvider() {
+  override fun getAvailableLocales(): Array<Locale> {
+    return arrayOf(Locales.GIBBERISH)
+  }
+
+  override fun getInstance(locale: Locale?): DecimalFormatSymbols {
+    return DecimalFormatSymbols(Locale.ENGLISH).apply {
+      decimalSeparator = ','
+      groupingSeparator = '&'
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
@@ -12,7 +12,6 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 import org.apache.commons.text.similarity.LevenshteinDistance
-import toGibberish
 
 /**
  * Generates a list of time zones with localized names for use by clients and other parts of the

--- a/src/main/resources/META-INF/services/java.text.spi.DecimalFormatSymbolsProvider
+++ b/src/main/resources/META-INF/services/java.text.spi.DecimalFormatSymbolsProvider
@@ -1,0 +1,1 @@
+com.terraformation.backend.i18n.GibberishDecimalFormatSymbolsProvider

--- a/src/test/kotlin/com/terraformation/backend/i18n/GibberishDecimalFormatSymbolsProviderTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/GibberishDecimalFormatSymbolsProviderTest.kt
@@ -1,0 +1,17 @@
+package com.terraformation.backend.i18n
+
+import java.text.NumberFormat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class GibberishDecimalFormatSymbolsProviderTest {
+  @Test
+  fun `uses correct punctuation in number formatting`() {
+    val formatter = NumberFormat.getNumberInstance(Locales.GIBBERISH)
+
+    val expected = "123&456,789"
+    val actual = formatter.format(123456.789)
+
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
To test localized number formats, the spec for the gibberish locale says it should
use ampersands as thousands separators and commas as decimal separators.

Implement a number formatter that uses those characters. Register it with Java's
localization system so call sites don't have to special-case the gibberish locale;
they can just call `NumberFormat` as usual.

Unfortunately, this requires adding a command-line argument to set a system
property when launching the server. Add it to the command line in the Docker image
and to the `generateOpenApiDocs` configuration, and add a check at start time to
tell people to include it in dev environments.