### PR TITLE
SW-3070 Exact Search Performs Substring Search for Selected Fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -36,13 +36,8 @@ class TextField(
     return when (fieldNode.type) {
       SearchFilterType.Exact ->
           DSL.or(
-              listOfNotNull(
-                  if (nonNullValues.isNotEmpty()) {
-                    DSL.lower(databaseField.unaccent()).`in`(nonNullValues)
-                  } else {
-                    null
-                  },
-                  if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+              listOfNotNull(if (fieldNode.values.any { it == null }) databaseField.isNull else null)
+                  .plus(nonNullValues.map { DSL.lower(databaseField).unaccent().contains(it) }))
       SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->
           DSL.or(

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -28,9 +28,8 @@ class UpperCaseTextField(
       SearchFilterType.Exact -> {
         val values = fieldNode.values.mapNotNull { it?.uppercase() }
         DSL.or(
-            listOfNotNull(
-                if (values.isNotEmpty()) databaseField.`in`(values) else null,
-                if (fieldNode.values.any { it == null }) databaseField.isNull else null))
+            listOfNotNull(if (fieldNode.values.any { it == null }) databaseField.isNull else null)
+                .plus(values.map { databaseField.contains(it) }))
       }
       SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy ->

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -59,6 +59,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected val activeField = rootPrefix.resolve("active")
   protected val bagNumberField = rootPrefix.resolve("bagNumber")
   protected val bagNumberFlattenedField = rootPrefix.resolve("bags_number")
+  protected val collectionSiteNameField = rootPrefix.resolve("collectionSiteName")
   protected val facilityIdField = rootPrefix.resolve("facility.id")
   protected val processingNotesField = rootPrefix.resolve("processingNotes")
   protected val receivedDateField = rootPrefix.resolve("receivedDate")


### PR DESCRIPTION
We want to have, for accession numbers and collection sites, among others, exact
search to return results with substring exact matches. This change updates the
TextField and UpperCaseTextField exact search conditions to account for this.
When exact substring matches are found, trigram (fuzzy) search should not
be in effect for exact-or-fuzzy search.