### PR TITLE
Remove unused search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -91,8 +91,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.EST_WEIGHT_QUANTITY,
             ACCESSIONS.EST_WEIGHT_UNITS_ID,
             ACCESSIONS.EST_WEIGHT_GRAMS),
-        // TODO: Remove this once clients no longer need it (new name is estimatedCount)
-        integerField("estimatedSeedsIncoming", ACCESSIONS.EST_SEED_COUNT),
         aliasField("geolocation", "geolocations_coordinates"),
         idWrapperField("id", ACCESSIONS.ID) { AccessionId(it) },
         textField("plantId", ACCESSIONS.FOUNDER_ID),
@@ -115,8 +113,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.TOTAL_WITHDRAWN_WEIGHT_QUANTITY,
             ACCESSIONS.TOTAL_WITHDRAWN_WEIGHT_UNITS_ID,
             ACCESSIONS.TOTAL_WITHDRAWN_WEIGHT_GRAMS),
-        // TODO: Remove this once clients no longer need it (new name is plantsCollectedFrom)
-        integerField("treesCollectedFrom", ACCESSIONS.TREES_COLLECTED_FROM),
         aliasField("withdrawalDate", "withdrawals_date"),
         aliasField("withdrawalDestination", "withdrawals_destination"),
         aliasField("withdrawalGrams", "withdrawals_grams"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ViabilityTestsTable.kt
@@ -33,13 +33,9 @@ class ViabilityTestsTable(private val tables: SearchTables) : SearchTable() {
           dateField("endDate", VIABILITY_TESTS.END_DATE),
           idWrapperField("id", VIABILITY_TESTS.ID) { ViabilityTestId(it) },
           textField("notes", VIABILITY_TESTS.NOTES),
-          // TODO: Remove this once clients are no longer using it (new name is viabilityPercent)
-          integerField("percentGerminated", VIABILITY_TESTS.TOTAL_PERCENT_GERMINATED),
           integerField("seedsCompromised", VIABILITY_TESTS.SEEDS_COMPROMISED),
           integerField("seedsEmpty", VIABILITY_TESTS.SEEDS_EMPTY),
           integerField("seedsFilled", VIABILITY_TESTS.SEEDS_FILLED),
-          // TODO: Remove this once clients are no longer using it (new name is seedsTested)
-          integerField("seedsSown", VIABILITY_TESTS.SEEDS_SOWN),
           integerField("seedsTested", VIABILITY_TESTS.SEEDS_SOWN),
           enumField("seedType", VIABILITY_TESTS.SEED_TYPE_ID),
           dateField("startDate", VIABILITY_TESTS.START_DATE),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
@@ -56,24 +56,25 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "treesCollectedFromAlias" to "2",
+                    "plantsCollectedFromAlias" to "2",
                 ),
                 mapOf(
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "treesCollectedFromAlias" to "1",
+                    "plantsCollectedFromAlias" to "1",
                 ),
             ),
             cursor = null)
 
     val actual =
