### PR TITLE
SW-2363 Remove /api/v1/facility alias

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -40,7 +40,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @CustomerEndpoint
 @RestController
-@RequestMapping("/api/v1/facility", "/api/v1/facilities")
+@RequestMapping("/api/v1/facilities")
 class FacilitiesController(
     private val facilityStore: FacilityStore,
     private val publisher: ApplicationEventPublisher,


### PR DESCRIPTION
All the clients were updated to use `/api/v1/facilities` instead of
`/api/v1/facility` some time ago, and there have been no hits on the singular
name for over a month. Remove the unused name from the API.