### PR TITLE
SW-1031 Run tests that depend on external services

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -5,15 +5,13 @@ set -euo pipefail
 commit_sha="${GITHUB_SHA:0:12}"
 docker_image='terraware/terraware-server'
 
+TIER=STAGING
+
 # Define tier based on branch ref
 if [[ "$GITHUB_REF" =~ refs/tags/v[0-9]+\.[0-9.]+ ]]; then
     TIER=PROD
     IS_CD=true
 elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
-    TIER=STAGING
-    IS_CD=true
-elif [[ "$GITHUB_REF" == refs/heads/qa ]]; then
-    TIER=QA
     IS_CD=true
 else
     IS_CD=false
@@ -22,14 +20,14 @@ fi
 (
     echo "IS_CD=$IS_CD"
     echo "COMMIT_SHA=$commit_sha"
+    echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
+    echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
 
     if [[ "$IS_CD" == true ]]; then
-        echo "TIER=$TIER"
         echo "DOCKER_TAGS=${docker_image}:$commit_sha,${docker_image}:${TIER}"
+        echo "TIER=$TIER"
 
         # Define secret names based on the tier
-        echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
-        echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
         echo "SSH_CONFIG_SECRET_NAME=${TIER}_SSH_CONFIG"
         echo "SSH_KEY_SECRET_NAME=${TIER}_SSH_KEY"
     fi

--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -5,15 +5,15 @@ set -euo pipefail
 commit_sha="${GITHUB_SHA:0:12}"
 docker_image='terraware/terraware-server'
 
-TIER=STAGING
-
 # Define tier based on branch ref
 if [[ "$GITHUB_REF" =~ refs/tags/v[0-9]+\.[0-9.]+ ]]; then
     TIER=PROD
     IS_CD=true
 elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
+    TIER=STAGING
     IS_CD=true
 else
+    TIER=CI
     IS_CD=false
 fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,12 @@ jobs:
     - name: Set environment
       run: ./.github/scripts/set-environment.sh
 
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
+        aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
+
     - name: Set up Java
       id: setup-java
       uses: actions/setup-java@v3
@@ -90,6 +96,15 @@ jobs:
     - name: Run tests
       run: ./gradlew test
 
+    - name: Run tests that depend on external services
+      # If there's a problem with an external service, we don't want the workflow to fail, but we
+      # still want errors flagged in the workflow's log.
+      continue-on-error: true
+      run: ./gradlew test --tests='*ExternalTest'
+      env:
+        TEST_BALENA_API_KEY: ${{ secrets.TEST_BALENA_API_KEY }}
+        TEST_S3_BUCKET_NAME: terraware-ci-test
+
     - name: Extract Docker image layers
       run: make -C docker prepare
 
@@ -126,13 +141,6 @@ jobs:
       run: |
         rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-    - name: Configure AWS Credentials
-      if: env.IS_CD == 'true'
-      uses: aws-actions/configure-aws-credentials@v1-node16
-      with:
-        role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
-        aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}
 
     - name: Deploy
       if: env.IS_CD == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,7 @@ jobs:
       # If there's a problem with an external service, we don't want the workflow to fail, but we
       # still want errors flagged in the workflow's log.
       continue-on-error: true
+      if: env.IS_CD == 'false'
       run: ./gradlew test --tests='*ExternalTest'
       env:
         TEST_BALENA_API_KEY: ${{ secrets.TEST_BALENA_API_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       run: ./gradlew test --tests='*ExternalTest'
       env:
         TEST_BALENA_API_KEY: ${{ secrets.TEST_BALENA_API_KEY }}
-        TEST_S3_BUCKET_NAME: terraware-ci-test-bogus
+        TEST_S3_BUCKET_NAME: terraware-ci-test
 
     - name: Extract Docker image layers
       run: make -C docker prepare

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./.github/scripts/set-environment.sh
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v2
       with:
         role-to-assume: ${{ secrets[env.AWS_ROLE_SECRET_NAME] }}
         aws-region: ${{ secrets[env.AWS_REGION_SECRET_NAME] }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       run: ./gradlew test --tests='*ExternalTest'
       env:
         TEST_BALENA_API_KEY: ${{ secrets.TEST_BALENA_API_KEY }}
-        TEST_S3_BUCKET_NAME: terraware-ci-test
+        TEST_S3_BUCKET_NAME: terraware-ci-test-bogus
 
     - name: Extract Docker image layers
       run: make -C docker prepare

--- a/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientExternalTest.kt
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.assertThrows
  * being used for real devices!_
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS) // Run setup once per class, not once per method
-internal class LiveBalenaClientTest {
+internal class LiveBalenaClientExternalTest {
   private val config: TerrawareServerConfig = mockk()
   private val log = perClassLogger()
 

--- a/src/test/kotlin/com/terraformation/backend/file/S3FileStoreExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/S3FileStoreExternalTest.kt
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
  * If `TEST_S3_BUCKET_NAME` is set and there are valid AWS credentials available, these tests will
  * run.
  */
-internal class S3FileStoreTest : FileStoreTest() {
+internal class S3FileStoreExternalTest : FileStoreTest() {
   private val bucketName = System.getenv("TEST_S3_BUCKET_NAME")
 
   private val config: TerrawareServerConfig = mockk()


### PR DESCRIPTION
By default, we skip tests like `S3FileStoreTest` in CI because we don't want our
CI builds to fail if the AWS API is having a glitch that's unrelated to the
changes we're making to our code. But that means we don't detect problems in
the code under test, or, more commonly, problems caused by upgrades of the client
libraries we use to talk to those services.

Add a build step that runs those tests (which are now required to have class names
ending in `ExternalTest` but doesn't cause the whole workflow to fail if they
don't pass. The failures will still be visible in the build log, so we can decide
on a case-by-case basis whether we care about them.