### PR TITLE
SW-3493 Remove duplicate single quotes from email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
+import com.terraformation.backend.i18n.FormattingResourceBundleModel
 import com.terraformation.backend.i18n.currentLocale
 import freemarker.core.HTMLOutputFormat
 import freemarker.ext.beans.ResourceBundleModel
@@ -40,7 +41,8 @@ abstract class EmailTemplateModel(config: TerrawareServerConfig) {
    * escaping. This is callable as `${strings("stringKey")}` in template files.
    */
   val strings: ResourceBundleModel by lazy {
-    ResourceBundleModel(bundle, DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_31).build())
+    FormattingResourceBundleModel(
+        bundle, DefaultObjectWrapperBuilder(Configuration.VERSION_2_3_31).build())
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/i18n/FormattingResourceBundleModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/FormattingResourceBundleModel.kt
@@ -1,0 +1,25 @@
+package com.terraformation.backend.i18n
+
+import freemarker.ext.beans.BeansWrapper
+import freemarker.ext.beans.ResourceBundleModel
+import java.text.MessageFormat
+import java.util.ResourceBundle
+
+/**
+ * Variant of [ResourceBundleModel] that always formats strings with [MessageFormat] even if they
+ * don't have any placeholders. This gives us consistent handling of single quote characters in
+ * localized strings: they always need to be doubled, rather than only needing to be doubled in
+ * strings that happen to also have placeholders.
+ */
+class FormattingResourceBundleModel(bundle: ResourceBundle, wrapper: BeansWrapper) :
+    ResourceBundleModel(bundle, wrapper) {
+  override fun exec(arguments: List<Any?>): Any? {
+    return if (arguments.size == 1) {
+      // No arguments supplied. Add a fake one to force the value to be treated as a format string
+      // rather than a constant.
+      super.exec(listOf(arguments[0], null))
+    } else {
+      super.exec(arguments)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -248,6 +248,7 @@ internal class EmailNotificationServiceTest {
     assertBodyContains(organization.name, "Organization name")
     assertBodyContains(adminUser.fullName!!, "Admin name")
     assertBodyContains(webAppUrls.fullOrganizationHome(organization.id), "Link URL")
+    assertSubjectContains("You've")
     assertRecipientsEqual(setOf(user.email))
   }
 


### PR DESCRIPTION
Commit 0e5e0dcc attempted to enforce consistent handling of single quotes in
localizable strings, but it missed a code path: the models that are used with
Freemarker templates such as email messages. We were thus still including
duplicate single quote marks in email messages.