### PR TITLE
SW-4301 Refine permissions for schedule/reschedule observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -177,11 +177,13 @@ data class DeviceManagerUser(
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
   override fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = false
+  override fun canRescheduleObservation(observationId: ObservationId): Boolean = false
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       false
   override fun canSetTerraformationContact(organizationId: OrganizationId): Boolean = false
   override fun canSetTestClock(): Boolean = false
   override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = false
+  override fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = false
   override fun canUpdateAppVersions(): Boolean = false
   override fun canUpdateBatch(batchId: BatchId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -116,9 +116,11 @@ data class IndividualUser(
     return CurrentUserHolder.runAs(this, func, authorities)
   }
 
-  /** Returns true if the user is an admin or owner of any organizations. */
+  /** Returns true if the user is an admin, owner or Terraformation Contact of any organizations. */
   override fun hasAnyAdminRole() =
-      organizationRoles.values.any { it == Role.Owner || it == Role.Admin }
+      organizationRoles.values.any {
+        it == Role.Owner || it == Role.Admin || it == Role.TerraformationContact
+      }
 
   override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
     return if (isSuperAdmin()) {
@@ -335,6 +337,9 @@ data class IndividualUser(
 
   override fun canRemoveTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 
+  override fun canRescheduleObservation(observationId: ObservationId) =
+      isSuperAdmin() || isAdminOrHigher(parentStore.getOrganizationId(observationId))
+
   override fun canSendAlert(facilityId: FacilityId) = isAdminOrHigher(facilityId)
 
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role) =
@@ -346,6 +351,9 @@ data class IndividualUser(
 
   override fun canSetWithdrawalUser(accessionId: AccessionId) =
       isManagerOrHigher(parentStore.getOrganizationId(accessionId))
+
+  override fun canScheduleObservation(plantingSiteId: PlantingSiteId) =
+      isSuperAdmin() || isAdminOrHigher(parentStore.getOrganizationId(plantingSiteId))
 
   override fun canTriggerAutomation(automationId: AutomationId) =
       isAdminOrHigher(parentStore.getFacilityId(automationId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -537,6 +537,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun rescheduleObservation(observationId: ObservationId) {
+    if (!user.canRescheduleObservation(observationId)) {
+      updateObservation(observationId)
+      throw AccessDeniedException("No permission to reschedule observation $observationId")
+    }
+  }
+
   fun sendAlert(facilityId: FacilityId) {
     if (!user.canSendAlert(facilityId)) {
       readFacility(facilityId)
@@ -570,6 +577,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canSetWithdrawalUser(accessionId)) {
       readAccession(accessionId)
       throw AccessDeniedException("No permission to set withdrawal user for accession $accessionId")
+    }
+  }
+
+  fun scheduleObservation(plantingSiteId: PlantingSiteId) {
+    if (!user.canScheduleObservation(plantingSiteId)) {
+      createObservation(plantingSiteId)
+      throw AccessDeniedException(
+          "No permission to schedule observation for planting site $plantingSiteId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -539,7 +539,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun rescheduleObservation(observationId: ObservationId) {
     if (!user.canRescheduleObservation(observationId)) {
-      updateObservation(observationId)
+      readObservation(observationId)
       throw AccessDeniedException("No permission to reschedule observation $observationId")
     }
   }
@@ -582,7 +582,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun scheduleObservation(plantingSiteId: PlantingSiteId) {
     if (!user.canScheduleObservation(plantingSiteId)) {
-      createObservation(plantingSiteId)
+      readPlantingSite(plantingSiteId)
       throw AccessDeniedException(
           "No permission to schedule observation for planting site $plantingSiteId")
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -183,12 +183,14 @@ class SystemUser(
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
   override fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = true
+  override fun canRescheduleObservation(observationId: ObservationId): Boolean = true
   override fun canSendAlert(facilityId: FacilityId): Boolean = true
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       true
   override fun canSetTerraformationContact(organizationId: OrganizationId): Boolean = true
   override fun canSetTestClock(): Boolean = true
   override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = true
+  override fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
   override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
   override fun canUpdateAppVersions(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -145,11 +145,13 @@ interface TerrawareUser : Principal {
   fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canRescheduleObservation(observationId: ObservationId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
   fun canSetTerraformationContact(organizationId: OrganizationId): Boolean
   fun canSetTestClock(): Boolean
   fun canSetWithdrawalUser(accessionId: AccessionId): Boolean
+  fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean
   fun canTriggerAutomation(automationId: AutomationId): Boolean
   fun canUpdateAccession(accessionId: AccessionId): Boolean
   fun canUpdateAppVersions(): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -157,7 +157,7 @@ class ObservationService(
   }
 
   fun scheduleObservation(observation: NewObservationModel): ObservationId {
-    requirePermissions { createObservation(observation.plantingSiteId) }
+    requirePermissions { scheduleObservation(observation.plantingSiteId) }
 
     validateSchedule(observation.plantingSiteId, observation.startDate, observation.endDate)
 
@@ -176,7 +176,7 @@ class ObservationService(
       startDate: LocalDate,
       endDate: LocalDate
   ) {
-    requirePermissions { updateObservation(observationId) }
+    requirePermissions { rescheduleObservation(observationId) }
 
     val observation = observationStore.fetchObservationById(observationId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -473,19 +473,11 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
-  fun updateTerraformationContact() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.updateTerraformationContact(organizationId)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<InvalidRoleUpdateException> {
-      requirements.updateTerraformationContact(organizationId)
-    }
-
-    grant { user.canUpdateTerraformationContact(organizationId) }
-    requirements.updateTerraformationContact(organizationId)
-  }
+  fun rescheduleObservation() =
+      allow { rescheduleObservation(observationId) } ifUser
+          {
+            canRescheduleObservation(observationId)
+          }
 
   @Test fun sendAlert() = allow { sendAlert(facilityId) } ifUser { canSendAlert(facilityId) }
 
@@ -502,6 +494,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun setWithdrawalUser() =
       allow { setWithdrawalUser(accessionId) } ifUser { canSetWithdrawalUser(accessionId) }
+
+  @Test
+  fun scheduleObservation() =
+      allow { scheduleObservation(plantingSiteId) } ifUser
+          {
+            canScheduleObservation(plantingSiteId)
+          }
 
   @Test
   fun triggerAutomation() =
@@ -592,6 +591,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
           {
             canUpdateStorageLocation(storageLocationId)
           }
+
+  @Test
+  fun updateTerraformationContact() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.updateTerraformationContact(organizationId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<InvalidRoleUpdateException> {
+      requirements.updateTerraformationContact(organizationId)
+    }
+
+    grant { user.canUpdateTerraformationContact(organizationId) }
+    requirements.updateTerraformationContact(organizationId)
+  }
 
   @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -64,6 +64,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 
 /**
@@ -402,6 +404,7 @@ internal class PermissionTest : DatabaseTest() {
         createDelivery = true,
         createObservation = true,
         readPlantingSite = true,
+        scheduleObservation = true,
         updatePlantingSite = true,
     )
 
@@ -438,6 +441,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *observationIds.forOrg1(),
         readObservation = true,
+        rescheduleObservation = true,
         updateObservation = true,
     )
 
@@ -493,9 +497,17 @@ internal class PermissionTest : DatabaseTest() {
     permissions.andNothingElse()
   }
 
-  @Test
-  fun `admin role grants all permissions except deleting organization`() {
-    givenRole(org1Id, Role.Admin)
+  @ParameterizedTest
+  @ValueSource(
+      strings =
+          [
+              "Admin",
+              "TerraformationContact",
+          ])
+  fun `admin equivalent role grants all permissions except deleting organization`(
+      roleName: String
+  ) {
+    givenRole(org1Id, Role.valueOf(roleName))
 
     val permissions = PermissionsTracker()
 
@@ -599,6 +611,7 @@ internal class PermissionTest : DatabaseTest() {
         createDelivery = true,
         createObservation = true,
         readPlantingSite = true,
+        scheduleObservation = true,
         updatePlantingSite = true,
     )
 
@@ -635,6 +648,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *observationIds.forOrg1(),
         readObservation = true,
+        rescheduleObservation = true,
         updateObservation = true,
     )
 
@@ -1067,6 +1081,7 @@ internal class PermissionTest : DatabaseTest() {
         createObservation = true,
         movePlantingSiteToAnyOrg = true,
         readPlantingSite = true,
+        scheduleObservation = true,
         updatePlantingSite = true,
     )
 
@@ -1103,6 +1118,7 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.toTypedArray(),
         manageObservation = true,
         readObservation = true,
+        rescheduleObservation = true,
         updateObservation = true,
     )
 
@@ -1146,6 +1162,7 @@ internal class PermissionTest : DatabaseTest() {
         createObservation = true,
         movePlantingSiteToAnyOrg = true,
         readPlantingSite = true,
+        scheduleObservation = true,
         updatePlantingSite = true,
     )
 
@@ -1153,6 +1170,7 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.forOrg1(),
         manageObservation = true,
         readObservation = true,
+        rescheduleObservation = true,
         updateObservation = true,
     )
 
@@ -1634,6 +1652,7 @@ internal class PermissionTest : DatabaseTest() {
         createObservation: Boolean = false,
         movePlantingSiteToAnyOrg: Boolean = false,
         readPlantingSite: Boolean = false,
+        scheduleObservation: Boolean = false,
         updatePlantingSite: Boolean = false,
     ) {
       plantingSiteIds.forEach { plantingSiteId ->
@@ -1653,6 +1672,10 @@ internal class PermissionTest : DatabaseTest() {
             readPlantingSite,
             user.canReadPlantingSite(plantingSiteId),
             "Can read planting site $plantingSiteId")
+        assertEquals(
+            scheduleObservation,
+            user.canScheduleObservation(plantingSiteId),
+            "Can schedule observation $plantingSiteId")
         assertEquals(
             updatePlantingSite,
             user.canUpdatePlantingSite(plantingSiteId),
@@ -1746,6 +1769,7 @@ internal class PermissionTest : DatabaseTest() {
         vararg observationIds: ObservationId,
         manageObservation: Boolean = false,
         readObservation: Boolean = false,
+        rescheduleObservation: Boolean = false,
         updateObservation: Boolean = false,
     ) {
       observationIds.forEach { observationId ->
@@ -1757,6 +1781,10 @@ internal class PermissionTest : DatabaseTest() {
             readObservation,
             user.canReadObservation(observationId),
             "Can read observation $observationId")
+        assertEquals(
+            rescheduleObservation,
+            user.canRescheduleObservation(observationId),
+            "Can reschedule observation $observationId")
         assertEquals(
             updateObservation,
             user.canUpdateObservation(observationId),

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -120,6 +120,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadObservation(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
     every { user.canReadPlantingZone(any()) } returns true
+    every { user.canRescheduleObservation(any()) } returns true
+    every { user.canScheduleObservation(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
   }
 
@@ -401,7 +403,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   inner class ScheduleObservation {
     @Test
     fun `throws exception scheduling an observation if no permission to create observation`() {
-      every { user.canCreateObservation(plantingSiteId) } returns false
+      every { user.canScheduleObservation(plantingSiteId) } returns false
 
       assertThrows<AccessDeniedException> {
         service.scheduleObservation(newObservationModel(plantingSiteId = plantingSiteId))
@@ -531,7 +533,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception rescheduling an observation if no permission to update observation`() {
-      every { user.canUpdateObservation(observationId) } returns false
+      every { user.canRescheduleObservation(observationId) } returns false
 
       val startDate = LocalDate.EPOCH
       val endDate = startDate.plusDays(1)

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -33,6 +33,7 @@ import com.terraformation.backend.tracking.db.ObservationHasNoPlotsException
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
 import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.ScheduleObservationWithoutPlantsException
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
@@ -402,10 +403,20 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   @Nested
   inner class ScheduleObservation {
     @Test
-    fun `throws exception scheduling an observation if no permission to create observation`() {
+    fun `throws access denied exception scheduling an observation if no permission to schedule observation`() {
       every { user.canScheduleObservation(plantingSiteId) } returns false
 
       assertThrows<AccessDeniedException> {
+        service.scheduleObservation(newObservationModel(plantingSiteId = plantingSiteId))
+      }
+    }
+
+    @Test
+    fun `throws planting site not found exception scheduling an observation if no permission to schedule observation or read the planting site`() {
+      every { user.canReadPlantingSite(plantingSiteId) } returns false
+      every { user.canScheduleObservation(plantingSiteId) } returns false
+
+      assertThrows<PlantingSiteNotFoundException> {
         service.scheduleObservation(newObservationModel(plantingSiteId = plantingSiteId))
       }
     }
@@ -532,13 +543,26 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception rescheduling an observation if no permission to update observation`() {
+    fun `throws access denied exception rescheduling an observation if no permission to reschedule observation`() {
       every { user.canRescheduleObservation(observationId) } returns false
 
       val startDate = LocalDate.EPOCH
       val endDate = startDate.plusDays(1)
 
       assertThrows<AccessDeniedException> {
+        service.rescheduleObservation(observationId, startDate, endDate)
+      }
+    }
+
+    @Test
+    fun `throws observation not found exception rescheduling an observation if no permission to reschedule or read observation`() {
+      every { user.canRescheduleObservation(observationId) } returns false
+      every { user.canReadObservation(observationId) } returns false
+
+      val startDate = LocalDate.EPOCH
+      val endDate = startDate.plusDays(1)
+
+      assertThrows<ObservationNotFoundException> {
         service.rescheduleObservation(observationId, startDate, endDate)
       }
     }


### PR DESCRIPTION
- We want admins/owners/TFContact/superadmins alone to be able to schedule/reschedule observations
- The UI handles this gating currently
- ObservationService.scheduleObservation/rescheduleObservation functions were piggy-backing onto create/update observations permissions earlier (update permissions is a bit more relaxed)
- Updated the functions them to use new permissions checks for schedule/reschedule observations
- Updated the tests