### PR TITLE
SW-3993 Facility-only filtering on facilityInventories

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -225,6 +225,10 @@ val EMBEDDABLES =
             .withTables("nursery.batch_withdrawals")
             .withColumns("batch_id", "withdrawal_id"),
         EmbeddableDefinitionType()
+            .withName("facility_inventory_id")
+            .withTables("nursery.facility_inventories")
+            .withColumns("facility_id", "species_id"),
+        EmbeddableDefinitionType()
             .withName("organization_user_id")
             .withTables("public.organization_users")
             .withColumns("organization_id", "user_id"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
@@ -16,7 +16,7 @@ import org.jooq.TableField
 
 class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = FACILITY_INVENTORIES.SPECIES_ID
+    get() = FACILITY_INVENTORIES.FACILITY_INVENTORY_ID
 
   override val defaultOrderFields: List<OrderField<*>>
     get() =

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -201,6 +201,39 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `facility inventories table can be searched by facility`() {
+      val prefix = SearchFieldPrefix(root = searchTables.facilityInventories)
+      val results =
+          searchService.search(
+              prefix,
+              listOf(
+                  prefix.resolve("species_id"),
+                  prefix.resolve("facility_id"),
+                  prefix.resolve("facility_name"),
+                  prefix.resolve("germinatingQuantity"),
+                  prefix.resolve("notReadyQuantity"),
+                  prefix.resolve("readyQuantity"),
+                  prefix.resolve("totalQuantity"),
+              ),
+              FieldNode(prefix.resolve("facility_id"), listOf("$facilityId2")))
+
+      assertEquals(
+          SearchResults(
+              listOf(
+                  mapOf(
+                      "species_id" to "1",
+                      "facility_id" to "$facilityId2",
+                      "facility_name" to "Other Nursery",
+                      "germinatingQuantity" to number(64),
+                      "notReadyQuantity" to number(128),
+                      "readyQuantity" to number(256),
+                      "totalQuantity" to number(128 + 256)),
+              ),
+              null),
+          results)
+    }
+
+    @Test
     fun `batches table returns correct totals`() {
       insertWithdrawal()
       insertBatchWithdrawal(


### PR DESCRIPTION
You should be able to ask for inventories of specific facilities using the
`facilityInventories` search table, but it was only allowing searches to be
narrowed by species ID.