### PR TITLE
Add GeoJSON download links to admin UI

### DIFF
--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -70,14 +70,11 @@
     <ul>
         <li th:each="zone : ${site.plantingZones}">
             <th:block th:text="${zone.name}">Zone Name</th:block>
+            <a th:href="|${prefix}/plantingSite/${site.id}/downloadZone/${zone.id}|">GeoJSON</a>
             <ul th:if="!${zone.plantingSubzones.isEmpty()}">
-                <li th:each="subzone : ${zone.plantingSubzones}">
-                    <th:block th:text="${subzone.fullName}">Subzone Name</th:block>
-                    <ul th:if="!${subzone.monitoringPlots.isEmpty()}">
-                        <li th:each="plot : ${subzone.monitoringPlots}">
-                            <th:block th:text="${plot.fullName}">Plot Name</th:block>
-                        </li>
-                    </ul>
+                <li th:each="subzone : ${zone.plantingSubzones}"
+                    th:text="|${subzone.name} (${subzone.monitoringPlots.size()})|">
+                    Subzone X (50)
                 </li>
             </ul>
         </li>


### PR DESCRIPTION
Currently, the admin UI's planting site details page shows a nested list that
includes a line item for each monitoring plot. A real planting site will have tens
of thousands of monitoring plots, making this display uselessly large.

Replace the list of individual monitoring plots with a link to download map data
for a planting zone.

The map data is in GeoJSON format and can be viewed using mapping tools such as
geojson.io. This is mostly for development purposes; the user-facing web app won't
have a view that shows thousands of monitoring plots all at once.

Downloads are per-zone rather than per-site just because the file size would be
unmanageably huge for a real planting site.