### PR TITLE
SW-4237 Add 'Terraformation Contact' role in database schema

### DIFF
--- a/src/main/resources/db/migration/0200/V209__TerraformationContact.sql
+++ b/src/main/resources/db/migration/0200/V209__TerraformationContact.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX organization_users_contact_uk
+ON organization_users (organization_id)
+WHERE role_id = 5;

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -174,7 +174,8 @@ INSERT INTO roles (id, name)
 VALUES (1, 'Contributor'),
        (2, 'Manager'),
        (3, 'Admin'),
-       (4, 'Owner')
+       (4, 'Owner'),
+       (5, 'Terraformation Contact')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO seedbank.seed_quantity_units (id, name)

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -81,6 +81,7 @@ public.Role.Admin=Admin
 public.Role.Contributor=Contributor
 public.Role.Manager=Manager
 public.Role.Owner=Owner
+public.Role.TerraformationContact=Terraformation Contact
 public.SeedStorageBehavior.Intermediate=Intermediate
 public.SeedStorageBehavior.LikelyIntermediate=Likely Intermediate
 public.SeedStorageBehavior.LikelyOrthodox=Likely Orthodox

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -520,6 +520,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
             Role.Manager to 0,
             Role.Contributor to 1,
             Role.Owner to 2,
+            Role.TerraformationContact to 0,
         )
     val actual = store.countRoleUsers(organizationId)
 


### PR DESCRIPTION
- Also add a unique index constraint on organization user with the Terraformation Contact role id
- Tested locally and observed error adding second Terraformation Contact in org
```
terraware=# insert into organization_users(user_id, organization_id, role_id, created_time, modified_time, created_by, modified_by) values(99, 1, 5, '2023-02-02 19:20:33.13388-08', '2023-02-02 19:20:33.13388-08', 2, 2);
INSERT 0 1
terraware=# insert into organization_users(user_id, organization_id, role_id, created_time, modified_time, created_by, modified_by) values(122, 1, 5, '2023-02-02 19:20:33.13388-08', '2023-02-02 19:20:33.13388-08', 2, 2);
ERROR:  duplicate key value violates unique constraint "organization_users_pkey"
DETAIL:  Key (user_id, organization_id)=(122, 1) already exists.
```