### PR TITLE
SW-3814 Non-sensitive config for prod and staging

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,5 +37,5 @@ terraware:
   report:
     export-enabled: true
   request-log:
-    email-regex: ".*@terraformation\.com"
+    email-regex: ".*@terraformation\\.com"
   web-app-url: "https://terraware.io/"

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,41 @@
+# Non-sensitive settings for the production environment.
+#
+# REMEMBER: THIS FILE IS PART OF THE OPEN-SOURCE REPO! Don't include any credentials here;
+# pass them in as environment variables.
+
+logging:
+  level:
+    com.terraformation: DEBUG
+
+server:
+  forward-headers-strategy: native
+
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak:
+            issuer-uri: "https://auth.prod.terraware.io/realms/terraware"
+        registration:
+          keycloak:
+            client-id: "prod-terraware-server"
+      resourceserver:
+        jwt:
+          issuer-uri: "https://auth.prod.terraware.io/realms/terraware"
+  thymeleaf:
+    prefix: "classpath:templates"
+
+terraware:
+  balena:
+    enabled: true
+  email:
+    always-send-to-override-address: false
+    enabled: true
+    use-ses: true
+    sender-address: "Terraware <no-reply@terraware.io>"
+  report:
+    export-enabled: true
+  request-log:
+    email-regex: ".*@terraformation\.com"
+  web-app-url: "https://terraware.io/"

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -38,6 +38,6 @@ terraware:
   report:
     export-enabled: true
   request-log:
-    email-regex: ".*@terraformation\.com"
+    email-regex: ".*@terraformation\\.com"
   use-test-clock: true
   web-app-url: "https://staging.terraware.io/"

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -1,0 +1,43 @@
+# Non-sensitive settings for the staging environment.
+#
+# REMEMBER: THIS FILE IS PART OF THE OPEN-SOURCE REPO! Don't include any credentials here;
+# pass them in as environment variables.
+
+logging:
+  level:
+    com.terraformation: DEBUG
+
+server:
+  forward-headers-strategy: native
+
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          keycloak:
+            issuer-uri: "https://auth.staging.terraware.io/realms/terraware"
+        registration:
+          keycloak:
+            client-id: "staging-terraware-server"
+      resourceserver:
+        jwt:
+          issuer-uri: "https://auth.staging.terraware.io/realms/terraware"
+  thymeleaf:
+    prefix: "classpath:templates"
+
+terraware:
+  balena:
+    enabled: true
+  email:
+    always-send-to-override-address: false
+    enabled: true
+    use-ses: true
+    sender-address: "Terraware Staging <no-reply@staging.terraware.io>"
+    subject-prefix: "[STAGING]"
+  report:
+    export-enabled: true
+  request-log:
+    email-regex: ".*@terraformation\.com"
+  use-test-clock: true
+  web-app-url: "https://staging.terraware.io/"


### PR DESCRIPTION
Some of the configuration for the prod and staging environments is safe to expose
to the world; add it to config files to reduce the amount of configuration that
needs to be supplied in environment variables at deployment time.