### PR TITLE
SW-3647 Accession species only editable if no deliveries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -67,6 +67,10 @@ abstract class MismatchedStateException(message: String) : RuntimeException(mess
 class AccessionNotFoundException(val accessionId: AccessionId) :
     EntityNotFoundException("Accession $accessionId not found")
 
+class AccessionSpeciesHasDeliveriesException(val accessionId: AccessionId) :
+    MismatchedStateException(
+        "Accession $accessionId has deliveries so its species cannot be changed")
+
 class AutomationNotFoundException(val automationId: AutomationId) :
     EntityNotFoundException("Automation $automationId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -173,6 +173,10 @@ data class AccessionPayloadV2(
     val facilityId: FacilityId,
     @Schema(
         description =
+            "If true, plants from this accession's seeds were delivered to a planting site.")
+    val hasDeliveries: Boolean,
+    @Schema(
+        description =
             "Server-generated unique identifier for the accession. This is unique across all " +
                 "seed banks, but is not suitable for display to end users.")
     val id: AccessionId,
@@ -256,6 +260,7 @@ data class AccessionPayloadV2(
       facilityId = model.facilityId
               ?: throw IllegalArgumentException("Accession did not have a facility ID"),
       plantId = model.founderId,
+      hasDeliveries = model.hasDeliveries,
       id = model.id ?: throw IllegalArgumentException("Accession did not have an ID"),
       latestObservedQuantity = model.latestObservedQuantity?.toPayload(),
       latestObservedTime = model.latestObservedTime,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.FacilityStore
@@ -63,6 +64,10 @@ class AccessionsV2Controller(
           "The accession was updated successfully. Response includes fields populated or " +
               "modified by the server as a result of the update.")
   @ApiResponse404(description = "The specified accession doesn't exist.")
+  @ApiResponse409(
+      description =
+          "One of the requested changes couldn't be made because the accession is in a state " +
+              "that doesn't allow the change.")
   @Operation(summary = "Update an existing accession.")
   @PutMapping("/{id}")
   fun updateAccession(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -74,6 +74,8 @@ data class AccessionModel(
     val facilityId: FacilityId? = null,
     val founderId: String? = null,
     val geolocations: Set<Geolocation> = emptySet(),
+    /** If true, seedlings from this accession have been delivered to planting sites. */
+    val hasDeliveries: Boolean = false,
     val latestObservedQuantity: SeedQuantityModel? = null,
     /**
      * If true, [latestObservedQuantity] already reflects the client-supplied value and shouldn't be

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
+import com.terraformation.backend.db.AccessionSpeciesHasDeliveriesException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 
 internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
@@ -154,7 +156,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update ignores species change if accession has deliveries`() {
+  fun `update throws exception on species change if accession has deliveries`() {
     val speciesId1 = insertSpecies()
     val speciesId2 = insertSpecies()
     val initial = store.create(accessionModel(speciesId = speciesId1))
@@ -167,9 +169,9 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     insertPlantingSite()
     insertDelivery()
 
-    val updated = store.updateAndFetch(initial.copy(speciesId = speciesId2))
-
-    assertEquals(speciesId1, updated.speciesId, "Species should not have been modified")
+    assertThrows<AccessionSpeciesHasDeliveriesException> {
+      store.update(initial.copy(speciesId = speciesId2))
+    }
   }
 
   @Test


### PR DESCRIPTION
In preparation for an upcoming change that causes changes to an accession's
species to be propagated to seedling batches that come from that accession,
add logic to prevent editing an accession's species if the accession's seeds
have already been sent to a nursery, and seedlings have already been withdrawn
from the nursery and delivered to a planting site.

This prevents accession species changes from causing inconsistencies between
nursery withdrawals and the species populations at planting sites. In the
future we may remove this restriction and make the species changes propagate to
planting site data too, but doing so would introduce a number of edge cases
that would require more detailed requirements definition.

The fact that seedlings from an accession's seeds have been delivered to planting
sites is exposed as a new `hasDeliveries` field on the accession payload. Clients
can use this to inform users that they can't edit the accession's species.