### PR TITLE
SW-3070 Add ExactOrFuzzy search type

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchFilter.kt
@@ -6,6 +6,7 @@ import org.jooq.impl.DSL
 
 enum class SearchFilterType {
   Exact,
+  ExactOrFuzzy,
   Fuzzy,
   Range
 }
@@ -14,9 +15,9 @@ interface SearchNode {
   fun toCondition(): Condition
 
   /**
-   * Converts this node and all its descendents from fuzzy to exact filtering. If this node does not
-   * currently contain any fuzzy filter criteria, this method _must_ return an object that tests
-   * equal to `this` (e.g., by just returning `this`).
+   * Converts this node and all its descendents from exact-or-fuzzy to exact filtering. If this node
+   * does not currently contain any exact-or-fuzzy filter criteria, this method _must_ return an
+   * object that tests equal to `this` (e.g., by just returning `this`).
    */
   fun toExactSearch(): SearchNode
 
@@ -126,7 +127,7 @@ data class FieldNode(
   }
 
   override fun toExactSearch(): FieldNode {
-    return if (type == SearchFilterType.Fuzzy && values.any { it != null }) {
+    return if (type == SearchFilterType.ExactOrFuzzy && values.any { it != null }) {
       FieldNode(field, values.filterNotNull())
     } else {
       this

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -175,25 +175,31 @@ class SearchService(private val dslContext: DSLContext) {
       throw IllegalArgumentException("Fetching nested field values is not supported.")
     }
 
-    val searchResults =
+    val exactCriteria = criteria.toExactSearch()
+
+    val exactResults =
         runQuery(
-                rootPrefix,
-                listOf(fieldPath),
-                criteria.toExactSearch(),
-                listOf(SearchSortField(fieldPath)),
-                limit = limit,
-                distinct = true,
-            )
-            .ifEmpty {
-              runQuery(
-                  rootPrefix,
-                  listOf(fieldPath),
-                  criteria,
-                  listOf(SearchSortField(fieldPath)),
-                  limit = limit,
-                  distinct = true,
-              )
-            }
+            rootPrefix,
+            listOf(fieldPath),
+            exactCriteria,
+            listOf(SearchSortField(fieldPath)),
+            limit = limit,
+            distinct = true,
+        )
+
+    val searchResults =
+        if (exactResults.isNotEmpty() || exactCriteria == criteria) {
+          exactResults
+        } else {
+          runQuery(
+              rootPrefix,
+              listOf(fieldPath),
+              criteria,
+              listOf(SearchSortField(fieldPath)),
+              limit = limit,
+              distinct = true,
+          )
+        }
 
     val fieldPathName = "$fieldPath"
 

--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -54,6 +54,7 @@ class AgeField(
                   databaseField.isNull
                 }
               })
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw IllegalArgumentException("Fuzzy search not supported for dates")
       SearchFilterType.Range -> {

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -46,6 +46,7 @@ class BooleanField(
                 if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
                 if (fieldNode.values.any { it == null }) databaseField.isNull else null))
       }
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw RuntimeException("Fuzzy search not supported for boolean fields")
       SearchFilterType.Range ->

--- a/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
@@ -36,6 +36,7 @@ class DateField(
                   if (nonNullDates.isNotEmpty()) databaseField.`in`(nonNullDates) else null,
                   if (fieldNode.values.any { it == null }) databaseField.isNull else null,
               ))
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw IllegalArgumentException("Fuzzy search not supported for dates")
       SearchFilterType.Range -> rangeCondition(dateValues)

--- a/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
@@ -22,6 +22,7 @@ class IdWrapperField<T : Any>(
     return when (fieldNode.type) {
       SearchFilterType.Exact ->
           if (allValues.isNotEmpty()) databaseField.`in`(allValues) else DSL.falseCondition()
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy -> throw RuntimeException("Fuzzy search not supported for IDs")
       SearchFilterType.Range -> throw RuntimeException("Range search not supported for IDs")
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -58,6 +58,7 @@ class LocalizedTextField(
                     null
                   },
                   if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw IllegalArgumentException("Fuzzy search not supported for localized text fields")
       SearchFilterType.Range ->

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -53,6 +53,7 @@ abstract class NumericSearchField<T : Number>(
                 if (nonNullValues.isNotEmpty()) databaseField.`in`(nonNullValues) else null,
                 if (fieldNode.values.any { it == null }) databaseField.isNull else null))
       }
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw RuntimeException("Fuzzy search not supported for numeric fields")
       SearchFilterType.Range -> rangeCondition(numericValues)

--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -43,6 +43,7 @@ class TextField(
                     null
                   },
                   if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           DSL.or(
               normalizedValues.map { value ->

--- a/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
@@ -39,6 +39,7 @@ class TimestampField(
                   if (nonNullInstants.isNotEmpty()) databaseField.`in`(nonNullInstants) else null,
                   if (fieldNode.values.any { it == null }) databaseField.isNull else null,
               ))
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           throw IllegalArgumentException("Fuzzy search not supported for timestamps")
       SearchFilterType.Range -> rangeCondition(instantValues)

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -32,6 +32,7 @@ class UpperCaseTextField(
                 if (values.isNotEmpty()) databaseField.`in`(values) else null,
                 if (fieldNode.values.any { it == null }) databaseField.isNull else null))
       }
