### PR TITLE
SW-2935 Support raw search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -86,7 +86,7 @@ class AgeField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      AgeField("$fieldName(raw)", databaseField, table, nullable, false, granularity, clock)
+      AgeField(rawFieldName(), databaseField, table, nullable, false, granularity, clock)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -1,8 +1,10 @@
 package com.terraformation.backend.search.field
 
+import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchTable
+import java.text.NumberFormat
 import java.time.Clock
 import java.time.LocalDate
 import java.util.EnumSet
@@ -29,6 +31,7 @@ class AgeField(
     override val databaseField: TableField<*, LocalDate?>,
     override val table: SearchTable,
     override val nullable: Boolean,
+    override val localize: Boolean = true,
     private val granularity: AgeGranularity,
     private val clock: Clock,
 ) : SingleColumnSearchField<LocalDate>() {
@@ -74,7 +77,19 @@ class AgeField(
 
     val difference = granularity.difference(date, now)
 
-    return "$difference"
+    return if (localize) {
+      NumberFormat.getIntegerInstance(currentLocale()).format(difference)
+    } else {
+      "$difference"
+    }
+  }
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      AgeField("$fieldName(raw)", databaseField, table, nullable, false, granularity, clock)
+    } else {
+      null
+    }
   }
 
   /**
@@ -82,7 +97,13 @@ class AgeField(
    * the age is null.
    */
   private fun dateRangeOrNull(ageString: String?, now: LocalDate): Pair<LocalDate, LocalDate>? {
-    val age = ageString?.toInt() ?: return null
+    val age =
+        when {
+          ageString == null -> return null
+          localize -> NumberFormat.getIntegerInstance(currentLocale()).parse(ageString).toInt()
+          else -> ageString.toInt()
+        }
+
     if (age < 0) {
       throw IllegalArgumentException("Age must be non-negative")
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -43,4 +43,13 @@ private constructor(
    * a table where the field is a required value.
    */
   override val nullable: Boolean = original.nullable || targetPath.sublists.any { !it.isRequired }
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      val rawOriginal = original.raw() ?: return null
+      AliasField("$fieldName(raw)", SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
+    } else {
+      null
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -47,9 +47,11 @@ private constructor(
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null
-      AliasField("$fieldName(raw)", SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
+      AliasField(rawFieldName(), SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
     } else {
       null
     }
   }
+
+  override fun rawFieldName() = if (localize) "$fieldName(raw)" else fieldName
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -12,13 +12,22 @@ class BigDecimalField(
     fieldName: String,
     databaseField: TableField<*, BigDecimal?>,
     table: SearchTable,
-) : NumericSearchField<BigDecimal>(fieldName, databaseField, table) {
+    localize: Boolean = true,
+) : NumericSearchField<BigDecimal>(fieldName, databaseField, table, localize = localize) {
   override fun fromString(value: String) = numberFormat.parseObject(value) as BigDecimal
 
   override fun makeNumberFormat(): NumberFormat {
     return (NumberFormat.getNumberInstance(currentLocale()) as DecimalFormat).apply {
       isParseBigDecimal = true
       maximumFractionDigits = MAXIMUM_FRACTION_DIGITS
+    }
+  }
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      BigDecimalField("$fieldName(raw)", databaseField, table, false)
+    } else {
+      null
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -25,7 +25,7 @@ class BigDecimalField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      BigDecimalField("$fieldName(raw)", databaseField, table, false)
+      BigDecimalField(rawFieldName(), databaseField, table, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -60,7 +60,7 @@ class BooleanField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      BooleanField("$fieldName(raw)", databaseField, table, nullable, false)
+      BooleanField(rawFieldName(), databaseField, table, nullable, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -19,6 +19,7 @@ class BooleanField(
     override val databaseField: TableField<*, Boolean?>,
     override val table: SearchTable,
     override val nullable: Boolean = true,
+    override val localize: Boolean = true,
 ) : SingleColumnSearchField<Boolean>() {
   private val trueStrings = ConcurrentHashMap<Locale, String>()
   private val falseStrings = ConcurrentHashMap<Locale, String>()
@@ -57,12 +58,24 @@ class BooleanField(
   override val possibleValues: List<String>
     get() = listOf(getString(true), getString(false))
 
-  private fun getString(value: Boolean): String {
-    val locale = currentLocale()
-    val stringMap = if (value) trueStrings else falseStrings
+  override fun raw(): SearchField? {
+    return if (localize) {
+      BooleanField("$fieldName(raw)", databaseField, table, nullable, false)
+    } else {
+      null
+    }
+  }
 
-    return stringMap.getOrPut(locale) {
-      ResourceBundle.getBundle("i18n.Messages", locale).getString("csvBooleanValues.$value.0")
+  private fun getString(value: Boolean): String {
+    return if (localize) {
+      val locale = currentLocale()
+      val stringMap = if (value) trueStrings else falseStrings
+
+      stringMap.getOrPut(locale) {
+        ResourceBundle.getBundle("i18n.Messages", locale).getString("csvBooleanValues.$value.0")
+      }
+    } else {
+      "$value"
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
@@ -41,4 +41,7 @@ class DateField(
       SearchFilterType.Range -> rangeCondition(dateValues)
     }
   }
+
+  // Dates are always returned in ISO-8601 format.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -23,7 +23,7 @@ class DoubleField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      DoubleField("$fieldName(raw)", databaseField, table, nullable, false)
+      DoubleField(rawFieldName(), databaseField, table, nullable, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -11,12 +11,21 @@ class DoubleField(
     databaseField: TableField<*, Double?>,
     table: SearchTable,
     nullable: Boolean = true,
-) : NumericSearchField<Double>(fieldName, databaseField, table, nullable) {
+    localize: Boolean = true,
+) : NumericSearchField<Double>(fieldName, databaseField, table, nullable, localize) {
   override fun fromString(value: String) = numberFormat.parse(value).toDouble()
 
   override fun makeNumberFormat(): NumberFormat {
     return NumberFormat.getNumberInstance(currentLocale()).apply {
       maximumFractionDigits = MAXIMUM_FRACTION_DIGITS
+    }
+  }
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      DoubleField("$fieldName(raw)", databaseField, table, nullable, false)
+    } else {
+      null
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -84,7 +84,7 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      EnumField("$fieldName(raw)", databaseField, table, enumClass, nullable, false)
+      EnumField(rawFieldName(), databaseField, table, enumClass, nullable, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -25,7 +25,8 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
     override val databaseField: TableField<*, T?>,
     override val table: SearchTable,
     private val enumClass: Class<T>,
-    override val nullable: Boolean = true
+    override val nullable: Boolean = true,
+    override val localize: Boolean = true,
 ) : SingleColumnSearchField<T>() {
   private val byLocalizedDisplayName = ConcurrentHashMap<Locale, Map<String, T>>()
   private val orderByFields = ConcurrentHashMap<Locale, Field<Int>>()
@@ -33,12 +34,12 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact)
   override val possibleValues
-    get() = enumClass.enumConstants!!.map { it.getDisplayName(currentLocale()) }
+    get() = enumClass.enumConstants!!.map { it.toSearchValue() }
 
   override fun getCondition(fieldNode: FieldNode): Condition {
     val byDisplayName: Map<String, T> =
         byLocalizedDisplayName.getOrPut(currentLocale()) {
-          enumClass.enumConstants!!.associateBy { it.getDisplayName(currentLocale()) }
+          enumClass.enumConstants!!.associateBy { it.toSearchValue() }
         }
 
     if (fieldNode.type != SearchFilterType.Exact) {
@@ -67,7 +68,7 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
       val locale = currentLocale()
       return orderByFields.getOrPut(locale) {
         val collator = Collator.getInstance(locale)
-        val toLowerCaseDisplayName: (T) -> String = { it.getDisplayName(locale).lowercase(locale) }
+        val toLowerCaseDisplayName: (T) -> String = { it.toSearchValue().lowercase(locale) }
 
         val valueToPosition =
             enumClass.enumConstants
@@ -79,5 +80,21 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
       }
     }
 
-  override fun computeValue(record: Record) = record[databaseField]?.getDisplayName(currentLocale())
+  override fun computeValue(record: Record) = record[databaseField]?.toSearchValue()
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      EnumField("$fieldName(raw)", databaseField, table, enumClass, nullable, false)
+    } else {
+      null
+    }
+  }
+
+  private fun T.toSearchValue(): String {
+    return if (localize) {
+      getDisplayName(currentLocale())
+    } else {
+      displayName
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
@@ -35,4 +35,7 @@ class GeometryField(
   override fun computeValue(record: Record): String? {
     return record[databaseField]
   }
+
+  // Geometry values are already machine-readable.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
@@ -26,4 +26,7 @@ class IdWrapperField<T : Any>(
       SearchFilterType.Range -> throw RuntimeException("Range search not supported for IDs")
     }
   }
+
+  // IDs are already machine-readable.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -19,7 +19,7 @@ class IntegerField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      IntegerField("$fieldName(raw)", databaseField, table, nullable, false)
+      IntegerField(rawFieldName(), databaseField, table, nullable, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -11,7 +11,17 @@ class IntegerField(
     databaseField: TableField<*, Int?>,
     table: SearchTable,
     nullable: Boolean = true,
-) : NumericSearchField<Int>(fieldName, databaseField, table, nullable) {
-  override fun fromString(value: String) = numberFormat.parse(value).toInt()
+    localize: Boolean = true,
+) : NumericSearchField<Int>(fieldName, databaseField, table, nullable, localize) {
+  override fun fromString(value: String) =
+      if (localize) numberFormat.parse(value).toInt() else value.toInt()
   override fun makeNumberFormat(): NumberFormat = NumberFormat.getIntegerInstance(currentLocale())
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      IntegerField("$fieldName(raw)", databaseField, table, nullable, false)
+    } else {
+      null
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -25,6 +25,7 @@ class LocalizedTextField(
     private val resourceBundleName: String,
     override val table: SearchTable,
     override val nullable: Boolean = true,
+    override val localize: Boolean = true,
 ) : SingleColumnSearchField<String>() {
   /**
    * Maps lower-case diacritic-free localized strings to their corresponding database field values.
@@ -85,6 +86,9 @@ class LocalizedTextField(
         return DSL.case_(databaseField).mapValues(fieldValuesToPosition).else_(valuesMap.size)
       }
     }
+
+  // Localized text fields are always localized and have no raw values.
+  override fun raw(): SearchField? = null
 
   private fun getLocalizedString(databaseValue: String): String {
     val locale = currentLocale()

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -18,7 +18,7 @@ class LongField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      LongField("$fieldName(raw)", databaseField, table, nullable, false)
+      LongField(rawFieldName(), databaseField, table, nullable, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -11,7 +11,16 @@ class LongField(
     databaseField: TableField<*, Long?>,
     table: SearchTable,
     nullable: Boolean = true,
-) : NumericSearchField<Long>(fieldName, databaseField, table, nullable) {
+    localize: Boolean = true,
+) : NumericSearchField<Long>(fieldName, databaseField, table, nullable, localize) {
   override fun fromString(value: String) = numberFormat.parse(value).toLong()
   override fun makeNumberFormat(): NumberFormat = NumberFormat.getIntegerInstance(currentLocale())
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      LongField("$fieldName(raw)", databaseField, table, nullable, false)
+    } else {
+      null
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -22,6 +22,7 @@ abstract class NumericSearchField<T : Number>(
     override val databaseField: TableField<*, T?>,
     override val table: SearchTable,
     override val nullable: Boolean = true,
+    override val localize: Boolean,
 ) : SingleColumnSearchField<T>() {
   companion object {
     const val MAXIMUM_FRACTION_DIGITS = 5
@@ -58,5 +59,8 @@ abstract class NumericSearchField<T : Number>(
     }
   }
 
-  override fun computeValue(record: Record) = record[databaseField]?.let { numberFormat.format(it) }
+  override fun computeValue(record: Record) =
+      record[databaseField]?.let { value ->
+        if (localize) numberFormat.format(value) else value.toString()
+      }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
@@ -58,6 +58,10 @@ interface SearchField {
   val nullable: Boolean
     get() = true
 
+  /** If true, values should be localized to the current locale. */
+  val localize: Boolean
+    get() = true
+
   /**
    * Returns a list of conditions to include in a WHERE clause when this field is used to filter
    * search results. This may vary based on the filter type.
@@ -76,4 +80,12 @@ interface SearchField {
   fun getDisplayName(messages: Messages): String {
     return messages.searchFieldDisplayName(table.name, fieldName)
   }
+
+  /**
+   * Returns a copy of this field that accepts and returns raw values rather than localized ones, if
+   * relevant. The copy should have a field name with a suffix of "(raw)".
+   *
+   * Returns null if raw values are irrelevant for the field or if this field is already raw.
+   */
+  fun raw(): SearchField?
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
@@ -88,4 +88,7 @@ interface SearchField {
    * Returns null if raw values are irrelevant for the field or if this field is already raw.
    */
   fun raw(): SearchField?
+
+  /** Returns the name of the raw variant of this field, if any. */
+  fun rawFieldName(): String = if (localize) "$fieldName(raw)" else fieldName
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -23,6 +23,8 @@ class TextField(
     override val table: SearchTable,
     override val nullable: Boolean = true,
 ) : SingleColumnSearchField<String>() {
+  override val localize: Boolean
+    get() = false
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy)
 
@@ -57,4 +59,7 @@ class TextField(
 
   override val orderByField: Field<*>
     get() = databaseField.collate(currentLocale().collation)
+
+  // Text fields are always raw.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
@@ -17,6 +17,8 @@ class TimestampField(
     override val table: SearchTable,
     override val nullable: Boolean = true
 ) : SingleColumnSearchField<Instant>() {
+  override val localize: Boolean
+    get() = false
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)
 
@@ -42,4 +44,7 @@ class TimestampField(
       SearchFilterType.Range -> rangeCondition(instantValues)
     }
   }
+
+  // Timestamp values are always machine-readable.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -18,6 +18,8 @@ class UpperCaseTextField(
     override val table: SearchTable,
     override val nullable: Boolean = true,
 ) : SingleColumnSearchField<String>() {
+  override val localize: Boolean
+    get() = false
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Fuzzy)
 
@@ -48,4 +50,7 @@ class UpperCaseTextField(
 
   override val orderByField: Field<*>
     get() = databaseField.collate(currentLocale().collation)
+
+  // Text fields aren't localized.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
@@ -179,8 +179,7 @@ class WeightField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      WeightField(
-          "$fieldName(raw)", quantityField, unitsField, gramsField, desiredUnits, table, false)
+      WeightField(rawFieldName(), quantityField, unitsField, gramsField, desiredUnits, table, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
@@ -33,6 +33,7 @@ class WeightField(
     private val gramsField: Field<BigDecimal?>,
     private val desiredUnits: SeedQuantityUnits,
     override val table: SearchTable,
+    override val localize: Boolean = true,
 ) : SearchField {
   private val formatRegex = Regex("(\\d|\\d.*\\d)\\s*(\\D*)")
   private val numberFormats = ConcurrentHashMap<Locale, NumberFormat>()
@@ -142,7 +143,12 @@ class WeightField(
             ?: throw IllegalStateException(
                 "Weight values must be a decimal number optionally followed by a unit name; couldn't interpret $value")
 
-    val number = numberFormat.parseObject(matches.groupValues[1]) as BigDecimal
+    val number =
+        if (localize) {
+          numberFormat.parseObject(matches.groupValues[1]) as BigDecimal
+        } else {
+          matches.groupValues[1].toBigDecimal()
+        }
     val unitsName = matches.groupValues[2].lowercase().replaceFirstChar { it.titlecase() }
 
     val units =
@@ -153,7 +159,7 @@ class WeightField(
   }
 
   override fun computeValue(record: Record): String? {
-    val quantity: BigDecimal? =
+    val quantity: BigDecimal =
         when (desiredUnits) {
           SeedQuantityUnits.Ounces,
           SeedQuantityUnits.Pounds ->
@@ -162,7 +168,21 @@ class WeightField(
                   ?.quantity
           else -> record[gramsField]?.let { desiredUnits.fromGrams(it) }
         }
+            ?: return null
 
-    return quantity?.stripTrailingZeros()?.let { numberFormat.format(it) }
+    return if (localize) {
+      numberFormat.format(quantity.stripTrailingZeros())
+    } else {
+      quantity.toPlainString()
+    }
+  }
+
+  override fun raw(): SearchField? {
+    return if (localize) {
+      WeightField(
+          "$fieldName(raw)", quantityField, unitsField, gramsField, desiredUnits, table, false)
+    } else {
+      null
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
@@ -19,6 +19,8 @@ class ZoneIdField(
 ) : SingleColumnSearchField<ZoneId>() {
   private val validZoneNames = ZoneId.getAvailableZoneIds()
 
+  override val localize: Boolean
+    get() = false
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact)
   override val possibleValues = validZoneNames.toList()
@@ -38,4 +40,7 @@ class ZoneIdField(
   }
 
   override fun computeValue(record: Record) = record[databaseField]?.id
+
+  // Zone IDs are always machine-readable.
+  override fun raw(): SearchField? = null
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionCollectorsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionCollectorsTable.kt
@@ -29,7 +29,7 @@ class AccessionCollectorsTable(private val tables: SearchTables) : SearchTable()
   override val fields: List<SearchField> =
       listOf(
           textField("name", ACCESSION_COLLECTORS.NAME),
-          integerField("position", ACCESSION_COLLECTORS.POSITION),
+          integerField("position", ACCESSION_COLLECTORS.POSITION, localize = false),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -141,6 +141,8 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
    * from the `state` field.
    */
   inner class ActiveField(override val fieldName: String) : SearchField {
+    override val localize: Boolean
+      get() = false
     override val table: SearchTable
       get() = this@AccessionsTable
     override val selectFields
@@ -170,6 +172,9 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
       get() =
           DSL.case_(ACCESSIONS.STATE_ID)
               .mapValues(AccessionState.values().associateWith { "${it?.toActiveEnum()}" })
+
+    // TODO: Localization support for ActiveField (SW-2939)
+    override fun raw(): SearchField? = null
 
     override fun toString() = fieldName
     override fun hashCode() = fieldName.hashCode()

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -50,7 +50,7 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
         integerField("totalQuantity", BATCH_SUMMARIES.TOTAL_QUANTITY, nullable = false),
         longField(
             "totalQuantityWithdrawn", BATCH_SUMMARIES.TOTAL_QUANTITY_WITHDRAWN, nullable = false),
-        integerField("version", BATCH_SUMMARIES.VERSION, nullable = false),
+        integerField("version", BATCH_SUMMARIES.VERSION, nullable = false, localize = false),
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
@@ -61,6 +61,9 @@ class GeolocationsTable(private val tables: SearchTables) : SearchTable() {
       private val longitudeField: TableField<*, BigDecimal?>,
       override val nullable: Boolean = true
   ) : SearchField {
+    override val localize: Boolean
+      get() = false
+
     override val table: SearchTable
       get() = this@GeolocationsTable
 
@@ -84,6 +87,9 @@ class GeolocationsTable(private val tables: SearchTables) : SearchTable() {
         }
       }
     }
+
+    // Geolocation fields are always machine-readable.
+    override fun raw(): SearchField? = null
 
     override fun toString() = fieldName
     override fun hashCode() = fieldName.hashCode()

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
@@ -4,8 +4,10 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
+import com.terraformation.backend.search.SearchFieldPath
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
+import com.terraformation.backend.search.field.AliasField
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -66,6 +68,30 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
 
     val actual =
         searchAccessions(facilityId, listOf(treesCollectedFromAlias), criteria = NoConditionNode())
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `raw variants of aliased fields use the alias name`() {
+    val rawAlias = SearchFieldPath(rootPrefix, AliasField("alias", treesCollectedFromField).raw()!!)
+
+    val expected =
+        SearchResults(
+            listOf(
+                mapOf(
+                    "id" to "1001",
+                    "accessionNumber" to "ABCDEFG",
+                    "alias(raw)" to "2",
+                ),
+                mapOf(
+                    "id" to "1000",
+                    "accessionNumber" to "XYZ",
+                    "alias(raw)" to "1",
+                ),
+            ),
+            cursor = null)
+
+    val actual = searchAccessions(facilityId, listOf(rawAlias), criteria = NoConditionNode())
     assertEquals(expected, actual)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
@@ -26,7 +26,7 @@ internal class SearchServiceInitializationTest : SearchServiceTest() {
         // "map" has the side effect of making sure the list is initialized.
         toVisit.addAll(table.sublists.map { it.searchTable }.filter { it !in visited })
 
-        table.fields.forEach { _ ->
+        table.fieldsWithVariants.forEach { _ ->
           // No-op; we just need to make sure we can iterate over the field list.
         }
       }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.seedbank.search
+
+import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.db.seedbank.AccessionState
+import com.terraformation.backend.i18n.Locales
+import com.terraformation.backend.i18n.use
+import com.terraformation.backend.search.AndNode
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.SearchResults
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class SearchServiceRawTest : SearchServiceTest() {
+  @Test
+  fun `can search for raw and localized fields at the same time`() {
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(estSeedCount = 12000))
+
+    val fields =
+        listOf(rootPrefix.resolve("estimatedCount"), rootPrefix.resolve("estimatedCount(raw)"))
+    val criteria = FieldNode(accessionIdField, listOf("1000"))
+
+    val result = searchService.search(rootPrefix, fields, criteria)
+
+    val expected =
+        SearchResults(
+            listOf(
+                mapOf("estimatedCount" to "12,000", "estimatedCount(raw)" to "12000"),
+            ),
+            cursor = null)
+
+    assertEquals(expected, result)
+  }
+
+  @Test
+  fun `accepts raw values as search criteria`() {
+    accessionsDao.update(
+        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(treesCollectedFrom = 8000))
+
+    val rawPlantsField = rootPrefix.resolve("plantsCollectedFrom(raw)")
+    val rawRareField = rootPrefix.resolve("species_rare(raw)")
+    val rawStateField = rootPrefix.resolve("state(raw)")
+    val rawTotalWeightField = rootPrefix.resolve("totalWithdrawnWeightGrams(raw)")
+
+    val fields =
+        listOf(
+            accessionIdField,
+            rawPlantsField,
+            rawRareField,
+            rawStateField,
+            rawTotalWeightField,
+        )
+
+    val criteria =
+        AndNode(
+            listOf(
+                FieldNode(rawPlantsField, listOf("8000")),
+                FieldNode(rawRareField, listOf("false")),
+                FieldNode(rawStateField, listOf(AccessionState.InStorage.displayName)),
+                FieldNode(rawTotalWeightField, listOf("5000")),
+            ))
+
+    val result = Locales.GIBBERISH.use { searchService.search(rootPrefix, fields, criteria) }
+
+    val expected =
+        SearchResults(
+            listOf(
+                mapOf(
+                    "id" to "1000",
+                    "plantsCollectedFrom(raw)" to "8000",
+                    "species_rare(raw)" to "false",
+                    "state(raw)" to "In Storage",
+                    "totalWithdrawnWeightGrams(raw)" to "5000",
+                ),
+            ),
+            cursor = null)
+
+    assertEquals(expected, result)
+  }
+}


### PR DESCRIPTION
To allow clients to more easily parse specific values in search results, add
support for "raw" variants of fields whose values can vary based on locale.

Specify that you want to use raw values rather than localized ones by
appending the string `(raw)` to the name of a search field. You can use raw
fields both for input (search criteria) and for output (list of fields to return).

These are treated as separate search fields with separate names. It is fully
supported to include both the raw and localized versions of a field in the same
search request, and indeed, that's expected to be a common usage pattern whenever
a client needs to both display a value to a user and use it internally for
business logic.