### PR TITLE
SW-3647 Apply accession species changes to batches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -67,6 +67,10 @@ abstract class MismatchedStateException(message: String) : RuntimeException(mess
 class AccessionNotFoundException(val accessionId: AccessionId) :
     EntityNotFoundException("Accession $accessionId not found")
 
+class AccessionSpeciesHasDeliveriesException(val accessionId: AccessionId) :
+    MismatchedStateException(
+        "Accession $accessionId has deliveries so its species cannot be changed")
+
 class AutomationNotFoundException(val automationId: AutomationId) :
     EntityNotFoundException("Automation $automationId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -173,6 +173,10 @@ data class AccessionPayloadV2(
     val facilityId: FacilityId,
     @Schema(
         description =
+            "If true, plants from this accession's seeds were delivered to a planting site.")
+    val hasDeliveries: Boolean,
+    @Schema(
+        description =
             "Server-generated unique identifier for the accession. This is unique across all " +
                 "seed banks, but is not suitable for display to end users.")
     val id: AccessionId,
@@ -256,6 +260,7 @@ data class AccessionPayloadV2(
       facilityId = model.facilityId
               ?: throw IllegalArgumentException("Accession did not have a facility ID"),
       plantId = model.founderId,
+      hasDeliveries = model.hasDeliveries,
       id = model.id ?: throw IllegalArgumentException("Accession did not have an ID"),
       latestObservedQuantity = model.latestObservedQuantity?.toPayload(),
       latestObservedTime = model.latestObservedTime,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonValue
 import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.FacilityStore
@@ -63,6 +64,10 @@ class AccessionsV2Controller(
           "The accession was updated successfully. Response includes fields populated or " +
               "modified by the server as a result of the update.")
   @ApiResponse404(description = "The specified accession doesn't exist.")
+  @ApiResponse409(
+      description =
+          "One of the requested changes couldn't be made because the accession is in a state " +
+              "that doesn't allow the change.")
   @Operation(summary = "Update an existing accession.")
   @PutMapping("/{id}")
   fun updateAccession(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/event/AccessionSpeciesChangedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/event/AccessionSpeciesChangedEvent.kt
@@ -1,0 +1,14 @@
+package com.terraformation.backend.seedbank.event
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.seedbank.AccessionId
+
+/**
+ * Published when the species of an accession is modified. Not published when the species of an
+ * accession is set initially, only when it is subsequently modified.
+ */
+data class AccessionSpeciesChangedEvent(
+    val accessionId: AccessionId,
+    val oldSpeciesId: SpeciesId,
+    val newSpeciesId: SpeciesId,
+)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -74,6 +74,8 @@ data class AccessionModel(
     val facilityId: FacilityId? = null,
     val founderId: String? = null,
     val geolocations: Set<Geolocation> = emptySet(),
+    /** If true, seedlings from this accession have been delivered to planting sites. */
+    val hasDeliveries: Boolean = false,
     val latestObservedQuantity: SeedQuantityModel? = null,
     /**
      * If true, [latestObservedQuantity] already reflects the client-supplied value and shouldn't be

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -117,6 +117,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             parentStore,
             WithdrawalStore(dslContext, clock, mockk(), parentStore),
             clock,
+            publisher,
             mockk(),
             IdentifierGenerator(clock, dslContext),
         )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAccessionSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAccessionSpeciesTest.kt
@@ -1,0 +1,56 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.seedbank.event.AccessionSpeciesChangedEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class BatchStoreAccessionSpeciesTest : BatchStoreTest() {
+  @Test
+  fun `updates affected batches`() {
+    val seedBankFacilityId = FacilityId(2)
+    insertFacility(id = seedBankFacilityId, type = FacilityType.SeedBank)
+    val accessionId = insertAccession(facilityId = seedBankFacilityId)
+    val otherAccessionId = insertAccession(facilityId = seedBankFacilityId)
+    val otherSpeciesId = insertSpecies()
+    val newSpeciesId = insertSpecies()
+    val batchId1 =
+        insertBatch(
+            BatchesRow(accessionId = accessionId, facilityId = facilityId, speciesId = speciesId))
+    val batchId2 =
+        insertBatch(
+            BatchesRow(accessionId = accessionId, facilityId = facilityId, speciesId = speciesId))
+    val otherSpeciesBatchId =
+        insertBatch(
+            BatchesRow(
+                accessionId = accessionId, facilityId = facilityId, speciesId = otherSpeciesId))
+    val otherAccessionBatchId =
+        insertBatch(
+            BatchesRow(
+                accessionId = otherAccessionId, facilityId = facilityId, speciesId = speciesId))
+
+    store.on(AccessionSpeciesChangedEvent(accessionId, speciesId, newSpeciesId))
+
+    assertEquals(
+        newSpeciesId,
+        batchesDao.fetchOneById(batchId1)?.speciesId,
+        "Batch 1 species should have changed")
+    assertEquals(
+        newSpeciesId,
+        batchesDao.fetchOneById(batchId2)?.speciesId,
+        "Batch 2 species should have changed")
+    assertEquals(
+        otherSpeciesId,
+        batchesDao.fetchOneById(otherSpeciesBatchId)?.speciesId,
+        "Non-matching species ID should not have changed")
+    assertEquals(
+        speciesId,
+        batchesDao.fetchOneById(otherAccessionBatchId)?.speciesId,
+        "Species ID from different accession should not have changed")
+
+    assertIsEventListener<AccessionSpeciesChangedEvent>(store)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -87,6 +87,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
             parentStore,
             mockk(),
             clock,
+            publisher,
             messages,
             mockk(),
         ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -75,6 +75,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>> =
       listOf(ACCESSION_QUANTITY_HISTORY, ACCESSIONS, SPECIES, UPLOADS, UPLOAD_PROBLEMS)
 
+  private val publisher = TestEventPublisher()
   private val accessionStore: AccessionStore by lazy {
     AccessionStore(
         dslContext,
@@ -84,6 +85,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         parentStore,
         WithdrawalStore(dslContext, clock, messages, parentStore),
         clock,
+        publisher,
         messages,
         IdentifierGenerator(clock, dslContext),
     )
@@ -94,7 +96,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
         clock,
         mockk(),
         dslContext,
-        TestEventPublisher(),
+        publisher,
         facilitiesDao,
         messages,
         organizationsDao,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
@@ -84,6 +85,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             mockk(),
             mockk(),
             clock,
+            TestEventPublisher(),
             mockk(),
             mockk(),
         )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
+import com.terraformation.backend.db.AccessionSpeciesHasDeliveriesException
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
 
 internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
@@ -154,7 +156,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `update ignores species change if accession has deliveries`() {
+  fun `update throws exception on species change if accession has deliveries`() {
     val speciesId1 = insertSpecies()
     val speciesId2 = insertSpecies()
     val initial = store.create(accessionModel(speciesId = speciesId1))
@@ -167,9 +169,9 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     insertPlantingSite()
     insertDelivery()
 
-    val updated = store.updateAndFetch(initial.copy(speciesId = speciesId2))
-
-    assertEquals(speciesId1, updated.speciesId, "Species should not have been modified")
+    assertThrows<AccessionSpeciesHasDeliveriesException> {
+      store.update(initial.copy(speciesId = speciesId2))
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
@@ -55,6 +56,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             WITHDRAWALS)
 
   protected val clock = TestClock()
+  protected val publisher = TestEventPublisher()
 
   protected lateinit var store: AccessionStore
   protected lateinit var parentStore: ParentStore
@@ -88,6 +90,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             parentStore,
             WithdrawalStore(dslContext, clock, messages, parentStore),
             clock,
+            publisher,
             messages,
             IdentifierGenerator(clock, dslContext),
         )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -29,7 +30,17 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val accessionStore: AccessionStore by lazy {
-    AccessionStore(dslContext, mockk(), mockk(), mockk(), mockk(), mockk(), clock, mockk(), mockk())
+    AccessionStore(
+        dslContext,
+        mockk(),
+        mockk(),
+        mockk(),
+        mockk(),
+        mockk(),
+        clock,
+        TestEventPublisher(),
+        mockk(),
+        mockk())
   }
   private val clock = TestClock()
   private val searchService: SearchService by lazy { SearchService(dslContext) }


### PR DESCRIPTION
It can be difficult to distinguish some species of seeds from others; sometimes
a definitive species ID can only happen after the seeds have sprouted and the
seedlings can be examined.

If it turns out that the initial guess at the species was wrong, we want to
update the accession to have the correct species. Currently, though, the species
of the seedling batches don't change, and there's no way to edit them manually;
they remain listed under the old incorrect species.

Update the system so that changing the species of an accession will automatically
update the species of all the seedling batches that came from that accession.

It is not currently permitted to change the species of an accession if there are
already outplanting withdrawals of its seedlings; we thus don't need to reflect
changes of accession species in the planting histories of planting sites. The
expectation is that this restriction is no big deal in practice because species
will have already been identified by the time seedlings go out for planting.