### PR TITLE
Use Java 21 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: "corretto"
-        java-version: "20"
+        java-version: "21"
 
     - name: Tell Gradle where the Java installation is
       run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,9 +238,9 @@ sourceSets.main { java.srcDir("build/generated/kotlin") }
 sourceSets.test { java.srcDir("build/generated-test/kotlin") }
 
 java {
-  toolchain { languageVersion = JavaLanguageVersion.of(20) }
-  // Kotlin compiler (as of 1.8.20) only supports Java 19 target compatibility.
-  targetCompatibility = JavaVersion.VERSION_19
+  toolchain { languageVersion = JavaLanguageVersion.of(21) }
+  // Kotlin compiler (as of 1.9.10) only supports Java 20 target compatibility.
+  targetCompatibility = JavaVersion.VERSION_20
 }
 
 node { yarnVersion = "1.22.17" }
@@ -248,7 +248,7 @@ node { yarnVersion = "1.22.17" }
 tasks.withType<KotlinCompile> {
   compilerOptions {
     // Kotlin and Java target compatibility must be the same.
-    jvmTarget = JvmTarget.JVM_19
+    jvmTarget = JvmTarget.JVM_20
     allWarningsAsErrors = true
   }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:20
+FROM amazoncorretto:21
 
 ARG USER_ID=1001
 

--- a/jooq/build.gradle.kts
+++ b/jooq/build.gradle.kts
@@ -37,11 +37,11 @@ gradlePlugin {
   }
 }
 
-java { targetCompatibility = JavaVersion.VERSION_19 }
+java { targetCompatibility = JavaVersion.VERSION_20 }
 
 tasks.withType<KotlinCompile> {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_19)
+    jvmTarget.set(JvmTarget.JVM_20)
     allWarningsAsErrors.set(true)
   }
 }


### PR DESCRIPTION
Previously, we were targeting Java 19 with the build (because that was the newest
version supported by the Kotlin compiler at one point) and using Java 20 as the
runtime JVM.

Update the runtime to use Java 21, and the build to target Java 20.

No functional change (we aren't using any of Java 21's new features) but it
should give us some minor performance improvements.