### PR TITLE
SW-2798 Localize notification email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -8,12 +8,14 @@ import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.email.model.EmailTemplateModel
+import com.terraformation.backend.i18n.use
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.processToString
 import freemarker.template.Configuration
 import freemarker.template.TemplateNotFoundException
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.util.*
 import javax.inject.Named
 import javax.mail.internet.InternetAddress
 import org.apache.commons.validator.routines.EmailValidator
@@ -93,7 +95,8 @@ class EmailService(
     if (requireOptIn && !user.emailNotificationsEnabled) {
       log.info("Skipping email notification for user ${user.userId} because they didn't enable it")
     } else {
-      send(model, listOf(user.email))
+      val locale = user.locale ?: Locale.ENGLISH
+      locale.use { send(model, listOf(user.email)) }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -7,6 +7,11 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
+import com.terraformation.backend.i18n.currentLocale
+import freemarker.ext.beans.ResourceBundleModel
+import freemarker.template.Configuration
+import freemarker.template.DefaultObjectWrapperBuilder
+import java.util.ResourceBundle
 
 /**
  * Common attributes for classes that can be passed as models when rendering email templates. This
@@ -15,6 +20,17 @@ import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
  */
 abstract class EmailTemplateModel(config: TerrawareServerConfig) {
   val webAppUrl: String = "${config.webAppUrl}".trimEnd('/')
+
+  /**
+   * Localized strings for the current recipient. The "by lazy" here is critical: this will be
+   * initialized the first time a template tries to use a string, at which point [currentLocale]
+   * will have already been set to the recipient's locale.
+   */
+  val strings: ResourceBundleModel by lazy {
+    ResourceBundleModel(
+        ResourceBundle.getBundle("i18n.Messages", currentLocale()),
+        DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_31).build())
+  }
 
   /**
    * Subdirectory of `src/main/resources/templates/email` containing the Freemarker templates to

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -107,25 +107,26 @@ class Messages {
   /** Title and body to use for "user added to organization" app notification */
   fun userAddedToOrganizationNotification(orgName: String): NotificationMessage =
       NotificationMessage(
-          title = getMessage("userAddedToOrganizationNotificationTitle"),
-          body = getMessage("userAddedToOrganizationNotificationBody", orgName))
+          title = getMessage("notification.user.addedToOrganization.app.title"),
+          body = getMessage("notification.user.addedToOrganization.app.body", orgName))
 
   fun accessionDryingEndNotification(accessionNumber: String): NotificationMessage =
       NotificationMessage(
-          title = getMessage("accessionDryingEndNotificationTitle"),
-          body = getMessage("accessionDryingEndNotificationBody", accessionNumber))
+          title = getMessage("notification.accession.dryingEnd.app.title"),
+          body = getMessage("notification.accession.dryingEnd.app.body", accessionNumber))
 
   fun nurserySeedlingBatchReadyNotification(
       batchNumber: String,
       facilityName: String
   ): NotificationMessage =
       NotificationMessage(
-          title = getMessage("nurserySeedlingBatchReadyNotificationTitle", batchNumber),
-          body = getMessage("nurserySeedlingBatchReadyNotificationBody", batchNumber, facilityName))
+          title = getMessage("notification.batch.ready.app.title", batchNumber),
+          body = getMessage("notification.batch.ready.app.body", batchNumber, facilityName))
 
   fun facilityIdle(): NotificationMessage =
       NotificationMessage(
-          title = getMessage("facilityIdleTitle"), body = getMessage("facilityIdleBody"))
+          title = getMessage("notification.seedBank.idle.app.title"),
+          body = getMessage("notification.seedBank.idle.app.body"))
 
   fun sensorBoundsAlert(
       device: DevicesRow,
@@ -137,19 +138,29 @@ class Messages {
           title =
               when {
                 device.deviceType == "BMU" && timeseriesName == "relative_state_of_charge" ->
-                    getMessage("lowPowerWarningTitle", facilityName)
-                else -> getMessage("sensorBoundsAlertTitle", device.name!!)
+                    getMessage("notification.seedBank.lowPower.app.title", facilityName)
+                else -> getMessage("notification.seedBank.sensorBounds.app.title", device.name!!)
               },
           body =
               when {
                 device.deviceType == "BMU" && timeseriesName == "relative_state_of_charge" ->
-                    getMessage("lowPowerWarningBody", value)
+                    getMessage("notification.seedBank.lowPower.app.body", value)
                 device.deviceType == "sensor" && timeseriesName == "humidity" ->
-                    getMessage("sensorBoundsAlertHumidityBody", device.name!!, value)
+                    getMessage(
+                        "notification.seedBank.sensorBounds.humidity.app.body",
+                        device.name!!,
+                        value)
                 device.deviceType == "sensor" && timeseriesName == "temperature" ->
-                    getMessage("sensorBoundsAlertTemperatureBody", device.name!!, value)
+                    getMessage(
+                        "notification.seedBank.sensorBounds.temperature.app.body",
+                        device.name!!,
+                        value)
                 else ->
-                    getMessage("sensorBoundsAlertDefaultBody", timeseriesName, device.name!!, value)
+                    getMessage(
+                        "notification.seedBank.sensorBounds.generic.app.body",
+                        timeseriesName,
+                        device.name!!,
+                        value)
               })
 
   fun unknownAutomationTriggered(
@@ -158,13 +169,17 @@ class Messages {
       message: String?
   ): NotificationMessage =
       NotificationMessage(
-          title = getMessage("unknownAutomationTriggeredTitle", automationName, facilityName),
-          body = message ?: getMessage("unknownAutomationTriggeredBody"))
+          title =
+              getMessage(
+                  "notification.seedBank.unknownAutomationTriggered.app.title",
+                  automationName,
+                  facilityName),
+          body = message ?: getMessage("notification.seedBank.unknownAutomationTriggered.app.body"))
 
   fun deviceUnresponsive(deviceName: String): NotificationMessage =
       NotificationMessage(
-          title = getMessage("deviceUnresponsiveTitle", deviceName),
-          body = getMessage("deviceUnresponsiveBody", deviceName))
+          title = getMessage("notification.seedBank.deviceUnresponsive.app.title", deviceName),
+          body = getMessage("notification.seedBank.deviceUnresponsive.app.body", deviceName))
 
   fun historyAccessionCreated() = getMessage("historyAccessionCreated")
 

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -79,32 +79,81 @@ csvBooleanValues.true.7=Y
 csvBooleanValues.true.8=TRUE
 csvBooleanValues.true.9=YES
 
