### PR TITLE
SW-3527 Allow Dashes in Scientific Names During Import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.importer.CsvImporter
 import com.terraformation.backend.species.model.NewSpeciesModel
+import com.terraformation.backend.species.model.normalizeScientificName
 import java.io.InputStream
 import javax.inject.Named
 import org.jobrunr.jobs.JobId
@@ -117,7 +118,7 @@ class SpeciesImporter(
           .map { rawValues -> rawValues.map { it.trim().ifEmpty { null } } }
           .map { values ->
             NewSpeciesModel(
-                scientificName = values[0]!!,
+                scientificName = normalizeScientificName(values[0]!!),
                 commonName = values[1],
                 familyName = values[2],
                 endangered = values[3]?.let { it in trueValues },

--- a/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.species.model
 
-private val invalidScientificNameChars = Regex("[^A-Za-z. —–-]")
+private val invalidScientificNameChars = Regex("[^A-Za-z. -]")
 
 /**
  * Validates the syntax of a scientific name. This does not check for higher-level conditions such
@@ -13,15 +13,25 @@ fun validateScientificNameSyntax(
     onTooLong: () -> Unit,
     onInvalidCharacter: (String) -> Unit
 ) {
-  val invalidChar = invalidScientificNameChars.find(value)?.value
+  val normalizedValue = normalizeScientificName(value)
+  val invalidChar = invalidScientificNameChars.find(normalizedValue)?.value
   if (invalidChar != null) {
     onInvalidCharacter(invalidChar)
   }
 
-  val wordCount = value.split(' ').size
+  val wordCount = normalizedValue.split(' ').size
   if (wordCount < 2) {
     onTooShort()
   } else if (wordCount > 4) {
     onTooLong()
   }
+}
+
+/**
+ * Normalizes the scientific name for a species. Normalizations performed include:
+ * - replace en- and em-dashes with hyphens
+ */
+fun normalizeScientificName(value: String): String {
+  // normalize dashes
+  return value.replace(Regex("[—–]"), "-")
 }

--- a/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/Validation.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.species.model
 
-private val invalidScientificNameChars = Regex("[^A-Za-z. ]")
+private val invalidScientificNameChars = Regex("[^A-Za-z. —–-]")
 
 /**
  * Validates the syntax of a scientific name. This does not check for higher-level conditions such

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
@@ -106,8 +106,8 @@ internal class SpeciesCsvValidatorTest {
                 "Name name subsp. name",
                 "Name name f. name",
                 "Name-name Name-name-name",
-                "Name–name Name–name–name",
-                "Name—name Name—name—name",
+                "Name–name Name–name–name", // en-dashes are converted to hyphens
+                "Name—name Name—name—name", // em-dashes are converted to hyphens
             ])
     fun `valid name formats are accepted`(scientificName: String) {
       assertValidationResults(csvWithScientificName(scientificName))

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
@@ -93,7 +93,7 @@ internal class SpeciesCsvValidatorTest {
     }
 
     @Test
-    fun `may not contain punctuation other than periods`() {
+    fun `may not contain punctuation other than periods or dashes`() {
       assertError("Name name var: x", MalformedValue, messages.csvScientificNameInvalidChar(":"))
     }
 
@@ -105,6 +105,9 @@ internal class SpeciesCsvValidatorTest {
                 "Name name var. name",
                 "Name name subsp. name",
                 "Name name f. name",
+                "Name-name Name-name-name",
+                "Name–name Name–name–name",
+                "Name—name Name—name—name",
             ])
     fun `valid name formats are accepted`(scientificName: String) {
       assertValidationResults(csvWithScientificName(scientificName))

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -308,10 +308,10 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `importCsv creates new species`() {
+  fun `importCsv creates new species with normalized scientific name`() {
     every { fileStore.read(storageUrl) } returns
         sizedInputStream(
-            "$header\nNew name,Common,Family,true,false,Shrub,Recalcitrant,\"Tundra \r\n Mangroves \r\n\"")
+            "$header\nNew—name a–b,Common,Family,true,false,Shrub,Recalcitrant,\"Tundra \r\n Mangroves \r\n\"") // note the dash types in the scientific name
     insertUpload(
         uploadId,
         organizationId = organizationId,
@@ -326,8 +326,8 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
             SpeciesRow(
                 id = SpeciesId(1),
                 organizationId = organizationId,
-                scientificName = "New name",
-                initialScientificName = "New name",
+                scientificName = "New-name a-b", // dashes replaced by hyphens
+                initialScientificName = "New-name a-b",
                 commonName = "Common",
                 familyName = "Family",
                 endangered = true,


### PR DESCRIPTION
Update the import validator to allow dashes in scientific names. We allow for
all three types of dashes that might be encountered, hyphen, en-, and em-.
Also update the tests to account for this change. 