### PR TITLE
Extract common photo endpoint code

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -1,7 +1,9 @@
 package com.terraformation.backend.api
 
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType
@@ -99,3 +101,32 @@ annotation class ApiResponseSimpleSuccess(
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class RequireExistingAdminRole
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@ApiResponse(
+    responseCode = "200",
+    description = "The photo was successfully retrieved.",
+    content =
+        [
+            Content(
+                schema = Schema(type = "string", format = "binary"),
+                mediaType = MediaType.IMAGE_JPEG_VALUE),
+            Content(
+                schema = Schema(type = "string", format = "binary"),
+                mediaType = MediaType.IMAGE_PNG_VALUE)])
+annotation class ApiResponse200Photo
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@RequestBody(
+    content =
+        [
+            Content(
+                encoding =
+                    [
+                        Encoding(
+                            name = "file",
+                            contentType =
+                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
+annotation class RequestBodyPhotoFile

--- a/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
@@ -1,9 +1,71 @@
 package com.terraformation.backend.api
 
+import com.terraformation.backend.file.SizedInputStream
 import java.io.InputStreamReader
+import javax.ws.rs.NotSupportedException
 import org.apache.commons.fileupload.FileItemStream
+import org.apache.tika.mime.MimeTypes
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.multipart.MultipartFile
 
 /** Reads an item of a streaming file-upload form submission as a string. */
 fun FileItemStream.readString(): String {
   return openStream().use { InputStreamReader(it).readText() }
+}
+
+/**
+ * Wraps a SizedInputStream in a response entity suitable for use as a return value from a
+ * controller method.
+ */
+fun SizedInputStream.toResponseEntity(): ResponseEntity<InputStreamResource> {
+  val headers = HttpHeaders()
+
+  headers.contentLength = size
+  headers.contentType = contentType
+
+  val resource = InputStreamResource(this)
+  return ResponseEntity(resource, headers, HttpStatus.OK)
+}
+
+/**
+ * Returns the content type of an uploaded file, minus any extended information. For example, if the
+ * client-supplied content type is, "text/plain;charset=UTF-8", returns "text/plain".
+ */
+fun MultipartFile.getPlainContentType(): String? {
+  return this.contentType?.substringBefore(';')?.lowercase()
+}
+
+/**
+ * Returns the content type of an uploaded file, minus any extended information. For example, if the
+ * client-supplied content type is, "text/plain;charset=UTF-8", returns "text/plain".
+ *
+ * @param allowedTypes Only accept content types from this set; throw NotSupportedException for
+ *   types that aren't listed.
+ */
+fun MultipartFile.getPlainContentType(allowedTypes: Set<String>): String {
+  val contentType = this.getPlainContentType()
+
+  if (contentType == null || contentType !in allowedTypes) {
+    throw NotSupportedException("Content type must be one of: ${allowedTypes.sorted()}")
+  }
+
+  return contentType
+}
+
+/**
+ * Returns the filename of an uploaded file. If the client supplied a filename, returns it as-is.
+ * Otherwise, constructs a filename based on a default base name and an appropriate extension for
+ * the content type, if any.
+ */
+fun MultipartFile.getFilename(defaultBaseName: String = "upload"): String {
+  return originalFilename
+      ?: run {
+        val contentType = getPlainContentType() ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
+        val extension = MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType) ?: ""
+        defaultBaseName + extension
+      }
 }

--- a/src/main/kotlin/com/terraformation/backend/file/PhotoTypes.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/PhotoTypes.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.file
+
+import org.springframework.http.MediaType
+
+/**
+ * List of supported photo content types. We only support content types that are compatible with our
+ * thumbnail generator.
+ */
+val SUPPORTED_PHOTO_TYPES = setOf(MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE)


### PR DESCRIPTION
In preparation for adding photo endpoints for reports, extract some OpenAPI
annotations and helper functions from the existing accession and seedling
withdrawal controllers.

No change in functionality here, just reduced code duplication.