### PR TITLE
SW-4308 Add API for replacing monitoring plot

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -177,6 +177,7 @@ data class DeviceManagerUser(
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
   override fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = false
+  override fun canReplaceObservationPlot(observationId: ObservationId): Boolean = false
   override fun canRescheduleObservation(observationId: ObservationId): Boolean = false
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -337,6 +337,9 @@ data class IndividualUser(
 
   override fun canRemoveTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 
+  override fun canReplaceObservationPlot(observationId: ObservationId) =
+      isAdminOrHigher(parentStore.getOrganizationId(observationId))
+
   override fun canRescheduleObservation(observationId: ObservationId) =
       isSuperAdmin() || isAdminOrHigher(parentStore.getOrganizationId(observationId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -537,6 +537,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun replaceObservationPlot(observationId: ObservationId) {
+    if (!user.canReplaceObservationPlot(observationId)) {
+      readObservation(observationId)
+      throw AccessDeniedException("No permission to replace plot in observation $observationId")
+    }
+  }
+
   fun rescheduleObservation(observationId: ObservationId) {
     if (!user.canRescheduleObservation(observationId)) {
       readObservation(observationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -183,6 +183,7 @@ class SystemUser(
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
   override fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = true
+  override fun canReplaceObservationPlot(observationId: ObservationId): Boolean = true
   override fun canRescheduleObservation(observationId: ObservationId): Boolean = true
   override fun canSendAlert(facilityId: FacilityId): Boolean = true
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -145,6 +145,7 @@ interface TerrawareUser : Principal {
   fun canRegenerateAllDeviceManagerTokens(): Boolean
   fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
   fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canReplaceObservationPlot(observationId: ObservationId): Boolean
   fun canRescheduleObservation(observationId: ObservationId): Boolean
   fun canSendAlert(facilityId: FacilityId): Boolean
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementResult.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementResult.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+
+/** The result of a request to replace a monitoring plot in an observation. */
+data class ReplacementResult(
+    val addedMonitoringPlotIds: Set<MonitoringPlotId>,
+    val removedMonitoringPlotIds: Set<MonitoringPlotId>,
+)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -473,6 +473,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun replaceObservationPlot() =
+      allow { replaceObservationPlot(observationId) } ifUser
+          {
+            canReplaceObservationPlot(observationId)
+          }
+
+  @Test
   fun rescheduleObservation() =
       allow { rescheduleObservation(observationId) } ifUser
           {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -441,6 +441,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *observationIds.forOrg1(),
         readObservation = true,
+        replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
     )
@@ -648,6 +649,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *observationIds.forOrg1(),
         readObservation = true,
+        replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
     )
@@ -1118,6 +1120,7 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.toTypedArray(),
         manageObservation = true,
         readObservation = true,
+        replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
     )
@@ -1170,6 +1173,7 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.forOrg1(),
         manageObservation = true,
         readObservation = true,
+        replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
     )
@@ -1769,6 +1773,7 @@ internal class PermissionTest : DatabaseTest() {
         vararg observationIds: ObservationId,
         manageObservation: Boolean = false,
         readObservation: Boolean = false,
+        replaceObservationPlot: Boolean = false,
         rescheduleObservation: Boolean = false,
         updateObservation: Boolean = false,
     ) {
@@ -1781,6 +1786,10 @@ internal class PermissionTest : DatabaseTest() {
             readObservation,
             user.canReadObservation(observationId),
             "Can read observation $observationId")
+        assertEquals(
+            replaceObservationPlot,
+            user.canReplaceObservationPlot(observationId),
+            "Can replace plot in observation $observationId")
         assertEquals(
             rescheduleObservation,
             user.canRescheduleObservation(observationId),


### PR DESCRIPTION
`POST /api/v1/tracking/observations/{observationId}/plots/{plotId}/replace` will
request that a monitoring plot in an observation be replaced.

Currently this triggers an email notification to be sent to the organization's
Terraware contact (or to the support email if there's no contact) but does not
actually cause the plot to be replaced. However, the API definition can be used
for client-side code generation.