### PR TITLE
SW-3041 Render reports as CSV files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -46,6 +46,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlantingSiteUploadProblemsException
 import com.terraformation.backend.tracking.model.Shapefile
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.time.Duration
@@ -68,6 +69,7 @@ import org.springframework.beans.propertyeditors.StringTrimmerEditor
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -304,6 +306,14 @@ class AdminController(
   @Produces("text/html")
   fun getReportHtml(@PathVariable("id") reportId: ReportId): ResponseEntity<String> {
     return ResponseEntity.ok(reportRenderer.renderReportHtml(reportId))
+  }
+
+  @GetMapping("/report/{id}/report.csv")
+  @Produces("text/csv")
+  fun getReportCsv(@PathVariable("id") reportId: ReportId): ResponseEntity<String> {
+    return ResponseEntity.ok()
+        .contentType(MediaType("text", "csv", StandardCharsets.UTF_8))
+        .body(reportRenderer.renderReportCsv(reportId))
   }
 
   @GetMapping("/report/{reportId}/file-{fileId:\\d+}-{filename}")

--- a/src/main/kotlin/com/terraformation/backend/report/render/ReportRenderer.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/render/ReportRenderer.kt
@@ -1,10 +1,14 @@
 package com.terraformation.backend.report.render
 
+import com.opencsv.CSVWriter
+import com.terraformation.backend.api.writeNext
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.report.ReportFileService
 import com.terraformation.backend.report.db.ReportStore
+import com.terraformation.backend.report.model.ReportBodyModel
 import com.terraformation.backend.report.model.ReportBodyModelV1
+import java.io.StringWriter
 import java.time.Month
 import java.time.format.TextStyle
 import java.util.Locale
@@ -43,5 +47,84 @@ class ReportRenderer(
         templateEngine.process("/reports/v1/index.html", context)
       }
     }
+  }
+
+  fun renderReportCsv(reportId: ReportId): String {
+    val report = reportStore.fetchOneById(reportId)
+
+    val body: ReportBodyModel = report.body
+    val columnValues: List<Pair<String, Any?>> =
+        when (body) {
+          is ReportBodyModelV1 -> {
+            val nurseries = body.nurseries.filter { it.selected }
+            val plantingSites = body.plantingSites.filter { it.selected }
+            val seedBanks = body.seedBanks.filter { it.selected }
+            val allWorkers =
+                nurseries.map { it.workers } +
+                    plantingSites.map { it.workers } +
+                    seedBanks.map { it.workers }
+
+            listOf(
+                "Deal ID" to null,
+                "Organization Name" to body.organizationName,
+                "Seed Bank: Count" to seedBanks.size,
+                "Seed Bank: Seeds Stored" to seedBanks.sumOf { it.totalSeedsStored },
+                "Nursery: Count" to nurseries.size,
+                "Nursery: Plants/Trees Propagated" to nurseries.sumOf { it.totalPlantsPropagated },
+                "Nursery: Mortality Rate (%)" to
+                    weightedAverage(nurseries.map { it.mortalityRate to it.totalPlantsPropagated }),
+                "Planted: Site Count" to plantingSites.size,
+                "Project Hectares" to plantingSites.sumOf { it.totalPlantingSiteArea ?: 0 },
+                "Planted: Ha to Date" to plantingSites.sumOf { it.totalPlantedArea ?: 0 },
+                "Planted: Trees" to plantingSites.sumOf { it.totalTreesPlanted ?: 0 },
+                "Planted: Non-Trees" to plantingSites.sumOf { it.totalPlantsPlanted ?: 0 },
+                "Planted: Mortality Rate (%)" to
+                    weightedAverage(
+                        plantingSites.map { site ->
+                          val weight =
+                              (site.totalPlantsPlanted ?: 0) + (site.totalTreesPlanted ?: 0)
+                          (site.mortalityRate ?: 0) to weight.toLong()
+                        }),
+                "Planted: Species" to
+                    plantingSites
+                        .flatMap { it.species.map { species -> species.scientificName } }
+                        .distinct()
+                        .sorted()
+                        .joinToString(","),
+                "Planted: Best Months to Monitor Plantings" to
+                    body.annualDetails?.bestMonthsForObservation?.sorted()?.joinToString(";") {
+                        monthNumber ->
+                      Month.of(monthNumber).getDisplayName(TextStyle.SHORT, Locale.US)
+                    },
+                "# of workers for TF projects" to allWorkers.sumOf { it.paidWorkers ?: 0 },
+                "# of workers who are women for TF projects" to
+                    allWorkers.sumOf { it.femalePaidWorkers ?: 0 },
+                "# of volunteers for TF projects" to allWorkers.sumOf { it.volunteers ?: 0 },
+                "Summary of progress" to body.summaryOfProgress,
+            )
+          }
+        }
+
+    val stringWriter = StringWriter()
+
+    CSVWriter(
+            stringWriter,
+            CSVWriter.DEFAULT_SEPARATOR,
+            CSVWriter.DEFAULT_QUOTE_CHARACTER,
+            CSVWriter.DEFAULT_ESCAPE_CHARACTER,
+            CSVWriter.RFC4180_LINE_END)
+        .use { csvWriter ->
+          csvWriter.writeNext(columnValues.map { it.first })
+          csvWriter.writeNext(columnValues.map { it.second })
+        }
+
+    return stringWriter.toString()
+  }
+
+  private fun weightedAverage(valuesAndWeights: List<Pair<Int, Long>>): Long {
+    val weightedValues = valuesAndWeights.sumOf { it.first * it.second }
+    val totalWeights = valuesAndWeights.sumOf { it.second }
+
+    return if (totalWeights > 0L) weightedValues / totalWeights else 0L
   }
 }

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -85,6 +85,8 @@
             <th:block th:text="|${report.year}-Q${report.quarter} (${report.id})|"></th:block>
             -
             <a th:href="|${prefix}/report/${report.id}/index.html|">View HTML</a>
