### PR TITLE
SW-2681 Include withdrawal notes in accession history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -113,11 +113,13 @@ data class AccessionHistoryEntryPayload(
     val description: String,
     @Schema(description = "Full name of the person responsible for the event, if known.")
     val fullName: String?,
+    @Schema(description = "User-entered notes about the event, if any.") //
+    val notes: String?,
     val type: AccessionHistoryType,
 ) {
   constructor(
       model: AccessionHistoryModel
-  ) : this(model.date, model.description, model.fullName, model.type)
+  ) : this(model.date, model.description, model.fullName, model.notes, model.type)
 }
 
 data class GetAccessionHistoryResponsePayload(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStore.kt
@@ -74,6 +74,7 @@ class WithdrawalStore(
           .select(
               CREATED_TIME,
               DATE,
+              NOTES,
               PURPOSE_ID,
               STAFF_RESPONSIBLE,
               WITHDRAWN_BY,
@@ -105,6 +106,7 @@ class WithdrawalStore(
                 fullName =
                     IndividualUser.makeFullName(record[USERS.FIRST_NAME], record[USERS.LAST_NAME])
                         ?: record[STAFF_RESPONSIBLE],
+                notes = record[NOTES],
                 type = type,
                 userId = record[WITHDRAWN_BY],
             )

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionHistoryModel.kt
@@ -36,6 +36,8 @@ data class AccessionHistoryModel(
      * people as plain text fields.
      */
     val fullName: String?,
+    /** User-entered notes for the event, if any. Not available for all history types. */
+    val notes: String? = null,
     val type: AccessionHistoryType,
     /** If the event was attributed to a Terraware user, that user's ID. */
     val userId: UserId?,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -152,6 +152,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
                     listOf(
                         WithdrawalModel(
                             date = LocalDate.ofInstant(firstWithdrawalTime, ZoneOffset.UTC),
+                            notes = "Some withdrawal notes",
                             purpose = WithdrawalPurpose.Nursery,
                             withdrawn = seeds(1),
                             withdrawnByUserId = firstWithdrawerUserId))))
@@ -222,6 +223,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
                 date = LocalDate.ofInstant(firstWithdrawalTime, ZoneOffset.UTC),
                 description = "withdrew 1 seed for nursery",
                 fullName = "First Withdrawer",
+                notes = "Some withdrawal notes",
                 type = AccessionHistoryType.Withdrawal,
                 userId = firstWithdrawerUserId,
             ),


### PR DESCRIPTION
Update `GET /api/v1/seedbank/accessions/{id}/history` to include user-entered
withdrawal notes when available.