### PR TITLE
SW-2283 Introduce SpeciesModel

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
-import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.file.FileStore
@@ -24,6 +23,7 @@ import com.terraformation.backend.i18n.toBigDecimal
 import com.terraformation.backend.importer.CsvImporter
 import com.terraformation.backend.importer.CsvValidator
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.species.model.NewSpeciesModel
 import java.io.InputStream
 import java.time.LocalDate
 import javax.inject.Named
@@ -108,9 +108,10 @@ class BatchImporter(
     val storedDate = LocalDate.parse(values[4])!!
 
     val speciesId =
-        speciesStore.importRow(
-            SpeciesRow(
+        speciesStore.importSpecies(
+            NewSpeciesModel(
                 commonName = commonName,
+                id = null,
                 organizationId = organizationId,
                 scientificName = scientificName),
             overwriteExisting = false)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
-import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadsRow
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
@@ -29,6 +28,7 @@ import com.terraformation.backend.importer.CsvImporter
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.species.model.NewSpeciesModel
 import java.io.InputStream
 import java.text.NumberFormat
 import java.time.Clock
@@ -154,7 +154,7 @@ class AccessionImporter(
     // Scientific name and collection date are required; everything else is optional.
 
     val accessionNumber = values[0]
-    val scientificName = values[1]
+    val scientificName = values[1]!!
     val commonName = values[2]
     val quantity = values[3]?.toBigDecimal(locale)
     val units =
@@ -181,9 +181,10 @@ class AccessionImporter(
     }
 
     val speciesId =
-        speciesStore.importRow(
-            SpeciesRow(
+        speciesStore.importSpecies(
+            NewSpeciesModel(
                 commonName = commonName,
+                id = null,
                 organizationId = organizationId,
                 scientificName = scientificName),
             overwriteExisting = false)

--- a/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/SpeciesService.kt
@@ -1,9 +1,10 @@
 package com.terraformation.backend.species
 
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.species.model.ExistingSpeciesModel
+import com.terraformation.backend.species.model.NewSpeciesModel
 import javax.inject.Named
 import org.jooq.DSLContext
 
@@ -14,21 +15,20 @@ class SpeciesService(
     private val speciesStore: SpeciesStore,
 ) {
   /** Creates a new species and checks it for potential problems. */
-  fun createSpecies(row: SpeciesRow): SpeciesId {
+  fun createSpecies(model: NewSpeciesModel): SpeciesId {
     return dslContext.transactionResult { _ ->
-      val speciesId = speciesStore.createSpecies(row)
+      val speciesId = speciesStore.createSpecies(model)
       speciesChecker.checkSpecies(speciesId)
       speciesId
     }
   }
 
   /** Updates an existing species and checks it for newly-introduced problems. */
-  fun updateSpecies(row: SpeciesRow): SpeciesRow {
+  fun updateSpecies(model: ExistingSpeciesModel): ExistingSpeciesModel {
     return dslContext.transactionResult { _ ->
-      val speciesId = row.id ?: throw IllegalArgumentException("ID must be non-null")
-      val existingRow = speciesStore.fetchSpeciesById(speciesId)
+      val existingRow = speciesStore.fetchSpeciesById(model.id)
 
-      val updatedRow = speciesStore.updateSpecies(row)
+      val updatedRow = speciesStore.updateSpecies(model)
       speciesChecker.recheckSpecies(existingRow, updatedRow)
 
       updatedRow

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
-import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadsRow
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.file.FileStore
@@ -20,6 +19,7 @@ import com.terraformation.backend.file.UploadStore
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.importer.CsvImporter
+import com.terraformation.backend.species.model.NewSpeciesModel
 import java.io.InputStream
 import javax.inject.Named
 import org.jobrunr.jobs.JobId
@@ -115,20 +115,21 @@ class SpeciesImporter(
       csvReader
           .map { rawValues -> rawValues.map { it.trim().ifEmpty { null } } }
           .map { values ->
-            SpeciesRow(
-                scientificName = values[0],
+            NewSpeciesModel(
+                scientificName = values[0]!!,
                 commonName = values[1],
                 familyName = values[2],
                 endangered = values[3]?.let { it in trueValues },
                 rare = values[4]?.let { it in trueValues },
-                growthFormId = values[5]?.let { GrowthForm.forDisplayName(it, locale) },
-                seedStorageBehaviorId =
+                growthForm = values[5]?.let { GrowthForm.forDisplayName(it, locale) },
+                seedStorageBehavior =
                     values[6]?.let { SeedStorageBehavior.forDisplayName(it, locale) },
+                id = null,
                 organizationId = organizationId,
             )
           }
           .forEach { row ->
-            speciesStore.importRow(row, overwriteExisting)
+            speciesStore.importSpecies(row, overwriteExisting)
             totalImported++
           }
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -235,7 +235,7 @@ class SpeciesStore(
    * @return The ID of the existing species that matched the requested name or the new species that
    *   was inserted.
    */
-  fun importRow(row: SpeciesRow, overwriteExisting: Boolean): SpeciesId {
+  fun importSpecies(model: NewSpeciesModel, overwriteExisting: Boolean): SpeciesId {
     return with(SPECIES) {
       /**
        * Updates the editable values of an existing species and marks it as not deleted. Leaves the
@@ -245,12 +245,12 @@ class SpeciesStore(
         val rowsUpdated =
             dslContext
                 .update(SPECIES)
-                .set(COMMON_NAME, row.commonName)
-                .set(FAMILY_NAME, row.familyName)
-                .set(ENDANGERED, row.endangered)
-                .set(RARE, row.rare)
-                .set(GROWTH_FORM_ID, row.growthFormId)
-                .set(SEED_STORAGE_BEHAVIOR_ID, row.seedStorageBehaviorId)
+                .set(COMMON_NAME, model.commonName)
+                .set(FAMILY_NAME, model.familyName)
+                .set(ENDANGERED, model.endangered)
+                .set(RARE, model.rare)
+                .set(GROWTH_FORM_ID, model.growthForm)
+                .set(SEED_STORAGE_BEHAVIOR_ID, model.seedStorageBehavior)
                 .setNull(DELETED_TIME)
                 .setNull(DELETED_BY)
                 .set(MODIFIED_BY, currentUser().userId)
@@ -266,8 +266,8 @@ class SpeciesStore(
           dslContext
               .select(SPECIES.ID, SPECIES.DELETED_TIME)
               .from(SPECIES)
-              .where(ORGANIZATION_ID.eq(row.organizationId))
-              .and(SCIENTIFIC_NAME.eq(row.scientificName))
+              .where(ORGANIZATION_ID.eq(model.organizationId))
+              .and(SCIENTIFIC_NAME.eq(model.scientificName))
               .fetchOne()
       val existingIdByCurrentName = existingByCurrentName?.get(ID)
 
@@ -281,27 +281,27 @@ class SpeciesStore(
             dslContext
                 .select(SPECIES.ID)
                 .from(SPECIES)
-                .where(ORGANIZATION_ID.eq(row.organizationId))
-                .and(INITIAL_SCIENTIFIC_NAME.eq(row.scientificName))
+                .where(ORGANIZATION_ID.eq(model.organizationId))
+                .and(INITIAL_SCIENTIFIC_NAME.eq(model.scientificName))
                 .and(DELETED_TIME.isNull)
                 .fetchOne(SPECIES.ID)
 
         if (existingIdByInitialName == null) {
           dslContext
               .insertInto(SPECIES)
-              .set(SCIENTIFIC_NAME, row.scientificName)
-              .set(INITIAL_SCIENTIFIC_NAME, row.scientificName)
-              .set(COMMON_NAME, row.commonName)
-              .set(FAMILY_NAME, row.familyName)
-              .set(ENDANGERED, row.endangered)
-              .set(RARE, row.rare)
-              .set(GROWTH_FORM_ID, row.growthFormId)
-              .set(SEED_STORAGE_BEHAVIOR_ID, row.seedStorageBehaviorId)
+              .set(SCIENTIFIC_NAME, model.scientificName)
+              .set(INITIAL_SCIENTIFIC_NAME, model.scientificName)
+              .set(COMMON_NAME, model.commonName)
+              .set(FAMILY_NAME, model.familyName)
+              .set(ENDANGERED, model.endangered)
+              .set(RARE, model.rare)
+              .set(GROWTH_FORM_ID, model.growthForm)
+              .set(SEED_STORAGE_BEHAVIOR_ID, model.seedStorageBehavior)
               .set(CREATED_BY, currentUser().userId)
               .set(CREATED_TIME, clock.instant())
               .set(MODIFIED_BY, currentUser().userId)
               .set(MODIFIED_TIME, clock.instant())
-              .set(ORGANIZATION_ID, row.organizationId)
+              .set(ORGANIZATION_ID, model.organizationId)
               .returning(ID)
               .fetchOne(ID)!!
         } else {

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.species.model
+
+import com.terraformation.backend.db.default_schema.GrowthForm
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SeedStorageBehavior
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import java.time.Instant
+import org.jooq.Record
+
+data class SpeciesModel<ID : SpeciesId?>(
+    val checkedTime: Instant? = null,
+    val commonName: String? = null,
+    val deletedTime: Instant? = null,
+    val endangered: Boolean? = null,
+    val familyName: String? = null,
+    val growthForm: GrowthForm? = null,
+    val id: ID,
+    val organizationId: OrganizationId,
+    val rare: Boolean? = null,
+    val scientificName: String,
+    val seedStorageBehavior: SeedStorageBehavior? = null,
+    val initialScientificName: String = scientificName,
+) {
+  companion object {
+    fun of(
+        record: Record,
+    ): ExistingSpeciesModel =
+        ExistingSpeciesModel(
+            checkedTime = record[SPECIES.CHECKED_TIME],
+            commonName = record[SPECIES.COMMON_NAME],
+            deletedTime = record[SPECIES.DELETED_TIME],
+            endangered = record[SPECIES.ENDANGERED],
+            familyName = record[SPECIES.FAMILY_NAME],
+            growthForm = record[SPECIES.GROWTH_FORM_ID],
+            id = record[SPECIES.ID]!!,
+            initialScientificName = record[SPECIES.INITIAL_SCIENTIFIC_NAME]!!,
+            organizationId = record[SPECIES.ORGANIZATION_ID]!!,
+            rare = record[SPECIES.RARE],
+            scientificName = record[SPECIES.SCIENTIFIC_NAME]!!,
+            seedStorageBehavior = record[SPECIES.SEED_STORAGE_BEHAVIOR_ID],
+        )
+  }
+}
+
+typealias NewSpeciesModel = SpeciesModel<Nothing?>
+
+typealias ExistingSpeciesModel = SpeciesModel<SpeciesId>

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -5,10 +5,10 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.species.model.NewSpeciesModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -46,7 +46,8 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   fun `createSpecies checks for problems with species data`() {
     val speciesId =
         service.createSpecies(
-            SpeciesRow(organizationId = organizationId, scientificName = "Scientific name"))
+            NewSpeciesModel(
+                id = null, organizationId = organizationId, scientificName = "Scientific name"))
 
     verify { speciesChecker.checkSpecies(speciesId) }
   }
@@ -56,11 +57,11 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     val speciesId = SpeciesId(1)
 
     insertSpecies(speciesId, "Old name")
-    val originalRow = speciesDao.fetchOneById(speciesId)!!
+    val originalModel = speciesStore.fetchSpeciesById(speciesId)
 
-    val updatedRow = service.updateSpecies(originalRow.copy(scientificName = "New name"))
+    val updatedModel = service.updateSpecies(originalModel.copy(scientificName = "New name"))
 
-    assertEquals("New name", updatedRow.scientificName)
+    assertEquals("New name", updatedModel.scientificName)
 
     verify {
       speciesChecker.recheckSpecies(


### PR DESCRIPTION
In preparation for adding a per-species list of ecosystem types, introduce a new
model class to represent the data about a species. Update internal APIs to use
these models instead of the generated jOOQ model classes.

No behavior change here; this is just groundwork for the upcoming change.