### PR TITLE
Track "Other" and "Can't Tell" plant totals

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -103,7 +103,7 @@ val ENUM_TABLES =
                     "RecordedPlantStatus"),
                 EnumTable(
                     "recorded_species_certainties",
-                    listOf("recorded_plants\\.certainty_id"),
+                    listOf("tracking\\..*\\.certainty_id"),
                     "RecordedSpeciesCertainty"),
             ),
     )

--- a/src/main/resources/db/migration/0151/V195__UnknownSpeciesTotals.sql
+++ b/src/main/resources/db/migration/0151/V195__UnknownSpeciesTotals.sql
@@ -1,0 +1,41 @@
+DROP TABLE tracking.observed_plot_species_totals;
+DROP TABLE tracking.observed_zone_species_totals;
+DROP TABLE tracking.observed_site_species_totals;
+
+CREATE PROCEDURE create_totals_table(table_name TEXT, scope_table TEXT, scope_column TEXT) AS $$
+    BEGIN
+        EXECUTE 'CREATE TABLE tracking.' || table_name || ' (
+            observation_id BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
+            ' || scope_column || ' BIGINT NOT NULL REFERENCES tracking.' || scope_table || ' ON DELETE CASCADE,
+            species_id BIGINT REFERENCES species,
+            species_name TEXT,
+            certainty_id INTEGER NOT NULL REFERENCES tracking.recorded_species_certainties,
+            total_live INTEGER NOT NULL DEFAULT 0,
+            total_dead INTEGER NOT NULL DEFAULT 0,
+            total_existing INTEGER NOT NULL DEFAULT 0,
+            total_plants INTEGER NOT NULL DEFAULT 0,
+            mortality_rate INTEGER NOT NULL DEFAULT 0,
+
+            CONSTRAINT species_identifier_for_certainty
+                CHECK (
+                    (certainty_id = 1 AND species_id IS NOT NULL AND species_name IS NULL)
+                    OR (certainty_id = 2 AND species_id IS NULL AND species_name IS NOT NULL)
+                    OR (certainty_id = 3 AND species_id IS NULL AND species_name IS NULL)
+                )
+        );';
+
+        EXECUTE 'CREATE UNIQUE INDEX ON tracking.' || table_name || ' (observation_id, ' || scope_column || ', species_id) WHERE species_id IS NOT NULL;';
+        EXECUTE 'CREATE UNIQUE INDEX ON tracking.' || table_name || ' (observation_id, ' || scope_column || ', species_name) WHERE species_name IS NOT NULL;';
+        EXECUTE 'CREATE UNIQUE INDEX ON tracking.' || table_name || ' (observation_id, ' || scope_column || ') WHERE species_id IS NULL AND species_name IS NULL;';
+
+        EXECUTE 'CREATE INDEX ON tracking.' || table_name || ' (observation_id);';
+        EXECUTE 'CREATE INDEX ON tracking.' || table_name || ' (species_id);';
+        EXECUTE 'CREATE INDEX ON tracking.' || table_name || ' (' || scope_column || ');';
+    END;
+$$ LANGUAGE plpgsql;
+
+CALL create_totals_table('observed_plot_species_totals', 'monitoring_plots', 'monitoring_plot_id');
+CALL create_totals_table('observed_zone_species_totals', 'planting_zones', 'planting_zone_id');
+CALL create_totals_table('observed_site_species_totals', 'planting_sites', 'planting_site_id');
+
+DROP PROCEDURE create_totals_table(table_name TEXT, scope_table TEXT, scope_column TEXT);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -106,9 +106,6 @@ import com.terraformation.backend.db.tracking.tables.daos.ObservationPhotosDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotConditionsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
-import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotSpeciesTotalsDao
-import com.terraformation.backend.db.tracking.tables.daos.ObservedSiteSpeciesTotalsDao
-import com.terraformation.backend.db.tracking.tables.daos.ObservedZoneSpeciesTotalsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSubzonesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingZonesDao
@@ -299,9 +296,6 @@ abstract class DatabaseTest {
   protected val observationPlotConditionsDao: ObservationPlotConditionsDao by lazyDao()
   protected val observationPlotsDao: ObservationPlotsDao by lazyDao()
   protected val observationsDao: ObservationsDao by lazyDao()
-  protected val observedPlotSpeciesTotalsDao: ObservedPlotSpeciesTotalsDao by lazyDao()
-  protected val observedSiteSpeciesTotalsDao: ObservedSiteSpeciesTotalsDao by lazyDao()
-  protected val observedZoneSpeciesTotalsDao: ObservedZoneSpeciesTotalsDao by lazyDao()
   protected val organizationInternalTagsDao: OrganizationInternalTagsDao by lazyDao()
   protected val organizationsDao: OrganizationsDao by lazyDao()
   protected val organizationUsersDao: OrganizationUsersDao by lazyDao()


### PR DESCRIPTION
Previously, we were only calculating total observations of plants of known
species, but we need to be able to show totals for "Can't Tell" plants as well as
break the "Other" plant totals down by user-supplied species names.

Change the totals tables to include both species ID and name columns whose
nullability depends on the recorded species certainty.

Since there aren't any observations in production yet, this is done by dropping
and recreating the tables rather than altering them.