### PR TITLE
Stop adding Row suffix to embeddable POJOs

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/PluralPojoStrategy.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/PluralPojoStrategy.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.jooq
 import org.jooq.codegen.DefaultGeneratorStrategy
 import org.jooq.codegen.GeneratorStrategy
 import org.jooq.meta.Definition
+import org.jooq.meta.EmbeddableDefinition
 
 /**
  * Generate less-awkward names for POJO classes for tables with plural names. For example, if
@@ -13,7 +14,7 @@ import org.jooq.meta.Definition
 class PluralPojoStrategy : DefaultGeneratorStrategy() {
   override fun getJavaClassName(definition: Definition, mode: GeneratorStrategy.Mode): String {
     val transformedName = super.getJavaClassName(definition, mode)
-    return if (mode == GeneratorStrategy.Mode.POJO) {
+    return if (mode == GeneratorStrategy.Mode.POJO && definition !is EmbeddableDefinition) {
       "${transformedName}Row"
     } else {
       transformedName


### PR DESCRIPTION
If we define an embeddable type to represent a compound key, the generated POJO
class shouldn't have a Row suffix on its name because it doesn't represent a
table row.

Update the naming strategy to exclude embeddable types.

Currently, we don't have any places in the code where we're referring to these
classes by name; everywhere we use them, we use type inference. So no changes
to the application code are needed here. But this will be less confusing in
the future if/when we do need to refer to the type of a compound key.