### PR TITLE
Return scheduled 'endDate' of observation in API response results payload 

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -674,6 +674,7 @@ data class ObservationResultsPayload(
             "Estimated total number of live plants at the site, based on the estimated planting " +
                 "density and site size. Only present if all the subzones in the site have been " +
                 "marked as having completed planting.")
+    val endDate: LocalDate,
     val estimatedPlants: Int?,
     @Schema(
         description =
@@ -698,6 +699,7 @@ data class ObservationResultsPayload(
       model: ObservationResultsModel
   ) : this(
       completedTime = model.completedTime,
+      endDate = model.endDate,
       estimatedPlants = model.estimatedPlants,
       mortalityRate = model.mortalityRate,
       observationId = model.observationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -425,6 +425,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
     return dslContext
         .select(
             OBSERVATIONS.COMPLETED_TIME,
+            OBSERVATIONS.END_DATE,
             OBSERVATIONS.ID,
             OBSERVATIONS.PLANTING_SITE_ID,
             OBSERVATIONS.START_DATE,
@@ -466,6 +467,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
           ObservationResultsModel(
               completedTime = record[OBSERVATIONS.COMPLETED_TIME],
+              endDate = record[OBSERVATIONS.END_DATE.asNonNullable()],
               estimatedPlants = estimatedPlants?.toInt(),
               mortalityRate = mortalityRate,
               observationId = record[OBSERVATIONS.ID.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -162,6 +162,7 @@ data class ObservationResultsModel(
      * and site size. Only present if all the subzones in the site have been marked as having
      * completed planting.
      */
+    val endDate: LocalDate,
     val estimatedPlants: Int?,
     /**
      * Percentage of plants of all species that were dead in this site's permanent monitoring plots.


### PR DESCRIPTION
- Populated 'endDate' in ObservationResultsModel
- This will be [shown](https://terraformation.atlassian.net/browse/SW-3999) in the observation results table