### PR TITLE
SW-3730 Observation results API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -217,9 +217,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               val subzones = record[plantingSubzoneMultiset]
 
               val isCompleted =
-                  subzones.all { subzone ->
-                    subzone.monitoringPlots.all { it.completedTime != null }
-                  }
+                  subzones.isNotEmpty() &&
+                      subzones.all { subzone ->
+                        subzone.monitoringPlots.all { it.completedTime != null }
+                      }
               val completedTime =
                   if (isCompleted) {
                     subzones.maxOf { subzone ->
@@ -284,7 +285,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
         .fetch { record ->
           val zones = record[plantingZoneMultiset]
 
-          val isCompleted = zones.all { it.completedTime != null }
+          val isCompleted = zones.isNotEmpty() && zones.all { it.completedTime != null }
           val completedTime =
               if (isCompleted) {
                 zones.maxOf { it.completedTime!! }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1,0 +1,346 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.forMultiset
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PHOTOS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
+import com.terraformation.backend.tracking.model.MONITORING_PLOTS_PER_HECTARE
+import com.terraformation.backend.tracking.model.ObservationMonitoringPlotPhotoPayload
+import com.terraformation.backend.tracking.model.ObservationMonitoringPlotResultsPayload
+import com.terraformation.backend.tracking.model.ObservationMonitoringPlotStatus
+import com.terraformation.backend.tracking.model.ObservationPlantingSubzoneResultsPayload
+import com.terraformation.backend.tracking.model.ObservationPlantingZoneResultsPayload
+import com.terraformation.backend.tracking.model.ObservationResultsPayload
+import com.terraformation.backend.tracking.model.ObservationSpeciesResultsPayload
+import java.math.BigDecimal
+import javax.inject.Named
+import kotlin.math.roundToInt
+import org.jooq.Condition
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.locationtech.jts.geom.Polygon
+
+@Named
+class ObservationResultsStore(private val dslContext: DSLContext) {
+  private val photosMultiset =
+      DSL.multiset(
+              DSL.select(OBSERVATION_PHOTOS.FILE_ID)
+                  .from(OBSERVATION_PHOTOS)
+                  .where(OBSERVATION_PHOTOS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+                  .and(OBSERVATION_PHOTOS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID)))
+          .convertFrom { result ->
+            result.map { record ->
+              ObservationMonitoringPlotPhotoPayload(
+                  fileId = record[OBSERVATION_PHOTOS.FILE_ID.asNonNullable()])
+            }
+          }
+
+  private val monitoringPlotSpeciesMultiset =
+      DSL.multiset(
+              DSL.select(
+                      OBSERVED_PLOT_SPECIES_TOTALS.MORTALITY_RATE,
+                      OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID,
+                      OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD,
+                      OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_PLANTS)
+                  .from(OBSERVED_PLOT_SPECIES_TOTALS)
+                  .where(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+                  .and(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+                  .orderBy(OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID))
+          .convertFrom { results ->
+            results.map { record ->
+              ObservationSpeciesResultsPayload(
+                  mortalityRate =
+                      record[OBSERVED_PLOT_SPECIES_TOTALS.MORTALITY_RATE.asNonNullable()],
+                  speciesId = record[OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID.asNonNullable()],
+                  totalDead = record[OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD.asNonNullable()],
+                  totalPlants = record[OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_PLANTS.asNonNullable()],
+              )
+            }
+          }
+
+  private val monitoringPlotsBoundaryField = MONITORING_PLOTS.BOUNDARY.forMultiset()
+
+  private val monitoringPlotMultiset =
+      DSL.multiset(
+              DSL.select(
+                      USERS.FIRST_NAME,
+                      USERS.LAST_NAME,
+                      OBSERVATION_PLOTS.CLAIMED_BY,
+                      OBSERVATION_PLOTS.COMPLETED_TIME,
+                      OBSERVATION_PLOTS.IS_PERMANENT,
+                      OBSERVATION_PLOTS.NOTES,
+                      monitoringPlotsBoundaryField,
+                      MONITORING_PLOTS.ID,
+                      MONITORING_PLOTS.FULL_NAME,
+                      monitoringPlotSpeciesMultiset,
+                      photosMultiset)
+                  .from(OBSERVATION_PLOTS)
+                  .join(MONITORING_PLOTS)
+                  .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+                  .leftJoin(USERS)
+                  .on(OBSERVATION_PLOTS.CLAIMED_BY.eq(USERS.ID))
+                  .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+                  .and(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID)))
+          .convertFrom { results ->
+            results.map { record ->
+              val claimedBy = record[OBSERVATION_PLOTS.CLAIMED_BY]
+              val completedTime = record[OBSERVATION_PLOTS.COMPLETED_TIME]
+              val species = record[monitoringPlotSpeciesMultiset]
+              val totalIdentifiedPlants = species.sumOf { it.totalPlants }
+              val totalSpecies = species.distinctBy { it.speciesId }.count()
+
+              val mortalityRate =
+                  if (totalIdentifiedPlants > 0) {
+                    species.sumOf { it.totalDead } * 100 / totalIdentifiedPlants
+                  } else {
+                    0
+                  }
+
+              // TODO: These need to count unidentified and existing plants too
+              val totalPlants = totalIdentifiedPlants
+              val plantingDensity = (totalPlants * MONITORING_PLOTS_PER_HECTARE).roundToInt()
+
+              val status =
+                  when {
+                    completedTime != null -> ObservationMonitoringPlotStatus.Completed
+                    claimedBy != null -> ObservationMonitoringPlotStatus.InProgress
+                    else -> ObservationMonitoringPlotStatus.Outstanding
+                  }
+
+              ObservationMonitoringPlotResultsPayload(
+                  boundary = record[monitoringPlotsBoundaryField] as Polygon,
+                  claimedByName =
+                      IndividualUser.makeFullName(
+                          record[USERS.FIRST_NAME], record[USERS.LAST_NAME]),
+                  claimedByUserId = claimedBy,
+                  completedTime = completedTime,
+                  isPermanent = record[OBSERVATION_PLOTS.IS_PERMANENT.asNonNullable()],
+                  monitoringPlotId = record[MONITORING_PLOTS.ID.asNonNullable()],
+                  monitoringPlotName = record[MONITORING_PLOTS.FULL_NAME.asNonNullable()],
+                  mortalityRate = mortalityRate,
+                  notes = record[OBSERVATION_PLOTS.NOTES],
+                  photos = record[photosMultiset],
+                  plantingDensity = plantingDensity,
+                  species = species,
+                  status = status,
+                  totalPlants = totalPlants,
+                  totalSpecies = totalSpecies)
+            }
+          }
+
+  private val plantingSubzoneMultiset =
+      DSL.multiset(
+              DSL.select(PLANTING_SUBZONES.ID, monitoringPlotMultiset)
+                  .from(PLANTING_SUBZONES)
+                  .where(
+                      PLANTING_SUBZONES.ID.`in`(
+                          DSL.select(MONITORING_PLOTS.PLANTING_SUBZONE_ID)
+                              .from(MONITORING_PLOTS)
+                              .join(OBSERVATION_PLOTS)
+                              .on(MONITORING_PLOTS.ID.eq(OBSERVATION_PLOTS.MONITORING_PLOT_ID))
+                              .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(OBSERVATIONS.ID)))))
+          .convertFrom { results ->
+            results.map { record ->
+              ObservationPlantingSubzoneResultsPayload(
+                  monitoringPlots = record[monitoringPlotMultiset],
+                  plantingSubzoneId = record[PLANTING_SUBZONES.ID.asNonNullable()],
+              )
+            }
+          }
+
+  private val plantingZoneSpeciesMultiset =
+      DSL.multiset(
+              DSL.select(
+                      OBSERVED_ZONE_SPECIES_TOTALS.MORTALITY_RATE,
+                      OBSERVED_ZONE_SPECIES_TOTALS.SPECIES_ID,
+                      OBSERVED_ZONE_SPECIES_TOTALS.TOTAL_DEAD,
+                      OBSERVED_ZONE_SPECIES_TOTALS.TOTAL_PLANTS)
+                  .from(OBSERVED_ZONE_SPECIES_TOTALS)
+                  .where(OBSERVED_ZONE_SPECIES_TOTALS.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
+                  .and(OBSERVED_ZONE_SPECIES_TOTALS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
+                  .orderBy(OBSERVED_ZONE_SPECIES_TOTALS.SPECIES_ID))
+          .convertFrom { results ->
+            results.map { record ->
+              ObservationSpeciesResultsPayload(
+                  mortalityRate =
+                      record[OBSERVED_ZONE_SPECIES_TOTALS.MORTALITY_RATE.asNonNullable()],
+                  speciesId = record[OBSERVED_ZONE_SPECIES_TOTALS.SPECIES_ID.asNonNullable()],
+                  totalDead = record[OBSERVED_ZONE_SPECIES_TOTALS.TOTAL_DEAD.asNonNullable()],
+                  totalPlants = record[OBSERVED_ZONE_SPECIES_TOTALS.TOTAL_PLANTS.asNonNullable()],
+              )
+            }
+          }
+
+  private val zoneFinishedPlantingField =
+      DSL.field(
+          DSL.notExists(
+              DSL.selectOne()
+                  .from(PLANTING_SUBZONES)
+                  .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
+                  .and(PLANTING_SUBZONES.FINISHED_PLANTING.isFalse)))
+
+  private val plantingZoneMultiset =
+      DSL.multiset(
+              DSL.select(
+                      PLANTING_ZONES.AREA_HA,
+                      PLANTING_ZONES.ID,
+                      plantingSubzoneMultiset,
+                      plantingZoneSpeciesMultiset,
+                      zoneFinishedPlantingField,
+                  )
+                  .from(PLANTING_ZONES)
+                  .where(PLANTING_ZONES.PLANTING_SITE_ID.eq(OBSERVATIONS.PLANTING_SITE_ID))
+                  .and(
+                      PLANTING_ZONES.ID.`in`(
+                          DSL.select(PLANTING_SUBZONES.PLANTING_ZONE_ID)
+                              .from(OBSERVATION_PLOTS)
+                              .join(MONITORING_PLOTS)
+                              .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+                              .join(PLANTING_SUBZONES)
+                              .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+                              .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(OBSERVATIONS.ID)))))
+          .convertFrom { results ->
+            results.map { record ->
+              val species = record[plantingZoneSpeciesMultiset]
+              val subzones = record[plantingSubzoneMultiset]
+
+              val isCompleted =
+                  subzones.all { subzone ->
+                    subzone.monitoringPlots.all { it.completedTime != null }
+                  }
+              val completedTime =
+                  if (isCompleted) {
+                    subzones.maxOf { subzone ->
+                      subzone.monitoringPlots.maxOf { it.completedTime!! }
+                    }
+                  } else {
+                    null
+                  }
+
+              val totalIdentifiedPlants =
+                  subzones.sumOf { subzone -> subzone.monitoringPlots.sumOf { it.totalPlants } }
+              val totalSpecies =
+                  subzones
+                      .flatMap { subzone ->
+                        subzone.monitoringPlots.flatMap { plot ->
+                          plot.species.map { it.speciesId }
+                        }
+                      }
+                      .distinct()
+                      .count()
+
+              val mortalityRate =
+                  if (totalIdentifiedPlants > 0) {
+                    species.sumOf { it.totalDead } * 100 / totalIdentifiedPlants
+                  } else {
+                    0
+                  }
+
+              // TODO: These need to count unidentified and existing plants too
+              val totalPlants = totalIdentifiedPlants
+              val plantingDensity =
+                  if (record[zoneFinishedPlantingField]) {
+                    (BigDecimal(totalPlants) / record[PLANTING_ZONES.AREA_HA.asNonNullable()])
+                        .toInt()
+                  } else {
+                    null
+                  }
+
+              ObservationPlantingZoneResultsPayload(
+                  completedTime = completedTime,
+                  mortalityRate = mortalityRate,
+                  plantingDensity = plantingDensity,
+                  plantingSubzones = subzones,
+                  plantingZoneId = record[PLANTING_ZONES.ID.asNonNullable()],
+                  species = species,
+                  totalPlants = totalPlants,
+                  totalSpecies = totalSpecies)
+            }
+          }
+
+  private fun fetchByCondition(condition: Condition): List<ObservationResultsPayload> {
+    return dslContext
+        .select(
+            OBSERVATIONS.ID,
+            OBSERVATIONS.PLANTING_SITE_ID,
+            OBSERVATIONS.START_DATE,
+            OBSERVATIONS.STATE_ID,
+            plantingZoneMultiset)
+        .from(OBSERVATIONS)
+        .where(condition)
+        .orderBy(OBSERVATIONS.ID)
+        .fetch { record ->
+          val zones = record[plantingZoneMultiset]
+
+          val isCompleted = zones.all { it.completedTime != null }
+          val completedTime =
+              if (isCompleted) {
+                zones.maxOf { it.completedTime!! }
+              } else {
+                null
+              }
+
+          val totalIdentifiedPlants = zones.sumOf { it.totalPlants }
+          val totalSpecies =
+              zones.flatMap { zone -> zone.species.map { it.speciesId } }.distinct().count()
+
+          val totalDead =
+              zones.sumOf { zone ->
+                zone.plantingSubzones.sumOf { subzone ->
+                  subzone.monitoringPlots.sumOf { plot -> plot.species.sumOf { it.totalDead } }
+                }
+              }
+          val mortalityRate =
+              if (totalIdentifiedPlants > 0) {
+                totalDead * 100 / totalIdentifiedPlants
+              } else {
+                0
+              }
+
+          // TODO: These need to count unidentified and existing plants too
+          val totalPlants = totalIdentifiedPlants
+
+          ObservationResultsPayload(
+              completedTime = completedTime,
+              mortalityRate = mortalityRate,
+              observationId = record[OBSERVATIONS.ID.asNonNullable()],
+              plantingSiteId = record[OBSERVATIONS.PLANTING_SITE_ID.asNonNullable()],
+              plantingZones = zones,
+              startDate = record[OBSERVATIONS.START_DATE.asNonNullable()],
+              state = record[OBSERVATIONS.STATE_ID.asNonNullable()],
+              totalPlants = totalPlants,
+              totalSpecies = totalSpecies,
+          )
+        }
+  }
+
+  fun fetchOneById(observationId: ObservationId): ObservationResultsPayload {
+    requirePermissions { readObservation(observationId) }
+
+    return fetchByCondition(OBSERVATIONS.ID.eq(observationId)).first()
+  }
+
+  fun fetchByPlantingSiteId(plantingSiteId: PlantingSiteId): List<ObservationResultsPayload> {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return fetchByCondition(OBSERVATIONS.PLANTING_SITE_ID.eq(plantingSiteId))
+  }
+
+  fun fetchByOrganizationId(organizationId: OrganizationId): List<ObservationResultsPayload> {
+    requirePermissions { readOrganization(organizationId) }
+
+    return fetchByCondition(OBSERVATIONS.plantingSites.ORGANIZATION_ID.eq(organizationId))
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -223,15 +223,15 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                 .orderBy(SPECIES_ID, SPECIES_NAME))
       }
 
-  // TODO: This needs to be temporally aware (what we want is whether or not the zone was finished
-  //       planting at the time of the observation, not at the present time).
   private val zoneFinishedPlantingField =
       DSL.field(
           DSL.notExists(
               DSL.selectOne()
                   .from(PLANTING_SUBZONES)
                   .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
-                  .and(PLANTING_SUBZONES.FINISHED_PLANTING.isFalse)))
+                  .and(
+                      PLANTING_SUBZONES.FINISHED_TIME.gt(OBSERVATIONS.COMPLETED_TIME)
+                          .or(PLANTING_SUBZONES.FINISHED_TIME.isNull))))
 
   private val plantingZoneMultiset =
       DSL.multiset(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -230,8 +230,8 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   .from(PLANTING_SUBZONES)
                   .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
                   .and(
-                      PLANTING_SUBZONES.FINISHED_TIME.gt(OBSERVATIONS.COMPLETED_TIME)
-                          .or(PLANTING_SUBZONES.FINISHED_TIME.isNull))))
+                      PLANTING_SUBZONES.FINISHED_PLANTING_TIME.gt(OBSERVATIONS.COMPLETED_TIME)
+                          .or(PLANTING_SUBZONES.FINISHED_PLANTING_TIME.isNull))))
 
   private val plantingZoneMultiset =
       DSL.multiset(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.ShapefileFeature
 import java.math.BigDecimal
@@ -58,9 +59,6 @@ class PlantingSiteImporter(
      * factor is needed to account for floating-point inaccuracy.
      */
     const val OUTSIDE_BOUNDS_MIN_PERCENT = 0.01
-
-    /** Monitoring plot width and height in meters. */
-    const val MONITORING_PLOT_SIZE: Double = 25.0
 
     /** Number of digits after the decimal point to retain in area (hectares) calculations. */
     const val HECTARES_SCALE = 1

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -1,4 +1,14 @@
 package com.terraformation.backend.tracking.model
 
+/** Monitoring plot width and height in meters. */
+const val MONITORING_PLOT_SIZE: Double = 25.0
+
 /** Number of square meters in a hectare. */
 const val SQUARE_METERS_PER_HECTARE: Double = 10000.0
+
+/** Number of square meters in a monitoring plot. */
+const val SQUARE_METERS_PER_MONITORING_PLOT: Double = MONITORING_PLOT_SIZE * MONITORING_PLOT_SIZE
+
+/** Number of monitoring plots in a hectare. */
+const val MONITORING_PLOTS_PER_HECTARE: Double =
+    SQUARE_METERS_PER_HECTARE / SQUARE_METERS_PER_MONITORING_PLOT

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
@@ -9,7 +9,9 @@ import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
 import org.locationtech.jts.geom.Polygon
@@ -19,9 +21,13 @@ data class ObservationMonitoringPlotPhotoPayload(
 )
 
 data class ObservationSpeciesResultsPayload(
+    val certainty: RecordedSpeciesCertainty,
     val mortalityRate: Int,
-    val speciesId: SpeciesId,
+    val speciesId: SpeciesId?,
+    val speciesName: String?,
     val totalDead: Int,
+    val totalExisting: Int,
+    val totalLive: Int,
     val totalPlants: Int,
 )
 
@@ -45,7 +51,16 @@ data class ObservationMonitoringPlotResultsPayload(
     val plantingDensity: Int,
     val species: List<ObservationSpeciesResultsPayload>,
     val status: ObservationMonitoringPlotStatus,
+    @Schema(
+        description =
+            "Total number of plants recorded. Includes all plants, regardless of live/dead " +
+                "status or species.")
     val totalPlants: Int,
+    @Schema(
+        description =
+            "Total number of species observed. Includes plants with Known and Other certainties. " +
+                "In the case of Other, each distinct user-supplied species name is counted as a " +
+                "separate species for purposes of this total.")
     val totalSpecies: Int,
 )
 
@@ -55,6 +70,7 @@ data class ObservationPlantingSubzoneResultsPayload(
 )
 
 data class ObservationPlantingZoneResultsPayload(
+    val areaHa: BigDecimal,
     val completedTime: Instant?,
     val mortalityRate: Int,
     @Schema(
@@ -67,6 +83,12 @@ data class ObservationPlantingZoneResultsPayload(
     val plantingZoneId: PlantingZoneId,
     val species: List<ObservationSpeciesResultsPayload>,
     val totalPlants: Int,
+    @Schema(
+        description =
+            "Total number of species observed, not counting dead or existing plants. Includes " +
+                "plants with Known and Other certainties. In the case of Other, each distinct " +
+                "user-supplied species name is counted as a separate species for purposes of " +
+                "this total.")
     val totalSpecies: Int,
 )
 
@@ -74,10 +96,21 @@ data class ObservationResultsPayload(
     val completedTime: Instant?,
     val mortalityRate: Int,
     val observationId: ObservationId,
+    @Schema(
+        description =
+            "Estimated planting density for the site, based on the observed planting densities " +
+                "of monitoring plots. Only present if all the subzones in the site have been " +
+                "marked as finished planting.")
+    val plantingDensity: Int?,
     val plantingSiteId: PlantingSiteId,
     val plantingZones: List<ObservationPlantingZoneResultsPayload>,
     val startDate: LocalDate,
     val state: ObservationState,
-    val totalPlants: Int,
+    @Schema(
+        description =
+            "Estimated total number of live plants at the site, based on the estimated planting " +
+                "density and site size. Only present if all the subzones in the site have been " +
+                "marked as finished planting.")
+    val totalPlants: Int?,
     val totalSpecies: Int,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
@@ -22,12 +22,13 @@ data class ObservationMonitoringPlotPhotoPayload(
 
 data class ObservationSpeciesResultsPayload(
     val certainty: RecordedSpeciesCertainty,
-    val mortalityRate: Int,
+    val mortalityRate: Int?,
     val speciesId: SpeciesId?,
     val speciesName: String?,
     val totalDead: Int,
     val totalExisting: Int,
     val totalLive: Int,
+    @Schema(description = "Total number of live and existing plants of this species.")
     val totalPlants: Int,
 )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
@@ -1,0 +1,83 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+import java.time.LocalDate
+import org.locationtech.jts.geom.Polygon
+
+data class ObservationMonitoringPlotPhotoPayload(
+    val fileId: FileId,
+)
+
+data class ObservationSpeciesResultsPayload(
+    val mortalityRate: Int,
+    val speciesId: SpeciesId,
+    val totalDead: Int,
+    val totalPlants: Int,
+)
+
+enum class ObservationMonitoringPlotStatus {
+  Outstanding,
+  InProgress,
+  Completed
+}
+
+data class ObservationMonitoringPlotResultsPayload(
+    val boundary: Polygon,
+    val claimedByName: String?,
+    val claimedByUserId: UserId?,
+    val completedTime: Instant?,
+    val isPermanent: Boolean,
+    val monitoringPlotId: MonitoringPlotId,
+    val monitoringPlotName: String,
+    val mortalityRate: Int,
+    val notes: String?,
+    val photos: List<ObservationMonitoringPlotPhotoPayload>,
+    val plantingDensity: Int,
+    val species: List<ObservationSpeciesResultsPayload>,
+    val status: ObservationMonitoringPlotStatus,
+    val totalPlants: Int,
+    val totalSpecies: Int,
+)
+
+data class ObservationPlantingSubzoneResultsPayload(
+    val monitoringPlots: List<ObservationMonitoringPlotResultsPayload>,
+    val plantingSubzoneId: PlantingSubzoneId,
+)
+
+data class ObservationPlantingZoneResultsPayload(
+    val completedTime: Instant?,
+    val mortalityRate: Int,
+    @Schema(
+        description =
+            "Estimated planting density for the zone, based on the observed planting densities " +
+                "of monitoring plots. Only present if all the subzones in the zone have been " +
+                "marked as finished planting.")
+    val plantingDensity: Int?,
+    val plantingSubzones: List<ObservationPlantingSubzoneResultsPayload>,
+    val plantingZoneId: PlantingZoneId,
+    val species: List<ObservationSpeciesResultsPayload>,
+    val totalPlants: Int,
+    val totalSpecies: Int,
+)
+
+data class ObservationResultsPayload(
+    val completedTime: Instant?,
+    val mortalityRate: Int,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    val plantingZones: List<ObservationPlantingZoneResultsPayload>,
+    val startDate: LocalDate,
+    val state: ObservationState,
+    val totalPlants: Int,
+    val totalSpecies: Int,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsPayload.kt
@@ -59,9 +59,9 @@ data class ObservationMonitoringPlotResultsPayload(
     val totalPlants: Int,
     @Schema(
         description =
-            "Total number of species observed. Includes plants with Known and Other certainties. " +
-                "In the case of Other, each distinct user-supplied species name is counted as a " +
-                "separate species for purposes of this total.")
+            "Total number of species observed, not counting dead plants. Includes plants with " +
+                "Known and Other certainties. In the case of Other, each distinct user-supplied " +
+                "species name is counted as a separate species for purposes of this total.")
     val totalSpecies: Int,
 )
 
@@ -86,10 +86,9 @@ data class ObservationPlantingZoneResultsPayload(
     val totalPlants: Int,
     @Schema(
         description =
-            "Total number of species observed, not counting dead or existing plants. Includes " +
-                "plants with Known and Other certainties. In the case of Other, each distinct " +
-                "user-supplied species name is counted as a separate species for purposes of " +
-                "this total.")
+            "Total number of species observed, not counting dead plants. Includes plants with " +
+                "Known and Other certainties. In the case of Other, each distinct user-supplied " +
+                "species name is counted as a separate species for purposes of this total.")
     val totalSpecies: Int,
 )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -231,11 +231,14 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
       val finishedPlanting = cols[2] == "Yes"
       val zoneId = zoneIds[zoneName]!!
 
-      val finishedTime = if (finishedPlanting) Instant.EPOCH else clock.instant.plusSeconds(1)
+      val finishedPlantingTime =
+          if (finishedPlanting) Instant.EPOCH else clock.instant.plusSeconds(1)
 
       subzoneName to
           insertPlantingSubzone(
-              finishedTime = finishedTime, name = subzoneName, plantingZoneId = zoneId)
+              finishedPlantingTime = finishedPlantingTime,
+              name = subzoneName,
+              plantingZoneId = zoneId)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -1,0 +1,330 @@
+package com.terraformation.backend.tracking.db
+
+import com.opencsv.CSVReader
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
+import com.terraformation.backend.tracking.model.ObservationResultsPayload
+import io.ktor.utils.io.core.use
+import io.mockk.every
+import java.io.InputStreamReader
+import java.nio.file.NoSuchFileException
+import java.time.Instant
+import kotlin.math.roundToInt
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private lateinit var observationId: ObservationId
+  private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var plotIds: Map<String, MonitoringPlotId>
+  private lateinit var speciesIds: Map<String, SpeciesId>
+  private lateinit var subzoneIds: Map<String, PlantingSubzoneId>
+  private lateinit var zoneIds: Map<String, PlantingZoneId>
+
+  private val clock = TestClock()
+  private val observationStore by lazy {
+    ObservationStore(
+        clock,
+        dslContext,
+        observationsDao,
+        observationPlotConditionsDao,
+        observationPlotsDao,
+        recordedPlantsDao)
+  }
+  private val resultsStore by lazy { ObservationResultsStore(dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    plantingSiteId = insertPlantingSite()
+    observationId = insertObservation()
+
+    every { user.canReadObservation(any()) } returns true
+    every { user.canUpdateObservation(any()) } returns true
+  }
+
+  @Test
+  fun `site with one zone finished planting and another not finished yet`() {
+    runScenario("/tracking/observation/OneZoneFinished")
+  }
+
+  private fun runScenario(prefix: String) {
+    importFromCsvFiles(prefix)
+    val results = resultsStore.fetchOneById(observationId)
+    assertResults(prefix, results)
+  }
+
+  private fun assertResults(prefix: String, results: ObservationResultsPayload) {
+    assertAll(
+        { assertSiteResults(prefix, results) },
+        { assertZoneResults(prefix, results) },
+        { assertZoneSpeciesResults(prefix, results) },
+        { assertPlotResults(prefix, results) },
+        { assertPlotSpeciesResults(prefix, results) },
+    )
+  }
+
+  private fun assertSiteResults(prefix: String, results: ObservationResultsPayload) {
+    assertResultsMatchCsv("$prefix/SiteStats.csv") { cols ->
+      val plantingDensity = cols[0].toIntOrNull()
+      val numPlants = cols[1].toIntOrNull()
+      val numSpecies = cols[2].toInt()
+      val mortalityRate = cols[3].toDouble().roundToInt()
+
+      ({
+        assertAll(
+            "Site",
+            listOf(
+                { assertEquals(plantingDensity, results.plantingDensity, "Planting density") },
+                { assertEquals(numPlants, results.totalPlants, "Estimated # plants") },
+                { assertEquals(numSpecies, results.totalSpecies, "Total species") },
+                { assertEquals(mortalityRate, results.mortalityRate, "Mortality rate") },
+            ))
+      })
+    }
+  }
+
+  private fun assertZoneResults(prefix: String, results: ObservationResultsPayload) {
+    assertResultsMatchCsv("$prefix/ZoneStats.csv") { cols ->
+      val zoneName = cols[0]
+      val numPlants = cols[1].toInt()
+      val plantingDensity = cols[2].toDoubleOrNull()?.roundToInt()
+      val numSpecies = cols[3].toInt()
+      val mortalityRate = cols[4].toDouble().roundToInt()
+
+      val zoneId = zoneIds[zoneName]!!
+      val zoneResults = results.plantingZones.single { it.plantingZoneId == zoneId }
+
+      ({
+        assertAll(
+            "Zone $zoneName",
+            listOf(
+                { assertEquals(numPlants, zoneResults.totalPlants, "Total plants") },
+                { assertEquals(plantingDensity, zoneResults.plantingDensity, "Planting density") },
+                { assertEquals(numSpecies, zoneResults.totalSpecies, "Total species") },
+                { assertEquals(mortalityRate, zoneResults.mortalityRate, "Mortality rate") },
+            ))
+      })
+    }
+  }
+
+  private fun assertPlotResults(prefix: String, results: ObservationResultsPayload) {
+    assertResultsMatchCsv("$prefix/PlotStats.csv") { cols ->
+      val plotName = cols[0]
+      val numPlants = cols[1].toInt()
+      val numSpecies = cols[2].toInt()
+      val mortalityRate = cols[3].toDoubleOrNull()?.roundToInt()
+      val plantingDensity = cols[5].toDoubleOrNull()?.roundToInt()
+
+      val plotId = plotIds[plotName]
+      val plotResults =
+          results.plantingZones
+              .flatMap { zone -> zone.plantingSubzones.flatMap { it.monitoringPlots } }
+              .single { it.monitoringPlotId == plotId }
+
+      ({
+        assertAll(
+            "Plot $plotName",
+            listOf(
+                { assertEquals(numPlants, plotResults.totalPlants, "Total plants") },
+                { assertEquals(numSpecies, plotResults.totalSpecies, "Total species") },
+                { assertEquals(mortalityRate, plotResults.mortalityRate, "Mortality rate") },
+                { assertEquals(plantingDensity, plotResults.plantingDensity, "Planting density") },
+            ))
+      })
+    }
+  }
+
+  private fun assertZoneSpeciesResults(prefix: String, results: ObservationResultsPayload) {
+    assertResultsMatchCsv("$prefix/ZoneStatsPerSpecies.csv") { cols ->
+      val zoneName = cols[0]
+      val speciesName = cols[1]
+      val numPlants = cols[2].toInt()
+      val mortalityRate = cols[3].toDoubleOrNull()?.roundToInt()
+
+      val zoneId = zoneIds[zoneName]!!
+      val speciesId = speciesIds[speciesName]
+      val zoneResults = results.plantingZones.single { it.plantingZoneId == zoneId }
+      val speciesResults =
+          zoneResults.species.single { species ->
+            (species.speciesId == null && species.speciesName == speciesName) ||
+                (species.speciesId != null && species.speciesId == speciesId)
+          }
+
+      ({
+        assertAll(
+            "Zone $zoneName species $speciesName",
+            listOf(
+                { assertEquals(numPlants, speciesResults.totalPlants, "Total plants") },
+                { assertEquals(mortalityRate, speciesResults.mortalityRate, "Mortality rate") },
+            ))
+      })
+    }
+  }
+
+  private fun assertPlotSpeciesResults(prefix: String, results: ObservationResultsPayload) {
+    assertResultsMatchCsv("$prefix/PlotStatsPerSpecies.csv") { cols ->
+      val plotName = cols[0]
+      val speciesName = cols[1]
+      val numPlants = cols[2].toInt()
+      val mortalityRate = cols[3].toDoubleOrNull()?.roundToInt()
+
+      val plotId = plotIds[plotName]!!
+      val speciesId = speciesIds[speciesName]
+      val plotResults =
+          results.plantingZones
+              .flatMap { zone -> zone.plantingSubzones.flatMap { it.monitoringPlots } }
+              .single { it.monitoringPlotId == plotId }
+      val speciesResults =
+          plotResults.species.single { species ->
+            (species.speciesId == null && species.speciesName == speciesName) ||
+                (species.speciesId != null && species.speciesId == speciesId)
+          }
+
+      ({
+        assertAll(
+            "Plot $plotName species $speciesName",
+            listOf(
+                { assertEquals(numPlants, speciesResults.totalPlants, "Total plants") },
+                { assertEquals(mortalityRate, speciesResults.mortalityRate, "Mortality rate") },
+            ))
+      })
+    }
+  }
+
+  private fun importFromCsvFiles(prefix: String) {
+    zoneIds = importZonesCsv(prefix)
+    subzoneIds = importSubzonesCsv(prefix)
+    plotIds = importPlotsCsv(prefix)
+    speciesIds = importPlantsCsv(prefix)
+  }
+
+  private fun importZonesCsv(prefix: String): Map<String, PlantingZoneId> {
+    return associateCsv("$prefix/Zones.csv") { cols ->
+      val zoneName = cols[1]
+
+      zoneName to insertPlantingZone(name = zoneName)
+    }
+  }
+
+  private fun importSubzonesCsv(prefix: String): Map<String, PlantingSubzoneId> {
+    return associateCsv("$prefix/Subzones.csv") { cols ->
+      val zoneName = cols[0]
+      val subzoneName = cols[1]
+      val finishedPlanting = cols[2] == "Yes"
+      val zoneId = zoneIds[zoneName]!!
+
+      subzoneName to
+          insertPlantingSubzone(
+              finishedPlanting = finishedPlanting, name = subzoneName, plantingZoneId = zoneId)
+    }
+  }
+
+  private fun importPlotsCsv(prefix: String): Map<String, MonitoringPlotId> {
+    return associateCsv("$prefix/Plots.csv") { cols ->
+      val subzoneName = cols[0]
+      val plotName = cols[1]
+      val subzoneId = subzoneIds[subzoneName]!!
+
+      val plotId = insertMonitoringPlot(name = plotName, plantingSubzoneId = subzoneId)
+
+      insertObservationPlot(
+          claimedBy = user.userId,
+          claimedTime = Instant.EPOCH,
+          isPermanent = cols[2] == "Permanent")
+
+      plotName to plotId
+    }
+  }
+
+  private fun importPlantsCsv(prefix: String): Map<String, SpeciesId> {
+    val knownSpeciesIds = mutableMapOf<String, SpeciesId>()
+
+    val plantsRows =
+        mapCsv("$prefix/Plants.csv") { cols ->
+          val plotName = cols[0]
+          val certainty = RecordedSpeciesCertainty.forJsonValue(cols[1])
+          val speciesName = cols[2].ifBlank { null }
+          val status = RecordedPlantStatus.forJsonValue(cols[3])
+          val plotId = plotIds[plotName]!!
+
+          val speciesId =
+              if (speciesName != null && certainty == RecordedSpeciesCertainty.Known) {
+                knownSpeciesIds.computeIfAbsent(speciesName) { _ ->
+                  insertSpecies(scientificName = speciesName)
+                }
+              } else {
+                null
+              }
+          val speciesNameIfOther =
+              if (certainty == RecordedSpeciesCertainty.Other) {
+                speciesName
+              } else {
+                null
+              }
+
+          RecordedPlantsRow(
+              certaintyId = certainty,
+              gpsCoordinates = point(1.0),
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              speciesId = speciesId,
+              speciesName = speciesNameIfOther,
+              statusId = status,
+          )
+        }
+
+    plantsRows
+        .groupBy { it.monitoringPlotId!! }
+        .forEach { (plotId, plants) ->
+          observationStore.completePlot(
+              observationId, plotId, emptySet(), "Notes", Instant.EPOCH, plants)
+        }
+
+    return knownSpeciesIds
+  }
+
+  /** Maps each data row of a CSV to a value. */
+  private fun <T> mapCsv(path: String, func: (Array<String>) -> T): List<T> {
+    val stream = javaClass.getResourceAsStream(path) ?: throw NoSuchFileException(path)
+
+    return stream.use { inputStream ->
+      CSVReader(InputStreamReader(inputStream)).use { csvReader ->
+        // We never care about the header row.
+        csvReader.skip(1)
+
+        csvReader.map(func)
+      }
+    }
+  }
+
+  /** For each data row of a CSV, associates a string identifier with a value. */
+  private fun <T> associateCsv(
+      path: String,
+      func: (Array<String>) -> Pair<String, T>
+  ): Map<String, T> {
+    return mapCsv(path, func).toMap()
+  }
+
+  private fun assertResultsMatchCsv(path: String, func: (Array<String>) -> (() -> Unit)) {
+    val assertions = mapCsv(path, func)
+    assertAll(assertions)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -231,9 +231,11 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
       val finishedPlanting = cols[2] == "Yes"
       val zoneId = zoneIds[zoneName]!!
 
+      val finishedTime = if (finishedPlanting) Instant.EPOCH else clock.instant.plusSeconds(1)
+
       subzoneName to
           insertPlantingSubzone(
-              finishedPlanting = finishedPlanting, name = subzoneName, plantingZoneId = zoneId)
+              finishedTime = finishedTime, name = subzoneName, plantingZoneId = zoneId)
     }
   }
 

--- a/src/test/resources/tracking/observation/OneZoneFinished/Plants.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/Plants.csv
@@ -1,0 +1,31 @@
+Plot,Certainty,Species,Status
+Alpha-2-1,Unknown,,Live
+Alpha-2-1,Known,Known 1,Live
+Alpha-2-1,Known,Known 1,Live
+Alpha-2-1,Known,Known 2,Live
+Alpha-2-1,Known,Known 2,Existing
+Alpha-2-1,Known,Known 2,Dead
+Alpha-2-1,Other,Other A,Live
+Alpha-2-1,Other,Other A,Dead
+Alpha-2-1,Other,Other B,Live
+Alpha-2-2,Known,Known 3,Live
+Alpha-2-2,Known,Known 1,Existing
+Alpha-2-3,Known,Known 4,Existing
+Alpha-2-4,Other,Other C,Dead
+Alpha-2-4,Unknown,,Dead
+Alpha-2-4,Other,Other D,Dead
+Alpha-2-160,Known,Known 2,Live
+Alpha-2-160,Known,Known 2,Live
+Beta-1-1,Known,Known 5,Live
+Beta-1-1,Known,Known 5,Live
+Beta-1-1,Known,Known 5,Dead
+Beta-1-2,Other,Other C,Dead
+Beta-1-2,Known,Known 3,Live
+Beta-1-3,Known,Known 3,Live
+Beta-1-3,Known,Known 5,Live
+Beta-1-4,Known,Known 3,Live
+Beta-1-4,Known,Known 5,Live
+Beta-1-57,Known,Known 5,Existing
+Beta-1-57,Known,Known 3,Dead
+Beta-2-91,Unknown,,Live
+Beta-2-91,Known,Known 5,Live

--- a/src/test/resources/tracking/observation/OneZoneFinished/PlotStats.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/PlotStats.csv
@@ -1,0 +1,12 @@
+Plot,# Plants,# Species,Mortality Rate,Live Plants,Planting Density
+Alpha-2-1,9,4,25.00,6,96
+Alpha-2-2,2,2,0.00,1,16
+Alpha-2-3,1,1,0.00,0,0
+Alpha-2-4,3,0,0.00,0,0
+Alpha-2-160,2,1,0.00,2,32
+Beta-1-1,3,1,33.33,2,32
+Beta-1-2,2,1,0.00,1,16
+Beta-1-3,2,2,0.00,2,32
+Beta-1-4,2,2,0.00,2,32
+Beta-1-57,2,1,100.00,0,0
+Beta-2-91,2,1,0.00,2,32

--- a/src/test/resources/tracking/observation/OneZoneFinished/PlotStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/PlotStatsPerSpecies.csv
@@ -1,0 +1,18 @@
+Plot,Species,# Plants,Mortality Rate
+Alpha-2-1,Known 1,2,0.00
+Alpha-2-1,Known 2,2,50.00
+Alpha-2-1,Other A,1,
+Alpha-2-1,Other B,1,
+Alpha-2-2,Known 1,1,0.00
+Alpha-2-2,Known 3,1,0.00
+Alpha-2-3,Known 4,1,0.00
+Alpha-2-4,Other C,0,
+Alpha-2-160,Known 2,2,0.00
+Beta-1-1,Known 5,2,33.33
+Beta-1-2,Known 3,1,0.00
+Beta-1-3,Known 3,1,0.00
+Beta-1-3,Known 5,1,0.00
+Beta-1-4,Known 3,1,0.00
+Beta-1-4,Known 5,1,0.00
+Beta-1-57,Known 5,1,0.00
+Beta-2-91,Known 5,1,0.00

--- a/src/test/resources/tracking/observation/OneZoneFinished/Plots.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/Plots.csv
@@ -1,0 +1,12 @@
+Subzone,Name,Type,Area (ha)
+Alpha-2,Alpha-2-1,Permanent,0.0625
+Alpha-2,Alpha-2-2,Permanent,0.0625
+Alpha-2,Alpha-2-3,Permanent,0.0625
+Alpha-2,Alpha-2-4,Permanent,0.0625
+Alpha-2,Alpha-2-160,Temporary,0.0625
+Beta-1,Beta-1-1,Permanent,0.0625
+Beta-1,Beta-1-2,Permanent,0.0625
+Beta-1,Beta-1-3,Permanent,0.0625
+Beta-1,Beta-1-4,Permanent,0.0625
+Beta-1,Beta-1-57,Temporary,0.0625
+Beta-2,Beta-2-91,Temporary,0.0625

--- a/src/test/resources/tracking/observation/OneZoneFinished/SiteStats.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/SiteStats.csv
@@ -1,0 +1,2 @@
+Planting Density,Estimated # Plants,# Species,Mortality Rate
+,,7,17.65

--- a/src/test/resources/tracking/observation/OneZoneFinished/Subzones.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/Subzones.csv
@@ -1,0 +1,5 @@
+Zone,Name,Finished planting?
+Alpha,Alpha-1,No
+Alpha,Alpha-2,Yes
+Beta,Beta-1,Yes
+Beta,Beta-2,Yes

--- a/src/test/resources/tracking/observation/OneZoneFinished/ZoneStats.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/ZoneStats.csv
@@ -1,0 +1,3 @@
+Zone,# Plants,Planting Density,# Species,Mortality Rate
+Alpha,14,,6,14.29
+Beta,12,24,2,20.00

--- a/src/test/resources/tracking/observation/OneZoneFinished/ZoneStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/ZoneStatsPerSpecies.csv
@@ -1,0 +1,7 @@
+Zone,Species,# Plants,Mortality Rate
+Alpha,Known 1,3,0.00
+Alpha,Known 2,4,25.00
+Alpha,Other A,1,
+Alpha,Other B,1,
+Beta,Known 3,3,25.00
+Beta,Known 5,6,16.67

--- a/src/test/resources/tracking/observation/OneZoneFinished/Zones.csv
+++ b/src/test/resources/tracking/observation/OneZoneFinished/Zones.csv
@@ -1,0 +1,3 @@
+Site,Name,Area (ha),Finished planting?
+Demo Site,Alpha,1500,No
+Demo Site,Beta,1000,Yes


### PR DESCRIPTION
Add GET endpoints to fetch observation results.

* `/api/v1/tracking/observations/results?organizationId={id}` gets the results 
  of all observations across all an organization's planting sites.
* `/api/v1/tracking/observations/results?plantingSiteId={id}` gets the results 
  of all observations of a single planting site.
* `/api/v1/tracking/observations/{id}/results` gets tthe results of a single
  observation.
  
The summary calculations are tested against the numbers from a spreadsheet we're
using as part of the requirements process.