### PR TITLE
SW-3192 Round Instead of Floor Mortality Rate

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.nursery.model
 
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import kotlin.math.roundToInt
 
 /** Aggregated statistics for a nursery. Totals are across all batches and withdrawals. */
 data class NurseryStats(
@@ -18,13 +19,13 @@ data class NurseryStats(
    */
   val mortalityRate: Int
     get() {
-      val totalDead = totalWithdrawnByPurpose[WithdrawalPurpose.Dead] ?: 0L
-      val totalPlants = totalInventory + totalWithdrawnByPurpose.values.sum()
+      val totalDead = totalWithdrawnByPurpose[WithdrawalPurpose.Dead]?.toDouble() ?: 0.0
+      val totalPlants = (totalInventory + totalWithdrawnByPurpose.values.sum()).toDouble()
 
-      return if (totalPlants == 0L) {
+      return if (totalPlants == 0.0) {
         0
       } else {
-        ((totalDead * 100) / totalPlants).toInt()
+        ((totalDead * 100) / totalPlants).roundToInt()
       }
     }
 

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -188,8 +188,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                               buildStartedDateEditable = false,
                               capacity = 1000,
                               id = nurseryId,
-                              // 150 dead / (500 remaining + 200 total withdrawn) = 21.4%
-                              mortalityRate = 21,
+                              // 152 dead / (498 remaining + 200 total withdrawn) = 21.8%
+                              mortalityRate = 22,
                               name = "Facility $nurseryId",
                               // inventory (200 not-ready, 300 ready) +
                               // outplanting withdrawals (20 not-ready, 30 ready)
@@ -453,7 +453,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                               initialBody.nurseries[0].copy(
                                   buildCompletedDate = LocalDate.of(2023, 1, 15),
                                   buildCompletedDateEditable = false,
-                                  // 150 dead / (630 remaining + 200 total withdrawn) = 18%
+                                  // 152 dead / (628 remaining + 200 total withdrawn) = 18.4%
                                   mortalityRate = 18,
                                   name = "Facility $firstNursery",
                                   // initial batch (60 not-ready, 70 ready) +
@@ -611,7 +611,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
         batchId = batchId,
         withdrawalId = deadWithdrawalId,
         readyQuantityWithdrawn = 100,
-        notReadyQuantityWithdrawn = 50,
+        notReadyQuantityWithdrawn = 52,
     )
 
     val outplantWithdrawalId =


### PR DESCRIPTION
In the calculation for mortality rate, integer math was being used, which
caused the result to truncate the decimal portion. To avoid this, convert
to double, perform the calculation, and then round to integer.