### PR TITLE
Stop double-building Renovate PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,16 @@ on:
   push:
     branches:
       - main
-      - qa
-      - renovate/*
-      - wip-*
+      # Renovate waits for CI builds to succeed before opening PRs, so we need to run builds on
+      # pushes to its branches.
+      - renovate/**
     tags:
-      # Semver (these are glob-like patterns, not regexes; the "." has no special meaning)
-      - v[0-9].[0-9]+.[0-9]+
-      # Date-based
+      # Releases with date-based tags, e.g., v20230411.1
       - v2[0-9]+.[0-9]+
   pull_request:
+    branches-ignore:
+      # No need to run the workflow on Renovate PRs; it will have already run on the branches.
+      - renovate/**
 
 permissions:
   id-token: write


### PR DESCRIPTION
Currently, when Renovate opens a PR, two CI builds are kicked off, one when it
pushes to its branch and another for the PR. Update the configuration to skip the
second of those.