### PR TITLE
Upgrade to Java 20

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,8 +27,8 @@ jobs:
       id: setup-java
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
-        java-version: "17"
+        distribution: "corretto"
+        java-version: "20"
 
     - name: Tell Gradle where the Java installation is
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
       id: setup-java
       uses: actions/setup-java@v3
       with:
-        distribution: temurin
-        java-version: "17"
+        distribution: "corretto"
+        java-version: "20"
 
     - name: Tell Gradle where the Java installation is
       run: |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -4,7 +4,7 @@ The code should be written in idiomatic Kotlin and should generally follow the g
 
 It runs on the JVM, and thus makes extensive use of Java libraries. There are no plans to support multiplatform builds. If you find a Java library that does just what you need, use it rather than reinventing the wheel!
 
-Currently, the build targets the Java 17 JVM.
+Currently, the build targets the Java 20 JVM.
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You may see references to some private repositories in the documentation. We're 
 ### Prerequisites
 
 * Docker (used by the build process and by automated tests)
-* Java version 17 or higher ([AdoptOpenJDK](https://adoptopenjdk.net/) is a convenient place to get it)
+* Java version 20 or higher ([AdoptOpenJDK](https://adoptopenjdk.net/) is a convenient place to get it)
 * PostgreSQL (version 13 or higher recommended)
 * PostGIS (version 3.1 or higher recommended)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jk1.license.render.InventoryHtmlReportRenderer
 import com.terraformation.gradle.PostgresDockerConfigTask
 import com.terraformation.gradle.VersionFileTask
 import com.terraformation.gradle.computeGitVersion
-import java.net.URL
+import java.net.URI
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.deprecation.DeprecatableConfiguration
 import org.jetbrains.dokka.gradle.DokkaTask
@@ -248,7 +248,7 @@ node { yarnVersion.set("1.22.17") }
 tasks.withType<KotlinCompile> {
   compilerOptions {
     // Kotlin and Java target compatibility must be the same.
-    jvmTarget.set(JvmTarget.valueOf("JVM_" + tasks.compileJava.get().targetCompatibility))
+    jvmTarget.set(JvmTarget.JVM_19)
     allWarningsAsErrors.set(true)
   }
 
@@ -333,7 +333,7 @@ tasks.withType<DokkaTask>().configureEach {
       sourceLink {
         localDirectory.set(file("src/main/kotlin"))
         remoteUrl.set(
-            URL("https://github.com/terraware/terraware-server/tree/main/src/main/kotlin"))
+            URI("https://github.com/terraware/terraware-server/tree/main/src/main/kotlin").toURL())
         remoteLineSuffix.set("#L")
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,7 +248,7 @@ node { yarnVersion.set("1.22.17") }
 tasks.withType<KotlinCompile> {
   compilerOptions {
     // Kotlin and Java target compatibility must be the same.
-    jvmTarget.set(JvmTarget.JVM_19)
+    jvmTarget.set(JvmTarget.valueOf("JVM_" + tasks.compileJava.get().targetCompatibility))
     allWarningsAsErrors.set(true)
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,6 @@ group = "com.terraformation"
 
 version = computeGitVersion("0.1")
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-node { yarnVersion.set("1.22.17") }
-
 repositories {
   maven("https://repo.osgeo.org/repository/geotools-releases/")
   mavenCentral()
@@ -241,10 +237,19 @@ sourceSets.main { java.srcDir("build/generated/kotlin") }
 
 sourceSets.test { java.srcDir("build/generated-test/kotlin") }
 
+java {
+  toolchain { languageVersion.set(JavaLanguageVersion.of(20)) }
+  // Kotlin compiler (as of 1.8.20) only supports Java 19 target compatibility.
+  targetCompatibility = JavaVersion.VERSION_19
+}
+
+node { yarnVersion.set("1.22.17") }
+
 tasks.withType<KotlinCompile> {
   compilerOptions {
+    // Kotlin and Java target compatibility must be the same.
+    jvmTarget.set(JvmTarget.valueOf("JVM_" + tasks.compileJava.get().targetCompatibility))
     allWarningsAsErrors.set(true)
-    jvmTarget.set(JvmTarget.JVM_17)
   }
 
   dependsOn(generateVersionFile)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,7 +248,7 @@ node { yarnVersion.set("1.22.17") }
 tasks.withType<KotlinCompile> {
   compilerOptions {
     // Kotlin and Java target compatibility must be the same.
-    jvmTarget.set(JvmTarget.valueOf("JVM_" + tasks.compileJava.get().targetCompatibility))
+    jvmTarget.set(JvmTarget.JVM_19)
     allWarningsAsErrors.set(true)
   }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins { `kotlin-dsl` }
 
 repositories {
@@ -8,4 +10,12 @@ repositories {
 dependencies {
   implementation("com.github.node-gradle:gradle-node-plugin:3.5.1")
   implementation("org.eclipse.jgit:org.eclipse.jgit:5.10.+")
+}
+
+tasks.withType<KotlinCompile> {
+  compilerOptions {
+    jvmTarget.set(
+        rootProject.tasks.withType<KotlinCompile>().first().compilerOptions.jvmTarget.get())
+    allWarningsAsErrors.set(true)
+  }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins { `kotlin-dsl` }
@@ -12,10 +13,11 @@ dependencies {
   implementation("org.eclipse.jgit:org.eclipse.jgit:5.10.+")
 }
 
+java { targetCompatibility = JavaVersion.VERSION_19 }
+
 tasks.withType<KotlinCompile> {
   compilerOptions {
-    jvmTarget.set(
-        rootProject.tasks.withType<KotlinCompile>().first().compilerOptions.jvmTarget.get())
+    jvmTarget.set(JvmTarget.JVM_19)
     allWarningsAsErrors.set(true)
   }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,9 @@
-FROM openjdk:17.0.2-slim-buster
+FROM amazoncorretto:20
 
 ARG USER_ID=1001
 
-RUN useradd -u $USER_ID -c "Terraware server" -d /home/app -m terraware
-
-WORKDIR /home/app
+RUN mkdir /app && chown $USER_ID /app
+WORKDIR /app
 
 # Copy libraries as an explicit step so they end up in a separate layer from the
 # application code. This way, pulling a new version of the application when the

--- a/jooq/build.gradle.kts
+++ b/jooq/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   `java-gradle-plugin`
@@ -32,5 +33,13 @@ gradlePlugin {
   plugins.register("jooq") {
     id = "terraware-jooq"
     implementationClass = "com.terraformation.backend.jooq.JooqPlugin"
+  }
+}
+
+tasks.withType<KotlinCompile> {
+  compilerOptions {
+    jvmTarget.set(
+        rootProject.tasks.withType<KotlinCompile>().first().compilerOptions.jvmTarget.get())
+    allWarningsAsErrors.set(true)
   }
 }

--- a/jooq/build.gradle.kts
+++ b/jooq/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.util.Properties
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -36,10 +37,11 @@ gradlePlugin {
   }
 }
 
+java { targetCompatibility = JavaVersion.VERSION_19 }
+
 tasks.withType<KotlinCompile> {
   compilerOptions {
-    jvmTarget.set(
-        rootProject.tasks.withType<KotlinCompile>().first().compilerOptions.jvmTarget.get())
+    jvmTarget.set(JvmTarget.JVM_19)
     allWarningsAsErrors.set(true)
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,4 +15,9 @@ pluginManagement {
   includeBuild("jooq")
 }
 
+plugins {
+  // Automatically downloads the correct JDK version if it's not installed locally.
+  id("org.gradle.toolchains.foojay-resolver-convention") version ("0.4.0")
+}
+
 rootProject.name = "terraware-server"

--- a/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/mapbox/MapboxService.kt
@@ -9,6 +9,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import java.net.URI
 import java.net.URL
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -73,7 +74,7 @@ class MapboxService(
   }
 
   private fun mapboxUrl(endpoint: String): URL =
-      URL("https://api.mapbox.com/$endpoint?access_token=${config.mapbox.apiToken}")
+      URI("https://api.mapbox.com/$endpoint?access_token=${config.mapbox.apiToken}").toURL()
 
   data class TemporaryTokenRequestPayload(
       val expires: Instant,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -370,7 +370,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   fun `updateUser updates profile information`() {
     val newFirstName = "Testy"
     val newLastName = "McTestalot"
-    val newLocale = Locale("gx")
+    val newLocale = Locale.forLanguageTag("gx")
     val newTimeZone = insertTimeZone()
 
     insertUser(authId = userRepresentation.id, email = userRepresentation.email)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -860,9 +860,10 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns template with most specific matching locale`() {
       assertTemplateContains(
-          Locale("gx", "US", "test"), "Template,with,full,locale,including,variant")
-      assertTemplateContains(Locale("gx", "US"), "Template,with,language,and,country")
-      assertTemplateContains(Locale("gx"), "gibberish for")
+          Locale.forLanguageTag("gx-US-x-lvariant-test"),
+          "Template,with,full,locale,including,variant")
+      assertTemplateContains(Locale.forLanguageTag("gx-US"), "Template,with,language,and,country")
+      assertTemplateContains(Locale.forLanguageTag("gx"), "gibberish for")
     }
 
     private fun assertTemplateContains(locale: Locale, searchString: String) {


### PR DESCRIPTION
Generate Docker images that run on a Java 20 JVM to take advantage of recent
performance improvements and bugfixes.

Currently, the Kotlin compiler only supports generating classfiles for JVM
versions up to 19, so configure the target classfile version separately from the
version of the JVM itself.

To make it easier to switch versions in the future, start using Gradle's Java
toolchain support to automatically install an appropriate JVM version.

A couple of Java standard library functions have been deprecated in recent
releases; update our uses of them to use the non-deprecated alternatives.