### PR TITLE
Use inserted test IDs as defaults

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -1109,7 +1109,7 @@ abstract class DatabaseTest {
     val plantingSiteId
       get() = plantingSiteIds.last()
     val plantingSubzoneId
-      get() = plantingSiteIds.last()
+      get() = plantingSubzoneIds.last()
     val plantingZoneId
       get() = plantingZoneIds.last()
     val reportId

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
@@ -31,73 +31,59 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
             germinatingQuantity = 4,
             notReadyQuantity = 5,
             readyQuantity = 6)
-    val otherNurseryBatchId =
-        insertBatch(
-            facilityId = otherNurseryId,
-            speciesId = speciesId,
-            germinatingQuantity = 7,
-            notReadyQuantity = 8,
-            readyQuantity = 9)
 
-    val outplantId1 =
-        insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.OutPlant)
+    insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.OutPlant)
     insertBatchWithdrawal(
         batchId = batchId1,
-        withdrawalId = outplantId1,
         germinatingQuantityWithdrawn = 10,
         notReadyQuantityWithdrawn = 11,
         readyQuantityWithdrawn = 12)
     insertBatchWithdrawal(
         batchId = batchId2,
-        withdrawalId = outplantId1,
         germinatingQuantityWithdrawn = 13,
         notReadyQuantityWithdrawn = 14,
         readyQuantityWithdrawn = 15)
 
-    val outplantId2 =
-        insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.OutPlant)
+    insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.OutPlant)
     insertBatchWithdrawal(
         batchId = batchId1,
-        withdrawalId = outplantId2,
         germinatingQuantityWithdrawn = 16,
         notReadyQuantityWithdrawn = 17,
         readyQuantityWithdrawn = 18)
 
-    val deadId1 = insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.Dead)
+    insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.Dead)
     insertBatchWithdrawal(
         batchId = batchId1,
-        withdrawalId = deadId1,
         germinatingQuantityWithdrawn = 19,
         notReadyQuantityWithdrawn = 20,
         readyQuantityWithdrawn = 21)
     insertBatchWithdrawal(
         batchId = batchId2,
-        withdrawalId = deadId1,
         germinatingQuantityWithdrawn = 22,
         notReadyQuantityWithdrawn = 23,
         readyQuantityWithdrawn = 24)
 
-    val deadId2 = insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.Dead)
+    insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.Dead)
     insertBatchWithdrawal(
         batchId = batchId1,
-        withdrawalId = deadId2,
         germinatingQuantityWithdrawn = 25,
         notReadyQuantityWithdrawn = 26,
         readyQuantityWithdrawn = 27)
 
-    val otherOutplantId =
-        insertWithdrawal(facilityId = otherNurseryId, purpose = WithdrawalPurpose.OutPlant)
+    insertBatch(
+        facilityId = otherNurseryId,
+        speciesId = speciesId,
+        germinatingQuantity = 7,
+        notReadyQuantity = 8,
+        readyQuantity = 9)
+    insertWithdrawal(facilityId = otherNurseryId, purpose = WithdrawalPurpose.OutPlant)
     insertBatchWithdrawal(
-        batchId = otherNurseryBatchId,
-        withdrawalId = otherOutplantId,
         germinatingQuantityWithdrawn = 28,
         notReadyQuantityWithdrawn = 29,
         readyQuantityWithdrawn = 30)
-    val otherDeadId =
-        insertWithdrawal(facilityId = otherNurseryId, purpose = WithdrawalPurpose.Dead)
+
+    insertWithdrawal(facilityId = otherNurseryId, purpose = WithdrawalPurpose.Dead)
     insertBatchWithdrawal(
-        batchId = otherNurseryBatchId,
-        withdrawalId = otherDeadId,
         germinatingQuantityWithdrawn = 31,
         notReadyQuantityWithdrawn = 32,
         readyQuantityWithdrawn = 33)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