+            -
+            <a th:href="|${prefix}/report/${report.id}/report.csv|">View CSV</a>
         </li>
     </ul>
 

--- a/src/test/kotlin/com/terraformation/backend/report/render/ReportRendererTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/render/ReportRendererTest.kt
@@ -1,0 +1,198 @@
+package com.terraformation.backend.report.render
+
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.db.default_schema.ReportStatus
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.report.db.ReportStore
+import com.terraformation.backend.report.model.ReportBodyModelV1
+import com.terraformation.backend.report.model.ReportMetadata
+import com.terraformation.backend.report.model.ReportModel
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ReportRendererTest {
+  private val reportStore: ReportStore = mockk()
+  private val renderer = ReportRenderer(mockk(), mockk(), reportStore, mockk())
+
+  private val reportId = ReportId(1)
+  private val metadata =
+      ReportMetadata(
+          id = reportId,
+          quarter = 4,
+          year = 2023,
+          organizationId = OrganizationId(1),
+          status = ReportStatus.Submitted)
+
+  private val csvHeader =
+      "Deal ID" +
+          ",Organization Name" +
+          ",Seed Bank: Count" +
+          ",Seed Bank: Seeds Stored" +
+          ",Nursery: Count" +
+          ",Nursery: Plants/Trees Propagated" +
+          ",Nursery: Mortality Rate (%)" +
+          ",Planted: Site Count" +
+          ",Project Hectares" +
+          ",Planted: Ha to Date" +
+          ",Planted: Trees" +
+          ",Planted: Non-Trees" +
+          ",Planted: Mortality Rate (%)" +
+          ",Planted: Species" +
+          ",Planted: Best Months to Monitor Plantings" +
+          ",# of workers for TF projects" +
+          ",# of workers who are women for TF projects" +
+          ",# of volunteers for TF projects" +
+          ",Summary of progress"
+
+  @Test
+  fun `renderReportCsv correctly aggregates data`() {
+    val reportBody =
+        ReportBodyModelV1(
+            annualDetails =
+                ReportBodyModelV1.AnnualDetails(
+                    bestMonthsForObservation = setOf(1, 2, 3),
+                ),
+            isAnnual = true,
+            nurseries =
+                listOf(
+                    ReportBodyModelV1.Nursery(
+                        id = FacilityId(1),
+                        mortalityRate = 25,
+                        name = "selected nursery 1",
+                        totalPlantsPropagated = 100,
+                        workers = ReportBodyModelV1.Workers(1, 2, 3),
+                    ),
+                    ReportBodyModelV1.Nursery(
+                        id = FacilityId(2),
+                        mortalityRate = 50,
+                        name = "selected nursery 2",
+                        totalPlantsPropagated = 50,
+                        workers = ReportBodyModelV1.Workers(4, 5, 6),
+                    ),
+                    ReportBodyModelV1.Nursery(
+                        id = FacilityId(3),
+                        mortalityRate = 75,
+                        name = "non-selected nursery",
+                        totalPlantsPropagated = 1000,
+                        selected = false,
+                        workers = ReportBodyModelV1.Workers(7, 8, 9),
+                    ),
+                ),
+            organizationName = "org name",
+            plantingSites =
+                listOf(
+                    ReportBodyModelV1.PlantingSite(
+                        id = PlantingSiteId(1),
+                        mortalityRate = 10,
+                        name = "planting site",
+                        species =
+                            listOf(
+                                ReportBodyModelV1.PlantingSite.Species(
+                                    id = SpeciesId(1),
+                                    scientificName = "Species b",
+                                ),
+                                ReportBodyModelV1.PlantingSite.Species(
+                                    id = SpeciesId(2),
+                                    scientificName = "Species a",
+                                ),
+                            ),
+                        totalPlantedArea = 10,
+                        totalPlantingSiteArea = 11,
+                        totalPlantsPlanted = 12,
+                        totalTreesPlanted = 13,
+                        workers = ReportBodyModelV1.Workers(10, 11, 12),
+                    ),
+                ),
+            seedBanks =
+                listOf(
+                    ReportBodyModelV1.SeedBank(
+                        id = FacilityId(4),
+                        name = "seed bank",
+                        totalSeedsStored = 1000L,
+                        workers = ReportBodyModelV1.Workers(13, 14, 15),
+                    ),
+                ),
+            summaryOfProgress = "summary of progress",
+            totalNurseries = 2,
+            totalPlantingSites = 1,
+            totalSeedBanks = 1,
+        )
+
+    every { reportStore.fetchOneById(reportId) } returns ReportModel(reportBody, metadata)
+
+    val dataRow =
+        "" +
+            ",org name" +
+            ",1" +
+            ",1000" +
+            ",2" +
+            ",150" +
+            // Weighted nursery mortality rate for 25% of 100 plants + 50% of 50 plants = 33%
+            ",33" +
+            ",1" +
+            ",11" +
+            ",10" +
+            ",13" +
+            ",12" +
+            ",10" +
+            ",\"Species a,Species b\"" +
+            ",Jan;Feb;Mar" +
+            ",32" +
+            ",28" +
+            ",36" +
+            ",summary of progress"
+
+    val expected = "$csvHeader\r\n$dataRow\r\n"
+    val actual = renderer.renderReportCsv(reportId)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `renderReportCsv outputs default values for missing data`() {
+    val reportBody =
+        ReportBodyModelV1(
+            isAnnual = false,
+            nurseries = emptyList(),
+            organizationName = "org name",
+            plantingSites = emptyList(),
+            seedBanks = emptyList(),
+            totalNurseries = 0,
+            totalPlantingSites = 0,
+            totalSeedBanks = 0,
+        )
+
+    every { reportStore.fetchOneById(reportId) } returns ReportModel(reportBody, metadata)
+
+    val dataRow =
+        "" +
+            ",org name" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            ",0" +
+            "," +
+            "," +
+            ",0" +
+            ",0" +
+            ",0" +
+            ","
+
+    val expected = "$csvHeader\r\n$dataRow\r\n"
+    val actual = renderer.renderReportCsv(reportId)
+
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
Add rendering logic to produce a summary of the data in a report in CSV format.
The CSV file can be downloaded from the admin UI for local testing.