### PR TITLE
SW-2986 Add endpoints to attach photos to reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/ReportPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportPhotoService.kt
@@ -1,0 +1,85 @@
+package com.terraformation.backend.report
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.db.default_schema.tables.daos.ReportPhotosDao
+import com.terraformation.backend.db.default_schema.tables.pojos.ReportPhotosRow
+import com.terraformation.backend.file.PhotoService
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.model.PhotoMetadata
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.report.model.ReportPhotoModel
+import java.io.InputStream
+import javax.inject.Named
+
+@Named
+class ReportPhotoService(
+    private val photoService: PhotoService,
+    private val reportPhotosDao: ReportPhotosDao,
+) {
+  private val log = perClassLogger()
+
+  fun storePhoto(reportId: ReportId, data: InputStream, metadata: PhotoMetadata): PhotoId {
+    requirePermissions { updateReport(reportId) }
+
+    val photoId =
+        photoService.storePhoto("report", data, metadata.size, metadata) { photoId ->
+          reportPhotosDao.insert(ReportPhotosRow(photoId = photoId, reportId = reportId))
+        }
+
+    log.info("Stored photo $photoId for report $reportId")
+
+    return photoId
+  }
+
+  fun readPhoto(
+      reportId: ReportId,
+      photoId: PhotoId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null
+  ): SizedInputStream {
+    requirePermissions { readReport(reportId) }
+
+    val row = reportPhotosDao.fetchOneByPhotoId(photoId)
+
+    if (row?.reportId != reportId) {
+      throw PhotoNotFoundException(photoId)
+    }
+
+    return photoService.readPhoto(photoId, maxWidth, maxHeight)
+  }
+
+  fun listPhotos(reportId: ReportId): List<ReportPhotoModel> {
+    requirePermissions { readReport(reportId) }
+
+    return reportPhotosDao
+        .fetchByReportId(reportId)
+        .map { ReportPhotoModel(it) }
+        .sortedBy { it.photoId.value }
+  }
+
+  fun updatePhoto(model: ReportPhotoModel) {
+    requirePermissions { updateReport(model.reportId) }
+
+    val row = reportPhotosDao.fetchOneByPhotoId(model.photoId)
+
+    if (row?.reportId != model.reportId) {
+      throw PhotoNotFoundException(model.photoId)
+    }
+
+    reportPhotosDao.update(row.copy(caption = model.caption))
+  }
+
+  fun deletePhoto(reportId: ReportId, photoId: PhotoId) {
+    requirePermissions { updateReport(reportId) }
+
+    val row = reportPhotosDao.fetchOneByPhotoId(photoId)
+    if (row?.reportId != reportId) {
+      throw PhotoNotFoundException(photoId)
+    }
+
+    photoService.deletePhoto(photoId) { reportPhotosDao.delete(row) }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -176,7 +176,7 @@ class ReportsController(
       maxHeight: Int? = null,
   ): ResponseEntity<InputStreamResource> {
     return try {
-      reportPhotoService.readPhoto(reportId, photoId).toResponseEntity()
+      reportPhotoService.readPhoto(reportId, photoId, maxWidth, maxHeight).toResponseEntity()
     } catch (e: NoSuchFileException) {
       throw NotFoundException()
     }

--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -1,24 +1,45 @@
 package com.terraformation.backend.report.api
 
 import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse200Photo
 import com.terraformation.backend.api.ApiResponse400
 import com.terraformation.backend.api.ApiResponse409
+import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_OPERATION_DESCRIPTION
+import com.terraformation.backend.api.RequestBodyPhotoFile
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.getFilename
+import com.terraformation.backend.api.getPlainContentType
+import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.PhotoId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
+import com.terraformation.backend.file.model.PhotoMetadata
 import com.terraformation.backend.report.ReportNotCompleteException
+import com.terraformation.backend.report.ReportPhotoService
 import com.terraformation.backend.report.ReportService
 import com.terraformation.backend.report.db.ReportStore
 import com.terraformation.backend.report.model.ReportMetadata
+import com.terraformation.backend.report.model.ReportPhotoModel
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import java.nio.file.NoSuchFileException
 import java.time.Instant
 import javax.ws.rs.BadRequestException
+import javax.ws.rs.NotFoundException
+import javax.ws.rs.QueryParam
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -26,12 +47,15 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
 
 @CustomerEndpoint
 @RequestMapping("/api/v1/reports")
 @RestController
 class ReportsController(
+    private val reportPhotoService: ReportPhotoService,
     private val reportService: ReportService,
     private val reportStore: ReportStore,
     private val userStore: UserStore,
@@ -129,6 +153,77 @@ class ReportsController(
 
     return SimpleSuccessResponsePayload()
   }
+
+  @GetMapping("/{id}/photos")
+  @Operation(summary = "Lists the photos associated with a report.")
+  fun listReportPhotos(@PathVariable("id") id: ReportId): ListReportPhotosResponsePayload {
+    val photos = reportPhotoService.listPhotos(id)
+
+    return ListReportPhotosResponsePayload(photos.map { ListReportPhotosResponseElement(it) })
+  }
+
+  @ApiResponse200Photo
+  @GetMapping("/{reportId}/photos/{photoId}")
+  @Operation(summary = "Gets the contents of a photo.", description = PHOTO_OPERATION_DESCRIPTION)
+  fun getReportPhoto(
+      @PathVariable("reportId") reportId: ReportId,
+      @PathVariable("photoId") photoId: PhotoId,
+      @QueryParam("maxWidth")
+      @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
+      maxWidth: Int? = null,
+      @QueryParam("maxHeight")
+      @Schema(description = PHOTO_MAXHEIGHT_DESCRIPTION)
+      maxHeight: Int? = null,
+  ): ResponseEntity<InputStreamResource> {
+    return try {
+      reportPhotoService.readPhoto(reportId, photoId).toResponseEntity()
+    } catch (e: NoSuchFileException) {
+      throw NotFoundException()
+    }
+  }
+
+  @Operation(summary = "Updates a photo's caption.")
+  @PutMapping("/{reportId}/photos/{photoId}")
+  fun updateReportPhoto(
+      @PathVariable("reportId") reportId: ReportId,
+      @PathVariable("photoId") photoId: PhotoId,
+      @RequestBody payload: UpdateReportPhotoRequestPayload
+  ): SimpleSuccessResponsePayload {
+    val model = payload.toModel(reportId, photoId)
+
+    reportPhotoService.updatePhoto(model)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @Operation(summary = "Uploads a photo to include with a report.")
+  @PostMapping("/{reportId}/photos")
+  @RequestBodyPhotoFile
+  fun uploadReportPhoto(
+      @PathVariable("reportId") reportId: ReportId,
+      @RequestPart("file") file: MultipartFile
+  ): UploadReportPhotoResponsePayload {
+    val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
+    val filename = file.getFilename()
+
+    val photoId =
+        reportPhotoService.storePhoto(
+            reportId, file.inputStream, PhotoMetadata(filename, contentType, file.size))
+
+    return UploadReportPhotoResponsePayload(photoId)
+  }
+
+  @ApiResponseSimpleSuccess
+  @Operation(summary = "Deletes a photo from a report.")
+  @DeleteMapping("/{reportId}/photos/{photoId}")
+  fun deleteReportPhoto(
+      @PathVariable("reportId") reportId: ReportId,
+      @PathVariable("photoId") photoId: PhotoId
+  ): SimpleSuccessResponsePayload {
+    reportPhotoService.deletePhoto(reportId, photoId)
+
+    return SimpleSuccessResponsePayload()
+  }
 }
 
 data class ListReportsResponseElement(
@@ -154,6 +249,13 @@ data class ListReportsResponseElement(
   )
 }
 
+data class ListReportPhotosResponseElement(
+    val caption: String?,
+    val id: PhotoId,
+) {
+  constructor(model: ReportPhotoModel) : this(model.caption, model.photoId)
+}
+
 data class GetReportResponsePayload(
     val report: GetReportPayload,
 ) : SuccessResponsePayload
@@ -165,3 +267,13 @@ data class ListReportsResponsePayload(
 data class PutReportRequestPayload(
     val report: PutReportPayload,
 )
+
+data class ListReportPhotosResponsePayload(
+    val photos: List<ListReportPhotosResponseElement>,
+) : SuccessResponsePayload
+
+data class UpdateReportPhotoRequestPayload(val caption: String?) {
+  fun toModel(reportId: ReportId, photoId: PhotoId) = ReportPhotoModel(caption, photoId, reportId)
+}
+
+data class UploadReportPhotoResponsePayload(val photoId: PhotoId) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportPhotoModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportPhotoModel.kt
@@ -1,0 +1,13 @@
+package com.terraformation.backend.report.model
+
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.db.default_schema.tables.pojos.ReportPhotosRow
+
+data class ReportPhotoModel(
+    val caption: String? = null,
+    val photoId: PhotoId,
+    val reportId: ReportId,
+) {
+  constructor(row: ReportPhotosRow) : this(row.caption, row.photoId!!, row.reportId!!)
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -34,6 +34,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.NotificationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationUsersDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.PhotosDao
+import com.terraformation.backend.db.default_schema.tables.daos.ReportPhotosDao
 import com.terraformation.backend.db.default_schema.tables.daos.ReportsDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesEcosystemTypesDao
@@ -265,6 +266,7 @@ abstract class DatabaseTest {
   protected val plantingSitesDao: PlantingSitesDao by lazyDao()
   protected val plantingZonesDao: PlantingZonesDao by lazyDao()
   protected val plotsDao: PlotsDao by lazyDao()
+  protected val reportPhotosDao: ReportPhotosDao by lazyDao()
   protected val reportsDao: ReportsDao by lazyDao()
   protected val speciesDao: SpeciesDao by lazyDao()
   protected val speciesEcosystemTypesDao: SpeciesEcosystemTypesDao by lazyDao()

--- a/src/test/kotlin/com/terraformation/backend/report/ReportPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportPhotoServiceTest.kt
@@ -1,0 +1,191 @@
+package com.terraformation.backend.report
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.PhotoNotFoundException
+import com.terraformation.backend.db.ReportNotFoundException
+import com.terraformation.backend.db.default_schema.PhotoId
+import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.db.default_schema.tables.pojos.ReportPhotosRow
+import com.terraformation.backend.file.FileStore
+import com.terraformation.backend.file.PhotoService
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailStore
+import com.terraformation.backend.file.model.PhotoMetadata
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.report.model.ReportPhotoModel
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.net.URI
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+
+class ReportPhotoServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val fileStore: FileStore = mockk()
+  private val thumbnailStore: ThumbnailStore = mockk()
+  private val photoService: PhotoService by lazy {
+    PhotoService(dslContext, clock, fileStore, photosDao, thumbnailStore)
+  }
+  private val service: ReportPhotoService by lazy {
+    ReportPhotoService(photoService, reportPhotosDao)
+  }
+
+  private lateinit var reportId: ReportId
+  private var storageUrlCount = 0
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    reportId = insertReport()
+
+    every { fileStore.delete(any()) } just Runs
+    every { fileStore.newUrl(any(), any(), any()) } answers { URI("${++storageUrlCount}") }
+    every { fileStore.write(any(), any()) } just Runs
+    every { thumbnailStore.deleteThumbnails(any()) } just Runs
+    every { user.canReadReport(any()) } returns true
+    every { user.canUpdateReport(any()) } returns true
+  }
+
+  @Nested
+  inner class ListPhotos {
+    @Test
+    fun `returns photos with captions`() {
+      val photoId1 = storePhoto()
+      val photoId2 = storePhoto()
+      // Shouldn't include photos from other reports
+      storePhoto(insertReport(year = 1990))
+
+      reportPhotosDao.update(
+          reportPhotosDao.fetchOneByPhotoId(photoId2)!!.copy(caption = "caption"))
+
+      val expected =
+          listOf(
+              ReportPhotoModel(null, photoId1, reportId),
+              ReportPhotoModel("caption", photoId2, reportId),
+          )
+
+      val actual = service.listPhotos(reportId)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `throws exception if no permission to read report`() {
+      every { user.canReadReport(any()) } returns false
+
+      assertThrows<ReportNotFoundException> { service.listPhotos(reportId) }
+    }
+  }
+
+  @Nested
+  inner class ReadPhoto {
+    @Test
+    fun `returns photo data`() {
+      val content = Random.Default.nextBytes(10)
+      val photoId = storePhoto(content = content)
+
+      every { fileStore.read(URI("1")) } returns SizedInputStream(content.inputStream(), 10L)
+
+      val inputStream = service.readPhoto(reportId, photoId)
+      assertArrayEquals(content, inputStream.readAllBytes(), "File content")
+    }
+
+    @Test
+    fun `returns thumbnail data`() {
+      val content = Random.nextBytes(10)
+      val photoId = storePhoto()
+      val maxWidth = 10
+      val maxHeight = 20
+
+      every { thumbnailStore.getThumbnailData(photoId, maxWidth, maxHeight) } returns
+          SizedInputStream(content.inputStream(), 10L)
+
+      val inputStream = service.readPhoto(reportId, photoId, maxWidth, maxHeight)
+      assertArrayEquals(content, inputStream.readAllBytes(), "Thumbnail content")
+    }
+
+    @Test
+    fun `throws exception if photo is on a different report`() {
+      val otherReportId = insertReport(year = 1990)
+      val photoId = storePhoto()
+
+      assertThrows<PhotoNotFoundException> { service.readPhoto(otherReportId, photoId) }
+    }
+
+    @Test
+    fun `throws exception if no permission to read report`() {
+      val photoId = storePhoto()
+
+      every { user.canReadReport(any()) } returns false
+
+      assertThrows<ReportNotFoundException> { service.readPhoto(reportId, photoId) }
+    }
+  }
+
+  @Nested
+  inner class StorePhoto {
+    @Test
+    fun `associates photo with report`() {
+      val photoId = storePhoto()
+
+      assertEquals(listOf(ReportPhotosRow(reportId, photoId)), reportPhotosDao.findAll())
+    }
+
+    @Test
+    fun `throws exception if no permission to update report`() {
+      every { user.canUpdateReport(any()) } returns false
+
+      assertThrows<AccessDeniedException> { storePhoto() }
+    }
+  }
+
+  @Nested
+  inner class UpdatePhoto {
+    @Test
+    fun `updates caption`() {
+      val photoId = storePhoto()
+      val newCaption = "new caption"
+
+      service.updatePhoto(ReportPhotoModel(newCaption, photoId, reportId))
+
+      val row = reportPhotosDao.fetchOneByPhotoId(photoId)
+
+      assertEquals(newCaption, row?.caption)
+    }
+
+    @Test
+    fun `throws exception if no permission to update report`() {
+      val photoId = storePhoto()
+
+      every { user.canUpdateReport(any()) } returns false
+
+      assertThrows<AccessDeniedException> {
+        service.updatePhoto(ReportPhotoModel("caption", photoId, reportId))
+      }
+    }
+  }
+
+  private fun storePhoto(
+      reportId: ReportId = this.reportId,
+      content: ByteArray = ByteArray(0),
+      contentType: String = MediaType.IMAGE_JPEG_VALUE
+  ): PhotoId {
+    return service.storePhoto(
+        reportId,
+        content.inputStream(),
+        PhotoMetadata("upload", contentType, content.size.toLong()))
+  }
+}


### PR DESCRIPTION
Add endpoints to allow uploading and downloading report-related photos. These
endpoints follow the usual pattern for photos in our API (similar to the endpoints
for nursery withdrawal photos) including server-generated thumbnail images.

One difference from nursery withdrawal photos is that report photos need to
support captions; there is a POST endpoint to update a photo's caption, and the
captions are included in the `GET /api/v1/reports/{id}/photos` response.