### PR TITLE
Ignore whitespace in numbers in CSV files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
@@ -44,6 +44,18 @@ fun getBigDecimalParser(locale: Locale): DecimalFormat {
   }
 }
 
+private val whitespace = Regex("\\s")
+
+/**
+ * Parses a string representation of a numeric value into a BigDecimal using the number formatting
+ * rules for a locale.
+ *
+ * Some locales such as French use whitespace as the separator character, but they usually use a
+ * non-breaking space character such as U+00A0 rather than an ASCII space. Java's number parsers are
+ * strict about accepting specific Unicode code points as separator characters. Users, however,
+ * might type ASCII spaces into a spreadsheet and expect them to be accepted. So we strip all
+ * whitespace characters from the string before parsing it.
+ */
 fun String.toBigDecimal(locale: Locale): BigDecimal {
-  return getBigDecimalParser(locale).parse(this) as BigDecimal
+  return getBigDecimalParser(locale).parse(this.replace(whitespace, "")) as BigDecimal
 }

--- a/src/main/resources/csv/accessions-template_gx.csv
+++ b/src/main/resources/csv/accessions-template_gx.csv
@@ -4,7 +4,7 @@ Please input the scientific name in the following format:
 
 Genus species ",Species (Common Name),"QTY
 
-Numbers should use & and , as the thousands and decimal separators, respectively.
+Numbers should use space and , as the thousands and decimal separators, respectively.
 Only enter numbers or an error will occur during upload. ","QTY Units
 
 Please choose from the following list or an error will occur during upload:


### PR DESCRIPTION
Locales such as French (and thus gibberish) use whitespace as the thousands
separator, but they don't use an ASCII space; instead they use a special
non-breaking space. Users, however, don't have an easy way to enter that kind
of space when they're manually typing numbers into spreadsheets, which means
the numbers in uploaded CSV files would technically not be valid.

Work around the problem by stripping all whitespace characters from numeric
cells in uploaded CSV files before parsing them.