### PR TITLE
SW-4071 Thread safety for reading Geometry from DB

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
@@ -12,6 +12,7 @@ import org.jooq.BindingSetStatementContext
 import org.jooq.Converter
 import org.jooq.impl.DSL
 import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.io.WKBReader
@@ -40,13 +41,13 @@ class GeometryBinding : Binding<JooqGeometry, Geometry> {
   private val converter = GeometryConverter()
 
   class GeometryConverter : Converter<JooqGeometry, Geometry> {
-    private val wkbReader = WKBReader()
+    private val geometryFactory = GeometryFactory()
 
     override fun from(databaseObject: JooqGeometry?): Geometry? {
       // Geometry values are returned in WKB (Well Known Binary) form, encoded in hexadecimal.
       val wkb = databaseObject?.data() ?: return null
 
-      return wkbReader.read(WKBReader.hexToBytes(wkb))
+      return WKBReader(geometryFactory).read(WKBReader.hexToBytes(wkb))
     }
 
     /**


### PR DESCRIPTION
The JTS `WKBReader` class is not thread-safe, but we were sharing an instance of
it between threads in the code that reads geometry values from the database.

Create a fresh instance each time; it's a cheap class to instantiate. The
instances share a `GeometryFactory`, which is documented as thread-safe.