### PR TITLE
Ignore irrelevant fields in plant observation payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -376,8 +376,8 @@ data class RecordedPlantPayload(
     return RecordedPlantsRow(
         certaintyId = certainty,
         gpsCoordinates = gpsCoordinates,
-        speciesId = speciesId,
-        speciesName = speciesName,
+        speciesId = if (certainty == RecordedSpeciesCertainty.Known) speciesId else null,
+        speciesName = if (certainty == RecordedSpeciesCertainty.Other) speciesName else null,
         statusId = status,
     )
   }


### PR DESCRIPTION
If a recorded plant's species is known, the server is supposed to ignore the
value of the `speciesName` field in the plot observation completion API
payload, but it doesn't; instead the request fails due to a database constraint
violation.

Update the code to conditionally ignore species ID and name like the API
documentation says it does.