### PR TITLE
Show planting site map in popup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -224,6 +224,16 @@ class AdminController(
     model.addAttribute("prefix", prefix)
     model.addAttribute("site", plantingSite)
 
+    return "/admin/plantingSite"
+  }
+
+  @GetMapping("/plantingSite/{plantingSiteId}/map")
+  fun getPlantingSiteMap(@PathVariable plantingSiteId: PlantingSiteId, model: Model): String {
+    val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Subzone)
+
+    model.addAttribute("prefix", prefix)
+    model.addAttribute("site", plantingSite)
+
     if (plantingSite.boundary != null) {
       model.addAttribute("envelope", objectMapper.valueToTree(plantingSite.boundary.envelope))
       model.addAttribute("siteGeoJson", objectMapper.valueToTree(plantingSite.boundary))
@@ -233,7 +243,7 @@ class AdminController(
       model.addAttribute("mapboxToken", mapboxService.generateTemporaryToken())
     }
 
-    return "/admin/plantingSite"
+    return "/admin/plantingSiteMap"
   }
 
   @GetMapping("/plantingSite/{plantingSiteId}/plots", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -15,11 +15,6 @@
             display: block;
         }
 
-        #map {
-            width: 100%;
-            height: 600px;
-        }
-
         table#plotCounts input {
             text-align: right;
         }
@@ -34,9 +29,7 @@
     </style>
 
     <th:block th:fragment="additionalScript">
-        <link href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css" rel="stylesheet">
-        <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
-        <script>
+        <script th:inline="javascript">
             function registerPlotCalculator(zoneId) {
                 const errorMarginField = document.getElementById(`errorMargin-${zoneId}`);
                 const permanentPlotsField = document.getElementById(`numPermanent-${zoneId}`);
@@ -86,6 +79,16 @@
                 varianceField.addEventListener('change', recalculatePermanentPlots);
                 permanentPlotsField.addEventListener('change', recalculateTemporaryPlots);
                 temporaryPlotsField.addEventListener('change', recalculateTotalPlots);
+            }
+
+            function showMapPopup() {
+                /*<![CDATA[*/
+                const prefix = /*[[${prefix}]]*/;
+                const envelope = /*[[${envelope}]]*/;
+                const siteId = /*[[${site.id}]]*/;
+                /*]]>*/
+
+                window.open(`${prefix}/plantingSite/${siteId}/map`);
             }
         </script>
     </th:block>
@@ -223,131 +226,11 @@
         </table>
     </th:block>
 
-    <h3>Site Map</h3>
-
-    <div id="map"></div>
-
-    <script th:inline="javascript">
-        /*<![CDATA[*/
-        mapboxgl.accessToken = /*[[${mapboxToken}]]*/;
-
-        const prefix = /*[[${prefix}]]*/;
-        const envelope = /*[[${envelope}]]*/;
-        const siteId = /*[[${site.id}]]*/;
-        const bounds = new mapboxgl.LngLatBounds(envelope.coordinates[0][0], envelope.coordinates[0][2]);
-
-        const map = new mapboxgl.Map({
-            bounds: bounds,
-            container: 'map',
-            fitBoundsOptions: { padding: 10 },
-            style: 'mapbox://styles/mapbox/satellite-streets-v12',
-        });
-
-        map.on('load', () => {
-            map.addSource('site', {
-                type: 'geojson',
-                data: /*[[${siteGeoJson}]]*/,
-            });
-
-            map.addSource('zones', {
-                type: 'geojson',
-                data: /*[[${zonesGeoJson}]]*/,
-            });
-
-            map.addSource('subzones', {
-                type: 'geojson',
-                data: /*[[${subzonesGeoJson}]]*/,
-            });
-
-            map.addSource('plots', {
-                type: 'geojson',
-                data: `${prefix}/plantingSite/${siteId}/plots`,
-            });
-
-            map.addLayer({
-                id: 'plots',
-                type: 'line',
-                source: 'plots',
-                filter: [
-                    'match',
-                    ['get', 'type'],
-                    'permanent',
-                    false,
-                    true,
-                ],
-                layout: {},
-                paint: {
-                    'line-color': 'green'
-                }
-            });
-
-            map.addLayer({
-                id: 'permanentPlots',
-                type: 'line',
-                source: 'plots',
-                filter: [
-                    'match',
-                    ['get', 'type'],
-                    'permanent',
-                    true,
-                    false,
-                ],
-                layout: {},
-                paint: {
-                    'line-color': 'lightgreen',
-                }
-            });
-
-            map.addLayer({
-                id: 'subzones',
-                type: 'line',
-                source: 'subzones',
-                layout: {},
-                paint: {
-                    'line-color': 'grey',
-                }
-            });
-
-            map.addLayer({
-                id: 'zones',
-                type: 'line',
-                source: 'zones',
-                layout: {},
-                paint: {
-                    'line-color': 'yellow',
-                }
-            });
-
-            map.addLayer({
-                id: 'zoneLabels',
-                type: 'symbol',
-                source: 'zones',
-                layout: {
-                    'text-field': ['get', 'name'],
-                },
-                paint: {
-                    'text-color': 'yellow',
-                    'text-halo-color': 'black',
-                    'text-halo-width': 2,
-                }
-            });
-
-            map.addLayer({
-                id: 'site',
-                type: 'line',
-                source: 'site',
-                layout: {},
-                paint: {
-                    'line-color': 'white',
-                }
-            });
-        });
-        /*]]>*/
-    </script>
-
     <h3 th:text="|Planting Zones (${numPlantingZones}) and Subzones (${numSubzones}) and Monitoring Plots (${numPlots})|">
         Planting Zones (1) and Subzones (2) and Monitoring Plots (3)
     </h3>