-# In-app notifications
-userAddedToOrganizationNotificationTitle=You've been added to a new organization!
-userAddedToOrganizationNotificationBody=You are now a member of {0}. Welcome!
+# Notifications.
+notification.accession.email.linkIntro=Please click the link below to go to your Terraware account where you can view the accession.
+notification.accession.email.buttonIntro=Please click the button below to go to your Terraware account where you can view the accession.
+notification.batch.email.linkIntro=Please click the link below to go to your Terraware account where you can view the batch.
+notification.batch.email.buttonIntro=Please click the button below to go to your Terraware account where you can view the batch.
+notification.organization.email.linkIntro=Please click the link below to go to your Terraware account where you can view the organization.
+notification.organization.email.buttonIntro=Please click the button below to go to your Terraware account where you can view the organization.
+notification.seedBank.email.linkIntro=Please click the link below to go to your Terraware account where you can view the seed bank.
+notification.seedBank.email.buttonIntro=Please click the button below to go to your Terraware account where you can view the seed bank.
+notification.email.buttonLabel=Go to Terraware
+notification.email.text.footer=Terraformation Inc.\n\
+  PO Box 3470, PMB 15777, Honolulu, HI 96801-3470\n\
+  \n\
+  https://twitter.com/TF_Global\n\
+  https://www.linkedin.com/company/terraformation/\n\
+  https://www.instagram.com/globalterraform/\n\
+  https://www.facebook.com/GlobalTerraform\n\
+  https://terraformation.com/
+notification.email.html.footer.1=Terraformation Inc.
+notification.email.html.footer.2=PO Box 3470, PMB 15777
+notification.email.html.footer.3=Honolulu, HI 96801-3470
 
