### PR TITLE
Revert "Calculate per-subzone plant totals (#1291)"

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -177,23 +177,8 @@ data class PlantingSitePayload(
   )
 }
 
-data class PlantingSubzoneReportedPlantsPayload(
-    val id: PlantingSubzoneId,
-    val plantsSinceLastObservation: Int,
-    val totalPlants: Int,
-) {
-  constructor(
-      subzoneTotals: PlantingSiteReportedPlantTotals.PlantingSubzone
-  ) : this(
-      id = subzoneTotals.id,
-      plantsSinceLastObservation = subzoneTotals.plantsSinceLastObservation,
-      totalPlants = subzoneTotals.totalPlants,
-  )
-}
-
 data class PlantingZoneReportedPlantsPayload(
     val id: PlantingZoneId,
-    val plantingSubzones: List<PlantingSubzoneReportedPlantsPayload>,
     val plantsSinceLastObservation: Int,
     val progressPercent: Int,
     val totalPlants: Int,
@@ -202,8 +187,6 @@ data class PlantingZoneReportedPlantsPayload(
       zoneTotals: PlantingSiteReportedPlantTotals.PlantingZone
   ) : this(
       id = zoneTotals.id,
-      plantingSubzones =
-          zoneTotals.plantingSubzones.map { PlantingSubzoneReportedPlantsPayload(it) },
       plantsSinceLastObservation = zoneTotals.plantsSinceLastObservation,
       progressPercent = zoneTotals.progressPercent,
       totalPlants = zoneTotals.totalPlants,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteReportedPlantTotals.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteReportedPlantTotals.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.PlantingSiteId
-import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import kotlin.math.roundToInt
 
@@ -25,15 +24,8 @@ data class PlantingSiteReportedPlantTotals(
       }
     }
 
-  data class PlantingSubzone(
-      val id: PlantingSubzoneId,
-      val plantsSinceLastObservation: Int,
-      val totalPlants: Int,
-  )
-
   data class PlantingZone(
       val id: PlantingZoneId,
-      val plantingSubzones: List<PlantingSubzone>,
       val plantsSinceLastObservation: Int,
       val targetPlants: Int,
       val totalPlants: Int,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -679,15 +679,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns correct zone-level and subzone-level totals`() {
+    fun `returns correct zone-level totals`() {
       val plantingSiteId = insertPlantingSite()
       val plantingZoneId1 =
           insertPlantingZone(areaHa = BigDecimal(10), targetPlantingDensity = BigDecimal(2))
-      val plantingSubzoneId1 = insertPlantingSubzone()
       insertSpecies()
-      insertPlantingSubzonePopulation(plantsSinceLastObservation = 0, totalPlants = 4)
-      val plantingSubzoneId2 = insertPlantingSubzone()
-      insertPlantingSubzonePopulation(plantsSinceLastObservation = 1, totalPlants = 6)
       insertPlantingZonePopulation(plantsSinceLastObservation = 1, totalPlants = 10)
       insertPlantingSitePopulation(plantsSinceLastObservation = 1, totalPlants = 10)
       insertSpecies()
@@ -707,25 +703,12 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                   listOf(
                       PlantingSiteReportedPlantTotals.PlantingZone(
                           id = plantingZoneId1,
-                          plantingSubzones =
-                              listOf(
-                                  PlantingSiteReportedPlantTotals.PlantingSubzone(
-                                      id = plantingSubzoneId1,
-                                      plantsSinceLastObservation = 0,
-                                      totalPlants = 4,
-                                  ),
-                                  PlantingSiteReportedPlantTotals.PlantingSubzone(
-                                      id = plantingSubzoneId2,
-                                      plantsSinceLastObservation = 1,
-                                      totalPlants = 6,
-                                  )),
                           plantsSinceLastObservation = 3,
                           targetPlants = 20,
                           totalPlants = 30,
                       ),
                       PlantingSiteReportedPlantTotals.PlantingZone(
                           id = plantingZoneId2,
-                          plantingSubzones = emptyList(),
                           plantsSinceLastObservation = 12,
                           targetPlants = 404,
                           totalPlants = 120,


### PR DESCRIPTION
This reverts commit 2cf2f9e84f6a028caa113a771b196e199390b0e1.

We needed to be able to retrieve the totals across planting sites, not one site at
a time, so this initial stab was the wrong approach.