### PR TITLE
SW-2388 Add instructions to species CSV template

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
@@ -44,20 +44,6 @@ class SpeciesCsvValidator(
     return messages.speciesCsvColumnName(position)
   }
 
-  override fun validateHeaderRow(rawValues: Array<String?>?): Boolean {
-    return super.validateHeaderRow(rawValues) && headersExactlyMatchExpectedNames(rawValues)
-  }
-
-  private fun headersExactlyMatchExpectedNames(rawValues: Array<String?>?): Boolean {
-    val columnNames = validators.indices.map { getColumnName(it) }
-    return if (rawValues?.toList() != columnNames) {
-      addError(UploadProblemType.MalformedValue, null, null, messages.csvBadHeader())
-      false
-    } else {
-      true
-    }
-  }
-
   private fun validateUniqueScientificName(value: String?, field: String) {
     validateScientificName(value, field)
 

--- a/src/main/resources/csv/species-template.csv
+++ b/src/main/resources/csv/species-template.csv
@@ -1,1 +1,49 @@
-Scientific Name,Common Name,Family,Endangered,Rare,Growth Form,Seed Storage Behavior,Ecosystem Types
+"Scientific Name
+
+Please input the scientific name in the following format:
+
+Genus species",Common Name,Family,"Endangered
+
+Please choose from the following list or an error will occur during upload:
+
+- Yes
+- No","Rare
+
+Please choose from the following list or an error will occur during upload:
+
+- Yes
+- No","Growth Form
+
+Please choose from the following list or an error will occur during upload:
+
+- Tree
+- Shrub
+- Forb
+- Graminoid
+- Fern","Seed Storage Behavior
+
+Please choose from the following list or an error will occur during upload:
+
+- Orthodox
+- Recalcitrant
+- Intermediate
+- Unknown","Ecosystem Types
+
+Please choose from the following list or an error will occur during upload:
+
+- Boreal forests/Taiga
+- Deserts and xeric shrublands
+- Flooded grasslands and savannas
+- Mangroves
+- Mediterranean forests, woodlands and scrubs
+- Montane grasslands and shrublands
+- Temperate broad leaf and mixed forests
+- Temperate coniferous forest
+- Temperate grasslands, savannas and shrublands
+- Tropical and subtropical coniferous forests
+- Tropical and subtropical dry broad leaf forests
+- Tropical and subtropical grasslands, savannas and shrublands
+- Tropical and subtropical moist broad leaf forests
+- Tundra
+
+You can add multiple ecosystem types if they are separated with line breaks."

--- a/src/main/resources/csv/species-template_gx.csv
+++ b/src/main/resources/csv/species-template_gx.csv
@@ -1,1 +1,33 @@
-TmFtZQ U2NpZW50aWZpYw,TmFtZQ Q29tbW9u,RmFtaWx5,RW5kYW5nZXJlZA,UmFyZQ,Rm9ybQ R3Jvd3Ro,QmVoYXZpb3I U3RvcmFnZQ U2VlZA,KGNvbW1hLXNlcGFyYXRlZCk VHlwZXM RWNvc3lzdGVt
+TmFtZQ U2NpZW50aWZpYw,TmFtZQ Q29tbW9u,RmFtaWx5,"RW5kYW5nZXJlZA
+
+- WWVz
+- Tm8","UmFyZQ
+
+- WWVz
+- Tm8","Rm9ybQ R3Jvd3Ro
+
+- RmVybg
+- Rm9yYg
+- R3JhbWlub2lk
+- U2hydWI
+- VHJlZQ","QmVoYXZpb3I U3RvcmFnZQ U2VlZA
+
+- SW50ZXJtZWRpYXRl
+- T3J0aG9kb3g
+- UmVjYWxjaXRyYW50
+- VW5rbm93bg","KGNvbW1hLXNlcGFyYXRlZCk VHlwZXM RWNvc3lzdGVt
+
+- Zm9yZXN0cy9UYWlnYQ Qm9yZWFs
+- c2hydWJsYW5kcw eGVyaWM YW5k RGVzZXJ0cw
+- c2F2YW5uYXM YW5k Z3Jhc3NsYW5kcw Rmxvb2RlZA
+- TWFuZ3JvdmVz
+- c2NydWJz YW5k d29vZGxhbmRz Zm9yZXN0cyw TWVkaXRlcnJhbmVhbg
+- c2hydWJsYW5kcw YW5k Z3Jhc3NsYW5kcw TW9udGFuZQ
+- Zm9yZXN0cw bWl4ZWQ YW5k bGVhZg YnJvYWQ VGVtcGVyYXRl
+- Zm9yZXN0 Y29uaWZlcm91cw VGVtcGVyYXRl
+- c2hydWJsYW5kcw YW5k c2F2YW5uYXM Z3Jhc3NsYW5kcyw VGVtcGVyYXRl
+- Zm9yZXN0cw Y29uaWZlcm91cw c3VidHJvcGljYWw YW5k VHJvcGljYWw
+- Zm9yZXN0cw bGVhZg YnJvYWQ ZHJ5 c3VidHJvcGljYWw YW5k VHJvcGljYWw
+- c2hydWJsYW5kcw YW5k c2F2YW5uYXM Z3Jhc3NsYW5kcyw c3VidHJvcGljYWw YW5k VHJvcGljYWw
+- Zm9yZXN0cw bGVhZg YnJvYWQ bW9pc3Q c3VidHJvcGljYWw YW5k VHJvcGljYWw
+- VHVuZHJh"

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
@@ -40,8 +40,8 @@ internal class SpeciesCsvValidatorTest {
     }
 
     @Test
-    fun `may not include unknown columns`() {
-      assertError(header.replace("Family", "X"), MalformedValue, messages.csvBadHeader())
+    fun `may not include extra columns`() {
+      assertError(header.replace("Family", "X,Y"), MalformedValue, messages.csvBadHeader())
     }
 
     @Test


### PR DESCRIPTION
Include lists of supported enum values and other guidance in the template for
importing species list CSV files.

Previously, per the initial requirements, we were checking for exact matches of
the header column names, but this was causing problems for users, and with the
instructions included, it's now much more likely that people will upload otherwise
valid CSV files where the header row isn't byte-identical to our template. Remove
the strict checking in favor of just checking that the number of columns in the
header row is correct.

Add test cases to ensure that localized templates work as intended.

Also partially addresses SW-3071.