### PR TITLE
Handle apostrophes in enum display names

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -69,9 +69,9 @@ class TerrawareGenerator : KotlinGenerator() {
             // Capitalize each word of multi-word values and concatenate them without spaces or
             // punctuation.
             val capitalizedName =
-                name.split(Regex("[-,/ ]")).joinToString("") { word ->
-                  word.replaceFirstChar { it.uppercaseChar() }
-                }
+                name.split(Regex("[-,/ ]"))
+                    .joinToString("") { word -> word.replaceFirstChar { it.uppercaseChar() } }
+                    .replace(Regex("[^0-9A-Za-z]"), "")
             val properties =
                 (listOf("\"$name\"") +
                         table.additionalColumns.mapIndexed { i, columnInfo ->


### PR DESCRIPTION
The localized English name for `RecordedSpeciesCertainty.CantTell` was being
rendered as `Can''t Tell` because single quotes in properties files are always
escaped by Phrase and we weren't unescaping them.

Including an apostrophe in an enum's name in the reference table was generating
broken code because it isn't a valid character in a Kotlin symbol. Update the
code generator to strip non-alphanumeric characters out of enum values.