### PR TITLE
Allow enums to use string IDs

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/EnumTable.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/EnumTable.kt
@@ -30,6 +30,8 @@ class EnumTable(
      * used in any of its generated code, in which case we can use this to suppress the forced type.
      */
     val generateForcedType: Boolean = true,
+    /** If true, use the ID instead of the name as the enum's JSON representation. */
+    val useIdAsJsonValue: Boolean = false,
 ) {
   constructor(
       tableName: String,
@@ -52,7 +54,6 @@ class EnumTable(
       ForcedType()
           .withUserType("$targetPackage.$enumName")
           .withConverter("$targetPackage.$converterName")
-          .withIncludeTypes("INTEGER")
           .withIncludeExpression(includeExpression)
     } else {
       null

--- a/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/EnumFromReferenceTable.kt
@@ -3,8 +3,8 @@ package com.terraformation.backend.db
 import java.util.Locale
 import org.springframework.context.support.ResourceBundleMessageSource
 
-interface EnumFromReferenceTable<T : Enum<T>> {
-  val id: Int
+interface EnumFromReferenceTable<ID : Any, T : Enum<T>> {
+  val id: ID
   /** JSON string representation of this enum value. */
   val jsonValue: String
   val tableName: String
@@ -21,7 +21,7 @@ interface EnumFromReferenceTable<T : Enum<T>> {
           setDefaultEncoding("UTF-8")
         }
 
-    fun <T : EnumFromReferenceTable<T>> loadLocalizedDisplayNames(
+    fun <T : EnumFromReferenceTable<*, T>> loadLocalizedDisplayNames(
         locale: Locale,
         values: Array<T>
     ): Map<T, String> {

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -274,7 +274,7 @@ class Messages {
     return getMessage(messageName, formattedNumber)
   }
 
-  private fun <T : EnumFromReferenceTable<*>> getEnumValuesList(values: Array<T>): String {
+  private fun <T : EnumFromReferenceTable<*, *>> getEnumValuesList(values: Array<T>): String {
     val locale = currentLocale()
     return values.joinToString(listDelimiter()) { it.getDisplayName(locale) }
   }

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -246,7 +246,7 @@ abstract class SearchTable {
       nullable: Boolean = false
   ) = DoubleField(fieldName, databaseField, this, nullable)
 
-  inline fun <E : Enum<E>, reified T : EnumFromReferenceTable<E>> enumField(
+  inline fun <E : Enum<E>, reified T : EnumFromReferenceTable<*, E>> enumField(
       fieldName: String,
       databaseField: TableField<*, T?>,
       nullable: Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -20,7 +20,7 @@ import org.jooq.impl.DSL
  * during code generation. Because the contents of these tables are known at compile time, we don't
  * need to join with them and can instead directly include their IDs in our generated SQL.
  */
-class EnumField<E : Enum<E>, T : EnumFromReferenceTable<E>>(
+class EnumField<E : Enum<E>, T : EnumFromReferenceTable<*, E>>(
     override val fieldName: String,
     override val databaseField: TableField<*, T?>,
     override val table: SearchTable,

--- a/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
@@ -20,7 +20,7 @@ class EnumsTest : DatabaseTest() {
     val keys =
         scanner
             .findCandidateComponents("com.terraformation.backend.db")
-            .map { Class.forName(it.beanClassName) as Class<EnumFromReferenceTable<*>> }
+            .map { Class.forName(it.beanClassName) as Class<EnumFromReferenceTable<*, *>> }
             .flatMap { enumClass ->
               val enumName = enumClass.simpleName
               val packageName = enumClass.packageName.substringAfterLast('.')


### PR DESCRIPTION
IUCN conservation categories are identified with two-letter codes. We'll want to
use those codes directly in our database schema rather than defining a synthetic
numeric ID like we do for our other enumerated types. We'll also want to use the
codes in the API, as opposed to our usual approach of using enum display names.

Update the enum code generator to support both integers and strings as enum IDs,
and to optionally allow the ID, rather than the name, to be used as the JSON
value.

Existing enums should continue to work as before.