### PR TITLE
SW-4365 Carry accession ID across nursery transfers

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -655,6 +655,7 @@ class BatchStore(
         val newBatch =
             create(
                 NewBatchModel(
+                    accessionId = sourceBatch.accessionId,
                     addedDate = withdrawal.withdrawnDate,
                     batchNumber = destinationBatchNumbersBySourceBatchId[batchWithdrawal.batchId],
                     facilityId = withdrawal.destinationFacilityId,


### PR DESCRIPTION
If a batch was originally created via a nursery transfer from a seed bank, it will
have an accession ID indicating where it came from. If plants from the batch are
then transferred to a different nursery, the newly-created batch should have the
same accession ID so it can be traced back to its original seeds.