@@ -26,20 +26,17 @@ internal class BatchStoreSpeciesSummaryTest : BatchStoreTest() {
 
   @Test
   fun `does not include germinating quantities in loss rate`() {
-    val batchId =
-        insertBatch(
-            germinatingQuantity = 10,
-            notReadyQuantity = 1,
-            readyQuantity = 1,
-            speciesId = speciesId,
-        )
-    val withdrawalId = insertWithdrawal(purpose = WithdrawalPurpose.Dead)
+    insertBatch(
+        germinatingQuantity = 10,
+        notReadyQuantity = 1,
+        readyQuantity = 1,
+        speciesId = speciesId,
+    )
+    insertWithdrawal(purpose = WithdrawalPurpose.Dead)
     insertBatchWithdrawal(
-        batchId = batchId,
         germinatingQuantityWithdrawn = 20,
         notReadyQuantityWithdrawn = 2,
         readyQuantityWithdrawn = 3,
-        withdrawalId = withdrawalId,
     )
 
     val summary = store.getSpeciesSummary(speciesId)
@@ -50,10 +47,9 @@ internal class BatchStoreSpeciesSummaryTest : BatchStoreTest() {
 
   @Test
   fun `rounds loss rate to nearest integer`() {
-    val batchId = insertBatch(speciesId = speciesId, readyQuantity = 197)
-    val withdrawalId = insertWithdrawal(purpose = WithdrawalPurpose.Dead)
-    insertBatchWithdrawal(
-        batchId = batchId, withdrawalId = withdrawalId, notReadyQuantityWithdrawn = 3)
+    insertBatch(speciesId = speciesId, readyQuantity = 197)
+    insertWithdrawal(purpose = WithdrawalPurpose.Dead)
+    insertBatchWithdrawal(notReadyQuantityWithdrawn = 3)
 
     val summary = store.getSpeciesSummary(speciesId)
 

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -596,33 +596,20 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
       nurseryId: FacilityId,
       plantingSiteId: PlantingSiteId
   ) {
-    val batchId =
-        insertBatch(
-            facilityId = nurseryId,
-            germinatingQuantity = 100,
-            notReadyQuantity = 200,
-            readyQuantity = 300,
-            speciesId = speciesId,
-        )
-    val deadWithdrawalId =
-        insertWithdrawal(facilityId = nurseryId, purpose = WithdrawalPurpose.Dead)
-    insertBatchWithdrawal(
-        batchId = batchId,
-        withdrawalId = deadWithdrawalId,
-        readyQuantityWithdrawn = 100,
-        notReadyQuantityWithdrawn = 52,
+    insertBatch(
+        facilityId = nurseryId,
+        germinatingQuantity = 100,
+        notReadyQuantity = 200,
+        readyQuantity = 300,
+        speciesId = speciesId,
     )
 
-    val outplantWithdrawalId =
-        insertWithdrawal(facilityId = nurseryId, purpose = WithdrawalPurpose.OutPlant)
-    insertBatchWithdrawal(
-        batchId = batchId,
-        withdrawalId = outplantWithdrawalId,
-        readyQuantityWithdrawn = 20,
-        notReadyQuantityWithdrawn = 30,
-    )
-    val deliveryId =
-        insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = outplantWithdrawalId)
-    insertPlanting(deliveryId = deliveryId, speciesId = speciesId)
+    insertWithdrawal(facilityId = nurseryId, purpose = WithdrawalPurpose.Dead)
+    insertBatchWithdrawal(readyQuantityWithdrawn = 100, notReadyQuantityWithdrawn = 52)
+
+    insertWithdrawal(facilityId = nurseryId, purpose = WithdrawalPurpose.OutPlant)
+    insertBatchWithdrawal(readyQuantityWithdrawn = 20, notReadyQuantityWithdrawn = 30)
+    insertDelivery(plantingSiteId = plantingSiteId)
+    insertPlanting(speciesId = speciesId)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -54,62 +54,41 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val monitoringPlotGeometry7 = polygon(0.1)
     val monitoringPlotGeometry8 = polygon(0.1)
     val plantingSiteId = insertPlantingSite(boundary = plantingSiteGeometry)
-    val plantingZoneId =
-        insertPlantingZone(boundary = plantingZoneGeometry, id = 2, plantingSiteId = plantingSiteId)
-    val plantingSubzoneId1 =
-        insertPlantingSubzone(
-            boundary = plantingSubzoneGeometry3,
-            id = 3,
-            plantingSiteId = plantingSiteId,
-            plantingZoneId = plantingZoneId)
-    val plantingSubzoneId2 =
-        insertPlantingSubzone(
-            boundary = plantingSubzoneGeometry4,
-            id = 4,
-            plantingSiteId = plantingSiteId,
-            plantingZoneId = plantingZoneId)
-    insertMonitoringPlot(
-        boundary = monitoringPlotGeometry5, id = 5, plantingSubzoneId = plantingSubzoneId1)
-    insertMonitoringPlot(
-        boundary = monitoringPlotGeometry6, id = 6, plantingSubzoneId = plantingSubzoneId1)
-    insertMonitoringPlot(
-        boundary = monitoringPlotGeometry7, id = 7, plantingSubzoneId = plantingSubzoneId2)
-    insertMonitoringPlot(
-        boundary = monitoringPlotGeometry8, id = 8, plantingSubzoneId = plantingSubzoneId2)
+    insertPlantingZone(boundary = plantingZoneGeometry, id = 2)
+
+    insertPlantingSubzone(boundary = plantingSubzoneGeometry3, id = 3)
+    insertMonitoringPlot(boundary = monitoringPlotGeometry5, id = 5)
+    insertMonitoringPlot(boundary = monitoringPlotGeometry6, id = 6)
+
+    insertPlantingSubzone(boundary = plantingSubzoneGeometry4, id = 4)
+    insertMonitoringPlot(boundary = monitoringPlotGeometry7, id = 7)
+    insertMonitoringPlot(boundary = monitoringPlotGeometry8, id = 8)
 
     val speciesId1 = insertSpecies(1)
     val speciesId2 = insertSpecies(2)
 
     insertFacility(type = FacilityType.Nursery)
 
-    val withdrawalId1 = insertWithdrawal()
-    val withdrawalId2 = insertWithdrawal()
-    val deliveryId1 = insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
-    val deliveryId2 = insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId2)
+    insertWithdrawal()
+    val deliveryId1 = insertDelivery(plantingSiteId = plantingSiteId)
+    insertWithdrawal()
 
-    val plantingId1 =
-        insertPlanting(
-            deliveryId = deliveryId1, numPlants = 1, plantingSubzoneId = 3, speciesId = speciesId1)
-    val plantingId2 =
-        insertPlanting(
-            deliveryId = deliveryId2, numPlants = 4, plantingSubzoneId = 3, speciesId = speciesId1)
+    val plantingId1 = insertPlanting(numPlants = 1, plantingSubzoneId = 3, speciesId = speciesId1)
     val plantingId3 =
         insertPlanting(
-            deliveryId = deliveryId1,
             numPlants = -2,
             plantingTypeId = PlantingType.ReassignmentFrom,
             plantingSubzoneId = 3,
             speciesId = speciesId1)
     val plantingId4 =
         insertPlanting(
-            deliveryId = deliveryId1,
             numPlants = 2,
             plantingTypeId = PlantingType.ReassignmentTo,
             plantingSubzoneId = 4,
             speciesId = speciesId1)
-    val plantingId5 =
-        insertPlanting(
-            deliveryId = deliveryId1, numPlants = 8, plantingSubzoneId = 4, speciesId = speciesId2)
+    val plantingId5 = insertPlanting(numPlants = 8, plantingSubzoneId = 4, speciesId = speciesId2)
+    val deliveryId2 = insertDelivery(plantingSiteId = plantingSiteId)
+    val plantingId2 = insertPlanting(numPlants = 4, plantingSubzoneId = 3, speciesId = speciesId1)
 
     val expected =
         SearchResults(
@@ -280,9 +259,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val otherOrganizationId = OrganizationId(2)
 
     insertOrganization(otherOrganizationId)
-    val plantingSiteId = insertPlantingSite(organizationId = otherOrganizationId)
-    val plantingZoneId = insertPlantingZone(plantingSiteId = plantingSiteId)
-    insertPlantingSubzone(plantingSiteId = plantingSiteId, plantingZoneId = plantingZoneId)
+    insertPlantingSite(organizationId = otherOrganizationId)
+    insertPlantingZone()
+    insertPlantingSubzone()
 
     val prefix = SearchFieldPrefix(root = searchTables.plantingSubzones)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -326,16 +326,10 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns delivery and plantings`() {
       val deliveryId = insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId)
       val plantingId1 =
-          insertPlanting(
-              deliveryId = deliveryId,
-              speciesId = speciesId1,
-              plantingSubzoneId = plantingSubzoneId)
+          insertPlanting(speciesId = speciesId1, plantingSubzoneId = plantingSubzoneId)
       val plantingId2 =
           insertPlanting(
-              deliveryId = deliveryId,
-              speciesId = speciesId2,
-              plantingSubzoneId = plantingSubzoneId,
-              numPlants = 2)
+              speciesId = speciesId2, plantingSubzoneId = plantingSubzoneId, numPlants = 2)
 
       val expected =
           DeliveryModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -63,15 +63,9 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `fetchSiteById honors depth`() {
     val plantingSiteId = insertPlantingSite(boundary = multiPolygon(3.0), timeZone = timeZone)
-    val plantingZoneId =
-        insertPlantingZone(boundary = multiPolygon(2.0), plantingSiteId = plantingSiteId)
-    val plantingSubzoneId =
-        insertPlantingSubzone(
-            boundary = multiPolygon(1.0),
-            plantingSiteId = plantingSiteId,
-            plantingZoneId = plantingZoneId)
-    val monitoringPlotId =
-        insertMonitoringPlot(boundary = polygon(0.1), plantingSubzoneId = plantingSubzoneId)
+    val plantingZoneId = insertPlantingZone(boundary = multiPolygon(2.0))
+    val plantingSubzoneId = insertPlantingSubzone(boundary = multiPolygon(1.0))
+    val monitoringPlotId = insertMonitoringPlot(boundary = polygon(0.1))
 
     val expectedWithSite =
         PlantingSiteModel(
@@ -177,16 +171,9 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     val monitoringPlotBoundary3857 = monitoringPlotBoundary4326.to3857()
 
     val plantingSiteId = insertPlantingSite(boundary = siteBoundary3857)
-    val plantingZoneId =
-        insertPlantingZone(boundary = zoneBoundary3857, plantingSiteId = plantingSiteId)
-    val plantingSubzoneId =
-        insertPlantingSubzone(
-            boundary = subzoneBoundary3857,
-            plantingSiteId = plantingSiteId,
-            plantingZoneId = plantingZoneId)
-    val monitoringPlotId =
-        insertMonitoringPlot(
-            boundary = monitoringPlotBoundary3857, plantingSubzoneId = plantingSubzoneId)
+    val plantingZoneId = insertPlantingZone(boundary = zoneBoundary3857)
+    val plantingSubzoneId = insertPlantingSubzone(boundary = subzoneBoundary3857)
+    val monitoringPlotId = insertMonitoringPlot(boundary = monitoringPlotBoundary3857)
 
     val expected =
         PlantingSiteModel(
@@ -448,8 +435,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updatePlantingZone throws exception if no permission`() {
-    val plantingSiteId = insertPlantingSite()
-    val plantingZoneId = insertPlantingZone(plantingSiteId = plantingSiteId)
+    insertPlantingSite()
+    val plantingZoneId = insertPlantingZone()
 
     every { user.canUpdatePlantingZone(plantingZoneId) } returns false
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -244,62 +244,39 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `fetchPlantedSubzoneIds returns subzones with nursery deliveries`() {
     insertFacility(type = FacilityType.Nursery)
+    insertSpecies()
+
     val plantingSiteId = insertPlantingSite()
-    val plantingZoneId1 = insertPlantingZone(name = "1", plantingSiteId = plantingSiteId)
-    val plantingZoneId2 = insertPlantingZone(name = "2", plantingSiteId = plantingSiteId)
-    val plantingSubzoneId11 =
-        insertPlantingSubzone(
-            name = "11", plantingSiteId = plantingSiteId, plantingZoneId = plantingZoneId1)
-    val plantingSubzoneId12 =
-        insertPlantingSubzone(
-            name = "12", plantingSiteId = plantingSiteId, plantingZoneId = plantingZoneId1)
-    val plantingSubzoneId21 =
-        insertPlantingSubzone(
-            name = "21", plantingSiteId = plantingSiteId, plantingZoneId = plantingZoneId2)
-    val speciesId1 = insertSpecies(speciesId = 1)
-    val speciesId2 = insertSpecies(speciesId = 2)
-    val withdrawalId1 = insertWithdrawal(purpose = WithdrawalPurpose.OutPlant)
-    val withdrawalId2 = insertWithdrawal(purpose = WithdrawalPurpose.OutPlant)
-    val deliveryId1 = insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId1)
-    val deliveryId2 = insertDelivery(plantingSiteId = plantingSiteId, withdrawalId = withdrawalId2)
+
+    insertPlantingZone()
+    val plantingSubzoneId11 = insertPlantingSubzone()
+    val plantingSubzoneId12 = insertPlantingSubzone()
+
+    insertPlantingZone()
+    val plantingSubzoneId21 = insertPlantingSubzone()
 
     // Original delivery to subzone 12, then reassignment to 11, so 12 shouldn't be counted as
     // planted any more.
+    insertWithdrawal(purpose = WithdrawalPurpose.OutPlant)
+    insertDelivery()
+    insertPlanting(numPlants = 1, plantingSubzoneId = plantingSubzoneId12)
     insertPlanting(
-        deliveryId = deliveryId1,
-        numPlants = 1,
-        plantingSiteId = plantingSiteId,
-        plantingSubzoneId = plantingSubzoneId12,
-        speciesId = speciesId1,
-        plantingTypeId = PlantingType.Delivery)
-    insertPlanting(
-        deliveryId = deliveryId1,
         numPlants = -1,
-        plantingSiteId = plantingSiteId,
         plantingSubzoneId = plantingSubzoneId12,
-        speciesId = speciesId1,
         plantingTypeId = PlantingType.ReassignmentFrom)
     insertPlanting(
-        deliveryId = deliveryId1,
         numPlants = 1,
-        plantingSiteId = plantingSiteId,
         plantingSubzoneId = plantingSubzoneId11,
-        speciesId = speciesId1,
         plantingTypeId = PlantingType.ReassignmentTo)
-    insertPlanting(
-        deliveryId = deliveryId1,
-        plantingSiteId = plantingSiteId,
-        plantingSubzoneId = plantingSubzoneId21,
-        speciesId = speciesId2)
-    insertPlanting(
-        deliveryId = deliveryId2,
-        plantingSiteId = plantingSiteId,
-        plantingSubzoneId = plantingSubzoneId21,
-        speciesId = speciesId1)
+    insertSpecies()
+    insertPlanting(plantingSubzoneId = plantingSubzoneId21)
+
+    insertWithdrawal(purpose = WithdrawalPurpose.OutPlant)
+    insertDelivery()
+    insertPlanting(plantingSubzoneId = plantingSubzoneId21)
 
     // Additional planting subzone with no plantings.
-    insertPlantingSubzone(
-        name = "22", plantingSiteId = plantingSiteId, plantingZoneId = plantingZoneId2)
+    insertPlantingSubzone()
 
     assertEquals(
         setOf(plantingSubzoneId11, plantingSubzoneId21),


### PR DESCRIPTION
Make the insert helper functions in `DatabaseTest` remember the IDs of the rows
they've inserted, and use the most recently inserted ID as the default in places
where callers previously had to pass in IDs explicitly.

This will help us write more succinct tests, especially in cases where a complex
graph of entities has to be built.

Update the tests that construct planting sites to use this new functionality.