### PR TITLE
SW-2710 Use non-deprecated Thymeleaf includes

### DIFF
--- a/src/main/resources/templates/admin/appVersions.html
+++ b/src/main/resources/templates/admin/appVersions.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 

--- a/src/main/resources/templates/admin/deviceManager.html
+++ b/src/main/resources/templates/admin/deviceManager.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head">
+<head th:replace="~{/admin/header :: head}">
     <script th:fragment="additionalScript">
         function showAdvanced() {
             document.getElementById("advanced").style.display = "block";
@@ -17,7 +17,7 @@
 </head>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a> -
 <a th:if="${facility} == null" th:href="|${prefix}/deviceManagers|">Device Managers</a>

--- a/src/main/resources/templates/admin/deviceTemplates.html
+++ b/src/main/resources/templates/admin/deviceTemplates.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head">
+<head th:replace="~{/admin/header :: head}">
     <script th:fragment="additionalScript">
         function fillOut(event, settings) {
             event.preventDefault();
@@ -60,7 +60,7 @@
 </head>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a> -
 <a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <h2>Organizations</h2>
 

--- a/src/main/resources/templates/admin/internalTag.html
+++ b/src/main/resources/templates/admin/internalTag.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head">
+<head th:replace="~{/admin/header :: head}">
     <script th:fragment="additionalScript">
         function warnOnTagDelete(event) {
             if (!confirm("Deleting a tag will remove it from all organizations! Are you sure?")) {
@@ -19,7 +19,7 @@
 </head>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 -

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 

--- a/src/main/resources/templates/admin/listInternalTags.html
+++ b/src/main/resources/templates/admin/listInternalTags.html
@@ -1,9 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head"/>
+<head th:replace="~{/admin/header :: head}"/>
 <script th:fragment="additionalScript" th:inline="javascript">
     /*<![CDATA[*/
     function warnOnDelete(event) {
@@ -126,7 +126,7 @@
 </style>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head">
+<head th:replace="~{/admin/header :: head}">
     <style th:fragment="additionalStyle">
         table.bordered, table.bordered tr th, table.bordered tr td {
             border: 1px solid black;
@@ -113,7 +113,7 @@
 
 <body>
 
-<th:block th:include="/admin/header :: top"/>
+<th:block th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a> -
 <a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>

--- a/src/main/resources/templates/admin/testClock.html
+++ b/src/main/resources/templates/admin/testClock.html
@@ -1,13 +1,13 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org">
-<head th:replace="/admin/header :: head">
+<head th:replace="~{/admin/header :: head}">
     <script th:fragment="additionalScript">
         setTimeout(() => location.reload(), 30000);
     </script>
 </head>
 <body>
 
-<span th:include="/admin/header :: top"/>
+<span th:replace="~{/admin/header :: top}"/>
 
 <a th:href="|${prefix}/|">Home</a>
 


### PR DESCRIPTION
Upcoming versions of Thymeleaf are going to stop supporting the `th:include`
directive as well as the shorthand syntax for referencing other templates.
Update our `th:include` directives to use the syntax that will be supported
going forward.

No behavior change here.