### PR TITLE
Group GitHub Actions dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,11 @@
             "matchPackagePatterns": ["spring"],
             "groupName": "Spring dependencies"
         },
+        {
+            "description": "Group GitHub Actions dependencies",
+            "matchPaths": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+            "groupName": "GitHub Actions"
+        },
     ],
     "prCreation": "not-pending",
     "stabilityDays": 3


### PR DESCRIPTION
Updates to GitHub Actions plugins tend to come in waves, e.g., when a bunch of
plugins are updated to a newer Node.js version. Make Renovate group the updates
together into single PRs to reduce clutter in git history.