### PR TITLE
SW-3617 Update states of overdue observations

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -362,6 +362,89 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
+  inner class FetchObservationsPastEndDate {
+    @Test
+    fun `honors planting site time zones`() {
+      // Three adjacent time zones, 1 hour apart
+      val zone1 = insertTimeZone("America/Los_Angeles")
+      val zone2 = insertTimeZone("America/Denver")
+      val zone3 = insertTimeZone("America/Chicago")
+
+      val startDate = LocalDate.of(2023, 3, 1)
+      val endDate = LocalDate.of(2023, 3, 31)
+
+      // Current time in zone 1: 2023-03-31 23:00:00
+      // Current time in zone 2: 2023-04-01 00:00:00
+      // Current time in zone 3: 2023-04-01 01:00:00
+      val now = ZonedDateTime.of(endDate.plusDays(1), LocalTime.MIDNIGHT, zone2).toInstant()
+      clock.instant = now
+
+      organizationsDao.update(
+          organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = zone2))
+
+      // End date ending now at a site that inherits its time zone from its organization.
+      insertPlantingSite()
+      val observationId1 =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      // End date ended an hour ago.
+      insertPlantingSite(timeZone = zone3)
+      val observationId2 =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      // End date isn't over yet in the site's time zone.
+      insertPlantingSite(timeZone = zone1)
+      insertObservation(
+          endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      // Observation already completed; shouldn't be marked as overdue
+      insertPlantingSite(timeZone = zone3)
+      insertObservation(
+          ObservationsRow(completedTime = Instant.EPOCH),
+          endDate = endDate,
+          startDate = startDate,
+          state = ObservationState.Completed)
+
+      // End date is still in the future.
+      insertPlantingSite(timeZone = zone3)
+      insertObservation(
+          endDate = endDate.plusDays(1), startDate = startDate, state = ObservationState.InProgress)
+
+      val expected = setOf(observationId1, observationId2)
+      val actual = store.fetchObservationsPastEndDate().map { it.id }.toSet()
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `limits results to requested planting site`() {
+      val timeZone = insertTimeZone("America/Denver")
+
+      val startDate = LocalDate.of(2023, 4, 1)
+      val endDate = LocalDate.of(2023, 4, 30)
+
+      val now = ZonedDateTime.of(endDate.plusDays(1), LocalTime.MIDNIGHT, timeZone).toInstant()
+      clock.instant = now
+
+      val plantingSiteId = insertPlantingSite(timeZone = timeZone)
+      val observationId =
+          insertObservation(
+              endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      insertPlantingSite(timeZone = timeZone)
+      insertObservation(
+          endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+
+      val expected = setOf(observationId)
+      val actual = store.fetchObservationsPastEndDate(plantingSiteId).map { it.id }.toSet()
+
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Nested
   inner class CreateObservation {
     @Test
     fun `saves fields that are relevant to a new observation`() {


### PR DESCRIPTION
When an observation's end date passes and it is still in progress, change its
state to "Overdue."