### PR TITLE
SW-2933 Use French number formatting for gibberish

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -21,17 +21,13 @@ fun String.toGibberish(): String {
 }
 
 /**
- * Customizes the number formatting in the gibberish locale to use different separator characters.
+ * Customizes the number formatting in the gibberish locale to use French-style separator
+ * characters.
  */
 class GibberishDecimalFormatSymbolsProvider : DecimalFormatSymbolsProvider() {
   override fun getAvailableLocales(): Array<Locale> {
     return arrayOf(Locales.GIBBERISH)
   }
 
-  override fun getInstance(locale: Locale?): DecimalFormatSymbols {
-    return DecimalFormatSymbols(Locale.ENGLISH).apply {
-      decimalSeparator = ','
-      groupingSeparator = '&'
-    }
-  }
+  override fun getInstance(locale: Locale?) = DecimalFormatSymbols(Locale.FRENCH)
 }

--- a/src/test/kotlin/com/terraformation/backend/i18n/GibberishDecimalFormatSymbolsProviderTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/GibberishDecimalFormatSymbolsProviderTest.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.i18n
 
 import java.text.NumberFormat
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class GibberishDecimalFormatSymbolsProviderTest {
@@ -9,7 +9,8 @@ class GibberishDecimalFormatSymbolsProviderTest {
   fun `uses correct punctuation in number formatting`() {
     val formatter = NumberFormat.getNumberInstance(Locales.GIBBERISH)
 
-    val expected = "123&456,789"
+    val narrowNonBreakingSpace = '\u202f'
+    val expected = "123${narrowNonBreakingSpace}456,789"
     val actual = formatter.format(123456.789)
 
     assertEquals(expected, actual)

--- a/src/test/resources/nursery/Gibberish.csv
+++ b/src/test/resources/nursery/Gibberish.csv
@@ -8,4 +8,4 @@ If you have any seeds that are germinating of this species in your nursery input
 
 This number will add inventory with the ""not ready"" status in Terraware. Only enter numbers or an error will occur during upload. ","Stored Date*
 Please enter in YYYY-MM-DD format or an error will occur during upload. If you are unsure of the exact date an estimate is fine!"
-Scientific name, Common name ,"123&456",2,2022-01-01
+Scientific name, Common name ,"123 456",2,2022-01-01

--- a/src/test/resources/seedbank/accession/Gibberish.csv
+++ b/src/test/resources/seedbank/accession/Gibberish.csv
@@ -29,4 +29,4 @@ Please choose from the following list or an error will occur during upload:
 - UmVpbnRyb2R1Y2Vk (gibberish for Reintroduced)
 - Q3VsdGl2YXRlZA (gibberish for Cultivated)
 - T3RoZXI (gibberish for Other)",Number of Plants ,Plant ID
-12345,New species var. new,New common name,"123&456,78",S2lsb2dyYW1z,U3RvcmFnZQ SW4,2022-03-05,,,,,vwdhbmrh,,,V2lsZA,,
+12345,New species var. new,New common name,"123 456,78",S2lsb2dyYW1z,U3RvcmFnZQ SW4,2022-03-05,,,,,vwdhbmrh,,,V2lsZA,,


### PR DESCRIPTION
Replace the custom separator characters in gibberish number formatting with the
French ones. This eases implementation on the client side, where it's harder to
define custom locales with custom formatting rules.