### PR TITLE
SW-2951 Move FacilityStore.create params into class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.customer.db.AppVersionStore
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
+import com.terraformation.backend.customer.model.NewFacilityModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.BalenaDeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -263,7 +264,8 @@ class AdminController(
       return organization(organizationId)
     }
 
-    facilityStore.create(organizationId, type, name)
+    facilityStore.create(
+        NewFacilityModel(name = name, organizationId = organizationId, type = type))
 
     redirectAttributes.successMessage = "Facility created."
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
 import com.terraformation.backend.customer.model.FacilityModel
+import com.terraformation.backend.customer.model.NewFacilityModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
@@ -67,14 +68,7 @@ class FacilitiesController(
   fun createFacility(
       @RequestBody payload: CreateFacilityRequestPayload
   ): CreateFacilityResponsePayload {
-    val model =
-        facilityStore.create(
-            description = payload.description,
-            name = payload.name,
-            organizationId = payload.organizationId,
-            timeZone = payload.timeZone,
-            type = payload.type,
-        )
+    val model = facilityStore.create(payload.toModel())
 
     return CreateFacilityResponsePayload(model.id)
   }
@@ -180,9 +174,9 @@ data class FacilityPayload(
 
 data class CreateFacilityRequestPayload(
     val description: String?,
+    val name: String,
     @Schema(description = "Which organization this facility belongs to.")
     val organizationId: OrganizationId,
-    val name: String,
     @ArraySchema(
         schema =
             Schema(
@@ -194,7 +188,16 @@ data class CreateFacilityRequestPayload(
     val storageLocationNames: Set<String>?,
     val timeZone: ZoneId?,
     val type: FacilityType,
-)
+) {
+  fun toModel() =
+      NewFacilityModel(
+          description = description,
+          name = name,
+          organizationId = organizationId,
+          storageLocationNames = storageLocationNames,
+          timeZone = timeZone,
+          type = type)
+}
 
 data class CreateFacilityResponsePayload(val id: FacilityId) : SuccessResponsePayload
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FacilityModel.kt
@@ -12,6 +12,19 @@ import java.time.LocalDate
 import java.time.ZoneId
 import org.jooq.Record
 
+/** Maximum device manager idle time, in minutes, to assign to new facilities by default. */
+const val DEFAULT_MAX_IDLE_MINUTES = 30
+
+data class NewFacilityModel(
+    val description: String? = null,
+    val name: String,
+    val maxIdleMinutes: Int = DEFAULT_MAX_IDLE_MINUTES,
+    val organizationId: OrganizationId,
+    val storageLocationNames: Set<String>? = null,
+    val timeZone: ZoneId? = null,
+    val type: FacilityType,
+)
+
 data class FacilityModel(
     val connectionState: FacilityConnectionState,
     val createdTime: Instant,


### PR DESCRIPTION
To prepare for adding more facility attributes, refactor `FacilityStore.create` to
take its parameters in an object rather than individually.

No functional change.