### PR TITLE
SW-3992 Add sub-location delete endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/SubLocationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SubLocationsController.kt
@@ -93,6 +93,7 @@ class SubLocationsController(
     return SimpleSuccessResponsePayload()
   }
 
+  @ApiResponse200
   @ApiResponse409(
       description = "The sub-location is in use, e.g., there are seeds or seedlings stored there.")
   @DeleteMapping("/{subLocationId}")

--- a/src/main/kotlin/com/terraformation/backend/customer/api/SubLocationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/SubLocationsController.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SubLocationsRow
 import com.terraformation.backend.seedbank.db.AccessionStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -88,6 +89,26 @@ class SubLocationsController(
     }
 
     facilityStore.updateSubLocation(subLocationId, payload.name)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse409(
+      description = "The sub-location is in use, e.g., there are seeds or seedlings stored there.")
+  @DeleteMapping("/{subLocationId}")
+  @Operation(
+      summary = "Deletes a sub-location from a facility.",
+      description = "The sub-location must not be in use.")
+  fun deleteSubLocation(
+      @PathVariable facilityId: FacilityId,
+      @PathVariable subLocationId: SubLocationId
+  ): SimpleSuccessResponsePayload {
+    val location = facilityStore.fetchSubLocation(subLocationId)
+    if (location.facilityId != facilityId) {
+      throw SubLocationNotFoundException(subLocationId)
+    }
+
+    facilityStore.deleteSubLocation(subLocationId)
 
     return SimpleSuccessResponsePayload()
   }


### PR DESCRIPTION
Left this out of commit bfea4017. It won't be used initially for nursery
sub-locations, but is needed to support deleting seed bank sub-locations.