### PR TITLE
Gradle: Use lazy property to get build directory

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
@@ -20,11 +20,14 @@ abstract class PostgresDockerConfigTask : DefaultTask() {
 
   @get:OutputFile
   val outputFile =
-      File("${project.buildDir}/generated-test/kotlin/com/terraformation/backend/db/DockerImage.kt")
+      project
+          .layout
+          .buildDirectory
+          .file("generated-test/kotlin/com/terraformation/backend/db/DockerImage.kt")
 
   @TaskAction
   fun generate() {
-    val path = outputFile.toPath()
+    val path = outputFile.get().asFile.toPath()
     Files.createDirectories(path.parent)
     Files.writeString(
         path,

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
@@ -31,7 +31,8 @@ abstract class RenderMjmlTask : DefaultTask() {
       project.files(
           project.fileTree("src/main/resources/templates/email") { include("**/body.ftlh.mjml") })
 
-  @get:OutputDirectory val outputDir = project.buildDir.resolve("resources/main/templates/email")
+  @get:OutputDirectory val outputDir =
+      project.layout.buildDirectory.dir("resources/main/templates/email")
 
   @get:Inject abstract val objects: ObjectFactory
 
@@ -95,6 +96,12 @@ abstract class RenderMjmlTask : DefaultTask() {
         File(change.file.path.substring(0, change.file.path.length - mjmlExtension.length))
             .relativeTo(project.projectDir.resolve("src/main/resources"))
 
-    return project.buildDir.resolve("resources/main").resolve(targetRelativeToResourcesDir)
+    return project
+        .layout
+        .buildDirectory
+        .get()
+        .asFile
+        .resolve("resources/main")
+        .resolve(targetRelativeToResourcesDir)
   }
 }

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
@@ -16,11 +16,11 @@ abstract class VersionFileTask : DefaultTask() {
 
   @get:OutputFile
   val outputFile =
-      File("${project.buildDir}/generated/kotlin/com/terraformation/backend/Version.kt")
+      project.layout.buildDirectory.file("generated/kotlin/com/terraformation/backend/Version.kt")
 
   @TaskAction
   fun generate() {
-    val path = outputFile.toPath()
+    val path = outputFile.get().asFile.toPath()
     Files.createDirectories(path.parent)
     Files.writeString(
         path, "package com.terraformation.backend\nconst val VERSION = \"$version\"\n")


### PR DESCRIPTION
Gradle plugins are supposed to use lazy evaluation when fetching the build
directory since it can change at runtime, but we were using the non-lazy
getter. It is deprecated starting in Gradle 8.3; switch to the appropriate
lazy property.