### PR TITLE
SW-3646 Scripts to create species and complete observations

### DIFF
--- a/scripts/client.py
+++ b/scripts/client.py
@@ -90,6 +90,18 @@ class TerrawareClient:
                     )
             r.raise_for_status()
 
+    def list_organizations(self):
+        return self.get("/api/v1/organizations")["organizations"]
+
+    def get_default_organization_id(self, require_admin=True):
+        return min(
+            [
+                organization["id"]
+                for organization in self.list_organizations()
+                if not require_admin or organization["role"] in ["Admin", "Owner"]
+            ]
+        )
+
     def get_facility(self, facility_id):
         return self.get(f"/api/v1/facilities/{facility_id}")["facility"]
 
@@ -162,11 +174,45 @@ class TerrawareClient:
     def search_all_accession_values(self, payload):
         return self.post("/api/v1/seedbank/values/all", json=payload)["results"]
 
+    def create_species(self, payload):
+        return self.post("/api/v1/species", json=payload)["id"]
+
     def list_species(self, organization_id):
         return self.get(f"/api/v1/species?organizationId={organization_id}")["species"]
 
     def create_seedling_batch(self, payload):
         return self.post("/api/v1/nursery/batches", json=payload)["batch"]
+
+    def get_planting_site(self, planting_site_id, depth="Site"):
+        return self.get(f"/api/v1/tracking/sites/{planting_site_id}?depth={depth}")[
+            "site"
+        ]
+
+    def get_observation(self, observation_id):
+        return self.get(f"/api/v1/tracking/observations/{observation_id}")[
+            "observation"
+        ]
+
+    def list_observations(self, organization_id):
+        return self.get(
+            f"/api/v1/tracking/observations?organizationId={organization_id}"
+        )["observations"]
+
+    def list_observation_plots(self, observation_id):
+        return self.get(f"/api/v1/tracking/observations/{observation_id}/plots")[
+            "plots"
+        ]
+
+    def claim_observation_plot(self, observation_id, plot_id):
+        return self.post(
+            f"/api/v1/tracking/observations/{observation_id}/plots/{plot_id}/claim"
+        )
+
+    def complete_observation(self, observation_id, plot_id, payload):
+        return self.post(
+            f"/api/v1/tracking/observations/{observation_id}/plots/{plot_id}",
+            json=payload,
+        )
 
     def fetch_access_token(self):
         if self.refresh_token:

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -90,6 +90,9 @@ class TerrawareClient:
                     )
             r.raise_for_status()
 
+    def get_me(self):
+        return self.get("/api/v1/users/me")["user"]
+
     def list_organizations(self):
         return self.get("/api/v1/organizations")["organizations"]
 

--- a/scripts/create_species.py
+++ b/scripts/create_species.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import argparse
+
+import example_values
+from client import add_terraware_args, client_from_args
+
+
+def main():
+    parser = argparse.ArgumentParser("Add a set of example species to an organization")
+    parser.add_argument(
+        "--organization",
+        "-o",
+        type=int,
+        help="Generate species in this organization. Default is to use the lowest-numbered "
+        + "organization where the current user is an admin.",
+    )
+    parser.add_argument(
+        "--number",
+        "-n",
+        type=int,
+        help="Number of species to create. Default is to create all example species in "
+        + "example_values.py.",
+    )
+    add_terraware_args(parser)
+
+    args = parser.parse_args()
+    client = client_from_args(args)
+
+    if args.organization:
+        organization_id = args.organization
+    else:
+        organization_id = client.get_default_organization_id()
+
+    existing_species_names = [
+        species["scientificName"] for species in client.list_species(organization_id)
+    ]
+    new_species_names = [
+        name
+        for name in example_values.TREE_SPECIES
+        if name not in existing_species_names
+    ]
+
+    if not new_species_names:
+        raise Exception("No new species names available")
+    if args.number and args.number > len(new_species_names):
+        raise Exception(f"Only {len(new_species_names)} new species names available")
+
+    for scientific_name in new_species_names[: args.number]:
+        client.create_species(
+            {
+                "organizationId": organization_id,
+                "scientificName": scientific_name,
+            }
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -25,7 +25,7 @@ def generate_recorded_plant(species_ids):
         species_id = None
         species_name = f"Other {random.randint(1, 5)}"
     else:
-        certainty = "Can't Tell"
+        certainty = "CantTell"
         species_id = None
         species_name = None
 
@@ -48,6 +48,16 @@ def generate_complete_plot_payload(plot_id, species_ids):
         "observedTime": isoformat(int(time.time())),
         "plants": [generate_recorded_plant(species_ids) for i in range(0, num_plants)],
     }
+
+
+def get_incomplete_plot_ids(client, observation_id):
+    my_user_id = client.get_me()["id"]
+    return [
+        plot["plotId"]
+        for plot in client.list_observation_plots(observation_id)
+        if "completedByUserId" not in plot
+        and ("claimedByUserId" not in plot or plot["claimedByUserId"] == my_user_id)
+    ]
 
 
 def main():
@@ -102,11 +112,7 @@ def main():
     if args.plot:
         plot_ids = [args.plot]
     else:
