### PR TITLE
Add docs to all API endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -43,12 +43,14 @@ class ProjectsController(private val projectStore: ProjectStore) {
   }
 
   @GetMapping("/{id}")
+  @Operation(summary = "Gets information about a specific project.")
   fun getProject(@PathVariable id: ProjectId): GetProjectResponsePayload {
     val project = projectStore.fetchOneById(id)
 
     return GetProjectResponsePayload(ProjectPayload(project))
   }
 
+  @Operation(summary = "Creates a new project.")
   @PostMapping
   fun createProject(
       @RequestBody payload: CreateProjectRequestPayload
@@ -65,12 +67,18 @@ class ProjectsController(private val projectStore: ProjectStore) {
   }
 
   @DeleteMapping("/{id}")
+  @Operation(
+      summary = "Deletes an existing project.",
+      description =
+          "Any accessions, seedling batches, or planting sites that were assigned to the project " +
+              "will no longer be assigned to any project.")
   fun deleteProject(@PathVariable id: ProjectId): SimpleSuccessResponsePayload {
     projectStore.delete(id)
 
     return SimpleSuccessResponsePayload()
   }
 
+  @Operation(summary = "Updates information about an existing project.")
   @PutMapping("/{id}")
   fun updateProject(
       @PathVariable id: ProjectId,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/VersionsController.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.AppVersionStore
 import com.terraformation.backend.db.default_schema.tables.pojos.AppVersionsRow
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class VersionsController(private val appVersionStore: AppVersionStore) {
   @GetMapping
+  @Operation(
+      summary = "Gets the minimum and recommended versions for Terraware's client applications.")
   fun getVersions(): VersionsResponsePayload {
     val entries = appVersionStore.findAll().map { VersionsEntryPayload(it) }
     return VersionsResponsePayload(entries)

--- a/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/AutomationsController.kt
@@ -50,6 +50,7 @@ class AutomationsController(
   }
 
   @GetMapping("/{automationId}")
+  @Operation(summary = "Gets the details of a single automation for a device or facility.")
   fun getAutomation(
       @PathVariable("automationId") automationId: AutomationId
   ): GetAutomationResponsePayload {
@@ -57,6 +58,7 @@ class AutomationsController(
     return GetAutomationResponsePayload(AutomationPayload(automation))
   }
 
+  @Operation(summary = "Creates a new automation for a device or facility.")
   @PostMapping
   fun createAutomation(
       @RequestBody payload: CreateAutomationRequestPayload
@@ -78,6 +80,7 @@ class AutomationsController(
     return CreateAutomationResponsePayload(automationId)
   }
 
+  @Operation(summary = "Updates an existing automation for a device or facility.")
   @PutMapping("/{automationId}")
   fun updateAutomation(
       @PathVariable("automationId") automationId: AutomationId,
@@ -89,6 +92,7 @@ class AutomationsController(
   }
 
   @DeleteMapping("/{automationId}")
+  @Operation(summary = "Deletes an existing automation from a device or facility.")
   fun deleteAutomation(
       @PathVariable("automationId") automationId: AutomationId
   ): SimpleSuccessResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceManagersController.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceManagersRow
 import com.terraformation.backend.device.DeviceManagerService
 import com.terraformation.backend.device.db.DeviceManagerStore
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
@@ -28,9 +30,18 @@ class DeviceManagersController(
     private val deviceManagerStore: DeviceManagerStore,
 ) {
   @GetMapping
+  @Operation(summary = "Searches for device managers matching a set of criteria.")
   fun getDeviceManagers(
-      @RequestParam sensorKitId: String?,
-      @RequestParam facilityId: FacilityId?,
+      @Parameter(
+          description =
+              "Search for device managers with this sensor kit ID. Either this or facilityId must be specified.")
+      @RequestParam
+      sensorKitId: String?,
+      @Parameter(
+          description =
+              "Search for device managers associated with this facility. Either this or sensorKitId must be specified.")
+      @RequestParam
+      facilityId: FacilityId?,
   ): GetDeviceManagersResponsePayload {
     return when {
       sensorKitId != null && facilityId == null -> {
@@ -48,6 +59,7 @@ class DeviceManagersController(
   }
 
   @GetMapping("/{deviceManagerId}")
+  @Operation(summary = "Gets information about a specific device manager.")
   fun getDeviceManager(
       @PathVariable deviceManagerId: DeviceManagerId
   ): GetDeviceManagerResponsePayload {
@@ -56,6 +68,7 @@ class DeviceManagersController(
     return GetDeviceManagerResponsePayload(DeviceManagerPayload(manager))
   }
 
+  @Operation(summary = "Connects a device manager to a facility.")
   @PostMapping("/{deviceManagerId}/connect")
   fun connectDeviceManager(
       @PathVariable deviceManagerId: DeviceManagerId,

--- a/src/main/kotlin/com/terraformation/backend/device/api/DeviceTemplatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DeviceTemplatesController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.DeviceTemplateCategory
 import com.terraformation.backend.db.default_schema.DeviceTemplateId
 import com.terraformation.backend.db.default_schema.tables.daos.DeviceTemplatesDao
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceTemplatesRow
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class DeviceTemplatesController(private val deviceTemplatesDao: DeviceTemplatesDao) {
   @GetMapping
+  @Operation(summary = "Lists the available templates for new devices.")
   fun listDeviceTemplates(
       @RequestParam category: DeviceTemplateCategory? = null
   ): ListDeviceTemplatesResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/device/api/DevicesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/api/DevicesController.kt
@@ -41,6 +41,7 @@ class DevicesController(
   }
 
   @ApiResponseSimpleSuccess
+  @Operation(summary = "Registers a new device a facility's device manager.")
   @PostMapping("/api/v1/devices")
   fun createDevice(@RequestBody payload: CreateDeviceRequestPayload): CreateDeviceResponsePayload {
     val devicesRow = payload.toRow()

--- a/src/main/kotlin/com/terraformation/backend/i18n/api/TimeZonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/api/TimeZonesController.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.i18n.TimeZones
 import com.terraformation.backend.i18n.currentLocale
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
 import java.util.Locale
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class TimeZonesController(private val timeZones: TimeZones) {
   @GetMapping
+  @Operation(summary = "Gets a list of supported time zones and their names.")
   fun listTimeZoneNames(
       @RequestParam("locale")
       @Schema(

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -43,6 +43,7 @@ class BatchesController(
   @ApiResponse(responseCode = "200")
   @ApiResponse404
   @GetMapping("/{id}")
+  @Operation(summary = "Gets information about a single seedling batch.")
   fun getBatch(@PathVariable("id") id: BatchId): BatchResponsePayload {
     val row = batchStore.fetchOneById(id)
     return BatchResponsePayload(BatchPayload(row))
@@ -53,6 +54,7 @@ class BatchesController(
       description =
           "The batch was created successfully. Response includes fields populated by the " +
               "server, including the batch ID.")
+  @Operation(summary = "Creates a new seedling batch at a nursery.")
   @PostMapping
   fun createBatch(@RequestBody payload: CreateBatchRequestPayload): BatchResponsePayload {
     val insertedRow = batchStore.create(payload.toRow())
@@ -61,6 +63,7 @@ class BatchesController(
 
   @ApiResponseSimpleSuccess
   @DeleteMapping("/{id}")
+  @Operation(summary = "Deletes an existing seedling batch from a nursery.")
   fun deleteBatch(@PathVariable("id") id: BatchId): SimpleSuccessResponsePayload {
     batchStore.delete(id)
     return SimpleSuccessResponsePayload()
@@ -92,6 +95,10 @@ class BatchesController(
   @ApiResponse200
   @ApiResponse404
   @ApiResponse412
+  @Operation(
+      summary = "Updates the remaining quantities in a seedling batch.",
+      description =
+          "This should not be used to record withdrawals; use the withdrawal API for that.")
   @PutMapping("/{id}/quantities")
   fun updateBatchQuantities(
       @PathVariable("id") id: BatchId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.model.SpeciesSummary
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -20,6 +21,7 @@ class SpeciesController(
     private val batchStore: BatchStore,
 ) {
   @GetMapping("/{speciesId}/summary")
+  @Operation(summary = "Gets a summary of the numbers of plants of each species in all nurseries.")
   fun getSpeciesSummary(
       @PathVariable("speciesId") speciesId: SpeciesId
   ): GetSpeciesSummaryResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -63,6 +63,7 @@ class WithdrawalsController(
     val withdrawalPhotoService: WithdrawalPhotoService,
 ) {
   @GetMapping("/{withdrawalId}")
+  @Operation(summary = "Gets information about a specific nursery withdrawal.")
   fun getNurseryWithdrawal(
       @PathVariable("withdrawalId") withdrawalId: WithdrawalId
   ): GetNurseryWithdrawalResponsePayload {
@@ -78,6 +79,7 @@ class WithdrawalsController(
     return GetNurseryWithdrawalResponsePayload(batches, deliveryModel, withdrawal)
   }
 
+  @Operation(summary = "Withdraws seedlings from one or more seedling batches at a nursery.")
   @PostMapping
   fun createBatchWithdrawal(
       @RequestBody payload: CreateNurseryWithdrawalRequestPayload

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -33,6 +34,7 @@ class SearchController(
 ) {
   private val organizationsTable = tables.organizations
 
+  @Operation(summary = "Searches for data matching a supplied set of search criteria.")
   @PostMapping
   fun search(
       @RequestBody
@@ -81,6 +83,11 @@ class SearchController(
       responseCode = "200",
       content =
           [Content(mediaType = "text/csv", schema = Schema(type = "string", format = "binary"))])
+  @Operation(
+      summary = "Exports selected fields from data matching a set of search criteria.",
+      description =
+          "If a sublist field has multiple values, they are separated with line breaks in the " +
+              "exported file.")
   @PostMapping(produces = ["text/csv"])
   fun export(@RequestBody payload: SearchRequestPayload): ResponseEntity<ByteArray> {
     val rootPrefix = resolvePrefix(payload.prefix)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsController.kt
@@ -39,6 +39,7 @@ class AccessionsController(
   @ApiResponseSimpleSuccess
   @ApiResponse404
   @DeleteMapping("/{id}")
+  @Operation(summary = "Deletes an existing accession.")
   fun delete(@PathVariable("id") accessionId: AccessionId): SimpleSuccessResponsePayload {
     accessionService.deleteAccession(accessionId)
     return SimpleSuccessResponsePayload()

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/LogController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/LogController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.seedbank.api
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.log.log
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import org.slf4j.LoggerFactory
 import org.slf4j.event.Level
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @SeedBankAppEndpoint
 class LogController(private val objectMapper: ObjectMapper) {
+  @Operation(summary = "Records a log message from a device at a seed bank.")
   @PostMapping("/{tag}")
   fun recordLogMessage(
       @PathVariable

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/StorageLocationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/StorageLocationsController.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.seedbank.StorageLocationId
 import com.terraformation.backend.db.seedbank.tables.pojos.StorageLocationsRow
 import com.terraformation.backend.seedbank.db.AccessionStore
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -28,6 +29,7 @@ class StorageLocationsController(
     private val facilityStore: FacilityStore
 ) {
   @GetMapping
+  @Operation(summary = "Gets a list of storage locations at a seed bank facility.")
   fun listStorageLocations(
       @RequestParam facilityId: FacilityId
   ): ListStorageLocationsResponsePayload {
@@ -39,6 +41,8 @@ class StorageLocationsController(
   }
 
   @GetMapping("/{id}")
+  @Operation(
+      summary = "Gets information about a specific storage location at a seed bank facility.")
   fun getStorageLocation(
       @PathVariable("id") id: StorageLocationId
   ): GetStorageLocationResponsePayload {
@@ -51,6 +55,7 @@ class StorageLocationsController(
   @ApiResponse200
   @ApiResponse409(
       description = "A storage location with the requested name already exists at the facility.")
+  @Operation(summary = "Creates a new storage location at a seed bank facility.")
   @PostMapping
   fun createStorageLocation(
       @RequestBody payload: CreateStorageLocationRequestPayload
@@ -65,6 +70,7 @@ class StorageLocationsController(
   @ApiResponse200
   @ApiResponse409(
       description = "A storage location with the requested name already exists at the facility.")
+  @Operation(summary = "Updates the name of a storage location at a seed bank facility.")
   @PutMapping("/{id}")
   fun updateStorageLocation(
       @PathVariable("id") id: StorageLocationId,
@@ -75,7 +81,13 @@ class StorageLocationsController(
     return SimpleSuccessResponsePayload()
   }
 
+  @ApiResponse200
+  @ApiResponse409(
+      description =
+          "The storage location contains accessions. Move them to a different storage location " +
+              "first.")
   @DeleteMapping("/{id}")
+  @Operation(summary = "Deletes a storage location from a seed bank facility.")
   fun deleteStorageLocation(
       @PathVariable("id") id: StorageLocationId
   ): SimpleSuccessResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesAdminController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.species.api
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.species.db.GbifImporter
 import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
 import jakarta.ws.rs.FormParam
 import jakarta.ws.rs.ServerErrorException
 import jakarta.ws.rs.core.Response
@@ -18,6 +19,9 @@ import org.springframework.web.bind.annotation.RestController
 class SpeciesAdminController(
     private val gbifImporter: GbifImporter,
 ) {
+  @Operation(
+      summary = "Imports a GBIF backbone dataset into the system.",
+      description = "Only available for super-admin users.")
   @PostMapping("/importGbif")
   fun importGbif(@FormParam("source") source: URI): SimpleSuccessResponsePayload {
     try {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.tracking.PlantingType
 import com.terraformation.backend.tracking.db.DeliveryStore
 import com.terraformation.backend.tracking.model.DeliveryModel
 import com.terraformation.backend.tracking.model.PlantingModel
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import org.springframework.web.bind.annotation.GetMapping
@@ -31,11 +32,15 @@ class DeliveriesController(
     private val deliveryStore: DeliveryStore,
 ) {
   @GetMapping("/{id}")
+  @Operation(
+      summary = "Gets information about a specific delivery of seedlings to a planting site.")
   fun getDelivery(@PathVariable("id") deliveryId: DeliveryId): GetDeliveryResponsePayload {
     val model = deliveryStore.fetchOneById(deliveryId)
     return GetDeliveryResponsePayload(DeliveryPayload(model))
   }
 
+  @Operation(
+      summary = "Reassigns some of the seedlings from a delivery to a different planting subzone.")
   @PostMapping("/{id}/reassign")
   fun reassignDelivery(
       @PathVariable("id") deliveryId: DeliveryId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MapboxController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.tracking.mapbox.MapboxRequestFailedException
 import com.terraformation.backend.tracking.mapbox.MapboxService
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.ws.rs.NotFoundException
 import jakarta.ws.rs.ServiceUnavailableException
@@ -27,6 +28,9 @@ class MapboxController(
       responseCode = "503",
       description = "The server is temporarily unable to generate a new Mapbox token.")
   @GetMapping("/token")
+  @Operation(
+      summary = "Gets an API token to use for displaying Mapbox maps.",
+      description = "Mapbox API tokens are short-lived; when a token expires, request a new one.")
   fun getMapboxToken(): GetMapboxTokenResponsePayload {
     val token =
         if (mapboxService.enabled) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -178,6 +178,9 @@ class ObservationsController(
   }
 
   @GetMapping("/{observationId}/results")
+  @Operation(
+      summary = "Gets the results of an observation of a planting site.",
+      description = "Some information is only available once all plots have been completed.")
   fun getObservationResults(
       @PathVariable observationId: ObservationId
   ): GetObservationResultsResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteReportedPlantTotals
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -39,6 +40,10 @@ class PlantingSitesController(
     private val plantingSiteStore: PlantingSiteStore,
 ) {
   @GetMapping
+  @Operation(
+      summary = "Gets a list of an organization's planting sites.",
+      description =
+          "The list can optionally contain information about planting zones and subzones.")
   fun listPlantingSites(
       @RequestParam //
       organizationId: OrganizationId,
@@ -55,6 +60,9 @@ class PlantingSitesController(
   }
 
   @GetMapping("/{id}")
+  @Operation(
+      summary = "Gets information about a specific planting site.",
+      description = "Includes information about the site's planting zones and subzones.")
   fun getPlantingSite(
       @PathVariable("id") id: PlantingSiteId,
   ): GetPlantingSiteResponsePayload {
@@ -63,6 +71,10 @@ class PlantingSitesController(
   }
 
   @GetMapping("/{id}/reportedPlants")
+  @Operation(
+      summary =
+          "Gets the total number of plants planted at a planting site and in each planting zone.",
+      description = "The totals are based on nursery withdrawals.")
   fun getPlantingSiteReportedPlants(
       @PathVariable id: PlantingSiteId,
   ): GetPlantingSiteReportedPlantsResponsePayload {
@@ -71,6 +83,7 @@ class PlantingSitesController(
     return GetPlantingSiteReportedPlantsResponsePayload(PlantingSiteReportedPlantsPayload(totals))
   }
 
+  @Operation(summary = "Creates a new planting site.")
   @PostMapping
   fun createPlantingSite(
       @RequestBody payload: CreatePlantingSiteRequestPayload
@@ -86,6 +99,7 @@ class PlantingSitesController(
     return CreatePlantingSiteResponsePayload(model.id)
   }
 
+  @Operation(summary = "Updates information about an existing planting site.")
   @PutMapping("/{id}")
   fun updatePlantingSite(
       @PathVariable("id") id: PlantingSiteId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import io.swagger.v3.oas.annotations.Operation
 import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -26,6 +27,9 @@ class PlantingSubzonesController(
     private val speciesStore: SpeciesStore,
 ) {
   @GetMapping("/{id}/species")
+  @Operation(
+      summary = "Gets a list of the species that have been planted in a specific planting subzone.",
+      description = "The list is based on nursery withdrawals.")
   fun listPlantingSubzoneSpecies(
       @PathVariable id: PlantingSubzoneId,
   ): ListPlantingSubzoneSpeciesResponsePayload {
@@ -35,6 +39,7 @@ class PlantingSubzonesController(
         species.map { PlantingSubzoneSpeciesPayload(it) })
   }
 
+  @Operation(summary = "Updates information about a planting subzone.")
   @PutMapping("/{id}")
   fun updatePlantingSubzone(
       @PathVariable id: PlantingSubzoneId,

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -1,11 +1,13 @@
 package com.terraformation.backend.api
 
 import io.swagger.v3.oas.annotations.Hidden
+import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import java.lang.reflect.Method
 import java.util.stream.Stream
 import kotlin.streams.asStream
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -38,10 +40,7 @@ class OpenApiAnnotationTest {
 
   @MethodSource("findAllEndpointMethods")
   @ParameterizedTest(name = "{0}")
-  fun `all endpoints declare their success responses`(
-      @Suppress("UNUSED_PARAMETER") name: String,
-      method: Method
-  ) {
+  fun `all endpoints declare their success responses`(name: String, method: Method) {
     val responseCodes =
         MergedAnnotations.from(method)
             .stream(ApiResponse::class.java)
@@ -50,7 +49,15 @@ class OpenApiAnnotationTest {
 
     assertTrue(
         responseCodes.isEmpty() || responseCodes.any { it in 200..299 },
-        "No response declared for HTTP 2xx response code")
+        "No response declared for HTTP 2xx response code on $name")
+  }
+
+  @MethodSource("findAllEndpointMethods")
+  @ParameterizedTest(name = "{0}")
+  fun `all endpoints have summaries`(name: String, method: Method) {
+    val operation = MergedAnnotations.from(method).get(Operation::class.java)
+    assertTrue(operation.isPresent, "No Operation annotation on $name")
+    assertNotNull(operation.getString("summary"), "Operation annotation on $name missing summary")
   }
 
   companion object {


### PR DESCRIPTION
Some of our API endpoints didn't have any documentation. Add a unit test to
detect when we add an endpoint that doesn't at least have a summary, and add
summaries (and descriptions, if needed) to the existing endpoints that didn't
have them.