### PR TITLE
Support strings with multiple links in email messages

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -59,15 +59,20 @@ abstract class EmailTemplateModel(config: TerrawareServerConfig) {
    */
   abstract val templateDir: String
 
-  /** Renders a localizable string that contains an embedded link. */
-  @JvmOverloads
-  fun link(key: String, href: String, cssClass: String = "text-link"): TemplateModel {
-    return bundle
-        .getString(key)
-        .let { HTMLOutputFormat.INSTANCE.escapePlainText(it) }
-        .replace("[", """<a href="$href" class="$cssClass">""")
-        .replace("]", "</a>")
-        .let { HTMLOutputFormat.INSTANCE.fromMarkup(it) }
+  /** Renders a localizable string that contains embedded links. */
+  fun link(key: String, vararg urls: String): TemplateModel {
+    val htmlWithLeftBrackets =
+        bundle
+            .getString(key)
+            .let { HTMLOutputFormat.INSTANCE.escapePlainText(it) }
+            .replace("]", "</a>")
+
+    val htmlWithLinks =
+        urls.toList().fold(htmlWithLeftBrackets) { html, url ->
+          html.replaceFirst("[", """<a href="$url" class="text-link">""")
+        }
+
+    return htmlWithLinks.let { HTMLOutputFormat.INSTANCE.fromMarkup(it) }
   }
 }
 


### PR DESCRIPTION
Currently, the helper function that replaces square brackets with `<a>` tags in
localizable strings in email notification bodies only supports one link per
string. Update it to support arbitrary numbers of links in preparation for adding
an email notification that has two links in one sentence.