+
+    <button onclick="showMapPopup()">Click to View Map</button> (opens in new window)
 
     <ul>
         <li th:each="zone : ${site.plantingZones}">

--- a/src/main/resources/templates/admin/plantingSiteMap.html
+++ b/src/main/resources/templates/admin/plantingSiteMap.html
@@ -1,0 +1,152 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title th:text="${site.name}">Planting Site Name</title>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        #map {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css" rel="stylesheet">
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
+</head>
+
+<body>
+
+<h1 th:if="${site.plantingZones.isEmpty()}">This planting site has no map data.</h1>
+
+<th:block th:if="!${site.plantingZones.isEmpty()}">
+
+    <div id="map"></div>
+
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        mapboxgl.accessToken = /*[[${mapboxToken}]]*/;
+
+        const prefix = /*[[${prefix}]]*/;
+        const envelope = /*[[${envelope}]]*/;
+        const siteId = /*[[${site.id}]]*/;
+        const bounds = new mapboxgl.LngLatBounds(envelope.coordinates[0][0], envelope.coordinates[0][2]);
+
+        const map = new mapboxgl.Map({
+            bounds: bounds,
+            container: 'map',
+            fitBoundsOptions: { padding: 10 },
+            style: 'mapbox://styles/mapbox/satellite-streets-v12',
+        });
+
+        map.on('load', () => {
+            map.addSource('site', {
+                type: 'geojson',
+                data: /*[[${siteGeoJson}]]*/,
+            });
+
+            map.addSource('zones', {
+                type: 'geojson',
+                data: /*[[${zonesGeoJson}]]*/,
+            });
+
+            map.addSource('subzones', {
+                type: 'geojson',
+                data: /*[[${subzonesGeoJson}]]*/,
+            });
+
+            map.addSource('plots', {
+                type: 'geojson',
+                data: `${prefix}/plantingSite/${siteId}/plots`,
+            });
+
+            map.addLayer({
+                id: 'plots',
+                type: 'line',
+                source: 'plots',
+                filter: [
+                    'match',
+                    ['get', 'type'],
+                    'permanent',
+                    false,
+                    true,
+                ],
+                layout: {},
+                paint: {
+                    'line-color': 'green'
+                }
+            });
+
+            map.addLayer({
+                id: 'permanentPlots',
+                type: 'line',
+                source: 'plots',
+                filter: [
+                    'match',
+                    ['get', 'type'],
+                    'permanent',
+                    true,
+                    false,
+                ],
+                layout: {},
+                paint: {
+                    'line-color': 'lightgreen',
+                }
+            });
+
+            map.addLayer({
+                id: 'subzones',
+                type: 'line',
+                source: 'subzones',
+                layout: {},
+                paint: {
+                    'line-color': 'grey',
+                }
+            });
+
+            map.addLayer({
+                id: 'zones',
+                type: 'line',
+                source: 'zones',
+                layout: {},
+                paint: {
+                    'line-color': 'yellow',
+                }
+            });
+
+            map.addLayer({
+                id: 'zoneLabels',
+                type: 'symbol',
+                source: 'zones',
+                layout: {
+                    'text-field': ['get', 'name'],
+                },
+                paint: {
+                    'text-color': 'yellow',
+                    'text-halo-color': 'black',
+                    'text-halo-width': 2,
+                }
+            });
+
+            map.addLayer({
+                id: 'site',
+                type: 'line',
+                source: 'site',
+                layout: {},
+                paint: {
+                    'line-color': 'white',
+                }
+            });
+        });
+        /*]]>*/
+    </script>
+
+</th:block>
+
+</body>
+</html>


### PR DESCRIPTION
To avoid cluttering the admin UI, the inline map on the planting site page had a
fixed height, which made it awkward to view sites with tall thin shapes. Move
the map to a popup window that can be resized as the user sees fit.