### PR TITLE
SW-3521 Store monitoring plot boundary as Polygon

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -392,7 +392,6 @@ class PlantingSiteImporter(
       subzonesFile: Shapefile,
   ): Map<String, List<ShapefileFeature>> {
     val crs = siteFeature.coordinateReferenceSystem
-    val factory = GeometryFactory(PrecisionModel(), siteFeature.geometry.srid)
     val allPlots = generateAllPlots(siteFeature)
 
     return subzonesFile.features.associate { subzoneFeature ->
@@ -401,7 +400,7 @@ class PlantingSiteImporter(
               .filter { it.coveredBy(subzoneFeature.geometry) }
               .mapIndexed { index, polygon ->
                 ShapefileFeature(
-                    factory.createMultiPolygon(arrayOf(polygon)),
+                    polygon,
                     mapOf(
                         PLOT_NAME_PROPERTY to "${index + 1}",
                         SUBZONE_NAME_PROPERTY to subzoneFeature.properties[SUBZONE_NAME_PROPERTY]!!,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -27,6 +27,7 @@ import org.jooq.Field
 import org.jooq.Record
 import org.jooq.impl.DSL
 import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Polygon
 
 @Named
 class PlantingSiteStore(
@@ -174,7 +175,7 @@ class PlantingSiteStore(
           .convertFrom { result ->
             result.map { record ->
               MonitoringPlotModel(
-                  record[monitoringPlotBoundaryField]!! as MultiPolygon,
+                  record[monitoringPlotBoundaryField]!! as Polygon,
                   record[MONITORING_PLOTS.ID]!!,
                   record[MONITORING_PLOTS.FULL_NAME]!!,
                   record[MONITORING_PLOTS.NAME]!!)

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -18,9 +18,10 @@ import org.jooq.Field
 import org.jooq.Record
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Polygon
 
 data class MonitoringPlotModel(
-    val boundary: MultiPolygon,
+    val boundary: Polygon,
     val id: MonitoringPlotId,
     val fullName: String,
     val name: String,

--- a/src/main/resources/db/migration/V184__MonitoringPlotPolygon.sql
+++ b/src/main/resources/db/migration/V184__MonitoringPlotPolygon.sql
@@ -1,0 +1,12 @@
+-- Convert monitoring plots from MultiPolygon to Polygon.
+
+ALTER TABLE tracking.monitoring_plots ADD COLUMN polygon_boundary GEOMETRY(Polygon);
+
+UPDATE tracking.monitoring_plots
+SET polygon_boundary = ST_GeometryN(boundary, 1)
+WHERE polygon_boundary IS NULL;
+
+ALTER TABLE tracking.monitoring_plots ALTER COLUMN polygon_boundary SET NOT NULL;
+
+ALTER TABLE tracking.monitoring_plots DROP COLUMN boundary;
+ALTER TABLE tracking.monitoring_plots RENAME COLUMN polygon_boundary TO boundary;

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.locationtech.jts.geom.CoordinateXY
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
 
 /**
  * ObjectMapper configured to pretty print. This is lazily instantiated since ObjectMappers aren't
@@ -39,17 +41,19 @@ fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
   }
 }
 
+/** Creates a simple triangular Polygon. */
+fun polygon(scale: Double): Polygon {
+  val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+  return geometryFactory.createPolygon(
+      arrayOf(
+          CoordinateXY(0.0, 0.0),
+          CoordinateXY(scale, 0.0),
+          CoordinateXY(scale, scale),
+          CoordinateXY(0.0, 0.0)))
+}
+
 /** Creates a simple triangular MultiPolygon. */
 fun multiPolygon(scale: Double): MultiPolygon {
-  val geometryFactory = GeometryFactory()
-  return geometryFactory
-      .createMultiPolygon(
-          arrayOf(
-              geometryFactory.createPolygon(
-                  arrayOf(
-                      CoordinateXY(0.0, 0.0),
-                      CoordinateXY(scale, 0.0),
-                      CoordinateXY(scale, scale),
-                      CoordinateXY(0.0, 0.0)))))
-      .also { it.srid = SRID.LONG_LAT }
+  val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+  return geometryFactory.createMultiPolygon(arrayOf(polygon(scale)))
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -128,6 +128,7 @@ import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.junit.jupiter.api.BeforeEach
 import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.Polygon
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
@@ -869,7 +870,7 @@ abstract class DatabaseTest {
 
   fun insertMonitoringPlot(
       row: MonitoringPlotsRow = MonitoringPlotsRow(),
-      boundary: Geometry? = row.boundary,
+      boundary: Polygon = row.boundary as Polygon,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.polygon
 import com.terraformation.backend.search.NoConditionNode
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchResults
@@ -48,10 +49,10 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val plantingZoneGeometry = multiPolygon(2.0)
     val plantingSubzoneGeometry3 = multiPolygon(1.0)
     val plantingSubzoneGeometry4 = multiPolygon(1.0)
-    val monitoringPlotGeometry5 = multiPolygon(0.1)
-    val monitoringPlotGeometry6 = multiPolygon(0.1)
-    val monitoringPlotGeometry7 = multiPolygon(0.1)
-    val monitoringPlotGeometry8 = multiPolygon(0.1)
+    val monitoringPlotGeometry5 = polygon(0.1)
+    val monitoringPlotGeometry6 = polygon(0.1)
+    val monitoringPlotGeometry7 = polygon(0.1)
+    val monitoringPlotGeometry8 = polygon(0.1)
     val plantingSiteId = insertPlantingSite(boundary = plantingSiteGeometry)
     val plantingZoneId =
         insertPlantingZone(boundary = plantingZoneGeometry, id = 2, plantingSiteId = plantingSiteId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.polygon
 import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
@@ -61,7 +62,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             plantingSiteId = plantingSiteId,
             plantingZoneId = plantingZoneId)
     val monitoringPlotId =
-        insertMonitoringPlot(boundary = multiPolygon(0.1), plantingSubzoneId = plantingSubzoneId)
+        insertMonitoringPlot(boundary = polygon(0.1), plantingSubzoneId = plantingSubzoneId)
 
     val expected =
         PlantingSiteModel(
@@ -85,7 +86,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                                     name = "1",
                                     listOf(
                                         MonitoringPlotModel(
-                                            boundary = multiPolygon(0.1),
+                                            boundary = polygon(0.1),
                                             id = monitoringPlotId,
                                             name = "1",
                                             fullName = "Z1-1-1")),
@@ -110,7 +111,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             boundary = multiPolygon(1.0),
             plantingSiteId = plantingSiteId,
             plantingZoneId = plantingZoneId)
-    insertMonitoringPlot(boundary = multiPolygon(0.1), plantingSubzoneId = plantingSubzoneId)
+    insertMonitoringPlot(boundary = polygon(0.1), plantingSubzoneId = plantingSubzoneId)
 
     val expected =
         PlantingSiteModel(
@@ -153,7 +154,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             boundary = multiPolygon(1.0),
             plantingSiteId = plantingSiteId,
             plantingZoneId = plantingZoneId)
-    insertMonitoringPlot(boundary = multiPolygon(0.1), plantingSubzoneId = plantingSubzoneId)
+    insertMonitoringPlot(boundary = polygon(0.1), plantingSubzoneId = plantingSubzoneId)
 
     val expected =
         PlantingSiteModel(
@@ -185,12 +186,16 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     val crs3857 = crsFactory.createCoordinateReferenceSystem("EPSG:3857")
     val crs4326 = crsFactory.createCoordinateReferenceSystem("EPSG:4326")
     val transform4326To3857 = CRS.findMathTransform(crs4326, crs3857)
-    fun Geometry.to3857() = JTS.transform(this, transform4326To3857).also { it.srid = 3857 }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Geometry> T.to3857(): T {
+      return JTS.transform(this, transform4326To3857).also { it.srid = 3857 } as T
+    }
 
     val siteBoundary4326 = multiPolygon(30.0)
     val zoneBoundary4326 = multiPolygon(20.0)
     val subzoneBoundary4326 = multiPolygon(10.0)
-    val monitoringPlotBoundary4326 = multiPolygon(1.0)
+    val monitoringPlotBoundary4326 = polygon(1.0)
 
     val siteBoundary3857 = siteBoundary4326.to3857()
     val zoneBoundary3857 = zoneBoundary4326.to3857()


### PR DESCRIPTION
When we thought we were going to be loading monitoring plot boundaries from
shapefiles, it made sense to allow complex geometries and normalize them to
MultiPolygon. But now that we're generating them programmatically, we can
guarantee they will never have multiple polygons; storing them that way adds
needless overhead.

Change the geometry type to Polygon and convert any existing monitoring plots
by extracting the first (and only) Polygon from the plot's MultiPolygon.