### PR TITLE
SW-3509 Handle duplicate accession photo filenames

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -115,6 +115,8 @@ class PhotoRepository(
         .on(FILES.ID.eq(ACCESSION_PHOTOS.FILE_ID))
         .where(ACCESSION_PHOTOS.ACCESSION_ID.eq(accessionId))
         .and(FILES.FILE_NAME.eq(filename))
+        .orderBy(FILES.CREATED_TIME.desc())
+        .limit(1)
         .fetchOneInto(FilesRow::class.java)
         ?: throw NoSuchFileException(filename)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -168,7 +168,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `readPhoto reads newest file with the requested filename`() {
-    val randm = Random(System.currentTimeMillis())
+    val random = Random(System.currentTimeMillis())
     val photoData1 = random.nextBytes(1000)
     val photoData2 = random.nextBytes(1000)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -29,7 +29,6 @@ import io.mockk.spyk
 import io.mockk.verify
 import java.io.ByteArrayInputStream
 import java.net.URI
-import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -41,6 +40,7 @@ import kotlin.random.Random
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -141,40 +141,34 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `storePhoto does not insert database row if file exists`() {
-    Files.createDirectories(photoPath.parent)
-    Files.createFile(photoPath)
+  fun `storePhoto replaces existing photo with same filename`() {
+    val photoData1 = byteArrayOf(1, 2, 3)
+    val photoData2 = byteArrayOf(4, 5, 6)
 
-    assertThrows(FileAlreadyExistsException::class.java) {
-      repository.storePhoto(accessionId, ByteArray(0).inputStream(), metadata)
-    }
+    every { thumbnailStore.deleteThumbnails(any()) } just Runs
 
-    val photosWritten = accessionPhotosDao.findAll()
-    assertEquals(0, photosWritten.size, "Should be 0 photos in database")
+    repository.storePhoto(accessionId, photoData1.inputStream(), metadata)
+    every { random.nextLong() } returns 1
+    repository.storePhoto(accessionId, photoData2.inputStream(), metadata)
 
-    assertTrue(Files.exists(photoPath), "Existing file should not be removed")
-  }
-
-  @Test
-  fun `readPhoto reads existing photo file`() {
-    val photoData = Random(System.currentTimeMillis()).nextBytes(1000)
-
-    repository.storePhoto(accessionId, photoData.inputStream(), metadata)
+    assertFalse(Files.exists(photoPath), "Earlier photo file should have been deleted")
+    assertEquals(1, accessionPhotosDao.fetchByAccessionId(accessionId).size, "Number of photos")
 
     val stream = repository.readPhoto(accessionId, filename)
 
-    assertArrayEquals(photoData, stream.readAllBytes())
+    assertArrayEquals(photoData2, stream.readAllBytes())
   }
 
   @Test
-  fun `readPhoto reads newest file with the requested filename`() {
-    val random = Random(System.currentTimeMillis())
-    val photoData1 = random.nextBytes(1000)
-    val photoData2 = random.nextBytes(1000)
+  fun `readPhoto reads newest existing photo file`() {
+    val photoData1 = byteArrayOf(1, 2, 3)
+    val photoData2 = byteArrayOf(4, 5, 6)
 
     repository.storePhoto(accessionId, photoData1.inputStream(), metadata)
-    clock.instant = clock.instant.plusSeconds(1)
-    repository.storePhoto(accessionId, photoData2.inputStream(), metadata)
+    every { random.nextLong() } returns 1
+    repository.storePhoto(accessionId, photoData2.inputStream(), metadata.copy(filename = "dupe"))
+
+    filesDao.update(filesDao.findAll().map { it.copy(fileName = filename) })
 
     val stream = repository.readPhoto(accessionId, filename)
 
@@ -214,6 +208,22 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     verify { thumbnailStore.getThumbnailData(fileId, width, height) }
 
     assertArrayEquals(thumbnailData, stream.readAllBytes())
+  }
+
+  @Test
+  fun `listPhotos does not return duplicate filenames`() {
+    val photoData = byteArrayOf(1, 2, 3)
+
+    every { random.nextLong() } returns 1
+    repository.storePhoto(accessionId, photoData.inputStream(), metadata.copy(filename = "1"))
+    every { random.nextLong() } returns 2
+    repository.storePhoto(accessionId, photoData.inputStream(), metadata.copy(filename = "2"))
+    every { random.nextLong() } returns 3
+    repository.storePhoto(accessionId, photoData.inputStream(), metadata.copy(filename = "3"))
+
+    filesDao.update(filesDao.findAll().map { it.copy(fileName = "1") })
+
+    assertEquals(1, repository.listPhotos(accessionId).size, "Number of photos")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -167,6 +167,21 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `readPhoto reads newest file with the requested filename`() {
+    val randm = Random(System.currentTimeMillis())
+    val photoData1 = random.nextBytes(1000)
+    val photoData2 = random.nextBytes(1000)
+
+    repository.storePhoto(accessionId, photoData1.inputStream(), metadata)
+    clock.instant = clock.instant.plusSeconds(1)
+    repository.storePhoto(accessionId, photoData2.inputStream(), metadata)
+
+    val stream = repository.readPhoto(accessionId, filename)
+
+    assertArrayEquals(photoData2, stream.readAllBytes())
+  }
+
+  @Test
   fun `readPhoto throws exception on nonexistent file`() {
     assertThrows(NoSuchFileException::class.java) { repository.readPhoto(accessionId, filename) }
   }


### PR DESCRIPTION
Initially, all the metadata about accession photos was stored in a single table
that had a unique constraint to enforce that a given accession could only have
one photo with a given filename. When the table was split up to add support for
nursery withdrawal photos, we lost that unique constraint and thus the server
started accepting uploads of accession photos with duplicate filenames.

When a client attempted to read one of those photos, the request would fail
because the server still assumed filenames were unique and a database query
that was expected to return a single row instead returned multiple rows.

Change the upload API so that uploading a photo overwrites any existing photo 
with the same filename on the same accession. To handle the duplicates that
already exist in the database, update the database queries to only return the
newest file with a given filename.