### PR TITLE
SW-4054 Count empty planting zones against progress

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -151,8 +151,8 @@ class PlantingSiteStore(
                 PLANTING_ZONES.TARGET_PLANTING_DENSITY,
                 zoneTotalSinceField,
                 zoneTotalPlantsField)
-            .from(PLANTING_ZONE_POPULATIONS)
-            .join(PLANTING_ZONES)
+            .from(PLANTING_ZONES)
+            .leftJoin(PLANTING_ZONE_POPULATIONS)
             .on(PLANTING_ZONE_POPULATIONS.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
             .where(PLANTING_ZONES.PLANTING_SITE_ID.eq(plantingSiteId))
             .groupBy(
@@ -165,9 +165,9 @@ class PlantingSiteStore(
 
               PlantingSiteReportedPlantTotals.PlantingZone(
                   id = record[PLANTING_ZONES.ID.asNonNullable()],
-                  plantsSinceLastObservation = record[zoneTotalSinceField].toInt(),
+                  plantsSinceLastObservation = record[zoneTotalSinceField]?.toInt() ?: 0,
                   targetPlants = targetPlants.toInt(),
-                  totalPlants = record[zoneTotalPlantsField].toInt(),
+                  totalPlants = record[zoneTotalPlantsField]?.toInt() ?: 0,
               )
             }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -743,6 +743,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       insertSpecies()
       insertPlantingZonePopulation(plantsSinceLastObservation = 8, totalPlants = 80)
       insertPlantingSitePopulation(plantsSinceLastObservation = 8, totalPlants = 80)
+      val emptyPlantingZoneId =
+          insertPlantingZone(areaHa = BigDecimal(50), targetPlantingDensity = BigDecimal(5))
 
       val expected =
           PlantingSiteReportedPlantTotals(
@@ -761,6 +763,12 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                           targetPlants = 404,
                           totalPlants = 120,
                       ),
+                      PlantingSiteReportedPlantTotals.PlantingZone(
+                          id = emptyPlantingZoneId,
+                          plantsSinceLastObservation = 0,
+                          targetPlants = 250,
+                          totalPlants = 0,
+                      ),
                   ),
               plantsSinceLastObservation = 15,
               totalPlants = 150,
@@ -774,6 +782,10 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
           (29.7).roundToInt(),
           actual.plantingZones[1].progressPercent,
           "Progress% for zone 2 should be rounded up")
+      assertEquals(
+          (150.0 / (20.0 + 404.0 + 250.0) * 100.0).roundToInt(),
+          actual.progressPercent,
+          "Progress% for site")
     }
 
     @Test


### PR DESCRIPTION
The planting site progress percentage was only computed across planting zones
with recorded plants. It needs to count all of the site's zones.