### PR TITLE
SW-3548 Calculate planting site areas

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,7 @@ dependencies {
   implementation("org.apache.tika:tika-core:2.7.0")
   implementation("org.flywaydb:flyway-core:9.17.0")
   implementation("org.freemarker:freemarker:2.3.32")
+  implementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
   implementation("org.geotools:gt-shapefile:$geoToolsVersion")
   implementation("org.jobrunr:jobrunr-spring-boot-starter:5.3.3")
   implementation("org.jooq:jooq:$jooqVersion")

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -235,6 +235,7 @@ class PlantingSiteStore(
 
     return DSL.multiset(
             DSL.select(
+                    PLANTING_SUBZONES.AREA_HA,
                     PLANTING_SUBZONES.ID,
                     PLANTING_SUBZONES.FULL_NAME,
                     PLANTING_SUBZONES.NAME,
@@ -246,6 +247,7 @@ class PlantingSiteStore(
         .convertFrom { result ->
           result.map { record: Record ->
             PlantingSubzoneModel(
+                record[PLANTING_SUBZONES.AREA_HA]!!,
                 record[plantingSubzoneBoundaryField]!! as MultiPolygon,
                 record[PLANTING_SUBZONES.ID]!!,
                 record[PLANTING_SUBZONES.FULL_NAME]!!,
@@ -266,6 +268,7 @@ class PlantingSiteStore(
 
     return DSL.multiset(
             DSL.select(
+                    PLANTING_ZONES.AREA_HA,
                     PLANTING_ZONES.ERROR_MARGIN,
                     PLANTING_ZONES.ID,
                     PLANTING_ZONES.NAME,
@@ -281,6 +284,7 @@ class PlantingSiteStore(
         .convertFrom { result ->
           result.map { record: Record ->
             PlantingZoneModel(
+                record[PLANTING_ZONES.AREA_HA]!!,
                 record[plantingZonesBoundaryField]!! as MultiPolygon,
                 record[PLANTING_ZONES.ERROR_MARGIN],
                 record[PLANTING_ZONES.ID]!!,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -42,6 +42,7 @@ data class MonitoringPlotModel(
 }
 
 data class PlantingSubzoneModel(
+    val areaHa: BigDecimal,
     val boundary: MultiPolygon,
     val id: PlantingSubzoneId,
     val fullName: String,
@@ -53,12 +54,14 @@ data class PlantingSubzoneModel(
         id == other.id &&
         fullName == other.fullName &&
         name == other.name &&
+        areaHa.equalsIgnoreScale(other.areaHa) &&
         monitoringPlots.zip(other.monitoringPlots).all { it.first.equals(it.second, tolerance) } &&
         boundary.equalsExact(other.boundary, tolerance)
   }
 }
 
 data class PlantingZoneModel(
+    val areaHa: BigDecimal,
     val boundary: MultiPolygon,
     val errorMargin: BigDecimal? = null,
     val id: PlantingZoneId,
@@ -75,6 +78,7 @@ data class PlantingZoneModel(
         name == other.name &&
         numPermanentClusters == other.numPermanentClusters &&
         numTemporaryPlots == other.numTemporaryPlots &&
+        areaHa.equalsIgnoreScale(other.areaHa) &&
         errorMargin.equalsIgnoreScale(other.errorMargin) &&
         studentsT.equalsIgnoreScale(other.studentsT) &&
         variance.equalsIgnoreScale(other.variance) &&
@@ -84,6 +88,7 @@ data class PlantingZoneModel(
 }
 
 data class PlantingSiteModel(
+    val areaHa: BigDecimal? = null,
     val boundary: MultiPolygon?,
     val description: String?,
     val id: PlantingSiteId,
@@ -98,6 +103,7 @@ data class PlantingSiteModel(
       record: Record,
       plantingZonesMultiset: Field<List<PlantingZoneModel>>? = null
   ) : this(
+      areaHa = record[PLANTING_SITES.AREA_HA],
       boundary = record[PLANTING_SITES.BOUNDARY] as? MultiPolygon,
       description = record[PLANTING_SITES.DESCRIPTION],
       id = record[PLANTING_SITES.ID]!!,
@@ -118,6 +124,7 @@ data class PlantingSiteModel(
         plantingSeasonEndMonth == other.plantingSeasonEndMonth &&
         plantingSeasonStartMonth == other.plantingSeasonStartMonth &&
         plantingZones.size == other.plantingZones.size &&
+        areaHa.equalsIgnoreScale(other.areaHa) &&
         plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) } &&
         (boundary == null && other.boundary == null ||
             boundary != null &&
@@ -169,3 +176,6 @@ enum class PlantingSiteDepth {
   Subzone,
   Plot
 }
+
+/** Number of square meters in a hectare. */
+const val SQUARE_METERS_PER_HECTARE: Double = 10000.0

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
@@ -8,9 +8,15 @@ import java.util.zip.ZipFile
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.extension
 import org.geotools.data.DataStoreFinder
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
+import org.geotools.referencing.operation.projection.TransverseMercator
 import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.Point
 import org.opengis.feature.simple.SimpleFeature
 import org.opengis.filter.Filter
+import org.opengis.referencing.FactoryException
 import org.opengis.referencing.crs.CoordinateReferenceSystem
 
 /** Simplified representation of the data about a single feature from a shapefile. */
@@ -19,6 +25,38 @@ data class ShapefileFeature(
     val properties: Map<String, String>,
     val coordinateReferenceSystem: CoordinateReferenceSystem,
 ) {
+  /**
+   * Calculates the approximate area of a shapefile feature in hectares. If the feature isn't
+   * already in a UTM coordinate system, converts it to the appropriate one first.
+   *
+   * @throws FactoryException The feature couldn't be converted to UTM.
+   */
+  fun calculateAreaHectares(): Double {
+    // Transform feature to UTM if it isn't already.
+    val utmGeometry =
+        if (CRS.getProjectedCRS(coordinateReferenceSystem) is TransverseMercator) {
+          this.geometry
+        } else {
+          // To use the "look up the right UTM for a location" feature of GeoTools, we need to
+          // know the location in WGS84 (EPSG:4326) longitude and latitude; transform the feature's
+          // centroid coordinates to WGS84.
+          val wgs84Centroid =
+              if (CRS.lookupEpsgCode(coordinateReferenceSystem, false) == SRID.LONG_LAT) {
+                geometry.centroid
+              } else {
+                val wgs84Transform =
+                    CRS.findMathTransform(coordinateReferenceSystem, DefaultGeographicCRS.WGS84)
+                JTS.transform(geometry.centroid, wgs84Transform) as Point
+              }
+
+          val utmCrs = CRS.decode("AUTO2:42001,${wgs84Centroid.x},${wgs84Centroid.y}")
+
+          JTS.transform(geometry, CRS.findMathTransform(coordinateReferenceSystem, utmCrs))
+        }
+
+    return utmGeometry.area / SQUARE_METERS_PER_HECTARE
+  }
+
   companion object {
     fun fromGeotools(feature: SimpleFeature): ShapefileFeature {
       val defaultGeometry = feature.defaultGeometry as Geometry

--- a/src/main/resources/db/migration/0151/V188__PlantingSiteAreas.sql
+++ b/src/main/resources/db/migration/0151/V188__PlantingSiteAreas.sql
@@ -1,0 +1,23 @@
+ALTER TABLE tracking.planting_sites ADD COLUMN area_ha NUMERIC;
+ALTER TABLE tracking.planting_zones ADD COLUMN area_ha NUMERIC;
+ALTER TABLE tracking.planting_subzones ADD COLUMN area_ha NUMERIC;
+
+-- Area must be calculated during shapefile import, so we don't want it to have a default,
+-- but sites in existing test databases need to be made valid.
+UPDATE tracking.planting_zones
+SET area_ha = 1
+WHERE area_ha IS NULL;
+
+UPDATE tracking.planting_subzones
+SET area_ha = 1
+WHERE area_ha IS NULL;
+
+ALTER TABLE tracking.planting_zones ALTER COLUMN area_ha SET NOT NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN boundary SET NOT NULL;
+
+ALTER TABLE tracking.planting_subzones ALTER COLUMN area_ha SET NOT NULL;
+ALTER TABLE tracking.planting_subzones ALTER COLUMN boundary SET NOT NULL;
+
+ALTER TABLE tracking.planting_sites ADD CONSTRAINT area_positive CHECK (area_ha > 0);
+ALTER TABLE tracking.planting_zones ADD CONSTRAINT area_positive CHECK (area_ha > 0);
+ALTER TABLE tracking.planting_subzones ADD CONSTRAINT area_positive CHECK (area_ha > 0);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -110,6 +110,8 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
+import com.terraformation.backend.multiPolygon
+import java.math.BigDecimal
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
@@ -767,6 +769,7 @@ abstract class DatabaseTest {
 
   fun insertPlantingSite(
       row: PlantingSitesRow = PlantingSitesRow(),
+      areaHa: BigDecimal? = row.areaHa,
       boundary: Geometry? = row.boundary,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
@@ -779,6 +782,7 @@ abstract class DatabaseTest {
   ): PlantingSiteId {
     val rowWithDefaults =
         row.copy(
+            areaHa = areaHa,
             boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,
@@ -799,7 +803,8 @@ abstract class DatabaseTest {
 
   fun insertPlantingZone(
       row: PlantingZonesRow = PlantingZonesRow(),
-      boundary: Geometry? = row.boundary,
+      areaHa: BigDecimal = row.areaHa ?: BigDecimal.TEN,
+      boundary: Geometry = row.boundary ?: multiPolygon(1.0),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,
@@ -811,6 +816,7 @@ abstract class DatabaseTest {
   ): PlantingZoneId {
     val rowWithDefaults =
         row.copy(
+            areaHa = areaHa,
             boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,
@@ -831,7 +837,8 @@ abstract class DatabaseTest {
 
   fun insertPlantingSubzone(
       row: PlantingSubzonesRow = PlantingSubzonesRow(),
-      boundary: Geometry? = row.boundary,
+      areaHa: BigDecimal = row.areaHa ?: BigDecimal.ONE,
+      boundary: Geometry = row.boundary ?: multiPolygon(1.0),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,
@@ -851,6 +858,7 @@ abstract class DatabaseTest {
 
     val rowWithDefaults =
         row.copy(
+            areaHa = areaHa,
             boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -86,6 +86,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             plantingZones =
                 listOf(
                     PlantingZoneModel(
+                        areaHa = BigDecimal.TEN,
                         boundary = multiPolygon(2.0),
                         id = plantingZoneId,
                         name = "Z1",
@@ -101,6 +102,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                         plantingSubzones =
                             listOf(
                                 PlantingSubzoneModel(
+                                    areaHa = BigDecimal.ONE,
                                     boundary = multiPolygon(1.0),
                                     id = plantingSubzoneId,
                                     fullName = "Z1-1",
@@ -188,12 +190,14 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             plantingZones =
                 listOf(
                     PlantingZoneModel(
+                        areaHa = BigDecimal.TEN,
                         boundary = zoneBoundary4326,
                         id = plantingZoneId,
                         name = "Z1",
                         plantingSubzones =
                             listOf(
                                 PlantingSubzoneModel(
+                                    areaHa = BigDecimal.ONE,
                                     boundary = subzoneBoundary4326,
                                     id = plantingSubzoneId,
                                     fullName = "Z1-1",
@@ -332,6 +336,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     insertUser(createdBy)
     val initialRow =
         PlantingZonesRow(
+            areaHa = BigDecimal.ONE,
+            boundary = multiPolygon(1.0),
             createdBy = createdBy,
             createdTime = createdTime,
             errorMargin = null,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileFeatureTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileFeatureTest.kt
@@ -1,0 +1,72 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.SRID
+import org.geotools.referencing.CRS
+import org.geotools.referencing.crs.DefaultGeographicCRS
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.CoordinateXY
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.PrecisionModel
+
+class ShapefileFeatureTest {
+  @Nested
+  inner class CalculateAreaHectares {
+    @Test
+    fun `calculates correct value for UTM coordinates`() {
+      val srid = 21818 // UTM zone 18N
+      val factory = GeometryFactory(PrecisionModel(), srid)
+      val geometry =
+          factory.createMultiPolygon(
+              arrayOf(
+                  factory.createPolygon(
+                      arrayOf(
+                          CoordinateXY(373929.1743, 662471.6669),
+                          CoordinateXY(374819.6281, 662469.8334),
+                          CoordinateXY(374817.2842, 661326.4376),
+                          CoordinateXY(373926.8137, 661328.268),
+                          CoordinateXY(373929.1743, 662471.6669)))))
+      val feature = ShapefileFeature(geometry, emptyMap(), CRS.decode("EPSG:$srid"))
+
+      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+    }
+
+    @Test
+    fun `calculates correct value for WGS84 coordinates`() {
+      val factory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+      val geometry =
+          factory.createMultiPolygon(
+              arrayOf(
+                  factory.createPolygon(
+                      arrayOf(
+                          CoordinateXY(-76.13567116641384, 5.989357251936355),
+                          CoordinateXY(-76.12762679268639, 5.989357251773201),
+                          CoordinateXY(-76.12762679270281, 5.979015683955292),
+                          CoordinateXY(-76.13567116598097, 5.979015684419131),
+                          CoordinateXY(-76.13567116641384, 5.989357251936355)))))
+      val feature = ShapefileFeature(geometry, emptyMap(), DefaultGeographicCRS.WGS84)
+
+      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+    }
+
+    @Test
+    fun `calculates correct value for spherical Mercator coordinates`() {
+      val factory = GeometryFactory(PrecisionModel(), SRID.SPHERICAL_MERCATOR)
+      val geometry =
+          factory.createMultiPolygon(
+              arrayOf(
+                  factory.createPolygon(
+                      arrayOf(
+                          CoordinateXY(-8475384.145449309, 667949.7974625841),
+                          CoordinateXY(-8474488.649862219, 667949.7974443221),
+                          CoordinateXY(-8474488.649864046, 666792.2716823813),
+                          CoordinateXY(-8475384.145401122, 666792.2717342979),
+                          CoordinateXY(-8475384.145449309, 667949.7974625841)))))
+      val feature =
+          ShapefileFeature(geometry, emptyMap(), CRS.decode("EPSG:${SRID.SPHERICAL_MERCATOR}"))
+
+      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+    }
+  }
+}


### PR DESCRIPTION
Planting density is calculated as number of plants per unit of area, so we need to
know the areas of planting sites and their subdivisions. This can be calculated on
the fly from the boundaries, but it never changes, so calculate it at import time.