### PR TITLE
Accept canonical enum values in API payloads

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -133,6 +133,7 @@ class TerrawareGenerator : KotlinGenerator() {
               private val displayNames = ConcurrentHashMap<Locale, Map<$enumName, String>>()
               private val byLocalizedName = ConcurrentHashMap<Locale, Map<String, $enumName>>()
               private val byId = values().associateBy { it.id }
+              private val byApiName = values().associateBy { it.displayName }
               
               fun forDisplayName(name: String, locale: Locale): $enumName {
                 val valuesForLocale = byLocalizedName.getOrPut(locale) {
@@ -145,7 +146,10 @@ class TerrawareGenerator : KotlinGenerator() {
               
               @JsonCreator
               @JvmStatic
-              fun forDisplayName(name: String) = forDisplayName(name, Locale.ENGLISH)
+              fun forApiName(name: String): $enumName {
+                return byApiName[name]
+                    ?: throw IllegalArgumentException("Unrecognized value: ${dollarSign}name")
+              }
               
               fun forId(id: Int) = byId[id]
           }

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -107,7 +107,7 @@ class TerrawareGenerator : KotlinGenerator() {
     val properties =
         (listOf(
                 "override val id: Int",
-                "@get:JsonValue override val displayName: String",
+                "@get:JsonValue override val jsonValue: String",
             ) + additionalProperties)
             .joinToString(separator = ",\n          ")
 
@@ -133,7 +133,7 @@ class TerrawareGenerator : KotlinGenerator() {
               private val displayNames = ConcurrentHashMap<Locale, Map<$enumName, String>>()
               private val byLocalizedName = ConcurrentHashMap<Locale, Map<String, $enumName>>()
               private val byId = values().associateBy { it.id }
-              private val byApiName = values().associateBy { it.displayName }
+              private val byJsonValue = values().associateBy { it.jsonValue }
               
               fun forDisplayName(name: String, locale: Locale): $enumName {
                 val valuesForLocale = byLocalizedName.getOrPut(locale) {
@@ -146,9 +146,9 @@ class TerrawareGenerator : KotlinGenerator() {
               
               @JsonCreator
               @JvmStatic
-              fun forApiName(name: String): $enumName {
-                return byApiName[name]
-                    ?: throw IllegalArgumentException("Unrecognized value: ${dollarSign}name")
+              fun forJsonValue(jsonValue: String): $enumName {
+                return byJsonValue[jsonValue]
+                    ?: throw IllegalArgumentException("Unrecognized value: ${dollarSign}jsonValue")
               }
               
               fun forId(id: Int) = byId[id]

--- a/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
@@ -7,8 +7,8 @@ import java.util.ResourceBundle
 
 interface EnumFromReferenceTable<T : Enum<T>> {
   val id: Int
-  /** Display name in US English. */
-  val displayName: String
+  /** JSON string representation of this enum value. */
+  val jsonValue: String
   val tableName: String
 
   fun getDisplayName(locale: Locale?): String
@@ -26,7 +26,7 @@ interface EnumFromReferenceTable<T : Enum<T>> {
               perClassLogger()
                   .error("No localization bundle for enum names in $locale; defaulting to English")
             }
-            return values.associateWith { it.displayName }
+            return values.associateWith { it.jsonValue }
           }
 
       val enumClass = values.first().javaClass
@@ -40,7 +40,7 @@ interface EnumFromReferenceTable<T : Enum<T>> {
           bundle.getString(key)
         } else {
           perClassLogger().error("No translation for $key in $locale")
-          enumValue.displayName
+          enumValue.jsonValue
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -86,7 +86,7 @@ class FacilityNotFoundException(val facilityId: FacilityId) :
     EntityNotFoundException("Facility $facilityId not found")
 
 class FacilityTypeMismatchException(val facilityId: FacilityId, val requiredType: FacilityType) :
-    MismatchedStateException("Facility $facilityId is not of type ${requiredType.displayName}")
+    MismatchedStateException("Facility $facilityId is not of type ${requiredType.jsonValue}")
 
 class FileNotFoundException(val fileId: FileId) : EntityNotFoundException("File $fileId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -94,7 +94,7 @@ class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
     return if (localize) {
       getDisplayName(currentLocale())
     } else {
-      displayName
+      jsonValue
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -112,15 +112,15 @@ enum class AccessionStateV2(val modelState: AccessionState) {
   InStorage(AccessionState.InStorage),
   UsedUp(AccessionState.UsedUp);
 
-  @get:JsonValue val displayName: String = modelState.displayName
+  @get:JsonValue val jsonValue: String = modelState.jsonValue
 
   companion object {
     private val byModelState: Map<AccessionState, AccessionStateV2> by lazy {
       values().associateBy { it.modelState }
     }
 
-    private val byDisplayName: Map<String, AccessionStateV2> by lazy {
-      values().associateBy { it.displayName }
+    private val byJsonValue: Map<String, AccessionStateV2> by lazy {
+      values().associateBy { it.jsonValue }
     }
 
     fun of(state: AccessionState): AccessionStateV2 =
@@ -128,8 +128,8 @@ enum class AccessionStateV2(val modelState: AccessionState) {
 
     @JsonCreator
     @JvmStatic
-    fun of(displayName: String): AccessionStateV2 =
-        byDisplayName[displayName] ?: throw IllegalArgumentException("Unknown state $displayName")
+    fun forJsonValue(value: String): AccessionStateV2 =
+        byJsonValue[value] ?: throw IllegalArgumentException("Unknown state $value")
 
     fun isValid(state: AccessionState): Boolean = state in byModelState
   }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/ViabilityTest.kt
@@ -59,7 +59,7 @@ data class ViabilityTestModel(
         }
     if (!substrateValidForTestType) {
       throw IllegalArgumentException(
-          "Substrate ${substrate?.displayName} not valid for test type ${testType.displayName}")
+          "Substrate ${substrate?.jsonValue} not valid for test type ${testType.jsonValue}")
     }
 
     assertNotMixingCutAndGerminationResults()

--- a/src/main/resources/templates/admin/deviceTemplates.html
+++ b/src/main/resources/templates/admin/deviceTemplates.html
@@ -46,7 +46,7 @@
             <select name="categoryId" th:form="|template${template.id}|">
                 <option th:each="category : ${categories}"
                         th:selected="${template.categoryId == category}"
-                        th:text="${category.displayName}"
+                        th:text="${category.jsonValue}"
                         th:value="${category.name}">PV
                 </option>
             </select>
@@ -101,7 +101,7 @@
         <td></td>
         <td>
             <select name="categoryId" form="createTemplate">
-                <option th:each="category : ${categories}" th:text="${category.displayName}"
+                <option th:each="category : ${categories}" th:text="${category.jsonValue}"
                         th:value="${category.name}">PV
                 </option>
             </select>

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -79,7 +79,7 @@
     <select name="type" id="type">
         <option th:each="type : ${facilityTypes}"
                 th:selected="${facility.type} == ${type}"
-                th:text="${type.displayName}"
+                th:text="${type.jsonValue}"
                 th:value="${type.id}">
             Type
         </option>
@@ -94,7 +94,7 @@
     <select name="connectionState" id="connectionState">
         <option th:each="state: ${connectionStates}"
                 th:selected="${facility.connectionState} == ${state}"
-                th:text="${state.displayName}"
+                th:text="${state.jsonValue}"
                 th:value="${state}">
             State
         </option>
@@ -105,7 +105,7 @@
 
 <div th:if="!${canUpdateFacility}">
     Facility Type:
-    <span th:text="${facility.type.displayName}">Seed Bank</span>
+    <span th:text="${facility.type.jsonValue}">Seed Bank</span>
 </div>
 
 <h3>Devices</h3>

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -36,7 +36,7 @@
     <li th:each="facility : ${facilities}">
         <a th:href="|${prefix}/facility/${facility.id}|">
             <span th:text="|${facility.name}|">MySeedBank</span>
-            (<span th:text="${facility.type.displayName}">Seed Bank</span>
+            (<span th:text="${facility.type.jsonValue}">Seed Bank</span>
             <span th:text="${facility.id}">12345</span>)
         </a>
     </li>
@@ -51,7 +51,7 @@
     <label for="facilityType">Type</label>
     <select name="type" id="facilityType">
         <option th:each="type : ${facilityTypes}" th:value="${type.id}"
-                th:text="${type.displayName}">Type
+                th:text="${type.jsonValue}">Type
         </option>
     </select>
     <input type="submit" value=" Create Facility "/>

--- a/src/main/resources/templates/reports/v1/index.html
+++ b/src/main/resources/templates/reports/v1/index.html
@@ -140,7 +140,7 @@ Renders an item with an h3 label. <div th:replace="::h3Item ('Foo', 'Bar')"/> be
             </tr>
             <tr th:each="species : ${site.species}">
                 <td th:text="${species.scientificName}"></td>
-                <td th:text="${species.growthForm?.displayName}"></td>
+                <td th:text="${species.growthForm?.jsonValue}"></td>
                 <td th:text="${species.totalPlanted}"></td>
                 <td th:text="${species.mortalityRateInField}"></td>
             </tr>

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.search.table.SearchTables
 import io.mockk.every
 import java.text.NumberFormat
 import java.time.LocalDate
+import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -409,7 +410,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "facility_name" to "Nursery",
                       "hasReassignments" to "false",
                       "id" to "$nurseryTransferWithdrawalId",
-                      "purpose" to WithdrawalPurpose.NurseryTransfer.displayName,
+                      "purpose" to WithdrawalPurpose.NurseryTransfer.getDisplayName(Locale.ENGLISH),
                       "totalWithdrawn" to number(3),
                       "withdrawnDate" to "2021-01-01",
                   ),
@@ -423,7 +424,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "facility_name" to "Nursery",
                       "hasReassignments" to "false",
                       "id" to "$otherWithdrawalId",
-                      "purpose" to WithdrawalPurpose.Other.displayName,
+                      "purpose" to WithdrawalPurpose.Other.getDisplayName(Locale.ENGLISH),
                       "totalWithdrawn" to number(4),
                       "withdrawnDate" to "2022-02-02",
                   ),
@@ -443,7 +444,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "hasReassignments" to "true",
                       "id" to "$outplantWithdrawalId",
                       "plantingSubzoneNames" to "Z1-1 (Z1-2, Z1-3)",
-                      "purpose" to WithdrawalPurpose.OutPlant.displayName,
+                      "purpose" to WithdrawalPurpose.OutPlant.getDisplayName(Locale.ENGLISH),
                       "totalWithdrawn" to number(24),
                       "withdrawnDate" to "2023-03-03",
                   ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.search.SearchDirection
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
 import com.terraformation.backend.seedbank.model.AccessionActive
+import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -125,7 +126,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   @Test
   fun `matches localized display name`() {
     val gibberishActive = AccessionActive.Active.toString().toGibberish()
-    val gibberishInStorage = AccessionState.InStorage.displayName.toGibberish()
+    val gibberishInStorage = AccessionState.InStorage.getDisplayName(Locale.ENGLISH).toGibberish()
     val fields = listOf(activeField, stateField)
     val search =
         AndNode(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.search.FacilityIdScope
 import com.terraformation.backend.search.OrganizationIdScope
 import io.mockk.every
 import java.time.LocalDate
+import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
@@ -28,7 +29,8 @@ internal class SearchServiceFetchAllValuesTest : SearchServiceTest() {
 
   @Test
   fun `returns values for enum-mapped field`() {
-    val expected = listOf(null) + ViabilityTestType.values().map { it.displayName }
+    val expected =
+        listOf(null) + ViabilityTestType.values().map { it.getDisplayName(Locale.ENGLISH) }
     val values = searchService.fetchAllValues(viabilityTestsTypeField, searchScopes)
     assertEquals(expected, values)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -58,7 +58,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
                 FieldNode(rawActiveField, listOf("Active")),
                 FieldNode(rawPlantsField, listOf("8000")),
                 FieldNode(rawRareField, listOf("false")),
-                FieldNode(rawStateField, listOf(AccessionState.InStorage.displayName)),
+                FieldNode(rawStateField, listOf(AccessionState.InStorage.jsonValue)),
                 FieldNode(rawTotalWeightField, listOf("5000")),
             ))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
 import io.mockk.every
+import java.util.Locale
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -136,7 +137,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
     val criteria =
         AndNode(
             listOf(
-                FieldNode(roleNameField, listOf(Role.Admin.displayName)),
+                FieldNode(roleNameField, listOf(Role.Admin.getDisplayName(Locale.ENGLISH))),
                 FieldNode(organizationIdField, listOf("$organizationId"))))
     val sortOrder = fields.map { SearchSortField(it) }
 
@@ -152,7 +153,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "organization_id" to "$organizationId",
-                    "roleName" to Role.Admin.displayName,
+                    "roleName" to Role.Admin.getDisplayName(Locale.ENGLISH),
                 )),
             null)
 


### PR DESCRIPTION
JSON deserialization of our reference table enums was expecting English
display names as values, rather than the non-localized names from the
`name` columns of the reference tables.

Historically, those two were the same since we didn't have any concept of
localizing an enum name. But now that we support localization, there is
a distinction between the enum string values in the API (which uses the
names from the database) and the human-readable values that get included
in exported CSV files and the like.

We were correctly using the names from the database in responses, and listing
those names as the acceptable values in the OpenAPI schema. But the actual
JSON deserialization was expecting the localized English names.

This caused the server to reject the value `CantTell` of the
`RecordedSpeciesCertainty` enum because its localized English name is "Can't
Tell". (Currently, that's the only enum value whose string representation
in the API differs from the localized English name.)