### PR TITLE
SW-3394 Deploy using Tailscale instead of bastion

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -17,5 +17,6 @@ aws ec2 describe-instances --filters "Name=tag:Application,Values=terraware" \
       echo
       echo "Deploying to $_host"
       echo
-      ssh -n $_host "/usr/local/bin/update.sh terraware-server $COMMIT_SHA"
+      #ssh -n "$_host" "/usr/local/bin/update.sh terraware-server $COMMIT_SHA"
+      ssh -n "$_host" "ls -l /"
     done

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -3,7 +3,13 @@
 mkdir -p ~/.ssh
 echo "$SSH_KEY" > ~/.ssh/key
 chmod 600 ~/.ssh/key
-echo "$SSH_CONFIG" > ~/.ssh/config
+
+cat >> ~/.ssh/config << END
+Host terraware*
+  User $SSH_USER
+  IdentityFile ~/.ssh/key
+  StrictHostKeyChecking no
+END
 
 aws ec2 describe-instances --filters "Name=tag:Application,Values=terraware" \
   | jq -r ' .Reservations[].Instances[].Tags[] | select(.Key == "Hostname") | .Value' \

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -17,6 +17,5 @@ aws ec2 describe-instances --filters "Name=tag:Application,Values=terraware" \
       echo
       echo "Deploying to $_host"
       echo
-      #ssh -n "$_host" "/usr/local/bin/update.sh terraware-server $COMMIT_SHA"
-      ssh -n "$_host" "ls -l /"
+      ssh -n $_host "/usr/local/bin/update.sh terraware-server $COMMIT_SHA"
     done

--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -13,10 +13,8 @@ elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
     TIER=STAGING
     IS_CD=true
 else
-    TIER=STAGING
-    IS_CD=true
-    #TIER=CI
-    #IS_CD=false
+    TIER=CI
+    IS_CD=false
 fi
 
 (

--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -13,8 +13,10 @@ elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
     TIER=STAGING
     IS_CD=true
 else
-    TIER=CI
-    IS_CD=false
+    TIER=STAGING
+    IS_CD=true
+    #TIER=CI
+    #IS_CD=false
 fi
 
 (
@@ -28,7 +30,7 @@ fi
         echo "TIER=$TIER"
 
         # Define secret names based on the tier
-        echo "SSH_CONFIG_SECRET_NAME=${TIER}_SSH_CONFIG"
         echo "SSH_KEY_SECRET_NAME=${TIER}_SSH_KEY"
+        echo "SSH_USER_SECRET_NAME=${TIER}_SSH_USER"
     fi
 ) >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,11 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+    - name: Connect to Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
     - name: Deploy
       if: env.IS_CD == 'true'
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,20 +40,6 @@ jobs:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
-    - name: Connect to Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
-    - name: Run deploy script to see if it can connect to hosts
-      env:
-        SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
-        SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
-      run: ./.github/scripts/deploy.sh
-
-    - name: Abort
-      run: exit 1
-
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3
@@ -156,6 +142,11 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+    - name: Connect to Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
     - name: Deploy
       if: env.IS_CD == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,20 @@ jobs:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
+    - name: Connect to Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
+    - name: Run deploy script to see if it can connect to hosts
+      env:
+        SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
+        SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
+      run: ./.github/scripts/deploy.sh
+
+    - name: Abort
+      run: exit 1
+
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3
@@ -143,16 +157,11 @@ jobs:
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-    - name: Connect to Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
     - name: Deploy
       if: env.IS_CD == 'true'
       env:
-        SSH_CONFIG: ${{ secrets[env.SSH_CONFIG_SECRET_NAME] }}
         SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
+        SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
       run: ./.github/scripts/deploy.sh
 
     - name: Log into Jira

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,11 @@ jobs:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
+    - name: Connect to Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3
@@ -142,11 +147,6 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-    - name: Connect to Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
     - name: Deploy
       if: env.IS_CD == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,15 +40,6 @@ jobs:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
-    - name: Connect to Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
-    - name: Try connecting to a host (should fail with an ssh error)
-      run: |
-        ssh bogususer@terraware-1.staging.terraware.io
-
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3
@@ -151,6 +142,11 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+    - name: Connect to Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
     - name: Deploy
       if: env.IS_CD == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,10 @@ jobs:
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
+    - name: Try connecting to a host (should fail with an ssh error)
+      run: |
+        ssh bogususer@terraware-1.staging.terraware.io
+
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3


### PR DESCRIPTION
When deploying to the AWS hosts, connect to the VPC network using Tailscale and
ssh directly to the hosts rather than bouncing through a bastion host.