### PR TITLE
Ignore no-op batch quantity edits

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -389,6 +389,13 @@ class BatchStore(
 
     requirePermissions { updateBatch(batchId) }
 
+    val batch = fetchOneById(batchId)
+    if (batch.germinatingQuantity == germinating &&
+        batch.notReadyQuantity == notReady &&
+        batch.readyQuantity == ready) {
+      return
+    }
+
     dslContext.transaction { _ ->
       val successFunc = { newVersion: Int ->
         insertQuantityHistoryRow(

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
@@ -102,6 +102,26 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
   }
 
   @Test
+  fun `does nothing if quantities are the same as the current values`() {
+    val before =
+        batchesDao
+            .fetchOneById(batchId)!!
+            .copy(germinatingQuantity = 1, notReadyQuantity = 2, readyQuantity = 3)
+    batchesDao.update(before)
+
+    store.updateQuantities(
+        batchId = batchId,
+        version = 1,
+        germinating = 1,
+        notReady = 2,
+        ready = 3,
+        historyType = BatchQuantityHistoryType.Observed)
+
+    assertEquals(before, batchesDao.fetchOneById(batchId))
+    assertEquals(emptyList<Any>(), batchQuantityHistoryDao.findAll(), "Quantity history")
+  }
+
+  @Test
   fun `throws exception if version number does not match current version`() {
     assertThrows<BatchStaleException> {
       store.updateQuantities(


### PR DESCRIPTION
The web app has a single UI where both the non-quantity-related details and the
quantities can be edited, and when the user hits the save button, the app
updates both the details and the quantities even if the quantities didn't
actually change.

Currently, this results in a manual edit being recorded in the batch's quantity
history, which will show up as a line item in the history view once that's
implemented. Since the user didn't actually change the quantities, the line item
will be meaningless.

Add logic to detect and ignore no-op quantity edits.