-accessionDryingEndNotificationTitle=An accession has dried
-accessionDryingEndNotificationBody={0} has finished drying.
+notification.user.addedToOrganization.app.title=You''ve been added to a new organization!
+notification.user.addedToOrganization.app.body=You are now a member of {0}. Welcome!
+notification.user.addedToOrganization.email.subject=You''ve been added to a new organization!
+notification.user.addedToOrganization.email.body.1=You are now a member of {0}. Welcome!
+notification.user.addedToOrganization.email.body.2=Added by {0} ({1})
 
-nurserySeedlingBatchReadyNotificationTitle={0} has reached its scheduled ready by date.
-nurserySeedlingBatchReadyNotificationBody={0} (located in {1}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
+notification.accession.dryingEnd.app.title=An accession has dried
+notification.accession.dryingEnd.app.body={0} has finished drying.
+notification.accession.dryingEnd.email.subject=An accession has dried.
+notification.accession.dryingEnd.email.body={0} (located in {1}) has reached its scheduled drying date. It is ready to be moved into storage now.
 
-facilityIdleTitle=Device manager cannot be detected.
-facilityIdleBody=Device manager is disconnected. Please check on it.
+notification.batch.ready.app.title={0} has reached its scheduled ready by date.
+notification.batch.ready.app.body={0} (located in {1}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
+notification.batch.ready.email.subject=A Seedling Batch is Ready
+notification.batch.ready.email.body={0} (located in {1}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
 
-lowPowerWarningTitle=Low power warning for {0}
-lowPowerWarningBody=The relative state of charge of the solar power system is at {0}%.
+notification.seedBank.alert.email.subject=Alert: {0}
+notification.seedBank.alert.email.body=Alert received from facility {0}:
 
-sensorBoundsAlertTitle={0} is out of range.
-sensorBoundsAlertDefaultBody={0} on {1} is {2}, which is out of threshold.
-sensorBoundsAlertHumidityBody={0} has been or is at {1}% RH for the past 5 minutes, which is out of threshold. Please check on it.
-sensorBoundsAlertTemperatureBody={0} has been or is at {1}°C for the past 5 minutes, which is out of threshold. Please check on it."
+notification.seedBank.idle.app.title=Device manager cannot be detected.
+notification.seedBank.idle.app.body=Device manager is disconnected. Please check on it.
+notification.seedBank.idle.email.subject=Device manager cannot be detected.
+notification.seedBank.idle.email.body.1=Device manager is disconnected. Please go to {0} and check on it.
+notification.seedBank.idle.email.body.text.2=Submit an issue request at https://www.terraformation.com/contact-us/terraware-support if issues persist.
+notification.seedBank.idle.email.body.html.2.beforeLink=
+notification.seedBank.idle.email.body.html.2.link=Contact Us
+notification.seedBank.idle.email.body.html.2.afterLink=\ to submit an issue request if issues persist.
 
-unknownAutomationTriggeredTitle={0} triggered at {1}
-unknownAutomationTriggeredBody=Please check on it.
+notification.seedBank.lowPower.app.title=Low power warning for {0}
+notification.seedBank.lowPower.app.body=The relative state of charge of the solar power system is at {0}%.
+notification.seedBank.lowPower.email.subject=Low power warning for {0}
+notification.seedBank.lowPower.email.body=The relative state of charge of the solar power system is at {0}%.
 
-deviceUnresponsiveTitle={0} cannot be detected.
-deviceUnresponsiveBody={0} cannot be detected. Please check on it.
+notification.seedBank.sensorBounds.app.title={0} is out of range.
+notification.seedBank.sensorBounds.email.subject={0} is out of range.
+notification.seedBank.sensorBounds.generic.app.body={0} on {1} is {2}, which is out of threshold.
+notification.seedBank.sensorBounds.humidity.app.body={0} has been or is at {1}% RH for the past 5 minutes, which is out of threshold. Please check on it.
+notification.seedBank.sensorBounds.humidity.email.body.1={0} has been or is at {1}% RH for the past 5 minutes, which is out of threshold.
+notification.seedBank.sensorBounds.temperature.app.body={0} has been or is at {1}°C for the past 5 minutes, which is out of threshold. Please check on it."
+notification.seedBank.sensorBounds.temperature.email.body.1={0} has been or is at {1}°C for the past 5 minutes, which is out of threshold.
+notification.seedBank.sensorBounds.generic.email.body.1={0} on {1} is {2}, which is out of threshold.
+notification.seedBank.sensorBounds.generic.email.body.2=Please go to {0} to check on it.
+
+notification.seedBank.unknownAutomationTriggered.app.title={0} triggered at {1}
+notification.seedBank.unknownAutomationTriggered.app.body=Please check on it.
+notification.seedBank.unknownAutomationTriggered.email.subject={0} triggered at {1}
+notification.seedBank.unknownAutomationTriggered.email.body.1=Automation {0} has been triggered at {1}.
+notification.seedBank.unknownAutomationTriggered.email.body.2=Additional details: {0}
+
+notification.seedBank.deviceUnresponsive.app.title={0} cannot be detected.
+notification.seedBank.deviceUnresponsive.app.body={0} cannot be detected. Please check on it.
+notification.seedBank.deviceUnresponsive.email.subject={0} cannot be detected.
+notification.seedBank.deviceUnresponsive.email.body={0}''s {1} cannot be detected. Please check on it.
 
 # Accession history line items. There are separate strings for different purposes because the
 # purpose might require changes to other words in the string (e.g., if the language is gendered).

--- a/src/main/resources/templates/email/accession/dryingEnd/body.ftlh.mjml
+++ b/src/main/resources/templates/email/accession/dryingEnd/body.ftlh.mjml
@@ -8,8 +8,7 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    ${accessionNumber} (located in ${facilityName}) has reached its scheduled drying
-                    date. It is ready to be moved into storage now.
+                    ${strings("notification.accession.dryingEnd.email.body", accessionNumber, facilityName)}
                 </mj-text>
                 <mj-include path="../link.ftlh.mjml"/>
             </mj-column>

--- a/src/main/resources/templates/email/accession/dryingEnd/body.txt.ftl
+++ b/src/main/resources/templates/email/accession/dryingEnd/body.txt.ftl
@@ -1,17 +1,10 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.AccessionDryingEnd" -->
-${accessionNumber} (located in ${facilityName}) has reached its scheduled drying date. It is ready to be moved into storage now.
+${strings("notification.accession.dryingEnd.email.body", accessionNumber, facilityName)}
 
-Please click the link below to go to your Terraware account where you can view the accession.
+${strings("notification.accession.email.linkIntro")}
 ${accessionUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/accession/dryingEnd/subject.ftl
+++ b/src/main/resources/templates/email/accession/dryingEnd/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.AccessionDryingEnd" -->
-An accession has dried.
+${strings("notification.accession.dryingEnd.email.subject")}

--- a/src/main/resources/templates/email/accession/link.ftlh.mjml
+++ b/src/main/resources/templates/email/accession/link.ftlh.mjml
@@ -1,6 +1,6 @@
 <mj-text mj-class="text-body03">
-    Please click the button below to go to your Terraware account where you can view
-    the accession.
+    ${strings("notification.accession.email.buttonIntro")}
 </mj-text>
-<mj-button mj-class="btn-productive-primary-md" href="${accessionUrl?no_esc}">Go to Terraware
+<mj-button mj-class="btn-productive-primary-md"
+           href="${accessionUrl?no_esc}">${strings("notification.email.buttonLabel")}
 </mj-button>

--- a/src/main/resources/templates/email/device/humidity/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/humidity/body.ftlh.mjml
@@ -9,12 +9,11 @@
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
                     <p>
-                        ${device.name} has been or is ${value}% RH for the past 5 minutes, which
-                        is out of threshold.
+                        ${strings("notification.seedBank.sensorBounds.humidity.email.body.1", device.name, value)}
                     </p>
 
                     <p>
-                        Please go to ${facility.name} and check on it.
+                        ${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
                     </p>
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>

--- a/src/main/resources/templates/email/device/humidity/body.txt.ftl
+++ b/src/main/resources/templates/email/device/humidity/body.txt.ftl
@@ -1,19 +1,12 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${device.name} has been or is ${value}% RH for the past 5 minutes, which is out of threshold.
+${strings("notification.seedBank.sensorBounds.humidity.email.body.1", device.name, value)}
 
-Please go to ${facility.name} and check on it.
+${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/humidity/subject.ftl
+++ b/src/main/resources/templates/email/device/humidity/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${device.name} is out of range.
+${strings("notification.seedBank.sensorBounds.email.subject", device.name)}

--- a/src/main/resources/templates/email/device/lowPower/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/lowPower/body.ftlh.mjml
@@ -8,7 +8,7 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    The relative state of charge of the solar power system is at ${value}%.
+                    ${strings("notification.seedBank.lowPower.email.body", value)}
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>
             </mj-column>

--- a/src/main/resources/templates/email/device/lowPower/body.txt.ftl
+++ b/src/main/resources/templates/email/device/lowPower/body.txt.ftl
@@ -1,17 +1,12 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-The relative state of charge of the solar power system is at ${value}%.
+${strings("notification.seedBank.lowPower.email.body", value)}
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
+
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/lowPower/subject.ftl
+++ b/src/main/resources/templates/email/device/lowPower/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-Low power warning for ${facility.name}
+${strings("notification.seedBank.lowPower.email.subject", facility.name)}

--- a/src/main/resources/templates/email/device/sensorBounds/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/sensorBounds/body.ftlh.mjml
@@ -9,12 +9,11 @@
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
                     <p>
-                        ${automation.timeseriesName} on ${device.name} is ${value}, which is out of
-                        threshold.
+                        ${strings("notification.seedBank.sensorBounds.generic.email.body.1", automation.timeseriesName, device.name, value)}
                     </p>
 
                     <p>
-                        Please go to ${facility.name} and check on it.
+                        ${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
                     </p>
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>

--- a/src/main/resources/templates/email/device/sensorBounds/body.txt.ftl
+++ b/src/main/resources/templates/email/device/sensorBounds/body.txt.ftl
@@ -1,19 +1,12 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${automation.timeseriesName} on ${device.name} is ${value}, which is out of threshold.
+${strings("notification.seedBank.sensorBounds.generic.email.body.1", automation.timeseriesName, device.name, value)}
 
-Please go to ${facility.name} and check on it.
+${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/sensorBounds/subject.ftl
+++ b/src/main/resources/templates/email/device/sensorBounds/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${device.name} is out of range.
+${strings("notification.seedBank.sensorBounds.email.subject", device.name)}

--- a/src/main/resources/templates/email/device/temperature/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/temperature/body.ftlh.mjml
@@ -9,12 +9,11 @@
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
                     <p>
-                        ${device.name} has been or is ${value}&deg;C for the past 5 minutes, which
-                        is out of threshold.
+                        ${strings("notification.seedBank.sensorBounds.temperature.email.body.1", device.name, value)}
                     </p>
 
                     <p>
-                        Please go to ${facility.name} and check on it.
+                        ${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
                     </p>
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>

--- a/src/main/resources/templates/email/device/temperature/body.txt.ftl
+++ b/src/main/resources/templates/email/device/temperature/body.txt.ftl
@@ -1,19 +1,12 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${device.name} has been or is ${value}°C for the past 5 minutes, which is out of threshold.
+${strings("notification.seedBank.sensorBounds.temperature.email.body.1", device.name, value)}
 
-Please go to ${facility.name} and check on it.
+${strings("notification.seedBank.sensorBounds.generic.email.body.2", facility.name)}
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/temperature/subject.ftl
+++ b/src/main/resources/templates/email/device/temperature/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.SensorBoundsAlert" -->
-${device.name} is out of range.
+${strings("notification.seedBank.sensorBounds.email.subject", device.name)}

--- a/src/main/resources/templates/email/device/unknownAutomation/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/unknownAutomation/body.ftlh.mjml
@@ -8,10 +8,10 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    Automation ${automation.name} has been triggered at ${facility.name}.
+                    ${strings("notification.seedBank.unknownAutomationTriggered.email.body.1", automation.name, facility.name)}
 
                     <!-- htmlmin:ignore --><#if message?has_content><!-- htmlmin:ignore -->
-                        <p>Additional details: ${message}</p>
+                        <p>${strings("notification.seedBank.unknownAutomationTriggered.email.body.2", message)}</p>
                     <!-- htmlmin:ignore --></#if><!-- htmlmin:ignore -->
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>

--- a/src/main/resources/templates/email/device/unknownAutomation/body.txt.ftl
+++ b/src/main/resources/templates/email/device/unknownAutomation/body.txt.ftl
@@ -1,21 +1,14 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UnknownAutomationTriggered" -->
-Automation ${automation.name} has been triggered at ${facility.name}.
+${strings("notification.seedBank.unknownAutomationTriggered.email.body.1", automation.name, facility.name)}
 <#if message?has_content>
 
-Additional details: ${message}
+${strings("notification.seedBank.unknownAutomationTriggered.email.body.2", message)}
 </#if>
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/unknownAutomation/subject.ftl
+++ b/src/main/resources/templates/email/device/unknownAutomation/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UnknownAutomationTriggered" -->
-${automation.name} triggered at ${facility.name}
+${strings("notification.seedBank.unknownAutomationTriggered.email.subject", automation.name, facility.name)}

--- a/src/main/resources/templates/email/device/unresponsive/body.ftlh.mjml
+++ b/src/main/resources/templates/email/device/unresponsive/body.ftlh.mjml
@@ -8,7 +8,7 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    ${facility.name}'s ${device.name} cannot be detected. Please check on it.
+                    ${strings("notification.seedBank.deviceUnresponsive.email.body", facility.name, device.name)}
                 </mj-text>
                 <mj-include path="../../facility/link.ftlh.mjml"/>
             </mj-column>

--- a/src/main/resources/templates/email/device/unresponsive/body.txt.ftl
+++ b/src/main/resources/templates/email/device/unresponsive/body.txt.ftl
@@ -1,17 +1,10 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeviceUnresponsive" -->
-${facility.name}'s ${device.name} cannot be detected. Please check on it.
+${strings("notification.seedBank.deviceUnresponsive.email.body", facility.name, device.name)}
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/device/unresponsive/subject.ftl
+++ b/src/main/resources/templates/email/device/unresponsive/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeviceUnresponsive" -->
-${device.name} cannot be detected.
+${strings("notification.seedBank.deviceUnresponsive.email.subject", device.name)}

--- a/src/main/resources/templates/email/facility/alert/body.txt.ftl
+++ b/src/main/resources/templates/email/facility/alert/body.txt.ftl
@@ -1,4 +1,4 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityAlertRequested" -->
-Alert received from facility ${facility.name}:
+${strings("notification.seedBank.alert.email.body", facility.name)}
 
 ${body}

--- a/src/main/resources/templates/email/facility/alert/subject.ftl
+++ b/src/main/resources/templates/email/facility/alert/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityAlertRequested" -->
-Alert: ${subject}
+${strings("notification.seedBank.alert.email.subject", subject)}

--- a/src/main/resources/templates/email/facility/idle/body.ftlh.mjml
+++ b/src/main/resources/templates/email/facility/idle/body.ftlh.mjml
@@ -1,21 +1,23 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityIdle" --> -->
 <mjml>
-    <mj-include path="../../head.ftlh.mjml" />
+    <mj-include path="../../head.ftlh.mjml"/>
 
     <mj-body>
-        <mj-include path="../../logo.ftlh.mjml" />
+        <mj-include path="../../logo.ftlh.mjml"/>
 
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    Device manager is disconnected. Please go to ${facility.name} and check on it. 
+                    ${strings("notification.seedBank.idle.email.body.1")}
 
-                    Submit an issue request at <a href="https://www.terraformation.com/contact-us/terraware-support" target="_blank">Contact Us: Terraware</a> if issues persist. 
+                    ${strings("notification.seedBank.idle.email.body.html.2.beforeLink")}<a href="https://www.terraformation.com/contact-us/terraware-support"
+                       target="_blank">${strings("notification.seedBank.idle.email.body.html.2.link")}</a
+                    >${strings("notification.seedBank.idle.email.body.html.2.afterLink")}
                 </mj-text>
-                <mj-include path="../link.ftlh.mjml" />
+                <mj-include path="../link.ftlh.mjml"/>
             </mj-column>
         </mj-section>
 
-        <mj-include path="../../footer.ftlh.mjml" />
+        <mj-include path="../../footer.ftlh.mjml"/>
     </mj-body>
 </mjml>

--- a/src/main/resources/templates/email/facility/idle/body.txt.ftl
+++ b/src/main/resources/templates/email/facility/idle/body.txt.ftl
@@ -1,20 +1,13 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityIdle" -->
-Device manager is disconnected. Please go to ${facility.name} and check on it.
+${strings("notification.seedBank.idle.email.body.1", facility.name)}
 
-Submit an issue request at https://www.terraformation.com/contact-us/terraware-support if issues persist.
+${strings("notification.seedBank.idle.email.body.text.2")}
 
 
-Please click the link below to go to your Terraware account where you can view the seed bank.
+${strings("notification.seedBank.email.linkIntro")}
 ${facilityMonitoringUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/facility/idle/subject.ftl
+++ b/src/main/resources/templates/email/facility/idle/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.FacilityIdle" -->
-Device manager cannot be detected.
+${strings("notification.seedBank.idle.email.subject")}

--- a/src/main/resources/templates/email/facility/link.ftlh.mjml
+++ b/src/main/resources/templates/email/facility/link.ftlh.mjml
@@ -1,7 +1,6 @@
 <mj-text mj-class="text-body03">
-    Please click the button below to go to your Terraware account where you can view
-    the seed bank.
+    ${strings("notification.seedBank.email.buttonIntro")}
 </mj-text>
 <mj-button mj-class="btn-productive-primary-md" href="${facilityMonitoringUrl?no_esc}">
-    Go to Terraware
+    ${strings("notification.email.buttonLabel")}
 </mj-button>

--- a/src/main/resources/templates/email/footer.ftlh.mjml
+++ b/src/main/resources/templates/email/footer.ftlh.mjml
@@ -1,9 +1,9 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.EmailTemplateModel" --> -->
 <mj-section padding="0px">
     <mj-column mj-class="footer-wrapper">
-        <mj-text mj-class="text-body02 text-bold">Terraformation Inc.</mj-text>
-        <mj-text mj-class="text-body02">PO Box 3470, PMB 15777</mj-text>
-        <mj-text mj-class="text-body02">Honolulu, HI 96801-3470</mj-text>
+        <mj-text mj-class="text-body02 text-bold">${strings("notification.email.html.footer.1")}</mj-text>
+        <mj-text mj-class="text-body02">${strings("notification.email.html.footer.2")}</mj-text>
+        <mj-text mj-class="text-body02">${strings("notification.email.html.footer.3")}</mj-text>
         <mj-social mj-class="social-wrapper">
             <mj-social-element
                     mj-class="social-icons"

--- a/src/main/resources/templates/email/logo.ftlh.mjml
+++ b/src/main/resources/templates/email/logo.ftlh.mjml
@@ -1,7 +1,5 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.EmailTemplateModel" --> -->
-<mj-hero>
-    <mj-column mj-class="logo-wrapper">
-        <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.png">
-        </mj-image>
-    </mj-column>
+<mj-hero mj-class="logo-wrapper">
+    <mj-image mj-class="logo-img" src="${webAppUrl}/assets/logo-terraformation.png">
+    </mj-image>
 </mj-hero>

--- a/src/main/resources/templates/email/nursery/link.ftlh.mjml
+++ b/src/main/resources/templates/email/nursery/link.ftlh.mjml
@@ -1,6 +1,5 @@
 <mj-text mj-class="text-body03">
-    Please click the button below to go to your Terraware account where you can view
-    the batch.
+    ${strings("notification.batch.email.buttonIntro")}
 </mj-text>
-<mj-button mj-class="btn-productive-primary-md" href="${seedlingBatchUrl?no_esc}">Go to Terraware
+<mj-button mj-class="btn-productive-primary-md" href="${seedlingBatchUrl?no_esc}">${strings("notification.email.buttonLabel")}
 </mj-button>

--- a/src/main/resources/templates/email/nursery/seedlingBatchReady/body.ftlh.mjml
+++ b/src/main/resources/templates/email/nursery/seedlingBatchReady/body.ftlh.mjml
@@ -8,8 +8,7 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    ${seedlingBatchNumber} (located in ${nurseryName}) has reached its scheduled
-                    ready by date. Check on your plants and update their status if needed.
+                    ${strings("notification.batch.ready.email.body", seedlingBatchNumber, nurseryName)}
                 </mj-text>
                 <mj-include path="../link.ftlh.mjml"/>
             </mj-column>

--- a/src/main/resources/templates/email/nursery/seedlingBatchReady/body.txt.ftl
+++ b/src/main/resources/templates/email/nursery/seedlingBatchReady/body.txt.ftl
@@ -1,17 +1,10 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.NurserySeedlingBatchReady" -->
-${seedlingBatchNumber} (located in ${nurseryName}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
+${strings("notification.batch.ready.email.body", seedlingBatchNumber, nurseryName)}
 
-Please click the link below to go to your Terraware account where you can view the batch.
+${strings("notification.batch.email.linkIntro")}
 ${seedlingBatchUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/nursery/seedlingBatchReady/subject.ftl
+++ b/src/main/resources/templates/email/nursery/seedlingBatchReady/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.NurserySeedlingBatchReady" -->
-A Seedling Batch is Ready
+${strings("notification.batch.ready.email.subject")}

--- a/src/main/resources/templates/email/user/addedToOrganization/body.ftlh.mjml
+++ b/src/main/resources/templates/email/user/addedToOrganization/body.ftlh.mjml
@@ -1,28 +1,23 @@
 <!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" --> -->
 <mjml>
-    <mj-include path="../../head.ftlh.mjml" />
+    <mj-include path="../../head.ftlh.mjml"/>
 
     <mj-body>
-        <mj-include path="../../logo.ftlh.mjml" />
+        <mj-include path="../../logo.ftlh.mjml"/>
 
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                    You are now a member of ${organization.name}. Welcome!</mj-text
-                >
+                ${strings("notification.user.addedToOrganization.email.body.1", organization.name)}</mj-text>
                 <mj-text mj-class="text-body03">
-                    Added by ${admin.fullName!} (<a href="">${admin.email}</a>)</mj-text
-                >
+                ${strings("notification.user.addedToOrganization.email.body.2", admin.fullName, admin.email)}</mj-text>
                 <mj-text mj-class="text-body03">
-                    Please click the button below to go to your Terraware account where you can view
-                    the organization.</mj-text
-                >
+                ${strings("notification.organization.email.buttonIntro")}</mj-text>
                 <mj-button mj-class="btn-productive-primary-md" href="${organizationHomeUrl?no_esc}"
-                    >Go to Terraware</mj-button
-                >
+                >${strings("notification.email.buttonLabel")}</mj-button>
             </mj-column>
         </mj-section>
 
-        <mj-include path="../../footer.ftlh.mjml" />
+        <mj-include path="../../footer.ftlh.mjml"/>
     </mj-body>
 </mjml>

--- a/src/main/resources/templates/email/user/addedToOrganization/body.txt.ftl
+++ b/src/main/resources/templates/email/user/addedToOrganization/body.txt.ftl
@@ -1,19 +1,12 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" -->
-You are now a member of ${organization.name}. Welcome!
+${strings("notification.user.addedToOrganization.email.body.1", organization.name)}
 
-Added by ${admin.fullName} (${admin.email})
+${strings("notification.user.addedToOrganization.email.body.2", admin.fullName, admin.email)}
 
-Please click the link below to go to your Terraware account where you can view the organization.
+${strings("notification.organization.email.linkIntro")}
 ${organizationHomeUrl}
 
 
 ------------------------------
 
-Terraformation Inc.
-PO Box 3470, PMB 15777, Honolulu, HI 96801-3470
-
-https://twitter.com/TF_Global
-https://www.linkedin.com/company/terraformation/
-https://www.instagram.com/globalterraform/
-https://www.facebook.com/GlobalTerraform
-https://terraformation.com/
+${strings("notification.email.text.footer")}

--- a/src/main/resources/templates/email/user/addedToOrganization/subject.ftl
+++ b/src/main/resources/templates/email/user/addedToOrganization/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.UserAddedToOrganization" -->
-You've been added to a new organization!
+${strings("notification.user.addedToOrganization.email.subject")}


### PR DESCRIPTION
Look up the human-readable text in email messages from a localizable resource
bundle using the recipient's locale instead of hardwiring English into the
templates.

Rename the strings for the existing in-app notification messages so they're
named consistently with the strings for the email notifications.

Also implements SW-1046.