### PR TITLE
SW-4084 Allow Used Up accessions to be imported

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -218,8 +218,6 @@ class AccessionStore(
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
     val state =
         when {
-          accession.state == AccessionState.UsedUp ->
-              throw IllegalArgumentException("Accessions cannot be set to Used Up at creation time")
           accession.state.isV2Compatible -> accession.state
           else -> throw IllegalArgumentException("Initial state must be v2-compatible")
         }
@@ -234,6 +232,11 @@ class AccessionStore(
       createAccession(facilityId)
       accession.projectId?.let { readProject(it) }
       accession.speciesId?.let { readSpecies(it) }
+    }
+
+    if (accession.state == AccessionState.UsedUp &&
+        (accession.remaining == null || accession.remaining.quantity.signum() != 0)) {
+      throw IllegalArgumentException("Quantity must be zero if state is UsedUp")
     }
 
     if (parentStore.getFacilityType(facilityId) != FacilityType.SeedBank) {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -233,6 +233,63 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `can set status to Used Up if quantity is zero`() {
+
+      runHappyPath(
+          "UsedUp.csv",
+          Locale.ENGLISH,
+          listOf(
+              SpeciesRow(
+                  id = SpeciesId(1),
+                  organizationId = organizationId,
+                  scientificName = "New species",
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  initialScientificName = "New species")),
+          listOf(
+              AccessionsRow(
+                  collectedDate = LocalDate.of(2023, 6, 1),
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  dataSourceId = DataSource.FileImport,
+                  estSeedCount = 0,
+                  facilityId = facilityId,
+                  id = AccessionId(1),
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  number = "1",
+                  remainingQuantity = BigDecimal.ZERO,
+                  remainingUnitsId = SeedQuantityUnits.Seeds,
+                  speciesId = SpeciesId(1),
+                  stateId = AccessionState.UsedUp,
+              ),
+              AccessionsRow(
+                  collectedDate = LocalDate.of(2023, 6, 1),
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  dataSourceId = DataSource.FileImport,
+                  estWeightGrams = BigDecimal.ZERO,
+                  estWeightQuantity = BigDecimal.ZERO,
+                  estWeightUnitsId = SeedQuantityUnits.Grams,
+                  facilityId = facilityId,
+                  id = AccessionId(2),
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  number = "2",
+                  remainingGrams = BigDecimal.ZERO,
+                  remainingQuantity = BigDecimal.ZERO,
+                  remainingUnitsId = SeedQuantityUnits.Grams,
+                  speciesId = SpeciesId(1),
+                  stateId = AccessionState.UsedUp,
+              ),
+          ),
+          emptyList(),
+          emptyList())
+    }
+
+    @Test
     fun `valid localized file causes accessions and species to be created`() {
       runHappyPath(
           "Gibberish.csv",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -104,9 +104,9 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   }
 
   @Test
-  fun `create with isManualState does not allow setting state to Used Up`() {
+  fun `create with isManualState does not allow setting state to Used Up if quantity is nonzero`() {
     assertThrows<IllegalArgumentException> {
-      store.create(accessionModel(state = AccessionState.UsedUp))
+      store.create(accessionModel(remaining = seeds(1), state = AccessionState.UsedUp))
     }
   }
 

--- a/src/test/resources/seedbank/accession/UsedUp.csv
+++ b/src/test/resources/seedbank/accession/UsedUp.csv
@@ -1,0 +1,3 @@
+Accession Number,Species (Scientific Name)*,Species (Common Name),QTY,QTY Units,Status,Collection Date*,Collecting Site Name,Landowner,City or County,State / Province / Region,Country,Site Description / Notes,Collector Name ,Collection Source,Number of Plants,Plant ID,Latitude,Longitude
+1,New species,,0,Seeds,Used Up,2023-06-01,,,,,,,,,,,,
+2,New species,,0,Grams,Used Up,2023-06-01,,,,,,,,,,,,


### PR DESCRIPTION
We were explicitly disallowing accessions from being created in Used Up state
because it doesn't make much sense for a typical interactive workflow, but it
does make sense to be able to import historical accession data that includes
accessions that have already been fully withdrawn.