### PR TITLE
SW-4279 Don't send org email notifications to Terraformation Contact users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -42,6 +42,7 @@ import com.terraformation.backend.device.DeviceManagerService
 import com.terraformation.backend.device.DeviceService
 import com.terraformation.backend.device.db.DeviceManagerStore
 import com.terraformation.backend.device.db.DeviceStore
+import com.terraformation.backend.email.EmailService
 import com.terraformation.backend.file.useAndDelete
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.report.ReportService
@@ -194,7 +195,11 @@ class AdminController(
   fun getFacility(@PathVariable facilityId: FacilityId, model: Model): String {
     val facility = facilityStore.fetchOneById(facilityId)
     val organization = organizationStore.fetchOneById(facility.organizationId)
-    val recipients = userStore.fetchByOrganizationId(facility.organizationId).map { it.email }
+    val recipients =
+        userStore
+            .fetchByOrganizationId(
+                facility.organizationId, roles = EmailService.defaultOrgRolesForNotification)
+            .map { it.email }
     val storageLocations = facilityStore.fetchStorageLocations(facilityId)
     val deviceManager = deviceManagerStore.fetchOneByFacilityId(facilityId)
     val devices = deviceStore.fetchByFacilityId(facilityId)

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -254,9 +254,7 @@ class EmailNotificationService(
         webAppUrls.fullObservations(plantingSite.organizationId, plantingSite.id).toString()
 
     emailService.sendOrganizationNotification(
-        plantingSite.organizationId,
-        ObservationStarted(config, observationsUrl),
-        roles = defaultRolesForNotification())
+        plantingSite.organizationId, ObservationStarted(config, observationsUrl))
   }
 
   @EventListener
@@ -274,8 +272,7 @@ class EmailNotificationService(
             event.observation.startDate,
             observationsUrl,
             webAppUrls.appStore.toString(),
-            webAppUrls.googlePlay.toString()),
-        roles = defaultRolesForNotification())
+            webAppUrls.googlePlay.toString()))
   }
 
   @EventListener
@@ -431,7 +428,8 @@ class EmailNotificationService(
   private fun getRecipients(facilityId: FacilityId): List<IndividualUser> {
     val organizationId =
         parentStore.getOrganizationId(facilityId) ?: throw FacilityNotFoundException(facilityId)
-    return userStore.fetchByOrganizationId(organizationId, roles = defaultRolesForNotification())
+    return userStore.fetchByOrganizationId(
+        organizationId, roles = EmailService.defaultOrgRolesForNotification)
   }
 
   private fun getTerraformationContactUser(organizationId: OrganizationId): IndividualUser? {
@@ -439,9 +437,6 @@ class EmailNotificationService(
     return userStore.fetchOneById(tfContactId) as? IndividualUser
         ?: throw IllegalArgumentException("Terraformation Contact user must be an individual user")
   }
-
-  private fun defaultRolesForNotification(): Set<Role> =
-      Role.values().filter { it != Role.TerraformationContact }.toSet()
 
   data class EmailRequest(val user: IndividualUser, val emailTemplateModel: EmailTemplateModel)
 }

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -385,12 +385,12 @@ internal class EmailNotificationServiceTest {
 
   @Test
   fun observationScheduledNotification() {
-    val tfContactUserId = UserId(5)
-    val tfContactUser = userForEmail("tfcontact@terraformation.com")
+    val recipients = setOf("tfcontact@terraformation.com")
 
     every { parentStore.getOrganizationId(ObservationId(1)) } returns organization.id
-    every { organizationStore.fetchTerraformationContact(organization.id) } returns tfContactUserId
-    every { userStore.fetchOneById(tfContactUserId) } returns tfContactUser
+    every {
+      userStore.fetchByOrganizationId(organization.id, false, setOf(Role.TerraformationContact))
+    } returns recipients.map { userForEmail(it) }
 
     every { organizationStore.fetchOneById(organization.id) } returns
         OrganizationModel(
@@ -435,12 +435,12 @@ internal class EmailNotificationServiceTest {
 
   @Test
   fun observationRescheduledNotification() {
-    val tfContactUserId = UserId(5)
-    val tfContactUser = userForEmail("tfcontact@terraformation.com")
+    val recipients = setOf("tfcontact@terraformation.com")
 
     every { parentStore.getOrganizationId(ObservationId(1)) } returns organization.id
-    every { organizationStore.fetchTerraformationContact(organization.id) } returns tfContactUserId
-    every { userStore.fetchOneById(tfContactUserId) } returns tfContactUser
+    every {
+      userStore.fetchByOrganizationId(organization.id, false, setOf(Role.TerraformationContact))
+    } returns recipients.map { userForEmail(it) }
 
     every { organizationStore.fetchOneById(organization.id) } returns
         OrganizationModel(


### PR DESCRIPTION
- TF Contact receives very specific email notifications as defined in the PRD
- Skip sending routine org email notifications to TF Contact users
- Refactored a couple notifications to use the `sendOrganizationNotification`
- Not sure how this current approach will ensure correctness for future email notifications
- Another option is to initialize this default roles list in the EmailService.sendOrganizationNotification function argument instead, future email notifications will by default skip TF Contacts unless explicitly passed into the roles