### PR TITLE
SW-3183 Include Withdrawn Quantity in Seed Count

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -216,8 +216,10 @@ class ReportService(
     val seedBankBodies =
         seedBankModels
             .map { facility ->
+              val accessionDataForSeedbank = accessionStore.getSummaryStatistics(facility.id)
               val totalSeedsStored =
-                  accessionStore.getSummaryStatistics(facility.id).totalSeedsRemaining
+                  accessionDataForSeedbank.totalSeedsRemaining +
+                      accessionDataForSeedbank.seedsWithdrawn
               body?.seedBanks?.find { it.id == facility.id }?.populate(facility, totalSeedsStored)
                   ?: ReportBodyModelV1.SeedBank(facility, totalSeedsStored)
             }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -874,6 +874,7 @@ class AccessionStore(
                 DSL.countDistinct(ACCESSIONS.SPECIES_ID),
                 seedsRemaining,
                 estimatedSeedsRemaining,
+                DSL.sum(ACCESSIONS.TOTAL_WITHDRAWN_COUNT),
                 unknownQuantity)
             .from(ACCESSIONS)
             .where(ACCESSIONS.ID.`in`(subquery))
@@ -886,6 +887,7 @@ class AccessionStore(
                   species,
                   subtotalBySeedCount,
                   subtotalByWeightEstimate,
+                  seedsWithdrawn,
                   unknownQuantityAccessions,
               ) ->
             AccessionSummaryStatistics(
@@ -893,6 +895,7 @@ class AccessionStore(
                 species ?: 0,
                 subtotalBySeedCount ?: BigDecimal.ZERO,
                 subtotalByWeightEstimate ?: BigDecimal.ZERO,
+                seedsWithdrawn ?: BigDecimal.ZERO,
                 unknownQuantityAccessions ?: BigDecimal.ZERO,
             )
           }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
@@ -8,6 +8,7 @@ data class AccessionSummaryStatistics(
     val subtotalBySeedCount: Long,
     val subtotalByWeightEstimate: Long,
     val totalSeedsRemaining: Long,
+    val seedsWithdrawn: Long,
     val unknownQuantityAccessions: Int,
 ) {
   constructor(
@@ -15,6 +16,7 @@ data class AccessionSummaryStatistics(
       species: Int,
       subtotalBySeedCount: BigDecimal,
       subtotalByWeightEstimate: BigDecimal,
+      seedsWithdrawn: BigDecimal,
       unknownQuantityAccessions: BigDecimal,
   ) : this(
       accessions = accessions,
@@ -22,6 +24,7 @@ data class AccessionSummaryStatistics(
       subtotalBySeedCount = subtotalBySeedCount.toLong(),
       subtotalByWeightEstimate = subtotalByWeightEstimate.toLong(),
       totalSeedsRemaining = subtotalBySeedCount.toLong() + subtotalByWeightEstimate.toLong(),
+      seedsWithdrawn = seedsWithdrawn.toLong(),
       unknownQuantityAccessions = unknownQuantityAccessions.toInt(),
   )
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -260,6 +260,93 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   }
 
   @Test
+  fun `getSummaryStatistics counts total withdrawn quantity`() {
+    val otherOrganizationId = OrganizationId(2)
+    val otherOrgFacilityId = FacilityId(4)
+    val sameOrgFacilityId = FacilityId(5)
+    insertOrganization(otherOrganizationId)
+    insertFacility(otherOrgFacilityId, otherOrganizationId)
+    insertFacility(sameOrgFacilityId)
+
+    listOf(
+            AccessionsRow(
+                facilityId = facilityId,
+                remainingGrams = BigDecimal(1),
+                remainingQuantity = BigDecimal(1),
+                remainingUnitsId = SeedQuantityUnits.Grams,
+                stateId = AccessionState.Processing,
+                subsetCount = 10,
+                subsetWeightGrams = BigDecimal(10),
+                totalWithdrawnCount = 10,
+            ),
+            // Second accession at same facility
+            AccessionsRow(
+                facilityId = facilityId,
+                remainingGrams = BigDecimal(2000),
+                remainingQuantity = BigDecimal(2),
+                remainingUnitsId = SeedQuantityUnits.Kilograms,
+                stateId = AccessionState.Drying,
+                subsetCount = 1,
+                subsetWeightGrams = BigDecimal(1000),
+                totalWithdrawnCount = 10,
+            ),
+            // Wrong facility
+            AccessionsRow(
+                facilityId = sameOrgFacilityId,
+                remainingGrams = BigDecimal(4),
+                remainingQuantity = BigDecimal(4),
+                remainingUnitsId = SeedQuantityUnits.Grams,
+                stateId = AccessionState.Processing,
+                subsetCount = 10,
+                subsetWeightGrams = BigDecimal(10),
+                totalWithdrawnCount = 5,
+            ),
+            // Wrong organization
+            AccessionsRow(
+                facilityId = otherOrgFacilityId,
+                remainingGrams = BigDecimal(8),
+                remainingQuantity = BigDecimal(8),
+                remainingUnitsId = SeedQuantityUnits.Grams,
+                stateId = AccessionState.Processing,
+                subsetCount = 10,
+                subsetWeightGrams = BigDecimal(10),
+                totalWithdrawnCount = 10,
+            ),
+            // Accession not active
+            AccessionsRow(
+                facilityId = facilityId,
+                remainingGrams = BigDecimal.ZERO,
+                remainingQuantity = BigDecimal.ZERO,
+                remainingUnitsId = SeedQuantityUnits.Grams,
+                stateId = AccessionState.UsedUp,
+                subsetCount = 10,
+                subsetWeightGrams = BigDecimal(10),
+                totalWithdrawnCount = 10,
+            ),
+        )
+        .forEach { insertAccession(it) }
+
+    assertEquals(
+        20,
+        store.getSummaryStatistics(facilityId).seedsWithdrawn,
+        "Seeds withdrawn for single facility")
+    assertEquals(
+        25,
+        store.getSummaryStatistics(organizationId).seedsWithdrawn,
+        "Seeds withdrawn for organization")
+    assertEquals(
+        10,
+        store
+            .getSummaryStatistics(
+                DSL.select(ACCESSIONS.ID)
+                    .from(ACCESSIONS)
+                    .where(ACCESSIONS.FACILITY_ID.eq(facilityId))
+                    .and(ACCESSIONS.STATE_ID.eq(AccessionState.Processing)))
+            .seedsWithdrawn,
+        "Seeds withdrawn for subquery")
+  }
+
+  @Test
   fun `getSummaryStatistics counts unknown-quantity accessions`() {
     val otherOrganizationId = OrganizationId(2)
     val otherOrgFacilityId = FacilityId(4)
@@ -417,7 +504,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics returns all zeroes if no accessions match criteria`() {
-    val expected = AccessionSummaryStatistics(0, 0, 0, 0, 0, 0)
+    val expected = AccessionSummaryStatistics(0, 0, 0, 0, 0, 0, 0)
 
     assertEquals(expected, store.getSummaryStatistics(facilityId), "No accessions in facility")
     assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -90,6 +90,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
                   subtotalBySeedCount = 10L,
                   subtotalByWeightEstimate = 0L,
                   totalSeedsRemaining = 10L,
+                  seedsWithdrawn = 0L,
                   unknownQuantityAccessions = 0),
               service.getSearchSummaryStatistics(criteriaWithExactMatch),
               "Statistics for fuzzy search that has an exact match")
@@ -102,6 +103,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
                   subtotalBySeedCount = 10L,
                   subtotalByWeightEstimate = 0L,
                   totalSeedsRemaining = 10L,
+                  seedsWithdrawn = 0L,
                   unknownQuantityAccessions = 1),
               service.getSearchSummaryStatistics(criteriaWithoutExactMatch),
               "Statistics for fuzzy search that does not have an exact match")


### PR DESCRIPTION
We want the total seed count for a seedbank to include the seed quantity
withdrawn from that seedbank as well as the seeds currently stored. This
results in the total number of seeds stored in the seedbank for all time
which is the value that is required for reports. We had to add the total
withdrawn seeds to the seedbank summary statistics to get this value.

(sorry I accidentally pushed this to main but reverted it)