### PR TITLE
Increase heap size to fix Dokka failures

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -56,6 +56,9 @@ jobs:
     - name: Allow generated docs to be committed to gh-pages branch
       run: rm docs/.gitignore
 
+    - name: Generate code docs
+      run: ./gradlew dokkaHtml
+
     - name: Make directory for schema docs
       run: mkdir -p docs/schema
 
@@ -68,9 +71,6 @@ jobs:
 
     - name: Generate license report
       run: ./gradlew generateLicenseReport
-
-    - name: Generate code docs
-      run: ./gradlew dokkaHtml
 
     - name: Output git log since last release
       run: bash ./.github/scripts/gitlog.sh

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfile.encoding=UTF-8 -Xmx3172m
+org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfile.encoding=UTF-8 -Xmx4096m
 
 # Version numbers of dependencies that come in multiple related artifacts. This ensures we have
 # consistent versions across all the parts of a given dependency.


### PR DESCRIPTION
The recent upgrade to Dokka caused it to need more memory, which caused it to run
out of memory in CI builds. Bump up the maximum heap size to give it enough room
to run successfully, and move it a bit earlier in the CI build process so we'll
get faster failures if it breaks in the future.