### PR TITLE
SW-3868 Add country code to users, locales

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/LocaleConfig.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.api
 
-import com.terraformation.backend.i18n.Locales
 import java.util.Locale
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -17,7 +16,6 @@ class LocaleConfig {
     val resolver = AcceptHeaderLocaleResolver()
 
     resolver.setDefaultLocale(Locale.ENGLISH)
-    resolver.supportedLocales = Locales.supported
 
     return resolver
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -35,6 +35,7 @@ class UsersController(private val userStore: UserStore) {
     if (user is IndividualUser) {
       return GetUserResponsePayload(
           UserProfilePayload(
+              user.countryCode,
               user.userId,
               user.email,
               user.emailNotificationsEnabled,
@@ -54,6 +55,7 @@ class UsersController(private val userStore: UserStore) {
     if (user is IndividualUser) {
       val model =
           user.copy(
+              countryCode = payload.countryCode,
               emailNotificationsEnabled = payload.emailNotificationsEnabled
                       ?: user.emailNotificationsEnabled,
               firstName = payload.firstName,
@@ -103,6 +105,8 @@ class UsersController(private val userStore: UserStore) {
 }
 
 data class UserProfilePayload(
+    @Schema(description = "Two-letter code of the user's country.", example = "US")
+    val countryCode: String?,
     @Schema(
         description =
             "User's unique ID. This should not be shown to the user, but is a required input to " +
@@ -125,6 +129,8 @@ data class UserProfilePayload(
 data class GetUserResponsePayload(val user: UserProfilePayload) : SuccessResponsePayload
 
 data class UpdateUserRequestPayload(
+    @Schema(description = "Two-letter code of the user's country.", example = "US")
+    val countryCode: String?,
     @Schema(
         description =
             "If true, the user wants to receive all the notifications for their organizations " +

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -248,7 +248,7 @@ class UserStore(
             ?: throw IllegalStateException("Current user not found in users table")
 
     // If the country code is set, include it in the locale.
-    val newLocale = model.locale?.let { Locale.of(it.language, model.countryCode ?: it.country) }
+    val newLocale = model.locale?.let { Locale.of(it.language, model.countryCode ?: "") }
 
     dslContext.transaction { _ ->
       usersDao.update(

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -247,13 +247,17 @@ class UserStore(
         usersDao.fetchOneById(model.userId)
             ?: throw IllegalStateException("Current user not found in users table")
 
+    // If the country code is set, include it in the locale.
+    val newLocale = model.locale?.let { Locale.of(it.language, model.countryCode ?: it.country) }
+
     dslContext.transaction { _ ->
       usersDao.update(
           usersRow.copy(
+              countryCode = model.countryCode,
               emailNotificationsEnabled = model.emailNotificationsEnabled,
               firstName = model.firstName,
               lastName = model.lastName,
-              locale = model.locale,
+              locale = newLocale,
               timeZone = model.timeZone))
 
       try {
@@ -538,6 +542,7 @@ class UserStore(
             ?: throw IllegalArgumentException("Email notifications enabled should never be null"),
         usersRow.firstName,
         usersRow.lastName,
+        usersRow.countryCode,
         usersRow.locale,
         usersRow.timeZone,
         usersRow.userTypeId ?: throw IllegalArgumentException("User type should never be null"),

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -72,6 +72,7 @@ data class IndividualUser(
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
     val lastName: String?,
+    val countryCode: String?,
     override val locale: Locale?,
     override val timeZone: ZoneId?,
     override val userType: UserType,

--- a/src/main/resources/db/migration/0200/V207__UserCountry.sql
+++ b/src/main/resources/db/migration/0200/V207__UserCountry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN country_code TEXT;
+ALTER TABLE users ADD FOREIGN KEY (country_code) REFERENCES countries (code);

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -352,9 +352,11 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateUser updates profile information`() {
+    val newCountryCode = "AR"
     val newFirstName = "Testy"
     val newLastName = "McTestalot"
-    val newLocale = Locale.forLanguageTag("gx")
+    val newLanguage = Locale.forLanguageTag("gx")
+    val newLocale = Locale.of(newLanguage.language, newCountryCode)
     val newTimeZone = insertTimeZone()
 
     insertUser(authId = userRepresentation.id, email = userRepresentation.email)
@@ -366,17 +368,19 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     val modelWithEdits =
         model.copy(
+            countryCode = newCountryCode,
             email = "newemail@x.com",
             firstName = newFirstName,
             lastName = newLastName,
             emailNotificationsEnabled = true,
-            locale = newLocale,
+            locale = newLanguage,
             timeZone = newTimeZone,
         )
     userStore.updateUser(modelWithEdits)
 
     val updatedModel = userStore.fetchOneById(model.userId) as IndividualUser
 
+    assertEquals(newCountryCode, updatedModel.countryCode, "Country code (DB)")
     assertEquals(oldEmail, updatedModel.email, "Email (DB)")
     assertEquals(newFirstName, updatedModel.firstName, "First name (DB)")
     assertEquals(newLastName, updatedModel.lastName, "Last name (DB)")


### PR DESCRIPTION
To support variation of number formatting rules in different Spanish-speaking
countries, keep track of users' countries. If the user has selected a country,
their locale will include a country code as well as a language.

The server will automatically include the user's country code in their locale
when they update their profile information, to account for the fact that clients
have language selectors that don't include country codes. That is, if the user
sets their locale to `es` and their country to `MX`, the server will save the
locale as `es-MX`.

Number and date formatting will automatically use country-specific rules once
the user has set their country.