### PR TITLE
SW-2789 Remove wildcard import of java.util

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -212,7 +212,7 @@ ij_javascript_while_brace_force = never
 ij_javascript_while_on_new_line = false
 ij_javascript_wrap_comments = false
 
-[{*.kt,*.kts}]
+[{*.gradle.kts,*.kt,*.kts,*.main.kts,*.space.kts}]
 indent_size = 2
 tab_width = 2
 ij_continuation_indent_size = 4
@@ -228,6 +228,7 @@ ij_kotlin_assignment_wrap = normal
 ij_kotlin_blank_lines_after_class_header = 0
 ij_kotlin_blank_lines_around_block_when_branches = 0
 ij_kotlin_blank_lines_before_declaration_with_comment_or_annotation_on_separate_line = 1
+ij_kotlin_block_comment_add_space = false
 ij_kotlin_block_comment_at_first_column = true
 ij_kotlin_call_parameters_new_line_after_left_paren = true
 ij_kotlin_call_parameters_right_paren_on_new_line = false
@@ -258,7 +259,9 @@ ij_kotlin_keep_first_column_comment = true
 ij_kotlin_keep_indents_on_empty_lines = false
 ij_kotlin_keep_line_breaks = true
 ij_kotlin_lbrace_on_next_line = false
+ij_kotlin_line_break_after_multiline_when_entry = true
 ij_kotlin_line_comment_add_space = false
+ij_kotlin_line_comment_add_space_on_reformat = false
 ij_kotlin_line_comment_at_first_column = true
 ij_kotlin_method_annotation_wrap = split_into_lines
 ij_kotlin_method_call_chain_wrap = normal
@@ -267,6 +270,7 @@ ij_kotlin_method_parameters_right_paren_on_new_line = true
 ij_kotlin_method_parameters_wrap = on_every_item
 ij_kotlin_name_count_to_use_star_import = 99999
 ij_kotlin_name_count_to_use_star_import_for_members = 99999
