### PR TITLE
Remove redundant @RequestParam arguments

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -319,8 +319,8 @@ class AdminController(
 
   @PostMapping("/createFacility")
   fun createFacility(
-      @RequestParam("organizationId") organizationId: OrganizationId,
-      @NotBlank @RequestParam("name") name: String,
+      @RequestParam organizationId: OrganizationId,
+      @NotBlank @RequestParam name: String,
       @RequestParam("type") typeId: Int,
       redirectAttributes: RedirectAttributes,
   ): String {
@@ -341,11 +341,11 @@ class AdminController(
 
   @PostMapping("/updateFacility")
   fun updateFacility(
-      @RequestParam("connectionState") connectionState: FacilityConnectionState,
-      @RequestParam("description") description: String?,
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("maxIdleMinutes") maxIdleMinutes: Int,
-      @RequestParam("name") name: String,
+      @RequestParam connectionState: FacilityConnectionState,
+      @RequestParam description: String?,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam maxIdleMinutes: Int,
+      @RequestParam name: String,
       @RequestParam("type") typeId: Int,
       redirectAttributes: RedirectAttributes
   ): String {
@@ -375,9 +375,9 @@ class AdminController(
 
   @PostMapping("/sendAlert")
   fun sendAlert(
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("subject") subject: String,
-      @RequestParam("body") body: String,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam subject: String,
+      @RequestParam body: String,
       redirectAttributes: RedirectAttributes
   ): String {
     if (facilityStore.fetchOneById(facilityId).connectionState !=
@@ -407,8 +407,8 @@ class AdminController(
 
   @PostMapping("/createStorageLocation")
   fun createStorageLocation(
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("name") name: String,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam name: String,
       redirectAttributes: RedirectAttributes
   ): String {
     facilityStore.createStorageLocation(facilityId, name)
@@ -420,9 +420,9 @@ class AdminController(
 
   @PostMapping("/updateStorageLocation")
   fun updateStorageLocation(
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("storageLocationId") storageLocationId: StorageLocationId,
-      @RequestParam("name") name: String,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam storageLocationId: StorageLocationId,
+      @RequestParam name: String,
       redirectAttributes: RedirectAttributes
   ): String {
     facilityStore.updateStorageLocation(storageLocationId, name)
@@ -434,8 +434,8 @@ class AdminController(
 
   @PostMapping("/deleteStorageLocation")
   fun deleteStorageLocation(
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("storageLocationId") storageLocationId: StorageLocationId,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam storageLocationId: StorageLocationId,
       redirectAttributes: RedirectAttributes
   ): String {
     try {
@@ -480,7 +480,7 @@ class AdminController(
   fun createDeviceTemplate(
       redirectAttributes: RedirectAttributes,
       @ModelAttribute templatesRow: DeviceTemplatesRow,
-      @RequestParam("settings") settings: String?,
+      @RequestParam settings: String?,
   ): String {
     requirePermissions { updateDeviceTemplates() }
 
@@ -500,7 +500,7 @@ class AdminController(
   @PostMapping("/deviceManagers")
   fun createDeviceManager(
       redirectAttributes: RedirectAttributes,
-      @RequestParam("sensorKitId") sensorKitId: String,
+      @RequestParam sensorKitId: String,
   ): String {
     val row =
         DeviceManagersRow(
@@ -619,8 +619,8 @@ class AdminController(
   fun updateTemplate(
       redirectAttributes: RedirectAttributes,
       @ModelAttribute templatesRow: DeviceTemplatesRow,
-      @RequestParam("settings") settings: String?,
-      @RequestParam("delete") delete: String?,
+      @RequestParam settings: String?,
+      @RequestParam delete: String?,
   ): String {
     requirePermissions { updateDeviceTemplates() }
 
@@ -645,14 +645,14 @@ class AdminController(
   @PostMapping("/createDevices")
   fun createDevices(
       redirectAttributes: RedirectAttributes,
-      @RequestParam("address") address: String?,
-      @RequestParam("count") count: Int,
-      @RequestParam("facilityId") facilityId: FacilityId,
-      @RequestParam("make") make: String,
-      @RequestParam("model") model: String,
-      @RequestParam("name") name: String?,
-      @RequestParam("protocol") protocol: String?,
-      @RequestParam("type") type: String,
+      @RequestParam address: String?,
+      @RequestParam count: Int,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam make: String,
+      @RequestParam model: String,
+      @RequestParam name: String?,
+      @RequestParam protocol: String?,
+      @RequestParam type: String,
   ): String {
     try {
       repeat(count) {
@@ -927,8 +927,8 @@ class AdminController(
   @PostMapping("/updateInternalTag/{id}")
   fun updateInternalTag(
       @PathVariable("id") id: InternalTagId,
-      @RequestParam("name") name: String,
-      @RequestParam("description") description: String?,
+      @RequestParam name: String,
+      @RequestParam description: String?,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/NotificationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/NotificationsController.kt
@@ -50,7 +50,7 @@ class NotificationsController(private val notificationStore: NotificationStore) 
   @GetMapping()
   @Operation(summary = "Retrieve all notifications for current user scoped to an organization.")
   fun readAll(
-      @RequestParam("organizationId", required = false)
+      @RequestParam
       @Schema(description = "If set, return notifications relevant to that organization.")
       organizationId: OrganizationId?
   ): GetNotificationsResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -81,7 +81,7 @@ class UsersController(private val userStore: UserStore) {
   @GetMapping("/me/preferences")
   @Operation(summary = "Gets the current user's preferences.")
   fun getUserPreferences(
-      @RequestParam("organizationId")
+      @RequestParam
       @Schema(
           description =
               "If present, get the user's per-organization preferences for this organization. " +

--- a/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
@@ -34,8 +34,8 @@ class AutomationsController(
   @GetMapping
   @Operation(summary = "Gets a list of automations for a device or facility.")
   fun listAutomations(
-      @RequestParam("deviceId") deviceId: DeviceId?,
-      @RequestParam("facilityId") facilityId: FacilityId?
+      @RequestParam deviceId: DeviceId?,
+      @RequestParam facilityId: FacilityId?
   ): ListAutomationsResponsePayload {
     val automations =
         if (facilityId != null && deviceId == null) {

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
@@ -29,8 +29,8 @@ class DeviceManagersController(
 ) {
   @GetMapping
   fun getDeviceManagers(
-      @RequestParam("sensorKitId") sensorKitId: String?,
-      @RequestParam("facilityId") facilityId: FacilityId?,
+      @RequestParam sensorKitId: String?,
+      @RequestParam facilityId: FacilityId?,
   ): GetDeviceManagersResponsePayload {
     return when {
       sensorKitId != null && facilityId == null -> {

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesUploadsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesUploadsController.kt
@@ -58,7 +58,7 @@ class BatchesUploadsController(
   )
   fun uploadSeedlingBatchesList(
       @RequestPart("file") file: MultipartFile,
-      @RequestParam("facilityId", required = true) facilityId: FacilityId,
+      @RequestParam facilityId: FacilityId,
   ): UploadFileResponsePayload {
     val fileName = file.originalFilename ?: "batches.csv"
 

--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsController.kt
@@ -69,9 +69,7 @@ class ReportsController(
 ) {
   @GetMapping
   @Operation(summary = "Lists an organization's reports.")
-  fun listReports(
-      @RequestParam(required = true) organizationId: OrganizationId
-  ): ListReportsResponsePayload {
+  fun listReports(@RequestParam organizationId: OrganizationId): ListReportsResponsePayload {
     val names = mutableMapOf<UserId, String?>()
 
     val reports =

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsUploadsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsUploadsController.kt
@@ -53,7 +53,7 @@ class AccessionsUploadsController(
   )
   fun uploadAccessionsList(
       @RequestPart("file") file: MultipartFile,
-      @RequestParam("facilityId", required = true) facilityId: FacilityId,
+      @RequestParam facilityId: FacilityId,
   ): UploadFileResponsePayload {
     val fileName = file.originalFilename ?: "accessions.csv"
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/StorageLocationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/StorageLocationsController.kt
@@ -29,7 +29,7 @@ class StorageLocationsController(
 ) {
   @GetMapping
   fun listStorageLocations(
-      @RequestParam(required = true) facilityId: FacilityId
+      @RequestParam facilityId: FacilityId
   ): ListStorageLocationsResponsePayload {
     val locations = facilityStore.fetchStorageLocations(facilityId)
     val counts = accessionStore.countActiveByStorageLocation(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/SummaryController.kt
@@ -37,10 +37,10 @@ class SummaryController(
           "Get summary statistics about a specific seed bank or all seed banks within an " +
               "organization.")
   fun getSeedBankSummary(
-      @RequestParam("organizationId", required = false)
+      @RequestParam
       @Schema(description = "If set, return summary on all seedbanks for that organization.")
       organizationId: OrganizationId?,
-      @RequestParam("facilityId", required = false)
+      @RequestParam
       @Schema(description = "If set, return summary on that specific seedbank.")
       facilityId: FacilityId?
   ): SummaryResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -63,7 +63,7 @@ class SpeciesController(
   @GetMapping
   @Operation(summary = "Lists all the species available in an organization.")
   fun listSpecies(
-      @RequestParam("organizationId", required = true)
+      @RequestParam
       @Schema(description = "Organization whose species should be listed.")
       organizationId: OrganizationId
   ): ListSpeciesResponsePayload {
@@ -96,7 +96,7 @@ class SpeciesController(
   @Operation(summary = "Gets information about a single species.")
   fun getSpecies(
       @PathVariable speciesId: SpeciesId,
-      @RequestParam("organizationId", required = true)
+      @RequestParam
       @Schema(description = "Organization whose information about the species should be returned.")
       organizationId: OrganizationId,
   ): GetSpeciesResponsePayload {
@@ -131,7 +131,7 @@ class SpeciesController(
               "data (plants, seeds, etc.) that refer to the species will still refer to it.")
   fun deleteSpecies(
       @PathVariable speciesId: SpeciesId,
-      @RequestParam("organizationId", required = true)
+      @RequestParam
       @Schema(description = "Organization from which the species should be deleted.")
       organizationId: OrganizationId,
   ): SimpleSuccessResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
@@ -28,7 +28,7 @@ class SpeciesLookupController(private val gbifStore: GbifStore) {
       description =
           "Gets a list of known scientific names whose words begin with particular letters.")
   fun listSpeciesNames(
-      @RequestParam("search")
+      @RequestParam
       @Schema(
           description =
               "Space-delimited list of word prefixes to search for. Non-alphabetic characters " +
@@ -64,10 +64,10 @@ class SpeciesLookupController(private val gbifStore: GbifStore) {
   @GetMapping("/details")
   @Operation(summary = "Gets more information about a species with a particular scientific name.")
   fun getSpeciesDetails(
-      @RequestParam("scientificName")
+      @RequestParam
       @Schema(description = "Exact scientific name to look up. This name is case-sensitive.")
       scientificName: String,
-      @RequestParam("language")
+      @RequestParam
       @Schema(
           description =
               "If specified, only return common names in this language or whose language is " +

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesUploadsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesUploadsController.kt
@@ -53,7 +53,7 @@ class SpeciesUploadsController(
   )
   fun uploadSpeciesList(
       @RequestPart("file") file: MultipartFile,
-      @RequestParam("organizationId", required = true) organizationId: OrganizationId,
+      @RequestParam organizationId: OrganizationId,
   ): UploadFileResponsePayload {
     val fileName = file.originalFilename ?: "species.csv"
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -34,7 +34,7 @@ class PlantingSitesController(
   fun listPlantingSites(
       @RequestParam //
       organizationId: OrganizationId,
-      @RequestParam(required = false)
+      @RequestParam
       @Schema(
           description = "If true, include planting zones and plots for each site.",
           defaultValue = "false")


### PR DESCRIPTION
Spring uses the controller argument names as the names of query string parameters
by default, so there's no need to specify them explicitly. Spring also infers
whether or not a query string parameter is required based on the nullability of
the argument's type, so there's no need to explicitly specify that in the
annotation either.

There's no change in behavior or the OpenAPI schema here.