### PR TITLE
Clean up conditional bean declarations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTask.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.daily
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.daily.DailyTask
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import com.terraformation.backend.log.perClassLogger
@@ -15,6 +16,7 @@ import org.springframework.context.event.EventListener
     TerrawareServerConfig.NOTIFICATIONS_CLEANUP_ENABLED_PROPERTY,
     havingValue = "true",
     matchIfMissing = true)
+@DailyTask
 @Named
 class NotificationsCleanupTask(
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/daily/DailyTask.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/DailyTask.kt
@@ -1,0 +1,14 @@
+package com.terraformation.backend.daily
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.DisableIfNoDatabase
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/**
+ * Indicates that a bean class implements a daily task and should only be instantiated if daily
+ * tasks are enabled.
+ */
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@DisableIfNoDatabase
+@Target(AnnotationTarget.CLASS)
+annotation class DailyTask

--- a/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/DailyTaskRunner.kt
@@ -8,7 +8,6 @@ import java.time.Clock
 import javax.inject.Inject
 import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
@@ -21,7 +20,7 @@ import org.springframework.context.event.EventListener
  * that take the event class as an argument, and will call those methods; the listeners may return
  * values that are themselves published as events, allowing tasks to depend on other tasks.
  */
-@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@DailyTask
 @Named
 class DailyTaskRunner(
     private val clock: Clock,

--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.daily
 
-import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.DisableIfNoDatabase
 import com.terraformation.backend.log.perClassLogger
 import java.sql.SQLException
 import java.time.Duration
@@ -11,7 +11,6 @@ import javax.annotation.PreDestroy
 import javax.inject.Named
 import javax.sql.DataSource
 import org.jobrunr.server.BackgroundJobServer
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 /**
  * Restarts JobRunr's background job processing thread after database problems. JobRunr shuts down
@@ -19,7 +18,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
  * up when the database becomes available again. We want the server to recover from transient
  * database problems.
  */
-@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@DisableIfNoDatabase
 @Named
 class JobRunrRecoveryThread(
     private val backgroundJobServer: BackgroundJobServer,

--- a/src/main/kotlin/com/terraformation/backend/daily/NotificationScanner.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/NotificationScanner.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.event.FacilityTimeZoneChangedEvent
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.DisableIfNoDatabase
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.time.ClockAdvancedEvent
 import java.time.InstantSource
@@ -13,12 +14,11 @@ import javax.inject.Inject
 import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.jobrunr.scheduling.cron.Cron
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.core.annotation.Order
 
-@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@DisableIfNoDatabase
 @Named
 class NotificationScanner(
     private val clock: InstantSource,

--- a/src/main/kotlin/com/terraformation/backend/db/DisableIfNoDatabase.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/DisableIfNoDatabase.kt
@@ -1,0 +1,14 @@
+package com.terraformation.backend.db
+
+import javax.sql.DataSource
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+
+/**
+ * Indicates that a class shouldn't be instantiated by Spring if there's no database configured.
+ *
+ * Use this to stop database-dependent initialization code from breaking `./gradlew
+ * generateOpenApiDocs`.
+ */
+@ConditionalOnBean(DataSource::class)
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
+annotation class DisableIfNoDatabase

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.db
 
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.default_schema.tables.records.TimeZonesRecord
 import com.terraformation.backend.db.default_schema.tables.references.TIME_ZONES
 import com.terraformation.backend.log.perClassLogger
@@ -8,13 +7,12 @@ import java.time.ZoneId
 import javax.annotation.PostConstruct
 import javax.inject.Named
 import org.jooq.DSLContext
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 /**
  * Ensures that the `time_zones` table has all the time zone names recognized by the Java standard
  * library. Java uses the IANA tz database.
  */
-@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@DisableIfNoDatabase
 @Named
 class TimeZonePopulator(private val dslContext: DSLContext) {
   private val log = perClassLogger()

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/MigrateWithdrawnTotals.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/MigrateWithdrawnTotals.kt
@@ -1,13 +1,13 @@
 package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.DisableIfNoDatabase
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.log.perClassLogger
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
 
@@ -15,7 +15,7 @@ import org.springframework.context.event.EventListener
  * Migration to calculate total withdrawal weights and counts for accessions that don't already have
  * them. This can be removed after it has run.
  */
-@ConditionalOnBean(DSLContext::class)
+@DisableIfNoDatabase
 @Named
 class MigrateWithdrawnTotals(
     private val accessionStore: AccessionStore,


### PR DESCRIPTION
To stop database-related code from running at start time when there's no database
(e.g., when generating OpenAPI docs) we used a Spring Boot annotation that checked
whether the `terraware.dailyTasks.enabled` property was set to `false`. That
works, but it's both verbose and misleading: we had the annotation on classes
that weren't actually daily tasks at all.

Define two new annotations that make the intent clearer:

`@DisableIfNoDatabase` does what the name implies: disables the bean if there
isn't a database configured, regardless of whether or not daily tasks are
enabled.

`@DailyTask` encapsulates the configuration check and is used on actual daily
tasks. It implies `@DisableIfNoDatabase`.