### PR TITLE
SW-2991 Include reporting ability in organization API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.OrganizationService
 import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.OrganizationUserModel
 import com.terraformation.backend.db.CannotRemoveLastOwnerException
@@ -298,6 +299,8 @@ data class UpdateOrganizationRequestPayload(
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class OrganizationPayload(
+    @Schema(description = "Whether this organization can submit reports to Terraformation.")
+    val canSubmitReports: Boolean,
     @Schema(
         description = "ISO 3166 alpha-2 code of organization's country.",
         example = "AU",
@@ -336,6 +339,7 @@ data class OrganizationPayload(
       model: OrganizationModel,
       role: Role,
   ) : this(
+      canSubmitReports = InternalTagIds.Reporter in model.internalTags,
       model.countryCode,
       model.countrySubdivisionCode,
       model.createdTime.truncatedTo(ChronoUnit.SECONDS),

--- a/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/OrganizationModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.model
 
+import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
@@ -17,6 +18,7 @@ data class OrganizationModel(
     val countrySubdivisionCode: String? = null,
     val createdTime: Instant,
     val disabledTime: Instant? = null,
+    val internalTags: Set<InternalTagId> = emptySet(),
     val facilities: List<FacilityModel>? = null,
     val totalUsers: Int,
     val timeZone: ZoneId? = null,
@@ -24,6 +26,7 @@ data class OrganizationModel(
   constructor(
       record: Record,
       facilitiesMultiset: Field<List<FacilityModel>>?,
+      internalTagsMultiset: Field<List<InternalTagId>>,
       totalUsersSubquery: Field<Int>,
   ) : this(
       id = record[ORGANIZATIONS.ID] ?: throw IllegalArgumentException("ID is required"),
@@ -35,6 +38,7 @@ data class OrganizationModel(
               ?: throw IllegalArgumentException("Created time is required"),
       disabledTime = record[ORGANIZATIONS.DISABLED_TIME],
       facilities = record[facilitiesMultiset],
+      internalTags = record[internalTagsMultiset]?.toSet() ?: emptySet(),
       totalUsers = record[totalUsersSubquery],
       timeZone = record[ORGANIZATIONS.TIME_ZONE],
   )

--- a/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
@@ -115,8 +115,8 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     val otherOrganizationId = OrganizationId(2)
     insertOrganization(organizationId)
     insertOrganization(otherOrganizationId)
-    insertOrganizationTag(organizationId, InternalTagIds.Reporter)
-    insertOrganizationTag(otherOrganizationId, otherTagId)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
+    insertOrganizationInternalTag(otherOrganizationId, otherTagId)
 
     assertEquals(
         listOf(organizationId),
@@ -128,9 +128,9 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     val otherOrganizationId = OrganizationId(2)
     insertOrganization(organizationId)
     insertOrganization(otherOrganizationId)
-    insertOrganizationTag(organizationId, InternalTagIds.Reporter)
-    insertOrganizationTag(organizationId, InternalTagIds.Testing)
-    insertOrganizationTag(otherOrganizationId, InternalTagIds.Testing)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
+    insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Testing)
 
     assertEquals(
         mapOf(
@@ -145,9 +145,9 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     val otherOrganizationId = OrganizationId(2)
     insertOrganization(organizationId)
     insertOrganization(otherOrganizationId)
-    insertOrganizationTag(organizationId, InternalTagIds.Reporter)
-    insertOrganizationTag(organizationId, InternalTagIds.Testing)
-    insertOrganizationTag(otherOrganizationId, InternalTagIds.Internal)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
+    insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Internal)
 
     assertEquals(
         setOf(InternalTagIds.Reporter, InternalTagIds.Testing),
@@ -166,9 +166,9 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     val otherOrganizationId = OrganizationId(2)
     insertOrganization(organizationId)
     insertOrganization(otherOrganizationId)
-    insertOrganizationTag(organizationId, InternalTagIds.Reporter)
-    insertOrganizationTag(organizationId, InternalTagIds.Internal)
-    insertOrganizationTag(otherOrganizationId, InternalTagIds.Reporter)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Internal)
+    insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Reporter)
 
     val newTime = Instant.ofEpochSecond(1000)
     clock.instant = newTime
@@ -240,17 +240,5 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     internalTagsDao.insert(row)
 
     return row.id!!
-  }
-
-  private fun insertOrganizationTag(
-      organizationId: OrganizationId = this.organizationId,
-      tagId: InternalTagId = InternalTagIds.Reporter
-  ) {
-    organizationInternalTagsDao.insert(
-        OrganizationInternalTagsRow(
-            internalTagId = tagId,
-            organizationId = organizationId,
-            createdBy = user.userId,
-            createdTime = clock.instant))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.model.FacilityModel
+import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.OrganizationUserModel
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -71,6 +72,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
           countrySubdivisionCode = "US-HI",
           createdTime = Instant.EPOCH,
           facilities = listOf(facilityModel),
+          internalTags = setOf(InternalTagIds.Reporter),
           timeZone = null,
           totalUsers = 0,
       )
@@ -99,6 +101,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
         name = organizationModel.name,
         countryCode = organizationModel.countryCode,
         countrySubdivisionCode = organizationModel.countrySubdivisionCode)
+    insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     insertFacility()
     timeZone = insertTimeZone()
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.AutomationModel
+import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.EcosystemType
@@ -12,6 +13,7 @@ import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.GrowthForm
+import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.NotificationType
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -48,6 +50,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
+import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
@@ -957,6 +960,20 @@ abstract class DatabaseTest {
     val zoneId = if (timeZone is ZoneId) timeZone else ZoneId.of("$timeZone")
     timeZonesDao.insert(TimeZonesRow(zoneId))
     return zoneId
+  }
+
+  protected fun insertOrganizationInternalTag(
+      organizationId: Any = this.organizationId,
+      tagId: InternalTagId = InternalTagIds.Reporter,
+      createdBy: Any = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+  ) {
+    organizationInternalTagsDao.insert(
+        OrganizationInternalTagsRow(
+            internalTagId = tagId,
+            organizationId = organizationId.toIdWrapper { OrganizationId(it) },
+            createdBy = createdBy.toIdWrapper { UserId(it) },
+            createdTime = createdTime))
   }
 
   class DockerPostgresDataSourceInitializer :


### PR DESCRIPTION
The client needs to know whether or not an organization is eligible to submit
reports so it can show or hide the reporting-related UI elements. Include a
field in the `GET /api/v1/organizations` payloads to indicate whether or not
the organization is supposed to submit reports.