### PR TITLE
Remove unused config option

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -6,7 +6,6 @@ import java.time.Duration
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
-import javax.validation.constraints.Min
 import javax.validation.constraints.NotNull
 import org.springframework.boot.autoconfigure.mail.MailProperties
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -53,14 +53,6 @@ class TerrawareServerConfig(
     val photoDir: Path? = null,
 
     /**
-     * Number of levels of parent directories to create for photos. Photos are stored in a tree of
-     * single-character subdirectories from the beginning of the accession number. For example, if
-     * this is 3, and `photoDir` is `/x/y`, photos for accession `ABCDEFG` will be stored in
-     * `/x/y/A/B/C/ABCDEFG`.
-     */
-    @Min(0) val photoIntermediateDepth: Int = 3,
-
-    /**
      * Server's time zone. This is mostly used to determine when scheduled daily jobs are run.
      * Default is UTC. May be specified as a tz database time zone name such as `US/Hawaii` or a UTC
      * offset such as `+04:00`.

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -67,7 +67,6 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
 
     clock.instant = uploadedTime
     every { config.photoDir } returns tempDir
-    every { config.photoIntermediateDepth } returns 3
 
     every { random.nextLong() } returns 0x0123456789abcdef
     pathGenerator = PathGenerator(random)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -91,7 +91,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     tempDir = Files.createTempDirectory(javaClass.simpleName)
 
     every { config.photoDir } returns tempDir
-    every { config.photoIntermediateDepth } returns 3
 
     every { random.nextLong() } returns 0x0123456789abcdef
     pathGenerator = PathGenerator(random)


### PR DESCRIPTION
The `photoIntermediateDepth` config option used to control the structure of the
paths the server generates when it stores photo files. But we changed the paths
to be date-based, so the option is no longer used anywhere.