### PR TITLE
SW-4238 Update permissions for "Terraformation Contact" role

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -439,7 +439,10 @@ class OrganizationStore(
    * @throws UserNotFoundException The user is not a member of the organization.
    */
   fun setUserRole(organizationId: OrganizationId, userId: UserId, role: Role) {
-    requirePermissions { setOrganizationUserRole(organizationId, role) }
+    requirePermissions {
+      updateOrganizationUser(organizationId, userId)
+      setOrganizationUserRole(organizationId, role)
+    }
 
     dslContext.transaction { _ ->
       if (role != Role.Owner) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -189,6 +189,8 @@ data class DeviceManagerUser(
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canUpdateObservation(observationId: ObservationId): Boolean = false
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = false
+  override fun canUpdateOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      false
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = false
   override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -640,6 +640,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateOrganizationUser(organizationId: OrganizationId, userId: UserId) {
+    if (!user.canUpdateOrganizationUser(organizationId, userId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to update user $userId in organization $organizationId")
+    }
+  }
+
   fun updatePlantingSite(plantingSiteId: PlantingSiteId) {
     if (!user.canUpdatePlantingSite(plantingSiteId)) {
       readPlantingSite(plantingSiteId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -199,6 +199,8 @@ class SystemUser(
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canUpdateObservation(observationId: ObservationId): Boolean = true
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
+  override fun canUpdateOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      true
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = true
   override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -160,6 +160,7 @@ interface TerrawareUser : Principal {
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
   fun canUpdateObservation(observationId: ObservationId): Boolean
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
+  fun canUpdateOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
   fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean
   fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -86,6 +86,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
     every { user.canReadOrganization(any()) } returns true
     every { user.canUpdateOrganization(any()) } returns true
+    every { user.canUpdateOrganizationUser(any(), any()) } returns true
     every { user.canAddOrganizationUser(any()) } returns true
     every { user.canListOrganizationUsers(any()) } returns true
     every { user.canRemoveOrganizationUser(any(), any()) } returns true
@@ -504,6 +505,26 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     configureUser(admin)
 
     assertThrows<CannotRemoveLastOwnerException> {
+      store.setUserRole(organizationId, owner.userId, Role.Admin)
+    }
+  }
+
+  @Test
+  fun `setUserRole throws exception if no permission to set user role`() {
+    val owner = organizationUserModel(userId = UserId(100), role = Role.Owner)
+    every { user.canSetOrganizationUserRole(organizationId, Role.Admin) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.setUserRole(organizationId, owner.userId, Role.Admin)
+    }
+  }
+
+  @Test
+  fun `setUserRole throws exception if no permission to update user`() {
+    val owner = organizationUserModel(userId = UserId(100), role = Role.Owner)
+    every { user.canUpdateOrganizationUser(organizationId, owner.userId) } returns false
+
+    assertThrows<AccessDeniedException> {
       store.setUserRole(organizationId, owner.userId, Role.Admin)
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/IndividualUserTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/IndividualUserTest.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.customer.model
+
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.UserType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import java.time.ZoneId
+import java.util.Locale
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class IndividualUserTest {
+  private val organizationId = OrganizationId(1)
+  private val userId = UserId(1)
+
+  private lateinit var parentStore: ParentStore
+  private lateinit var user: IndividualUser
+
+  @BeforeEach
+  fun setup() {
+    parentStore = mockk()
+    user =
+        spyk(
+            IndividualUser(
+                userId = UserId(1),
+                authId = "authId",
+                email = "user@terraformation.com",
+                emailNotificationsEnabled = false,
+                firstName = "first",
+                lastName = "last",
+                countryCode = "US",
+                locale = Locale.of("en"),
+                timeZone = ZoneId.of("America/Los_Angeles"),
+                userType = UserType.Individual,
+                parentStore = parentStore,
+                permissionStore = mockk()))
+
+    every { user.organizationRoles } returns mapOf(organizationId to Role.Owner)
+    every { parentStore.getUserRole(any(), any()) } returns Role.Contributor
+  }
+
+  @Test
+  fun `can set assignable roles`() {
+    assertTrue(user.canSetOrganizationUserRole(organizationId, Role.Admin))
+  }
+
+  @Test
+  fun `cannot set unassignable roles`() {
+    assertFalse(user.canSetOrganizationUserRole(organizationId, Role.TerraformationContact))
+  }
+
+  @Test
+  fun `can remove organization user that is not a Terraformation Contact`() {
+    assertTrue(user.canRemoveOrganizationUser(organizationId, userId))
+  }
+
+  @Test
+  fun `cannot remove organization user that is a Terraformation Contact`() {
+    every { parentStore.getUserRole(organizationId, userId) } returns Role.TerraformationContact
+    assertFalse(user.canRemoveOrganizationUser(organizationId, userId))
+  }
+
+  @Test
+  fun `can update organization user that is not a Terraformation Contact`() {
+    assertTrue(user.canUpdateOrganizationUser(organizationId, userId))
+  }
+
+  @Test
+  fun `cannot update organization user that is a Terraformation Contact`() {
+    every { parentStore.getUserRole(organizationId, userId) } returns Role.TerraformationContact
+    assertFalse(user.canUpdateOrganizationUser(organizationId, userId))
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -447,6 +447,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.removeOrganizationUser(organizationId, userId)
   }
 
+  @Test
+  fun updateOrganizationUser() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.updateOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.updateOrganizationUser(organizationId, userId)
+    }
+
+    grant { user.canUpdateOrganizationUser(organizationId, userId) }
+    requirements.updateOrganizationUser(organizationId, userId)
+  }
+
   @Test fun sendAlert() = allow { sendAlert(facilityId) } ifUser { canSendAlert(facilityId) }
 
   @Test


### PR DESCRIPTION
- Add 'Terraformation Contact' to `isAdminOrHigher` / `isManagerOrHigher` checks, since this role will have the same permissions as an Admin
- Disallow adding a user with 'Terraformation Contact' role
- Disallow updating a user's role as 'Terraformation Contact'
- Disallow modifying a 'Terraformation Contact' user with another role
- Leveraged existing permissions layers instead of special-casing these semantics in OrganizationStore or OrganizationService. Advantage of this is we can use the SystemUser (in admin ui) to create a TF contact org user (until we have more clarity on super-admin privileges here). Downside to this approach is being unable to mock the role. Added an `IndividualUserTest` to test for the logic instead.
- Open to doing this some other way if there's a preference.