### PR TITLE
SW-3600 Make monitoring plot config mandatory

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -290,7 +290,7 @@ class AdminController(
           "type" to "FeatureCollection",
           "features" to
               site.plantingZones.flatMap { zone ->
-                val numPermanent = zone.numPermanentClusters ?: 0
+                val numPermanent = zone.numPermanentClusters
 
                 zone.plantingSubzones.flatMap { subzone ->
                   val permanentPlotIds =
@@ -302,14 +302,10 @@ class AdminController(
                           .toSet()
 
                   val temporaryPlotIds =
-                      if (zone.numTemporaryPlots != null) {
-                        zone
-                            .chooseTemporaryPlots(permanentPlotIds, plantedSubzoneIds)
-                            .map { it.id }
-                            .toSet()
-                      } else {
-                        emptySet()
-                      }
+                      zone
+                          .chooseTemporaryPlots(permanentPlotIds, plantedSubzoneIds)
+                          .map { it.id }
+                          .toSet()
 
                   subzone.monitoringPlots.map { plot ->
                     val properties =

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -63,11 +63,16 @@ class PlantingSiteImporter(
     /** Number of digits after the decimal point to retain in area (hectares) calculations. */
     const val HECTARES_SCALE = 1
 
-    /**
-     * Default value of the "Student's t" parameter for planting zones. This is the value for a 90%
-     * confidence level.
-     */
-    private val DEFAULT_STUDENTS_T = BigDecimal("1.645")
+    // Default values of the three parameters that determine how many monitoring plots should be
+    // required in each observation. The "Student's t" value is a constant based on a 90% confidence
+    // level and should rarely need to change, but the other two will be adjusted by admins based on
+    // the conditions at the planting site. These defaults mean that planting zones will have 12
+    // permanent clusters and 16 temporary plots.
+    val DEFAULT_ERROR_MARGIN = BigDecimal(40)
+    val DEFAULT_STUDENTS_T = BigDecimal("1.645")
+    val DEFAULT_VARIANCE = BigDecimal(6700)
+    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 12
+    const val DEFAULT_NUM_TEMPORARY_PLOTS = 16
 
     const val AZIMUTH_EAST: Double = 90.0
     const val AZIMUTH_NORTH: Double = 0.0
@@ -166,11 +171,15 @@ class PlantingSiteImporter(
                 boundary = zoneFeature.geometry,
                 createdBy = userId,
                 createdTime = now,
+                errorMargin = DEFAULT_ERROR_MARGIN,
                 modifiedBy = userId,
                 modifiedTime = now,
                 name = zoneName,
+                numPermanentClusters = DEFAULT_NUM_PERMANENT_CLUSTERS,
+                numTemporaryPlots = DEFAULT_NUM_TEMPORARY_PLOTS,
                 plantingSiteId = siteId,
                 studentsT = DEFAULT_STUDENTS_T,
+                variance = DEFAULT_VARIANCE,
             )
 
         plantingZonesDao.insert(zonesRow)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -306,14 +306,14 @@ class PlantingSiteStore(
             PlantingZoneModel(
                 record[PLANTING_ZONES.AREA_HA]!!,
                 record[plantingZonesBoundaryField]!! as MultiPolygon,
-                record[PLANTING_ZONES.ERROR_MARGIN],
+                record[PLANTING_ZONES.ERROR_MARGIN]!!,
                 record[PLANTING_ZONES.ID]!!,
                 record[PLANTING_ZONES.NAME]!!,
-                record[PLANTING_ZONES.NUM_PERMANENT_CLUSTERS],
-                record[PLANTING_ZONES.NUM_TEMPORARY_PLOTS],
+                record[PLANTING_ZONES.NUM_PERMANENT_CLUSTERS]!!,
+                record[PLANTING_ZONES.NUM_TEMPORARY_PLOTS]!!,
                 subzonesField?.let { record[it] } ?: emptyList(),
-                record[PLANTING_ZONES.STUDENTS_T],
-                record[PLANTING_ZONES.VARIANCE],
+                record[PLANTING_ZONES.STUDENTS_T]!!,
+                record[PLANTING_ZONES.VARIANCE]!!,
             )
           }
         }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Models.kt
@@ -63,14 +63,14 @@ data class PlantingSubzoneModel(
 data class PlantingZoneModel(
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
-    val errorMargin: BigDecimal? = null,
+    val errorMargin: BigDecimal,
     val id: PlantingZoneId,
     val name: String,
-    val numPermanentClusters: Int? = null,
-    val numTemporaryPlots: Int? = null,
+    val numPermanentClusters: Int,
+    val numTemporaryPlots: Int,
     val plantingSubzones: List<PlantingSubzoneModel>,
-    val studentsT: BigDecimal? = null,
-    val variance: BigDecimal? = null,
+    val studentsT: BigDecimal,
+    val variance: BigDecimal,
 ) {
   /**
    * Chooses a set of plots to act as temporary monitoring plots. The number of plots is determined
@@ -95,11 +95,6 @@ data class PlantingZoneModel(
       permanentPlotIds: Set<MonitoringPlotId>,
       plantedSubzoneIds: Set<PlantingSubzoneId>,
   ): Collection<MonitoringPlotModel> {
-    if (numTemporaryPlots == null) {
-      throw IllegalArgumentException(
-          "Number of temporary plots not configured for planting zone $id")
-    }
-
     if (plantingSubzones.isEmpty()) {
       throw IllegalArgumentException("No subzones found for planting zone $id (wrong fetch depth?)")
     }

--- a/src/main/resources/db/migration/0151/V190__DefaultVarianceAndError.sql
+++ b/src/main/resources/db/migration/0151/V190__DefaultVarianceAndError.sql
@@ -1,0 +1,18 @@
+UPDATE tracking.planting_zones SET error_margin = 40 WHERE error_margin IS NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN error_margin SET NOT NULL;
+
+UPDATE tracking.planting_zones SET variance = 6700 WHERE variance IS NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN variance SET NOT NULL;
+
+UPDATE tracking.planting_zones SET students_t = 1.645 WHERE students_t IS NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN students_t SET NOT NULL;
+
+UPDATE tracking.planting_zones SET num_permanent_clusters = 12 WHERE num_permanent_clusters IS NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN num_permanent_clusters SET NOT NULL;
+ALTER TABLE tracking.planting_zones ADD CONSTRAINT must_have_permanent_clusters
+    CHECK (num_permanent_clusters > 0);
+
+UPDATE tracking.planting_zones SET num_temporary_plots = 16 WHERE num_temporary_plots IS NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN num_temporary_plots SET NOT NULL;
+ALTER TABLE tracking.planting_zones ADD CONSTRAINT must_have_temporary_plots
+    CHECK (num_temporary_plots > 0);

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -36,52 +36,54 @@
         <script th:inline="javascript">
             function registerPlotCalculator(zoneId) {
                 const errorMarginField = document.getElementById(`errorMargin-${zoneId}`);
-                const permanentPlotsField = document.getElementById(`numPermanent-${zoneId}`);
-                const permanent25PlotsField = document.getElementById(`numPermanent25-${zoneId}`);
+                const permanentClustersField = document.getElementById(`numPermanent-${zoneId}`);
+                const permanentPlotsField = document.getElementById(`numPermanent25-${zoneId}`);
                 const studentsTField = document.getElementById(`studentsT-${zoneId}`);
                 const temporaryPlotsField = document.getElementById(`numTemporary-${zoneId}`);
                 const totalPlotsField = document.getElementById(`total25-${zoneId}`);
                 const varianceField = document.getElementById(`variance-${zoneId}`);
 
                 const recalculateTotalPlots = () => {
-                    const permanentPlots = Number.parseFloat(permanentPlotsField.value) || 0;
+                    const permanentClusters = Number.parseFloat(permanentClustersField.value) || 0;
                     const temporaryPlots = Number.parseFloat(temporaryPlotsField.value) || 0;
+                    const totalPlots = (permanentClusters * 4) + temporaryPlots;
 
-                    if (permanentPlots >= 0 && temporaryPlots >= 0) {
-                        totalPlotsField.innerText = (permanentPlots * 4) + temporaryPlots;
-                    }
+                    totalPlotsField.innerText = `${totalPlots}`;
                 };
 
                 const recalculateTemporaryPlots = () => {
-                    const permanentPlots = Number.parseFloat(permanentPlotsField.value);
+                    const permanentClusters = Number.parseFloat(permanentClustersField.value);
+                    const temporaryPlots = Math.floor(permanentClusters * 4 / 3);
 
-                    if (permanentPlots > 0) {
-                        const temporaryPlots = Math.floor(permanentPlots * 4 / 3);
-                        temporaryPlotsField.value = temporaryPlots;
+                    temporaryPlotsField.value = `${temporaryPlots}`;
 
-                        recalculateTotalPlots();
-                    }
+                    recalculateTotalPlots();
                 };
 
                 const recalculatePermanentPlots = () => {
+                    const permanentClusters = Number.parseFloat(permanentClustersField.value);
+                    const permanentPlots = permanentClusters * 4;
+
+                    permanentPlotsField.innerText = `${permanentPlots}`;
+
+                    recalculateTemporaryPlots();
+                };
+
+                const recalculatePermanentClusters = () => {
                     const errorMargin = Number.parseFloat(errorMarginField.value);
                     const studentsT = Number.parseFloat(studentsTField.value);
                     const variance = Number.parseFloat(varianceField.value);
+                    const permanentClusters = Math.ceil((studentsT * studentsT) * variance / errorMargin / errorMargin);
 
-                    if (errorMargin > 0 && studentsT > 0 && variance > 0) {
-                        const permanentPlots = Math.ceil((studentsT * studentsT) * variance / errorMargin / errorMargin);
+                    permanentClustersField.value = `${permanentClusters}`;
 
-                        permanentPlotsField.value = permanentPlots;
-                        permanent25PlotsField.innerText = permanentPlots * 4;
-
-                        recalculateTemporaryPlots();
-                    }
+                    recalculatePermanentPlots();
                 };
 
-                errorMarginField.addEventListener('change', recalculatePermanentPlots);
-                studentsTField.addEventListener('change', recalculatePermanentPlots);
-                varianceField.addEventListener('change', recalculatePermanentPlots);
-                permanentPlotsField.addEventListener('change', recalculateTemporaryPlots);
+                errorMarginField.addEventListener('change', recalculatePermanentClusters);
+                studentsTField.addEventListener('change', recalculatePermanentClusters);
+                varianceField.addEventListener('change', recalculatePermanentClusters);
+                permanentClustersField.addEventListener('change', recalculatePermanentPlots);
                 temporaryPlotsField.addEventListener('change', recalculateTotalPlots);
             }
 
@@ -183,23 +185,23 @@
                 <td th:text="${zone.id}">1</td>
                 <td th:text="${zone.name}">XYZ</td>
                 <td>
-                    <input type="number" step="0.001" name="variance" size="8" th:id="|variance-${zone.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="variance" size="8" th:id="|variance-${zone.id}|"
                            th:value="${zone.variance}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
-                    <input type="number" step="0.001" name="errorMargin" th:id="|errorMargin-${zone.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="errorMargin" th:id="|errorMargin-${zone.id}|"
                            th:value="${zone.errorMargin}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
-                    <input type="number" step="0.001" name="studentsT" th:id="|studentsT-${zone.id}|"
+                    <input type="number" required min="0.001" step="0.001" name="studentsT" th:id="|studentsT-${zone.id}|"
                            th:value="${zone.studentsT}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
-                    <input type="number" name="numPermanent" th:id="|numPermanent-${zone.id}|"
+                    <input type="number" required min="1" name="numPermanent" th:id="|numPermanent-${zone.id}|"
                            th:value="${zone.numPermanentClusters}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
-                    <input type="number" name="numTemporary" th:id="|numTemporary-${zone.id}|"
+                    <input type="number" required min="1" name="numTemporary" th:id="|numTemporary-${zone.id}|"
                            th:value="${zone.numTemporaryPlots}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -111,6 +111,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
 import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import java.math.BigDecimal
 import java.net.URI
 import java.time.Instant
@@ -807,12 +808,19 @@ abstract class DatabaseTest {
       boundary: Geometry = row.boundary ?: multiPolygon(1.0),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      errorMargin: BigDecimal = row.errorMargin ?: PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
       id: Any? = row.id,
       plantingSiteId: Any =
           row.plantingSiteId ?: throw IllegalArgumentException("Missing planting site ID"),
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: id?.let { "Z$id" } ?: "Z${nextPlantingZoneNumber++}",
+      numPermanentClusters: Int =
+          row.numPermanentClusters ?: PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      numTemporaryPlots: Int =
+          row.numTemporaryPlots ?: PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
+      studentsT: BigDecimal = row.studentsT ?: PlantingSiteImporter.DEFAULT_STUDENTS_T,
+      variance: BigDecimal = row.variance ?: PlantingSiteImporter.DEFAULT_VARIANCE,
   ): PlantingZoneId {
     val rowWithDefaults =
         row.copy(
@@ -820,11 +828,16 @@ abstract class DatabaseTest {
             boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,
+            errorMargin = errorMargin,
             id = id?.toIdWrapper { PlantingZoneId(it) },
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             name = name,
+            numPermanentClusters = numPermanentClusters,
+            numTemporaryPlots = numTemporaryPlots,
             plantingSiteId = plantingSiteId.toIdWrapper { PlantingSiteId(it) },
+            studentsT = studentsT,
+            variance = variance,
         )
 
     plantingZonesDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -91,9 +91,14 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                     PlantingZoneModel(
                         areaHa = BigDecimal.TEN,
                         boundary = multiPolygon(2.0),
+                        errorMargin = PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
                         id = plantingZoneId,
                         name = "Z1",
+                        numPermanentClusters = PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                        numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
                         plantingSubzones = emptyList(),
+                        studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
+                        variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                     ),
                 ))
 
@@ -195,8 +200,13 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                     PlantingZoneModel(
                         areaHa = BigDecimal.TEN,
                         boundary = zoneBoundary4326,
+                        errorMargin = PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
                         id = plantingZoneId,
                         name = "Z1",
+                        numPermanentClusters = PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                        numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
+                        studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
+                        variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                         plantingSubzones =
                             listOf(
                                 PlantingSubzoneModel(
@@ -408,7 +418,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             boundary = multiPolygon(1.0),
             createdBy = createdBy,
             createdTime = createdTime,
-            errorMargin = null,
+            errorMargin = BigDecimal.TWO,
             plantingSiteId = plantingSiteId,
             modifiedBy = createdBy,
             modifiedTime = createdTime,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -110,13 +110,6 @@ class PlantingZoneModelTest {
     }
 
     @Test
-    fun `throws exception if temporary plot count not set`() {
-      val model = plantingZoneModel()
-
-      assertThrows<IllegalArgumentException> { model.chooseTemporaryPlots(emptySet(), emptySet()) }
-    }
-
-    @Test
     fun `throws exception if no subzones`() {
       val model = plantingZoneModel(numTemporaryPlots = 1, subzones = emptyList())
 
@@ -176,15 +169,19 @@ class PlantingZoneModelTest {
   private fun plantingSubzoneIds(vararg id: Int) = id.map { PlantingSubzoneId(it.toLong()) }.toSet()
 
   private fun plantingZoneModel(
-      numTemporaryPlots: Int? = null,
+      numTemporaryPlots: Int,
       subzones: List<PlantingSubzoneModel> = this.subzones
   ) =
       PlantingZoneModel(
           areaHa = BigDecimal.ONE,
           boundary = multiPolygon(1.0),
+          errorMargin = BigDecimal.ONE,
           id = PlantingZoneId(1),
           name = "name",
+          numPermanentClusters = 1,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = subzones,
+          studentsT = BigDecimal.ONE,
+          variance = BigDecimal.ONE,
       )
 }


### PR DESCRIPTION
To avoid situations where nobody has entered the variance and error margin for a
planting zone and thus the system has no idea how many monitoring plots to assign,
make those values (and the monitoring plot counts derived from them) mandatory
with defaults rather than optional.

In addition, don't allow either the permanent or the temporary plot count to be
zero; we always want at least one permanent cluster and one temporary plot per
observation.