### PR TITLE
Fix bug in AccessionStore.forEachAccession

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -902,6 +902,7 @@ class AccessionStore(
                 .from(ACCESSIONS)
                 .where(condition)
                 .and(nextAccessionId?.let { ACCESSIONS.ID.gt(it) } ?: DSL.trueCondition())
+                .orderBy(ACCESSIONS.ID)
                 .limit(1)
                 .forUpdate()
                 .skipLocked()


### PR DESCRIPTION
The query to fetch the next accession ID was missing an ORDER BY clause,
causing it to skip a lot of accessions.