### PR TITLE
SW-2854 Allow contributors to upload accession photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -173,6 +173,7 @@ data class DeviceManagerUser(
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = false
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = false
   override fun canUpdateUpload(uploadId: UploadId): Boolean = false
+  override fun canUploadPhoto(accessionId: AccessionId): Boolean = false
   override fun hasAnyAdminRole(): Boolean = false
 
   override fun getAuthorities(): MutableCollection<out GrantedAuthority> {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -353,6 +353,8 @@ data class IndividualUser(
 
   override fun canUpdateUpload(uploadId: UploadId) = canReadUpload(uploadId)
 
+  override fun canUploadPhoto(accessionId: AccessionId) = canReadAccession(accessionId)
+
   private fun isSuperAdmin() = userType == UserType.SuperAdmin
 
   private fun isOwner(organizationId: OrganizationId?) =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -570,4 +570,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
       throw AccessDeniedException("No permission to update upload")
     }
   }
+
+  fun uploadPhoto(accessionId: AccessionId) {
+    if (!user.canUploadPhoto(accessionId)) {
+      readAccession(accessionId)
+      throw AccessDeniedException("No permission to upload photo for accession $accessionId")
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -183,4 +183,5 @@ class SystemUser(
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = true
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true
   override fun canUpdateUpload(uploadId: UploadId): Boolean = true
+  override fun canUploadPhoto(accessionId: AccessionId): Boolean = true
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -145,6 +145,7 @@ interface TerrawareUser : Principal {
   fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean
   fun canUpdateUpload(uploadId: UploadId): Boolean
+  fun canUploadPhoto(accessionId: AccessionId): Boolean
 
   // When adding new permissions, put them in alphabetical order in the above block.
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -31,7 +31,7 @@ class PhotoRepository(
 
   @Throws(IOException::class)
   fun storePhoto(accessionId: AccessionId, data: InputStream, size: Long, metadata: PhotoMetadata) {
-    requirePermissions { updateAccession(accessionId) }
+    requirePermissions { uploadPhoto(accessionId) }
 
     val photoId =
         photoService.storePhoto("accession", data, size, metadata) { photoId ->

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -477,5 +477,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
 
+  @Test
+  fun uploadAccessionPhoto() =
+      allow { uploadPhoto(accessionId) } ifUser { canUploadPhoto(accessionId) }
+
   // When adding new permission tests, put them in alphabetical order.
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -284,6 +284,7 @@ internal class PermissionTest : DatabaseTest() {
         updateAccession = true,
         deleteAccession = true,
         setWithdrawalUser = true,
+        uploadPhoto = true,
     )
 
     permissions.expect(
@@ -450,6 +451,7 @@ internal class PermissionTest : DatabaseTest() {
         updateAccession = true,
         deleteAccession = true,
         setWithdrawalUser = true,
+        uploadPhoto = true,
     )
 
     permissions.expect(
@@ -563,6 +565,7 @@ internal class PermissionTest : DatabaseTest() {
         updateAccession = true,
         deleteAccession = true,
         setWithdrawalUser = true,
+        uploadPhoto = true,
     )
 
     permissions.expect(
@@ -662,6 +665,7 @@ internal class PermissionTest : DatabaseTest() {
         readAccession = true,
         updateAccession = false,
         deleteAccession = false,
+        uploadPhoto = true,
     )
 
     permissions.expect(
@@ -827,6 +831,7 @@ internal class PermissionTest : DatabaseTest() {
         updateAccession = true,
         deleteAccession = true,
         setWithdrawalUser = true,
+        uploadPhoto = true,
     )
 
     permissions.expect(
@@ -1170,6 +1175,7 @@ internal class PermissionTest : DatabaseTest() {
         updateAccession: Boolean = false,
         deleteAccession: Boolean = false,
         setWithdrawalUser: Boolean = false,
+        uploadPhoto: Boolean = false,
     ) {
       accessions.forEach { accessionId ->
         assertEquals(
@@ -1186,6 +1192,10 @@ internal class PermissionTest : DatabaseTest() {
             setWithdrawalUser,
             user.canSetWithdrawalUser(accessionId),
             "Can set withdrawal user for accession $accessionId")
+        assertEquals(
+            uploadPhoto,
+            user.canUploadPhoto(accessionId),
+            "Can upload photo for accession $accessionId")
 
         uncheckedAccessions.remove(accessionId)
       }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -103,7 +103,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     photoStorageUrl = URI("file:///${relativePath.invariantSeparatorsPathString}")
 
     every { user.canReadAccession(any()) } returns true
-    every { user.canUpdateAccession(any()) } returns true
+    every { user.canUploadPhoto(any()) } returns true
 
     photoService = PhotoService(dslContext, clock, fileStore, photosDao, thumbnailStore)
     repository = PhotoRepository(accessionPhotosDao, dslContext, photoService)
@@ -133,8 +133,8 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `storePhoto throws exception if user does not have permission to update accession`() {
-    every { user.canUpdateAccession(accessionId) } returns false
+  fun `storePhoto throws exception if user does not have permission to upload photos`() {
+    every { user.canUploadPhoto(accessionId) } returns false
 
     assertThrows(AccessDeniedException::class.java) {
       repository.storePhoto(accessionId, ByteArray(0).inputStream(), 0, metadata)
@@ -207,6 +207,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     val photoData = Random.nextBytes(10)
 
     every { thumbnailStore.deleteThumbnails(any()) } just Runs
+    every { user.canUpdateAccession(any()) } returns true
 
     every { random.nextLong() } returns 1L
     repository.storePhoto(


### PR DESCRIPTION
Uploading an accession photo required permission to update the accession, which
meant that contributor users couldn't upload photos as part of creating new
accessions.

Add a separate permission for accession photo upload, allowing it for everyone
who has permission to read the accession.