### PR TITLE
SW-4258 Email notifications when end user schedules/reschedules an observation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -512,6 +512,7 @@ class OrganizationStore(
     return Role.entries.associateWith { countByRoleId[it] ?: 0 }
   }
 
+  /** Fetches the Terraformation Contact role user in an organization, if one exists. */
   fun fetchTerraformationContact(organizationId: OrganizationId): UserId? =
       dslContext
           .select(ORGANIZATION_USERS.USER_ID)

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -77,6 +77,9 @@ abstract class EmailTemplateModel(config: TerrawareServerConfig) {
 
     return htmlWithLinks.let { HTMLOutputFormat.INSTANCE.fromMarkup(it) }
   }
+
+  fun dateString(date: LocalDate): String =
+      DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL).withLocale(currentLocale()).format(date)
 }
 
 class FacilityAlertRequested(
@@ -219,8 +222,47 @@ class ObservationUpcoming(
     get() = "observation/upcoming"
 
   val startDateString: String
-    get() =
-        DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL)
-            .withLocale(currentLocale())
-            .format(startDate)
+    get() = dateString(startDate)
+}
+
+class ObservationScheduled(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "observation/scheduled"
+
+  val startDateString: String
+    get() = dateString(startDate)
+
+  val endDateString: String
+    get() = dateString(endDate)
+}
+
+class ObservationRescheduled(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+    val originalStartDate: LocalDate,
+    val originalEndDate: LocalDate,
+    val newStartDate: LocalDate,
+    val newEndDate: LocalDate,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "observation/rescheduled"
+
+  val originalStartDateString: String
+    get() = dateString(originalStartDate)
+
+  val originalEndDateString: String
+    get() = dateString(originalEndDate)
+
+  val newStartDateString: String
+    get() = dateString(newStartDate)
+
+  val newEndDateString: String
+    get() = dateString(newEndDate)
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -14,3 +14,14 @@ data class ObservationStartedEvent(
 data class ObservationUpcomingNotificationDueEvent(
     val observation: ExistingObservationModel,
 )
+
+/** Published when an observation is scheduled by an end user in Terraware. */
+data class ObservationScheduledEvent(
+    val observation: ExistingObservationModel,
+)
+
+/** Published when an observation is rescheduled by an end user in Terraware. */
+data class ObservationRescheduledEvent(
+    val originalObservation: ExistingObservationModel,
+    val rescheduledObservation: ExistingObservationModel,
+)

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -89,6 +89,18 @@ notification.email.html.footer.2=PO Box 3470, PMB 15777
 notification.email.html.footer.3=Honolulu, HI 96801-3470
 notification.email.html.manageSettings=Manage your [notification settings].
 notification.email.text.footer=Manage your notification settings\: {0}\n\nTerraformation Inc.\nPO Box 3470, PMB 15777, Honolulu, HI 96801-3470\n\nhttps\://twitter.com/TF_Global\nhttps\://www.linkedin.com/company/terraformation/\nhttps\://www.instagram.com/globalterraform/\nhttps\://www.facebook.com/GlobalTerraform\nhttps\://terraformation.com/
+# {0} is the name of a planting site.
+notification.observation.rescheduled.email.body.1=The planting site {0} has had an observation rescheduled. 
+# {0} and {1} are dates.
+notification.observation.rescheduled.email.body.2=Previously it was scheduled for {0} through {1}.
+# {0} and {1} are dates.
+notification.observation.rescheduled.email.body.3=Now the next observation is scheduled for {0} through {1}.
+# {0} is the name of an organization. {1} is the name of a planting site.
+notification.observation.rescheduled.email.subject=Organization {0} has rescheduled an observation of planting site {1}
+# {0} is the name of a planting site. {1} and {2} are dates.
+notification.observation.scheduled.email.body.1=The planting site {0} has had an observation scheduled for {1} through {2}
+# {0} is the name of an organization. {1} is the name of a planting site.
+notification.observation.scheduled.email.subject=Organization {0} has scheduled an observation of planting site {1}
 notification.observation.started.app.body=Observations of your plantings need to be completed this month.
 notification.observation.started.app.title=It is time to monitor your plantings\!
 notification.observation.started.email.body.1=It is time to monitor your plantings\!

--- a/src/main/resources/templates/email/head.ftlh.mjml
+++ b/src/main/resources/templates/email/head.ftlh.mjml
@@ -40,6 +40,15 @@
             padding="0px 32px 24px 32px"
         />
         <mj-class
+            name="text-body03-leading"
+            font-family="Inter, sans-serif"
+            font-weight="400"
+            font-size="14px"
+            line-height="20px"
+            color="#333025"
+            padding="24px 32px 24px 32px"
+        />
+        <mj-class
             name="btn-productive-primary-md"
             background-color="#2C8658"
             color="#FFFFFF"

--- a/src/main/resources/templates/email/observation/rescheduled/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/rescheduled/body.ftlh.mjml
@@ -1,0 +1,26 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationRescheduled" --> -->
+<!-- <#setting date_format="full"> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03-leading">
+                ${strings("notification.observation.rescheduled.email.body.1", plantingSiteName)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.rescheduled.email.body.2", originalStartDateString, originalEndDateString)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.rescheduled.email.body.3", newStartDateString, newEndDateString)}
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/observation/rescheduled/body.txt.ftl
+++ b/src/main/resources/templates/email/observation/rescheduled/body.txt.ftl
@@ -1,0 +1,10 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationRescheduled" -->
+${strings("notification.observation.rescheduled.email.body.1", plantingSiteName)}
+
+${strings("notification.observation.rescheduled.email.body.2", originalStartDateString, originalEndDateString)}
+
+${strings("notification.observation.rescheduled.email.body.3", newStartDateString, newEndDateString)}
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/observation/rescheduled/subject.ftl
+++ b/src/main/resources/templates/email/observation/rescheduled/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationRescheduled" -->
+${strings("notification.observation.rescheduled.email.subject", organizationName, plantingSiteName)}

--- a/src/main/resources/templates/email/observation/scheduled/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/scheduled/body.ftlh.mjml
@@ -1,0 +1,20 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationScheduled" --> -->
+<!-- <#setting date_format="full"> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03-leading">
+                ${strings("notification.observation.scheduled.email.body.1", plantingSiteName, startDateString, endDateString)}
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/observation/scheduled/body.txt.ftl
+++ b/src/main/resources/templates/email/observation/scheduled/body.txt.ftl
@@ -1,0 +1,6 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationScheduled" -->
+${strings("notification.observation.scheduled.email.body.1", plantingSiteName, startDateString, endDateString)}
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/observation/scheduled/subject.ftl
+++ b/src/main/resources/templates/email/observation/scheduled/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationScheduled" -->
+${strings("notification.observation.scheduled.email.subject", organizationName, plantingSiteName)}


### PR DESCRIPTION
- Email notification is sent to the relevant organization's Terraformation Contact *only*, if one exists
- There is no headline or web link in these notifications
- There are no in-app notifications for this use case

##### Schedule
<img width="539" alt="DEV  Organization my org has scheduled an observation of planting site malingunde - karthik balach@gmail com - Gmail 2023-10-02 11-54-42" src="https://github.com/terraware/terraware-server/assets/1865174/aecfba5e-f940-402d-810f-b89b2d71db9b">

##### Reschedule
<img width="534" alt="DEV  Organization my org has rescheduled an observation of planting site tracking-v2-tw3-dupe - karthik balach@gmail com - Gma… 2023-10-02 11-55-41" src="https://github.com/terraware/terraware-server/assets/1865174/930c4e3f-e30a-401a-978f-9a02664353e2">