### PR TITLE
SW-3504 Omit plots from planting site payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -182,7 +182,7 @@ class AdminController(
 
   @GetMapping("/plantingSite/{plantingSiteId}")
   fun getPlantingSite(@PathVariable plantingSiteId: PlantingSiteId, model: Model): String {
-    val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId)
+    val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, true)
     val organization = organizationStore.fetchOneById(plantingSite.organizationId)
 
     val allOrganizations =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -5,12 +5,10 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.tracking.db.PlantingSiteStore
-import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
@@ -75,23 +73,11 @@ class PlantingSitesController(
   }
 }
 
-data class MonitoringPlotPayload(
-    val boundary: MultiPolygon,
-    val fullName: String,
-    val id: MonitoringPlotId,
-    val name: String,
-) {
-  constructor(
-      model: MonitoringPlotModel
-  ) : this(model.boundary, model.fullName, model.id, model.name)
-}
-
 data class PlantingSubzonePayload(
     val boundary: MultiPolygon,
     val fullName: String,
     val id: PlantingSubzoneId,
     val name: String,
-    val monitoringPlots: List<MonitoringPlotPayload>,
 ) {
   constructor(
       model: PlantingSubzoneModel
@@ -100,7 +86,7 @@ data class PlantingSubzonePayload(
       model.fullName,
       model.id,
       model.name,
-      model.monitoringPlots.map { MonitoringPlotPayload(it) })
+  )
 }
 
 data class PlantingZonePayload(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -93,6 +93,49 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             timeZone = timeZone,
         )
 
+    val actual = store.fetchSiteById(plantingSiteId, true)
+
+    if (!expected.equals(actual, 0.00001)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Test
+  fun `fetchSiteById omits monitoring plots by default`() {
+    val plantingSiteId = insertPlantingSite(boundary = multiPolygon(3.0), timeZone = timeZone)
+    val plantingZoneId =
+        insertPlantingZone(boundary = multiPolygon(2.0), plantingSiteId = plantingSiteId)
+    val plantingSubzoneId =
+        insertPlantingSubzone(
+            boundary = multiPolygon(1.0),
+            plantingSiteId = plantingSiteId,
+            plantingZoneId = plantingZoneId)
+    insertMonitoringPlot(boundary = multiPolygon(0.1), plantingSubzoneId = plantingSubzoneId)
+
+    val expected =
+        PlantingSiteModel(
+            boundary = multiPolygon(3.0),
+            description = null,
+            id = plantingSiteId,
+            name = "Site 1",
+            organizationId = organizationId,
+            plantingZones =
+                listOf(
+                    PlantingZoneModel(
+                        boundary = multiPolygon(2.0),
+                        id = plantingZoneId,
+                        name = "Z1",
+                        plantingSubzones =
+                            listOf(
+                                PlantingSubzoneModel(
+                                    boundary = multiPolygon(1.0),
+                                    id = plantingSubzoneId,
+                                    fullName = "Z1-1",
+                                    name = "1",
+                                    emptyList())))),
+            timeZone = timeZone,
+        )
+
     val actual = store.fetchSiteById(plantingSiteId)
 
     if (!expected.equals(actual, 0.00001)) {
@@ -158,7 +201,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                                             fullName = "Z1-1-1")),
                                 )))))
 
-    val actual = store.fetchSiteById(plantingSiteId)
+    val actual = store.fetchSiteById(plantingSiteId, true)
 
     if (!expected.equals(actual, 0.000001)) {
       assertEquals(expected, actual)


### PR DESCRIPTION
For a real planting site, the list of monitoring plots will be too large to
reasonably include in its entirety when a client fetches a site's information.
Remove them from the planting site API.

Monitoring plots may still be queried using the search API.