### PR TITLE
SW-3433 Save SeedBank and Nursery Info on Submit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -12,10 +12,12 @@ import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.ReportNotLockedException
 import com.terraformation.backend.db.ReportSubmittedException
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
+import com.terraformation.backend.db.default_schema.tables.daos.FacilitiesDao
 import com.terraformation.backend.db.default_schema.tables.daos.ReportsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportsRow
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -51,6 +53,7 @@ class ReportStore(
     private val eventPublisher: ApplicationEventPublisher,
     private val objectMapper: ObjectMapper,
     private val reportsDao: ReportsDao,
+    private val facilitiesDao: FacilitiesDao,
 ) {
   private val log = perClassLogger()
 
@@ -390,12 +393,23 @@ class ReportStore(
     reportBody.seedBanks
         .filter { it.selected }
         .forEach {
+          val seedBank = facilitiesDao.fetchOneById(it.id)
+          if (it.buildStartedDate == seedBank?.buildStartedDate &&
+              it.buildCompletedDate == seedBank?.buildCompletedDate &&
+              it.operationStartedDate == seedBank?.operationStartedDate) {
+            return
+          }
           dslContext
               .update(FACILITIES)
-              .set(FACILITIES.BUILD_STARTED_DATE, it.buildStartedDate)
-              .set(FACILITIES.BUILD_COMPLETED_DATE, it.buildCompletedDate)
-              .set(FACILITIES.OPERATION_STARTED_DATE, it.operationStartedDate)
-              .where(FACILITIES.ID.eq(it.id))
+              .set(FACILITIES.BUILD_STARTED_DATE, it.buildStartedDate ?: seedBank?.buildStartedDate)
+              .set(
+                  FACILITIES.BUILD_COMPLETED_DATE,
+                  it.buildCompletedDate ?: seedBank?.buildCompletedDate)
+              .set(
+                  FACILITIES.OPERATION_STARTED_DATE,
+                  it.operationStartedDate ?: seedBank?.operationStartedDate)
+              .where(FACILITIES.TYPE_ID.eq(FacilityType.SeedBank))
+              .and(FACILITIES.ID.eq(it.id))
               .execute()
         }
   }
@@ -406,13 +420,25 @@ class ReportStore(
     reportBody.nurseries
         .filter { it.selected }
         .forEach {
+          val nursery = facilitiesDao.fetchOneById(it.id)
+          if (it.buildStartedDate == nursery?.buildStartedDate &&
+              it.buildCompletedDate == nursery?.buildCompletedDate &&
+              it.operationStartedDate == nursery?.operationStartedDate &&
+              it.capacity == nursery?.capacity) {
+            return
+          }
           dslContext
               .update(FACILITIES)
-              .set(FACILITIES.BUILD_STARTED_DATE, it.buildStartedDate)
-              .set(FACILITIES.BUILD_COMPLETED_DATE, it.buildCompletedDate)
-              .set(FACILITIES.OPERATION_STARTED_DATE, it.operationStartedDate)
-              .set(FACILITIES.CAPACITY, it.capacity)
-              .where(FACILITIES.ID.eq(it.id))
+              .set(FACILITIES.BUILD_STARTED_DATE, it.buildStartedDate ?: nursery?.buildStartedDate)
+              .set(
+                  FACILITIES.BUILD_COMPLETED_DATE,
+                  it.buildCompletedDate ?: nursery?.buildCompletedDate)
+              .set(
+                  FACILITIES.OPERATION_STARTED_DATE,
+                  it.operationStartedDate ?: nursery?.operationStartedDate)
+              .set(FACILITIES.CAPACITY, it.capacity ?: nursery?.capacity)
+              .where(FACILITIES.TYPE_ID.eq(FacilityType.Nursery))
+              .and(FACILITIES.ID.eq(it.id))
               .execute()
         }
   }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -54,6 +54,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
+import com.terraformation.backend.db.default_schema.tables.records.FacilitiesRecord
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -376,6 +377,14 @@ abstract class DatabaseTest {
           .set(TYPE_ID, type)
           .execute()
     }
+  }
+
+  protected fun getFacilityById(facilityId: FacilityId): FacilitiesRecord {
+    return dslContext
+        .select(FACILITIES)
+        .from(FACILITIES)
+        .where(FACILITIES.ID.eq(facilityId))
+        .fetchOne { model -> model.component1() }!!
   }
 
   protected fun insertDevice(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -51,10 +51,10 @@ import com.terraformation.backend.db.default_schema.tables.daos.TimeseriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
+import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.TimeZonesRow
-import com.terraformation.backend.db.default_schema.tables.records.FacilitiesRecord
 import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
 import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -115,6 +115,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Locale
+import javax.ws.rs.NotFoundException
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
 import org.jooq.Configuration
@@ -379,12 +380,8 @@ abstract class DatabaseTest {
     }
   }
 
