### PR TITLE
SW-2823 Add "None" viability test substrate type

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -48,6 +48,7 @@ data class ViabilityTestModel(
           ViabilityTestSubstrate.Agar -> isLab
           ViabilityTestSubstrate.MediaMix -> isNursery
           ViabilityTestSubstrate.Moss -> isNursery
+          ViabilityTestSubstrate.None -> isLab || isNursery
           ViabilityTestSubstrate.NurseryMedia -> isLab
           ViabilityTestSubstrate.Other -> isLab || isNursery
           ViabilityTestSubstrate.Paper -> isLab

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -198,7 +198,8 @@ VALUES (1, 'Nursery Media'),
        (6, 'Media Mix'),
        (7, 'Soil'),
        (8, 'Moss'),
-       (9, 'Perlite/Vermiculite')
+       (9, 'Perlite/Vermiculite'),
+       (10, 'None')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO seedbank.viability_test_treatments (id, name)


### PR DESCRIPTION
Users want to indicate that a viability test didn't use a substrate. Add "None" to
the list of substrate types, valid for both lab and nursery tests.