### PR TITLE
SW-3535 Add permissions for planting zones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -38,9 +38,11 @@ import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import java.time.ZoneId
 import java.time.ZoneOffset
 import javax.inject.Named
@@ -99,6 +101,10 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(plantingSiteId: PlantingSiteId): OrganizationId? =
       fetchFieldById(plantingSiteId, PLANTING_SITES.ID, PLANTING_SITES.ORGANIZATION_ID)
+
+  fun getOrganizationId(plantingZoneId: PlantingZoneId): OrganizationId? =
+      fetchFieldById(
+          plantingZoneId, PLANTING_ZONES.ID, PLANTING_ZONES.plantingSites.ORGANIZATION_ID)
 
   fun getOrganizationId(reportId: ReportId): OrganizationId? =
       fetchFieldById(reportId, REPORTS.ID, REPORTS.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -153,6 +154,7 @@ data class DeviceManagerUser(
       false
   override fun canReadPlanting(plantingId: PlantingId): Boolean = false
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
+  override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = false
   override fun canReadReport(reportId: ReportId): Boolean = false
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = false
@@ -177,6 +179,7 @@ data class DeviceManagerUser(
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = false
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
+  override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = false
   override fun canUpdateReport(reportId: ReportId): Boolean = false
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = false
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
 import java.util.Locale
@@ -275,6 +276,9 @@ data class IndividualUser(
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId) =
       isMember(parentStore.getOrganizationId(plantingSiteId))
 
+  override fun canReadPlantingZone(plantingZoneId: PlantingZoneId) =
+      isMember(parentStore.getOrganizationId(plantingZoneId))
+
   override fun canReadReport(reportId: ReportId) =
       isAdminOrHigher(parentStore.getOrganizationId(reportId))
 
@@ -356,6 +360,9 @@ data class IndividualUser(
 
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId) =
       isAdminOrHigher(parentStore.getOrganizationId(plantingSiteId))
+
+  override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId) =
+      isAdminOrHigher(parentStore.getOrganizationId(plantingZoneId))
 
   override fun canUpdateReport(reportId: ReportId) =
       isAdminOrHigher(parentStore.getOrganizationId(reportId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -34,11 +34,13 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -397,6 +399,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readPlantingZone(plantingZoneId: PlantingZoneId) {
+    if (!user.canReadPlantingZone(plantingZoneId)) {
+      throw PlantingZoneNotFoundException(plantingZoneId)
+    }
+  }
+
   fun readReport(reportId: ReportId) {
     if (!user.canReadReport(reportId)) {
       throw ReportNotFoundException(reportId)
@@ -576,6 +584,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdatePlantingSite(plantingSiteId)) {
       readPlantingSite(plantingSiteId)
       throw AccessDeniedException("No permission to update planting site $plantingSiteId")
+    }
+  }
+
+  fun updatePlantingZone(plantingZoneId: PlantingZoneId) {
+    if (!user.canUpdatePlantingZone(plantingZoneId)) {
+      readPlantingZone(plantingZoneId)
+      throw AccessDeniedException("No permission to update planting zone $plantingZoneId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import java.time.ZoneId
 import java.time.ZoneOffset
 import javax.inject.Named
@@ -157,6 +158,7 @@ class SystemUser(
       true
   override fun canReadPlanting(plantingId: PlantingId): Boolean = true
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
+  override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
   override fun canReadReport(reportId: ReportId): Boolean = true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
   override fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean = true
@@ -186,6 +188,7 @@ class SystemUser(
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
+  override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
   override fun canUpdateReport(reportId: ReportId): Boolean = true
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true
   override fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import java.security.Principal
 import java.time.ZoneId
 import java.util.Locale
@@ -121,6 +122,7 @@ interface TerrawareUser : Principal {
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canReadPlanting(plantingId: PlantingId): Boolean
   fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean
   fun canReadReport(reportId: ReportId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean
   fun canReadStorageLocation(storageLocationId: StorageLocationId): Boolean
@@ -148,6 +150,7 @@ interface TerrawareUser : Principal {
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
   fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean
   fun canUpdateReport(reportId: ReportId): Boolean
   fun canUpdateSpecies(speciesId: SpeciesId): Boolean
   fun canUpdateStorageLocation(storageLocationId: StorageLocationId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 
 class CrossDeliveryReassignmentNotAllowedException(
     val plantingId: PlantingId,
@@ -36,6 +37,9 @@ class PlantingNotFoundException(val plantingId: PlantingId) :
 
 class PlantingSiteNotFoundException(val plantingSiteId: PlantingSiteId) :
     EntityNotFoundException("Planting site $plantingSiteId not found")
+
+class PlantingZoneNotFoundException(val plantingZoneId: PlantingZoneId) :
+    EntityNotFoundException("Planting zone $plantingZoneId not found")
 
 class PlantingSiteUploadProblemsException(val problems: List<String>) :
     Exception("Found problems in uploaded planting site file") {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -34,11 +34,13 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -109,6 +111,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(PlantingNotFoundException::class) { canReadPlanting(it) }
   private val plantingSiteId: PlantingSiteId by
       readableId(PlantingSiteNotFoundException::class) { canReadPlantingSite(it) }
+  private val plantingZoneId: PlantingZoneId by
+      readableId(PlantingZoneNotFoundException::class) { canReadPlantingZone(it) }
   private val reportId: ReportId by readableId(ReportNotFoundException::class) { canReadReport(it) }
   private val role = Role.Contributor
   private val speciesId: SpeciesId by
@@ -376,6 +380,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun readPlantingSite() = testRead { readPlantingSite(plantingSiteId) }
 
+  @Test fun readPlantingZone() = testRead { readPlantingZone(plantingZoneId) }
+
   @Test fun readReport() = testRead { readReport(reportId) }
 
   @Test fun readSpecies() = testRead { readSpecies(speciesId) }
@@ -482,6 +488,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updatePlantingSite() =
       allow { updatePlantingSite(plantingSiteId) } ifUser { canUpdatePlantingSite(plantingSiteId) }
+
+  @Test
+  fun updatePlantingZone() =
+      allow { updatePlantingZone(plantingZoneId) } ifUser { canUpdatePlantingZone(plantingZoneId) }
 
   @Test fun updateReport() = allow { updateReport(reportId) } ifUser { canUpdateReport(reportId) }
 


### PR DESCRIPTION
In preparation for being able to configure the number of monitoring plots on a
per-planting-zone basis, add read and update permission logic for planting zones.
There are no create or delete permissions since planting zones are only created
via shapefile import, and are never deleted independently of the planting site.