### PR TITLE
Only define Logback console appender if it's used

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,6 @@
 <!-- Logging configuration. -->
 <configuration>
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-  <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
   <springProfile name="jsonlog">
     <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -17,14 +16,17 @@
     </appender>
   </springProfile>
 
-  <root level="INFO">
-    <!-- If we aren't logging to a JSON logfile, log to the console, but don't do both. -->
-    <springProfile name="!jsonlog">
+  <!-- If we aren't logging to a JSON logfile, log to the console, but don't do both. -->
+  <springProfile name="!jsonlog">
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <root level="INFO">
       <appender-ref ref="CONSOLE"/>
-    </springProfile>
+    </root>
+  </springProfile>
 
-    <springProfile name="jsonlog">
+  <springProfile name="jsonlog">
+    <root level="INFO">
       <appender-ref ref="JSONFILE"/>
-    </springProfile>
-  </root>
+    </root>
+  </springProfile>
 </configuration>


### PR DESCRIPTION
Spring Boot 3 has stricter validation of the logging configuration, and complains
if the console appender is defined but not used. Move it to a conditional block.