### PR TITLE
SW-4082 Calculate more observation plot counts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationPlotCounts.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationPlotCounts.kt
@@ -1,0 +1,7 @@
+package com.terraformation.backend.tracking.model
+
+data class ObservationPlotCounts(
+    val totalIncomplete: Int,
+    val totalPlots: Int,
+    val totalUnclaimed: Int,
+)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -1240,7 +1240,10 @@ abstract class DatabaseTest {
   fun insertObservationPlot(
       row: ObservationPlotsRow = ObservationPlotsRow(),
       claimedBy: UserId? = row.claimedBy,
-      claimedTime: Instant? = row.claimedTime,
+      claimedTime: Instant? = row.claimedTime ?: if (claimedBy != null) Instant.EPOCH else null,
+      completedBy: UserId? = row.completedBy,
+      completedTime: Instant? =
+          row.completedTime ?: if (completedBy != null) Instant.EPOCH else null,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       isPermanent: Boolean = row.isPermanent ?: false,
@@ -1251,6 +1254,8 @@ abstract class DatabaseTest {
         row.copy(
             claimedBy = claimedBy,
             claimedTime = claimedTime,
+            completedBy = completedBy,
+            completedTime = completedTime,
             createdBy = createdBy,
             createdTime = createdTime,
             isPermanent = isPermanent,


### PR DESCRIPTION
The mobile app needs to display a count of the number of monitoring plots in an
observation that haven't been completed yet, whether or not they've been claimed.
Add that count to the observation API, as well as a count of the total number of
monitoring plots in the observation regardless of status.