### PR TITLE
SW-4407 Fix adding user to org from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.customer.event.FacilityIdleEvent
 import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
 import com.terraformation.backend.customer.event.UserAddedToTerrawareEvent
 import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.daily.NotificationJobFinishedEvent
 import com.terraformation.backend.daily.NotificationJobStartedEvent
@@ -72,6 +73,7 @@ class EmailNotificationService(
     private val organizationStore: OrganizationStore,
     private val parentStore: ParentStore,
     private val plantingSiteStore: PlantingSiteStore,
+    private val systemUser: SystemUser,
     private val userStore: UserStore,
     private val webAppUrls: WebAppUrls,
 ) {
@@ -172,7 +174,7 @@ class EmailNotificationService(
     val user =
         userStore.fetchOneById(event.userId) as? IndividualUser
             ?: throw IllegalArgumentException("User must be an individual user")
-    val organization = organizationStore.fetchOneById(event.organizationId)
+    val organization = systemUser.run { organizationStore.fetchOneById(event.organizationId) }
 
     val organizationHomeUrl = webAppUrls.fullOrganizationHome(event.organizationId).toString()
 
@@ -190,7 +192,7 @@ class EmailNotificationService(
     val user =
         userStore.fetchOneById(event.userId) as? IndividualUser
             ?: throw IllegalArgumentException("User must be an individual user")
-    val organization = organizationStore.fetchOneById(event.organizationId)
+    val organization = systemUser.run { organizationStore.fetchOneById(event.organizationId) }
 
     val terrawareRegistrationUrl =
         webAppUrls.terrawareRegistrationUrl(event.organizationId, user.email).toString()

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.FacilityIdleEvent
 import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
 import com.terraformation.backend.customer.event.UserAddedToTerrawareEvent
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
@@ -171,6 +172,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             organizationStore,
             parentStore,
             plantingSiteStore,
+            SystemUser(usersDao),
             userStore,
             messages,
             webAppUrls)

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.customer.model.OrganizationModel
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.NotificationJobFinishedEvent
 import com.terraformation.backend.daily.NotificationJobSucceededEvent
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -88,6 +89,7 @@ internal class EmailNotificationServiceTest {
   private val parentStore: ParentStore = mockk()
   private val plantingSiteStore: PlantingSiteStore = mockk()
   private val sender: EmailSender = mockk()
+  private val systemUser: SystemUser = SystemUser(mockk())
   private val user: IndividualUser = mockk()
   private val userStore: UserStore = mockk()
 
@@ -112,6 +114,7 @@ internal class EmailNotificationServiceTest {
           organizationStore,
           parentStore,
           plantingSiteStore,
+          systemUser,
           userStore,
           webAppUrls)
 


### PR DESCRIPTION
Commit 7c9a28a introduced the ability for a super-admin to add a user to any
organization without the super-admin having to be a member of the organization.
Unfortunately, this would fail when the system tried to generate in-app and
email notifications to tell the user they'd been added.

For now, switch to the system user when generating these notifications. We will be
revamping the permission system for super-admins in the near future, at which
point we'll replace this with something more robust.