### PR TITLE
SW-2777 Use selected locale from Keycloak for new users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -30,7 +30,7 @@ import io.ktor.http.Parameters
 import io.ktor.serialization.JsonConvertException
 import java.time.Clock
 import java.time.Instant
-import java.util.Base64
+import java.util.*
 import javax.inject.Named
 import javax.ws.rs.core.Response
 import kotlin.random.Random
@@ -546,6 +546,8 @@ class UserStore(
       usersDao.update(updatedRow)
       updatedRow
     } else {
+      val localeAttribute =
+          keycloakUser.attributes?.get("locale")?.firstOrNull()?.let { Locale.forLanguageTag(it) }
       val usersRow =
           UsersRow(
               authId = keycloakUser.id,
@@ -553,6 +555,7 @@ class UserStore(
               emailNotificationsEnabled = false,
               firstName = keycloakUser.firstName,
               lastName = keycloakUser.lastName,
+              locale = localeAttribute,
               userTypeId = type,
               createdTime = clock.instant(),
               modifiedTime = clock.instant(),

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.records.UserPreferencesRecord
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
+import com.terraformation.backend.i18n.Locales
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.util.HttpClientConfig
 import io.ktor.client.HttpClient
@@ -93,6 +94,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   private val authId = "authId"
   private val userRepresentation =
       UserRepresentation().apply {
+        attributes = mapOf("locale" to listOf("gx"))
         email = "email"
         firstName = "firstName"
         id = authId
@@ -163,7 +165,8 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchByAuthId fetches user information from Keycloak if not found locally`() {
     val user = userStore.fetchByAuthId(authId) as IndividualUser
 
-    assertEquals(userRepresentation.email, user.email)
+    assertEquals(userRepresentation.email, user.email, "Email")
+    assertEquals(Locales.GIBBERISH, user.locale, "Locale")
   }
 
   @Test


### PR DESCRIPTION
If a new user has selected a locale during registration, record it in their
Terraware user information.