### PR TITLE
SW-3536 Add planting season start/end months

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -191,6 +191,10 @@ class TerrawareGenerator : KotlinGenerator() {
                 .withIncludeExpression("locale")
                 .withConverter("com.terraformation.backend.db.LocaleConverter")
                 .withUserType("java.util.Locale"),
+            ForcedType()
+                .withIncludeExpression("(?i:.*_month)")
+                .withConverter("com.terraformation.backend.db.MonthConverter")
+                .withUserType("java.time.Month"),
         )
 
     ENUM_TABLES.forEach { (schemaName, tables) ->

--- a/src/main/kotlin/com/terraformation/backend/db/MonthConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/MonthConverter.kt
@@ -1,0 +1,21 @@
+package com.terraformation.backend.db
+
+import java.time.DateTimeException
+import java.time.Month
+import org.jooq.impl.AbstractConverter
+
+/**
+ * Converts integer values from the database to and from Month objects.
+ *
+ * This is referenced in generated database classes.
+ */
+class MonthConverter : AbstractConverter<Int, Month>(Int::class.java, Month::class.java) {
+  /**
+   * Converts a month number (1-12) to a Month.
+   *
+   * @throws DateTimeException The value was not between 1 and 12.
+   */
+  override fun from(databaseObject: Int?): Month? = databaseObject?.let { Month.of(it) }
+
+  override fun to(month: Month?): Int? = month?.value
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import java.time.InstantSource
+import java.time.Month
 import java.time.ZoneId
 import javax.inject.Named
 import org.jooq.DSLContext
@@ -109,6 +110,8 @@ class PlantingSiteStore(
       name: String,
       description: String?,
       timeZone: ZoneId?,
+      plantingSeasonEndMonth: Month? = null,
+      plantingSeasonStartMonth: Month? = null,
   ): PlantingSiteModel {
     requirePermissions { createPlantingSite(organizationId) }
 
@@ -122,6 +125,8 @@ class PlantingSiteStore(
             modifiedTime = now,
             name = name,
             organizationId = organizationId,
+            plantingSeasonEndMonth = plantingSeasonEndMonth,
+            plantingSeasonStartMonth = plantingSeasonStartMonth,
             timeZone = timeZone,
         )
 
@@ -146,6 +151,8 @@ class PlantingSiteStore(
           .set(MODIFIED_BY, currentUser().userId)
           .set(MODIFIED_TIME, clock.instant())
           .set(NAME, edited.name)
+          .set(PLANTING_SEASON_END_MONTH, edited.plantingSeasonEndMonth)
+          .set(PLANTING_SEASON_START_MONTH, edited.plantingSeasonStartMonth)
           .set(TIME_ZONE, edited.timeZone)
           .where(ID.eq(plantingSiteId))
           .execute()

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.util.equalsIgnoreScale
 import java.math.BigDecimal
+import java.time.Month
 import java.time.ZoneId
 import org.jooq.Field
 import org.jooq.Record
@@ -88,6 +89,8 @@ data class PlantingSiteModel(
     val id: PlantingSiteId,
     val name: String,
     val organizationId: OrganizationId,
+    val plantingSeasonEndMonth: Month? = null,
+    val plantingSeasonStartMonth: Month? = null,
     val plantingZones: List<PlantingZoneModel>,
     val timeZone: ZoneId? = null,
 ) {
@@ -95,13 +98,15 @@ data class PlantingSiteModel(
       record: Record,
       plantingZonesMultiset: Field<List<PlantingZoneModel>>? = null
   ) : this(
-      record[PLANTING_SITES.BOUNDARY] as? MultiPolygon,
-      record[PLANTING_SITES.DESCRIPTION],
-      record[PLANTING_SITES.ID]!!,
-      record[PLANTING_SITES.NAME]!!,
-      record[PLANTING_SITES.ORGANIZATION_ID]!!,
-      plantingZonesMultiset?.let { record[it] } ?: emptyList(),
-      record[PLANTING_SITES.TIME_ZONE],
+      boundary = record[PLANTING_SITES.BOUNDARY] as? MultiPolygon,
+      description = record[PLANTING_SITES.DESCRIPTION],
+      id = record[PLANTING_SITES.ID]!!,
+      name = record[PLANTING_SITES.NAME]!!,
+      organizationId = record[PLANTING_SITES.ORGANIZATION_ID]!!,
+      plantingSeasonEndMonth = record[PLANTING_SITES.PLANTING_SEASON_END_MONTH],
+      plantingSeasonStartMonth = record[PLANTING_SITES.PLANTING_SEASON_START_MONTH],
+      plantingZones = plantingZonesMultiset?.let { record[it] } ?: emptyList(),
+      timeZone = record[PLANTING_SITES.TIME_ZONE],
   )
 
   fun equals(other: Any?, tolerance: Double): Boolean {
@@ -110,6 +115,8 @@ data class PlantingSiteModel(
         id == other.id &&
         name == other.name &&
         timeZone == other.timeZone &&
+        plantingSeasonEndMonth == other.plantingSeasonEndMonth &&
+        plantingSeasonStartMonth == other.plantingSeasonStartMonth &&
         plantingZones.size == other.plantingZones.size &&
         plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) } &&
         (boundary == null && other.boundary == null ||

--- a/src/main/resources/db/migration/0151/V187__PlantingSiteDates.sql
+++ b/src/main/resources/db/migration/0151/V187__PlantingSiteDates.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tracking.planting_sites ADD COLUMN planting_season_start_month INTEGER;
+ALTER TABLE tracking.planting_sites ADD COLUMN planting_season_end_month INTEGER;
+
+ALTER TABLE tracking.planting_sites ADD CONSTRAINT start_month_valid
+    CHECK (planting_season_start_month BETWEEN 1 AND 12);
+ALTER TABLE tracking.planting_sites ADD CONSTRAINT end_month_valid
+    CHECK (planting_season_end_month BETWEEN 1 AND 12);

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -92,6 +92,16 @@
 
 </head>
 
+<!--/* Renders a month selector. */-->
+<select th:fragment="monthSelect (id,value)" th:id="${id}" th:name="${id}" th:if="${id}">
+    <option value="" th:selected="${value == null}">--</option>
+    <option th:each="month : ${months}"
+            th:value="${month.key}"
+            th:text="${month.value}"
+            th:selected="${value == month.key}">
+    </option>
+</select>
+
 <body>
 
 <th:block th:include="/admin/header :: top"/>
@@ -108,6 +118,10 @@
            required/>
     <label for="description">Description</label>
     <input type="text" id="description" name="description" th:value="${site.description}"/>
+    <label for="plantingSeasonStartMonth">Planting Season Start</label>
+    <select th:replace="::monthSelect ('plantingSeasonStartMonth', ${site.plantingSeasonStartMonth})"/>
+    <label for="plantingSeasonEndMonth">Planting Season End</label>
+    <select th:replace="::monthSelect ('plantingSeasonEndMonth', ${site.plantingSeasonEndMonth})"/>
     <br/>
     <input type="submit" value="Update"/>
 </form>


### PR DESCRIPTION
Add optional planting season start and end month fields to planting sites.
These will be used to determine the schedule for the site's observations.