### PR TITLE
Add API endpoint to list species in subzone

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -39,11 +39,13 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -106,6 +108,10 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(plantingSiteId: PlantingSiteId): OrganizationId? =
       fetchFieldById(plantingSiteId, PLANTING_SITES.ID, PLANTING_SITES.ORGANIZATION_ID)
+
+  fun getOrganizationId(plantingSubzoneId: PlantingSubzoneId): OrganizationId? =
+      fetchFieldById(
+          plantingSubzoneId, PLANTING_SUBZONES.ID, PLANTING_SUBZONES.plantingSites.ORGANIZATION_ID)
 
   fun getOrganizationId(plantingZoneId: PlantingZoneId): OrganizationId? =
       fetchFieldById(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
@@ -158,6 +159,7 @@ data class DeviceManagerUser(
       false
   override fun canReadPlanting(plantingId: PlantingId): Boolean = false
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
+  override fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = false
   override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = false
   override fun canReadReport(reportId: ReportId): Boolean = false
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
@@ -283,6 +284,9 @@ data class IndividualUser(
 
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId) =
       isMember(parentStore.getOrganizationId(plantingSiteId))
+
+  override fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId) =
+      isMember(parentStore.getOrganizationId(plantingSubzoneId))
 
   override fun canReadPlantingZone(plantingZoneId: PlantingZoneId) =
       isMember(parentStore.getOrganizationId(plantingZoneId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -35,6 +35,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
@@ -42,6 +43,7 @@ import com.terraformation.backend.tracking.db.DeliveryNotFoundException
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSubzoneNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
@@ -418,6 +420,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readPlantingSite(plantingSiteId: PlantingSiteId) {
     if (!user.canReadPlantingSite(plantingSiteId)) {
       throw PlantingSiteNotFoundException(plantingSiteId)
+    }
+  }
+
+  fun readPlantingSubzone(plantingSubzoneId: PlantingSubzoneId) {
+    if (!user.canReadPlantingSubzone(plantingSubzoneId)) {
+      throw PlantingSubzoneNotFoundException(plantingSubzoneId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -163,6 +164,7 @@ class SystemUser(
       true
   override fun canReadPlanting(plantingId: PlantingId): Boolean = true
   override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
+  override fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = true
   override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
   override fun canReadReport(reportId: ReportId): Boolean = true
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import java.security.Principal
 import java.time.ZoneId
@@ -126,6 +127,7 @@ interface TerrawareUser : Principal {
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canReadPlanting(plantingId: PlantingId): Boolean
   fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean
   fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean
   fun canReadReport(reportId: ReportId): Boolean
   fun canReadSpecies(speciesId: SpeciesId): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
@@ -1,0 +1,41 @@
+package com.terraformation.backend.tracking.api
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.species.model.ExistingSpeciesModel
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/api/v1/tracking/subzones")
+@RestController
+@TrackingEndpoint
+class PlantingSubzonesController(private val speciesStore: SpeciesStore) {
+  @GetMapping("/{id}/species")
+  fun listPlantingSubzoneSpecies(
+      @PathVariable id: PlantingSubzoneId,
+  ): ListPlantingSubzoneSpeciesResponsePayload {
+    val species = speciesStore.fetchSpeciesByPlantingSubzoneId(id)
+
+    return ListPlantingSubzoneSpeciesResponsePayload(
+        species.map { PlantingSubzoneSpeciesPayload(it) })
+  }
+}
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+data class PlantingSubzoneSpeciesPayload(
+    val commonName: String?,
+    val id: SpeciesId,
+    val scientificName: String,
+) {
+  constructor(model: ExistingSpeciesModel) : this(model.commonName, model.id, model.scientificName)
+}
+
+data class ListPlantingSubzoneSpeciesResponsePayload(
+    val species: List<PlantingSubzoneSpeciesPayload>
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 
 class CrossDeliveryReassignmentNotAllowedException(
@@ -48,6 +49,9 @@ class PlantingNotFoundException(val plantingId: PlantingId) :
 
 class PlantingSiteNotFoundException(val plantingSiteId: PlantingSiteId) :
     EntityNotFoundException("Planting site $plantingSiteId not found")
+
+class PlantingSubzoneNotFoundException(val plantingSubzoneId: PlantingSubzoneId) :
+    EntityNotFoundException("Planting subzone $plantingSubzoneId not found")
 
 class PlantingZoneNotFoundException(val plantingZoneId: PlantingZoneId) :
     EntityNotFoundException("Planting zone $plantingZoneId not found")

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -35,6 +35,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
@@ -42,6 +43,7 @@ import com.terraformation.backend.tracking.db.DeliveryNotFoundException
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSubzoneNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
@@ -115,6 +117,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(PlantingNotFoundException::class) { canReadPlanting(it) }
   private val plantingSiteId: PlantingSiteId by
       readableId(PlantingSiteNotFoundException::class) { canReadPlantingSite(it) }
+  private val plantingSubzoneId: PlantingSubzoneId by
+      readableId(PlantingSubzoneNotFoundException::class) { canReadPlantingSubzone(it) }
   private val plantingZoneId: PlantingZoneId by
       readableId(PlantingZoneNotFoundException::class) { canReadPlantingZone(it) }
   private val reportId: ReportId by readableId(ReportNotFoundException::class) { canReadReport(it) }
@@ -394,6 +398,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readPlanting() = testRead { readPlanting(plantingId) }
 
   @Test fun readPlantingSite() = testRead { readPlantingSite(plantingSiteId) }
+
+  @Test fun readPlantingSubzone() = testRead { readPlantingSubzone(plantingSubzoneId) }
 
   @Test fun readPlantingZone() = testRead { readPlantingZone(plantingZoneId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -46,6 +46,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
@@ -116,6 +117,7 @@ internal class PermissionTest : DatabaseTest() {
 
   private val facilityIds = listOf(1000, 1001, 3000).map { FacilityId(it.toLong()) }
   private val plantingSiteIds = facilityIds.map { PlantingSiteId(it.value) }
+  private val plantingSubzoneIds = facilityIds.map { PlantingSubzoneId(it.value) }
   private val plantingZoneIds = facilityIds.map { PlantingZoneId(it.value) }
   private val observationIds = plantingSiteIds.map { ObservationId(it.value) }
 
@@ -260,6 +262,15 @@ internal class PermissionTest : DatabaseTest() {
       )
     }
 
+    plantingSubzoneIds.forEach { plantingSubzoneId ->
+      insertPlantingSubzone(
+          createdBy = userId,
+          id = plantingSubzoneId,
+          plantingSiteId = PlantingSiteId(plantingSubzoneId.value),
+          plantingZoneId = PlantingZoneId(plantingSubzoneId.value),
+      )
+    }
+
     reportIds.forEach { reportId ->
       val organizationId = OrganizationId(reportId.value)
       insertReport(id = reportId, organizationId = organizationId)
@@ -376,6 +387,11 @@ internal class PermissionTest : DatabaseTest() {
         createDelivery = true,
         readPlantingSite = true,
         updatePlantingSite = true,
+    )
+
+    permissions.expect(
+        *plantingSubzoneIds.forOrg1(),
+        readPlantingSubzone = true,
     )
 
     permissions.expect(
@@ -560,6 +576,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *plantingSubzoneIds.forOrg1(),
+        readPlantingSubzone = true,
+    )
+
+    permissions.expect(
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
         updatePlantingZone = true,
@@ -683,6 +704,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *plantingSubzoneIds.forOrg1(),
+        readPlantingSubzone = true,
+    )
+
+    permissions.expect(
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
     )
@@ -788,6 +814,11 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSiteIds.forOrg1(),
         readPlantingSite = true,
+    )
+
+    permissions.expect(
+        *plantingSubzoneIds.forOrg1(),
+        readPlantingSubzone = true,
     )
 
     permissions.expect(
@@ -992,6 +1023,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *plantingSubzoneIds.toTypedArray(),
+        readPlantingSubzone = true,
+    )
+
+    permissions.expect(
         *plantingZoneIds.toTypedArray(),
         readPlantingZone = true,
         updatePlantingZone = true,
@@ -1161,6 +1197,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedObservations = observationIds.toMutableSet()
     private val uncheckedPlantings = plantingIds.toMutableSet()
     private val uncheckedPlantingSites = plantingSiteIds.toMutableSet()
+    private val uncheckedPlantingSubzones = plantingSubzoneIds.toMutableSet()
     private val uncheckedPlantingZones = plantingZoneIds.toMutableSet()
     private val uncheckedReports = reportIds.toMutableSet()
     private val uncheckedSpecies = speciesIds.toMutableSet()
@@ -1561,6 +1598,20 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     fun expect(
+        vararg plantingSubzoneIds: PlantingSubzoneId,
+        readPlantingSubzone: Boolean = false,
+    ) {
+      plantingSubzoneIds.forEach { plantingSubzoneId ->
+        assertEquals(
+            readPlantingSubzone,
+            user.canReadPlantingSubzone(plantingSubzoneId),
+            "Can read planting subzone $plantingSubzoneId")
+
+        uncheckedPlantingSubzones.remove(plantingSubzoneId)
+      }
+    }
+
+    fun expect(
         vararg plantingZoneIds: PlantingZoneId,
         readPlantingZone: Boolean = false,
         updatePlantingZone: Boolean = false,
@@ -1657,6 +1708,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedOrgs.toTypedArray())
       expect(*uncheckedPlantings.toTypedArray())
       expect(*uncheckedPlantingSites.toTypedArray())
+      expect(*uncheckedPlantingSubzones.toTypedArray())
       expect(*uncheckedPlantingZones.toTypedArray())
       expect(*uncheckedReports.toTypedArray())
       expect(*uncheckedSpecies.toTypedArray())

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -366,7 +366,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val speciesId1 = insertSpecies(scientificName = "Species 1")
       val speciesId2 = insertSpecies(scientificName = "Species 2", commonName = "Common 2")
       val speciesId3 = insertSpecies(scientificName = "Species 3")
-      insertSpecies(scientificName = "Species 4")
+      val speciesId4 = insertSpecies(scientificName = "Species 4", deletedTime = Instant.EPOCH)
+      insertSpecies(scientificName = "Species 5")
 
       insertPlantingSite()
       insertPlantingZone()
@@ -379,6 +380,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertWithdrawal()
       insertDelivery()
       insertPlanting(speciesId = speciesId1)
+      insertPlanting(speciesId = speciesId4)
 
       insertPlantingSubzone()
       insertWithdrawal()

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -20,11 +20,13 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.NewSpeciesModel
+import com.terraformation.backend.tracking.db.PlantingSubzoneNotFoundException
 import io.mockk.every
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -355,6 +357,71 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     insertSpecies(uncheckedSpeciesId)
 
     assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
+  }
+
+  @Nested
+  inner class FetchSpeciesByPlantingSubzoneId {
+    @Test
+    fun `returns species for requested subzone`() {
+      val speciesId1 = insertSpecies(scientificName = "Species 1")
+      val speciesId2 = insertSpecies(scientificName = "Species 2", commonName = "Common 2")
+      val speciesId3 = insertSpecies(scientificName = "Species 3")
+      insertSpecies(scientificName = "Species 4")
+
+      insertPlantingSite()
+      insertPlantingZone()
+
+      val subzoneId = insertPlantingSubzone()
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting(speciesId = speciesId1)
+      insertPlanting(speciesId = speciesId2)
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting(speciesId = speciesId1)
+
+      insertPlantingSubzone()
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting(speciesId = speciesId2)
+      insertPlanting(speciesId = speciesId3)
+
+      every { user.canReadPlantingSubzone(subzoneId) } returns true
+
+      val expected =
+          listOf(
+              ExistingSpeciesModel(
+                  id = speciesId1,
+                  initialScientificName = "Species 1",
+                  organizationId = organizationId,
+                  scientificName = "Species 1",
+              ),
+              ExistingSpeciesModel(
+                  commonName = "Common 2",
+                  id = speciesId2,
+                  initialScientificName = "Species 2",
+                  organizationId = organizationId,
+                  scientificName = "Species 2",
+              ),
+          )
+
+      val actual = store.fetchSpeciesByPlantingSubzoneId(subzoneId)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `throws exception if no permission to read subzone`() {
+      insertPlantingSite()
+      insertPlantingZone()
+      val subzoneId = insertPlantingSubzone()
+
+      every { user.canReadPlantingSubzone(subzoneId) } returns false
+
+      assertThrows<PlantingSubzoneNotFoundException> {
+        store.fetchSpeciesByPlantingSubzoneId(subzoneId)
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
When users are in the field conductng an obaservation, the mobile app needs to
show the list of species that have been planted in a particular subzone. Add
`GET /api/v1/tracking/subzones/{id}/species` to return that list.