### PR TITLE
SW-4324 Add user to any organization from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -122,6 +122,7 @@ data class DeviceManagerUser(
         organizationId in permissionStore.fetchOrganizationRoles(targetUserId)
   }
 
+  override fun canAddAnyOrganizationUser(): Boolean = false
   override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = false
   override fun canAddTerraformationContact(organizationId: OrganizationId): Boolean = false
   override fun canCountNotifications(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -142,8 +142,10 @@ data class IndividualUser(
   override fun isCredentialsNonExpired() = true
   override fun isEnabled() = true
 
+  override fun canAddAnyOrganizationUser() = isSuperAdmin()
+
   override fun canAddOrganizationUser(organizationId: OrganizationId) =
-      isAdminOrHigher(organizationId)
+      isSuperAdmin() || isAdminOrHigher(organizationId)
 
   override fun canAddTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 
@@ -346,7 +348,7 @@ data class IndividualUser(
   override fun canSendAlert(facilityId: FacilityId) = isAdminOrHigher(facilityId)
 
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role) =
-      isAdminOrHigher(organizationId)
+      isSuperAdmin() || isAdminOrHigher(organizationId)
 
   override fun canSetTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -111,6 +111,7 @@ class SystemUser(
    * manually by a system administrator.
    */
 
+  override fun canAddAnyOrganizationUser(): Boolean = true
   override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = true
   override fun canAddTerraformationContact(organizationId: OrganizationId): Boolean = true
   override fun canCountNotifications(): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -79,6 +79,7 @@ interface TerrawareUser : Principal {
    * Permission checks. Each of these returns true if the user has permission to perform the action.
    */
 
+  fun canAddAnyOrganizationUser(): Boolean
   fun canAddOrganizationUser(organizationId: OrganizationId): Boolean
   fun canAddTerraformationContact(organizationId: OrganizationId): Boolean
   fun canCountNotifications(): Boolean

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -66,5 +66,35 @@
     </p>
 </th:block>
 
+<th:block th:if="${canAddAnyOrganizationUser}">
+    <h2>Add Organization User</h2>
+
+    <p>
+        If the role is "Terraformation Contact" and the organization already has a Terraformation
+        contact, the existing contact will be replaced by the new one.
+    </p>
+
+    <form method="POST" th:action="|${prefix}/addOrganizationUser|">
+        <label for="addUserEmail">Email (user must already exist)</label>
+        <input id="addUserEmail" type="email" name="email" required />
+        <label for="addUserOrganizationId">Organization</label>
+        <select id="addUserOrganizationId" name="organizationId">
+            <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
+                    th:text="|${organization.name} (${organization.id})|">
+                My Org (123)
+            </option>
+        </select>
+        <label for="addUserRole">Role</label>
+        <select id="addUserRole" name="role">
+            <option th:each="role : ${roles}"
+                    th:value="${role.first}"
+                    th:text="${role.second}"
+                    th:selected="${role.second} == 'Admin'">
+                Some Role
+            </option>
+        </select>
+        <input type="submit" value="Add User"/>
+    </form>
+</th:block>
 </body>
 </html>

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -354,23 +354,5 @@
     document.getElementById('showMap').addEventListener('click', showMap);
 </script>
 
-<hr style="margin-top: 20px"/>
-
-<h3>Terraformation Contact</h3>
-<span th:text="|Current Terraformation Contact:  ${terraformationContact != null ? terraformationContact.email : 'none'}|">Terraformation Contact</span>
-
-<form method="POST" th:action="|${prefix}/assignTerraformationContact|" th:if="${canAssignTerraformationContact}">
-    <h4>Assign New Terraformation Contact (interim solution - until we add TW support)</h4>
-    <p>
-        The current Terraformation Contact will be removed from the org (if one exists) and the new one will be assigned.
-    </p>
-    <label for="email" style="margin-top: 20px">Enter the Terraformation Contact's <i>(@terraformation.com)</i> email:</label>
-    <input type="email" id="terraformationContactEmail" name="terraformationContactEmail" style="min-width: 300px; padding: 2px;" pattern="^\S+@terraformation\.com$">
-    <input type="hidden" name="organizationId" th:value="${organization.id}"/>
-    <input type="submit" value=" Assign Terraformation Contact "/>
-</form>
-
-<hr style="margin-top: 20px"/>
-
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1068,6 +1068,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        addAnyOrganizationUser = true,
         createDeviceManager = true,
         manageNotifications = true,
         setTestClock = true,
@@ -1177,6 +1178,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        addAnyOrganizationUser = true,
         createDeviceManager = true,
         deleteSelf = true,
         importGlobalSpeciesData = true,
@@ -1570,6 +1572,7 @@ internal class PermissionTest : DatabaseTest() {
 
     /** Checks for globally-scoped permissions. */
     fun expect(
+        addAnyOrganizationUser: Boolean = false,
         createDeviceManager: Boolean = false,
         deleteSelf: Boolean = false,
         importGlobalSpeciesData: Boolean = false,
@@ -1580,6 +1583,8 @@ internal class PermissionTest : DatabaseTest() {
         updateAppVersions: Boolean = false,
         updateDeviceTemplates: Boolean = false,
     ) {
+      assertEquals(
+          addAnyOrganizationUser, user.canAddAnyOrganizationUser(), "Can add any organization user")
       assertEquals(createDeviceManager, user.canCreateDeviceManager(), "Can create device manager")
       assertEquals(deleteSelf, user.canDeleteSelf(), "Can delete self")
       assertEquals(


### PR DESCRIPTION
Allow super-admins to add a user to any organization from the admin UI.

This replaces the previous UI for adding a Terraformation contact, which required
the super-admin to be in the organization.