### PR TITLE
SW-4007 Use nursery time zone to check withdrawn date

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -167,6 +167,13 @@ class ParentStore(private val dslContext: DSLContext) {
               ACCESSIONS.facilities.TIME_ZONE, ACCESSIONS.facilities.organizations.TIME_ZONE))
           ?: ZoneOffset.UTC
 
+  fun getEffectiveTimeZone(batchId: BatchId): ZoneId =
+      fetchFieldById(
+          batchId,
+          BATCHES.ID,
+          DSL.coalesce(BATCHES.facilities.TIME_ZONE, BATCHES.facilities.organizations.TIME_ZONE))
+          ?: ZoneOffset.UTC
+
   fun exists(deviceManagerId: DeviceManagerId): Boolean =
       fetchFieldById(deviceManagerId, DEVICE_MANAGERS.ID, DSL.one()) != null
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -48,7 +48,6 @@ import com.terraformation.backend.seedbank.event.AccessionSpeciesChangedEvent
 import jakarta.inject.Named
 import java.time.Clock
 import java.time.LocalDate
-import java.time.ZoneOffset
 import org.jooq.DSLContext
 import org.jooq.UpdateSetFirstStep
 import org.jooq.UpdateSetMoreStep
@@ -451,6 +450,7 @@ class BatchStore(
                         germinatingQuantityWithdrawn = batchWithdrawal.germinatingQuantityWithdrawn,
                         notReadyQuantityWithdrawn = batchWithdrawal.notReadyQuantityWithdrawn,
                         readyQuantityWithdrawn = batchWithdrawal.readyQuantityWithdrawn)
+                val nurseryTimeZone = parentStore.getEffectiveTimeZone(batchId)
 
                 var retriesRemaining = MAX_WITHDRAW_RETRIES
                 var succeeded = false
@@ -474,7 +474,7 @@ class BatchStore(
                     // might have been updated by whatever operation caused our version number to
                     // be out of date.
                     val latestObservedDate =
-                        LocalDate.ofInstant(batch.latestObservedTime!!, ZoneOffset.UTC)
+                        LocalDate.ofInstant(batch.latestObservedTime!!, nurseryTimeZone)
                     val withdrawalIsNewerThanObservation =
                         withdrawal.withdrawnDate >= latestObservedDate
 


### PR DESCRIPTION
If a nursery withdrawal is dated earlier than the time a batch's remaining
quantity was most recently manually observed, we don't override the
manually-entered quantity.

Unfortunately, we were using UTC to figure out which date the last observation
fell on, meaning the system could erroneously think that a withdrawal happened
before the last observation instead of on the same day. This caused the system
to not update the quantities of batches when it should have.

A followup change will backfill the missing quantity updates.