### PR TITLE
SW-3021 Populate facility details from reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/FacilityService.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.customer.event.FacilityIdleEvent
 import com.terraformation.backend.customer.event.FacilityTimeZoneChangedEvent
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.report.event.ReportSubmittedEvent
 import javax.inject.Named
 import org.jobrunr.jobs.annotations.Job
 import org.jobrunr.spring.annotations.Recurring
@@ -18,6 +20,8 @@ class FacilityService(
     private val publisher: ApplicationEventPublisher,
     private val systemUser: SystemUser,
 ) {
+  private val log = perClassLogger()
+
   /** Sends alert email when facilities go idle. Runs once per minute. */
   @Job(name = SCAN_FOR_IDLE_FACILITIES_JOB_NAME, retries = 0)
   @Recurring(id = SCAN_FOR_IDLE_FACILITIES_JOB_NAME, cron = "* * * * *")
@@ -39,6 +43,42 @@ class FacilityService(
         .fetchByOrganizationId(event.organizationId)
         .filter { it.timeZone == null }
         .forEach { facility -> publisher.publishEvent(FacilityTimeZoneChangedEvent(facility)) }
+  }
+
+  @EventListener
+  fun on(event: ReportSubmittedEvent) {
+    event.body.nurseries.forEach { nurseryBody ->
+      val existing = facilityStore.fetchOneById(nurseryBody.id)
+      val updated =
+          existing.copy(
+              buildCompletedDate = existing.buildCompletedDate ?: nurseryBody.buildCompletedDate,
+              buildStartedDate = existing.buildStartedDate ?: nurseryBody.buildStartedDate,
+              capacity = existing.capacity ?: nurseryBody.capacity,
+              operationStartedDate = existing.operationStartedDate
+                      ?: nurseryBody.operationStartedDate,
+          )
+
+      if (existing != updated) {
+        log.info("Updating nursery ${updated.id} data from report")
+        facilityStore.update(updated)
+      }
+    }
+
+    event.body.seedBanks.forEach { seedBankBody ->
+      val existing = facilityStore.fetchOneById(seedBankBody.id)
+      val updated =
+          existing.copy(
+              buildCompletedDate = existing.buildCompletedDate ?: seedBankBody.buildCompletedDate,
+              buildStartedDate = existing.buildStartedDate ?: seedBankBody.buildStartedDate,
+              operationStartedDate = existing.operationStartedDate
+                      ?: seedBankBody.operationStartedDate,
+          )
+
+      if (existing != updated) {
+        log.info("Updating seed bank ${updated.id} data from report")
+        facilityStore.update(updated)
+      }
+    }
   }
 
   companion object {


### PR DESCRIPTION
When a report is submitted, update the build/operation dates and (for nurseries)
the capacity on the facility if they aren't already set, so they'll be prefilled
when a subsequent report is generated.