### PR TITLE
SW-3815 Read Google credentials from environment

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -286,6 +286,13 @@ class TerrawareServerConfig(
        * to the shared drive's root directory.
        */
       val googleFolderId: String? = null,
+
+      /**
+       * If set, use this JSON object as the Google account credentials. Otherwise, use default
+       * credentials as described
+       * [here](https://cloud.google.com/docs/authentication/application-default-credentials).
+       */
+      val googleCredentialsJson: String? = null,
   )
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
@@ -37,9 +37,14 @@ class GoogleDriveWriter(
    * exception if authentication fails.
    */
   private val driveClient by lazy {
+    val baseCredentials =
+        config.report.googleCredentialsJson?.let { json ->
+          GoogleCredentials.fromStream(json.byteInputStream())
+        }
+            ?: GoogleCredentials.getApplicationDefault()
+
     val serviceAccountCredentials =
-        GoogleCredentials.getApplicationDefault()
-            .createScoped(listOf("https://www.googleapis.com/auth/drive"))
+        baseCredentials.createScoped(listOf("https://www.googleapis.com/auth/drive"))
 
     // Service accounts can't access private shared drives; we have to impersonate a user who has
     // access. Documentation:


### PR DESCRIPTION
The credentials for the Google API, which we use to export report files to Google
Drive, have to be in JSON form. By default, the Google client library expects the
credentials to be in a file, but it also allows callers to directly supply a JSON
object.

Add a Terraware config value that lets us pass the JSON object in an environment
variable so we don't have to write it to a file on the server.