### PR TITLE
SW-3797 Improve Spanish CSV templates

### DIFF
--- a/src/main/resources/csv/accessions-template_es.csv
+++ b/src/main/resources/csv/accessions-template_es.csv
@@ -21,13 +21,13 @@ Elija de la siguiente lista o se producirá un error durante la carga:
 - Procesando
 - Secando
 - En almacén
-- Agotado","Fecha de colección*
+- Agotado","Fecha de recolección*
 
-Ingrese el formato AAAA-MM-DD o se producirá un error durante la carga. Si no está seguro de la fecha exacta, ¡una estimación está bien!",Nombre del lugar de recolección,Propietario del lugar,Ciudad o condado,Estado / Provincia / Región,País,Descripción o notas del lugar,Nombre del recolector,"Origen de la recolección
+Ingrese en el formato AAAA-MM-DD o se producirá un error durante la carga. Si no está seguro de la fecha exacta, ¡una estimación está bien!",Nombre del lugar de recolección,Propietario del lugar,Ciudad o condado,Estado / Provincia / Región,País,Descripción o notas del lugar,Nombre del recolector,"Origen de la recolección
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 
 - Salvaje
-- Reintrodujo
+- Reintroducido
 - Cultivado
 - Otros",Número de plantas,ID de planta

--- a/src/main/resources/csv/accessions-template_es.csv
+++ b/src/main/resources/csv/accessions-template_es.csv
@@ -4,7 +4,7 @@ Ingrese el nombre científico en el siguiente formato:
 
 Género especie",Especie (Nombre común),"Cantidad
 
-Only enter numbers or an error will occur during upload. ","Unidades de cantidad
+Ingrese solo números o se producirá un error durante la carga.","Unidades de cantidad
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 

--- a/src/main/resources/csv/species-template_es.csv
+++ b/src/main/resources/csv/species-template_es.csv
@@ -7,7 +7,7 @@ Género especie",Nombre común,Familia,"En peligro de extinción
 Elija de la siguiente lista o se producirá un error durante la carga:
 
 - Si
-- No","Poco común
+- No","Raro
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 

--- a/src/main/resources/csv/species-template_es.csv
+++ b/src/main/resources/csv/species-template_es.csv
@@ -12,7 +12,7 @@ Elija de la siguiente lista o se producirá un error durante la carga:
 Elija de la siguiente lista o se producirá un error durante la carga:
 
 - Si
-- No","Formulario de crecimiento
+- No","Forma de crecimiento
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 
@@ -23,14 +23,14 @@ Elija de la siguiente lista o se producirá un error durante la carga:
 - Helecho
 - Hongo
 - Liquen
-- Musgo","Ver comportamiento de almacenamiento
+- Musgo","Comportamiento de almacenamiento
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 
 - Ortodoxo
 - Recalcitrante
 - Intermediario
-- Desconocido","Tipos de ecosistema
+- Desconocido","Tipo de ecosistema
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 


### PR DESCRIPTION
Fix some problems with the Spanish CSV templates found during QA:

* The accessions template had a line of instructions that was still in English.

* The field name for "rare" in the species CSV template didn't match the field
  name in the error message for validation failures on that field.

* Some of the translations were badly worded.