### PR TITLE
SW-4223 Add Parent ID to admin facility devices form

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.customer.event.FacilityAlertRequestedEvent
 import com.terraformation.backend.customer.model.NewFacilityModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.BalenaDeviceId
+import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.DeviceTemplateCategory
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
@@ -821,15 +822,16 @@ class AdminController(
 
   @PostMapping("/createDevices")
   fun createDevices(
-      redirectAttributes: RedirectAttributes,
-      @RequestParam address: String?,
-      @RequestParam count: Int,
-      @RequestParam facilityId: FacilityId,
-      @RequestParam make: String,
-      @RequestParam model: String,
-      @RequestParam name: String?,
-      @RequestParam protocol: String?,
-      @RequestParam type: String,
+    redirectAttributes: RedirectAttributes,
+    @RequestParam address: String?,
+    @RequestParam count: Int,
+    @RequestParam facilityId: FacilityId,
+    @RequestParam make: String,
+    @RequestParam model: String,
+    @RequestParam name: String?,
+    @RequestParam protocol: String?,
+    @RequestParam parentId: DeviceId?,
+    @RequestParam type: String,
   ): String {
     try {
       repeat(count) {
@@ -845,6 +847,7 @@ class AdminController(
                 model = model,
                 name = calculatedName,
                 protocol = protocol,
+                parentId = parentId,
             )
 
         deviceService.create(devicesRow)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -829,8 +829,8 @@ class AdminController(
       @RequestParam make: String,
       @RequestParam model: String,
       @RequestParam name: String?,
-      @RequestParam protocol: String?,
       @RequestParam parentId: DeviceId?,
+      @RequestParam protocol: String?,
       @RequestParam type: String,
   ): String {
     try {
@@ -846,8 +846,8 @@ class AdminController(
                 make = make,
                 model = model,
                 name = calculatedName,
-                protocol = protocol,
                 parentId = parentId,
+                protocol = protocol,
             )
 
         deviceService.create(devicesRow)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -822,16 +822,16 @@ class AdminController(
 
   @PostMapping("/createDevices")
   fun createDevices(
-    redirectAttributes: RedirectAttributes,
-    @RequestParam address: String?,
-    @RequestParam count: Int,
-    @RequestParam facilityId: FacilityId,
-    @RequestParam make: String,
-    @RequestParam model: String,
-    @RequestParam name: String?,
-    @RequestParam protocol: String?,
-    @RequestParam parentId: DeviceId?,
-    @RequestParam type: String,
+      redirectAttributes: RedirectAttributes,
+      @RequestParam address: String?,
+      @RequestParam count: Int,
+      @RequestParam facilityId: FacilityId,
+      @RequestParam make: String,
+      @RequestParam model: String,
+      @RequestParam name: String?,
+      @RequestParam protocol: String?,
+      @RequestParam parentId: DeviceId?,
+      @RequestParam type: String,
   ): String {
     try {
       repeat(count) {

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -128,6 +128,7 @@
         <th>Model</th>
         <th>Address</th>
         <th>Protocol</th>
+        <th>Parent ID</th>
     </tr>
 
     <tr th:each="device : ${devices}">
@@ -137,6 +138,7 @@
         <td th:text="${device.model}">ABC</td>
         <td th:text="${device.address}">1.2.3.4</td>
         <td th:text="${device.protocol}">modbus</td>
+        <td th:text="${device.parentId}">42</td>
     </tr>
 </table>
 
@@ -183,6 +185,12 @@
         <label for="address">Address</label>
         <input type="text" id="address" name="address"/>
         Leave blank to use the device name.
+    </div>
+
+    <div>
+        <label for="address">Parent ID</label>
+        <input type="text" id="parentId" name="parentId"/>
+        Optional. Use this if you are adding a sensor that sits behind a hub. Put the hub's ID here.
     </div>
 
     <div>


### PR DESCRIPTION
- Add the field to the admin devices form
- Plumb the field through the form controller to it saves in the DB

![2023-09-19 10 28 33](https://github.com/terraware/terraware-server/assets/9541815/1bc9b5f5-c710-49cc-aa87-92e729205dcc)