-        plot_ids = [
-            plot["plotId"]
-            for plot in client.list_observation_plots(observation_id)
-            if "claimedByUserId" not in plot
-        ]
+        plot_ids = get_incomplete_plot_ids(client, observation_id)
         if args.num_plots:
             plot_ids = plot_ids[: args.num_plots]
 

--- a/scripts/observe.py
+++ b/scripts/observe.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+import argparse
+from datetime import datetime, timezone
+import json
+import random
+import time
+from client import add_terraware_args, client_from_args
+
+
+def isoformat(timestamp: int) -> str:
+    return (
+        datetime.fromtimestamp(timestamp, timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def generate_recorded_plant(species_ids):
+    if random.randint(1, 10) > 1:
+        certainty = "Known"
+        species_id = random.choice(species_ids)
+        species_name = None
+    elif random.randint(1, 2) == 1:
+        certainty = "Other"
+        species_id = None
+        species_name = f"Other {random.randint(1, 5)}"
+    else:
+        certainty = "Can't Tell"
+        species_id = None
+        species_name = None
+
+    status = "Live" if random.randint(1, 5) > 1 else random.choice(["Dead", "Existing"])
+
+    return {
+        "certainty": certainty,
+        "gpsCoordinates": {"type": "Point", "coordinates": [1, 2]},
+        "speciesId": species_id,
+        "speciesName": species_name,
+        "status": status,
+    }
+
+
+def generate_complete_plot_payload(plot_id, species_ids):
+    num_plants = random.randint(25, 200)
+    return {
+        "conditions": [],
+        "notes": f"Notes for plot {plot_id}",
+        "observedTime": isoformat(int(time.time())),
+        "plants": [generate_recorded_plant(species_ids) for i in range(0, num_plants)],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser("Complete observations of monitoring plots")
+    parser.add_argument(
+        "--observation", "-o", type=int, help="Record results for this observation."
+    )
+    parser.add_argument(
+        "--organization",
+        "-O",
+        type=int,
+        help="Choose observation from this organization. Default is the current user's "
+        + "lowest-numbered organization.",
+    )
+    parser.add_argument(
+        "--plot",
+        "-p",
+        type=int,
+        help="Record results for this plot. Default is to record results for multiple plots.",
+    )
+    parser.add_argument(
+        "--num-plots",
+        "-n",
+        type=int,
+        help="Record results for this many plots. Default is to record results for all "
+        + "incomplete plots. Ignored if --plot is specified.",
+    )
+    add_terraware_args(parser)
+    args = parser.parse_args()
+
+    client = client_from_args(args)
+
+    if args.observation:
+        observation_id = args.observation
+        observation = client.get_observation(observation_id)
+        planting_site = client.get_planting_site(observation["plantingSiteId"])
+        organization_id = planting_site["organizationId"]
+    else:
+        organization_id = client.get_default_organization_id(require_admin=False)
+        incomplete_observations = [
+            observation
+            for observation in client.list_observations(organization_id)
+            if observation["state"] in ["InProgress", "Overdue"]
+        ]
+        if not incomplete_observations:
+            raise Exception(
+                f"Organization {organization_id} has no incomplete observations"
+            )
+        observation_id = incomplete_observations[0]["id"]
+        print(f"Picked observation {observation_id}")
+
+    if args.plot:
+        plot_ids = [args.plot]
+    else:
+        plot_ids = [
+            plot["plotId"]
+            for plot in client.list_observation_plots(observation_id)
+            if "claimedByUserId" not in plot
+        ]
+        if args.num_plots:
+            plot_ids = plot_ids[: args.num_plots]
+
+    if not plot_ids:
+        raise Exception("No incomplete monitoring plots found in observation.")
+
+    # Use the organization's species list, rather than the list of planted species in each subzone,
+    # so we can run this without needing to first create a bunch of nursery withdrawals.
+    species_ids = [species["id"] for species in client.list_species(organization_id)]
+
+    for plot_id in plot_ids:
+        client.claim_observation_plot(observation_id, plot_id)
+        print(f"Completing plot {plot_id}")
+        payload = generate_complete_plot_payload(plot_id, species_ids)
+        client.complete_observation(observation_id, plot_id, payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -123,6 +123,7 @@ data class PlantingSitePayload(
     val description: String?,
     val id: PlantingSiteId,
     val name: String,
+    val organizationId: OrganizationId,
     @Max(12)
     @Min(1)
     @Schema(description = "What month this site's planting season ends. 1=January.")
@@ -141,6 +142,7 @@ data class PlantingSitePayload(
       description = model.description,
       id = model.id,
       name = model.name,
+      organizationId = model.organizationId,
       plantingSeasonEndMonth = model.plantingSeasonEndMonth?.value,
       plantingSeasonStartMonth = model.plantingSeasonStartMonth?.value,
       plantingZones = model.plantingZones.map { PlantingZonePayload(it) },


### PR DESCRIPTION
Add two new scripts in the `scripts` directory:

* `create_species.py` creates some example species in an organization so
  that there are species IDs available to associate with recorded plants.
* `observe.py` claims then completes some or all of the outstanding monitoring
  plot observations in an observation round. It generates semi-random data
  that should have enough variety to be useful for testing.

The second script required a way to fetch the details of a single observation,
so there's now a GET endpoint for that. It also required a way to figure out
the organization ID starting from an observation ID; the planting site payload
now includes the site's organization ID.