### PR TITLE
SW-4309 Send email on monitoring plot replacement

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.i18n.FormattingResourceBundleModel
 import com.terraformation.backend.i18n.currentLocale
+import com.terraformation.backend.tracking.model.ReplacementDuration
 import freemarker.core.HTMLOutputFormat
 import freemarker.ext.beans.ResourceBundleModel
 import freemarker.template.Configuration
@@ -307,4 +308,16 @@ class ObservationNotScheduledSupport(
 ) : EmailTemplateModel(config) {
   override val templateDir: String
     get() = "observation/notScheduledSupport"
+}
+
+class ObservationPlotReplaced(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+    val justification: String,
+    val duration: ReplacementDuration,
+    val hasPrimaryContact: Boolean,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "observation/plotReplaced"
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -1,7 +1,17 @@
 package com.terraformation.backend.tracking.event
 
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.model.ExistingObservationModel
+import com.terraformation.backend.tracking.model.ReplacementDuration
+
+/** Published when an organization requests that a monitoring plot be replaced in an observation. */
+data class ObservationPlotReplacedEvent(
+    val duration: ReplacementDuration,
+    val justification: String,
+    val observation: ExistingObservationModel,
+    val monitoringPlotId: MonitoringPlotId,
+)
 
 /** Published when an observation has just started. */
 data class ObservationStartedEvent(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementDuration.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementDuration.kt
@@ -1,0 +1,6 @@
+package com.terraformation.backend.tracking.model
+
+enum class ReplacementDuration(val displayName: String) {
+  Temporary("Temporary"),
+  LongTerm("Long-Term/Permanent")
+}

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -89,6 +89,12 @@ notification.email.html.footer.2=PO Box 3470, PMB 15777
 notification.email.html.footer.3=Honolulu, HI 96801-3470
 notification.email.html.manageSettings=Manage your [notification settings].
 notification.email.text.footer=Manage your notification settings\: {0}\n\nTerraformation Inc.\nPO Box 3470, PMB 15777, Honolulu, HI 96801-3470\n\nhttps\://twitter.com/TF_Global\nhttps\://www.linkedin.com/company/terraformation/\nhttps\://www.instagram.com/globalterraform/\nhttps\://www.facebook.com/GlobalTerraform\nhttps\://terraformation.com/
+notification.observation.monitoringPlotReplaced.email.body.1=There is currently no assigned Terraformation primary project contact for this organization. Please assign one and let them know of this requested change.
+# {0} is the name of a planting site
+notification.observation.monitoringPlotReplaced.email.body.2=The planting site {0} has had an observation plot change request.
+notification.observation.monitoringPlotReplaced.email.body.3=The justification given is: {0}
+notification.observation.monitoringPlotReplaced.email.body.4=The duration for the change is: {0}
+notification.observation.monitoringPlotReplaced.email.subject=Organization {0} has requested an observation plot change
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduled.email.body.1=Organization {0} has not scheduled an observation of planting site {1}
 # {0} is the name of a planting site

--- a/src/main/resources/templates/email/observation/plotReplaced/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/plotReplaced/body.ftlh.mjml
@@ -1,0 +1,31 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationPlotReplaced" --> -->
+<!-- <#setting date_format="full"> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <#if !hasPrimaryContact>
+                    <mj-text mj-class="text-body03">
+                        ${strings("notification.observation.monitoringPlotReplaced.email.body.1")}
+                    </mj-text>
+                </#if>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.monitoringPlotReplaced.email.body.2", plantingSiteName)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.monitoringPlotReplaced.email.body.3", justification)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.monitoringPlotReplaced.email.body.4", duration.displayName)}
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/observation/plotReplaced/body.txt.ftl
+++ b/src/main/resources/templates/email/observation/plotReplaced/body.txt.ftl
@@ -1,0 +1,15 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationPlotReplaced" -->
+<#if !hasPrimaryContact>
+${strings("notification.observation.monitoringPlotReplaced.email.body.1")}
+</#if>
+
+${strings("notification.observation.monitoringPlotReplaced.email.body.2", plantingSiteName)}
+
+${strings("notification.observation.monitoringPlotReplaced.email.body.3", justification)}
+
+${strings("notification.observation.monitoringPlotReplaced.email.body.4", duration.displayName)}
+
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/observation/plotReplaced/subject.ftl
+++ b/src/main/resources/templates/email/observation/plotReplaced/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationPlotReplaced" -->
+${strings("notification.observation.monitoringPlotReplaced.email.subject", organizationName)}


### PR DESCRIPTION
Add an email notification that will be sent when the user replaces a monitoring
plot in an observation. Nothing triggers this notification yet.