### PR TITLE
Download GBIF data instead of uploading it

### DIFF
--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -21,11 +21,13 @@
 
     <p>You can download the data
         <a href="https://hosted-datasets.gbif.org/datasets/backbone/current/backbone.zip">here</a>.
+        Use a <code>file://</code> URL to load the data from a file on the server's local filesystem.
     </p>
 
-    <form method="POST" enctype="multipart/form-data" action="uploadGbif">
-        <input type="file" name="zipfile" accept="application/zip" />
-        <input type="submit" value=" Upload Zipfile " />
+    <form method="POST" enctype="multipart/form-data" action="importGbif">
+        <label for="gbifUrl">URL of backbone.zip</label>
+        <input id="gbifUrl" type="url" name="url" required />
+        <input type="submit" value="Import" />
         (can take several minutes)
     </form>
 </div>


### PR DESCRIPTION
The admin UI allows importing GBIF species data from a zipfile. Previously, the
zipfile was uploaded by the browser using a file input. It is a huge file and
requires special treatment to avoid running into request size limits. And the
way file uploads are handled is different in Spring Boot 3, so we'd need to
implement a brand-new mechanism for dealing with the file.

Change the admin UI so it accepts a URL as input and pulls the file from there.
The common case will be in dev environments with a `file://` URL pointing to the
local filesystem. It's not quite as convenient, but GBIF import is a pretty rare
operation so the added burden should be miniscule.