### PR TITLE
Add totalWithdrawn to batch payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -246,6 +246,7 @@ data class BatchPayload(
     val subLocationIds: Set<SubLocationId>,
     val substrate: BatchSubstrate?,
     val substrateNotes: String?,
+    val totalWithdrawn: Int,
     val treatment: SeedTreatment?,
     val treatmentNotes: String?,
     @Schema(
@@ -277,6 +278,7 @@ data class BatchPayload(
       subLocationIds = model.subLocationIds,
       substrate = model.substrate,
       substrateNotes = model.substrateNotes,
+      totalWithdrawn = model.totalWithdrawn,
       treatment = model.treatment,
       treatmentNotes = model.treatmentNotes,
       version = model.version,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
@@ -83,6 +83,7 @@ data class ExistingBatchModel(
     val subLocationIds: Set<SubLocationId> = emptySet(),
     val substrate: BatchSubstrate? = null,
     val substrateNotes: String? = null,
+    val totalWithdrawn: Int,
     val treatment: SeedTreatment? = null,
     val treatmentNotes: String? = null,
     val version: Int,
@@ -90,6 +91,7 @@ data class ExistingBatchModel(
   constructor(
       row: BatchesRow,
       subLocationIds: Set<SubLocationId> = emptySet(),
+      totalWithdrawn: Int,
   ) : this(
       accessionId = row.accessionId,
       addedDate = row.addedDate!!,
@@ -114,6 +116,7 @@ data class ExistingBatchModel(
       subLocationIds = subLocationIds,
       substrate = row.substrateId,
       substrateNotes = row.substrateNotes,
+      totalWithdrawn = totalWithdrawn,
       treatment = row.treatmentId,
       treatmentNotes = row.treatmentNotes,
       version = row.version!!,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -75,7 +75,7 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
             substrateNotes = "My substrate",
             treatmentId = SeedTreatment.Chemical,
             version = 1)
-    val expectedModel = ExistingBatchModel(expectedRow, setOf(subLocationId1, subLocationId2))
+    val expectedModel = ExistingBatchModel(expectedRow, setOf(subLocationId1, subLocationId2), 0)
 
     val expectedQuantityHistory =
         listOf(

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
@@ -1,15 +1,75 @@
 package com.terraformation.backend.nursery.db.batchStore
 
+import com.terraformation.backend.db.default_schema.SeedTreatment
+import com.terraformation.backend.db.nursery.BatchSubstrate
+import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.nursery.model.ExistingBatchModel
+import java.time.Instant
+import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class BatchStoreFetchTest : BatchStoreTest() {
   @Test
   fun `returns model from database row`() {
-    val batchId = insertBatch(speciesId = speciesId)
+    val batchId =
+        insertBatch(
+            BatchesRow(
+                notes = "Notes",
+                substrateId = BatchSubstrate.Moss,
+                substrateNotes = "Substrate Notes",
+                treatmentId = SeedTreatment.Chemical,
+                treatmentNotes = "Treatment Notes",
+            ),
+            batchNumber = "23-2-1-008",
+            germinatingQuantity = 64,
+            notReadyQuantity = 128,
+            readyByDate = LocalDate.of(2023, 6, 7),
+            readyQuantity = 256,
+            speciesId = speciesId,
+        )
 
-    val expected = ExistingBatchModel(batchesDao.fetchOneById(batchId)!!)
+    val subLocationId1 = insertSubLocation()
+    insertBatchSubLocation()
+    val subLocationId2 = insertSubLocation()
+    insertBatchSubLocation()
+
+    insertWithdrawal()
+    insertBatchWithdrawal(
+        germinatingQuantityWithdrawn = 1, notReadyQuantityWithdrawn = 2, readyQuantityWithdrawn = 4)
+    insertWithdrawal()
+    insertBatchWithdrawal(
+        germinatingQuantityWithdrawn = 8,
+        notReadyQuantityWithdrawn = 16,
+        readyQuantityWithdrawn = 32)
+
+    val expected =
+        ExistingBatchModel(
+            addedDate = LocalDate.EPOCH,
+            batchNumber = "23-2-1-008",
+            facilityId = facilityId,
+            germinatingQuantity = 64,
+            id = batchId,
+            latestObservedGerminatingQuantity = 64,
+            latestObservedNotReadyQuantity = 128,
+            latestObservedReadyQuantity = 256,
+            latestObservedTime = Instant.EPOCH,
+            lossRate = 0,
+            notes = "Notes",
+            notReadyQuantity = 128,
+            organizationId = organizationId,
+            readyByDate = LocalDate.of(2023, 6, 7),
+            readyQuantity = 256,
+            speciesId = speciesId,
+            subLocationIds = setOf(subLocationId1, subLocationId2),
+            substrate = BatchSubstrate.Moss,
+            substrateNotes = "Substrate Notes",
+            treatment = SeedTreatment.Chemical,
+            treatmentNotes = "Treatment Notes",
+            totalWithdrawn = 63,
+            version = 1,
+        )
+
     val actual = store.fetchOneById(batchId)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -264,6 +264,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
                 readyByDate = batchSlot.captured.readyByDate,
                 readyQuantity = batchSlot.captured.readyQuantity,
                 speciesId = batchSlot.captured.speciesId ?: SpeciesId(1),
+                totalWithdrawn = 0,
                 version = 1,
             )
           }


### PR DESCRIPTION
Calculate the total number of seedlings withdrawn from a batch and return it along
with the other batch details so it can be shown in the web app.