### PR TITLE
Use separate map layer for permanent plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -278,14 +278,21 @@ class AdminController(
                 val numPermanent = zone.numPermanentClusters ?: 0
 
                 zone.plantingSubzones.flatMap { subzone ->
+                  val permanentPlotIds =
+                      subzone.monitoringPlots
+                          .filter {
+                            it.permanentCluster != null && it.permanentCluster <= numPermanent
+                          }
+                          .map { it.id }
+                          .toSet()
+
                   subzone.monitoringPlots.map { plot ->
                     val properties =
-                        if (plot.permanentCluster != null &&
-                            plot.permanentCluster <= numPermanent) {
-                          mapOf("permanent" to "true")
-                        } else {
-                          emptyMap()
+                        when (plot.id) {
+                          in permanentPlotIds -> mapOf("type" to "permanent")
+                          else -> emptyMap()
                         }
+
                     mapOf(
                         "type" to "Feature",
                         "properties" to properties,

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -268,15 +268,33 @@
                 id: 'plots',
                 type: 'line',
                 source: 'plots',
+                filter: [
+                    'match',
+                    ['get', 'type'],
+                    'permanent',
+                    false,
+                    true,
+                ],
                 layout: {},
                 paint: {
-                    'line-color': [
-                        'match',
-                        ['get', 'permanent'],
-                        'true',
-                        'lightgreen',
-                        'green',
-                    ],
+                    'line-color': 'green'
+                }
+            });
+
+            map.addLayer({
+                id: 'permanentPlots',
+                type: 'line',
+                source: 'plots',
+                filter: [
+                    'match',
+                    ['get', 'type'],
+                    'permanent',
+                    true,
+                    false,
+                ],
+                layout: {},
+                paint: {
+                    'line-color': 'lightgreen',
                 }
             });
 


### PR DESCRIPTION
When showing the map of a planting site in the admin UI, we highlight permanent
monitoring plots. Previously, this was done by selecting the line color, but that
meant that on the grid of plots, only the left and bottom borders were colored
because the right and top ones were overwritten by other grid cells.

Add a separate layer for permanent plots so they show up more distinctly on the
map. Restructure the way the plot types are labeled in the GeoJSON data so that
it will be possible to do the same for temporary plots later.