### PR TITLE
SW-3536 Improve PlantingSiteStore fetch/update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -18,7 +18,6 @@ import java.math.BigDecimal
 import java.time.ZoneId
 import org.jooq.Field
 import org.jooq.Record
-import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
 
@@ -94,10 +93,9 @@ data class PlantingSiteModel(
 ) {
   constructor(
       record: Record,
-      plantingSitesBoundaryField: Field<Geometry?>,
       plantingZonesMultiset: Field<List<PlantingZoneModel>>? = null
   ) : this(
-      record[plantingSitesBoundaryField] as? MultiPolygon,
+      record[PLANTING_SITES.BOUNDARY] as? MultiPolygon,
       record[PLANTING_SITES.DESCRIPTION],
       record[PLANTING_SITES.ID]!!,
       record[PLANTING_SITES.NAME]!!,
@@ -156,4 +154,11 @@ data class DeliveryModel(
       record[DELIVERIES.PLANTING_SITE_ID]!!,
       record[DELIVERIES.WITHDRAWAL_ID]!!,
   )
+}
+
+enum class PlantingSiteDepth {
+  Site,
+  Zone,
+  Subzone,
+  Plot
 }


### PR DESCRIPTION
In preparation for adding more values to planting sites, update the fetch and
update methods in `PlantingSiteStore` to be a bit more flexible:

* The `fetch` methods now take a "depth" argument to control how many levels of
  hierarchy to fetch.  This replaces the boolean flags.
* The `updatePlantingSite` method now takes a function that modifies the existing
  model object.

These changes are purely implementation details; client-facing API behavior is
unchanged.