### PR TITLE
SW-2994 Limit Jira transitions during prod release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,4 +152,4 @@ jobs:
       uses: terraware/gajira-transition-multiple@master
       with:
         issueList: ./docs/jiralist.txt
-        transition: "Released to Production"
+        transition: "Released to Production from Done"


### PR DESCRIPTION
Only transition to "Released to Production" if the status is already "Done"