### PR TITLE
SW-2710 Remove Apache Commons FileUpload library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
   implementation("com.google.apis:google-api-services-drive:v3-rev20230610-2.0.0")
   implementation("com.opencsv:opencsv:5.7.1")
   implementation("com.squarespace.cldr-engine:cldr-engine:1.7.0")
-  implementation("commons-fileupload:commons-fileupload:1.5")
   implementation("commons-validator:commons-validator:1.7")
   implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:3.4.6")
   implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")

--- a/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
@@ -1,9 +1,7 @@
 package com.terraformation.backend.api
 
 import com.terraformation.backend.file.SizedInputStream
-import java.io.InputStreamReader
 import javax.ws.rs.NotSupportedException
-import org.apache.commons.fileupload.FileItemStream
 import org.apache.tika.mime.MimeTypes
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
@@ -11,11 +9,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.multipart.MultipartFile
-
-/** Reads an item of a streaming file-upload form submission as a string. */
-fun FileItemStream.readString(): String {
-  return openStream().use { InputStreamReader(it).readText() }
-}
 
 /**
  * Wraps a SizedInputStream in a response entity suitable for use as a return value from a

--- a/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SpringMvcConfig.kt
@@ -1,14 +1,6 @@
 package com.terraformation.backend.api
 
-import javax.servlet.http.HttpServletRequest
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.env.Environment
-import org.springframework.core.env.getProperty
-import org.springframework.util.unit.DataSize
-import org.springframework.web.multipart.MultipartFile
-import org.springframework.web.multipart.MultipartResolver
-import org.springframework.web.multipart.commons.CommonsMultipartResolver
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -34,34 +26,5 @@ class SpringMvcConfig(private val superAdminInterceptor: SuperAdminInterceptor) 
 
   override fun addInterceptors(registry: InterceptorRegistry) {
     registry.addInterceptor(superAdminInterceptor)
-  }
-
-  /**
-   * Configure the application's handling of multipart form data (file uploads) to allow streaming
-   * of the file data.
-   *
-   * By default, the entire request is loaded into memory before the controller method is called.
-   * With the "resolve lazily" flag, Spring will only load the request into memory if the controller
-   * method has a parameter such as a [MultipartFile] that requires everything to already be in
-   * memory.
-   *
-   * We can thus have controller methods that take [HttpServletRequest] parameters and access the
-   * underlying input stream, allowing us to support uploading huge files without requiring equally
-   * huge amounts of memory.
-   *
-   * Honors the standard Spring settings for maximum file size for file upload endpoints that need
-   * the file to be loaded into memory. Endpoints that stream the file data can check the file size
-   * explicitly if needed.
-   */
-  @Bean
-  fun customMultipartResolver(env: Environment): MultipartResolver {
-    val maxFileSize = env.getProperty<DataSize?>("spring.servlet.multipart.max-file-size")
-    val maxUploadSize = env.getProperty<DataSize?>("spring.servlet.multipart.max-request-size")
-
-    return CommonsMultipartResolver().apply {
-      setResolveLazily(true)
-      setMaxUploadSize(maxUploadSize?.toBytes() ?: -1)
-      setMaxUploadSizePerFile(maxFileSize?.toBytes() ?: -1)
-    }
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,7 +70,7 @@ spring:
 
   servlet:
     multipart:
-      enabled: false
+      enabled: true
       max-request-size: 20MB
       max-file-size: 20MB
 


### PR DESCRIPTION
We were using an Apache library to make it easier to work with uploads of large
files. Spring Boot 3 doesn't support that library; rather than implementing new
code to support large file uploads, we've instead removed the need to upload
large files in the first place. We can thus get rid of the library and rely on
Spring's built-in file upload support.