### PR TITLE
SW-4084 Validation error for nonzero Used Up quantities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -81,6 +81,11 @@ class Messages {
 
   fun accessionCsvLongitudeInvalid() = getMessage("accessionCsvLongitudeInvalid")
 
+  fun accessionCsvNonZeroUsedUpQuantity() =
+      getMessage(
+          "accessionCsvNonZeroUsedUpQuantity",
+          AccessionState.UsedUp.getDisplayName(currentLocale()))
+
   fun accessionCsvNumberDuplicate(lineNumber: Int) =
       getMessage("accessionCsvNumberDuplicate", lineNumber)
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionCsvValidator.kt
@@ -68,7 +68,7 @@ class AccessionCsvValidator(
           this::validateLongitude,
       )
 
-  override val rowValidators = listOf(this::validateLatitudeLongitude)
+  override val rowValidators = listOf(this::validateLatitudeLongitude, this::validateUsedUpQuantity)
 
   override fun getColumnName(position: Int): String {
     return messages.accessionCsvColumnName(position)
@@ -226,6 +226,18 @@ class AccessionCsvValidator(
           getColumnName(18),
           null,
           messages.accessionCsvLatitudeLongitude())
+    }
+  }
+
+  private fun validateUsedUpQuantity(values: List<String?>) {
+    val quantity = values[3]?.toDoubleOrNull()
+
+    if (values[5] == AccessionState.UsedUp.getDisplayName(currentLocale()) && quantity != 0.0) {
+      addError(
+          UploadProblemType.MalformedValue,
+          getColumnName(3),
+          values[3],
+          messages.accessionCsvNonZeroUsedUpQuantity())
     }
   }
 }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -22,6 +22,7 @@ accessionCsvCountryInvalid=Country must be a valid two-letter ISO country code o
 accessionCsvLatitudeInvalid=Latitude must be a number between -90 and 90
 accessionCsvLatitudeLongitude=Latitude and longitude must either both be present or both be blank
 accessionCsvLongitudeInvalid=Longitude must be a number between -180 and 180
+accessionCsvNonZeroUsedUpQuantity=Quantity must be 0 for accessions with status {0}
 accessionCsvNumberDuplicate=Accession number already used on line {0}
 accessionCsvNumberExists=Accession number already exists
 accessionCsvNumberOfPlantsInvalid=Number of plants must be 1 or more

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -627,6 +627,23 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `rejects rows with Used Up status and nonzero quantities`() {
+      testValidation(
+          ",Scientific name,,1,Seeds,Used Up,2023-01-01,,,,,,,,,,,,",
+          UploadStatus.Invalid,
+          UploadProblemsRow(
+              id = UploadProblemId(1),
+              uploadId = uploadId,
+              typeId = UploadProblemType.MalformedValue,
+              isError = true,
+              position = 2,
+              field = "QTY",
+              message = messages.accessionCsvNonZeroUsedUpQuantity(),
+              value = "1",
+          ))
+    }
+
+    @Test
     fun `rejects rows with malformed collection sources`() {
       testValidation(
           ",Scientific name,,,,,2022-03-04,,,,,,,,Unknown,,,,\n",


### PR DESCRIPTION
Return a validation error if someone imports an accession whose status is Used Up
but whose quantity is nonzero.