### PR TITLE
SW-3601 Add permissions for observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -36,10 +36,12 @@ import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.STORAGE_LOCATIONS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
@@ -95,6 +97,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.ORGANIZATION_ID)
+
+  fun getOrganizationId(observationId: ObservationId): OrganizationId? =
+      fetchFieldById(observationId, OBSERVATIONS.ID, OBSERVATIONS.plantingSites.ORGANIZATION_ID)
 
   fun getOrganizationId(plantingId: PlantingId): OrganizationId? =
       fetchFieldById(plantingId, PLANTINGS.ID, PLANTINGS.plantingSites.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -146,11 +147,13 @@ data class DeviceManagerUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
   override fun canListReports(organizationId: OrganizationId): Boolean = false
   override fun canManageInternalTags(): Boolean = false
+  override fun canManageObservation(observationId: ObservationId): Boolean = false
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
   override fun canReadBatch(batchId: BatchId): Boolean = false
   override fun canReadDelivery(deliveryId: DeliveryId): Boolean = false
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
+  override fun canReadObservation(observationId: ObservationId): Boolean = false
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
   override fun canReadPlanting(plantingId: PlantingId): Boolean = false
@@ -178,6 +181,7 @@ data class DeviceManagerUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false
+  override fun canUpdateObservation(observationId: ObservationId): Boolean = false
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = false
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -232,6 +233,8 @@ data class IndividualUser(
 
   override fun canManageInternalTags() = isSuperAdmin()
 
+  override fun canManageObservation(observationId: ObservationId) = isSuperAdmin()
+
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId) =
       canUpdatePlantingSite(plantingSiteId) && isSuperAdmin()
 
@@ -261,6 +264,9 @@ data class IndividualUser(
 
   override fun canReadNotification(notificationId: NotificationId) =
       parentStore.getUserId(notificationId) == userId
+
+  override fun canReadObservation(observationId: ObservationId) =
+      isMember(parentStore.getOrganizationId(observationId))
 
   override fun canReadOrganization(organizationId: OrganizationId) = isMember(organizationId)
 
@@ -356,6 +362,9 @@ data class IndividualUser(
 
   override fun canUpdateNotifications(organizationId: OrganizationId?) =
       canListNotifications(organizationId)
+
+  override fun canUpdateObservation(observationId: ObservationId) =
+      isMember(parentStore.getOrganizationId(observationId))
 
   override fun canUpdateOrganization(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -32,12 +32,14 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
+import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
@@ -326,6 +328,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun manageObservation(observationId: ObservationId) {
+    if (!user.canManageObservation(observationId)) {
+      readObservation(observationId)
+      throw AccessDeniedException("No permission to manage observation $observationId")
+    }
+  }
+
   fun movePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId) {
     if (!user.canMovePlantingSiteToAnyOrg(plantingSiteId)) {
       readPlantingSite(plantingSiteId)
@@ -378,6 +387,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readNotification(notificationId: NotificationId) {
     if (!user.canReadNotification(notificationId)) {
       throw NotificationNotFoundException(notificationId)
+    }
+  }
+
+  fun readObservation(observationId: ObservationId) {
+    if (!user.canReadObservation(observationId)) {
+      throw ObservationNotFoundException(observationId)
     }
   }
 
@@ -577,6 +592,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
         readOrganization(organizationId)
       }
       throw AccessDeniedException("No permission to update notifications")
+    }
+  }
+
+  fun updateObservation(observationId: ObservationId) {
+    if (!user.canUpdateObservation(observationId)) {
+      readObservation(observationId)
+      throw AccessDeniedException("No permission to update observation $observationId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -146,6 +147,7 @@ class SystemUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
   override fun canListReports(organizationId: OrganizationId): Boolean = true
   override fun canManageInternalTags(): Boolean = false
+  override fun canManageObservation(observationId: ObservationId): Boolean = true
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
@@ -155,6 +157,7 @@ class SystemUser(
   override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
   override fun canReadNotification(notificationId: NotificationId): Boolean = true
+  override fun canReadObservation(observationId: ObservationId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
@@ -188,6 +191,7 @@ class SystemUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
+  override fun canUpdateObservation(observationId: ObservationId): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -110,6 +111,7 @@ interface TerrawareUser : Principal {
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
   fun canListReports(organizationId: OrganizationId): Boolean
   fun canManageInternalTags(): Boolean
+  fun canManageObservation(observationId: ObservationId): Boolean
   fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean
   fun canReadAccession(accessionId: AccessionId): Boolean
   fun canReadAutomation(automationId: AutomationId): Boolean
@@ -119,6 +121,7 @@ interface TerrawareUser : Principal {
   fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canReadFacility(facilityId: FacilityId): Boolean
   fun canReadNotification(notificationId: NotificationId): Boolean
+  fun canReadObservation(observationId: ObservationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canReadPlanting(plantingId: PlantingId): Boolean
@@ -149,6 +152,7 @@ interface TerrawareUser : Principal {
   fun canUpdateFacility(facilityId: FacilityId): Boolean
   fun canUpdateNotification(notificationId: NotificationId): Boolean
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
+  fun canUpdateObservation(observationId: ObservationId): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
   fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
   fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -31,6 +32,9 @@ class DeliveryMissingSubzoneException(val plantingSiteId: PlantingSiteId) :
 
 class DeliveryNotFoundException(val deliveryId: DeliveryId) :
     EntityNotFoundException("Delivery $deliveryId not found")
+
+class ObservationNotFoundException(val observationId: ObservationId) :
+    EntityNotFoundException("Observation $observationId not found")
 
 class PlantingNotFoundException(val plantingId: PlantingId) :
     EntityNotFoundException("Planting $plantingId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -32,12 +32,14 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
+import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
@@ -105,6 +107,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val notificationUserId = UserId(2)
   private val notificationId: NotificationId by
       readableId(NotificationNotFoundException::class) { canReadNotification(it) }
+  private val observationId: ObservationId by
+      readableId(ObservationNotFoundException::class) { canReadObservation(it) }
   private val organizationId: OrganizationId by
       readableId(OrganizationNotFoundException::class) { canReadOrganization(it) }
   private val plantingId: PlantingId by
@@ -333,6 +337,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { listReports(organizationId) } ifUser { canListReports(organizationId) }
 
   @Test
+  fun manageObservation() =
+      allow { manageObservation(observationId) } ifUser { canManageObservation(observationId) }
+
+  @Test
   fun movePlantingSite() {
     assertThrows<PlantingSiteNotFoundException> {
       requirements.movePlantingSiteToAnyOrg(plantingSiteId)
@@ -363,6 +371,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readFacility() = testRead { readFacility(facilityId) }
 
   @Test fun readNotification() = testRead { readNotification(notificationId) }
+
+  @Test fun readObservation() = testRead { readObservation(observationId) }
 
   @Test fun readOrganization() = testRead { readOrganization(organizationId) }
 
@@ -478,6 +488,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateNotification() =
       allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }
+
+  @Test
+  fun updateObservation() =
+      allow { updateObservation(observationId) } ifUser { canUpdateObservation(observationId) }
 
   @Test
   fun updateOrganization() =


### PR DESCRIPTION
Add read and update permissions for observations, plus a special "manage"
permission for privileged operations that will be performed by the system user or
by super-admins but shouldn't be available to regular users (even organization
admins).

Nothing uses these permissions yet.