### PR TITLE
SW-2988 Simplify HTML for Google Docs import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -17,7 +17,6 @@ import com.terraformation.backend.db.default_schema.DeviceTemplateCategory
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
@@ -55,7 +54,6 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.zip.ZipFile
 import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import javax.validation.constraints.NotBlank
 import javax.ws.rs.Produces
 import kotlin.io.path.createTempFile
@@ -314,35 +312,6 @@ class AdminController(
     return ResponseEntity.ok()
         .contentType(MediaType("text", "csv", StandardCharsets.UTF_8))
         .body(reportRenderer.renderReportCsv(reportId))
-  }
-
-  @GetMapping("/report/{reportId}/file-{fileId:\\d+}-{filename}")
-  fun getReportFile(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      @PathVariable("filename") filename: String?,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/files/$fileId")
-  }
-
-  @GetMapping("/report/{reportId}/photo-{fileId:\\d+}-{filename}")
-  fun getReportPhoto(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      @PathVariable("filename") filename: String,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/photos/$fileId")
-  }
-
-  @GetMapping("/report/{reportId}/thumbnail-{fileId:\\d+}.jpg")
-  fun getReportPhotoThumbnail(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/photos/$fileId?maxWidth=120&maxHeight=120")
   }
 
   @PostMapping("/createFacility")

--- a/src/main/resources/templates/reports/v1/index.html
+++ b/src/main/resources/templates/reports/v1/index.html
@@ -24,10 +24,6 @@
         h4 {
             margin-bottom: 0;
         }
-
-        img.thumbnail {
-            height: 120px;
-        }
     </style>
 </head>
 
@@ -39,25 +35,25 @@
 <!--/*
 Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> becomes:
 
-<div class="item">
+<span class="item">
     <h3>Foo</h3>
     <div>Bar</div>
-</div>
+</span>
 */-->
-<div class="item" th:fragment="h3Item (label,item)" th:if="${label}">
+<span class="item" th:fragment="h3Item (label,item)" th:if="${label}">
     <h3 th:text="${label}"></h3>
     <div>
         <th:block th:replace=":: multiline (${item})"/>
     </div>
-</div>
+</span>
 
 <!--/* Renders an item with an h4 label. Same as h3Item above, just with h4 instead of h3. */-->
-<div class="item" th:fragment="h4Item (label,item)" th:if="${label}">
+<span class="item" th:fragment="h4Item (label,item)" th:if="${label}">
     <h4 th:text="${label}"></h4>
     <div>
         <th:block th:replace=":: multiline (${item})"/>
     </div>
-</div>
+</span>
 
 <body>
 <h1 th:text="|Report (${metadata.year}-Q${metadata.quarter})|">
@@ -76,15 +72,15 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
 
 <h2>Project Photos</h2>
 
-<div class="photos">
-    <div class="photo" th:each="photo : ${photos}">
-        <a th:href="|photo-${photo.metadata.id}-${#uris.escapePathSegment(photo.metadata.filenameWithoutPath)}|">
-            <img class="thumbnail" th:src="|thumbnail-${photo.metadata.id}.jpg|"/>
-        </a>
-        <div class="photoFilename" th:text="${photo.metadata.filenameWithoutPath}"/>
-        <div class="photoCaption" th:text="${photo.caption}"/>
-    </div>
-</div>
+<ul class="photos">
+    <li class="photo" th:each="photo : ${photos}">
+        <span class="photoFilename" th:text="${photo.metadata.filenameWithoutPath}"/>
+        <th:block th:if="${photo.caption}">
+            -
+            <span class="photoCaption" th:text="${photo.caption}"/>
+        </th:block>
+    </li>
+</ul>
 
 <h2>Seed Banks</h2>
 
@@ -169,11 +165,11 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
 
     <h4>Budget Document</h4>
 
-    <th:div th:each="file : ${files}">
-        <a th:href="|file-${file.metadata.id}-${#uris.escapePathSegment(file.metadata.filenameWithoutPath)}|" th:text="${file.metadata.filenameWithoutPath}">
+    <ul>
+        <li th:each="file : ${files}" th:text="${file.metadata.filenameWithoutPath}">
             spreadsheet-file.xls
-        </a>
-    </th:div>
+        </li>
+    </ul>
 
     <div th:replace="::h3Item ('Social Impact and Community Benefits',${body.annualDetails.socialImpact})"/>
 


### PR DESCRIPTION
Remove links and thumbnails from the HTML-rendered reports since they won't work
when we export the report to Google Docs.

Use `<span>` instead of `<div>` to wrap line items on the report; Google Docs
doesn't recognize header tags inside `<div>`.