### PR TITLE
SW-2908 Allow deleting seedling batches with photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/event/WithdrawalDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/event/WithdrawalDeletionStartedEvent.kt
@@ -1,0 +1,6 @@
+package com.terraformation.backend.nursery.event
+
+import com.terraformation.backend.db.nursery.WithdrawalId
+
+/** Published when a withdrawal is about to be deleted from the database. */
+data class WithdrawalDeletionStartedEvent(val withdrawalId: WithdrawalId)

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.nursery
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
@@ -14,7 +15,9 @@ import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.tracking.db.DeliveryStore
 import io.mockk.every
 import java.time.LocalDate
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,6 +35,7 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
             batchWithdrawalsDao,
             clock,
             dslContext,
+            TestEventPublisher(),
             IdentifierGenerator(clock, dslContext),
             parentStore,
             nurseryWithdrawalsDao),

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
@@ -65,6 +66,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
         batchWithdrawalsDao,
         clock,
         dslContext,
+        TestEventPublisher(),
         IdentifierGenerator(clock, dslContext),
         parentStore,
         nurseryWithdrawalsDao)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.nursery.event.WithdrawalDeletionStartedEvent
 import com.terraformation.backend.nursery.model.SpeciesSummary
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -61,6 +62,9 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
                 .copy(modifiedTime = deleteTime))
 
     store.delete(batchIdToDelete)
+
+    eventPublisher.assertExactEventsPublished(
+        listOf(WithdrawalDeletionStartedEvent(singleBatchWithdrawlId)))
 
     assertEquals(
         expectedWithdrawals,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
@@ -22,6 +23,7 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences = listOf(BATCHES, BATCH_QUANTITY_HISTORY)
 
   protected val clock = TestClock()
+  protected val eventPublisher = TestEventPublisher()
   protected val store: BatchStore by lazy {
     BatchStore(
         batchesDao,
@@ -29,6 +31,7 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
         batchWithdrawalsDao,
         clock,
         dslContext,
+        eventPublisher,
         IdentifierGenerator(clock, dslContext),
         ParentStore(dslContext),
         nurseryWithdrawalsDao,


### PR DESCRIPTION
When you delete a seedling batch that is associated with a withdrawal, and the
withdrawal isn't also associated with other batches, the withdrawal is
automatically deleted as well. This was failing if the withdrawal had photos.

Add logic to delete the photos (including the files in the file store) before
attempting to delete the withdrawal from the database.