### PR TITLE
Move ID and storage URL into FileMetadata

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.tables.daos.FilesDao
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.references.FILES
-import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import java.io.IOException
 import java.io.InputStream
@@ -35,8 +35,7 @@ class FileService(
   fun storeFile(
       category: String,
       data: InputStream,
-      size: Long,
-      metadata: FileMetadata,
+      metadata: NewFileMetadata,
       insertChildRows: (FileId) -> Unit
   ): FileId {
     val storageUrl = fileStore.newUrl(clock.instant(), category, metadata.contentType)
@@ -52,7 +51,7 @@ class FileService(
               fileName = metadata.filename,
               modifiedBy = currentUser().userId,
               modifiedTime = clock.instant(),
-              size = size,
+              size = metadata.size,
               storageUrl = storageUrl,
           )
 

--- a/src/main/kotlin/com/terraformation/backend/file/model/FileMetadata.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/model/FileMetadata.kt
@@ -1,33 +1,54 @@
 package com.terraformation.backend.file.model
 
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import java.net.URI
 import org.jooq.Record
 import org.springframework.http.MediaType
 
-data class FileMetadata(
-    val filename: String,
+data class FileMetadata<I : FileId?, U : URI?>(
     val contentType: String,
+    val filename: String,
+    val id: I,
     val size: Long,
+    val storageUrl: U,
 ) {
-  constructor(
-      record: Record
-  ) : this(
-      contentType = record[FILES.CONTENT_TYPE] ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
-      filename = record[FILES.FILE_NAME.asNonNullable()],
-      size = record[FILES.SIZE.asNonNullable()],
-  )
-
-  constructor(
-      row: FilesRow
-  ) : this(
-      contentType = row.contentType ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
-      filename = row.fileName!!,
-      size = row.size!!,
-  )
-
   /** The filename with any directory names stripped off. */
   val filenameWithoutPath: String
     get() = filename.substringAfterLast('/').substringAfterLast('\\')
+
+  companion object {
+    fun of(row: FilesRow): ExistingFileMetadata =
+        ExistingFileMetadata(
+            contentType = row.contentType ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
+            filename = row.fileName!!,
+            id = row.id!!,
+            size = row.size!!,
+            storageUrl = row.storageUrl!!,
+        )
+
+    fun of(record: Record): ExistingFileMetadata =
+        ExistingFileMetadata(
+            contentType = record[FILES.CONTENT_TYPE] ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
+            filename = record[FILES.FILE_NAME.asNonNullable()],
+            id = record[FILES.ID.asNonNullable()],
+            size = record[FILES.SIZE.asNonNullable()],
+            storageUrl = record[FILES.STORAGE_URL.asNonNullable()],
+        )
+
+    fun of(contentType: String, filename: String, size: Long): NewFileMetadata =
+        NewFileMetadata(
+            contentType = contentType,
+            filename = filename,
+            id = null,
+            size = size,
+            storageUrl = null,
+        )
+  }
 }
+
+typealias NewFileMetadata = FileMetadata<Nothing?, Nothing?>
+
+typealias ExistingFileMetadata = FileMetadata<FileId, URI>

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -103,10 +103,7 @@ class WithdrawalsController(
 
     val fileId =
         withdrawalPhotoService.storePhoto(
-            withdrawalId,
-            file.inputStream,
-            file.size,
-            FileMetadata(filename, contentType, file.size))
+            withdrawalId, file.inputStream, FileMetadata.of(contentType, filename, file.size))
 
     return CreateNurseryWithdrawalPhotoResponsePayload(fileId)
   }

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -11,7 +11,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
-import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.WithdrawalDeletionStartedEvent
 import java.io.InputStream
@@ -28,16 +28,11 @@ class WithdrawalPhotoService(
 ) {
   private val log = perClassLogger()
 
-  fun storePhoto(
-      withdrawalId: WithdrawalId,
-      data: InputStream,
-      size: Long,
-      metadata: FileMetadata
-  ): FileId {
+  fun storePhoto(withdrawalId: WithdrawalId, data: InputStream, metadata: NewFileMetadata): FileId {
     requirePermissions { createWithdrawalPhoto(withdrawalId) }
 
     val fileId =
-        fileService.storeFile("withdrawal", data, size, metadata) { fileId ->
+        fileService.storeFile("withdrawal", data, metadata) { fileId ->
           withdrawalPhotosDao.insert(
               WithdrawalPhotosRow(fileId = fileId, withdrawalId = withdrawalId))
         }

--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -216,7 +216,7 @@ class ReportsController(
 
     val fileId =
         reportFileService.storePhoto(
-            reportId, file.inputStream, FileMetadata(filename, contentType, file.size))
+            reportId, file.inputStream, FileMetadata.of(contentType, filename, file.size))
 
     return UploadReportFileResponsePayload(fileId)
   }
@@ -281,7 +281,7 @@ class ReportsController(
 
     val fileId =
         reportFileService.storeFile(
-            reportId, file.inputStream, FileMetadata(filename, contentType, file.size))
+            reportId, file.inputStream, FileMetadata.of(contentType, filename, file.size))
 
     return UploadReportFileResponsePayload(fileId)
   }
@@ -327,14 +327,16 @@ data class ListReportPhotosResponseElement(
     val filename: String,
     val id: FileId,
 ) {
-  constructor(model: ReportPhotoModel) : this(model.caption, model.metadata.filename, model.fileId)
+  constructor(
+      model: ReportPhotoModel
+  ) : this(model.caption, model.metadata.filename, model.metadata.id)
 }
 
 data class ListReportFilesResponseElement(
     val filename: String,
     val id: FileId,
 ) {
-  constructor(model: ReportFileModel) : this(model.metadata.filename, model.fileId)
+  constructor(model: ReportFileModel) : this(model.metadata.filename, model.metadata.id)
 }
 
 data class GetReportResponsePayload(

--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -237,7 +237,13 @@ class ReportStore(
     requirePermissions { readReport(reportId) }
 
     return dslContext
-        .select(FILES.ID, FILES.FILE_NAME, FILES.CONTENT_TYPE, FILES.SIZE)
+        .select(
+            FILES.CONTENT_TYPE,
+            FILES.FILE_NAME,
+            FILES.ID,
+            FILES.SIZE,
+            FILES.STORAGE_URL,
+        )
         .from(REPORT_FILES)
         .join(FILES)
         .on(REPORT_FILES.FILE_ID.eq(FILES.ID))
@@ -245,8 +251,7 @@ class ReportStore(
         .orderBy(FILES.ID)
         .fetch { record ->
           ReportFileModel(
-              fileId = record[FILES.ID.asNonNullable()],
-              metadata = FileMetadata(record),
+              metadata = FileMetadata.of(record),
               reportId = reportId,
           )
         }
@@ -256,7 +261,13 @@ class ReportStore(
     requirePermissions { readReport(reportId) }
 
     return dslContext
-        .select(FILES.ID, FILES.FILE_NAME, FILES.CONTENT_TYPE, FILES.SIZE)
+        .select(
+            FILES.CONTENT_TYPE,
+            FILES.FILE_NAME,
+            FILES.ID,
+            FILES.SIZE,
+            FILES.STORAGE_URL,
+        )
         .from(REPORT_FILES)
         .join(FILES)
         .on(REPORT_FILES.FILE_ID.eq(FILES.ID))
@@ -264,8 +275,7 @@ class ReportStore(
         .and(REPORT_FILES.FILE_ID.eq(fileId))
         .fetchOne { record ->
           ReportFileModel(
-              fileId = record[FILES.ID.asNonNullable()],
-              metadata = FileMetadata(record),
+              metadata = FileMetadata.of(record),
               reportId = reportId,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportFileModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportFileModel.kt
@@ -1,11 +1,9 @@
 package com.terraformation.backend.report.model
 
-import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ReportId
-import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.file.model.ExistingFileMetadata
 
 data class ReportFileModel(
-    val fileId: FileId,
-    val metadata: FileMetadata,
+    val metadata: ExistingFileMetadata,
     val reportId: ReportId,
 )

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportPhotoModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportPhotoModel.kt
@@ -1,19 +1,18 @@
 package com.terraformation.backend.report.model
 
-import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportPhotosRow
+import com.terraformation.backend.file.model.ExistingFileMetadata
 import com.terraformation.backend.file.model.FileMetadata
 
 data class ReportPhotoModel(
     val caption: String? = null,
-    val fileId: FileId,
-    val metadata: FileMetadata,
+    val metadata: ExistingFileMetadata,
     val reportId: ReportId,
 ) {
   constructor(
       photosRow: ReportPhotosRow,
-      metadataRow: FilesRow,
-  ) : this(photosRow.caption, photosRow.fileId!!, FileMetadata(metadataRow), photosRow.reportId!!)
+      filesRow: FilesRow,
+  ) : this(photosRow.caption, FileMetadata.of(filesRow), photosRow.reportId!!)
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/PhotosController.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
+import com.terraformation.backend.file.model.ExistingFileMetadata
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.seedbank.db.PhotoRepository
@@ -70,10 +71,7 @@ class PhotosController(private val photoRepository: PhotoRepository) {
 
     try {
       photoRepository.storePhoto(
-          accessionId,
-          file.inputStream,
-          file.size,
-          FileMetadata(photoFilename, contentType, file.size))
+          accessionId, file.inputStream, FileMetadata.of(contentType, photoFilename, file.size))
     } catch (e: AccessionNotFoundException) {
       throw e
     } catch (e: FileAlreadyExistsException) {
@@ -133,7 +131,7 @@ data class ListPhotosResponseElement(
     val filename: String,
     val size: Long,
 ) {
-  constructor(metadata: FileMetadata) : this(metadata.filename, metadata.size)
+  constructor(metadata: ExistingFileMetadata) : this(metadata.filename, metadata.size)
 }
 
 data class ListPhotosResponsePayload(val photos: List<ListPhotosResponseElement>) :

--- a/src/main/resources/templates/reports/v1/index.html
+++ b/src/main/resources/templates/reports/v1/index.html
@@ -78,8 +78,8 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
 
 <div class="photos">
     <div class="photo" th:each="photo : ${photos}">
-        <a th:href="|photo-${photo.fileId}-${#uris.escapePathSegment(photo.metadata.filenameWithoutPath)}|">
-            <img class="thumbnail" th:src="|thumbnail-${photo.fileId}.jpg|"/>
+        <a th:href="|photo-${photo.metadata.id}-${#uris.escapePathSegment(photo.metadata.filenameWithoutPath)}|">
+            <img class="thumbnail" th:src="|thumbnail-${photo.metadata.id}.jpg|"/>
         </a>
         <div class="photoFilename" th:text="${photo.metadata.filenameWithoutPath}"/>
         <div class="photoCaption" th:text="${photo.caption}"/>
@@ -170,7 +170,7 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
     <h4>Budget Document</h4>
 
     <th:div th:each="file : ${files}">
-        <a th:href="|file-${file.fileId}-${#uris.escapePathSegment(file.metadata.filenameWithoutPath)}|" th:text="${file.metadata.filenameWithoutPath}">
+        <a th:href="|file-${file.metadata.id}-${#uris.escapePathSegment(file.metadata.filenameWithoutPath)}|" th:text="${file.metadata.filenameWithoutPath}">
             spreadsheet-file.xls
         </a>
     </th:div>

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -47,7 +47,7 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
     WithdrawalPhotoService(dslContext, fileService, withdrawalPhotosDao)
   }
 
-  private val metadata = FileMetadata("filename", MediaType.IMAGE_JPEG_VALUE, 123L)
+  private val metadata = FileMetadata.of(MediaType.IMAGE_JPEG_VALUE, "filename", 123L)
   private val withdrawalId: WithdrawalId by lazy { insertWithdrawal() }
   private var storageUrlCount = 0
 
@@ -182,6 +182,6 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
       withdrawalId: WithdrawalId = this.withdrawalId,
       content: ByteArray = ByteArray(0)
   ): FileId {
-    return service.storePhoto(withdrawalId, content.inputStream(), content.size.toLong(), metadata)
+    return service.storePhoto(withdrawalId, content.inputStream(), metadata)
   }
 }


### PR DESCRIPTION
In preparation for implementing Google Drive export of report data, add fields for
the file ID and storage URL to `FileMetadata`. Since we use that class both for
new file uploads and for fetching existing files, introduce typealiases to make
the new fields null or non-nullable using the same scheme we use for other model
classes.

Remove redundant parameters and fields in places where we already have a
`FileMetadata` with the required information.

No change in client-visible behavior.