### PR TITLE
SW-2710 Upgrade to Jobrunr 6.2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ dependencies {
   implementation("org.freemarker:freemarker:2.3.32")
   implementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
   implementation("org.geotools:gt-shapefile:$geoToolsVersion")
-  implementation("org.jobrunr:jobrunr-spring-boot-starter:5.3.3")
+  implementation("org.jobrunr:jobrunr-spring-boot-2-starter:6.2.2")
   implementation("org.jooq:jooq:$jooqVersion")
   implementation("org.locationtech.jts:jts-core:$jtsVersion")
   implementation("org.locationtech.jts.io:jts-io-common:$jtsVersion")


### PR DESCRIPTION
JobRunr 6 adds support for Spring Boot 3 but still supports Spring Boot 2. Upgrade
to the latest version so we can catch any problems introduced by JobRunr 6
independently of the Spring Boot upgrade.