### PR TITLE
SW-3360 Disallow Lock/Unlock When Submitted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -127,6 +127,9 @@ class ReportAlreadySubmittedException(val reportId: ReportId) :
 class ReportLockedException(val reportId: ReportId) :
     MismatchedStateException("Report $reportId is locked by another user")
 
+class ReportSubmittedException(val reportId: ReportId) :
+    MismatchedStateException("Report $reportId has been submitted")
+
 class ReportNotFoundException(val reportId: ReportId) :
     EntityNotFoundException("Report $reportId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -113,15 +113,7 @@ class ReportStore(
             .execute()
 
     if (rowsUpdated != 1) {
-      val reportSubmitted =
-          dslContext
-              .selectOne()
-              .from(REPORTS)
-              .where(REPORTS.ID.eq(reportId))
-              .and(REPORTS.STATUS_ID.eq(ReportStatus.Submitted))
-              .fetch()
-              .isNotEmpty
-      if (reportSubmitted) {
+      if (isSubmitted(reportId)) {
         throw ReportSubmittedException(reportId)
       }
 
@@ -150,15 +142,7 @@ class ReportStore(
             .execute()
 
     if (rowsUpdated != 1) {
-      val reportSubmitted =
-          dslContext
-              .selectOne()
-              .from(REPORTS)
-              .where(REPORTS.ID.eq(reportId))
-              .and(REPORTS.STATUS_ID.eq(ReportStatus.Submitted))
-              .fetch()
-              .isNotEmpty
-      if (reportSubmitted) {
+      if (isSubmitted(reportId)) {
         throw ReportSubmittedException(reportId)
       }
 
@@ -394,6 +378,17 @@ class ReportStore(
 
       func()
     }
+  }
+
+  /** Returns whether a report corresponding to a given reportId has been submitted. */
+  private fun isSubmitted(reportId: ReportId): Boolean {
+    return dslContext
+        .selectOne()
+        .from(REPORTS)
+        .where(REPORTS.ID.eq(reportId))
+        .and(REPORTS.STATUS_ID.eq(ReportStatus.Submitted))
+        .fetch()
+        .isNotEmpty
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.ReportAlreadySubmittedException
 import com.terraformation.backend.db.ReportLockedException
 import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.ReportNotLockedException
+import com.terraformation.backend.db.ReportSubmittedException
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -98,6 +99,7 @@ class ReportStore(
     val conditions =
         listOfNotNull(
             REPORTS.ID.eq(reportId),
+            REPORTS.STATUS_ID.notEqual(ReportStatus.Submitted),
             if (force) null else REPORTS.LOCKED_TIME.isNull.or(REPORTS.LOCKED_BY.eq(userId)),
         )
 
@@ -111,6 +113,18 @@ class ReportStore(
             .execute()
 
     if (rowsUpdated != 1) {
+      val reportSubmitted =
+          dslContext
+              .selectOne()
+              .from(REPORTS)
+              .where(REPORTS.ID.eq(reportId))
+              .and(REPORTS.STATUS_ID.eq(ReportStatus.Submitted))
+              .fetch()
+              .isNotEmpty
+      if (reportSubmitted) {
+        throw ReportSubmittedException(reportId)
+      }
+
       val reportExists =
           dslContext.selectOne().from(REPORTS).where(REPORTS.ID.eq(reportId)).fetch().isNotEmpty
       if (reportExists) {
@@ -132,9 +146,22 @@ class ReportStore(
             .set(REPORTS.STATUS_ID, ReportStatus.InProgress)
             .where(REPORTS.ID.eq(reportId))
             .and(REPORTS.LOCKED_BY.eq(currentUser().userId).or(REPORTS.LOCKED_BY.isNull))
+            .and(REPORTS.STATUS_ID.notEqual(ReportStatus.Submitted))
             .execute()
 
     if (rowsUpdated != 1) {
+      val reportSubmitted =
+          dslContext
+              .selectOne()
+              .from(REPORTS)
+              .where(REPORTS.ID.eq(reportId))
+              .and(REPORTS.STATUS_ID.eq(ReportStatus.Submitted))
+              .fetch()
+              .isNotEmpty
+      if (reportSubmitted) {
+        throw ReportSubmittedException(reportId)
+      }
+
       val reportExists =
           dslContext.selectOne().from(REPORTS).where(REPORTS.ID.eq(reportId)).fetch().isNotEmpty
       if (reportExists) {

--- a/src/main/resources/db/migration/V181__ReportStatusConstraint.sql
+++ b/src/main/resources/db/migration/V181__ReportStatusConstraint.sql
@@ -1,0 +1,10 @@
+-- Update existing data to have the `Submitted` status when submitted_by is not null.
+UPDATE reports
+    SET status_id = 4
+    WHERE submitted_by IS NOT NULL;
+
+-- Add constraint that makes sure the status correctly reflects whether the report is submitted.
+ALTER TABLE reports
+    ADD CONSTRAINT status_reflects_submitted
+        CHECK (submitted_by IS NULL AND status_id <> 4
+            OR submitted_by IS NOT NULL AND status_id = 4);


### PR DESCRIPTION
We want to make sure the data in the database is consistent with its
submission status. Therefore, add a database migration which makes sure that
existing reports are in the submitted state when there is a submitted_by
user. It also adds a constraint that ensures that when there is such a user
the report must be submitted. And when the it is submitted there must be
a submitted_by user.

In the lock and unlock methods of ReportService, add a condition that the
report is not submitted and throw an exception otherwise.