### PR TITLE
SW-3601 Start observations from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/log/LoggingExtensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/log/LoggingExtensions.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.log
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.slf4j.event.Level
 
 /**
@@ -73,4 +74,18 @@ fun <T> Logger.debugWithTiming(message: String, func: () -> T): T {
   debug("$message: ${endTime-startTime}ms")
 
   return result
+}
+
+/**
+ * Adds key/value pairs to the mapped diagnostic context and calls a function. The values will be
+ * removed when the function returns.
+ */
+fun <T> Logger.withMDC(vararg items: Pair<String, Any?>, func: () -> T): T {
+  val oldMdc = MDC.getCopyOfContextMap() ?: emptyMap()
+  try {
+    items.forEach { MDC.put(it.first, "${it.second}") }
+    return func()
+  } finally {
+    MDC.setContextMap(oldMdc)
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -29,7 +29,7 @@ class ObservationService(
         }
 
         if (observationStore.hasPlots(observationId)) {
-          log.warn("BUG! Observation has plots but state is still ${observation.state}")
+          log.error("BUG! Observation has plots but state is still ${observation.state}")
           throw ObservationAlreadyStartedException(observationId)
         }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -1,0 +1,74 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.log.withMDC
+import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
+import com.terraformation.backend.tracking.db.ObservationHasNoPlotsException
+import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import javax.inject.Named
+
+@Named
+class ObservationService(
+    private val observationStore: ObservationStore,
+    private val plantingSiteStore: PlantingSiteStore,
+) {
+  private val log = perClassLogger()
+
+  fun startObservation(observationId: ObservationId) {
+    requirePermissions { manageObservation(observationId) }
+
+    log.withMDC("observationId" to observationId) {
+      observationStore.withLockedObservation(observationId) { observation ->
+        if (observation.state != ObservationState.Upcoming) {
+          throw ObservationAlreadyStartedException(observationId)
+        }
+
+        if (observationStore.hasPlots(observationId)) {
+          log.warn("BUG! Observation has plots but state is still ${observation.state}")
+          throw ObservationAlreadyStartedException(observationId)
+        }
+
+        val plantingSite =
+            plantingSiteStore.fetchSiteById(observation.plantingSiteId, PlantingSiteDepth.Plot)
+        val plantedSubzoneIds =
+            plantingSiteStore.countReportedPlantsInSubzones(plantingSite.id).keys
+
+        if (plantedSubzoneIds.isEmpty()) {
+          throw ObservationHasNoPlotsException(observationId)
+        }
+
+        log.info("Starting observation")
+
+        plantingSite.plantingZones.forEach { plantingZone ->
+          log.withMDC("plantingZoneId" to plantingZone.id) {
+            if (plantingZone.plantingSubzones.any { it.id in plantedSubzoneIds }) {
+              val permanentPlotIds =
+                  plantingSiteStore.fetchPermanentPlotIds(
+                      plantingZone.id, plantingZone.numPermanentClusters)
+              val temporaryPlotIds =
+                  plantingZone.chooseTemporaryPlots(permanentPlotIds, plantedSubzoneIds)
+
+              observationStore.addPlotsToObservation(
+                  observationId, permanentPlotIds, isPermanent = true)
+              observationStore.addPlotsToObservation(
+                  observationId, temporaryPlotIds, isPermanent = false)
+
+              log.info(
+                  "Added ${permanentPlotIds.size} permanent and ${temporaryPlotIds.size} " +
+                      "temporary plots")
+            } else {
+              log.info("Skipping zone because it has no reported plants")
+            }
+          }
+        }
+
+        observationStore.updateObservationState(observationId, ObservationState.InProgress)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -33,6 +33,12 @@ class DeliveryMissingSubzoneException(val plantingSiteId: PlantingSiteId) :
 class DeliveryNotFoundException(val deliveryId: DeliveryId) :
     EntityNotFoundException("Delivery $deliveryId not found")
 
+class ObservationAlreadyStartedException(val observationId: ObservationId) :
+    MismatchedStateException("Observation $observationId is already started")
+
+class ObservationHasNoPlotsException(val observationId: ObservationId) :
+    MismatchedStateException("No plots are eligible for observation $observationId")
+
 class ObservationNotFoundException(val observationId: ObservationId) :
     EntityNotFoundException("Observation $observationId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1,25 +1,42 @@
 package com.terraformation.backend.tracking.db
 
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationPlotsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.ObservationModel
 import java.time.InstantSource
 import javax.inject.Named
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @Named
 class ObservationStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val observationsDao: ObservationsDao,
+    private val observationPlotsDao: ObservationPlotsDao,
 ) {
+  fun fetchObservationById(observationId: ObservationId): ExistingObservationModel {
+    requirePermissions { readObservation(observationId) }
+
+    return dslContext.selectFrom(OBSERVATIONS).where(OBSERVATIONS.ID.eq(observationId)).fetchOne {
+      ObservationModel.of(it)
+    }
+        ?: throw ObservationNotFoundException(observationId)
+  }
+
   fun fetchObservationsByPlantingSite(
       plantingSiteId: PlantingSiteId
   ): List<ExistingObservationModel> {
@@ -30,6 +47,37 @@ class ObservationStore(
         .where(OBSERVATIONS.PLANTING_SITE_ID.eq(plantingSiteId))
         .orderBy(OBSERVATIONS.START_DATE, OBSERVATIONS.ID)
         .fetch { ObservationModel.of(it) }
+  }
+
+  /**
+   * Locks an observation and calls a function. The function is called in a database transaction.
+   */
+  fun withLockedObservation(
+      observationId: ObservationId,
+      func: (ExistingObservationModel) -> Unit
+  ) {
+    requirePermissions { updateObservation(observationId) }
+
+    dslContext.transaction { _ ->
+      val model =
+          dslContext
+              .selectFrom(OBSERVATIONS)
+              .where(OBSERVATIONS.ID.eq(observationId))
+              .forUpdate()
+              .fetchOne { ObservationModel.of(it) }
+              ?: throw ObservationNotFoundException(observationId)
+
+      func(model)
+    }
+  }
+
+  fun hasPlots(observationId: ObservationId): Boolean {
+    fetchObservationById(observationId)
+
+    return dslContext.fetchExists(
+        DSL.selectOne()
+            .from(OBSERVATION_PLOTS)
+            .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId)))
   }
 
   fun createObservation(newModel: NewObservationModel): ObservationId {
@@ -47,5 +95,80 @@ class ObservationStore(
     observationsDao.insert(row)
 
     return row.id!!
+  }
+
+  fun updateObservationState(observationId: ObservationId, newState: ObservationState) {
+    requirePermissions {
+      if (newState == ObservationState.Completed) {
+        updateObservation(observationId)
+      } else {
+        manageObservation(observationId)
+      }
+    }
+
+    withLockedObservation(observationId) { observation ->
+      observation.validateStateTransition(newState)
+
+      dslContext
+          .update(OBSERVATIONS)
+          .apply {
+            if (newState == ObservationState.Completed)
+                set(OBSERVATIONS.COMPLETED_TIME, clock.instant())
+          }
+          .set(OBSERVATIONS.STATE_ID, newState)
+          .where(OBSERVATIONS.ID.eq(observationId))
+          .execute()
+    }
+  }
+
+  fun addPlotsToObservation(
+      observationId: ObservationId,
+      plotIds: Collection<MonitoringPlotId>,
+      isPermanent: Boolean
+  ) {
+    requirePermissions { manageObservation(observationId) }
+
+    if (plotIds.isEmpty()) {
+      return
+    }
+
+    val observation = fetchObservationById(observationId)
+
+    validatePlotsInPlantingSite(observation.plantingSiteId, plotIds)
+
+    val createdBy = currentUser().userId
+    val createdTime = clock.instant()
+
+    plotIds.forEach { plotId ->
+      observationPlotsDao.insert(
+          ObservationPlotsRow(
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              createdBy = createdBy,
+              createdTime = createdTime,
+              isPermanent = isPermanent,
+              modifiedBy = createdBy,
+              modifiedTime = createdTime,
+          ))
+    }
+  }
+
+  private fun validatePlotsInPlantingSite(
+      plantingSiteId: PlantingSiteId,
+      plotIds: Collection<MonitoringPlotId>
+  ) {
+    val nonMatchingPlot =
+        dslContext
+            .select(MONITORING_PLOTS.ID, MONITORING_PLOTS.plantingSubzones.PLANTING_SITE_ID)
+            .from(MONITORING_PLOTS)
+            .where(MONITORING_PLOTS.ID.`in`(plotIds))
+            .and(MONITORING_PLOTS.plantingSubzones.PLANTING_SITE_ID.ne(plantingSiteId))
+            .limit(1)
+            .fetchOne()
+
+    if (nonMatchingPlot != null) {
+      throw IllegalStateException(
+          "BUG! Plot ${nonMatchingPlot.value1()} is in site ${nonMatchingPlot.value2()}, not $plantingSiteId")
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -50,7 +50,8 @@ class ObservationStore(
   }
 
   /**
-   * Locks an observation and calls a function. The function is called in a database transaction.
+   * Locks an observation and calls a function. Starts a database transaction; the function is
+   * called with the transaction open, such that the lock is held while the function runs.
    */
   fun withLockedObservation(
       observationId: ObservationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
@@ -16,7 +16,21 @@ data class ObservationModel<ID : ObservationId?>(
     val startDate: LocalDate,
     val state: ObservationState,
 ) {
+  fun validateStateTransition(newState: ObservationState) {
+    if ((state to newState) !in validStateTransitions) {
+      throw IllegalArgumentException("Cannot transition observation from $state to $newState")
+    }
+  }
+
   companion object {
+    private val validStateTransitions =
+        setOf(
+            ObservationState.Upcoming to ObservationState.InProgress,
+            ObservationState.InProgress to ObservationState.Completed,
+            ObservationState.InProgress to ObservationState.Overdue,
+            ObservationState.Overdue to ObservationState.Completed,
+        )
+
     fun of(record: Record): ExistingObservationModel {
       return ObservationModel(
           completedTime = record[OBSERVATIONS.COMPLETED_TIME],

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -272,6 +272,7 @@
             <th>Start</th>
             <th>End</th>
             <th>State</th>
+            <th></th>
         </tr>
 
         <tr th:each="observation : ${observations}">
@@ -279,6 +280,16 @@
             <td th:text="${observation.startDate}">2023-01-01</td>
             <td th:text="${observation.endDate}">2023-01-31</td>
             <td th:text="${observation.state.getDisplayName(null)}">Upcoming</td>
+            <td>
+                <th:block th:text="${observationMessages[observation.id]}"></th:block>
+                <form th:if="${canStartObservations[observation.id]}"
+                      method="POST"
+                      th:action="|${prefix}/startObservation|">
+                    <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+                    <input type="hidden" name="observationId" th:value="${observation.id}"/>
+                    <input type="submit" value="Start"/>
+                </form>
+            </td>
         </tr>
 
         <tr th:if="${canCreateObservation}">

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -927,15 +927,18 @@ abstract class DatabaseTest {
 
   fun insertMonitoringPlot(
       row: MonitoringPlotsRow = MonitoringPlotsRow(),
-      boundary: Polygon = row.boundary as Polygon? ?: polygon(1.0),
+      boundary: Polygon = (row.boundary ?: polygon(1.0)) as Polygon? ?: polygon(1.0),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,
-      plantingSubzoneId: Any = row.plantingSubzoneId ?: inserted.plantingSubzoneId,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: id?.let { "$id" } ?: "${nextMonitoringPlotNumber++}",
       fullName: String = "Z1-1-$name",
+      permanentCluster: Int? = row.permanentCluster,
+      permanentClusterSubplot: Int? =
+          row.permanentClusterSubplot ?: if (permanentCluster != null) 1 else null,
+      plantingSubzoneId: Any = row.plantingSubzoneId ?: inserted.plantingSubzoneId,
   ): MonitoringPlotId {
     val plantingSubzoneIdWrapper = plantingSubzoneId.toIdWrapper { PlantingSubzoneId(it) }
 
@@ -949,6 +952,8 @@ abstract class DatabaseTest {
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             name = name,
+            permanentCluster = permanentCluster,
+            permanentClusterSubplot = permanentClusterSubplot,
             plantingSubzoneId = plantingSubzoneIdWrapper,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -1,0 +1,188 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
+import com.terraformation.backend.tracking.db.ObservationHasNoPlotsException
+import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val plantingSiteStore: PlantingSiteStore by lazy {
+    PlantingSiteStore(clock, dslContext, plantingSitesDao, plantingZonesDao)
+  }
+  private val service: ObservationService by lazy {
+    ObservationService(
+        ObservationStore(clock, dslContext, observationsDao, observationPlotsDao),
+        plantingSiteStore)
+  }
+
+  private lateinit var plantingSiteId: PlantingSiteId
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    plantingSiteId = insertPlantingSite()
+
+    every { user.canManageObservation(any()) } returns true
+    every { user.canReadObservation(any()) } returns true
+    every { user.canReadPlantingSite(any()) } returns true
+    every { user.canUpdateObservation(any()) } returns true
+  }
+
+  @Nested
+  inner class StartObservation {
+    @Test
+    fun `assigns correct plots to planting zones`() {
+      // Given a planting site with this structure:
+      //
+      // Zone 1 (2 permanent, 3 temporary)
+      //   Subzone 1 (has plants)
+      //     Plot A - permanent cluster 1
+      //     Plot B - permanent cluster 1
+      //     Plot C - permanent cluster 1
+      //     Plot D - permanent cluster 1
+      //     Plot E - permanent cluster 3
+      //     Plot F - permanent cluster 3
+      //     Plot G - permanent cluster 3
+      //     Plot H - permanent cluster 3
+      //     Plot I
+      //     Plot J
+      //   Subzone 2 (no plants)
+      //     Plot K - permanent cluster 2
+      //     Plot L - permanent cluster 2
+      //     Plot M - permanent cluster 2
+      //     Plot N - permanent cluster 2
+      //     Plot O
+      //     Plot P
+      // Zone 2 (2 permanent, 2 temporary)
+      //   Subzone 3 (no plants)
+      //     Plot Q - permanent 1
+      //
+      // We should get:
+      // - Plots A-D because they are the first permanent cluster in the zone and they lie in a
+      //   planted subzone. They should be selected as permanent plots.
+      // - Exactly one of plots E-J as a temporary plot. The zone is configured for 3 temporary
+      //   plots. 2 of them are spread evenly across the 2 subzones, and the remaining one is placed
+      //   in the subzone with the fewest permanent plots, which is subzone 2, but subzone 2's plots
+      //   are excluded because it has no plants.
+      // - Nothing from zone 2 because it has no plants.
+
+      insertFacility(type = FacilityType.Nursery)
+      insertSpecies()
+      insertPlantingSite()
+      insertWithdrawal()
+      insertDelivery()
+
+      insertPlantingZone(numPermanentClusters = 2, numTemporaryPlots = 3)
+      insertPlantingSubzone()
+      insertPlanting()
+      val zone1PermanentCluster1 =
+          setOf(
+              insertMonitoringPlot(permanentCluster = 1),
+              insertMonitoringPlot(permanentCluster = 1),
+              insertMonitoringPlot(permanentCluster = 1),
+              insertMonitoringPlot(permanentCluster = 1),
+          )
+      val zone1PermanentCluster3 =
+          setOf(
+              insertMonitoringPlot(permanentCluster = 3),
+              insertMonitoringPlot(permanentCluster = 3),
+              insertMonitoringPlot(permanentCluster = 3),
+              insertMonitoringPlot(permanentCluster = 3),
+          )
+      val zone1NonPermanent =
+          setOf(
+              insertMonitoringPlot(),
+              insertMonitoringPlot(),
+          )
+
+      insertPlantingSubzone()
+      insertMonitoringPlot(permanentCluster = 2)
+      insertMonitoringPlot()
+      insertMonitoringPlot()
+
+      insertPlantingZone(numPermanentClusters = 2, numTemporaryPlots = 2)
+      insertPlantingSubzone()
+      insertMonitoringPlot(permanentCluster = 1)
+
+      val observationId = insertObservation(state = ObservationState.Upcoming)
+
+      service.startObservation(observationId)
+
+      val observationPlots = observationPlotsDao.findAll()
+
+      assertEquals(5, observationPlots.size, "Should have selected 2 plots")
+      assertEquals(
+          zone1PermanentCluster1,
+          observationPlots.filter { it.isPermanent!! }.map { it.monitoringPlotId }.toSet(),
+          "Permanent plot IDs")
+      assertEquals(
+          1,
+          observationPlots
+              .filter { !it.isPermanent!! }
+              .map { it.monitoringPlotId }
+              .count { it in (zone1NonPermanent + zone1PermanentCluster3) },
+          "Should have selected one temporary plot")
+      assertEquals(
+          ObservationState.InProgress,
+          observationsDao.fetchOneById(observationId)!!.stateId,
+          "Observation state")
+    }
+
+    @Test
+    fun `throws exception if observation already started`() {
+      insertPlantingZone()
+      insertPlantingSubzone()
+      insertMonitoringPlot()
+      val observationId = insertObservation(state = ObservationState.InProgress)
+
+      assertThrows<ObservationAlreadyStartedException> { service.startObservation(observationId) }
+    }
+
+    @Test
+    fun `throws exception if observation already has plots assigned`() {
+      insertPlantingZone()
+      insertPlantingSubzone()
+      insertMonitoringPlot()
+      val observationId = insertObservation(state = ObservationState.Upcoming)
+
+      insertObservationPlot()
+
+      assertThrows<ObservationAlreadyStartedException> { service.startObservation(observationId) }
+    }
+
+    @Test
+    fun `throws exception if planting site has no planted subzones`() {
+      val observationId = insertObservation(state = ObservationState.Upcoming)
+
+      assertThrows<ObservationHasNoPlotsException> { service.startObservation(observationId) }
+    }
+
+    @Test
+    fun `throws exception if no permission to manage observation`() {
+      val observationId = insertObservation(state = ObservationState.Upcoming)
+
+      every { user.canManageObservation(observationId) } returns false
+
+      assertThrows<AccessDeniedException> { service.startObservation(observationId) }
+    }
+  }
+}


### PR DESCRIPTION
Implement the logic for assigning monitoring plots to an observation. In the
finished product, this will run automatically when the observation's start date
arrives, but for now super-admin users can trigger it manually via the admin UI
if the prerequisites are met (mainly: the start date has arrived and the site
has subzones with plants).