### PR TITLE
SW-4232 Return observation photo GPS information

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -454,8 +454,12 @@ data class RecordedPlantPayload(
 
 data class ObservationMonitoringPlotPhotoPayload(
     val fileId: FileId,
+    val gpsCoordinates: Point,
+    val position: ObservationPhotoPosition,
 ) {
-  constructor(model: ObservationMonitoringPlotPhotoModel) : this(model.fileId)
+  constructor(
+      model: ObservationMonitoringPlotPhotoModel
+  ) : this(model.fileId, model.gpsCoordinates, model.position)
 }
 
 data class ObservationSpeciesResultsPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationPhotoPosition
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
@@ -13,10 +14,13 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
+import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 
 data class ObservationMonitoringPlotPhotoModel(
     val fileId: FileId,
+    val gpsCoordinates: Point,
+    val position: ObservationPhotoPosition,
 )
 
 data class ObservationSpeciesResultsModel(


### PR DESCRIPTION
Currently, when it uploads photos of a permanent monitoring plot's four corners,
the mobile app includes GPS coordinates and an indication of which corner the
photo shows. But this information was write-only and couldn't be retrieved for
later display.

Return it as part of the list of an observed plot's photos.