### PR TITLE
Add a couple missing report fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
@@ -44,6 +44,7 @@ interface EditableReportFieldsV1 : EditableReportFields {
   interface PlantingSite {
     val id: PlantingSiteId
     val mortalityRate: Int?
+    val notes: String?
     val species: List<Species>
     val totalPlantedArea: Int?
     val totalPlantingSiteArea: Int?
@@ -82,6 +83,7 @@ interface EditableReportFieldsV1 : EditableReportFields {
     val isCatalytic: Boolean
     val keyLessons: String?
     val nextSteps: String?
+    val opportunities: String?
     val projectImpact: String?
     val projectSummary: String?
     val socialImpact: String?
@@ -173,9 +175,10 @@ data class GetReportPayloadV1(
 
   data class GetPlantingSiteV1(
       override val id: PlantingSiteId,
-      val name: String,
-      override val species: List<GetPlantingSiteSpeciesV1>,
       override val mortalityRate: Int?,
+      val name: String,
+      override val notes: String?,
+      override val species: List<GetPlantingSiteSpeciesV1>,
       override val totalPlantedArea: Int?,
       override val totalPlantingSiteArea: Int?,
       override val totalPlantsPlanted: Int?,
@@ -186,9 +189,10 @@ data class GetReportPayloadV1(
         model: ReportBodyModelV1.PlantingSite
     ) : this(
         id = model.id,
-        name = model.name,
-        species = model.species.map { GetPlantingSiteSpeciesV1(it) },
         mortalityRate = model.mortalityRate,
+        name = model.name,
+        notes = model.notes,
+        species = model.species.map { GetPlantingSiteSpeciesV1(it) },
         totalPlantedArea = model.totalPlantedArea,
         totalPlantingSiteArea = model.totalPlantingSiteArea,
         totalPlantsPlanted = model.totalPlantsPlanted,
@@ -295,6 +299,7 @@ data class PutReportPayloadV1(
 
   data class PutPlantingSiteV1(
       override val id: PlantingSiteId,
+      override val notes: String?,
       override val species: List<PutPlantingSiteSpeciesV1>,
       override val mortalityRate: Int?,
       override val totalPlantedArea: Int?,
@@ -380,6 +385,7 @@ data class AnnualDetailsPayloadV1(
     override val isCatalytic: Boolean,
     override val keyLessons: String?,
     override val nextSteps: String?,
+    override val opportunities: String?,
     override val projectImpact: String?,
     override val projectSummary: String?,
     override val socialImpact: String?,
@@ -396,6 +402,7 @@ data class AnnualDetailsPayloadV1(
       isCatalytic = model.isCatalytic,
       keyLessons = model.keyLessons,
       nextSteps = model.nextSteps,
+      opportunities = model.opportunities,
       projectImpact = model.projectImpact,
       projectSummary = model.projectSummary,
       socialImpact = model.socialImpact,
@@ -413,6 +420,7 @@ data class AnnualDetailsPayloadV1(
           isCatalytic = isCatalytic,
           keyLessons = keyLessons,
           nextSteps = nextSteps,
+          opportunities = opportunities,
           projectImpact = projectImpact,
           projectSummary = projectSummary,
           socialImpact = socialImpact,

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
@@ -94,6 +94,7 @@ data class ReportBodyModelV1(
       val id: PlantingSiteId,
       val mortalityRate: Int? = null,
       val name: String,
+      val notes: String? = null,
       val selected: Boolean = true,
       val species: List<Species> = emptyList(),
       val totalPlantedArea: Int? = null,
@@ -243,6 +244,7 @@ data class ReportBodyModelV1(
       val isCatalytic: Boolean = false,
       val keyLessons: String? = null,
       val nextSteps: String? = null,
+      val opportunities: String? = null,
       val projectImpact: String? = null,
       val projectSummary: String? = null,
       val socialImpact: String? = null,
@@ -262,6 +264,7 @@ data class ReportBodyModelV1(
         failIfNull(challenges, "challenges")
         failIfNull(keyLessons, "key lessons")
         failIfNull(nextSteps, "next steps")
+        failIfNull(opportunities, "opportunities")
         failIfNull(projectImpact, "project impact")
         failIfNull(projectSummary, "project summary")
         failIfNull(socialImpact, "social impact")

--- a/src/test/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1Test.kt
@@ -28,6 +28,7 @@ class ReportBodyModelV1Test {
                   isCatalytic = true,
                   keyLessons = "key lessons",
                   nextSteps = "next steps",
+                  opportunities = "opportunities",
                   projectImpact = "project impact",
                   projectSummary = "project summary",
                   socialImpact = "social impact",
@@ -62,6 +63,7 @@ class ReportBodyModelV1Test {
                       id = PlantingSiteId(1),
                       mortalityRate = 10,
                       name = "planting site name",
+                      notes = "planting site notes",
                       selected = true,
                       species =
                           listOf(
@@ -199,6 +201,7 @@ class ReportBodyModelV1Test {
             annualDetailsCase("challenges") { copy(challenges = null) },
             annualDetailsCase("keyLessons") { copy(keyLessons = null) },
             annualDetailsCase("nextSteps") { copy(nextSteps = null) },
+            annualDetailsCase("opportunities") { copy(opportunities = null) },
             annualDetailsCase("projectImpact") { copy(projectImpact = null) },
             annualDetailsCase("projectSummary") { copy(projectSummary = null) },
             annualDetailsCase("socialImpact") { copy(socialImpact = null) },


### PR DESCRIPTION
The report payloads and internal models were missing a couple fields: `notes` on
planting sites and `opportunities` on annual details. Add them.