### PR TITLE
SW-3608 Endpoints to get observation details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1,7 +1,11 @@
 package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
@@ -13,9 +17,11 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.tracking.model.AssignedPlotDetails
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.ObservationModel
+import com.terraformation.backend.tracking.model.ObservationPlotModel
 import java.time.InstantSource
 import javax.inject.Named
 import org.jooq.DSLContext
@@ -37,6 +43,18 @@ class ObservationStore(
         ?: throw ObservationNotFoundException(observationId)
   }
 
+  fun fetchObservationsByOrganization(
+      organizationId: OrganizationId
+  ): List<ExistingObservationModel> {
+    requirePermissions { readOrganization(organizationId) }
+
+    return dslContext
+        .selectFrom(OBSERVATIONS)
+        .where(OBSERVATIONS.plantingSites.ORGANIZATION_ID.eq(organizationId))
+        .orderBy(OBSERVATIONS.START_DATE, OBSERVATIONS.ID)
+        .fetch { ObservationModel.of(it) }
+  }
+
   fun fetchObservationsByPlantingSite(
       plantingSiteId: PlantingSiteId
   ): List<ExistingObservationModel> {
@@ -47,6 +65,94 @@ class ObservationStore(
         .where(OBSERVATIONS.PLANTING_SITE_ID.eq(plantingSiteId))
         .orderBy(OBSERVATIONS.START_DATE, OBSERVATIONS.ID)
         .fetch { ObservationModel.of(it) }
+  }
+
+  fun fetchObservationPlotDetails(observationId: ObservationId): List<AssignedPlotDetails> {
+    requirePermissions { readObservation(observationId) }
+
+    // Calculated field that turns a users row into a String? with the user's full name.
+    val fullNameField =
+        DSL.row(USERS.FIRST_NAME, USERS.LAST_NAME).convertFrom { record ->
+          record?.let { IndividualUser.makeFullName(it.value1(), it.value2()) }
+        }
+    val claimedByNameField =
+        DSL.field(
+            DSL.select(fullNameField).from(USERS).where(USERS.ID.eq(OBSERVATION_PLOTS.CLAIMED_BY)))
+    val completedByNameField =
+        DSL.field(
+            DSL.select(fullNameField)
+                .from(USERS)
+                .where(USERS.ID.eq(OBSERVATION_PLOTS.COMPLETED_BY)))
+
+    val earlierObservationPlots = OBSERVATION_PLOTS.`as`("earlier_plots")
+    val isFirstObservationField =
+        DSL.notExists(
+            DSL.selectOne()
+                .from(earlierObservationPlots)
+                .where(
+                    earlierObservationPlots.MONITORING_PLOT_ID.eq(
+                        OBSERVATION_PLOTS.MONITORING_PLOT_ID))
+                .and(earlierObservationPlots.OBSERVATION_ID.lt(OBSERVATION_PLOTS.OBSERVATION_ID)))
+
+    return dslContext
+        .select(
+            OBSERVATION_PLOTS.CLAIMED_BY,
+            OBSERVATION_PLOTS.CLAIMED_TIME,
+            OBSERVATION_PLOTS.COMPLETED_BY,
+            OBSERVATION_PLOTS.COMPLETED_TIME,
+            OBSERVATION_PLOTS.IS_PERMANENT,
+            OBSERVATION_PLOTS.MONITORING_PLOT_ID,
+            OBSERVATION_PLOTS.NOTES,
+            OBSERVATION_PLOTS.OBSERVED_TIME,
+            OBSERVATION_PLOTS.OBSERVATION_ID,
+            OBSERVATION_PLOTS.monitoringPlots.BOUNDARY,
+            OBSERVATION_PLOTS.monitoringPlots.FULL_NAME,
+            OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME,
+            OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID,
+            claimedByNameField,
+            completedByNameField,
+            isFirstObservationField,
+        )
+        .from(OBSERVATION_PLOTS)
+        .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
+        .orderBy(OBSERVATION_PLOTS.MONITORING_PLOT_ID)
+        .fetch { record ->
+          AssignedPlotDetails(
+              model = ObservationPlotModel.of(record),
+              boundary = record[OBSERVATION_PLOTS.monitoringPlots.BOUNDARY]!!,
+              claimedByName = record[claimedByNameField],
+              completedByName = record[completedByNameField],
+              isFirstObservation = record[isFirstObservationField]!!,
+              plantingSubzoneId = record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID]!!,
+              plantingSubzoneName =
+                  record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME]!!,
+              plotName = record[OBSERVATION_PLOTS.monitoringPlots.FULL_NAME]!!,
+          )
+        }
+  }
+
+  fun countUnclaimedPlots(plantingSiteId: PlantingSiteId): Map<ObservationId, Int> {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext
+        .select(OBSERVATION_PLOTS.OBSERVATION_ID, DSL.count())
+        .from(OBSERVATION_PLOTS)
+        .where(OBSERVATION_PLOTS.CLAIMED_TIME.isNull)
+        .and(OBSERVATION_PLOTS.observations.PLANTING_SITE_ID.eq(plantingSiteId))
+        .groupBy(OBSERVATION_PLOTS.OBSERVATION_ID)
+        .fetchMap(OBSERVATION_PLOTS.OBSERVATION_ID.asNonNullable()) { it.value2() }
+  }
+
+  fun countUnclaimedPlots(organizationId: OrganizationId): Map<ObservationId, Int> {
+    requirePermissions { readOrganization(organizationId) }
+
+    return dslContext
+        .select(OBSERVATION_PLOTS.OBSERVATION_ID, DSL.count())
+        .from(OBSERVATION_PLOTS)
+        .where(OBSERVATION_PLOTS.CLAIMED_TIME.isNull)
+        .and(OBSERVATION_PLOTS.observations.plantingSites.ORGANIZATION_ID.eq(organizationId))
+        .groupBy(OBSERVATION_PLOTS.OBSERVATION_ID)
+        .fetchMap(OBSERVATION_PLOTS.OBSERVATION_ID.asNonNullable()) { it.value2() }
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
@@ -1,0 +1,18 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import org.locationtech.jts.geom.Geometry
+
+/**
+ * Observation plot model with additional details needed by the "list assigned plots" API endpoint.
+ */
+data class AssignedPlotDetails(
+    val model: ObservationPlotModel,
+    val boundary: Geometry,
+    val claimedByName: String?,
+    val completedByName: String?,
+    val isFirstObservation: Boolean,
+    val plantingSubzoneId: PlantingSubzoneId,
+    val plantingSubzoneName: String,
+    val plotName: String,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationPlotModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationPlotModel.kt
@@ -1,0 +1,36 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import java.time.Instant
+import org.jooq.Record
+
+data class ObservationPlotModel(
+    val claimedBy: UserId? = null,
+    val claimedTime: Instant? = null,
+    val completedBy: UserId? = null,
+    val completedTime: Instant? = null,
+    val isPermanent: Boolean,
+    val monitoringPlotId: MonitoringPlotId,
+    val notes: String? = null,
+    val observedTime: Instant? = null,
+    val observationId: ObservationId,
+) {
+  companion object {
+    fun of(record: Record): ObservationPlotModel {
+      return ObservationPlotModel(
+          claimedBy = record[OBSERVATION_PLOTS.CLAIMED_BY],
+          claimedTime = record[OBSERVATION_PLOTS.CLAIMED_TIME],
+          completedBy = record[OBSERVATION_PLOTS.COMPLETED_BY],
+          completedTime = record[OBSERVATION_PLOTS.COMPLETED_TIME],
+          isPermanent = record[OBSERVATION_PLOTS.IS_PERMANENT]!!,
+          monitoringPlotId = record[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!!,
+          notes = record[OBSERVATION_PLOTS.NOTES],
+          observedTime = record[OBSERVATION_PLOTS.OBSERVED_TIME],
+          observationId = record[OBSERVATION_PLOTS.OBSERVATION_ID]!!,
+      )
+    }
+  }
+}


### PR DESCRIPTION
Add two API endpoints to support the monitoring plot selection UI in the mobile
app's pre-monitoring flow.

`GET /api/v1/tracking/observations` returns a list of observations for an
organization or for a single planting site.

`GET /api/v1/tracking/observations/{id}/plots` returns a list of the monitoring
plots assigned to a specific observation.