### PR TITLE
SW-4028 Rotate thumbnail image source

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.session:spring-session-jdbc")
 
+  implementation("com.drewnoakes:metadata-extractor:2.18.0")
   implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
   implementation("com.google.api-client:google-api-client:2.2.0")

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.ThumbnailsRow
 import com.terraformation.backend.db.default_schema.tables.references.THUMBNAILS
 import com.terraformation.backend.log.debugWithTiming
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.util.ImageUtils
 import jakarta.inject.Named
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
@@ -34,7 +35,8 @@ class ThumbnailStore(
     private val dslContext: DSLContext,
     private val fileStore: FileStore,
     private val filesDao: FilesDao,
-    private val thumbnailsDao: ThumbnailsDao
+    private val thumbnailsDao: ThumbnailsDao,
+    private val imageUtils: ImageUtils,
 ) {
   /**
    * If an image is scaled to this size or larger (on either axis), use a quality-optimized scaling
@@ -205,9 +207,7 @@ class ThumbnailStore(
   /** Scales an existing photo to a new set of maximum dimensions. */
   private fun scalePhoto(photoUrl: URI, maxWidth: Int?, maxHeight: Int?): BufferedImage {
     val originalImage =
-        log.debugWithTiming("Loaded $photoUrl into image buffer") {
-          fileStore.read(photoUrl).use { stream -> ImageIO.read(stream) }
-        }
+        log.debugWithTiming("Loaded $photoUrl into image buffer") { imageUtils.read(photoUrl) }
 
     // If the image is large enough for visual quality to matter, use a higher-quality scaling
     // algorithm.

--- a/src/main/kotlin/com/terraformation/backend/util/ImageUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/ImageUtils.kt
@@ -1,0 +1,77 @@
+package com.terraformation.backend.util
+
+import com.drew.imaging.ImageMetadataReader
+import com.drew.metadata.exif.ExifIFD0Directory
+import com.terraformation.backend.file.FileStore
+import jakarta.inject.Named
+import java.awt.image.BufferedImage
+import java.net.URI
+import javax.imageio.ImageIO
+import net.coobird.thumbnailator.filters.Flip
+import net.coobird.thumbnailator.filters.Rotation
+
+/** Utility class for image maniuplation */
+@Named
+class ImageUtils(private val fileStore: FileStore) {
+
+  companion object {
+    const val EXIF_ORIENTATION_TAG_ID = 274
+  }
+
+  /**
+   * Parse EXIF metadata and return orientation if present.
+   *
+   * @see https://exiv2.org/tags.html (274 decimal tag)
+   * @see https://drewnoakes.com/code/exif/
+   */
+  fun getOrientation(photoUrl: URI): Int? {
+    fileStore.read(photoUrl).use { stream ->
+      val metadata = ImageMetadataReader.readMetadata(stream)
+      val directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory::class.java)
+      return directory?.getInteger(EXIF_ORIENTATION_TAG_ID)
+    }
+  }
+
+  /** Utility to flip an image horizontally */
+  fun flipHorizontal(image: BufferedImage): BufferedImage = Flip.HORIZONTAL.apply(image)
+
+  /** Utility to flip an image vertically */
+  fun flipVertical(image: BufferedImage): BufferedImage = Flip.VERTICAL.apply(image)
+
+  /** Utility to rotate an image by degrees */
+  fun rotateByDegree(image: BufferedImage, degree: Double): BufferedImage =
+      Rotation.newRotator(degree).apply(image)
+
+  /**
+   * Rotate an image by a specified orientation. Orientations are from 1 through 8. This utility
+   * leverages Thumbnailator's built-in filters to rotate and flip.
+   *
+   * @see https://sirv.com/help/articles/rotate-photos-to-be-upright/
+   * @see
+   *   https://coobird.github.io/thumbnailator/javadoc/0.4.8/net/coobird/thumbnailator/util/exif/Orientation.html
+   */
+  fun rotate(image: BufferedImage, orientation: Int?): BufferedImage {
+    var rotated =
+        when (orientation) {
+          2 -> flipHorizontal(image)
+          3 -> rotateByDegree(image, 180.0)
+          4 -> flipVertical(image)
+          5 -> rotateByDegree(flipHorizontal(image), 270.0)
+          6 -> rotateByDegree(image, 90.0)
+          7 -> rotateByDegree(flipHorizontal(image), 90.0)
+          8 -> rotateByDegree(image, 270.0)
+          else -> image
+        }
+    return rotated
+  }
+
+  /**
+   * Utility to read an image from url into a buffered image, applying relevant metadata to the
+   * buffered image.
+   */
+  fun read(photoUrl: URI): BufferedImage {
+    val orientation = getOrientation(photoUrl)
+    val bufferedImage = fileStore.read(photoUrl).use { stream -> ImageIO.read(stream) }
+    return rotate(bufferedImage, orientation)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/util/ImageUtilsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ImageUtilsTest.kt
@@ -1,0 +1,156 @@
+package com.terraformation.backend.util
+
+import com.terraformation.backend.file.FileStore
+import com.terraformation.backend.file.SizedInputStream
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.net.URI
+import javax.imageio.ImageIO
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class ImageUtilsTest {
+  private val fileStore: FileStore = mockk()
+  private val utils: ImageUtils = spyk(ImageUtils(fileStore))
+  private val photoStorageUrl = URI("file:///a/b/c/original.jpg")
+
+  @BeforeEach
+  fun setUp() {
+    every { fileStore.read(photoStorageUrl) } answers
+        {
+          SizedInputStream(
+              ByteArrayInputStream(ImageUtilsTest.photoData),
+              ImageUtilsTest.photoData.size.toLong())
+        }
+  }
+
+  @Test
+  fun `should not process image for orientation 1`() {
+    every { utils.getOrientation(any()) } returns 1
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 0) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 0) { utils.rotateByDegree(any(), any()) }
+  }
+
+  @Test
+  fun `should flip image horizontally for orientation 2`() {
+    every { utils.getOrientation(any()) } returns 2
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 1) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 0) { utils.rotateByDegree(any(), any()) }
+  }
+
+  @Test
+  fun `should rotate image by 180 degrees for orientation 3`() {
+    every { utils.getOrientation(any()) } returns 3
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 0) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 1) { utils.rotateByDegree(any(), 180.0) }
+  }
+
+  @Test
+  fun `should flip image vertically for orientation 4`() {
+    every { utils.getOrientation(any()) } returns 4
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 0) { utils.flipHorizontal(any()) }
+    verify(exactly = 1) { utils.flipVertical(any()) }
+    verify(exactly = 0) { utils.rotateByDegree(any(), any()) }
+  }
+
+  @Test
+  fun `should flip image horizontally and then rotate image by 270 degrees for orientation 5`() {
+    every { utils.getOrientation(any()) } returns 5
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 1) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 1) { utils.rotateByDegree(any(), 270.0) }
+    verifyOrder {
+      utils.flipHorizontal(any())
+      utils.rotateByDegree(any(), 270.0)
+    }
+  }
+
+  @Test
+  fun `should rotate image by 90 degrees for orientation 6`() {
+    every { utils.getOrientation(any()) } returns 6
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 0) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 1) { utils.rotateByDegree(any(), 90.0) }
+  }
+
+  @Test
+  fun `should flip image horizontally and then rotate image by 90 degrees for orientation 7`() {
+    every { utils.getOrientation(any()) } returns 7
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 1) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 1) { utils.rotateByDegree(any(), 90.0) }
+    verifyOrder {
+      utils.flipHorizontal(any())
+      utils.rotateByDegree(any(), 90.0)
+    }
+  }
+
+  @Test
+  fun `should rotate image by 270 degrees for orientation 8`() {
+    every { utils.getOrientation(any()) } returns 8
+    val image = utils.read(photoStorageUrl)
+
+    assertNotNull(image)
+
+    verify(exactly = 1) { utils.getOrientation(photoStorageUrl) }
+    verify(exactly = 0) { utils.flipHorizontal(any()) }
+    verify(exactly = 0) { utils.flipVertical(any()) }
+    verify(exactly = 1) { utils.rotateByDegree(any(), 270.0) }
+  }
+  companion object {
+    private const val photoWidth = 5
+    private const val photoHeight = 5
+
+    private val photoData: ByteArray by lazy {
+      val canvas = BufferedImage(photoWidth, photoHeight, BufferedImage.TYPE_INT_RGB)
+      val outputStream = ByteArrayOutputStream()
+      ImageIO.write(canvas, "JPEG", outputStream)
+      outputStream.toByteArray()
+    }
+  }
+}


### PR DESCRIPTION
- Rotate image source (if needed) when creating thumbnails
- This is a copy of funder-backend PR https://github.com/terraware/funder-backend/pull/110
- Tested locally