### PR TITLE
EnumsTest shouldn't fail on extra values

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
@@ -46,11 +46,10 @@ class EnumsTest : DatabaseTest() {
 
   private fun assertBundleContains(bundleName: String, keys: Collection<String>) {
     val bundle = ResourceBundle.getBundle(bundleName, Locale.ENGLISH)
-    val keysInBundle = bundle.keys.toList().filter { bundle.getString(it).isNotBlank() }
+    val keysInBundle = bundle.keys.asSequence().filter { bundle.getString(it).isNotBlank() }.toSet()
+    val expectedKeys = keys.toSet()
+    val missingKeys = expectedKeys - keysInBundle
 
-    assertEquals(
-        keys.sorted(),
-        keysInBundle.sorted(),
-        "Bundle $bundleName did not include values for expected keys")
+    assertEquals(emptySet<String>(), missingKeys, "Bundle $bundleName is missing values")
   }
 }


### PR DESCRIPTION
If `Enums_en.properties` has a key that doesn't match any enum values, but does
have keys for all the values of all the enums, `EnumsTest` should pass.

This was causing CI failures after we deleted an enum value; the old English
display name was still in Phrase's string list and Phrase added it to back to
the properties file on export.