### PR TITLE
SW-3932 APIs to write planting site boundaries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -90,6 +90,7 @@ class PlantingSitesController(
   ): CreatePlantingSiteResponsePayload {
     val model =
         plantingSiteStore.createPlantingSite(
+            boundary = payload.boundary,
             description = payload.description,
             name = payload.name,
             organizationId = payload.organizationId,
@@ -230,6 +231,7 @@ data class PlantingSiteReportedPlantsPayload(
 }
 
 data class CreatePlantingSiteRequestPayload(
+    val boundary: MultiPolygon? = null,
     val description: String? = null,
     val name: String,
     val organizationId: OrganizationId,
@@ -257,6 +259,8 @@ data class ListPlantingSitesResponsePayload(val sites: List<PlantingSitePayload>
     SuccessResponsePayload
 
 data class UpdatePlantingSiteRequestPayload(
+    @Schema(description = "Site boundary. Ignored if this is a detailed planting site.")
+    val boundary: MultiPolygon? = null,
     val description: String? = null,
     val name: String,
     @Max(12)
@@ -272,6 +276,7 @@ data class UpdatePlantingSiteRequestPayload(
 ) {
   fun applyTo(model: PlantingSiteModel) =
       model.copy(
+          boundary = boundary,
           description = description?.ifBlank { null },
           name = name,
           plantingSeasonEndMonth = plantingSeasonEndMonth?.let { Month.of(it) },

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -372,6 +372,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     fun `updates values`() {
       val initialModel =
           store.createPlantingSite(
+              boundary = multiPolygon(1.0),
               description = null,
               name = "initial name",
               organizationId = organizationId,
@@ -385,6 +386,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.updatePlantingSite(initialModel.id) { model ->
         model.copy(
+            boundary = multiPolygon(2.0),
             description = "new description",
             name = "new name",
             plantingSeasonEndMonth = Month.MARCH,
@@ -396,6 +398,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           listOf(
               PlantingSitesRow(
+                  boundary = multiPolygon(2.0),
                   id = initialModel.id,
                   organizationId = organizationId,
                   name = "new name",
@@ -410,6 +413,16 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
               )),
           plantingSitesDao.findAll(),
           "Planting sites")
+    }
+
+    @Test
+    fun `ignores boundary updates on detailed planting sites`() {
+      val plantingSiteId = insertPlantingSite(boundary = multiPolygon(1.0))
+      insertPlantingZone()
+
+      store.updatePlantingSite(plantingSiteId) { model -> model.copy(boundary = multiPolygon(2.0)) }
+
+      assertEquals(multiPolygon(1.0), plantingSitesDao.findAll().first().boundary)
     }
 
     @Test


### PR DESCRIPTION
Add `boundary` fields to the PUT and POST request payloads for planting sites to
allow user-editable boundaries for simple planting sites. The boundary is ignored
on PUT for detailed planting sites.