### PR TITLE
SW-4323 Allow alternate names for feature properties

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -1016,14 +1016,14 @@ class AdminController(
                 Shapefile.fromBoundary(
                     "zone",
                     boundaryPolygon,
-                    mapOf(PlantingSiteImporter.ZONE_NAME_PROPERTY to "Zone"))
+                    mapOf(PlantingSiteImporter.zoneNameProperties.first() to "Zone"))
             val subzonesFile =
                 Shapefile.fromBoundary(
                     "subzone",
                     boundaryPolygon,
                     mapOf(
-                        PlantingSiteImporter.ZONE_NAME_PROPERTY to "Zone",
-                        PlantingSiteImporter.SUBZONE_NAME_PROPERTY to "Subzone"))
+                        PlantingSiteImporter.zoneNameProperties.first() to "Zone",
+                        PlantingSiteImporter.subzoneNameProperties.first() to "Subzone"))
 
             plantingSiteImporter.importShapefiles(
                 siteName,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
@@ -16,6 +16,14 @@ data class ShapefileFeature(
     val properties: Map<String, String>,
     val coordinateReferenceSystem: CoordinateReferenceSystem,
 ) {
+  /** Looks up a list of properties by name and returns the first value that exists. */
+  fun getProperty(names: Collection<String>): String? {
+    return names.firstNotNullOfOrNull { properties[it] }
+  }
+
+  /** Returns true if the feature has any of a number of properties. */
+  fun hasProperty(names: Collection<String>): Boolean = names.any { it in properties }
+
   /**
    * Calculates the approximate area of a shapefile feature in hectares. If the feature isn't
    * already in a UTM coordinate system, converts it to the appropriate one first.


### PR DESCRIPTION
Property (column) names in shapefiles are truncated to 10 characters, and
originally we were creating map data with property names longer than that.
Change the shapefile importer to accept either the original truncated names
or new shorter ones that don't include the "planting" prefix.