### PR TITLE
Add per-subzone total plants to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -225,7 +225,7 @@ abstract class SearchTable {
 
   fun bigDecimalField(
       fieldName: String,
-      databaseField: TableField<*, BigDecimal?>,
+      databaseField: Field<BigDecimal?>,
   ) = BigDecimalField(fieldName, databaseField, this)
 
   fun booleanField(fieldName: String, databaseField: Field<Boolean?>, nullable: Boolean = true) =
@@ -237,11 +237,8 @@ abstract class SearchTable {
       nullable: Boolean = false
   ) = DateField(fieldName, databaseField, this, nullable)
 
-  fun doubleField(
-      fieldName: String,
-      databaseField: TableField<*, Double?>,
-      nullable: Boolean = false
-  ) = DoubleField(fieldName, databaseField, this, nullable)
+  fun doubleField(fieldName: String, databaseField: Field<Double?>, nullable: Boolean = false) =
+      DoubleField(fieldName, databaseField, this, nullable)
 
   inline fun <E : Enum<E>, reified T : EnumFromReferenceTable<*, E>> enumField(
       fieldName: String,
@@ -264,7 +261,7 @@ abstract class SearchTable {
 
   fun integerField(
       fieldName: String,
-      databaseField: TableField<*, Int?>,
+      databaseField: Field<Int?>,
       nullable: Boolean = true,
       localize: Boolean = true,
   ) = IntegerField(fieldName, databaseField, this, nullable, localize)
@@ -276,7 +273,7 @@ abstract class SearchTable {
       nullable: Boolean = true
   ) = LocalizedTextField(fieldName, databaseField, resourceBundleName, this, nullable)
 
-  fun longField(fieldName: String, databaseField: TableField<*, Long?>, nullable: Boolean = true) =
+  fun longField(fieldName: String, databaseField: Field<Long?>, nullable: Boolean = true) =
       LongField(fieldName, databaseField, this, nullable)
 
   fun textField(fieldName: String, databaseField: Field<String?>, nullable: Boolean = true) =

--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -5,12 +5,12 @@ import com.terraformation.backend.search.SearchTable
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.text.NumberFormat
-import org.jooq.TableField
+import org.jooq.Field
 
 /** Search field for columns with decimal values. */
 class BigDecimalField(
     fieldName: String,
-    databaseField: TableField<*, BigDecimal?>,
+    databaseField: Field<BigDecimal?>,
     table: SearchTable,
     localize: Boolean = true,
 ) : NumericSearchField<BigDecimal>(fieldName, databaseField, table, localize = localize) {

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -3,12 +3,12 @@ package com.terraformation.backend.search.field
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.search.SearchTable
 import java.text.NumberFormat
-import org.jooq.TableField
+import org.jooq.Field
 
 /** Search field for columns with floating-point values. */
 class DoubleField(
     fieldName: String,
-    databaseField: TableField<*, Double?>,
+    databaseField: Field<Double?>,
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -3,12 +3,12 @@ package com.terraformation.backend.search.field
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.search.SearchTable
 import java.text.NumberFormat
-import org.jooq.TableField
+import org.jooq.Field
 
 /** Search field for numeric columns that don't allow fractional values. */
 class IntegerField(
     fieldName: String,
-    databaseField: TableField<*, Int?>,
+    databaseField: Field<Int?>,
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -3,12 +3,12 @@ package com.terraformation.backend.search.field
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.search.SearchTable
 import java.text.NumberFormat
-import org.jooq.TableField
+import org.jooq.Field
 
 /** Search field for numeric columns that don't allow fractional values. */
 class LongField(
     fieldName: String,
-    databaseField: TableField<*, Long?>,
+    databaseField: Field<Long?>,
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -9,8 +9,8 @@ import java.util.EnumSet
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import org.jooq.Condition
+import org.jooq.Field
 import org.jooq.Record
-import org.jooq.TableField
 import org.jooq.impl.DSL
 
 /**
@@ -19,7 +19,7 @@ import org.jooq.impl.DSL
  */
 abstract class NumericSearchField<T : Number>(
     override val fieldName: String,
-    override val databaseField: TableField<*, T?>,
+    override val databaseField: Field<T?>,
     override val table: SearchTable,
     override val nullable: Boolean = true,
     override val localize: Boolean,

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonesTable.kt
@@ -15,6 +15,7 @@ import org.jooq.Condition
 import org.jooq.Record
 import org.jooq.SelectJoinStep
 import org.jooq.TableField
+import org.jooq.impl.DSL
 
 class PlantingSubzonesTable(tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
@@ -48,6 +49,14 @@ class PlantingSubzonesTable(tables: SearchTables) : SearchTable() {
           textField("name", PLANTING_SUBZONES.NAME, nullable = false),
           timestampField(
               "plantingCompletedTime", PLANTING_SUBZONES.PLANTING_COMPLETED_TIME, nullable = false),
+          bigDecimalField(
+              "totalPlants",
+              DSL.field(
+                  DSL.select(DSL.sum(PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS))
+                      .from(PLANTING_SUBZONE_POPULATIONS)
+                      .where(
+                          PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID.eq(
+                              PLANTING_SUBZONES.ID)))),
       )
 
   override val inheritsVisibilityFrom: SearchTable = tables.plantingZones

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -301,6 +301,7 @@ search.plantingSubzones.id=Planting subzone ID
 search.plantingSubzones.modifiedTime=Planting subzone modified time
 search.plantingSubzones.name=Planting subzone name
 search.plantingSubzones.plantingCompletedTime=Planting subzone planting completed time
+search.plantingSubzones.totalPlants=Planting subzone total plants (all species)
 search.plantingZonePopulations.plantsSinceLastObservation=Planting zone plants added since last observation
 search.plantingZonePopulations.totalPlants=Planting zone total plants
 search.plantingZones.boundary=Planting zone boundary

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -191,6 +191,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                             "id" to "3",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "3",
+                                            "totalPlants" to "10",
                                             "populations" to
                                                 listOf(
                                                     mapOf(
@@ -209,6 +210,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "4",
                                             "plantingCompletedTime" to "1970-01-01T00:00:01Z",
+                                            "totalPlants" to "26",
                                             "populations" to
                                                 listOf(
                                                     mapOf(
@@ -286,6 +288,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "plantingZones.plantingSubzones.populations.species_id",
                 "plantingZones.plantingSubzones.populations.totalPlants",
                 "plantingZones.plantingSubzones.monitoringPlots.id",
+                "plantingZones.plantingSubzones.totalPlants",
                 "plantingZones.populations.plantsSinceLastObservation",
                 "plantingZones.populations.species_id",
                 "plantingZones.populations.totalPlants",


### PR DESCRIPTION
To allow clients to query the number of plants in each subzone across sites
in a single organization, add a search field to get the total plants of all
species in a subzone. The per-species totals continue to be available in the
`populations` sublist.