### PR TITLE
Add information to planting site map in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -348,12 +348,26 @@ class AdminController(
                       zone.chooseTemporaryPlots(permanentPlotIds, plantedSubzoneIds).toSet()
 
                   subzone.monitoringPlots.map { plot ->
-                    val properties =
+                    val plotTypeProperty =
                         when (plot.id) {
                           in permanentPlotIds -> mapOf("type" to "permanent")
                           in temporaryPlotIds -> mapOf("type" to "temporary")
                           else -> emptyMap()
                         }
+
+                    val cluster =
+                        if (plot.permanentCluster != null)
+                            "${plot.permanentCluster}-${plot.permanentClusterSubplot}"
+                        else null
+
+                    val properties =
+                        mapOf(
+                            "cluster" to cluster,
+                            "id" to "${plot.id}",
+                            "name" to plot.fullName,
+                            "subzone" to subzone.name,
+                            "zone" to zone.name,
+                        ) + plotTypeProperty
 
                     mapOf(
                         "type" to "Feature",

--- a/src/main/resources/templates/admin/plantingSiteMap.html
+++ b/src/main/resources/templates/admin/plantingSiteMap.html
@@ -79,7 +79,7 @@
 
             map.addLayer({
                 id: 'plots',
-                type: 'line',
+                type: 'fill',
                 source: 'plots',
                 filter: [
                     'match',
@@ -92,13 +92,15 @@
                 ],
                 layout: {},
                 paint: {
-                    'line-color': 'green'
+                    'fill-color': 'green',
+                    'fill-opacity': 0.5,
+                    'fill-outline-color': 'black'
                 }
             });
 
             map.addLayer({
                 id: 'temporaryPlots',
-                type: 'line',
+                type: 'fill',
                 source: 'plots',
                 filter: [
                     'match',
@@ -109,13 +111,15 @@
                 ],
                 layout: {},
                 paint: {
-                    'line-color': 'orange',
+                    'fill-color': 'orange',
+                    'fill-opacity': 0.5,
+                    'fill-outline-color': 'black'
                 }
             });
 
             map.addLayer({
                 id: 'permanentPlots',
-                type: 'line',
+                type: 'fill',
                 source: 'plots',
                 filter: [
                     'match',
@@ -126,7 +130,9 @@
                 ],
                 layout: {},
                 paint: {
-                    'line-color': 'lightgreen',
+                    'fill-color': 'lightgreen',
+                    'fill-opacity': 0.5,
+                    'fill-outline-color': 'black'
                 }
             });
 
@@ -147,6 +153,20 @@
                 layout: {},
                 paint: {
                     'line-color': 'yellow',
+                }
+            });
+
+            map.addLayer({
+                id: 'subzoneLabels',
+                type: 'symbol',
+                source: 'subzones',
+                layout: {
+                    'text-field': ['get', 'name'],
+                },
+                paint: {
+                    'text-color': 'grey',
+                    'text-halo-color': 'black',
+                    'text-halo-width': 2,
                 }
             });
 
@@ -173,6 +193,27 @@
                     'line-color': 'white',
                 }
             });
+
+            const plotClickHandler = (e) => {
+                const props = e.features[0].properties;
+                const description = [
+                        `<b>${props.name} (${props.id})</b>`,
+                        '',
+                        `Zone: ${props.zone}`,
+                        `Subzone: ${props.subzone}`,
+                        `Cluster: ${props.cluster}`,
+                        props.type ? `Type: ${props.type}` : '',
+                ].join('<br/>');
+
+                new mapboxgl.Popup()
+                        .setLngLat(e.lngLat)
+                        .setHTML(description)
+                        .addTo(map);
+            };
+
+            map.on('click', 'permanentPlots', plotClickHandler);
+            map.on('click', 'temporaryPlots', plotClickHandler);
+            map.on('click', 'plots', plotClickHandler);
         });
         /*]]>*/
     </script>


### PR DESCRIPTION
Make the admin UI's planting site map view more useful:

* Subzones are now labeled.
* Monitoring plots are drawn as filled polygons, not outlines, to make them more
  visible and to make permanent and temporary plots more visually distinct.
* Clicking on a monitoring plot now shows a popup with a bit of information.