### PR TITLE
SW-3229 Fix Locked by User Name in Report Payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
@@ -135,7 +135,7 @@ data class GetReportPayloadV1(
       annualDetails = body.annualDetails?.let { AnnualDetailsPayloadV1(it) },
       id = metadata.id,
       isAnnual = body.isAnnual,
-      lockedByName = metadata.modifiedBy?.let { getFullName(it) },
+      lockedByName = metadata.lockedBy?.let { getFullName(it) },
       lockedByUserId = metadata.lockedBy,
       lockedTime = metadata.lockedTime,
       modifiedByName = metadata.modifiedBy?.let { getFullName(it) },


### PR DESCRIPTION
The report payload `lockedByName` field was not being populated. It turned
out to have been trying to look up the user by the `modifiedBy` user id.
Change it to look up by `lockedBy` id.