### PR TITLE
SW-2925 Localize boolean search fields

### DIFF
--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -63,7 +63,7 @@ speciesCsvColumnName.7=Ecosystem Types
 
 # Values that will be accepted in uploaded CSVs to indicate "true" or "false". There can be up to
 # 10 values; if the locale needs fewer, leave the rest empty. "1" and "0" are always accepted and
-# don't need to be listed here.
+# don't need to be listed here. The first (.0) string for each value is used in exported CSVs.
 csvBooleanValues.false.0=false
 csvBooleanValues.false.1=f
 csvBooleanValues.false.2=False

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
@@ -1,0 +1,46 @@
+package com.terraformation.backend.seedbank.search
+
+import com.terraformation.backend.i18n.Locales
+import com.terraformation.backend.i18n.toGibberish
+import com.terraformation.backend.i18n.use
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.NoConditionNode
+import com.terraformation.backend.search.SearchFieldPrefix
+import com.terraformation.backend.search.SearchResults
+import com.terraformation.backend.search.SearchSortField
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SearchServiceBooleanTest : SearchServiceTest() {
+  @Test
+  fun `returns localized boolean values`() {
+    val prefix = SearchFieldPrefix(tables.species)
+    val fields = listOf(prefix.resolve("id"), prefix.resolve("endangered"), prefix.resolve("rare"))
+    val sortOrder = fields.map { SearchSortField(it) }
+
+    val result =
+        Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode(), sortOrder) }
+
+    val expected =
+        SearchResults(
+            listOf(
+                mapOf("id" to "10000", "rare" to "false".toGibberish()),
+                mapOf("id" to "10001", "endangered" to "true".toGibberish())),
+            cursor = null)
+
+    assertEquals(expected, result)
+  }
+
+  @Test
+  fun `accepts localized boolean values as search criteria`() {
+    val prefix = SearchFieldPrefix(tables.species)
+    val fields = listOf(prefix.resolve("id"))
+    val criteria = FieldNode(prefix.resolve("endangered"), listOf("true".toGibberish()))
+
+    val result = Locales.GIBBERISH.use { searchService.search(prefix, fields, criteria) }
+
+    val expected = SearchResults(listOf(mapOf("id" to "10001")), cursor = null)
+
+    assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
Boolean search fields were using the English words "true" and "false" rather than
treating them the same as enum fields and using localized strings.