### PR TITLE
Record withdrawal IDs for incoming transfers

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -637,6 +637,8 @@ class BatchStore(
    * original batches. If the destination facility already has a batch with that batch number, the
    * withdrawn quantity is added to the existing batch.
    *
+   * @param withdrawalId Withdrawal ID to include in the batch quantity history records of the new
+   *   batches. The withdrawal ID, if any, in [withdrawal] is ignored.
    * @return A map of the originating batch IDs to the destination batch IDs.
    */
   private fun createDestinationBatches(

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -108,7 +108,13 @@ class BatchStore(
     return withdrawalsRow.toModel(batchWithdrawalsRows)
   }
 
-  fun create(newModel: NewBatchModel): ExistingBatchModel {
+  /**
+   * Creates a new seedling batch.
+   *
+   * @param withdrawalId If this batch is being created by a transfer from another nursery, the ID
+   *   of the withdrawal that is creating it.
+   */
+  fun create(newModel: NewBatchModel, withdrawalId: WithdrawalId? = null): ExistingBatchModel {
     val facility =
         facilitiesDao.fetchOneById(newModel.facilityId)
             ?: throw FacilityNotFoundException(newModel.facilityId)
@@ -172,7 +178,8 @@ class BatchStore(
           rowWithDefaults.germinatingQuantity!!,
           rowWithDefaults.notReadyQuantity!!,
           rowWithDefaults.readyQuantity!!,
-          BatchQuantityHistoryType.Observed)
+          BatchQuantityHistoryType.Observed,
+          withdrawalId)
 
       updateSubLocations(
           rowWithDefaults.id!!, newModel.facilityId, emptySet(), newModel.subLocationIds)
@@ -514,7 +521,7 @@ class BatchStore(
       val withdrawalId = withdrawalsRow.id!!
 
       val destinationBatchIds: Map<BatchId, BatchId> =
-          createDestinationBatches(withdrawal, readyByDate)
+          createDestinationBatches(withdrawalId, withdrawal, readyByDate)
 
       val batchWithdrawalsRows =
           withdrawal.batchWithdrawals
@@ -633,6 +640,7 @@ class BatchStore(
    * @return A map of the originating batch IDs to the destination batch IDs.
    */
   private fun createDestinationBatches(
+      withdrawalId: WithdrawalId,
       withdrawal: WithdrawalModel<*>,
       readyByDate: LocalDate?
   ): Map<BatchId, BatchId> {
@@ -680,7 +688,7 @@ class BatchStore(
             destinationBatch.notReadyQuantity!! + batchWithdrawal.notReadyQuantityWithdrawn,
             destinationBatch.readyQuantity!! + batchWithdrawal.readyQuantityWithdrawn,
             BatchQuantityHistoryType.Computed,
-            withdrawal.id,
+            withdrawalId,
         )
 
         batchWithdrawal.batchId to destinationBatch.id!!
@@ -697,7 +705,9 @@ class BatchStore(
                     notReadyQuantity = batchWithdrawal.notReadyQuantityWithdrawn,
                     readyByDate = readyByDate,
                     readyQuantity = batchWithdrawal.readyQuantityWithdrawn,
-                    speciesId = sourceBatch.speciesId))
+                    speciesId = sourceBatch.speciesId,
+                ),
+                withdrawalId)
 
         batchWithdrawal.batchId to newBatch.id
       }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -643,7 +643,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
               BatchQuantityHistoryRow(
                   historyTypeId = BatchQuantityHistoryType.Observed,
                   createdBy = user.userId,
-                  createdTime = withdrawalTime)
+                  createdTime = withdrawalTime,
+                  withdrawalId = withdrawal.id)
           val originBatchHistoryRow =
               BatchQuantityHistoryRow(
                   historyTypeId = BatchQuantityHistoryType.Computed,
@@ -870,7 +871,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       historyTypeId = BatchQuantityHistoryType.Observed,
                       germinatingQuantity = 1,
                       notReadyQuantity = 2,
-                      readyQuantity = 3),
+                      readyQuantity = 3,
+                      withdrawalId = firstWithdrawal.id),
                   BatchQuantityHistoryRow(
                       batchId = newBatch.id!!,
                       createdBy = user.userId,
@@ -878,7 +880,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       historyTypeId = BatchQuantityHistoryType.Computed,
                       germinatingQuantity = 1 + 4,
                       notReadyQuantity = 2 + 5,
-                      readyQuantity = 3 + 6),
+                      readyQuantity = 3 + 6,
+                      withdrawalId = secondWithdrawal.id),
                   BatchQuantityHistoryRow(
                       batchId = species1Batch1Id,
                       createdBy = user.userId,


### PR DESCRIPTION
Previously, we only included the withdrawal ID on the batch quantity history
entries for the originating batch, but not for the destination batch; there
was thus no easy way to tell which withdrawal was responsible for a quantity
change.

Update the withdrawal code to include the withdrawal ID in the quantity
history on both sides of nursery transfers.