### PR TITLE
Generate code documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -69,6 +69,9 @@ jobs:
     - name: Generate license report
       run: ./gradlew generateLicenseReport
 
+    - name: Generate code docs
+      run: ./gradlew dokkaHtml
+
     - name: Output git log since last release
       run: bash ./.github/scripts/gitlog.sh
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,10 @@ import com.github.jk1.license.render.InventoryHtmlReportRenderer
 import com.terraformation.gradle.PostgresDockerConfigTask
 import com.terraformation.gradle.VersionFileTask
 import com.terraformation.gradle.computeGitVersion
+import java.net.URL
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.deprecation.DeprecatableConfiguration
+import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -24,6 +26,7 @@ plugins {
 
   id("dev.monosoul.jooq-docker") version "3.0.7"
   id("com.diffplug.spotless") version "6.4.2"
+  id("org.jetbrains.dokka") version "1.7.20"
   id("org.springframework.boot") version "2.7.8"
   id("io.spring.dependency-management") version "1.1.0"
 
@@ -143,6 +146,7 @@ dependencies {
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$jUnitVersion")
 
   developmentOnly("org.springframework.boot:spring-boot-devtools")
+  dokkaPlugin("com.glureau:html-mermaid-dokka-plugin:0.4.4")
 }
 
 tasks.register("downloadDependencies") {
@@ -304,4 +308,20 @@ licenseReport {
       arrayOf(LicenseBundleNormalizer("$projectDir/src/docs/license-normalizer-bundle.json", true))
   outputDir = "$projectDir/docs/license-report"
   renderers = arrayOf(InventoryHtmlReportRenderer())
+}
+
+tasks.withType<DokkaTask>().configureEach {
+  dokkaSourceSets {
+    named("main") {
+      outputDirectory.set(file("build/docs/dokka"))
+      moduleName.set("Terraware Server")
+      includes.from(fileTree("src/main/kotlin") { include("**/Package.md") })
+      sourceLink {
+        localDirectory.set(file("src/main/kotlin"))
+        remoteUrl.set(
+            URL("https://github.com/terraware/terraware-server/tree/main/src/main/kotlin"))
+        remoteLineSuffix.set("#L")
+      }
+    }
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,10 @@ The database has some subject-area-specific schemas as well as a default public 
 * [Seed bank schema](schema/all/seedbank/relationships.html) (`seedbank`)
 * [Tracking schema](schema/all/tracking/relationships.html) (`tracking`)
 
+## Code docs
+
+[Dokka class documentation](dokka/index.html)
+
 ## Other docs
 
 * [Dependency license report](license-report/index.html)


### PR DESCRIPTION
Add the Dokka plugin to generate HTML documentation from our code's
class and method doc blocks. Include the Mermaid module so we can put
diagrams in our docs as well.