### PR TITLE
Require planting sites to have at least 5 plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1010,6 +1010,9 @@ class AdminController(
               siteName, null, organizationId, siteFile, zonesFile, subzonesFile, emptySet())
 
       redirectAttributes.successMessage = "Planting site $siteId imported successfully."
+    } catch (e: PlantingSiteUploadProblemsException) {
+      log.warn("Site creation failed", e)
+      redirectAttributes.failureMessage = "Creation failed: ${e.problems.joinToString()}"
     } catch (e: Exception) {
       log.warn("Site creation failed", e)
       redirectAttributes.failureMessage = "Creation failed: ${e.message}"

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -143,8 +143,9 @@ class PlantingSiteImporter(
     val subzonesByZone = getSubzonesByZone(zonesByName, subzonesFile, validationOptions, problems)
     val plotBoundaries = generatePlotBoundaries(siteFeature)
 
-    if (plotBoundaries.isEmpty()) {
-      problems.add("Could not create any monitoring plots (is the site at least 50x50 meters?)")
+    // Need a minimum of 1 permanent cluster and 1 temporary plot.
+    if (plotBoundaries.size < 5) {
+      problems.add("Could not create enough monitoring plots (is the site at least 100x50 meters?)")
     }
 
     if (problems.isNotEmpty()) {


### PR DESCRIPTION
If you use the "draw site on map" feature of the admin UI to draw a planting site
that's only big enough for one 4-plot cluster, the server creates the planting
site but then can't start any observations because it can't allocate any temporary
plots.

Update the importer code to ensure that there are at least 5 plots available; if
not, site creation fails. Since plots are allocated in groups of 4, technically
"5 plots minimum" is really "8 plots minimum" and thus the planting site must be
at least 100x50 meters.