### PR TITLE
SW-4253 / SW-4254 API to schedule and reschedule observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -174,6 +174,13 @@ class ParentStore(private val dslContext: DSLContext) {
           DSL.coalesce(BATCHES.facilities.TIME_ZONE, BATCHES.facilities.organizations.TIME_ZONE))
           ?: ZoneOffset.UTC
 
+  fun getEffectiveTimeZone(plantingSiteId: PlantingSiteId): ZoneId =
+      fetchFieldById(
+          plantingSiteId,
+          PLANTING_SITES.ID,
+          DSL.coalesce(PLANTING_SITES.TIME_ZONE, PLANTING_SITES.organizations.TIME_ZONE))
+          ?: ZoneOffset.UTC
+
   fun exists(deviceManagerId: DeviceManagerId): Boolean =
       fetchFieldById(deviceManagerId, DEVICE_MANAGERS.ID, DSL.one()) != null
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -174,7 +174,8 @@ data class IndividualUser(
         organizationId in permissionStore.fetchOrganizationRoles(targetUserId)
   }
 
-  override fun canCreateObservation(plantingSiteId: PlantingSiteId) = isSuperAdmin()
+  override fun canCreateObservation(plantingSiteId: PlantingSiteId) =
+      isSuperAdmin() || isManagerOrHigher(plantingSiteId)
 
   override fun canCreatePlantingSite(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import java.time.LocalDate
 
 class CrossDeliveryReassignmentNotAllowedException(
     val plantingId: PlantingId,
@@ -34,6 +35,14 @@ class DeliveryMissingSubzoneException(val plantingSiteId: PlantingSiteId) :
 
 class DeliveryNotFoundException(val deliveryId: DeliveryId) :
     EntityNotFoundException("Delivery $deliveryId not found")
+
+class InvalidObservationStartDateException(val startDate: LocalDate) :
+    IllegalArgumentException(
+        "Observation start date $startDate should be within a year from today")
+
+class InvalidObservationEndDateException(val startDate: LocalDate, val endDate: LocalDate) :
+    IllegalArgumentException(
+        "Observation end date $endDate should be after and within two months of the start date $startDate")
 
 class ObservationAlreadyStartedException(val observationId: ObservationId) :
     MismatchedStateException("Observation $observationId is already started")
@@ -92,3 +101,10 @@ class ReassignmentTooLargeException(val plantingId: PlantingId) :
 
 class ReassignmentToSamePlotNotAllowedException(val plantingId: PlantingId) :
     IllegalArgumentException("Cannot reassign from planting $plantingId to its original plot")
+
+class ObservationRescheduleStateException(val observationId: ObservationId) :
+    MismatchedStateException("Observation $observationId is not overdue and cannot be rescheduled")
+
+class ScheduleObservationWithoutPlantsException(val plantingSiteId: PlantingSiteId) :
+    IllegalArgumentException(
+        "Cannot schedule observation in planting site $plantingSiteId which has no reported plants in subzones")

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -378,6 +378,24 @@ class ObservationStore(
     return row.id!!
   }
 
+  fun rescheduleObservation(
+      observationId: ObservationId,
+      startDate: LocalDate,
+      endDate: LocalDate
+  ) {
+    requirePermissions { updateObservation(observationId) }
+
+    withLockedObservation(observationId) { _ ->
+      dslContext
+          .update(OBSERVATIONS)
+          .set(OBSERVATIONS.STATE_ID, ObservationState.Upcoming)
+          .set(OBSERVATIONS.START_DATE, startDate)
+          .set(OBSERVATIONS.END_DATE, endDate)
+          .where(OBSERVATIONS.ID.eq(observationId))
+          .execute()
+    }
+  }
+
   fun updateObservationState(observationId: ObservationId, newState: ObservationState) {
     requirePermissions {
       if (newState == ObservationState.Completed) {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -400,6 +400,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
+        createObservation = true,
         readPlantingSite = true,
         updatePlantingSite = true,
     )
@@ -596,6 +597,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
+        createObservation = true,
         readPlantingSite = true,
         updatePlantingSite = true,
     )
@@ -733,6 +735,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
+        createObservation = true,
         readPlantingSite = true,
     )
 


### PR DESCRIPTION
- Added API to schedule/reschedule observations
- Added validation checks on the requests, based on requirements in the PRD
- Added tests for scheduling and rescheduling observations
- Also tested the API with real requests