-  protected fun getFacilityById(facilityId: FacilityId): FacilitiesRecord {
-    return dslContext
-        .select(FACILITIES)
-        .from(FACILITIES)
-        .where(FACILITIES.ID.eq(facilityId))
-        .fetchOne { model -> model.component1() }!!
+  protected fun getFacilityById(facilityId: FacilityId): FacilitiesRow {
+    return facilitiesDao.fetchOneById(facilityId) ?: throw NotFoundException()
   }
 
   protected fun insertDevice(

--- a/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
@@ -50,7 +50,8 @@ class ReportFileServiceTest : DatabaseTest(), RunsAsUser {
     FileService(dslContext, clock, filesDao, fileStore, thumbnailStore)
   }
   private val reportStore: ReportStore by lazy {
-    ReportStore(clock, dslContext, TestEventPublisher(), jacksonObjectMapper(), reportsDao)
+    ReportStore(
+        clock, dslContext, TestEventPublisher(), jacksonObjectMapper(), reportsDao, facilitiesDao)
   }
   private val service: ReportFileService by lazy {
     ReportFileService(filesDao, fileService, reportFilesDao, reportPhotosDao, reportStore)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -73,7 +73,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
   private val parentStore by lazy { ParentStore(dslContext) }
   private val reportRenderer: ReportRenderer = mockk()
   private val reportStore by lazy {
-    ReportStore(clock, dslContext, publisher, objectMapper, reportsDao)
+    ReportStore(clock, dslContext, publisher, objectMapper, reportsDao, facilitiesDao)
   }
   private val scheduler: JobScheduler = mockk()
 

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -36,6 +36,7 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -433,7 +434,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `saves seed bank and nursery information`() {
       insertFacility(1)
-      insertFacility(2, type = FacilityType.Nursery)
+      insertFacility(2)
+      insertFacility(3, type = FacilityType.Nursery)
       val body =
           ReportBodyModelV1(
               organizationName = "org",
@@ -448,11 +450,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
                           operationStartedDate = LocalDate.EPOCH,
                           workers = ReportBodyModelV1.Workers(1, 1, 1),
                       ),
+                      ReportBodyModelV1.SeedBank(
+                          id = FacilityId(2),
+                          selected = false,
+                          name = "bank",
+                          buildStartedDate = LocalDate.EPOCH,
+                          buildCompletedDate = LocalDate.EPOCH,
+                          operationStartedDate = LocalDate.EPOCH,
+                          workers = ReportBodyModelV1.Workers(1, 1, 1),
+                      ),
                   ),
               nurseries =
                   listOf(
                       ReportBodyModelV1.Nursery(
-                          id = FacilityId(2),
+                          id = FacilityId(3),
                           name = "nursery",
                           buildStartedDate = LocalDate.EPOCH,
                           buildCompletedDate = LocalDate.EPOCH,
@@ -474,7 +485,12 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(seedBankResult.buildCompletedDate, LocalDate.EPOCH)
       assertEquals(seedBankResult.operationStartedDate, LocalDate.EPOCH)
 
-      val nurseryResult = getFacilityById(FacilityId(2))
+      val unselectedSeedBankResult = getFacilityById(FacilityId(2))
+      assertNull(unselectedSeedBankResult.buildStartedDate)
+      assertNull(unselectedSeedBankResult.buildCompletedDate)
+      assertNull(unselectedSeedBankResult.operationStartedDate)
+
+      val nurseryResult = getFacilityById(FacilityId(3))
       assertEquals(nurseryResult.buildStartedDate, LocalDate.EPOCH)
       assertEquals(nurseryResult.buildCompletedDate, LocalDate.EPOCH)
       assertEquals(nurseryResult.operationStartedDate, LocalDate.EPOCH)

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -52,7 +52,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock(defaultTime.toInstant())
   private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
   private val publisher = TestEventPublisher()
-  private val store by lazy { ReportStore(clock, dslContext, publisher, objectMapper, reportsDao) }
+  private val store by lazy {
+    ReportStore(clock, dslContext, publisher, objectMapper, reportsDao, facilitiesDao)
+  }
 
   @BeforeEach
   fun setUp() {


### PR DESCRIPTION
When a report is submitted, we want to save build start, build completion, operation start, and capacity for seed banks and nurseries if they are entered in a report. They should be saved after report validation, and only facilities that are selected should have those values saved.