### PR TITLE
Remove PlantingSiteStore.fetchPlantedSubzoneIds

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -268,7 +268,7 @@ class AdminController(
   @ResponseBody
   fun getMonitoringPlots(@PathVariable plantingSiteId: PlantingSiteId): Map<String, Any> {
     val site = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
-    val plantedSubzoneIds = plantingSiteStore.fetchPlantedSubzoneIds(plantingSiteId)
+    val plantedSubzoneIds = plantingSiteStore.countReportedPlantsInSubzones(plantingSiteId).keys
 
     return plotsToGeoJson(site, plantedSubzoneIds)
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
+import java.math.BigDecimal
 import java.time.InstantSource
 import java.time.Month
 import java.time.ZoneId
@@ -84,10 +85,6 @@ class PlantingSiteStore(
         .fetch { PlantingSiteModel(it, zonesField) }
   }
 
-  fun fetchPlantedSubzoneIds(plantingSiteId: PlantingSiteId): Set<PlantingSubzoneId> {
-    return countReportedPlantsInSubzones(plantingSiteId).filterValues { it > 0 }.keys
-  }
-
   fun countMonitoringPlots(
       plantingSiteId: PlantingSiteId
   ): Map<PlantingZoneId, Map<PlantingSubzoneId, Int>> {
@@ -121,6 +118,7 @@ class PlantingSiteStore(
         .on(PLANTING_SUBZONES.ID.eq(PLANTINGS.PLANTING_SUBZONE_ID))
         .where(PLANTING_SUBZONES.PLANTING_SITE_ID.eq(plantingSiteId))
         .groupBy(PLANTING_SUBZONES.ID)
+        .having(sumField.gt(BigDecimal.ZERO))
         .fetch()
         .associate { it.value1() to it.value2().toLong() }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -229,7 +229,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchPlantedSubzoneIds returns subzones with nursery deliveries`() {
+  fun `countReportedPlantsInSubzones returns subzones with nursery deliveries`() {
     insertFacility(type = FacilityType.Nursery)
     insertSpecies()
 
@@ -256,18 +256,18 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
         plantingSubzoneId = plantingSubzoneId11,
         plantingTypeId = PlantingType.ReassignmentTo)
     insertSpecies()
-    insertPlanting(plantingSubzoneId = plantingSubzoneId21)
+    insertPlanting(numPlants = 2, plantingSubzoneId = plantingSubzoneId21)
 
     insertWithdrawal(purpose = WithdrawalPurpose.OutPlant)
     insertDelivery()
-    insertPlanting(plantingSubzoneId = plantingSubzoneId21)
+    insertPlanting(numPlants = 4, plantingSubzoneId = plantingSubzoneId21)
 
     // Additional planting subzone with no plantings.
     insertPlantingSubzone()
 
     assertEquals(
-        setOf(plantingSubzoneId11, plantingSubzoneId21),
-        store.fetchPlantedSubzoneIds(plantingSiteId))
+        mapOf(plantingSubzoneId11 to 1L, plantingSubzoneId21 to 6L),
+        store.countReportedPlantsInSubzones(plantingSiteId))
   }
 
   @Test


### PR DESCRIPTION
It was a one-statement wrapper around an underlying function that callers can call
directly instead.