### PR TITLE
SW-4349 Add sub-location fields to existing payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/FacilitiesController.kt
@@ -207,14 +207,17 @@ data class CreateFacilityRequestPayload(
     @Schema(description = "Which organization this facility belongs to.")
     val organizationId: OrganizationId,
     @ArraySchema(
+        arraySchema = Schema(deprecated = true, description = "Use subLocationNames instead."))
+    val storageLocationNames: Set<String>?,
+    @ArraySchema(
         schema =
             Schema(
                 description =
-                    "For seed banks, the list of storage locations to create. If this is absent " +
-                        "or null, the system will create a default set of storage locations. If " +
-                        "it is an empty list, the seed bank will not have any storage locations. " +
-                        "Ignored for other facility types."))
-    val storageLocationNames: Set<String>?,
+                    "The list of sub-locations to create. If this is absent or null, the system " +
+                        "will create a default set of sub-locations if the facility is a seed " +
+                        "bank. If it is an empty list, the seed bank will not have any " +
+                        "sub-locations."))
+    val subLocationNames: Set<String>?,
     val timeZone: ZoneId?,
     val type: FacilityType,
 ) {
@@ -227,7 +230,7 @@ data class CreateFacilityRequestPayload(
           name = name,
           operationStartedDate = operationStartedDate,
           organizationId = organizationId,
-          subLocationNames = storageLocationNames,
+          subLocationNames = subLocationNames ?: storageLocationNames,
           timeZone = timeZone,
           type = type)
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/FacilityStore.kt
@@ -133,14 +133,12 @@ class FacilityStore(
 
       val savedModel = row.toModel()
 
-      if (newModel.type == FacilityType.SeedBank) {
-        if (newModel.subLocationNames == null) {
-          (1..3).forEach { num ->
-            createSubLocation(savedModel.id, messages.refrigeratorName(num))
-            createSubLocation(savedModel.id, messages.freezerName(num))
-          }
-        } else {
-          newModel.subLocationNames.forEach { name -> createSubLocation(savedModel.id, name) }
+      if (newModel.subLocationNames != null) {
+        newModel.subLocationNames.forEach { name -> createSubLocation(savedModel.id, name) }
+      } else if (newModel.type == FacilityType.SeedBank) {
+        (1..3).forEach { num ->
+          createSubLocation(savedModel.id, messages.refrigeratorName(num))
+          createSubLocation(savedModel.id, messages.freezerName(num))
         }
       }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/AccessionsV2Controller.kt
@@ -224,7 +224,9 @@ data class AccessionPayloadV2(
     )
     val speciesId: SpeciesId?,
     val state: AccessionStateV2,
+    @Schema(deprecated = true, description = "Use subLocation instead.")
     val storageLocation: String?,
+    val subLocation: String?,
     val subsetCount: Int?,
     @Schema(
         description =
@@ -283,6 +285,7 @@ data class AccessionPayloadV2(
       speciesId = model.speciesId,
       state = AccessionStateV2.of(model.state),
       storageLocation = model.subLocation,
+      subLocation = model.subLocation,
       subsetCount = model.subsetCount,
       subsetWeight = model.subsetWeightQuantity?.toPayload(),
       totalWithdrawnCount = model.totalWithdrawnCount,
@@ -317,7 +320,9 @@ data class CreateAccessionRequestPayloadV2(
     val source: DataSource? = null,
     val speciesId: SpeciesId? = null,
     val state: AccessionStateV2? = null,
+    @Schema(deprecated = true, description = "Use subLocation instead.")
     val storageLocation: String? = null,
+    val subLocation: String? = null,
 ) {
   fun toModel(clock: Clock): AccessionModel {
     return AccessionModel(
@@ -342,7 +347,7 @@ data class CreateAccessionRequestPayloadV2(
         source = source,
         speciesId = speciesId,
         state = state?.modelState ?: AccessionState.AwaitingCheckIn,
-        subLocation = storageLocation,
+        subLocation = subLocation ?: storageLocation,
     )
   }
 }
@@ -376,7 +381,9 @@ data class UpdateAccessionRequestPayloadV2(
     val remainingQuantity: SeedQuantityPayload? = null,
     val speciesId: SpeciesId? = null,
     val state: AccessionStateV2,
+    @Schema(deprecated = true, description = "Use subLocation instead.")
     val storageLocation: String? = null,
+    val subLocation: String? = null,
     val subsetCount: Int? = null,
     @Schema(
         description =
@@ -408,11 +415,30 @@ data class UpdateAccessionRequestPayloadV2(
           remaining = remainingQuantity?.toModel(),
           speciesId = speciesId,
           state = state.modelState,
-          subLocation = storageLocation,
+          subLocation = getNewSubLocation(model),
           subsetCount = subsetCount,
           subsetWeightQuantity = subsetWeight?.toModel(),
           totalViabilityPercent = viabilityPercent,
       )
+
+  /**
+   * Returns whichever of the two sub-location fields has a different value than the sub-location in
+   * the model, or the original value if they're all the same.
+   *
+   * This is needed in order to support the transition to the new `subLocation` field name; the
+   * client usually PUTs an updated version of whatever payload it got back from the GET endpoint,
+   * which will include both the old and new field names, but it will only have modified one of the
+   * two.
+   */
+  private fun getNewSubLocation(model: AccessionModel): String? {
+    return if (storageLocation != model.subLocation) {
+      storageLocation
+    } else {
+      // subLocation is different from model or both storageLocation and subLocation are the same
+      // as the model
+      subLocation
+    }
+  }
 }
 
 data class CreateAccessionResponsePayloadV2(val accession: AccessionPayloadV2) :

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -202,6 +202,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             speciesId = SpeciesId(1),
             state = AccessionStateV2.AwaitingProcessing,
             storageLocation = "Location 1",
+            subLocation = "Location 1",
         )
 
     // Some fields are named differently in the v2 API and the model class.
@@ -238,6 +239,23 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             AccessionCollectorsRow(stored.id, 2, "second2")),
         accessionCollectorsDao.findAll().sortedBy { it.position },
         "Collectors are stored")
+  }
+
+  @Test
+  fun `create prefers subLocation over storageLocation`() {
+    insertSubLocation(name = "Location 1")
+    insertSubLocation(name = "Location 2")
+
+    val accession =
+        CreateAccessionRequestPayloadV2(
+            facilityId = facilityId,
+            storageLocation = "Location 1",
+            subLocation = "Location 2",
+        )
+
+    val stored = store.create(accession.toModel(clock))
+
+    assertEquals("Location 2", stored.subLocation)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -78,7 +78,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   @Test
   fun `update writes all API payload fields to database`() {
     val projectId = insertProject()
-    val storageLocationName = "Test Location"
+    val subLocationName = "Test Location"
     val today = LocalDate.now(clock)
     val update =
         UpdateAccessionRequestPayloadV2(
@@ -108,7 +108,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             remainingQuantity = kilograms(15),
             speciesId = SpeciesId(1),
             state = AccessionStateV2.Drying,
-            storageLocation = storageLocationName,
+            storageLocation = subLocationName,
+            subLocation = subLocationName,
             subsetCount = 5,
             subsetWeight = grams(9),
             viabilityPercent = 15,
@@ -140,7 +141,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     }
 
     insertSpecies(1)
-    insertSubLocation(1, name = storageLocationName)
+    insertSubLocation(1, name = subLocationName)
 
     val initial = store.create(accessionModel(source = DataSource.SeedCollectorApp))
     val stored = store.updateAndFetch(update.applyToModel(initial))
@@ -210,7 +211,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `delete removes data from child tables`() {
-    val storageLocationName = "Test Location"
+    val subLocationName = "Test Location"
     val today = LocalDate.now(clock)
     val update =
         UpdateAccessionRequestPayloadV2(
@@ -228,7 +229,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             remainingQuantity = seeds(100),
             speciesId = SpeciesId(1),
             state = AccessionStateV2.InStorage,
-            storageLocation = storageLocationName,
+            storageLocation = subLocationName,
         )
 
     val viabilityTest =
@@ -242,7 +243,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             withdrawnQuantity = seeds(41))
 
     insertSpecies(1)
-    insertSubLocation(1, name = storageLocationName)
+    insertSubLocation(1, name = subLocationName)
 
     val initial = store.create(accessionModel())
     val accessionId = initial.id!!

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -171,6 +171,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
       species: String? = null,
       speciesId: SpeciesId? = null,
       state: AccessionState = AccessionState.AwaitingCheckIn,
+      subLocation: String? = null,
       withdrawals: List<WithdrawalModel> = emptyList(),
   ): AccessionModel =
       AccessionModel(
@@ -186,6 +187,7 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
           species = species,
           speciesId = speciesId,
           state = state,
+          subLocation = subLocation,
           withdrawals = withdrawals,
       )
 }


### PR DESCRIPTION
The API refers to sub-locations using the older name "storage locations." To
support making our terminology consistent, add sub-location fields to the
existing payloads that have storage location fields.

Both field names are supported for now; once the client code has been updated
to switch to the sub-location fields, the storage location fields will be removed.