### PR TITLE
Expect canonical enum names in request payloads

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -178,9 +178,8 @@ class TerrawareGenerator : KotlinGenerator() {
               private val byLocalizedName = ConcurrentHashMap<Locale, Map<String, $enumName>>()
               private val byId = values().associateBy { it.id }
               
-              fun forDisplayName(name: String, locale: Locale?): $enumName {
-                val effectiveLocale = locale ?: Locale.ENGLISH
-                val valuesForLocale = byLocalizedName.getOrPut(effectiveLocale) {
+              fun forDisplayName(name: String, locale: Locale): $enumName {
+                val valuesForLocale = byLocalizedName.getOrPut(locale) {
                   $enumName.values().associateBy { it.getDisplayName(locale) }
                 }
               
@@ -190,7 +189,7 @@ class TerrawareGenerator : KotlinGenerator() {
               
               @JsonCreator
               @JvmStatic
-              fun forDisplayName(name: String) = forDisplayName(name, currentLocale())
+              fun forDisplayName(name: String) = forDisplayName(name, Locale.ENGLISH)
               
               fun forId(id: Int) = byId[id]
           }


### PR DESCRIPTION
Commit a5055833 added the ability to render enum display names in different
locales, but it erroneously changed the parsing logic such that clients had to
pass localized JSON string values for enum fields in request payloads.  This
violates the OpenAPI schema which specifies that enums are always represented
using their English display names in the API.

The practical effect of this bug is that if you switch locales in the client and
try to call a write endpoint whose payload includes an enum field, you'll get a
serialization error because the server doesn't recognize the English display name.