-        searchAccessions(facilityId, listOf(treesCollectedFromAlias), criteria = NoConditionNode())
+        searchAccessions(facilityId, listOf(plantsCollectedFromAlias), criteria = NoConditionNode())
     assertEquals(expected, actual)
   }
 
   @Test
   fun `raw variants of aliased fields use the alias name`() {
-    val rawAlias = SearchFieldPath(rootPrefix, AliasField("alias", treesCollectedFromField).raw()!!)
+    val rawAlias =
+        SearchFieldPath(rootPrefix, AliasField("alias", plantsCollectedFromField).raw()!!)
 
     val expected =
         SearchResults(
@@ -97,7 +98,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
 
   @Test
   fun `can use aliased field in search criteria`() {
-    val criteria = FieldNode(treesCollectedFromAlias, listOf("2"))
+    val criteria = FieldNode(plantsCollectedFromAlias, listOf("2"))
 
     val expected =
         SearchResults(
@@ -112,7 +113,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
 
   @Test
   fun `can sort by aliased field that is not in select list`() {
-    val sortOrder = listOf(SearchSortField(treesCollectedFromAlias))
+    val sortOrder = listOf(SearchSortField(plantsCollectedFromAlias))
 
     val expected =
         SearchResults(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -96,7 +96,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `honors sort order`() {
     val fields =
-        listOf(speciesNameField, accessionNumberField, treesCollectedFromField, activeField)
+        listOf(speciesNameField, accessionNumberField, plantsCollectedFromField, activeField)
     val sortOrder = fields.map { SearchSortField(it, SearchDirection.Descending) }
 
     val result =
@@ -109,14 +109,14 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                     "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "treesCollectedFrom" to "2",
+                    "plantsCollectedFrom" to "2",
                     "active" to "Active",
                 ),
                 mapOf(
                     "speciesName" to "Kousa Dogwood",
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "treesCollectedFrom" to "1",
+                    "plantsCollectedFrom" to "1",
                     "active" to "Active",
                 ),
             ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
@@ -71,11 +71,11 @@ internal class SearchServiceCompoundSearchTest : SearchServiceTest() {
         listOf(12, 14, 19))
   }
 
-  private fun exactly(value: Int) = FieldNode(treesCollectedFromField, listOf("$value"))
+  private fun exactly(value: Int) = FieldNode(plantsCollectedFromField, listOf("$value"))
 
   private fun between(minimum: Int?, maximum: Int?): FieldNode {
     return FieldNode(
-        treesCollectedFromField,
+        plantsCollectedFromField,
         listOf(minimum?.toString(), maximum?.toString()),
         type = SearchFilterType.Range)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
@@ -11,7 +11,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
   @Test
   fun `can use cursor to get next page of results`() {
     val fields =
-        listOf(speciesNameField, accessionNumberField, treesCollectedFromField, activeField)
+        listOf(speciesNameField, accessionNumberField, plantsCollectedFromField, activeField)
     val sortOrder = fields.map { SearchSortField(it) }
 
     val expectedFirstPageResults =
@@ -20,7 +20,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
                 "speciesName" to "Kousa Dogwood",
                 "id" to "1000",
                 "accessionNumber" to "XYZ",
-                "treesCollectedFrom" to "1",
+                "plantsCollectedFrom" to "1",
                 "active" to "Active",
             ),
         )
@@ -39,7 +39,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
                     "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "treesCollectedFrom" to "2",
+                    "plantsCollectedFrom" to "2",
                     "active" to "Active",
                 ),
             ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchAllValuesTest.kt
@@ -71,7 +71,7 @@ internal class SearchServiceFetchAllValuesTest : SearchServiceTest() {
 
     val expected = listOf(null, "1", "2")
 
-    val actual = searchService.fetchAllValues(treesCollectedFromField, organizationId)
+    val actual = searchService.fetchAllValues(plantsCollectedFromField, organizationId)
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -122,7 +122,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   fun `exact search of integer column value`() {
     val values =
         searchService.fetchValues(
-            rootPrefix, treesCollectedFromField, FieldNode(treesCollectedFromField, listOf("1")))
+            rootPrefix, plantsCollectedFromField, FieldNode(plantsCollectedFromField, listOf("1")))
 
     assertEquals(listOf("1"), values)
   }
@@ -151,7 +151,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
     val expected = listOf("1", "2")
 
-    val actual = searchService.fetchValues(rootPrefix, treesCollectedFromField, NoConditionNode())
+    val actual = searchService.fetchValues(rootPrefix, plantsCollectedFromField, NoConditionNode())
 
     assertEquals(expected, actual)
   }
@@ -167,7 +167,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
     val expected = listOf("1", "2", "3")
 
-    val actual = searchService.fetchValues(rootPrefix, treesCollectedFromField, NoConditionNode())
+    val actual = searchService.fetchValues(rootPrefix, plantsCollectedFromField, NoConditionNode())
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
@@ -42,7 +42,7 @@ internal class SearchServiceInitializationTest : SearchServiceTest() {
         listOf(
             speciesNameField,
             accessionNumberField,
-            treesCollectedFromField,
+            plantsCollectedFromField,
             activeField,
         )
     val sortOrder = fields.map { SearchSortField(it) }
@@ -57,14 +57,14 @@ internal class SearchServiceInitializationTest : SearchServiceTest() {
                     "speciesName" to "Kousa Dogwood",
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "treesCollectedFrom" to "1",
+                    "plantsCollectedFrom" to "1",
                     "active" to "Active",
                 ),
                 mapOf(
                     "speciesName" to "Other Dogwood",
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "treesCollectedFrom" to "2",
+                    "plantsCollectedFrom" to "2",
                     "active" to "Active",
                 ),
             ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -865,7 +865,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "source" to "Web",
                     "speciesName" to "Other Dogwood",
                     "state" to "Processing",
-                    "treesCollectedFrom" to "2",
                 ),
                 mapOf(
                     "accessionNumber" to "XYZ",
@@ -901,7 +900,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "totalWithdrawnWeightPounds" to "11.0231",
                     "totalWithdrawnWeightQuantity" to "5",
                     "totalWithdrawnWeightUnits" to "Kilograms",
-                    "treesCollectedFrom" to "1",
                     "viabilityTests" to
                         listOf(
                             mapOf(
@@ -914,8 +912,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                             "recordingDate" to "1970-01-02",
                                             "seedsGerminated" to "10")),
                                 "id" to "$testId",
-                                "percentGerminated" to "100",
-                                "seedsSown" to "15",
                                 "seedsTested" to "15",
                                 "type" to "Lab",
                                 "viabilityPercent" to "100",
@@ -925,7 +921,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                 "seedsCompromised" to "1",
                                 "seedsEmpty" to "2",
                                 "seedsFilled" to "3",
-                                "seedsSown" to "10",
                                 "seedsTested" to "10",
                                 "type" to "Cut",
                             ),

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
@@ -13,8 +13,9 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
   fun `can do range search on integer field`() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
-    val fields = listOf(treesCollectedFromField)
-    val searchNode = FieldNode(treesCollectedFromField, listOf("2", "3000"), SearchFilterType.Range)
+    val fields = listOf(plantsCollectedFromField)
+    val searchNode =
+        FieldNode(plantsCollectedFromField, listOf("2", "3000"), SearchFilterType.Range)
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -22,7 +23,9 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001", "accessionNumber" to "ABCDEFG", "treesCollectedFrom" to "500")),
+                    "id" to "1001",
+                    "accessionNumber" to "ABCDEFG",
+                    "plantsCollectedFrom" to "500")),
             cursor = null)
 
     assertEquals(expected, result)
