### PR TITLE
SW-2939 Localize accession active field

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -192,7 +192,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
 
     override fun raw(): SearchField? {
       return if (localize) {
-        ActiveField("$fieldName(raw)", false)
+        ActiveField(rawFieldName(), false)
       } else {
         null
       }

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -85,6 +85,10 @@ csvBooleanValues.true.7=Y
 csvBooleanValues.true.8=TRUE
 csvBooleanValues.true.9=YES
 
+# Accession active/inactive states (active = seeds are still available, inactive = used up)
+accessionState.Active=Active
+accessionState.Inactive=Inactive
+
 # Notifications.
 notification.accession.email.linkIntro=Please click the link below to go to your Terraware account where you can view the accession.
 notification.accession.email.buttonIntro=Please click the button below to go to your Terraware account where you can view the accession.

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -36,6 +36,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1000))!!.copy(treesCollectedFrom = 8000))
 
+    val rawActiveField = rootPrefix.resolve("active(raw)")
     val rawPlantsField = rootPrefix.resolve("plantsCollectedFrom(raw)")
     val rawRareField = rootPrefix.resolve("species_rare(raw)")
     val rawStateField = rootPrefix.resolve("state(raw)")
@@ -44,6 +45,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
     val fields =
         listOf(
             accessionIdField,
+            rawActiveField,
             rawPlantsField,
             rawRareField,
             rawStateField,
@@ -53,6 +55,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
     val criteria =
         AndNode(
             listOf(
+                FieldNode(rawActiveField, listOf("Active")),
                 FieldNode(rawPlantsField, listOf("8000")),
                 FieldNode(rawRareField, listOf("false")),
                 FieldNode(rawStateField, listOf(AccessionState.InStorage.displayName)),
@@ -65,6 +68,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
+                    "active(raw)" to "Active",
                     "id" to "1000",
                     "plantsCollectedFrom(raw)" to "8000",
                     "species_rare(raw)" to "false",


### PR DESCRIPTION
The "Active" search field on accessions is a one-off implementation rather than a
normal enum field, so it wasn't covered when `EnumField` gained localization
support. Update it to return localized values and to support a raw variant.