### PR TITLE
SW-1828 Ignore diacritics in species name lookup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifImporter.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.ParsedCsvReader
 import com.terraformation.backend.util.appendPath
 import com.terraformation.backend.util.onChunk
+import com.terraformation.backend.util.removeDiacritics
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.net.URI
@@ -302,7 +303,7 @@ class GbifImporter(
                       specificEpithet,
                       infraspecificEpithet,
                   )
-                  .map { word -> GbifNameWordsRecord(nameId, word.lowercase()) }
+                  .map { word -> GbifNameWordsRecord(nameId, word.removeDiacritics().lowercase()) }
             }
 
     val vernacularNameWords: Sequence<GbifNameWordsRecord> =
@@ -317,7 +318,7 @@ class GbifImporter(
               name!!
                   .split(' ')
                   .filter { it.length > 1 }
-                  .map { word -> GbifNameWordsRecord(nameId, word.lowercase()) }
+                  .map { word -> GbifNameWordsRecord(nameId, word.removeDiacritics().lowercase()) }
             }
 
     (scientificNameWords + vernacularNameWords).chunked(INSERT_BATCH_SIZE).forEach { records ->

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifImporterTest.kt
@@ -148,7 +148,7 @@ internal class GbifImporterTest : DatabaseTest(), RunsAsUser {
                     vernacularName = "My Species",
                     language = "en",
                     countryCode = "US"),
-                GbifVernacularNamesRow(taxonId = GbifTaxonId(12), vernacularName = "My Species 2"),
+                GbifVernacularNamesRow(taxonId = GbifTaxonId(12), vernacularName = "My Spécies 2"),
             ),
             listOf(
                 GbifNamesRow(
@@ -166,7 +166,7 @@ internal class GbifImporterTest : DatabaseTest(), RunsAsUser {
                 GbifNamesRow(
                     id = GbifNameId(3),
                     taxonId = GbifTaxonId(12),
-                    name = "My Species 2",
+                    name = "My Spécies 2",
                     language = null,
                     isScientific = false),
             ),

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.default_schema.tables.references.GBIF_TAXA
 import com.terraformation.backend.db.default_schema.tables.references.GBIF_VERNACULAR_NAMES
 import com.terraformation.backend.species.model.GbifTaxonModel
 import com.terraformation.backend.species.model.GbifVernacularNameModel
+import com.terraformation.backend.util.removeDiacritics
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
@@ -116,6 +117,17 @@ internal class GbifStoreTest : DatabaseTest() {
               namesRow(1, 1, "Species c"),
               namesRow(4, 4, "Another species"),
           )
+
+      val actual = store.findNamesByWordPrefixes(listOf("species"))
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ignores diacritics`() {
+      insertTaxon(1, "Spécies a")
+      insertTaxon(2, "Species b")
+
+      val expected = listOf(namesRow(1, 1, "Spécies a"), namesRow(2, 2, "Species b"))
 
       val actual = store.findNamesByWordPrefixes(listOf("species"))
       assertEquals(expected, actual)
@@ -377,7 +389,7 @@ internal class GbifStoreTest : DatabaseTest() {
       dslContext
           .insertInto(GBIF_NAME_WORDS)
           .set(GBIF_NAME_WORDS.GBIF_NAME_ID, nameId)
-          .set(GBIF_NAME_WORDS.WORD, word.lowercase())
+          .set(GBIF_NAME_WORDS.WORD, word.removeDiacritics().lowercase())
           .execute()
     }
   }

--- a/src/test/resources/species/gbif/VernacularName.tsv
+++ b/src/test/resources/species/gbif/VernacularName.tsv
@@ -1,5 +1,5 @@
 taxonID	vernacularName	language	country	countryCode	sex	lifeStage	source
 10	My Family						
 12	My Species	en	USA	US	M	stage	source
-12	My Species 2						
+12	My Spécies 2						
 50	Name for taxon that was not imported


### PR DESCRIPTION
When looking up a species name from the GBIF database, we want to ignore
diacritics like we do for searches of text fields in our search API.

For efficiency, this includes a change to the GBIF import logic: we need to
remove diacritics from the words in the `gbif_name_words` table so they
can be looked up using exact matches on the index on that table.