### PR TITLE
SW-4361 Add internal tag for accelerator participants

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/InternalTagIds.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/InternalTagIds.kt
@@ -10,4 +10,5 @@ object InternalTagIds {
   val Reporter = InternalTagId(1)
   val Internal = InternalTagId(2)
   val Testing = InternalTagId(3)
+  val Accelerator = InternalTagId(4)
 }

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -219,7 +219,8 @@ SELECT t.id, t.name, t.description, TRUE, system_user.id, NOW(), system_user.id,
     ) AS system_user, (
         VALUES (1, 'Reporter', 'Organization must submit reports to Terraformation.'),
                (2, 'Internal', 'Terraformation-managed internal organization, not a customer.'),
-               (3, 'Testing', 'Used for internal testing; may contain invalid data.')
+               (3, 'Testing', 'Used for internal testing; may contain invalid data.'),
+               (4, 'Accelerator', 'Organization is an accelerator participant.')
     ) AS t (id, name, description)
 ON CONFLICT (id) DO UPDATE SET name = excluded.name,
                                description = excluded.description;


### PR DESCRIPTION
We're going to be adding system behavior that only applies to participants in
the Terraformation Accelerator. Add an internal tag so super-admins can indicate
which organizations are in the accelerator.

Nothing uses this new tag yet, but it will appear in the admin UI.