### PR TITLE
Remove translatable string for list delimiter

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -223,7 +223,17 @@ class Messages {
 
   fun refrigeratorName(number: Int) = getMessage("seedBankRefrigeratorName", number)
 
-  private fun listDelimiter() = getMessage("listDelimiter")
+  /**
+   * Returns the string that should be used to separate items in a list. This is hardwired in the
+   * code rather than in a message bundle because Phrase seems to not send strings to translators if
+   * they only have punctuation and whitespace.
+   */
+  private fun listDelimiter() =
+      when (currentLocale().language) {
+        "gx" -> "_ "
+        "zh" -> "、"
+        else -> ", "
+      }
 
   private fun seedQuantity(quantity: SeedQuantityModel): String {
     val formattedNumber =

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -67,8 +67,6 @@ historyAccessionWithdrawnForNursery=withdrew seeds for nursery
 historyAccessionWithdrawnForOther=withdrew seeds for other
 historyAccessionWithdrawnForOutPlanting=withdrew seeds for outplanting
 historyAccessionWithdrawnForViabilityTesting=withdrew seeds for viability testing
-# Delimiter between list items. Note that this has a space at the end.
-listDelimiter=,
 notification.accession.dryingEnd.app.body={0} has finished drying.
 notification.accession.dryingEnd.app.title=An accession has dried
 notification.accession.dryingEnd.email.body={0} (located in {1}) has reached its scheduled drying date. It is ready to be moved into storage now.


### PR DESCRIPTION
Phrase doesn't handle punctuation-only strings very well; orders that include them
never get marked as completed, and it's unclear whether or not they ever get sent
to translators. Also, Phrase's GitHub export sometimes (though not always) trims
trailing whitespace from strings.

Remove the `listDelimiter` string and hardwire it into the code. The delimiter is
the same (comma followed by space) in English and Spanish, so add a value for
gibberish (underscore followed by space) and Chinese (a punctuation mark that
doesn't exist in English, not followed by space) mostly as documentation of what
the code should do.