### PR TITLE
Make AccessionModel.state non-nullable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -238,7 +238,7 @@ data class AccessionPayloadV2(
   ) : this(
       accessionNumber = model.accessionNumber
               ?: throw IllegalArgumentException("Accession did not have a number"),
-      active = model.active ?: AccessionActive.Active,
+      active = model.active,
       bagNumbers = model.bagNumbers.orNull(),
       collectedDate = model.collectedDate,
       collectionSiteCity = model.collectionSiteCity,
@@ -268,7 +268,7 @@ data class AccessionPayloadV2(
       speciesScientificName = model.species,
       speciesCommonName = model.speciesCommonName,
       speciesId = model.speciesId,
-      state = model.state?.let { AccessionStateV2.of(it) } ?: AccessionStateV2.AwaitingProcessing,
+      state = AccessionStateV2.of(model.state),
       storageLocation = model.storageLocation,
       subsetCount = model.subsetCount,
       subsetWeight = model.subsetWeightQuantity?.toPayload(),
@@ -326,7 +326,7 @@ data class CreateAccessionRequestPayloadV2(
         receivedDate = receivedDate,
         source = source,
         speciesId = speciesId,
-        state = state?.modelState,
+        state = state?.modelState ?: AccessionState.AwaitingCheckIn,
         storageLocation = storageLocation,
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -194,7 +194,6 @@ class AccessionStore(
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
     val state =
         when {
-          accession.state == null -> AccessionState.AwaitingCheckIn
           accession.state == AccessionState.UsedUp ->
               throw IllegalArgumentException("Accessions cannot be set to Used Up at creation time")
           accession.state.isV2Compatible -> accession.state
@@ -327,7 +326,7 @@ class AccessionStore(
     val organizationId =
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
 
-    if (updated.state?.isV2Compatible != true) {
+    if (!updated.state.isV2Compatible) {
       throw IllegalArgumentException("State must be v2-compatible")
     }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -91,7 +91,7 @@ data class AccessionModel(
     val species: String? = null,
     val speciesCommonName: String? = null,
     val speciesId: SpeciesId? = null,
-    val state: AccessionState? = null,
+    val state: AccessionState = AccessionState.AwaitingCheckIn,
     val storageLocation: String? = null,
     val subsetCount: Int? = null,
     val subsetWeightQuantity: SeedQuantityModel? = null,
@@ -107,19 +107,18 @@ data class AccessionModel(
     validate()
   }
 
-  val active: AccessionActive?
-    get() = state?.toActiveEnum()
+  val active: AccessionActive
+    get() = state.toActiveEnum()
 
   fun getStateTransition(newModel: AccessionModel): AccessionStateTransition? {
     val seedsRemaining = newModel.calculateRemaining(this)
     val allSeedsWithdrawn = seedsRemaining != null && seedsRemaining.quantity <= BigDecimal.ZERO
-    val oldState = state ?: AccessionState.AwaitingProcessing
-    val newState = newModel.state ?: AccessionState.AwaitingProcessing
+    val oldState = state
+    val newState = newModel.state
     val alreadyCheckedIn = oldState != AccessionState.AwaitingCheckIn
     val checkingIn =
         oldState == AccessionState.AwaitingCheckIn && newState == AccessionState.AwaitingProcessing
-    val revertingToAwaitingCheckIn =
-        alreadyCheckedIn && newModel.state == AccessionState.AwaitingCheckIn
+    val revertingToAwaitingCheckIn = alreadyCheckedIn && newState == AccessionState.AwaitingCheckIn
     val addingSeedsWhenUsedUp =
         oldState == AccessionState.UsedUp && newState == AccessionState.UsedUp && !allSeedsWithdrawn
     val changingToUsedUpWithoutWithdrawingAllSeeds =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -163,7 +163,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       source: DataSource? = null,
       species: String? = null,
       speciesId: SpeciesId? = null,
-      state: AccessionState? = null,
+      state: AccessionState = AccessionState.AwaitingCheckIn,
       withdrawals: List<WithdrawalModel> = emptyList(),
   ): AccessionModel =
       AccessionModel(


### PR DESCRIPTION
Accession states are never null (they are populated at creation time and never
cleared) so there's no reason for `AccessionModel` to be able to represent an
accession with a null state.

No behavior change here, just marginally cleaner code.