### PR TITLE
SW-2988 Upload submitted reports to Google Drive

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,9 @@ dependencies {
 
   implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+  implementation("com.google.api-client:google-api-client:2.2.0")
+  implementation("com.google.auth:google-auth-library-oauth2-http:1.16.0")
+  implementation("com.google.apis:google-api-services-drive:v3-rev20230212-2.0.0")
   implementation("com.opencsv:opencsv:5.7.1")
   implementation("com.squarespace.cldr-engine:cldr-engine:1.6.2")
   implementation("commons-fileupload:commons-fileupload:1.5")

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -110,6 +110,7 @@ class TerrawareServerConfig(
 
     /** Configures detailed request logging. */
     val requestLog: RequestLogConfig = RequestLogConfig(),
+    val report: ReportConfig = ReportConfig(),
 ) {
   @ConstructorBinding
   class DailyTasksConfig(
@@ -281,6 +282,26 @@ class TerrawareServerConfig(
        * than `abc/def`. Query string parameters are not included in the match.
        */
       val excludeRegex: Regex? = null,
+  )
+
+  @ConstructorBinding
+  class ReportConfig(
+      @DefaultValue("false") val exportEnabled: Boolean = false,
+
+      /** Export reports to the drive with this ID. Must be set if [exportEnabled] is true. */
+      val googleDriveId: String? = null,
+
+      /**
+       * If set, make Google Drive API requests as this user. This is needed in order to allow
+       * exporting to shared drives that don't allow access by external users.
+       */
+      val googleEmail: String? = null,
+
+      /**
+       * If set, export reports to this folder in the shared drive. If not set, reports are exported
+       * to the shared drive's root directory.
+       */
+      val googleFolderId: String? = null,
   )
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -17,7 +17,6 @@ import com.terraformation.backend.db.default_schema.DeviceTemplateCategory
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
@@ -55,7 +54,6 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import java.util.zip.ZipFile
 import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 import javax.validation.constraints.NotBlank
 import javax.ws.rs.Produces
 import kotlin.io.path.createTempFile
@@ -314,35 +312,6 @@ class AdminController(
     return ResponseEntity.ok()
         .contentType(MediaType("text", "csv", StandardCharsets.UTF_8))
         .body(reportRenderer.renderReportCsv(reportId))
-  }
-
-  @GetMapping("/report/{reportId}/file-{fileId:\\d+}-{filename}")
-  fun getReportFile(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      @PathVariable("filename") filename: String?,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/files/$fileId")
-  }
-
-  @GetMapping("/report/{reportId}/photo-{fileId:\\d+}-{filename}")
-  fun getReportPhoto(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      @PathVariable("filename") filename: String,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/photos/$fileId")
-  }
-
-  @GetMapping("/report/{reportId}/thumbnail-{fileId:\\d+}.jpg")
-  fun getReportPhotoThumbnail(
-      @PathVariable("reportId") reportId: ReportId,
-      @PathVariable("fileId") fileId: FileId,
-      response: HttpServletResponse
-  ) {
-    response.sendRedirect("/api/v1/reports/$reportId/photos/$fileId?maxWidth=120&maxHeight=120")
   }
 
   @PostMapping("/createFacility")

--- a/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
@@ -1,0 +1,208 @@
+package com.terraformation.backend.file
+
+import com.google.api.client.http.InputStreamContent
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.drive.Drive
+import com.google.api.services.drive.model.File
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.GoogleCredentials
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.file.model.ExistingFileMetadata
+import com.terraformation.backend.log.perClassLogger
+import java.io.InputStream
+import javax.inject.Named
+
+@Named
+class GoogleDriveWriter(
+    private val config: TerrawareServerConfig,
+    private val fileStore: FileStore,
+) {
+  private val log = perClassLogger()
+
+  /** "Folders" on Google Drive are files with a specific MIME type. */
+  private val folderMimeType = "application/vnd.google-apps.folder"
+
+  /**
+   * Name of custom property that holds our internal IDs for uploaded files. This is used by the
+   * "overwrite the previously-exported copy of the same file" logic and is necessary because
+   * filenames aren't required to be unique.
+   */
+  private val terrawareFileIdProperty = "terrawareFileId"
+
+  /**
+   * A client that can make Google Drive API requests. This is initialized lazily because it
+   * authenticates with Google, so it blocks until the authentication requests finish and throws an
+   * exception if authentication fails.
+   */
+  private val driveClient by lazy {
+    val serviceAccountCredentials =
+        GoogleCredentials.getApplicationDefault()
+            .createScoped(listOf("https://www.googleapis.com/auth/drive"))
+
+    // Service accounts can't access private shared drives; we have to impersonate a user who has
+    // access. Documentation:
+    // https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority
+    val credentials =
+        if (config.report.googleEmail != null) {
+          serviceAccountCredentials.createDelegated(config.report.googleEmail)
+        } else {
+          serviceAccountCredentials
+        }
+
+    Drive.Builder(
+            NetHttpTransport(),
+            GsonFactory.getDefaultInstance(),
+            HttpCredentialsAdapter(credentials))
+        .setApplicationName("terraware-server")
+        .build()
+  }
+
+  /**
+   * Returns the Google file ID of the innermost folder in a hierarchy. Creates new folders if there
+   * aren't already folders with the requested names.
+   *
+   * @param names List of path elements, starting from the parent folder.
+   * @return Google file ID of the innermost folder.
+   */
+  fun findOrCreateFolders(driveId: String, parentFolderId: String, names: List<String>): String {
+    return names.fold(parentFolderId) { parent, name -> findOrCreateFolder(driveId, parent, name) }
+  }
+
+  /**
+   * Uploads a file to Google Drive. If there is an existing file with the same [filename] and
+   * [fileId], replaces it. Otherwise creates a new one. Note that [filename] is not necessarily
+   * unique! It is valid to have multiple files with the same name.
+   *
+   * Google Drive doesn't provide any atomic create-or-replace APIs and doesn't guarantee ACID
+   * semantics, so it's not possible to make this fully concurrency-safe. It is possible to end up
+   * with two files with the same [filename] and [fileId] if this function is called from two
+   * threads or on two hosts at the same time.
+   *
+   * @param contentType The content type the file should have in Google Drive.
+   * @param fileId If non-null, it is used in combination with [filename] to try to detect
+   *   previously uploaded copies of the same file and overwrite them in place.
+   * @param inputStreamContentType The content type of the uploaded file. If this is different from
+   *   [contentType], Google Drive will attempt to convert the file. We use this to create Google
+   *   Docs documents from uploaded HTML files.
+   * @return Google file ID of the file.
+   */
+  fun uploadFile(
+      driveId: String,
+      parentFolderId: String,
+      filename: String,
+      contentType: String,
+      inputStream: InputStream,
+      description: String? = null,
+      fileId: FileId? = null,
+      inputStreamContentType: String = contentType,
+  ): String {
+    val existingFile = findFile(driveId, parentFolderId, filename, fileId)
+
+    val file = File()
+    file.driveId = driveId
+    file.name = filename
+    file.mimeType = contentType
+    file.description = description
+
+    if (existingFile == null) {
+      file.parents = listOf(parentFolderId)
+    }
+    if (fileId != null) {
+      file.properties = mapOf(terrawareFileIdProperty to "$fileId")
+    }
+
+    val content = InputStreamContent(inputStreamContentType, inputStream)
+
+    val result =
+        if (existingFile != null) {
+          driveClient
+              .files()
+              .update(existingFile, file, content)
+              .setSupportsAllDrives(true)
+              .setFields("id")
+              .execute()
+        } else {
+          driveClient
+              .files()
+              .create(file, content)
+              .setSupportsAllDrives(true)
+              .setFields("id")
+              .execute()
+        }
+
+    log.info("Uploaded $filename as ${result.id}")
+
+    return result.id
+  }
+
+  /** Copies a file from a [FileStore] to Google Drive. */
+  fun copyFile(
+      driveId: String,
+      parentFolderId: String,
+      metadata: ExistingFileMetadata,
+      description: String? = null,
+      name: String = metadata.filenameWithoutPath,
+  ): String {
+    return fileStore.read(metadata.storageUrl).use { inputStream ->
+      uploadFile(
+          driveId = driveId,
+          parentFolderId = parentFolderId,
+          filename = name,
+          contentType = metadata.contentType,
+          inputStream = inputStream,
+          description = description,
+          fileId = metadata.id)
+    }
+  }
+
+  /** Returns the ID of an existing file, or null if no file matches the search criteria. */
+  private fun findFile(
+      driveId: String,
+      parentFolderId: String,
+      name: String,
+      fileId: FileId? = null,
+      mimeType: String? = null
+  ): String? {
+    val escapedName = name.replace("\\", "\\\\").replace("'", "\\'")
+
+    val query =
+        listOfNotNull(
+            "trashed = false",
+            "name = '$escapedName'",
+            "'$parentFolderId' in parents",
+            mimeType?.let { "mimeType = '$mimeType'" },
+            fileId?.let { "properties has { key = '$terrawareFileIdProperty' and value='$it' }" },
+        )
+
+    val listRequest = driveClient.files().list()
+    listRequest.corpora = "drive"
+    listRequest.driveId = driveId
+    listRequest.includeItemsFromAllDrives = true
+    listRequest.supportsAllDrives = true
+    listRequest.q = query.joinToString(" and ")
+
+    val result = listRequest.execute()
+
+    return result.files.firstOrNull()?.id
+  }
+
+  private fun findFolder(driveId: String, parentFolderId: String, name: String): String? {
+    return findFile(driveId, parentFolderId, name, mimeType = folderMimeType)
+  }
+
+  private fun createFolder(driveId: String, parentFolderId: String, name: String): String {
+    val file = File()
+    file.driveId = driveId
+    file.name = name
+    file.mimeType = folderMimeType
+    file.parents = listOf(parentFolderId)
+
+    return driveClient.files().create(file).setSupportsAllDrives(true).setFields("id").execute().id
+  }
+
+  private fun findOrCreateFolder(driveId: String, parentFolderId: String, name: String): String {
+    return findFolder(driveId, parentFolderId, name) ?: createFolder(driveId, parentFolderId, name)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -26,6 +26,7 @@ import java.time.Clock
 import java.time.ZonedDateTime
 import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.http.MediaType
 
@@ -41,7 +42,7 @@ class ReportService(
     private val plantingSiteStore: PlantingSiteStore,
     private val reportRenderer: ReportRenderer,
     private val reportStore: ReportStore,
-    private val scheduler: JobScheduler,
+    @Lazy private val scheduler: JobScheduler,
     private val speciesStore: SpeciesStore,
     private val systemUser: SystemUser,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.report
 
+import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.model.SystemUser
@@ -7,13 +8,16 @@ import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.report.db.ReportStore
+import com.terraformation.backend.report.event.ReportSubmittedEvent
 import com.terraformation.backend.report.model.LatestReportBodyModel
 import com.terraformation.backend.report.model.ReportBodyModelV1
 import com.terraformation.backend.report.model.ReportMetadata
 import com.terraformation.backend.report.model.ReportModel
+import com.terraformation.backend.report.render.ReportRenderer
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.time.quarter
@@ -21,21 +25,29 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import java.time.Clock
 import java.time.ZonedDateTime
 import javax.inject.Named
+import org.jobrunr.scheduling.JobScheduler
 import org.springframework.context.event.EventListener
+import org.springframework.http.MediaType
 
 @Named
 class ReportService(
     private val accessionStore: AccessionStore,
     private val batchStore: BatchStore,
     private val clock: Clock,
+    private val config: TerrawareServerConfig,
     private val facilityStore: FacilityStore,
+    private val googleDriveWriter: GoogleDriveWriter,
     private val organizationStore: OrganizationStore,
     private val plantingSiteStore: PlantingSiteStore,
+    private val reportRenderer: ReportRenderer,
     private val reportStore: ReportStore,
+    private val scheduler: JobScheduler,
     private val speciesStore: SpeciesStore,
     private val systemUser: SystemUser,
 ) {
   private val log = perClassLogger()
+
+  private val googleDocsMimeType = "application/vnd.google-apps.document"
 
   /**
    * Fetches a report using the correct model version for the body and with server-supplied fields
@@ -85,6 +97,74 @@ class ReportService(
       systemUser.run { reportStore.findOrganizationsForCreate().forEach { create(it) } }
     } catch (e: Exception) {
       log.error("Unable to create reports", e)
+    }
+  }
+
+  @EventListener
+  fun on(event: ReportSubmittedEvent) {
+    if (config.report.exportEnabled && config.report.googleDriveId != null) {
+      val reportId = event.reportId
+      val jobId = scheduler.enqueue<ReportService> { exportToGoogleDrive(reportId) }
+
+      log.debug("Enqueued job $jobId to export report $reportId to Google Drive")
+    }
+  }
+
+  /**
+   * Exports a report and its supporting files to Google Drive if enabled.
+   *
+   * Creates a folder for the organization, then a subfolder for the year+quarter; the report is
+   * placed in the subfolder.
+   *
+   * The report is rendered as HTML and converted to a Google Docs document. It is also uploaded in
+   * CSV form. All files and photos associated with the report are uploaded using their original
+   * filenames.
+   *
+   * If the export fails, throws an exception. If the export was triggered by a report being
+   * submitted, the exception will cause JobRunr to retry the export after a delay.
+   */
+  fun exportToGoogleDrive(reportId: ReportId) {
+    val driveId = config.report.googleDriveId
+    if (config.report.exportEnabled && driveId != null) {
+      systemUser.run {
+        val report = reportStore.fetchOneById(reportId)
+        val organization = organizationStore.fetchOneById(report.metadata.organizationId)
+        val folderId =
+            googleDriveWriter.findOrCreateFolders(
+                driveId,
+                config.report.googleFolderId ?: driveId,
+                listOf(
+                    "${organization.name} (${organization.id})",
+                    "${report.metadata.year}-Q${report.metadata.quarter}"))
+        val baseFilename =
+            "${organization.name} ${report.metadata.year}-Q${report.metadata.quarter}"
+
+        val html = reportRenderer.renderReportHtml(report)
+        googleDriveWriter.uploadFile(
+            driveId = driveId,
+            parentFolderId = folderId,
+            filename = "$baseFilename Report",
+            // Auto-convert HTML to Google Docs.
+            contentType = googleDocsMimeType,
+            inputStream = html.byteInputStream(),
+            inputStreamContentType = MediaType.TEXT_HTML_VALUE)
+
+        val csv = reportRenderer.renderReportCsv(report)
+        googleDriveWriter.uploadFile(
+            driveId = driveId,
+            parentFolderId = folderId,
+            filename = "$baseFilename.csv",
+            contentType = "text/csv",
+            inputStream = csv.byteInputStream())
+
+        reportStore.fetchFilesByReportId(reportId).forEach { model ->
+          googleDriveWriter.copyFile(driveId, folderId, model.metadata)
+        }
+
+        reportStore.fetchPhotosByReportId(reportId).forEach { model ->
+          googleDriveWriter.copyFile(driveId, folderId, model.metadata, model.caption)
+        }
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/report/render/ReportRenderer.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/render/ReportRenderer.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.report.ReportFileService
 import com.terraformation.backend.report.db.ReportStore
 import com.terraformation.backend.report.model.ReportBodyModel
 import com.terraformation.backend.report.model.ReportBodyModelV1
+import com.terraformation.backend.report.model.ReportModel
 import java.io.StringWriter
 import java.time.Month
 import java.time.format.TextStyle
@@ -25,6 +26,13 @@ class ReportRenderer(
 ) {
   fun renderReportHtml(reportId: ReportId): String {
     val report = reportStore.fetchOneById(reportId)
+
+    return renderReportHtml(report)
+  }
+
+  fun renderReportHtml(report: ReportModel): String {
+    val reportId = report.metadata.id
+
     val files = reportFileService.listFiles(reportId)
     val photos = reportFileService.listPhotos(reportId)
     val organization = organizationStore.fetchOneById(report.metadata.organizationId)
@@ -52,6 +60,10 @@ class ReportRenderer(
   fun renderReportCsv(reportId: ReportId): String {
     val report = reportStore.fetchOneById(reportId)
 
+    return renderReportCsv(report)
+  }
+
+  fun renderReportCsv(report: ReportModel): String {
     val body: ReportBodyModel = report.body
     val columnValues: List<Pair<String, Any?>> =
         when (body) {

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -77,19 +77,27 @@
     <input type="submit" value=" Create Planting Site "/>
 </form>
 
+<h3>Reports</h3>
+
+<ul>
+    <li th:each="report : ${reports}">
+        <th:block th:text="|${report.year}-Q${report.quarter} (${report.id})|"></th:block>
+        -
+        <a th:href="|${prefix}/report/${report.id}/index.html|">View HTML</a>
+        -
+        <a th:href="|${prefix}/report/${report.id}/report.csv|">View CSV</a>
+        <form method="POST"
+              th:action="|${prefix}/exportReport|"
+              th:if="${canExportReport}"
+              style="display: inline-block;">
+            <input type="hidden" name="organizationId" th:value="${organization.id}"/>
+            <input type="hidden" name="reportId" th:value="${report.id}"/>
+            <input type="submit" value="Export to Google Drive"/>
+        </form>
+    </li>
+</ul>
+
 <form method="POST" th:action="|${prefix}/createReport|" th:if="${canCreateReport}">
-    <h3>Reports</h3>
-
-    <ul>
-        <li th:each="report : ${reports}">
-            <th:block th:text="|${report.year}-Q${report.quarter} (${report.id})|"></th:block>
-            -
-            <a th:href="|${prefix}/report/${report.id}/index.html|">View HTML</a>
-            -
-            <a th:href="|${prefix}/report/${report.id}/report.csv|">View CSV</a>
-        </li>
-    </ul>
-
     <h4>Create Report (for development testing)</h4>
     <p>
         The report will be created for the previous quarter. Adjust the test clock if you want to

--- a/src/main/resources/templates/reports/v1/index.html
+++ b/src/main/resources/templates/reports/v1/index.html
@@ -24,10 +24,6 @@
         h4 {
             margin-bottom: 0;
         }
-
-        img.thumbnail {
-            height: 120px;
-        }
     </style>
 </head>
 
@@ -39,25 +35,25 @@
 <!--/*
 Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> becomes:
 
-<div class="item">
+<span class="item">
     <h3>Foo</h3>
     <div>Bar</div>
-</div>
+</span>
 */-->
-<div class="item" th:fragment="h3Item (label,item)" th:if="${label}">
+<span class="item" th:fragment="h3Item (label,item)" th:if="${label}">
     <h3 th:text="${label}"></h3>
     <div>
         <th:block th:replace=":: multiline (${item})"/>
     </div>
-</div>
+</span>
 
 <!--/* Renders an item with an h4 label. Same as h3Item above, just with h4 instead of h3. */-->
-<div class="item" th:fragment="h4Item (label,item)" th:if="${label}">
+<span class="item" th:fragment="h4Item (label,item)" th:if="${label}">
     <h4 th:text="${label}"></h4>
     <div>
         <th:block th:replace=":: multiline (${item})"/>
     </div>
-</div>
+</span>
 
 <body>
 <h1 th:text="|Report (${metadata.year}-Q${metadata.quarter})|">
@@ -76,15 +72,15 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
 
 <h2>Project Photos</h2>
 
-<div class="photos">
-    <div class="photo" th:each="photo : ${photos}">
-        <a th:href="|photo-${photo.metadata.id}-${#uris.escapePathSegment(photo.metadata.filenameWithoutPath)}|">
-            <img class="thumbnail" th:src="|thumbnail-${photo.metadata.id}.jpg|"/>
-        </a>
-        <div class="photoFilename" th:text="${photo.metadata.filenameWithoutPath}"/>
-        <div class="photoCaption" th:text="${photo.caption}"/>
-    </div>
-</div>
+<ul class="photos">
+    <li class="photo" th:each="photo : ${photos}">
+        <span class="photoFilename" th:text="${photo.metadata.filenameWithoutPath}"/>
+        <th:block th:if="${photo.caption}">
+            -
+            <span class="photoCaption" th:text="${photo.caption}"/>
+        </th:block>
+    </li>
+</ul>
 
 <h2>Seed Banks</h2>
 
@@ -169,11 +165,11 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
 
     <h4>Budget Document</h4>
 
-    <th:div th:each="file : ${files}">
-        <a th:href="|file-${file.metadata.id}-${#uris.escapePathSegment(file.metadata.filenameWithoutPath)}|" th:text="${file.metadata.filenameWithoutPath}">
+    <ul>
+        <li th:each="file : ${files}" th:text="${file.metadata.filenameWithoutPath}">
             spreadsheet-file.xls
-        </a>
-    </th:div>
+        </li>
+    </ul>
 
     <div th:replace="::h3Item ('Social Impact and Community Benefits',${body.annualDetails.socialImpact})"/>
 


### PR DESCRIPTION
When a report is submitted, export it to Google Drive along with its supporting
files. The report itself is created as a Google Docs document. A CSV file with
the aggregated report data is also created, and all photos and files are copied.

This requires some configuration:

* The `GOOGLE_APPLICATION_CREDENTIALS` environment variable must be set to the
  path of a Google client credentials configuration file. The file can be
  generated using the `gcloud` tool from the Google Cloud SDK.
* `terraware.report.export-enabled` must be true.
* `terraware.report.google-drive-id` must be set to the ID of a shared drive.
* `terraware.report.google-folder-id` may optionally be set to the ID of a folder
  within the shared drive; reports will be placed inside that folder.
* `terraware.report.google-email` may optionally be set to the email address of
  a user in our Google domain. If set, the server will impersonate that user when
  making API requests. This is needed for access to non-public shared drives.

If enabled, export happens automatically when a report is submitted. It can also
be triggered manually from the admin UI, where an "Export to Google Drive" button
will appear for each report on the organization details page.