@@ -32,14 +35,14 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
   fun `can do range search on integer field with no minimum`() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
-    val fields = listOf(treesCollectedFromField)
-    val searchNode = FieldNode(treesCollectedFromField, listOf(null, "3"), SearchFilterType.Range)
+    val fields = listOf(plantsCollectedFromField)
+    val searchNode = FieldNode(plantsCollectedFromField, listOf(null, "3"), SearchFilterType.Range)
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "treesCollectedFrom" to "1")),
+            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "plantsCollectedFrom" to "1")),
             cursor = null)
 
     assertEquals(expected, result)
@@ -49,8 +52,8 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
   fun `can do range search on integer field with no maximum`() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
-    val fields = listOf(treesCollectedFromField)
-    val searchNode = FieldNode(treesCollectedFromField, listOf("2", null), SearchFilterType.Range)
+    val fields = listOf(plantsCollectedFromField)
+    val searchNode = FieldNode(plantsCollectedFromField, listOf("2", null), SearchFilterType.Range)
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -58,7 +61,9 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001", "accessionNumber" to "ABCDEFG", "treesCollectedFrom" to "500")),
+                    "id" to "1001",
+                    "accessionNumber" to "ABCDEFG",
+                    "plantsCollectedFrom" to "500")),
             cursor = null)
 
     assertEquals(expected, result)
@@ -66,8 +71,8 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
   @Test
   fun `range search on integer field with two nulls is rejected`() {
-    val fields = listOf(treesCollectedFromField)
-    val searchNode = FieldNode(treesCollectedFromField, listOf(null, null), SearchFilterType.Range)
+    val fields = listOf(plantsCollectedFromField)
+    val searchNode = FieldNode(plantsCollectedFromField, listOf(null, null), SearchFilterType.Range)
 
     assertThrows<IllegalArgumentException> { searchAccessions(facilityId, fields, searchNode) }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -66,9 +66,9 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected val speciesNameField = rootPrefix.resolve("speciesName")
   protected val stateField = rootPrefix.resolve("state")
   protected val storageLocationNameField = rootPrefix.resolve("storageLocationName")
-  protected val treesCollectedFromField = rootPrefix.resolve("treesCollectedFrom")
-  protected val treesCollectedFromAlias =
-      SearchFieldPath(rootPrefix, AliasField("treesCollectedFromAlias", treesCollectedFromField))
+  protected val plantsCollectedFromField = rootPrefix.resolve("plantsCollectedFrom")
+  protected val plantsCollectedFromAlias =
+      SearchFieldPath(rootPrefix, AliasField("plantsCollectedFromAlias", plantsCollectedFromField))
   protected val viabilityTestResultsSeedsGerminatedField =
       rootPrefix.resolve("viabilityTests_viabilityTestResults_seedsGerminated")
   protected val viabilityTestSeedsTestedField = rootPrefix.resolve("viabilityTests_seedsTested")


### PR DESCRIPTION
We renamed a few search fields and retained the old names for backward compatibility.
The old names are no longer referenced by any of the client code, so remove them.