+ij_kotlin_packages_to_use_import_on_demand = kotlinx.android.synthetic.**,io.ktor.*
 ij_kotlin_parameter_annotation_wrap = off
 ij_kotlin_space_after_comma = true
 ij_kotlin_space_after_extend_colon = true

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -15,6 +15,10 @@ All Kotlin code must be formatted with [ktfmt](https://github.com/facebookincuba
 
 There isn't currently a way to make IntelliJ's real-time formatting adhere strictly to ktfmt's formatting rules, but the supplied `.editorconfig` file is an approximation. IntelliJ should detect it and use it automatically.
 
+### Wildcard imports
+
+By default, IntelliJ uses wildcard imports for the `java.util` and `javax` packages, and overriding that default in `.editorconfig` doesn't work reliably. You'll want to remove those packages manually from the Kotlin code style preferences ("Auto-Import" tab) in IntelliJ's settings.
+
 ## Database access
 
 The code uses a schema-first, code-generation approach to its data model, as opposed to a code-first approach where the database gets created based on class structure. It uses the [jOOQ](https://jooq.org) library to generate code that provides a fluent, type-safe query building API as well as some basic ORM features.

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
@@ -3,7 +3,8 @@ package com.terraformation.gradle
 import com.github.gradle.node.util.ProjectApiHelper
 import java.io.File
 import java.nio.file.Files
-import java.util.*
+import java.util.Base64
+import java.util.Properties
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileType

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/SortedPropertiesFile.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/SortedPropertiesFile.kt
@@ -6,7 +6,7 @@ import java.io.StringWriter
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.Properties
 
 /** Wrapper around [Properties] that saves the properties in alphabetical order. */
 internal class SortedPropertiesFile(schemaFile: File, baseName: String) {

--- a/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.api
 
 import com.terraformation.backend.i18n.Locales
-import java.util.*
+import java.util.Locale
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -26,7 +26,7 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
 import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import java.net.URI
-import java.util.*
+import java.util.Locale
 import javax.inject.Named
 import org.jooq.DSLContext
 import org.springframework.context.event.EventListener

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -13,7 +13,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
-import java.util.*
+import java.util.Locale
 import javax.servlet.http.HttpSession
 import javax.ws.rs.ForbiddenException
 import org.springframework.web.bind.annotation.DeleteMapping

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -30,7 +30,8 @@ import io.ktor.http.Parameters
 import io.ktor.serialization.JsonConvertException
 import java.time.Clock
 import java.time.Instant
-import java.util.*
+import java.util.Base64
+import java.util.Locale
 import javax.inject.Named
 import javax.ws.rs.core.Response
 import kotlin.random.Random

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -26,7 +26,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
-import java.util.*
+import java.util.Locale
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -22,7 +22,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.security.Principal
 import java.time.ZoneId
-import java.util.*
+import java.util.Locale
 
 /**
  * An entity on whose behalf the system can do work.

--- a/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
@@ -1,7 +1,9 @@
 package com.terraformation.backend.db
 
 import com.terraformation.backend.log.perClassLogger
-import java.util.*
+import java.util.Locale
+import java.util.MissingResourceException
+import java.util.ResourceBundle
 
 interface EnumFromReferenceTable<T : Enum<T>> {
   val id: Int

--- a/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.db
 
-import java.util.*
+import java.util.Locale
 import org.jooq.Collation
 import org.jooq.Field
 import org.jooq.impl.DSL

--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -15,7 +15,7 @@ import freemarker.template.Configuration
 import freemarker.template.TemplateNotFoundException
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.Locale
 import javax.inject.Named
 import javax.mail.internet.InternetAddress
 import org.apache.commons.validator.routines.EmailValidator

--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -2,7 +2,8 @@ package com.terraformation.backend.i18n
 
 import java.text.DecimalFormatSymbols
 import java.text.spi.DecimalFormatSymbolsProvider
-import java.util.*
+import java.util.Base64
+import java.util.Locale
 
 /**
  * Converts an English string to gibberish for localization testing:

--- a/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/TimeZones.kt
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.squarespace.cldrengine.CLDR
 import java.io.InputStream
-import java.lang.RuntimeException
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.TextStyle
-import java.util.*
+import java.util.Locale
+import java.util.MissingResourceException
+import java.util.Optional
+import java.util.ResourceBundle
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Named
 import org.apache.commons.text.similarity.LevenshteinDistance

--- a/src/main/kotlin/com/terraformation/backend/importer/CsvImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/importer/CsvImporter.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.i18n.use
 import com.terraformation.backend.log.perClassLogger
 import java.io.InputStream
 import java.io.InputStreamReader
-import java.util.*
 import org.jobrunr.jobs.JobId
 import org.jooq.DSLContext
 

--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.time.Clock
 import java.time.LocalDate
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.Record

--- a/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.TableField
 import org.jooq.impl.DSL

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -6,7 +6,8 @@ import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.text.Collator
-import java.util.*
+import java.util.EnumSet
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import org.jooq.Condition
 import org.jooq.Field

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -6,7 +6,9 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.util.removeDiacritics
 import java.text.Collator
-import java.util.*
+import java.util.EnumSet
+import java.util.Locale
+import java.util.ResourceBundle
 import java.util.concurrent.ConcurrentHashMap
 import org.jooq.Condition
 import org.jooq.Field

--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.util.removeDiacritics
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.impl.DSL

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.impl.DSL

--- a/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.seedbank.model.fromGrams
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.text.NumberFormat
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import org.jooq.Condition
 import org.jooq.Field

--- a/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
 import java.time.ZoneId
-import java.util.*
+import java.util.EnumSet
 import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
@@ -9,8 +9,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.importer.CsvValidator
 import com.terraformation.backend.seedbank.model.isV2Compatible
-import java.lang.NumberFormatException
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 class AccessionCsvValidator(

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -54,7 +54,7 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.Locale
 import org.jooq.Record
 import org.jooq.Table
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -98,7 +98,7 @@ import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.util.*
+import java.util.Locale
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -39,7 +39,7 @@ import io.mockk.verify
 import java.net.URI
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.Locale
 import javax.mail.Message
 import javax.mail.Multipart
 import javax.mail.Part

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -16,7 +16,7 @@ import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
 import io.mockk.every
-import java.util.*
+import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
IntelliJ uses wildcard imports for `java.util` by default, but we want to be
explicit about what we're importing. Expand those wildcard imports.

Update the Kotlin `.editorconfig` section with settings that were added to
IntelliJ after the file was most recently generated.