### PR TITLE
SW-2878 Notify admins when reports are created

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.email.model.EmailTemplateModel
 import com.terraformation.backend.i18n.use
 import com.terraformation.backend.log.perClassLogger
@@ -69,12 +70,13 @@ class EmailService(
    *   opted out of email notifications. The default is to obey the user's notification preference,
    *   which is the correct thing to do in the vast majority of cases.
    */
-  private fun sendOrganizationNotification(
+  fun sendOrganizationNotification(
       organizationId: OrganizationId,
       model: EmailTemplateModel,
       requireOptIn: Boolean = true,
+      roles: Set<Role>? = null,
   ) {
-    val recipients = organizationStore.fetchEmailRecipients(organizationId, requireOptIn)
+    val recipients = organizationStore.fetchEmailRecipients(organizationId, requireOptIn, roles)
 
     send(model, recipients)
   }

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.email
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -106,6 +107,17 @@ class WebAppUrls(private val config: TerrawareServerConfig) {
     return UriBuilder.fromPath("/monitoring/${facilityId.value}")
         .let { devicePath(it, device) }
         .build()
+  }
+
+  fun fullReport(reportId: ReportId, organizationId: OrganizationId): URI {
+    return UriBuilder.fromUri(config.webAppUrl)
+        .path("/reports/$reportId")
+        .queryParam("organizationId", organizationId)
+        .build()
+  }
+
+  fun report(reportId: ReportId): URI {
+    return UriBuilder.fromPath("/reports/$reportId").build()
   }
 
   private fun devicePath(uriBuilder: UriBuilder, device: DevicesRow?): UriBuilder {

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -153,3 +153,20 @@ class NurserySeedlingBatchReady(
   override val templateDir: String
     get() = "nursery/seedlingBatchReady"
 }
+
+class ReportCreated(
+    config: TerrawareServerConfig,
+    val year: String,
+    val quarter: String,
+    val reportUrl: String,
+) : EmailTemplateModel(config) {
+  constructor(
+      config: TerrawareServerConfig,
+      year: Int,
+      quarter: Int,
+      reportUrl: String,
+  ) : this(config, "$year", "$quarter", reportUrl)
+
+  override val templateDir: String
+    get() = "report/created"
+}

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -188,6 +188,11 @@ class Messages {
           title = getMessage("notification.seedBank.deviceUnresponsive.app.title", deviceName),
           body = getMessage("notification.seedBank.deviceUnresponsive.app.body", deviceName))
 
+  fun reportCreated(year: Int, quarter: Int): NotificationMessage =
+      NotificationMessage(
+          title = getMessage("notification.report.created.app.title", "$year", "$quarter"),
+          body = getMessage("notification.report.created.app.body", "$year", "$quarter"))
+
   fun historyAccessionCreated() = getMessage("historyAccessionCreated")
 
   fun historyAccessionQuantityUpdated(newQuantity: SeedQuantityModel) =

--- a/src/main/kotlin/com/terraformation/backend/report/event/ReportCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/event/ReportCreatedEvent.kt
@@ -1,0 +1,5 @@
+package com.terraformation.backend.report.event
+
+import com.terraformation.backend.report.model.ReportMetadata
+
+data class ReportCreatedEvent(val metadata: ReportMetadata)

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -94,7 +94,8 @@ VALUES (1, 'User Added to Organization', 1),
        (12, 'Sensor Out Of Bounds', 3),
        (13, 'Unknown Automation Triggered', 3),
        (14, 'Device Unresponsive', 3),
-       (15, 'Nursery Seedling Batch Ready', 1)
+       (15, 'Nursery Seedling Batch Ready', 1),
+       (16, 'Report Created', 1)
 ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
                                notification_criticality_id = excluded.notification_criticality_id;
 

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -130,6 +130,12 @@ notification.batch.ready.app.body={0} (located in {1}) has reached its scheduled
 notification.batch.ready.email.subject=A Seedling Batch is Ready
 notification.batch.ready.email.body={0} (located in {1}) has reached its scheduled ready by date. Check on your plants and update their status if needed.
 
+notification.report.created.app.title=Time to Complete Your {0}-Q{1} Report
+notification.report.created.app.body=Your {0}-Q{1} Report is ready to be completed and submitted to Terraformation.
+notification.report.created.email.subject=Time to Complete Your {0}-Q{1} Report
+notification.report.created.email.body.1=Time to Complete Your {0}-Q{1} Report
+notification.report.created.email.body.2=Your {0}-Q{1} Report is ready to be completed and submitted to Terraformation.
+
 notification.seedBank.alert.email.subject=Alert: {0}
 notification.seedBank.alert.email.body=Alert received from facility {0}:
 

--- a/src/main/resources/templates/email/report/created/body.ftlh.mjml
+++ b/src/main/resources/templates/email/report/created/body.ftlh.mjml
@@ -1,0 +1,25 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ReportCreated" --> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-headline06-bold">
+                    ${strings("notification.report.created.email.body.1", year, quarter)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                    ${strings("notification.report.created.email.body.2", year, quarter)}
+                </mj-text>
+                <mj-button mj-class="btn-productive-primary-md"
+                           href="${reportUrl?no_esc}">${strings("notification.email.buttonLabel")}
+                </mj-button>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/report/created/body.txt.ftl
+++ b/src/main/resources/templates/email/report/created/body.txt.ftl
@@ -1,0 +1,9 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ReportCreated" -->
+${strings("notification.report.created.email.body.1", year, quarter)}
+
+${reportUrl}
+
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/report/created/subject.ftl
+++ b/src/main/resources/templates/email/report/created/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ReportCreated" -->
+${strings("notification.report.created.email.subject", year, quarter)}

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -556,6 +556,30 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     assertEquals(expected, actual)
   }
 
+  @Test
+  fun `fetchEmailRecipients returns addresses users with requested roles`() {
+    val admin1 = UserId(100)
+    val admin2 = UserId(101)
+    val manager = UserId(102)
+    val owner = UserId(103)
+
+    insertUser(admin1, email = "admin1@x.com", emailNotificationsEnabled = true)
+    insertUser(admin2, email = "admin2@x.com", emailNotificationsEnabled = true)
+    insertUser(manager, email = "manager@x.com", emailNotificationsEnabled = true)
+    insertUser(owner, email = "owner@x.com", emailNotificationsEnabled = true)
+
+    insertOrganizationUser(admin1, role = Role.Admin)
+    insertOrganizationUser(admin2, role = Role.Admin)
+    insertOrganizationUser(manager, role = Role.Manager)
+    insertOrganizationUser(owner, role = Role.Owner)
+
+    val expected = setOf("admin1@x.com", "admin2@x.com", "owner@x.com")
+    val actual =
+        store.fetchEmailRecipients(organizationId, roles = setOf(Role.Owner, Role.Admin)).toSet()
+
+    assertEquals(expected, actual)
+  }
+
   private fun organizationUserModel(
       userId: UserId = UserId(100),
       email: String = "$userId@y.com",

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.REPORTS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.report.ReportNotCompleteException
+import com.terraformation.backend.report.event.ReportCreatedEvent
 import com.terraformation.backend.report.event.ReportSubmittedEvent
 import com.terraformation.backend.report.model.ReportBodyModelV1
 import com.terraformation.backend.report.model.ReportMetadata
@@ -75,6 +76,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
       val actual = store.create(organizationId, ReportBodyModelV1(organizationName = "org"))
 
       assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `publishes ReportCreatedEvent`() {
+      val metadata = store.create(organizationId, ReportBodyModelV1(organizationName = "org"))
+
+      publisher.assertEventPublished(ReportCreatedEvent(metadata))
     }
 
     @Test


### PR DESCRIPTION
Generate email and in-app notifications when a new report is created. The
notifications only go to owners and admins, not to managers and contributors.