### PR TITLE
Add limit parameter to observation results API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -123,11 +123,19 @@ class ObservationsController(
   fun listObservationResults(
       @RequestParam organizationId: OrganizationId?,
       @RequestParam plantingSiteId: PlantingSiteId?,
+      @Parameter(
+          description =
+              "Maximum number of results to return. Results are always returned in order of " +
+                  "completion time, newest first, so setting this to 1 will return the results " +
+                  "of the most recently completed observation.")
+      limit: Int? = null,
   ): ListObservationResultsResponsePayload {
     val results =
         when {
-          plantingSiteId != null -> observationResultsStore.fetchByPlantingSiteId(plantingSiteId)
-          organizationId != null -> observationResultsStore.fetchByOrganizationId(organizationId)
+          plantingSiteId != null ->
+              observationResultsStore.fetchByPlantingSiteId(plantingSiteId, limit)
+          organizationId != null ->
+              observationResultsStore.fetchByOrganizationId(organizationId, limit)
           else -> throw BadRequestException("Must specify a search criterion")
         }
 


### PR DESCRIPTION
To allow the plants dashboard to show statistics from the most recent
observation of a given planting site, allow the client to request a maximum
number of results and change the result order so the most recently completed
observation always comes first. The client can thus pass in a planting site ID
and a limit of 1 to fetch the latest observation results for the site.

The default is still to return results from all observations.