### PR TITLE
Diff OpenAPI YAML in CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,8 +77,8 @@ jobs:
 
     - name: Diff OpenAPI docs against staging
       run: |
-        if curl -s https://staging.terraware.io/v3/api-docs.yml > /tmp/staging.yaml; then
-          diff -u /tmp/staging.yaml openapi.yaml
+        if curl -s https://staging.terraware.io/v3/api-docs.yaml > /tmp/staging.yaml; then
+          diff -u /tmp/staging.yaml openapi.yaml || true
         else
           echo Unable to fetch OpenAPI schema from staging
         fi


### PR DESCRIPTION
Make it easy to see what changes a given PR would cause to the OpenAPI schema
by including a diff between the locally-generated schema and the staging one
in the GitHub Actions output.

Failure to fetch the schema from staging is logged but not treated as a build
failure (we don't want CI builds to fail if staging is down).