### PR TITLE
SW-4376 Add API to change batch statuses

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.nursery.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls
@@ -277,6 +278,7 @@ data class ChangeBatchStatusRequestPayload(
     val quantity: Int,
 ) {
   val germinatingQuantityToChange
+    @JsonIgnore
     get() =
         if (operation == ChangeBatchStatusOperation.GerminatingToNotReady) {
           quantity
@@ -284,6 +286,7 @@ data class ChangeBatchStatusRequestPayload(
           0
         }
   val notReadyQuantityToChange
+    @JsonIgnore
     get() =
         if (operation == ChangeBatchStatusOperation.NotReadyToReady) {
           quantity

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -113,6 +113,23 @@ class BatchesController(
 
     return getBatch(id)
   }
+
+  @ApiResponse200
+  @ApiResponse404
+  @ApiResponse412
+  @Operation(
+      summary = "Changes the statuses of seedlings in a batch.",
+      description = "There must be enough seedlings available to move to the next status.")
+  @PostMapping("/{id}/changeStatuses")
+  fun changeBatchStatuses(
+      @PathVariable("id") id: BatchId,
+      @RequestBody payload: ChangeBatchStatusRequestPayload
+  ): BatchResponsePayload {
+    batchStore.changeStatuses(
+        id, payload.germinatingQuantityToChange, payload.notReadyQuantityToChange)
+
+    return getBatch(id)
+  }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -247,5 +264,32 @@ data class UpdateBatchQuantitiesRequestPayload(
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantity: Int,
     @JsonSetter(nulls = Nulls.FAIL) val version: Int,
 )
+
+enum class ChangeBatchStatusOperation {
+  GerminatingToNotReady,
+  NotReadyToReady,
+}
+
+data class ChangeBatchStatusRequestPayload(
+    @Schema(description = "Which status change to apply.")
+    val operation: ChangeBatchStatusOperation,
+    @Schema(description = "Number of seedlings to move from one status to the next.")
+    val quantity: Int,
+) {
+  val germinatingQuantityToChange
+    get() =
+        if (operation == ChangeBatchStatusOperation.GerminatingToNotReady) {
+          quantity
+        } else {
+          0
+        }
+  val notReadyQuantityToChange
+    get() =
+        if (operation == ChangeBatchStatusOperation.NotReadyToReady) {
+          quantity
+        } else {
+          0
+        }
+}
 
 data class BatchResponsePayload(val batch: BatchPayload) : SuccessResponsePayload

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -20,7 +20,8 @@ ON CONFLICT (id) DO UPDATE SET name   = excluded.name,
 
 INSERT INTO nursery.batch_quantity_history_types (id, name)
 VALUES (1, 'Observed'),
-       (2, 'Computed')
+       (2, 'Computed'),
+       (3, 'StatusChanged')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO nursery.batch_substrates (id, name)

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -1,5 +1,6 @@
 nursery.BatchQuantityHistoryType.Computed=Computed
 nursery.BatchQuantityHistoryType.Observed=Observed
+nursery.BatchQuantityHistoryType.StatusChanged=Status Changed
 nursery.BatchSubstrate.MediaMix=Media Mix
 nursery.BatchSubstrate.Moss=Moss
 nursery.BatchSubstrate.Other=Other

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
@@ -1,0 +1,90 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
+import io.mockk.every
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
+  private val batchId = BatchId(1)
+  private val updateTime = Instant.ofEpochSecond(1000)
+
+  @BeforeEach
+  fun setUpTestBatch() {
+    insertBatch(
+        id = batchId,
+        germinatingQuantity = 10,
+        notReadyQuantity = 20,
+        readyQuantity = 30,
+        speciesId = speciesId)
+
+    clock.instant = updateTime
+  }
+
+  @Test
+  fun `updates quantities and creates history entry`() {
+    val before = batchesDao.fetchOneById(batchId)!!
+
+    store.changeStatuses(batchId, 2, 7)
+
+    val after = batchesDao.fetchOneById(batchId)!!
+
+    assertEquals(
+        before.copy(
+            germinatingQuantity = 8,
+            notReadyQuantity = 15,
+            readyQuantity = 37,
+            modifiedTime = updateTime,
+            version = 2),
+        after)
+
+    assertEquals(
+        listOf(
+            BatchQuantityHistoryRow(
+                id = BatchQuantityHistoryId(1),
+                batchId = batchId,
+                historyTypeId = BatchQuantityHistoryType.StatusChanged,
+                createdBy = user.userId,
+                createdTime = updateTime,
+                germinatingQuantity = 8,
+                notReadyQuantity = 15,
+                readyQuantity = 37,
+            )),
+        batchQuantityHistoryDao.findAll())
+  }
+
+  @Test
+  fun `does not update quantities or create history entry if no statuses are changed`() {
+    val before = batchesDao.fetchOneById(batchId)
+
+    store.changeStatuses(batchId, 0, 0)
+
+    assertEquals(before, batchesDao.fetchOneById(batchId))
+    assertEquals(emptyList<Any>(), batchQuantityHistoryDao.findAll(), "Quantity history")
+  }
+
+  @Test
+  fun `throws exception if no permission to update batch`() {
+    every { user.canUpdateBatch(any()) } returns false
+
+    assertThrows<AccessDeniedException> { store.changeStatuses(batchId, 1, 1) }
+  }
+
+  @Test
+  fun `throws exception if not enough seedlings to satisfy request`() {
+    assertThrows<BatchInventoryInsufficientException>("Germinating") {
+      store.changeStatuses(batchId, 50, 0)
+    }
+    assertThrows<BatchInventoryInsufficientException>("Not Ready") {
+      store.changeStatuses(batchId, 0, 50)
+    }
+  }
+}


### PR DESCRIPTION
Calculating germination and loss rates will require that we distinguish between
the user overwriting the quantities of a batch and the user moving seedlings from
one status to another.

Add a new API endpoint `POST /api/v1/nursery/batches/{id}/changeStatuses` to move
seedlings between statuses. It causes a new type of quantity history entry to be
recorded, which will allow the germination and loss rate calculations to treat
status changes correctly.