### PR TITLE
SW-2797 Localize country names

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -50,6 +50,37 @@ class TerrawareGenerator : KotlinGenerator() {
     closeJavaWriter(out)
     english.save()
     gibberish.save()
+
+    generateCountryProperties(schema, "countries", "Countries")
+    generateCountryProperties(schema, "country_subdivisions", "CountrySubdivisions")
+  }
+
+  private fun generateCountryProperties(
+      schema: SchemaDefinition,
+      tableName: String,
+      baseName: String
+  ) {
+    if (!schema.isDefaultSchema) {
+      return
+    }
+
+    val english = SortedPropertiesFile(getFile(schema), baseName)
+    val gibberish = SortedPropertiesFile(getFile(schema), "${baseName}_gx")
+
+    schema.database.connection.prepareStatement("SELECT code, name FROM $tableName").use { ps ->
+      ps.executeQuery().use { rs ->
+        while (rs.next()) {
+          val code = rs.getString(1)
+          val englishName = rs.getString(2)
+
+          english[code] = englishName
+          gibberish[code] = englishName.toGibberish()
+        }
+      }
+    }
+
+    english.save()
+    gibberish.save()
   }
 
   private fun printEnum(

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.search.field.EnumField
 import com.terraformation.backend.search.field.GeometryField
 import com.terraformation.backend.search.field.IdWrapperField
 import com.terraformation.backend.search.field.IntegerField
+import com.terraformation.backend.search.field.LocalizedTextField
 import com.terraformation.backend.search.field.LongField
 import com.terraformation.backend.search.field.MappedField
 import com.terraformation.backend.search.field.SearchField
@@ -260,6 +261,14 @@ abstract class SearchTable {
       databaseField: TableField<*, Int?>,
       nullable: Boolean = true
   ) = IntegerField(fieldName, displayName, databaseField, this, nullable)
+
+  fun localizedTextField(
+      fieldName: String,
+      displayName: String,
+      databaseField: TableField<*, String?>,
+      resourceBundleName: String,
+      nullable: Boolean = true
+  ) = LocalizedTextField(fieldName, displayName, databaseField, resourceBundleName, this, nullable)
 
   fun longField(
       fieldName: String,

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -1,0 +1,107 @@
+package com.terraformation.backend.search.field
+
+import com.terraformation.backend.i18n.currentLocale
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchFilterType
+import com.terraformation.backend.search.SearchTable
+import java.text.Collator
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import org.jooq.Condition
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.impl.DSL
+
+/**
+ * Search field for values that are mapped to localized strings but are not represented as enums.
+ */
+class LocalizedTextField(
+    override val fieldName: String,
+    override val displayName: String,
+    /** The field that has the name of the string to look up in the resource bundle. */
+    override val databaseField: Field<String?>,
+    val resourceBundleName: String,
+    override val table: SearchTable,
+    override val nullable: Boolean = true,
+) : SingleColumnSearchField<String>() {
+  /**
+   * Maps the lower-case localized strings to their corresponding database field values. The
+   * interior Map is sorted alphabetically by localized string.
+   */
+  private val fieldValuesByLocalizedString = ConcurrentHashMap<Locale, Map<String, String>>()
+
+  /** Maps the database field values to their corresponding localized strings. */
+  private val localizedStringsByFieldValue = ConcurrentHashMap<Locale, Map<String, String>>()
+
+  /**  */
+  private val orderByFields = ConcurrentHashMap<Locale, Field<Int>>()
+
+  override val supportedFilterTypes: Set<SearchFilterType>
+    get() = EnumSet.of(SearchFilterType.Exact)
+
+  override fun getCondition(fieldNode: FieldNode): Condition {
+    val locale = currentLocale()
+    val valuesMap = getFieldValuesByLocalizedStringMap()
+    val nonNullFieldValues =
+        fieldNode.values.filterNotNull().map { valuesMap[it.lowercase(locale)] }
+
+    return when (fieldNode.type) {
+      SearchFilterType.Exact ->
+          DSL.or(
+              listOfNotNull(
+                  if (nonNullFieldValues.isNotEmpty()) {
+                    databaseField.`in`(nonNullFieldValues)
+                  } else {
+                    null
+                  },
+                  if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      SearchFilterType.Fuzzy ->
+          throw IllegalArgumentException("Fuzzy search not supported for localized text fields")
+      SearchFilterType.Range ->
+          throw IllegalArgumentException("Range search not supported for localized text fields")
+    }
+  }
+
+  override fun computeValue(record: Record): String? {
+    return record[databaseField]?.let { getLocalizedString(it) }
+  }
+
+  override val possibleValues: List<String>
+    get() = getFieldValuesByLocalizedStringMap().keys.toList()
+
+  /**
+   * Returns an expression that converts the database field to an integer sort position. We need to
+   * construct this in the application code because the database doesn't know the localized strings.
+   */
+  override val orderByField: Field<*>
+    get() {
+      return orderByFields.getOrPut(currentLocale()) {
+        val valuesMap = getFieldValuesByLocalizedStringMap()
+        val fieldValuesToPosition: Map<String?, Int> =
+            valuesMap.entries.mapIndexed { index, (_, fieldValue) -> fieldValue to index }.toMap()
+
+        return DSL.case_(databaseField).mapValues(fieldValuesToPosition).else_(valuesMap.size)
+      }
+    }
+
+  private fun getLocalizedString(databaseValue: String): String {
+    val locale = currentLocale()
+    val stringsForLocale =
+        localizedStringsByFieldValue.getOrPut(locale) {
+          val bundle = ResourceBundle.getBundle(resourceBundleName, locale)
+          bundle.keySet().associateWith { bundle.getString(it) }
+        }
+
+    return stringsForLocale[databaseValue]
+        ?: throw IllegalStateException("No localized string for $databaseValue in $locale")
+  }
+
+  private fun getFieldValuesByLocalizedStringMap(): Map<String, String> {
+    val locale = currentLocale()
+    return fieldValuesByLocalizedString.getOrPut(locale) {
+      val bundle = ResourceBundle.getBundle(resourceBundleName, locale)
+      val map = bundle.keySet().associateBy { bundle.getString(it).lowercase(locale) }
+      map.keys.sortedWith(Collator.getInstance(locale)).associateWith { map[it]!! }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountriesTable.kt
@@ -29,7 +29,7 @@ class CountriesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           textField("code", "Country code", COUNTRIES.CODE),
-          textField("name", "Country name", COUNTRIES.NAME),
+          localizedTextField("name", "Country name", COUNTRIES.CODE, "i18n.Countries"),
       )
 
   override fun conditionForScope(scope: SearchScope): Condition? = null

--- a/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CountrySubdivisionsTable.kt
@@ -30,7 +30,11 @@ class CountrySubdivisionsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           textField("code", "Country subdivision code", COUNTRY_SUBDIVISIONS.CODE),
-          textField("name", "Country subdivision name", COUNTRY_SUBDIVISIONS.NAME),
+          localizedTextField(
+              "name",
+              "Country subdivision name",
+              COUNTRY_SUBDIVISIONS.CODE,
+              "i18n.CountrySubdivisions"),
       )
 
   override fun conditionForScope(scope: SearchScope): Condition? = null


### PR DESCRIPTION
Make the search API return localized names for countries and country subdivisions.
The frontend uses the search API to get the list of available countries.

English country names are stored in the database, but they aren't turned into
Kotlin enums at build time, so the existing functionality for returning localized
strings for enum search fields won't work. But we still want to look up localized
names from resource bundles and generate the English and gibberish bundles from
the database, same as we do for enum tables.

To address this, introduce a new search field type, `LocalizedTextField`, that
works roughly the same way as `EnumField` but looks values up in resource bundles
explicitly rather than relying on the helper functions in
`EnumFromReferenceTable`.