### PR TITLE
SW-3616 Start observations on their start dates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.tracking.model.PlantingSiteModel
+
+/**
+ * Published when a planting site's time zone has changed, either because it was individually
+ * updated or because its organization's time zone was changed and the planting site doesn't have a
+ * time zone of its own.
+ */
+data class PlantingSiteTimeZoneChangedEvent(val plantingSite: PlantingSiteModel)

--- a/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
@@ -1,0 +1,26 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
+import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import javax.inject.Named
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
+
+@Named
+class PlantingSiteService(
+    private val eventPublisher: ApplicationEventPublisher,
+    private val plantingSiteStore: PlantingSiteStore,
+) {
+  /**
+   * Publishes [PlantingSiteTimeZoneChangedEvent]s for any planting sites whose time zones have
+   * changed implicitly thanks to a change of their owning organization's time zone.
+   */
+  @EventListener
+  fun on(event: OrganizationTimeZoneChangedEvent) {
+    plantingSiteStore
+        .fetchSitesByOrganizationId(event.organizationId)
+        .filter { it.timeZone == null }
+        .forEach { site -> eventPublisher.publishEvent(PlantingSiteTimeZoneChangedEvent(site)) }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -338,6 +338,7 @@ abstract class DatabaseTest {
       countryCode: String? = null,
       countrySubdivisionCode: String? = null,
       createdBy: UserId = currentUser().userId,
+      timeZone: ZoneId? = null,
   ): OrganizationId {
     return with(ORGANIZATIONS) {
       dslContext
@@ -350,6 +351,7 @@ abstract class DatabaseTest {
           .set(NAME, name)
           .set(MODIFIED_BY, createdBy)
           .set(MODIFIED_TIME, Instant.EPOCH)
+          .set(TIME_ZONE, timeZone)
           .returning(ID)
           .fetchOne(ID)!!
           .also { inserted.organizationIds.add(it) }

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -114,7 +114,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
         ),
         googleDriveWriter,
         OrganizationStore(clock, dslContext, organizationsDao, publisher),
-        PlantingSiteStore(clock, dslContext, plantingSitesDao, plantingZonesDao),
+        PlantingSiteStore(clock, dslContext, publisher, plantingSitesDao, plantingZonesDao),
         reportRenderer,
         reportStore,
         scheduler,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -49,7 +50,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
         dslContext, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), filesDao, fileStore, thumbnailStore)
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {
-    PlantingSiteStore(clock, dslContext, plantingSitesDao, plantingZonesDao)
+    PlantingSiteStore(clock, dslContext, TestEventPublisher(), plantingSitesDao, plantingZonesDao)
   }
   private val service: ObservationService by lazy {
     ObservationService(

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
+import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val eventPublisher = TestEventPublisher()
+  private val plantingSiteStore by lazy {
+    PlantingSiteStore(TestClock(), dslContext, eventPublisher, plantingSitesDao, plantingZonesDao)
+  }
+  private val service by lazy { PlantingSiteService(eventPublisher, plantingSiteStore) }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+
+    every { user.canReadOrganization(any()) } returns true
+    every { user.canReadPlantingSite(any()) } returns true
+  }
+
+  @Nested
+  inner class OnTimeZoneChange {
+    @Test
+    fun `publishes PlantingSiteTimeZoneChangedEvent when organization time zone changes`() {
+      val oldTimeZone = insertTimeZone("America/New_York")
+      val newTimeZone = insertTimeZone("America/Buenos_Aires")
+
+      insertOrganization(timeZone = oldTimeZone)
+      insertPlantingSite(timeZone = oldTimeZone)
+      val plantingSiteWithoutTimeZone1 =
+          plantingSiteStore.fetchSiteById(insertPlantingSite(), PlantingSiteDepth.Site)
+      val plantingSiteWithoutTimeZone2 =
+          plantingSiteStore.fetchSiteById(insertPlantingSite(), PlantingSiteDepth.Site)
+
+      organizationsDao.update(
+          organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = newTimeZone))
+
+      service.on(OrganizationTimeZoneChangedEvent(organizationId))
+
+      eventPublisher.assertExactEventsPublished(
+          setOf(
+              PlantingSiteTimeZoneChangedEvent(plantingSiteWithoutTimeZone1),
+              PlantingSiteTimeZoneChangedEvent(plantingSiteWithoutTimeZone2)))
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -26,6 +26,8 @@ import com.terraformation.backend.tracking.model.ObservationPlotModel
 import io.mockk.every
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -233,6 +235,84 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<ObservationNotFoundException> {
         store.fetchObservationPlotDetails(observationId)
       }
+    }
+  }
+
+  @Nested
+  inner class FetchStartableObservations {
+    @Test
+    fun `honors planting site time zones`() {
+      // Three adjacent time zones, 1 hour apart
+      val zone1 = insertTimeZone("America/Los_Angeles")
+      val zone2 = insertTimeZone("America/Denver")
+      val zone3 = insertTimeZone("America/Chicago")
+
+      val startDate = LocalDate.of(2023, 4, 1)
+      val endDate = LocalDate.of(2023, 4, 30)
+
+      // Current time in zone 1: 2023-03-31 23:00:00
+      // Current time in zone 2: 2023-04-01 00:00:00
+      // Current time in zone 3: 2023-04-01 01:00:00
+      val now = ZonedDateTime.of(startDate, LocalTime.MIDNIGHT, zone2).toInstant()
+      clock.instant = now
+
+      organizationsDao.update(
+          organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = zone2))
+
+      // Start date is now at a site that inherits its time zone from its organization.
+      insertPlantingSite()
+      val observationId1 =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+
+      // Start date is an hour ago.
+      insertPlantingSite(timeZone = zone3)
+      val observationId2 =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+
+      // Start date hasn't arrived yet in the site's time zone.
+      insertPlantingSite(timeZone = zone1)
+      insertObservation(endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+
+      // Observation already in progress; shouldn't be started
+      insertPlantingSite(timeZone = zone3)
+      insertObservation(
+          endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      // Start date is still in the future.
+      insertPlantingSite(timeZone = zone3)
+      insertObservation(
+          endDate = endDate, startDate = startDate.plusDays(1), state = ObservationState.Upcoming)
+
+      val expected = setOf(observationId1, observationId2)
+      val actual = store.fetchStartableObservations().map { it.id }.toSet()
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `limits results to requested planting site`() {
+      val timeZone = insertTimeZone("America/Denver")
+
+      val startDate = LocalDate.of(2023, 4, 1)
+      val endDate = LocalDate.of(2023, 4, 30)
+
+      val now = ZonedDateTime.of(startDate, LocalTime.MIDNIGHT, timeZone).toInstant()
+      clock.instant = now
+
+      val plantingSiteId = insertPlantingSite(timeZone = timeZone)
+      val observationId =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+
+      insertPlantingSite(timeZone = timeZone)
+      insertObservation(endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+
+      val expected = setOf(observationId)
+      val actual = store.fetchStartableObservations(plantingSiteId).map { it.id }.toSet()
+
+      assertEquals(expected, actual)
     }
   }
 


### PR DESCRIPTION
When the start date for an upcoming observation arrives in the planting site's
time zone, automatically start it.