### PR TITLE
Calculate per-subzone plant totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -177,8 +177,23 @@ data class PlantingSitePayload(
   )
 }
 
+data class PlantingSubzoneReportedPlantsPayload(
+    val id: PlantingSubzoneId,
+    val plantsSinceLastObservation: Int,
+    val totalPlants: Int,
+) {
+  constructor(
+      subzoneTotals: PlantingSiteReportedPlantTotals.PlantingSubzone
+  ) : this(
+      id = subzoneTotals.id,
+      plantsSinceLastObservation = subzoneTotals.plantsSinceLastObservation,
+      totalPlants = subzoneTotals.totalPlants,
+  )
+}
+
 data class PlantingZoneReportedPlantsPayload(
     val id: PlantingZoneId,
+    val plantingSubzones: List<PlantingSubzoneReportedPlantsPayload>,
     val plantsSinceLastObservation: Int,
     val progressPercent: Int,
     val totalPlants: Int,
@@ -187,6 +202,8 @@ data class PlantingZoneReportedPlantsPayload(
       zoneTotals: PlantingSiteReportedPlantTotals.PlantingZone
   ) : this(
       id = zoneTotals.id,
+      plantingSubzones =
+          zoneTotals.plantingSubzones.map { PlantingSubzoneReportedPlantsPayload(it) },
       plantsSinceLastObservation = zoneTotals.plantsSinceLastObservation,
       progressPercent = zoneTotals.progressPercent,
       totalPlants = zoneTotals.totalPlants,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
 import com.terraformation.backend.log.perClassLogger
@@ -136,6 +137,26 @@ class PlantingSiteStore(
   fun countReportedPlants(plantingSiteId: PlantingSiteId): PlantingSiteReportedPlantTotals {
     requirePermissions { readPlantingSite(plantingSiteId) }
 
+    val subzoneTotalSinceField = DSL.sum(PLANTING_SUBZONE_POPULATIONS.PLANTS_SINCE_LAST_OBSERVATION)
+    val subzoneTotalPlantsField = DSL.sum(PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS)
+    val subzoneTotalsMultiset =
+        DSL.multiset(
+                DSL.select(PLANTING_SUBZONES.ID, subzoneTotalSinceField, subzoneTotalPlantsField)
+                    .from(PLANTING_SUBZONE_POPULATIONS)
+                    .join(PLANTING_SUBZONES)
+                    .on(PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+                    .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
+                    .groupBy(PLANTING_SUBZONES.ID))
+            .convertFrom { result ->
+              result.map { record ->
+                PlantingSiteReportedPlantTotals.PlantingSubzone(
+                    id = record[PLANTING_SUBZONES.ID.asNonNullable()],
+                    plantsSinceLastObservation = record[subzoneTotalSinceField].toInt(),
+                    totalPlants = record[subzoneTotalPlantsField].toInt(),
+                )
+              }
+            }
+
     val zoneTotalSinceField = DSL.sum(PLANTING_ZONE_POPULATIONS.PLANTS_SINCE_LAST_OBSERVATION)
     val zoneTotalPlantsField = DSL.sum(PLANTING_ZONE_POPULATIONS.TOTAL_PLANTS)
     val zoneTotals =
@@ -145,7 +166,8 @@ class PlantingSiteStore(
                 PLANTING_ZONES.AREA_HA,
                 PLANTING_ZONES.TARGET_PLANTING_DENSITY,
                 zoneTotalSinceField,
-                zoneTotalPlantsField)
+                zoneTotalPlantsField,
+                subzoneTotalsMultiset)
             .from(PLANTING_ZONE_POPULATIONS)
             .join(PLANTING_ZONES)
             .on(PLANTING_ZONE_POPULATIONS.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
@@ -160,6 +182,7 @@ class PlantingSiteStore(
 
               PlantingSiteReportedPlantTotals.PlantingZone(
                   id = record[PLANTING_ZONES.ID.asNonNullable()],
+                  plantingSubzones = record[subzoneTotalsMultiset],
                   plantsSinceLastObservation = record[zoneTotalSinceField].toInt(),
                   targetPlants = targetPlants.toInt(),
                   totalPlants = record[zoneTotalPlantsField].toInt(),

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteReportedPlantTotals.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteReportedPlantTotals.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import kotlin.math.roundToInt
 
@@ -24,8 +25,15 @@ data class PlantingSiteReportedPlantTotals(
       }
     }
 
+  data class PlantingSubzone(
+      val id: PlantingSubzoneId,
+      val plantsSinceLastObservation: Int,
+      val totalPlants: Int,
+  )
+
   data class PlantingZone(
       val id: PlantingZoneId,
+      val plantingSubzones: List<PlantingSubzone>,
       val plantsSinceLastObservation: Int,
       val targetPlants: Int,
       val totalPlants: Int,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -679,11 +679,15 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns correct zone-level totals`() {
+    fun `returns correct zone-level and subzone-level totals`() {
       val plantingSiteId = insertPlantingSite()
       val plantingZoneId1 =
           insertPlantingZone(areaHa = BigDecimal(10), targetPlantingDensity = BigDecimal(2))
+      val plantingSubzoneId1 = insertPlantingSubzone()
       insertSpecies()
+      insertPlantingSubzonePopulation(plantsSinceLastObservation = 0, totalPlants = 4)
+      val plantingSubzoneId2 = insertPlantingSubzone()
+      insertPlantingSubzonePopulation(plantsSinceLastObservation = 1, totalPlants = 6)
       insertPlantingZonePopulation(plantsSinceLastObservation = 1, totalPlants = 10)
       insertPlantingSitePopulation(plantsSinceLastObservation = 1, totalPlants = 10)
       insertSpecies()
@@ -703,12 +707,25 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                   listOf(
                       PlantingSiteReportedPlantTotals.PlantingZone(
                           id = plantingZoneId1,
+                          plantingSubzones =
+                              listOf(
+                                  PlantingSiteReportedPlantTotals.PlantingSubzone(
+                                      id = plantingSubzoneId1,
+                                      plantsSinceLastObservation = 0,
+                                      totalPlants = 4,
+                                  ),
+                                  PlantingSiteReportedPlantTotals.PlantingSubzone(
+                                      id = plantingSubzoneId2,
+                                      plantsSinceLastObservation = 1,
+                                      totalPlants = 6,
+                                  )),
                           plantsSinceLastObservation = 3,
                           targetPlants = 20,
                           totalPlants = 30,
                       ),
                       PlantingSiteReportedPlantTotals.PlantingZone(
                           id = plantingZoneId2,
+                          plantingSubzones = emptyList(),
                           plantsSinceLastObservation = 12,
                           targetPlants = 404,
                           totalPlants = 120,


### PR DESCRIPTION
`GET /api/v1/tracking/sites/{id}/reportedPlants` currently breaks down the plant
totals by planting zone, but we need to show per-subzone totals in the web app.
Add a level of hierarchy to that API endpoint's response that returns per-subzone
totals.