### PR TITLE
Upgrade to geotools 28.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
   testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
   testImplementation("io.mockk:mockk:1.13.4")
   testImplementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
+  testImplementation("org.hsqldb:hsqldb:2.7.1")
   testImplementation("org.junit.jupiter:junit-jupiter-api:$jUnitVersion")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfil
 # directly in build.gradle.kts.
 
 awsSdkVersion=2.19.27
-geoToolsVersion=28.0
+geoToolsVersion=28.2
 jacksonVersion=2.14.2
 jooqVersion=3.17.8
 jtsVersion=1.19.0


### PR DESCRIPTION
Renovate attempted to upgrade it but the resulting configuration failed to
build because a test-only transitive dependency gets overridden to an
incompatible version. Add the latest version of the dependency explicitly.