### PR TITLE
Combine CSV boolean values into single strings

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
@@ -66,7 +66,11 @@ abstract class RenderGibberishTask : DefaultTask() {
 
     englishProperties.forEach { name, english ->
       gibberishProperties[name] =
-          "$english".split(' ').asReversed().joinToString(" ") { encodeWord(it) }
+          "$english"
+              .split('\n')
+              .joinToString("\n") { line ->
+                line.split(' ').asReversed().joinToString(" ") { encodeWord(it) }
+              }
     }
 
     targetFile.writer().use { gibberishProperties.store(it, null) }

--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -15,8 +15,10 @@ import java.util.Locale
 fun String.toGibberish(): String {
   val encoder = Base64.getEncoder()
 
-  return split(' ').asReversed().joinToString(" ") { word ->
-    encoder.encodeToString(word.toByteArray()).trimEnd('=')
+  return split('\n').joinToString("\n") { line ->
+    line.split(' ').asReversed().joinToString(" ") { word ->
+      encoder.encodeToString(word.toByteArray()).trimEnd('=')
+    }
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -57,9 +57,8 @@ class Messages {
 
   fun csvBooleanValues(value: Boolean): Set<String> {
     val numericValue = if (value) "1" else "0"
-    return (0..9)
-        .mapNotNull { getMessage("csvBooleanValues.$value.$it").ifBlank { null } }
-        .toSet() + numericValue
+    return getMessage("csvBooleanValues.$value").split('\n').map { it.trim() }.toSet() +
+        numericValue
   }
 
   fun accessionCsvColumnName(position: Int) = getMessage("accessionCsvColumnName.$position")

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -73,7 +73,7 @@ class BooleanField(
       val stringMap = if (value) trueStrings else falseStrings
 
       stringMap.getOrPut(locale) {
-        ResourceBundle.getBundle("i18n.Messages", locale).getString("csvBooleanValues.$value.0")
+        ResourceBundle.getBundle("i18n.Messages", locale).getString("boolean.$value")
       }
     } else {
       "$value"

--- a/src/main/resources/i18n/Messages.properties
+++ b/src/main/resources/i18n/Messages.properties
@@ -61,29 +61,17 @@ speciesCsvColumnName.5=Growth Form
 speciesCsvColumnName.6=Seed Storage Behavior
 speciesCsvColumnName.7=Ecosystem Types
 
-# Values that will be accepted in uploaded CSVs to indicate "true" or "false". There can be up to
-# 10 values; if the locale needs fewer, leave the rest empty. "1" and "0" are always accepted and
-# don't need to be listed here. The first (.0) string for each value is used in exported CSVs.
-csvBooleanValues.false.0=false
-csvBooleanValues.false.1=f
-csvBooleanValues.false.2=False
-csvBooleanValues.false.3=F
-csvBooleanValues.false.4=no
-csvBooleanValues.false.5=n
-csvBooleanValues.false.6=No
-csvBooleanValues.false.7=N
-csvBooleanValues.false.8=FALSE
-csvBooleanValues.false.9=NO
-csvBooleanValues.true.0=true
-csvBooleanValues.true.1=t
-csvBooleanValues.true.2=True
-csvBooleanValues.true.3=T
-csvBooleanValues.true.4=yes
-csvBooleanValues.true.5=y
-csvBooleanValues.true.6=Yes
-csvBooleanValues.true.7=Y
-csvBooleanValues.true.8=TRUE
-csvBooleanValues.true.9=YES
+boolean.false=false
+boolean.true=true
+
+# Case-sensitive list of words, one per line, that should be interpreted as "false" when they
+# appear in an uploaded spreadsheet file. The number of words doesn't have to be the same as in
+# English.
+csvBooleanValues.false=false\nf\nFalse\nF\nFALSE\nno\nn\nNo\nN\nNO
+# Case-sensitive list of words, one per line, that should be interpreted as "true" when they
+# appear in an uploaded spreadsheet file. The number of words doesn't have to be the same as in
+# English.
+csvBooleanValues.true=true\nt\nTrue\nT\nTRUE\nyes\ny\nYes\nY\nYES
 
 # Accession active/inactive states (active = seeds are still available, inactive = used up)
 accessionState.Active=Active


### PR DESCRIPTION
We accept a number of synonyms for "true" and "false" in boolean columns in
uploaded CSV files. Previously, each synonym was a separate translatable
string, but that's going to be confusing for translators, especially if the
number of words needs to vary between languages.

Combine the word lists into two strings and add a description to each one to tell
translators what to do.

Previously, we used the first word in the list as the canonical localized word
that was accepted by, and returned by, the search API. Add separate strings for
that purpose so we don't have to tell translators to be careful about the order
of the list of synomyms.

The "one synonym per line" format uncovered a bug in gibberish string conversion:
it wasn't preserving line breaks on multiline strings, which included things like
our plaintext email bodies. Update the gibberish logic to preserve line breaks.