### PR TITLE
SW-2904 Support CSV export of nested search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
@@ -16,4 +16,61 @@ data class SearchResults(
      * [results] contains the full set of results, this will be null.
      */
     val cursor: String?
-)
+) {
+  /**
+   * Turns nested field values into CRLF-delimited strings suitable for exporting to a CSV file.
+   *
+   * For example, if the client searched for fields `foo.bar` and `foo.oof` and the search results
+   * are
+   *
+   * ```
+   * [
+   *   {
+   *     "foo": [
+   *       { "bar": "bar 1", "oof": "oof 1" },
+   *       { "bar": "bar 2"  }
+   *     ]
+   *   }
+   * ]
+   * ```
+   *
+   * this function will return
+   *
+   * ```
+   * [
+   *   {
+   *     "foo.bar": "bar 1\r\nbar 2",
+   *     "foo.oof": "oof 1"
+   *   }
+   * ]
+   * ```
+   */
+  fun flattenForCsv(): SearchResults {
+    val flattenedResults = results.map { flatten(it) }
+    return SearchResults(flattenedResults, cursor)
+  }
+
+  /** Flattens the values of a single search result. */
+  private fun flatten(result: Map<*, *>): Map<String, String> {
+    return expandNestedFields(result)
+        .groupBy { it.first }
+        .mapValues { (_, pairs) -> pairs.joinToString("\r\n") { it.second } }
+  }
+
+  /** Converts nested search results into a flat list of pairs of field names and values. */
+  private fun expandNestedFields(
+      result: Map<*, *>,
+      prefix: String = ""
+  ): List<Pair<String, String>> {
+    return result.entries.flatMap { (key, value) ->
+      when (value) {
+        is String -> listOf(prefix + key to value)
+        is Map<*, *> -> expandNestedFields(value, "$prefix$key.")
+        is List<*> -> value.flatMap { expandNestedFields(it as Map<*, *>, "$prefix$key.") }
+        null -> emptyList()
+        else ->
+            throw IllegalArgumentException("Unexpected value of type ${value.javaClass} at $prefix")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Commit 07039f0e added the ability to import a species list CSV file with multiple
ecosystem types separated by line breaks.

Allow exporting the species list in the same format.

The actual change here is more general: it removes the nested-fields restriction
on CSV export of search results. Previously, only flattened fields could be
exported because there is no way to represent tree structures in a CSV file.
That's still the case, even though we now allow nested fields to be exported;
if there are multiple levels of nesting, or if the values contain line breaks,
the results will be ambiguous. But for simple "list of enumerated values" cases
like species ecosystem type, there's no ambiguity.