+      SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           DSL.or(
               fieldNode.values

--- a/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
@@ -96,6 +96,7 @@ class WeightField(
               gramsField.le(gramsQuantities[1])
             }
           }
+          SearchFilterType.ExactOrFuzzy,
           SearchFilterType.Fuzzy -> {
             val nullCondition = if (hasNull) gramsField.isNull else null
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -56,7 +56,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `returns exact-match statistics for fuzzy searches if there are exact matches`() {
+  fun `returns exact-match statistics for exact-or-fuzzy searches if there are exact matches`() {
     val speciesId1 = insertSpecies(1)
     val speciesId2 = insertSpecies(2)
     insertAccession(
@@ -77,9 +77,9 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
     val accessionNumberField =
         SearchFieldPrefix(root = searchTables.accessions).resolve("accessionNumber")
     val criteriaWithExactMatch =
-        FieldNode(accessionNumberField, listOf("22-1-001"), SearchFilterType.Fuzzy)
+        FieldNode(accessionNumberField, listOf("22-1-001"), SearchFilterType.ExactOrFuzzy)
     val criteriaWithoutExactMatch =
-        FieldNode(accessionNumberField, listOf("22-1-000"), SearchFilterType.Fuzzy)
+        FieldNode(accessionNumberField, listOf("22-1-000"), SearchFilterType.ExactOrFuzzy)
 
     assertAll(
         {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -26,12 +26,34 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   }
 
   @Test
-  fun `fuzzy search of accession number`() {
+  fun `fuzzy search of accession number with value that is not an exact match`() {
     val values =
         searchService.fetchValues(
             rootPrefix,
             speciesNameField,
             FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.Fuzzy))
+    assertEquals(listOf("Kousa Dogwood"), values)
+  }
+
+  @Test
+  fun `exact-or-fuzzy search of accession number with value that is not an exact match`() {
+    val values =
+        searchService.fetchValues(
+            rootPrefix,
+            speciesNameField,
+            FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.ExactOrFuzzy))
+    assertEquals(listOf("Kousa Dogwood"), values)
+  }
+
+  @Test
+  fun `exact-or-fuzzy search of accession number with value that is an exact match`() {
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "ABC"))
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "ABCD"))
+    val values =
+        searchService.fetchValues(
+            rootPrefix,
+            speciesNameField,
+            FieldNode(accessionNumberField, listOf("abc"), SearchFilterType.ExactOrFuzzy))
     assertEquals(listOf("Kousa Dogwood"), values)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -49,12 +49,13 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
   }
 
   @Test
-  fun `fuzzy search on text fields limits results to exact matches if any exist`() {
+  fun `exact-or-fuzzy search on text fields limits results to exact matches if any exist`() {
     accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "22-1-100"))
     accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "22-1-101"))
 
     val fields = listOf(accessionNumberField)
-    val searchNode = FieldNode(accessionNumberField, listOf("22-1-100"), SearchFilterType.Fuzzy)
+    val searchNode =
+        FieldNode(accessionNumberField, listOf("22-1-100"), SearchFilterType.ExactOrFuzzy)
 
     assertEquals(
         SearchResults(
@@ -76,12 +77,31 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
   }
 
   @Test
-  fun `fuzzy search for null and non-null values matches non-null exact values if any exist`() {
+  fun `fuzzy search on text fields does not limit results to exact matches`() {
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "22-1-10"))
+    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "22-1-100"))
+
+    val fields = listOf(accessionNumberField)
+    val searchNode = FieldNode(accessionNumberField, listOf("22-1-10"), SearchFilterType.Fuzzy)
+
+    assertEquals(
+        SearchResults(
+            listOf(
+                mapOf("id" to "1000", "accessionNumber" to "22-1-10"),
+                mapOf("id" to "1001", "accessionNumber" to "22-1-100"),
+            ),
+            null),
+        searchAccessions(facilityId, fields, searchNode))
+  }
+
+  @Test
+  fun `exact-or-fuzzy search for null and non-null values matches non-null exact values if any exist`() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
 
     val fields = listOf(processingNotesField)
-    val searchNode = FieldNode(processingNotesField, listOf("Notes", null), SearchFilterType.Fuzzy)
+    val searchNode =
+        FieldNode(processingNotesField, listOf("Notes", null), SearchFilterType.ExactOrFuzzy)
 
     assertEquals(
         SearchResults(


### PR DESCRIPTION
Allow clients to specify whether or not they want the "try an exact search
first, then fall back to fuzzy if there were no matches" behavior introduced in
commit 64c854c. After getting user feedback, it turns out we only want that
behavior on a few specific search fields, not across the board.

Search field criteria with a type of `Fuzzy` are now always fuzzy, with no
exact-then-fuzzy fallback. The new type `ExactOrFuzzy` will return exact matches
if there are any, or fuzzy matches if there are no exact ones.