### PR TITLE
Add model classes for seedling batches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/BatchService.kt
@@ -43,7 +43,7 @@ class BatchService(
 
       val quantitiesBySpecies: Map<SpeciesId, Int> =
           withdrawal.batchWithdrawals
-              .groupBy { batchStore.fetchOneById(it.batchId).speciesId!! }
+              .groupBy { batchStore.fetchOneById(it.batchId).speciesId }
               .mapValues { (_, batchWithdrawals) -> batchWithdrawals.sumOf { it.totalWithdrawn } }
 
       val deliveryId =

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -19,7 +19,6 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
-import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
@@ -28,6 +27,7 @@ import com.terraformation.backend.nursery.BatchService
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.db.WithdrawalPhotoService
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
+import com.terraformation.backend.nursery.model.ExistingBatchModel
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
 import com.terraformation.backend.tracking.api.DeliveryPayload
@@ -253,7 +253,7 @@ data class GetNurseryWithdrawalResponsePayload(
     val withdrawal: NurseryWithdrawalPayload
 ) : SuccessResponsePayload {
   constructor(
-      batches: List<BatchesRow>,
+      batches: List<ExistingBatchModel>,
       delivery: DeliveryModel?,
       withdrawal: ExistingWithdrawalModel,
   ) : this(

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.daos.UploadProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.UploadsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadsRow
-import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.UploadService
 import com.terraformation.backend.file.UploadStore
@@ -22,6 +21,7 @@ import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.i18n.toBigDecimal
 import com.terraformation.backend.importer.CsvImporter
 import com.terraformation.backend.importer.CsvValidator
+import com.terraformation.backend.nursery.model.NewBatchModel
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.NewSpeciesModel
 import jakarta.inject.Named
@@ -105,7 +105,7 @@ class BatchImporter(
     val commonName = values[1]
     val germinatingQuantity = values[2]?.toBigDecimal(locale)?.toInt() ?: 0
     val seedlingQuantity = values[3]?.toBigDecimal(locale)?.toInt() ?: 0
-    val storedDate = LocalDate.parse(values[4])!!
+    val storedDate = LocalDate.parse(values[4])
 
     val speciesId =
         speciesStore.importSpecies(
@@ -117,12 +117,11 @@ class BatchImporter(
             overwriteExisting = false)
 
     batchStore.create(
-        BatchesRow(
+        NewBatchModel(
             addedDate = storedDate,
             facilityId = facilityId,
             germinatingQuantity = germinatingQuantity,
             notReadyQuantity = seedlingQuantity,
-            organizationId = organizationId,
             readyQuantity = 0,
             speciesId = speciesId,
         ))

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
@@ -1,0 +1,90 @@
+package com.terraformation.backend.nursery.model
+
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.db.seedbank.AccessionId
+import java.time.Instant
+import java.time.LocalDate
+
+data class NewBatchModel(
+    val accessionId: AccessionId? = null,
+    val addedDate: LocalDate,
+    val batchNumber: String? = null,
+    val facilityId: FacilityId,
+    val germinatingQuantity: Int,
+    val notes: String? = null,
+    val notReadyQuantity: Int,
+    val projectId: ProjectId? = null,
+    val readyByDate: LocalDate? = null,
+    val readyQuantity: Int,
+    /**
+     * Species ID may be null if it will come from elsewhere, such as accession nursery transfer.
+     */
+    val speciesId: SpeciesId?,
+) {
+  fun toRow() =
+      BatchesRow(
+          accessionId = accessionId,
+          addedDate = addedDate,
+          batchNumber = batchNumber,
+          facilityId = facilityId,
+          germinatingQuantity = germinatingQuantity,
+          latestObservedGerminatingQuantity = germinatingQuantity,
+          latestObservedNotReadyQuantity = notReadyQuantity,
+          latestObservedReadyQuantity = readyQuantity,
+          notes = notes,
+          notReadyQuantity = notReadyQuantity,
+          projectId = projectId,
+          readyByDate = readyByDate,
+          readyQuantity = readyQuantity,
+          speciesId = speciesId,
+      )
+}
+
+data class ExistingBatchModel(
+    val accessionId: AccessionId? = null,
+    val addedDate: LocalDate,
+    val batchNumber: String,
+    val facilityId: FacilityId,
+    val germinatingQuantity: Int,
+    val id: BatchId,
+    val latestObservedGerminatingQuantity: Int,
+    val latestObservedNotReadyQuantity: Int,
+    val latestObservedReadyQuantity: Int,
+    val latestObservedTime: Instant,
+    val notes: String? = null,
+    val notReadyQuantity: Int,
+    val organizationId: OrganizationId,
+    val projectId: ProjectId? = null,
+    val readyByDate: LocalDate? = null,
+    val readyQuantity: Int,
+    val speciesId: SpeciesId,
+    val version: Int,
+) {
+  constructor(
+      row: BatchesRow
+  ) : this(
+      accessionId = row.accessionId,
+      addedDate = row.addedDate!!,
+      batchNumber = row.batchNumber!!,
+      facilityId = row.facilityId!!,
+      germinatingQuantity = row.germinatingQuantity!!,
+      id = row.id!!,
+      latestObservedGerminatingQuantity = row.latestObservedGerminatingQuantity!!,
+      latestObservedNotReadyQuantity = row.latestObservedNotReadyQuantity!!,
+      latestObservedReadyQuantity = row.latestObservedReadyQuantity!!,
+      latestObservedTime = row.latestObservedTime!!,
+      notes = row.notes,
+      notReadyQuantity = row.notReadyQuantity!!,
+      organizationId = row.organizationId!!,
+      projectId = row.projectId,
+      readyByDate = row.readyByDate,
+      readyQuantity = row.readyQuantity!!,
+      speciesId = row.speciesId!!,
+      version = row.version!!,
+  )
+}

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -6,9 +6,9 @@ import com.terraformation.backend.api.SeedBankAppEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.UserId
-import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.nursery.api.BatchPayload
+import com.terraformation.backend.nursery.model.NewBatchModel
 import com.terraformation.backend.seedbank.AccessionService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
@@ -34,7 +34,7 @@ class TransfersController(
   ): CreateNurseryTransferResponsePayload {
     val (accession, batch) =
         accessionService.createNurseryTransfer(
-            accessionId, payload.toBatchesRow(), payload.withdrawnByUserId)
+            accessionId, payload.toNewBatchModel(), payload.withdrawnByUserId)
     return CreateNurseryTransferResponsePayload(AccessionPayloadV2(accession), BatchPayload(batch))
   }
 }
@@ -60,8 +60,8 @@ data class CreateNurseryTransferRequestPayload(
                 "membership details in the organization.")
     val withdrawnByUserId: UserId? = null,
 ) {
-  fun toBatchesRow(): BatchesRow =
-      BatchesRow(
+  fun toNewBatchModel() =
+      NewBatchModel(
           addedDate = date,
           facilityId = destinationFacilityId,
           germinatingQuantity = germinatingQuantity,
@@ -69,6 +69,7 @@ data class CreateNurseryTransferRequestPayload(
           notReadyQuantity = notReadyQuantity,
           readyByDate = readyByDate,
           readyQuantity = readyQuantity,
+          speciesId = null,
       )
 }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
@@ -1,14 +1,15 @@
 package com.terraformation.backend.nursery.db.batchStore
 
+import com.terraformation.backend.nursery.model.ExistingBatchModel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class BatchStoreFetchTest : BatchStoreTest() {
   @Test
-  fun `returns database row`() {
+  fun `returns model from database row`() {
     val batchId = insertBatch(speciesId = speciesId)
 
-    val expected = batchesDao.fetchOneById(batchId)
+    val expected = ExistingBatchModel(batchesDao.fetchOneById(batchId)!!)
     val actual = store.fetchOneById(batchId)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStorePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStorePermissionTest.kt
@@ -15,7 +15,7 @@ internal class BatchStorePermissionTest : BatchStoreTest() {
     every { user.canCreateBatch(facilityId) } returns false
     every { user.canReadFacility(facilityId) } returns true
 
-    assertThrows<AccessDeniedException> { store.create(makeBatchesRow()) }
+    assertThrows<AccessDeniedException> { store.create(makeNewBatchModel()) }
   }
 
   @Test
@@ -41,8 +41,7 @@ internal class BatchStorePermissionTest : BatchStoreTest() {
     every { user.canUpdateBatch(batchId) } returns false
 
     assertThrows<AccessDeniedException> {
-      store.updateDetails(
-          batchId = batchId, version = 1, notes = null, projectId = null, readyByDate = null)
+      store.updateDetails(batchId = batchId, version = 1) { it }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -8,11 +8,11 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.model.NewBatchModel
 import io.mockk.every
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
@@ -55,21 +55,12 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateBatch(any()) } returns true
   }
 
-  protected fun makeBatchesRow() =
-      BatchesRow(
+  protected fun makeNewBatchModel() =
+      NewBatchModel(
           addedDate = LocalDate.now(clock),
-          createdBy = user.userId,
-          createdTime = clock.instant(),
           facilityId = facilityId,
           germinatingQuantity = 0,
-          latestObservedGerminatingQuantity = 0,
-          latestObservedNotReadyQuantity = 1,
-          latestObservedReadyQuantity = 2,
-          latestObservedTime = clock.instant(),
-          modifiedBy = user.userId,
-          modifiedTime = clock.instant(),
           notReadyQuantity = 1,
-          organizationId = organizationId,
           readyQuantity = 2,
           speciesId = speciesId,
       )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
@@ -34,12 +34,9 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
     val newProjectId = insertProject()
     val before = batchesDao.fetchOneById(batchId)!!
 
-    store.updateDetails(
-        batchId = batchId,
-        version = 1,
-        notes = "new notes",
-        projectId = newProjectId,
-        readyByDate = LocalDate.of(2022, 1, 1))
+    store.updateDetails(batchId, 1) {
+      it.copy(notes = "new notes", projectId = newProjectId, readyByDate = LocalDate.of(2022, 1, 1))
+    }
 
     val after = batchesDao.fetchOneById(batchId)!!
 
@@ -57,8 +54,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
   fun `can set optional values to null`() {
     val before = batchesDao.fetchOneById(batchId)!!
 
-    store.updateDetails(
-        batchId = batchId, version = 1, notes = null, projectId = null, readyByDate = null)
+    store.updateDetails(batchId, 1) { it.copy(notes = null, projectId = null, readyByDate = null) }
 
     val after = batchesDao.fetchOneById(batchId)!!
 
@@ -74,10 +70,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if version number does not match current version`() {
-    assertThrows<BatchStaleException> {
-      store.updateDetails(
-          batchId = batchId, version = 0, notes = null, projectId = null, readyByDate = null)
-    }
+    assertThrows<BatchStaleException> { store.updateDetails(batchId = batchId, version = 0) { it } }
   }
 
   @Test
@@ -87,12 +80,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
     val otherOrgProjectId = insertProject(organizationId = otherOrganizationId)
 
     assertThrows<ProjectInDifferentOrganizationException> {
-      store.updateDetails(
-          batchId = batchId,
-          version = 1,
-          notes = null,
-          projectId = otherOrgProjectId,
-          readyByDate = null)
+      store.updateDetails(batchId = batchId, version = 1) { it.copy(projectId = otherOrgProjectId) }
     }
   }
 }


### PR DESCRIPTION
In preparation for adding some new attributes to seedling batches that won't map
to single column values, add model classes to replace the internal use of the
jOOQ-generated `BatchesRow` class.