### PR TITLE
SW-3127 Remove endangered field from species API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
@@ -15,7 +14,6 @@ import com.terraformation.backend.search.field.SearchField
 import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.TableField
-import org.jooq.impl.DSL
 
 class SpeciesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
@@ -44,11 +42,6 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
           timestampField("checkedTime", SPECIES.CHECKED_TIME),
           textField("commonName", SPECIES.COMMON_NAME),
           enumField("conservationCategory", SPECIES.CONSERVATION_CATEGORY_ID, localize = false),
-          booleanField(
-              "endangered",
-              DSL.case_(SPECIES.CONSERVATION_CATEGORY_ID)
-                  .`when`(ConservationCategory.Endangered, true)
-                  .else_(null as Boolean?)),
           textField("familyName", SPECIES.FAMILY_NAME, nullable = false),
           enumField("growthForm", SPECIES.GROWTH_FORM_ID),
           idWrapperField("id", SPECIES.ID) { SpeciesId(it) },

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -218,7 +218,6 @@ data class SpeciesResponseElement(
         externalDocs =
             ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"))
     val conservationCategory: ConservationCategory?,
-    val endangered: Boolean?,
     val familyName: String?,
     val growthForm: GrowthForm?,
     val id: SpeciesId,
@@ -234,7 +233,6 @@ data class SpeciesResponseElement(
       ecosystemTypes = model.ecosystemTypes.ifEmpty { null },
       commonName = model.commonName,
       conservationCategory = model.conservationCategory,
-      endangered = model.conservationCategory == ConservationCategory.Endangered,
       familyName = model.familyName,
       growthForm = model.growthForm,
       id = model.id,
@@ -253,7 +251,6 @@ data class SpeciesRequestPayload(
         externalDocs =
             ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"))
     val conservationCategory: ConservationCategory?,
-    val endangered: Boolean?,
     val familyName: String?,
     val growthForm: GrowthForm?,
     @Schema(description = "Which organization's species list to update.")
@@ -265,8 +262,7 @@ data class SpeciesRequestPayload(
   fun <T : SpeciesId?> toModel(id: T) =
       SpeciesModel(
           commonName = commonName,
-          conservationCategory = conservationCategory
-                  ?: if (endangered == true) ConservationCategory.Endangered else null,
+          conservationCategory = conservationCategory,
           ecosystemTypes = ecosystemTypes ?: emptySet(),
           familyName = familyName,
           growthForm = growthForm,

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
@@ -119,12 +119,6 @@ data class SpeciesLookupDetailsResponsePayload(
     val familyName: String,
     @Schema(
         description =
-            "True if the species is known to be endangered, false if the species is known to not " +
-                "be endangered. This value will not be present if the server's taxonomic " +
-                "database doesn't indicate whether or not the species is endangered.")
-    val endangered: Boolean?,
-    @Schema(
-        description =
             "If this is not the accepted name for the species, the type of problem the name has. " +
                 "Currently, this will always be \"Name Is Synonym\".")
     val problemType: SpeciesProblemType?,
@@ -142,7 +136,6 @@ data class SpeciesLookupDetailsResponsePayload(
       model.vernacularNames.map { SpeciesLookupCommonNamePayload(it) }.ifEmpty { null },
       model.conservationCategory,
       model.familyName,
-      model.isEndangered,
       problem?.typeId,
       problem?.suggestedValue)
 }

--- a/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/GbifModels.kt
@@ -28,15 +28,6 @@ data class GbifTaxonModel(
   val conservationCategory: ConservationCategory?
     get() = threatStatus?.let { conservationCategories[it] }
 
-  /**
-   * Whether or not the species should be considered endangered by our app. This is derived from the
-   * "threat status" value in the GBIF distributions dataset; we consider certain threat statuses to
-   * be endangered, certain statuses to be non-endangered, and unrecognized statuses to be
-   * inconclusive.
-   */
-  val isEndangered: Boolean?
-    get() = threatStatus?.let { endangeredThreatStatuses[it] }
-
   companion object {
     private val conservationCategories =
         mapOf(
@@ -49,18 +40,6 @@ data class GbifTaxonModel(
             "extinct" to ConservationCategory.Extinct,
             "data deficient" to ConservationCategory.DataDeficient,
             "not evaluated" to ConservationCategory.NotEvaluated,
-        )
-
-    private val endangeredThreatStatuses =
-        mapOf(
-            // IUCN Red List categories
-            "least concern" to false,
-            "near threatened" to false,
-            "vulnerable" to true,
-            "endangered" to true,
-            "critically endangered" to true,
-            "extinct in the wild" to true,
-            "extinct" to true,
         )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
@@ -15,7 +15,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
   @Test
   fun `returns localized boolean values`() {
     val prefix = SearchFieldPrefix(tables.species)
-    val fields = listOf(prefix.resolve("id"), prefix.resolve("endangered"), prefix.resolve("rare"))
+    val fields = listOf(prefix.resolve("id"), prefix.resolve("rare"))
     val sortOrder = fields.map { SearchSortField(it) }
 
     val result =
@@ -25,7 +25,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("id" to "10000", "rare" to "false".toGibberish()),
-                mapOf("id" to "10001", "endangered" to "true".toGibberish())),
+                mapOf("id" to "10001", "rare" to "true".toGibberish())),
             cursor = null)
 
     assertEquals(expected, result)
@@ -35,7 +35,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
   fun `accepts localized boolean values as search criteria`() {
     val prefix = SearchFieldPrefix(tables.species)
     val fields = listOf(prefix.resolve("id"))
-    val criteria = FieldNode(prefix.resolve("endangered"), listOf("true".toGibberish()))
+    val criteria = FieldNode(prefix.resolve("rare"), listOf("true".toGibberish()))
 
     val result = Locales.GIBBERISH.use { searchService.search(prefix, fields, criteria) }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -953,8 +953,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             mapOf(
                 "commonName" to "Common 2",
                 "conservationCategory" to "EN",
-                "endangered" to "true",
                 "id" to "10001",
+                "rare" to "true",
                 "scientificName" to "Other Dogwood",
                 "seedStorageBehavior" to "Orthodox",
             ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -108,6 +108,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
             scientificName = "Other Dogwood",
             initialScientificName = "Other Dogwood",
             commonName = "Common 2",
+            rare = true,
             conservationCategoryId = ConservationCategory.Endangered,
             seedStorageBehaviorId = SeedStorageBehavior.Orthodox,
             createdBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/model/GbifTaxonModelTest.kt
@@ -4,51 +4,17 @@ import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.GbifTaxonId
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
 
 internal class GbifTaxonModelTest {
-  @ParameterizedTest
-  @ValueSource(
-      strings =
-          [
-              "critically endangered",
-              "endangered",
-              "extinct",
-              "extinct in the wild",
-              "vulnerable",
-          ])
-  fun `treats IUCN Red List categories of Vulnerable or worse as endangered`(threatStatus: String) {
-    val model = newModel(threatStatus = threatStatus)
-    assertEquals(true, model.isEndangered)
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = ["least concern", "near threatened"])
-  fun `treats IUCN Red list categories of Near Threatened or better as non-endangered`(
-      threatStatus: String
-  ) {
-    val model = newModel(threatStatus = threatStatus)
-    assertEquals(false, model.isEndangered)
-  }
-
-  @Test
-  fun `treats unrecognized threat statuses as unknown`() {
-    val model = newModel(threatStatus = "bogus")
-    assertNull(model.isEndangered)
-  }
-
   @Test
   fun `looks up conservation category for threat status`() {
-    val model = newModel(threatStatus = "least concern")
+    val model =
+        GbifTaxonModel(
+            taxonId = GbifTaxonId(1),
+            scientificName = "name",
+            familyName = "family",
+            vernacularNames = emptyList(),
+            threatStatus = "least concern")
     assertEquals(ConservationCategory.LeastConcern, model.conservationCategory)
   }
-
-  private fun newModel(threatStatus: String?) =
-      GbifTaxonModel(
-          taxonId = GbifTaxonId(1),
-          scientificName = "name",
-          familyName = "family",
-          vernacularNames = emptyList(),
-          threatStatus = threatStatus)
 }


### PR DESCRIPTION
Stop supporting the old `endangered` field in the various species API payloads.
Clients will need to use the `conservationCategory` field instead.

This should only be deployed after all clients have been updated to use the new
field.