### PR TITLE
SW-3493 Fix duplicate single quotes in notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -29,6 +29,9 @@ data class NotificationMessage(val title: String, val body: String)
 class Messages {
   private val messageSource =
       ResourceBundleMessageSource().apply {
+        // Make the handling of single quote characters consistent regardless of whether or not
+        // strings contain placeholders.
+        setAlwaysUseMessageFormat(true)
         setBasename("i18n.Messages")
         setDefaultEncoding("UTF-8")
       }


### PR DESCRIPTION
The `MessageFormat` class, which is used to format localized messages that contain
placeholders, requires single quote characters to be escaped. By default, Spring
only uses `MessageFormat` if there are actually placeholders. Unfortunately, that
means the escaping rule for single quote characters depends on whether or not the
string happens to have placeholders.

This was causing the added-to-organization notification to have an English title
of, `You''ve been added to a new organization!` (note the two single quote
characters).

Make the escaping behavior consistent by configuring the resource bundle to always
use `MessageFormat` even if there are no placeholders.