### PR TITLE
Show area and reported plants in each subzone

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -198,6 +198,7 @@ class AdminController(
   fun getPlantingSite(@PathVariable plantingSiteId: PlantingSiteId, model: Model): String {
     val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Subzone)
     val plotCounts = plantingSiteStore.countMonitoringPlots(plantingSiteId)
+    val plantCounts = plantingSiteStore.countReportedPlantsInSubzones(plantingSiteId)
     val organization = organizationStore.fetchOneById(plantingSite.organizationId)
 
     val allOrganizations =
@@ -221,6 +222,7 @@ class AdminController(
     model.addAttribute("numSubzones", plantingSite.plantingZones.sumOf { it.plantingSubzones.size })
     model.addAttribute("numPlots", plotCounts.values.flatMap { it.values }.sum())
     model.addAttribute("organization", organization)
+    model.addAttribute("plantCounts", plantCounts)
     model.addAttribute("plotCounts", plotCounts)
     model.addAttribute("prefix", prefix)
     model.addAttribute("site", plantingSite)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -23,7 +23,6 @@ import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
-import java.math.BigDecimal
 import java.time.InstantSource
 import java.time.Month
 import java.time.ZoneId
@@ -86,18 +85,7 @@ class PlantingSiteStore(
   }
 
   fun fetchPlantedSubzoneIds(plantingSiteId: PlantingSiteId): Set<PlantingSubzoneId> {
-    requirePermissions { readPlantingSite(plantingSiteId) }
-
-    val sumField = DSL.sum(PLANTINGS.NUM_PLANTS)
-
-    return dslContext
-        .select(PLANTINGS.PLANTING_SUBZONE_ID, sumField)
-        .from(PLANTINGS)
-        .where(PLANTINGS.PLANTING_SITE_ID.eq(plantingSiteId))
-        .and(PLANTINGS.PLANTING_SUBZONE_ID.isNotNull)
-        .groupBy(PLANTINGS.PLANTING_SUBZONE_ID)
-        .having(sumField.gt(BigDecimal.ZERO))
-        .fetchSet(PLANTINGS.PLANTING_SUBZONE_ID.asNonNullable())
+    return countReportedPlantsInSubzones(plantingSiteId).filterValues { it > 0 }.keys
   }
 
   fun countMonitoringPlots(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -122,6 +122,21 @@ class PlantingSiteStore(
         .fetchMap(PLANTING_ZONES.ID.asNonNullable(), countBySubzoneField)
   }
 
+  fun countReportedPlantsInSubzones(plantingSiteId: PlantingSiteId): Map<PlantingSubzoneId, Long> {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    val sumField = DSL.sum(PLANTINGS.NUM_PLANTS)
+    return dslContext
+        .select(PLANTING_SUBZONES.ID.asNonNullable(), sumField)
+        .from(PLANTING_SUBZONES)
+        .join(PLANTINGS)
+        .on(PLANTING_SUBZONES.ID.eq(PLANTINGS.PLANTING_SUBZONE_ID))
+        .where(PLANTING_SUBZONES.PLANTING_SITE_ID.eq(plantingSiteId))
+        .groupBy(PLANTING_SUBZONES.ID)
+        .fetch()
+        .associate { it.value1() to it.value2().toLong() }
+  }
+
   fun createPlantingSite(
       organizationId: OrganizationId,
       name: String,

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -10,6 +10,10 @@
             padding: .25em;
         }
 
+        table#subzones>tbody>tr>:nth-child(n+3) {
+            text-align: right;
+        }
+
         label::before {
             content: '';
             display: block;
@@ -226,24 +230,37 @@
         </table>
     </th:block>
 
-    <h3 th:text="|Planting Zones (${numPlantingZones}) and Subzones (${numSubzones}) and Monitoring Plots (${numPlots})|">
-        Planting Zones (1) and Subzones (2) and Monitoring Plots (3)
-    </h3>
+    <h3>Site Details</h3>
 
     <button onclick="showMapPopup()">Click to View Map</button> (opens in new window)
 
-    <ul>
-        <li th:each="zone : ${site.plantingZones}">
-            <th:block th:text="${zone.name}">Zone Name</th:block>
+    <h4 th:text="|Planting Zones (${numPlantingZones}) and Subzones (${numSubzones}) and Monitoring Plots (${numPlots})|">
+        Planting Zones (1) and Subzones (2) and Monitoring Plots (3)
+    </h4>
 
-            <ul th:if="!${zone.plantingSubzones.isEmpty()}">
-                <li th:each="subzone : ${zone.plantingSubzones}"
-                    th:text="|${subzone.name} (${plotCounts[zone.id][subzone.id] ?: 0})|">
-                    Subzone X (50)
-                </li>
-            </ul>
-        </li>
-    </ul>
+    <table id="subzones" class="bordered">
+        <tr>
+            <th>Zone</th>
+            <th>Subzone</th>
+            <th>Area<br/>(ha)</th>
+            <th>Plots</th>
+            <th>Reported<br/>Plants</th>
+        </tr>
+
+        <th:block th:each="zone : ${site.plantingZones}">
+            <tr>
+                <td colspan="5" th:text="${zone.name}">Zone</td>
+            </tr>
+
+            <tr th:each="subzone : ${zone.plantingSubzones}">
+                <td></td>
+                <td th:text="${subzone.name}">Subzone</td>
+                <td th:text="${subzone.areaHa}">123.45</td>
+                <td th:text="${plotCounts[zone.id][subzone.id] ?: 0}">1000</td>
+                <td th:text="${plantCounts[subzone.id] ?: 0}">543</td>
+            </tr>
+        </th:block>
+    </table>
 </th:block>
 
 <script th:if="${canMovePlantingSiteToAnyOrg}">


### PR DESCRIPTION
Include the area in hectares and the number of reported plants in each subzone
on the admin UI's planting site page. These numbers will be used to calculate
reported planting density as well as to determine which subzones are eligible
for monitoring, so being able to view them easily is useful for sanity-checking.