### PR TITLE
Fetch organization users with one query

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -219,10 +219,8 @@ class AppNotificationService(
       localUrl: URI,
       roles: Set<Role>? = null,
   ) {
-    val recipients =
-        organizationStore.fetchEmailRecipients(organizationId, false, roles).mapNotNull {
-          userStore.fetchByEmail(it)
-        }
+    val recipients = userStore.fetchByOrganizationId(organizationId, false, roles)
+
     dslContext.transaction { _ ->
       recipients.forEach { user ->
         insert(notificationType, user, organizationId, renderMessage, localUrl, organizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.customer.db.AppVersionStore
 import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.InternalTagStore
 import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
 import com.terraformation.backend.customer.model.NewFacilityModel
 import com.terraformation.backend.customer.model.requirePermissions
@@ -130,6 +131,7 @@ class AdminController(
     private val reportRenderer: ReportRenderer,
     private val reportService: ReportService,
     private val reportStore: ReportStore,
+    private val userStore: UserStore,
 ) {
   private val log = perClassLogger()
   private val prefix = "/admin"
@@ -186,7 +188,7 @@ class AdminController(
   fun getFacility(@PathVariable facilityId: FacilityId, model: Model): String {
     val facility = facilityStore.fetchOneById(facilityId)
     val organization = organizationStore.fetchOneById(facility.organizationId)
-    val recipients = organizationStore.fetchEmailRecipients(facility.organizationId)
+    val recipients = userStore.fetchByOrganizationId(facility.organizationId).map { it.email }
     val storageLocations = facilityStore.fetchStorageLocations(facilityId)
     val deviceManager = deviceManagerStore.fetchOneByFacilityId(facilityId)
     val devices = deviceStore.fetchByFacilityId(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -262,9 +262,7 @@ class EmailNotificationService(
   private fun getRecipients(facilityId: FacilityId): List<IndividualUser> {
     val organizationId =
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
-    return organizationStore.fetchEmailRecipients(organizationId).mapNotNull {
-      userStore.fetchByEmail(it)
-    }
+    return userStore.fetchByOrganizationId(organizationId)
   }
 
   data class EmailRequest(val user: IndividualUser, val emailTemplateModel: EmailTemplateModel)

--- a/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailService.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.email
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
@@ -37,6 +38,7 @@ class EmailService(
     private val organizationStore: OrganizationStore,
     private val parentStore: ParentStore,
     private val sender: EmailSender,
+    private val userStore: UserStore,
 ) {
   private val emailValidator = EmailValidator.getInstance()
   private val log = perClassLogger()
@@ -76,7 +78,8 @@ class EmailService(
       requireOptIn: Boolean = true,
       roles: Set<Role>? = null,
   ) {
-    val recipients = organizationStore.fetchEmailRecipients(organizationId, requireOptIn, roles)
+    val recipients =
+        userStore.fetchByOrganizationId(organizationId, requireOptIn, roles).map { it.email }
 
     send(model, recipients)
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -533,53 +533,6 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     assertThrows<AccessDeniedException> { store.countRoleUsers(organizationId) }
   }
 
-  @Test
-  fun `fetchEmailRecipients returns addresses of opted-in users`() {
-    val otherOrganizationId = OrganizationId(2)
-    val optedInNonMember = UserId(100)
-    val optedInMember = UserId(101)
-    val optedOutMember = UserId(102)
-
-    insertOrganization(otherOrganizationId)
-
-    insertUser(optedInNonMember, email = "optedInNonMember@x.com", emailNotificationsEnabled = true)
-    insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
-    insertUser(optedOutMember, email = "optedOutMember@x.com")
-
-    insertOrganizationUser(optedInNonMember, otherOrganizationId)
-    insertOrganizationUser(optedInMember, organizationId)
-    insertOrganizationUser(optedOutMember, organizationId)
-
-    val expected = setOf("optedInMember@x.com")
-    val actual = store.fetchEmailRecipients(organizationId).toSet()
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `fetchEmailRecipients returns addresses users with requested roles`() {
-    val admin1 = UserId(100)
-    val admin2 = UserId(101)
-    val manager = UserId(102)
-    val owner = UserId(103)
-
-    insertUser(admin1, email = "admin1@x.com", emailNotificationsEnabled = true)
-    insertUser(admin2, email = "admin2@x.com", emailNotificationsEnabled = true)
-    insertUser(manager, email = "manager@x.com", emailNotificationsEnabled = true)
-    insertUser(owner, email = "owner@x.com", emailNotificationsEnabled = true)
-
-    insertOrganizationUser(admin1, role = Role.Admin)
-    insertOrganizationUser(admin2, role = Role.Admin)
-    insertOrganizationUser(manager, role = Role.Manager)
-    insertOrganizationUser(owner, role = Role.Owner)
-
-    val expected = setOf("admin1@x.com", "admin2@x.com", "owner@x.com")
-    val actual =
-        store.fetchEmailRecipients(organizationId, roles = setOf(Role.Owner, Role.Admin)).toSet()
-
-    assertEquals(expected, actual)
-  }
-
   private fun organizationUserModel(
       userId: UserId = UserId(100),
       email: String = "$userId@y.com",

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -629,4 +629,64 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
           "Dummy post-deletion email address should not be searchable")
     }
   }
+
+  @Nested
+  inner class FetchByOrganizationId {
+    @BeforeEach
+    fun setUp() {
+      insertUser()
+      insertOrganization()
+    }
+
+    @Test
+    fun `returns opted-in users`() {
+      val otherOrganizationId = OrganizationId(2)
+      val optedInNonMember = UserId(100)
+      val optedInMember = UserId(101)
+      val optedOutMember = UserId(102)
+
+      insertOrganization(otherOrganizationId)
+
+      insertUser(
+          optedInNonMember, email = "optedInNonMember@x.com", emailNotificationsEnabled = true)
+      insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
+      insertUser(optedOutMember, email = "optedOutMember@x.com")
+
+      insertOrganizationUser(optedInNonMember, otherOrganizationId)
+      insertOrganizationUser(optedInMember, organizationId)
+      insertOrganizationUser(optedOutMember, organizationId)
+
+      val expected = setOf("optedInMember@x.com")
+      val actual = userStore.fetchByOrganizationId(organizationId).map { it.email }.toSet()
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns users with requested roles`() {
+      val admin1 = UserId(100)
+      val admin2 = UserId(101)
+      val manager = UserId(102)
+      val owner = UserId(103)
+
+      insertUser(admin1, email = "admin1@x.com", emailNotificationsEnabled = true)
+      insertUser(admin2, email = "admin2@x.com", emailNotificationsEnabled = true)
+      insertUser(manager, email = "manager@x.com", emailNotificationsEnabled = true)
+      insertUser(owner, email = "owner@x.com", emailNotificationsEnabled = true)
+
+      insertOrganizationUser(admin1, role = Role.Admin)
+      insertOrganizationUser(admin2, role = Role.Admin)
+      insertOrganizationUser(manager, role = Role.Manager)
+      insertOrganizationUser(owner, role = Role.Owner)
+
+      val expected = setOf("admin1@x.com", "admin2@x.com", "owner@x.com")
+      val actual =
+          userStore
+              .fetchByOrganizationId(organizationId, roles = setOf(Role.Owner, Role.Admin))
+              .map { it.email }
+              .toSet()
+
+      assertEquals(expected, actual)
+    }
+  }
 }


### PR DESCRIPTION
Rather than fetching a list of organization user email addresses and then fetching
the `IndividualUser` for each email address, fetch the list of `IndividualUser`s
directly. This will be more efficient when sending notifications to organizations
with large numbers of users.