### PR TITLE
SW-3605 Endpoints to claim and release plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -1,6 +1,9 @@
 package com.terraformation.backend.tracking.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ApiResponse409
+import com.terraformation.backend.api.ApiResponseSimpleSuccess
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -24,6 +27,7 @@ import javax.ws.rs.BadRequestException
 import org.locationtech.jts.geom.Geometry
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -91,6 +95,34 @@ class ObservationsController(
         observationStore.fetchObservationPlotDetails(observationId).map { AssignedPlotPayload(it) }
 
     return ListAssignedPlotsResponsePayload(payloads)
+  }
+
+  @ApiResponse409("The plot is already claimed by someone else.")
+  @ApiResponseSimpleSuccess
+  @Operation(
+      summary = "Claims a monitoring plot.",
+      description = "A plot may only be claimed by one user at a time.")
+  @PostMapping("/{observationId}/plots/{plotId}/claim")
+  fun claimMonitoringPlot(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+  ): SimpleSuccessResponsePayload {
+    observationStore.claimPlot(observationId, plotId)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse409("You don't have a claim on the plot.")
+  @ApiResponseSimpleSuccess
+  @Operation(summary = "Releases the claim on a monitoring plot.")
+  @PostMapping("/{observationId}/plots/{plotId}/release")
+  fun releaseMonitoringPlot(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+  ): SimpleSuccessResponsePayload {
+    observationStore.releasePlot(observationId, plotId)
+
+    return SimpleSuccessResponsePayload()
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.tracking.DeliveryId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -55,6 +56,20 @@ class PlantingSiteUploadProblemsException(val problems: List<String>) :
     Exception("Found problems in uploaded planting site file") {
   constructor(problem: String) : this(listOf(problem))
 }
+
+class PlotAlreadyClaimedException(val monitoringPlotId: MonitoringPlotId) :
+    MismatchedStateException("Monitoring plot $monitoringPlotId is claimed by another user")
+
+class PlotNotClaimedException(val monitoringPlotId: MonitoringPlotId) :
+    MismatchedStateException(
+        "Monitoring plot $monitoringPlotId is not claimed by the current user")
+
+class PlotNotInObservationException(
+    val observationId: ObservationId,
+    val monitoringPlotId: MonitoringPlotId
+) :
+    EntityNotFoundException(
+        "Monitoring plot $monitoringPlotId is not assigned to observation $observationId")
 
 class ReassignmentExistsException(val plantingId: PlantingId) :
     MismatchedStateException(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -1085,6 +1085,8 @@ abstract class DatabaseTest {
 
   fun insertObservationPlot(
       row: ObservationPlotsRow = ObservationPlotsRow(),
+      claimedBy: UserId? = row.claimedBy,
+      claimedTime: Instant? = row.claimedTime,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       isPermanent: Boolean = row.isPermanent ?: false,
@@ -1093,6 +1095,8 @@ abstract class DatabaseTest {
   ) {
     val rowWithDefaults =
         row.copy(
+            claimedBy = claimedBy,
+            claimedTime = claimedTime,
             createdBy = createdBy,
             createdTime = createdTime,
             isPermanent = isPermanent,


### PR DESCRIPTION
Add two API endpoints to support the monitoring plot selection UI in the mobile
app's pre-monitoring flow.

`POST /api/v1/tracking/observations/{observationId}/plots/{plotId}/claim` claims
one of the monitoring plots that has been assigned to an observation. A monitoring
plot may only be claimed by one user at a time.

`POST /api/v1/tracking/observations/{observationId}/plots/{plotId}/release`
releases a previously-acquired claim on a monitoring plot, making it available for
other users to claim.