### PR TITLE
Rename reports photo upload response to 'id' from 'fileId'

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -355,7 +355,7 @@ data class UpdateReportPhotoRequestPayload(val caption: String?) {
   fun toModel(reportId: ReportId, fileId: FileId) = ReportPhotoModel(caption, fileId, reportId)
 }
 
-data class UploadReportFileResponsePayload(val fileId: FileId) : SuccessResponsePayload
+data class UploadReportFileResponsePayload(val id: FileId) : SuccessResponsePayload
 
 data class ListReportFilesResponsePayload(
     val files: List<ListReportFilesResponseElement>,


### PR DESCRIPTION
- similar to [withdrawal photos response](https://github.com/terraware/terraware-server/blob/c9ebbd6e738b1e9d5ed447223d10577a0c33ee36/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt#L261)
- this is mostly for a reusable photo upload function in the FE codebase [see](https://github.com/terraware/terraware-web/commit/43f989c7bb02e05a8b51b816bd5c2b9ade9e9649#r102961693)