### PR TITLE
Suppress load balancer cookie warning

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -120,3 +120,8 @@ logging:
     # Suppress a warning message about deserialization (Keycloak tries to add a serialization filter
     # in the middle of an object graph). See https://issues.redhat.com/browse/KEYCLOAK-15901
     org.keycloak.common.util.DelegatingSerializationFilter: ERROR
+
+    # Suppress a warning message about invalid "expires" attributes on AWS load balancer cookies,
+    # which is caused by the Keycloak adapter using an out-of-date version of the Apache HTTP
+    # client library.
+    org.apache.http.client.protocol.ResponseProcessCookies: ERROR


### PR DESCRIPTION
The Keycloak adapter uses an out-of-date version of the Apache HTTP client that
doesn't know how to deal with the expiration times on the cookies that are added
by the load balancer that sits in front of our Keycloak instance. It spits out
a warning log message every time the adapter talks to Keycloak, which happens
often enough to add significant log clutter.

The eventual fix will be to stop using the Keycloak adapter (which is deprecated)
but for now, configure the logger to filter out warnings from the class in
question.