### PR TITLE
Remove pointless Flyway configuration

### DIFF
--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -16,11 +16,6 @@ terraware:
 
 spring:
   flyway:
-    locations:
-      # Allow dev-specific migrations, e.g., to insert dummy test data
-      - "classpath:db/migration/dev"
-      - "classpath:db/migration"
-
     # During development, it is convenient to temporarily add a repeatable migration and work on it
     # until it's correct, then make it a versioned migration. By default, Flyway would bomb out due
     # to the repeatable migration going missing.


### PR DESCRIPTION
Flyway looks for migrations in subdirectories, so there is no point in
configuring it to look in a specific subdirectory in dev environments.