### PR TITLE
SW-3641 Planting zone target planting densities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1034,11 +1034,12 @@ class AdminController(
   fun updatePlantingZone(
       @RequestParam plantingSiteId: PlantingSiteId,
       @RequestParam plantingZoneId: PlantingZoneId,
-      @RequestParam variance: BigDecimal?,
-      @RequestParam errorMargin: BigDecimal?,
-      @RequestParam studentsT: BigDecimal?,
-      @RequestParam numPermanent: Int?,
-      @RequestParam numTemporary: Int?,
+      @RequestParam variance: BigDecimal,
+      @RequestParam errorMargin: BigDecimal,
+      @RequestParam studentsT: BigDecimal,
+      @RequestParam numPermanent: Int,
+      @RequestParam numTemporary: Int,
+      @RequestParam targetPlantingDensity: BigDecimal,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
@@ -1048,6 +1049,7 @@ class AdminController(
             numPermanentClusters = numPermanent,
             numTemporaryPlots = numTemporary,
             studentsT = studentsT,
+            targetPlantingDensity = targetPlantingDensity,
             variance = variance,
         )
       }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 import java.time.Month
 import java.time.ZoneId
 import javax.validation.constraints.Max
@@ -103,6 +104,7 @@ data class PlantingZonePayload(
     val id: PlantingZoneId,
     val name: String,
     val plantingSubzones: List<PlantingSubzonePayload>,
+    val targetPlantingDensity: BigDecimal,
 ) {
   constructor(
       model: PlantingZoneModel
@@ -110,7 +112,9 @@ data class PlantingZonePayload(
       model.boundary,
       model.id,
       model.name,
-      model.plantingSubzones.map { PlantingSubzonePayload(it) })
+      model.plantingSubzones.map { PlantingSubzonePayload(it) },
+      model.targetPlantingDensity,
+  )
 }
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -242,6 +242,7 @@ class PlantingSiteStore(
           .set(NUM_PERMANENT_CLUSTERS, edited.numPermanentClusters)
           .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
           .set(STUDENTS_T, edited.studentsT)
+          .set(TARGET_PLANTING_DENSITY, edited.targetPlantingDensity)
           .set(VARIANCE, edited.variance)
           .where(ID.eq(plantingZoneId))
           .execute()
@@ -338,6 +339,7 @@ class PlantingSiteStore(
                     PLANTING_ZONES.NUM_PERMANENT_CLUSTERS,
                     PLANTING_ZONES.NUM_TEMPORARY_PLOTS,
                     PLANTING_ZONES.STUDENTS_T,
+                    PLANTING_ZONES.TARGET_PLANTING_DENSITY,
                     PLANTING_ZONES.VARIANCE,
                     plantingZonesBoundaryField,
                     subzonesField)
@@ -356,6 +358,7 @@ class PlantingSiteStore(
                 record[PLANTING_ZONES.NUM_TEMPORARY_PLOTS]!!,
                 subzonesField?.let { record[it] } ?: emptyList(),
                 record[PLANTING_ZONES.STUDENTS_T]!!,
+                record[PLANTING_ZONES.TARGET_PLANTING_DENSITY]!!,
                 record[PLANTING_ZONES.VARIANCE]!!,
             )
           }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -17,6 +17,7 @@ data class PlantingZoneModel(
     val numTemporaryPlots: Int,
     val plantingSubzones: List<PlantingSubzoneModel>,
     val studentsT: BigDecimal,
+    val targetPlantingDensity: BigDecimal,
     val variance: BigDecimal,
 ) {
   /**

--- a/src/main/resources/db/migration/0151/V192__PlantingZoneDensity.sql
+++ b/src/main/resources/db/migration/0151/V192__PlantingZoneDensity.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tracking.planting_zones
+    ADD COLUMN target_planting_density NUMERIC NOT NULL DEFAULT 1500;
+
+ALTER TABLE tracking.planting_zones
+    ADD CONSTRAINT positive_target_density CHECK (target_planting_density > 0);

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -165,12 +165,13 @@
 <th:block th:if="!${site.plantingZones.isEmpty()}">
 
     <th:block th:if="${canUpdatePlantingSite}">
-        <h3>Number of Monitoring Plots for Next Observation</h3>
+        <h3>Planting Zone Settings</h3>
 
         <table id="plotCounts">
             <tr>
                 <th>Zone ID</th>
                 <th>Name</th>
+                <th>Target<br/>Density</th>
                 <th>Variance</th>
                 <th>Error</th>
                 <th>Student's t</th>
@@ -184,6 +185,10 @@
             <tr th:each="zone : ${site.plantingZones}">
                 <td th:text="${zone.id}">1</td>
                 <td th:text="${zone.name}">XYZ</td>
+                <td>
+                    <input type="number" required min="1" name="targetPlantingDensity" size="8"
+                           th:value="${zone.targetPlantingDensity}" th:form="|zone-${zone.id}|"/>
+                </td>
                 <td>
                     <input type="number" required min="0.001" step="0.001" name="variance" size="8" th:id="|variance-${zone.id}|"
                            th:value="${zone.variance}" th:form="|zone-${zone.id}|"/>

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -96,6 +96,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                         numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
                         plantingSubzones = emptyList(),
                         studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
+                        targetPlantingDensity = BigDecimal.ONE,
                         variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                     ),
                 ))
@@ -197,6 +198,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                         numPermanentClusters = PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
                         numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
                         studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
+                        targetPlantingDensity = BigDecimal.ONE,
                         variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                         plantingSubzones =
                             listOf(
@@ -420,6 +422,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             numPermanentClusters = 1,
             numTemporaryPlots = 2,
             studentsT = BigDecimal.ONE,
+            targetPlantingDensity = BigDecimal.ONE,
             variance = BigDecimal.ZERO,
         )
 
@@ -431,6 +434,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     val newVariance = BigDecimal(12)
     val newPermanent = 13
     val newTemporary = 14
+    val newTargetPlantingDensity = BigDecimal(13)
 
     val expected =
         initialRow.copy(
@@ -440,6 +444,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             numPermanentClusters = newPermanent,
             numTemporaryPlots = newTemporary,
             studentsT = newStudentsT,
+            targetPlantingDensity = newTargetPlantingDensity,
             variance = newVariance,
         )
 
@@ -450,6 +455,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
           numPermanentClusters = newPermanent,
           numTemporaryPlots = newTemporary,
           studentsT = newStudentsT,
+          targetPlantingDensity = newTargetPlantingDensity,
           variance = newVariance,
           // Not editable
           createdBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -222,6 +222,7 @@ class PlantingZoneModelTest {
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = subzones,
           studentsT = BigDecimal.ONE,
+          targetPlantingDensity = BigDecimal.ONE,
           variance = BigDecimal.ONE,
       )
 }


### PR DESCRIPTION
Track the target planting density (in plants per hectare) for each planting zone.
The value is imported from the shapefile if present; otherwise we use a default.
It can be updated using the admin UI.

Nothing uses this value yet, but it will be an input into planting progress
calculations.