### PR TITLE
SW-4307 Support exclusions in shapefile import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1027,6 +1027,7 @@ class AdminController(
                 siteFile,
                 zonesFile,
                 subzonesFile,
+                null,
                 emptySet(),
                 fitSiteToPlots)
           } else {

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -241,7 +241,8 @@
     <br/>
     <label for="zipfile">Zipfile</label>
     <input type="file" name="zipfile" id="zipfile" required/>
-    Must contain three shapefiles and their associated supplementary datafiles.
+    Must contain either three or four shapefiles (exclusions shapefile is optional) and their
+    associated supplementary datafiles.
     <br/>
     Validation Options:
     <div class="validationOption" th:each="option : ${plantingSiteValidationOptions}">

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -69,7 +69,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       assertHasProblem(
           "TooFewShapefiles.zip",
           ValidationOption.ZonesContainedInSite,
-          "Expected 3 shapefiles (site, zones, subzones) but found 2")
+          "Expected 3 or 4 shapefiles (site, zones, subzones, and optionally exclusions) but found 2")
     }
 
     private fun assertProblems(


### PR DESCRIPTION
Planting site creation via shapefile upload now allows the zip archive to contain
an optional fourth shapefile. If present, the geometries in the fourth shapefile
are excluded from the site's geometry when monitoring plots are generated. In
other words, the fourth shapefile defines areas that aren't allowed to have
monitoring plots.