### PR TITLE
SW-4329 Add facility numbers to existing identifiers

### DIFF
--- a/src/main/resources/db/migration/0200/V216__FacilityNumberInIdentifiers.sql
+++ b/src/main/resources/db/migration/0200/V216__FacilityNumberInIdentifiers.sql
@@ -1,0 +1,23 @@
+UPDATE seedbank.accessions a
+SET number = regexp_replace(
+        number,
+        '^(\d\d-1-)(\d+)$',
+        (
+            SELECT '\1' || facility_number::text || '-\2'
+            FROM facilities f
+            WHERE f.id = a.facility_id
+        )
+)
+WHERE number ~ '^\d\d-1-\d+$';
+
+UPDATE nursery.batches b
+SET batch_number = regexp_replace(
+        batch_number,
+        '^(\d\d-2-)(\d+)$',
+        (
+            SELECT '\1' || facility_number::text || '-\2'
+            FROM facilities f
+            WHERE f.id = b.facility_id
+        )
+)
+WHERE batch_number ~ '^\d\d-2-\d+$';


### PR DESCRIPTION
Update the human-readable identifiers of accessions and batches to use the new
numbering scheme that includes the facility number.

Accessions with custom numbers from CSV uploads aren't updated, just ones whose
accession numbers match the old format.

DEPLOYMENT NOTE:

This should be deployed only after the code change to start generating new-style
identifiers has been deployed, so as to avoid any old identifiers slipping through
the cracks during deployment.