### PR TITLE
SW-3952 Reduce default confidence interval to 80%

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -64,15 +64,15 @@ class PlantingSiteImporter(
     const val HECTARES_SCALE = 1
 
     // Default values of the three parameters that determine how many monitoring plots should be
-    // required in each observation. The "Student's t" value is a constant based on a 90% confidence
-    // level and should rarely need to change, but the other two will be adjusted by admins based on
-    // the conditions at the planting site. These defaults mean that planting zones will have 12
-    // permanent clusters and 16 temporary plots.
+    // required in each observation. The "Student's t" value is a constant based on an 80%
+    // confidence level and should rarely need to change, but the other two will be adjusted by
+    // admins based on the conditions at the planting site. These defaults mean that planting zones
+    // will have 7 permanent clusters and 9 temporary plots.
     val DEFAULT_ERROR_MARGIN = BigDecimal(100)
-    val DEFAULT_STUDENTS_T = BigDecimal("1.645")
+    val DEFAULT_STUDENTS_T = BigDecimal("1.282")
     val DEFAULT_VARIANCE = BigDecimal(40000)
-    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 11
-    const val DEFAULT_NUM_TEMPORARY_PLOTS = 14
+    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 7
+    const val DEFAULT_NUM_TEMPORARY_PLOTS = 9
 
     /** Target planting density to use if not included in zone properties. */
     val DEFAULT_TARGET_PLANTING_DENSITY = BigDecimal(1500)


### PR DESCRIPTION
Based on feedback from our carbon consultant, we only need an 80% confidence level
on observations, not 90%. Change the default Student's t value to 1.282, which
corresponds with an 80% confidence level, and reduce the default number of
permanent clusters and temporary plots based on the new value.

This only changes the default for new planting sites; existing ones can be edited
in the admin UI if needed.