### PR TITLE
SW-3521 Generate permanent monitoring plot clusters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -267,7 +267,8 @@ class AdminController(
                 zone.plantingSubzones.flatMap { subzone ->
                   subzone.monitoringPlots.map { plot ->
                     val properties =
-                        if (plot.permanentSeq != null && plot.permanentSeq <= numPermanent) {
+                        if (plot.permanentCluster != null &&
+                            plot.permanentCluster <= numPermanent) {
                           mapOf("permanent" to "true")
                         } else {
                           emptyMap()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -393,16 +393,32 @@ class PlantingSiteImporter(
    * given cluster number in a given planting zone.
    *
    * The cluster numbers allow permanent monitoring plots to be allocated using a SQL query. If we
-   * want 5 clusters of permanent plots from planting zone 4321, we can do a query along the lines
+   * want 3 clusters of permanent plots from planting zone 4321, we can do a query along the lines
    * of
    *
-   *     SELECT mp.id
+   *     SELECT mp.id, mp.permanent_cluster, mp.permanent_cluster_subplot
    *     FROM tracking.monitoring_plots mp
    *     JOIN tracking.planting_subzones ps ON mp.planting_subzone_id = ps.id
    *     WHERE ps.planting_zone_id = 4321
-   *     AND mp.permanent_cluster <= 5;
+   *     AND mp.permanent_cluster <= 3
+   *     ORDER BY mp.permanent_cluster, mp.permanent_cluster_subplot;
    *
-   * and get back a list of all 20 monitoring plots in 5 randomly-chosen 2x2 clusters.
+   * and get back a result like
+   *
+   * | id   | cluster | subplot |
+   * |------|---------|---------|
+   * | 1756 | 1       | 1       |
+   * | 1757 | 1       | 2       |
+   * | 1758 | 1       | 3       |
+   * | 1759 | 1       | 4       |
+   * | 781  | 2       | 1       |
+   * | 782  | 2       | 2       |
+   * | 783  | 2       | 3       |
+   * | 784  | 2       | 4       |
+   * | 360  | 3       | 1       |
+   * | 361  | 3       | 2       |
+   * | 362  | 3       | 3       |
+   * | 363  | 3       | 4       |
    */
   private fun assignPlots(
       allClusters: Collection<Cluster>,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -168,7 +168,8 @@ class PlantingSiteStore(
                       MONITORING_PLOTS.ID,
                       MONITORING_PLOTS.FULL_NAME,
                       MONITORING_PLOTS.NAME,
-                      MONITORING_PLOTS.PERMANENT_SEQ,
+                      MONITORING_PLOTS.PERMANENT_CLUSTER,
+                      MONITORING_PLOTS.PERMANENT_CLUSTER_SUBPLOT,
                       monitoringPlotBoundaryField)
                   .from(MONITORING_PLOTS)
                   .where(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
@@ -176,11 +177,13 @@ class PlantingSiteStore(
           .convertFrom { result ->
             result.map { record ->
               MonitoringPlotModel(
-                  record[monitoringPlotBoundaryField]!! as Polygon,
-                  record[MONITORING_PLOTS.ID]!!,
-                  record[MONITORING_PLOTS.FULL_NAME]!!,
-                  record[MONITORING_PLOTS.NAME]!!,
-                  record[MONITORING_PLOTS.PERMANENT_SEQ])
+                  boundary = record[monitoringPlotBoundaryField]!! as Polygon,
+                  id = record[MONITORING_PLOTS.ID]!!,
+                  fullName = record[MONITORING_PLOTS.FULL_NAME]!!,
+                  name = record[MONITORING_PLOTS.NAME]!!,
+                  permanentCluster = record[MONITORING_PLOTS.PERMANENT_CLUSTER],
+                  permanentClusterSubplot = record[MONITORING_PLOTS.PERMANENT_CLUSTER_SUBPLOT],
+              )
             }
           }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -168,6 +168,7 @@ class PlantingSiteStore(
                       MONITORING_PLOTS.ID,
                       MONITORING_PLOTS.FULL_NAME,
                       MONITORING_PLOTS.NAME,
+                      MONITORING_PLOTS.PERMANENT_SEQ,
                       monitoringPlotBoundaryField)
                   .from(MONITORING_PLOTS)
                   .where(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
@@ -178,7 +179,8 @@ class PlantingSiteStore(
                   record[monitoringPlotBoundaryField]!! as Polygon,
                   record[MONITORING_PLOTS.ID]!!,
                   record[MONITORING_PLOTS.FULL_NAME]!!,
-                  record[MONITORING_PLOTS.NAME]!!)
+                  record[MONITORING_PLOTS.NAME]!!,
+                  record[MONITORING_PLOTS.PERMANENT_SEQ])
             }
           }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -25,12 +25,14 @@ data class MonitoringPlotModel(
     val id: MonitoringPlotId,
     val fullName: String,
     val name: String,
+    val permanentSeq: Int? = null,
 ) {
   fun equals(other: Any?, tolerance: Double): Boolean {
     return other is MonitoringPlotModel &&
         id == other.id &&
         fullName == other.fullName &&
         name == other.name &&
+        permanentSeq == other.permanentSeq &&
         boundary.equalsExact(other.boundary, tolerance)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -25,14 +25,16 @@ data class MonitoringPlotModel(
     val id: MonitoringPlotId,
     val fullName: String,
     val name: String,
-    val permanentSeq: Int? = null,
+    val permanentCluster: Int? = null,
+    val permanentClusterSubplot: Int? = null,
 ) {
   fun equals(other: Any?, tolerance: Double): Boolean {
     return other is MonitoringPlotModel &&
         id == other.id &&
         fullName == other.fullName &&
         name == other.name &&
-        permanentSeq == other.permanentSeq &&
+        permanentCluster == other.permanentCluster &&
+        permanentClusterSubplot == other.permanentClusterSubplot &&
         boundary.equalsExact(other.boundary, tolerance)
   }
 }

--- a/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentCluster.sql
+++ b/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentCluster.sql
@@ -1,0 +1,11 @@
+ALTER TABLE tracking.monitoring_plots ADD COLUMN permanent_cluster INTEGER;
+ALTER TABLE tracking.monitoring_plots ADD COLUMN permanent_cluster_subplot INTEGER;
+
+ALTER TABLE tracking.monitoring_plots ADD CONSTRAINT cluster_has_subplot
+    CHECK (
+        (permanent_cluster IS NOT NULL AND permanent_cluster_subplot IS NOT NULL)
+        OR (permanent_cluster IS NULL AND permanent_cluster_subplot IS NULL)
+    );
+
+ALTER TABLE tracking.monitoring_plots ADD CONSTRAINT subplot_is_valid
+    CHECK (permanent_cluster_subplot BETWEEN 1 AND 4);

--- a/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentSeq.sql
+++ b/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentSeq.sql
@@ -1,1 +1,0 @@
-ALTER TABLE tracking.monitoring_plots ADD COLUMN permanent_seq INTEGER;

--- a/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentSeq.sql
+++ b/src/main/resources/db/migration/0151/V185__MonitoringPlotPermanentSeq.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracking.monitoring_plots ADD COLUMN permanent_seq INTEGER;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -280,6 +280,7 @@ COMMENT ON COLUMN tracking.monitoring_plots.created_by IS 'Which user created th
 COMMENT ON COLUMN tracking.monitoring_plots.created_time IS 'When the monitoring plot was originally created.';
 COMMENT ON COLUMN tracking.monitoring_plots.modified_by IS 'Which user most recently modified the monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.modified_time IS 'When the monitoring plot was most recently modified.';
+COMMENT ON COLUMN tracking.monitoring_plots.permanent_seq IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is part of.';
 
 COMMENT ON VIEW tracking.planting_site_populations IS 'Total number of plants of each species in each planting site.';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -280,7 +280,8 @@ COMMENT ON COLUMN tracking.monitoring_plots.created_by IS 'Which user created th
 COMMENT ON COLUMN tracking.monitoring_plots.created_time IS 'When the monitoring plot was originally created.';
 COMMENT ON COLUMN tracking.monitoring_plots.modified_by IS 'Which user most recently modified the monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.modified_time IS 'When the monitoring plot was most recently modified.';
-COMMENT ON COLUMN tracking.monitoring_plots.permanent_seq IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
+COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
+COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster_subplot IS 'If this plot is a candidate to be a permanent monitoring plot, its ordinal position from 1 to 4 in the 4-plot cluster. 1=southwest, 2=southeast, 3=northeast, 4=northwest.';
 COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is part of.';
 
 COMMENT ON VIEW tracking.planting_site_populations IS 'Total number of plants of each species in each planting site.';

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -124,7 +124,13 @@
                 source: 'plots',
                 layout: {},
                 paint: {
-                    'line-color': 'green',
+                    'line-color': [
+                        'match',
+                        ['get', 'permanent'],
+                        'true',
+                        'lightgreen',
+                        'green',
+                    ],
                 }
             });
 


### PR DESCRIPTION
Group monitoring plots into 2x2 clusters. If all four plots in a cluster fall
within a single subzone, that cluster is eligible to be chosen as a set of
permanent monitoring plots.

An eligible cluster is identified by the presence of a permanent monitoring plot
cluster number. All four plots in a cluster will have the same cluster number.
The cluster numbers are randomized at import time.

The admin UI is updated to demonstrate/test the selection process; currently it
is hardwired to simulate 6 clusters of permanent plots per planting zone and
highlight them on the map.