### PR TITLE
Increase Kotlin compiler memory

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2400m -Dfile.encoding=UTF-8 -Xmx4096m
+org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx3072m -Dfile.encoding=UTF-8 -Xmx4096m
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Version numbers of dependencies that come in multiple related artifacts. This ensures we have


### PR DESCRIPTION
The current compiler memory limit is just barely enough on ARM systems; upcoming
changes that added more code were causing it to run out of memory. Increase its
maximum heap size.