### PR TITLE
SW-3348 Automatically log out incompatible sessions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/SessionConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SessionConfig.kt
@@ -1,0 +1,52 @@
+package com.terraformation.backend.auth
+
+import com.terraformation.backend.log.perClassLogger
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.core.convert.support.GenericConversionService
+import org.springframework.core.serializer.DefaultDeserializer
+import org.springframework.core.serializer.support.SerializingConverter
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository
+import org.springframework.session.config.SessionRepositoryCustomizer
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository
+
+@Configuration
+class SessionConfig {
+  /**
+   * Make the default security context repository available as an injectable dependency so our
+   * application code can manipulate session data.
+   */
+  @Bean fun securityContextRepository() = HttpSessionSecurityContextRepository()
+
+  @Bean
+  fun sessionRepositoryCustomizer(): SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
+    val service = GenericConversionService()
+    service.addConverter(Any::class.java, ByteArray::class.java, SerializingConverter())
+    service.addConverter(ByteArray::class.java, Any::class.java, SessionInvalidatingConverter())
+
+    return SessionRepositoryCustomizer { repository -> repository.setConversionService(service) }
+  }
+
+  /**
+   * Deserializer for session data that treats deserialization failures as missing sessions rather
+   * than as internal errors. With this class, we don't need to explicitly delete active login
+   * sessions when we upgrade Spring and there's a backward-incompatible change to one of the
+   * authentication objects that gets serialized as part of the session data. Without this class,
+   * existing sessions that aren't serialization-compatible with the current version of the code
+   * cause HTTP 500 responses.
+   */
+  class SessionInvalidatingConverter : Converter<ByteArray, Any> {
+    private val deserializer = DefaultDeserializer(javaClass.classLoader)
+    private val log = perClassLogger()
+
+    override fun convert(source: ByteArray): Any? {
+      return try {
+        deserializer.deserialize(source.inputStream())
+      } catch (e: Exception) {
+        log.warn("Failed to deserialize session data; will start a new session")
+        null
+      }
+    }
+  }
+}


### PR DESCRIPTION
When we make a non-backward-compatible change to one of the classes that is
stored as part of the user's login session data, treat the session as
nonexistent instead of bombing out with an internal error.

In practice, this will often be invisible to the user: they will be treated
as unauthenticated, so they'll be redirected to Keycloak. If Keycloak still
considers them logged in, they'll be issued a new access token and redirected
straight back to the web app which will then create a fresh session for them.

This is in preparation for moving away from the Keycloak adapter library; when
we switch away from it, sessions that include serialized objects from that
library will no longer be deserializable.