### PR TITLE
SW-4418 Aggregate germination and loss rates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
@@ -39,11 +39,12 @@ data class SpeciesSummaryNurseryPayload(
 
 data class SpeciesSummaryPayload(
     val germinatingQuantity: Long,
+    val germinationRate: Int?,
     @Schema(
         description = "Percentage of current and past inventory that was withdrawn due to death.",
         minimum = "0",
         maximum = "100")
-    val lossRate: Int,
+    val lossRate: Int?,
     val notReadyQuantity: Long,
     val nurseries: List<SpeciesSummaryNurseryPayload>,
     val readyQuantity: Long,
@@ -60,6 +61,7 @@ data class SpeciesSummaryPayload(
       summary: SpeciesSummary
   ) : this(
       germinatingQuantity = summary.germinatingQuantity,
+      germinationRate = summary.germinationRate,
       lossRate = summary.lossRate,
       notReadyQuantity = summary.notReadyQuantity,
       nurseries = summary.nurseries.map { SpeciesSummaryNurseryPayload(it) },

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -267,14 +267,20 @@ class BatchStore(
             .filter { it.value1() == WithdrawalPurpose.Dead }
             .sumOf { it.value2().toLong() }
 
-    val totalIncludingWithdrawn = totalWithdrawn + (inventory?.totalQuantity ?: 0)
-    val lossRate =
-        if (totalIncludingWithdrawn > 0) {
-          // Round to nearest integer percentage.
-          (totalDead * 100 + totalIncludingWithdrawn / 2) / totalIncludingWithdrawn
-        } else {
-          0
-        }
+    val (germinationRate: Double?, lossRate: Double?) =
+        dslContext
+            .select(
+                DSL.sum(BATCHES.TOTAL_GERMINATED)
+                    .times(100.0)
+                    .div(DSL.sum(BATCHES.TOTAL_GERMINATION_CANDIDATES))
+                    .cast(Double::class.java),
+                DSL.sum(BATCHES.TOTAL_LOST)
+                    .times(100.0)
+                    .div(DSL.sum(BATCHES.TOTAL_LOSS_CANDIDATES))
+                    .cast(Double::class.java))
+            .from(BATCHES)
+            .where(BATCHES.SPECIES_ID.eq(speciesId))
+            .fetchOne()!!
 
     val nurseries =
         dslContext
@@ -288,7 +294,8 @@ class BatchStore(
 
     return SpeciesSummary(
         germinatingQuantity = inventory?.germinatingQuantity ?: 0,
-        lossRate = lossRate.toInt(),
+        germinationRate = germinationRate?.roundToInt(),
+        lossRate = lossRate?.roundToInt(),
         notReadyQuantity = inventory?.notReadyQuantity ?: 0,
         nurseries = nurseries,
         readyQuantity = inventory?.readyQuantity ?: 0,
@@ -949,13 +956,24 @@ class BatchStore(
             .select(
                 DSL.sum(BATCHES.GERMINATING_QUANTITY),
                 DSL.sum(BATCHES.NOT_READY_QUANTITY),
-                DSL.sum(BATCHES.READY_QUANTITY))
+                DSL.sum(BATCHES.READY_QUANTITY),
+                DSL.sum(BATCHES.TOTAL_GERMINATED)
+                    .times(100.0)
+                    .div(DSL.sum(BATCHES.TOTAL_GERMINATION_CANDIDATES))
+                    .cast(Double::class.java),
+                DSL.sum(BATCHES.TOTAL_LOST)
+                    .times(100.0)
+                    .div(DSL.sum(BATCHES.TOTAL_LOSS_CANDIDATES))
+                    .cast(Double::class.java),
+            )
             .from(BATCHES)
             .where(BATCHES.FACILITY_ID.eq(facilityId))
             .fetchOne()
 
     return NurseryStats(
         facilityId = facilityId,
+        germinationRate = inventoryTotals?.value4()?.roundToInt(),
+        lossRate = inventoryTotals?.value5()?.roundToInt(),
         totalGerminating = inventoryTotals?.value1()?.toLong() ?: 0L,
         totalNotReady = inventoryTotals?.value2()?.toLong() ?: 0L,
         totalReady = inventoryTotals?.value3()?.toLong() ?: 0L,
@@ -1115,6 +1133,9 @@ class BatchStore(
         latestEvent[BATCH_QUANTITY_HISTORY.NOT_READY_QUANTITY]!! +
             latestEvent[BATCH_QUANTITY_HISTORY.READY_QUANTITY]!!
 
+    val totalGerminated =
+        currentNotReadyAndReady + totalWithdrawnNotReadyAndReady - initialNotReady - initialReady
+    val totalGerminationCandidates = initialGerminating - totalNonDeadGerminating
     val germinationRate: Int? =
         if (initialGerminating > 0 &&
             currentGerminating == 0 &&
@@ -1122,24 +1143,19 @@ class BatchStore(
             !hasManualNotReadyEdit &&
             !hasManualReadyEdit &&
             !hasAdditionalIncomingTransfers) {
-          val numerator =
-              currentNotReadyAndReady + totalWithdrawnNotReadyAndReady -
-                  initialNotReady -
-                  initialReady
-          val denominator = initialGerminating - totalNonDeadGerminating
-
-          (100.0 * numerator / denominator).roundToInt()
+          (100.0 * totalGerminated / totalGerminationCandidates).roundToInt()
         } else {
           null
         }
 
-    val lossRateDenominator = totalOutplantAndDeadNotReadyAndReady + currentNotReadyAndReady
+    val totalLost = totalDeadNotReadyAndReady
+    val totalLossCandidates = totalOutplantAndDeadNotReadyAndReady + currentNotReadyAndReady
     val lossRate: Int? =
-        if (lossRateDenominator > 0 &&
+        if (totalLossCandidates > 0 &&
             !hasManualNotReadyEdit &&
             !hasManualReadyEdit &&
             !hasAdditionalIncomingTransfers) {
-          (100.0 * totalDeadNotReadyAndReady / lossRateDenominator).roundToInt()
+          (100.0 * totalLost / totalLossCandidates).roundToInt()
         } else {
           null
         }
@@ -1147,7 +1163,13 @@ class BatchStore(
     dslContext
         .update(BATCHES)
         .set(BATCHES.GERMINATION_RATE, germinationRate)
+        .set(BATCHES.TOTAL_GERMINATED, germinationRate?.let { totalGerminated })
+        .set(
+            BATCHES.TOTAL_GERMINATION_CANDIDATES,
+            germinationRate?.let { totalGerminationCandidates })
         .set(BATCHES.LOSS_RATE, lossRate)
+        .set(BATCHES.TOTAL_LOST, lossRate?.let { totalLost })
+        .set(BATCHES.TOTAL_LOSS_CANDIDATES, lossRate?.let { totalLossCandidates })
         .where(BATCHES.ID.eq(batchId))
         .execute()
   }

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
@@ -7,6 +7,8 @@ import kotlin.math.roundToInt
 /** Aggregated statistics for a nursery. Totals are across all batches and withdrawals. */
 data class NurseryStats(
     val facilityId: FacilityId,
+    val germinationRate: Int?,
+    val lossRate: Int?,
     val totalGerminating: Long,
     val totalNotReady: Long,
     val totalReady: Long,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/SpeciesSummary.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/SpeciesSummary.kt
@@ -5,7 +5,8 @@ import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 
 data class SpeciesSummary(
     val germinatingQuantity: Long,
-    val lossRate: Int,
+    val germinationRate: Int?,
+    val lossRate: Int?,
     val notReadyQuantity: Long,
     val nurseries: List<FacilitiesRow>,
     val readyQuantity: Long,

--- a/src/main/resources/db/migration/0200/V224__BatchRateTotals.sql
+++ b/src/main/resources/db/migration/0200/V224__BatchRateTotals.sql
@@ -1,0 +1,4 @@
+ALTER TABLE nursery.batches ADD COLUMN total_germinated INTEGER;
+ALTER TABLE nursery.batches ADD COLUMN total_germination_candidates INTEGER;
+ALTER TABLE nursery.batches ADD COLUMN total_lost INTEGER;
+ALTER TABLE nursery.batches ADD COLUMN total_loss_candidates INTEGER;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -261,6 +261,10 @@ COMMENT ON COLUMN nursery.batches.organization_id IS 'Which organization owns th
 COMMENT ON COLUMN nursery.batches.ready_by_date IS 'User-supplied estimate of when the batch will be ready for planting.';
 COMMENT ON COLUMN nursery.batches.ready_quantity IS 'Number of ready-for-planting seedlings currently available in inventory. Withdrawals cause this to decrease.';
 COMMENT ON COLUMN nursery.batches.species_id IS 'Species of the batch''s plants. Must be under the same organization as the facility ID (enforced in application code).';
+COMMENT ON COLUMN nursery.batches.total_germinated IS 'Total number of seedlings that have moved from Germinating to Not Ready status over the lifetime of the batch. This is the numerator for the germination rate calculation.';
+COMMENT ON COLUMN nursery.batches.total_germination_candidates IS 'Total number of seedlings that have been candidates for moving from Germinating to Not Ready status. This includes seedlings that are already germinated and germinating seedlings that were withdrawn as Dead, but does not include germinating seedlings that were withdrawn for other reasons. This is the denominator for the germination rate calculation.';
+COMMENT ON COLUMN nursery.batches.total_loss_candidates IS 'Total number of non-germinating (Not Ready and Ready) seedlings that have been candidates for being withdrawn as dead. This includes seedlings that are still in the batch, seedlings that were withdrawn for outplanting, and seedlings that were already withdrawn as dead, but does not include germinating seedlings or seedlings that were withdrawn for other reasons. This is the denominator for the loss rate calculation.';
+COMMENT ON COLUMN nursery.batches.total_lost IS 'Total number of non-germinating (Not Ready and Ready) seedlings that have been withdrawn as Dead. This is the numerator for the loss rate calculation.';
 COMMENT ON COLUMN nursery.batches.version IS 'Increases by 1 each time the batch is modified. Used to detect when clients have stale data about batches.';
 
 COMMENT ON TABLE nursery.withdrawal_photos IS 'Linking table between `withdrawals` and `files`.';

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
@@ -42,6 +42,9 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
             germinatingQuantity = 8,
             notReadyQuantity = 15,
             readyQuantity = 37,
+            totalLost = 0,
+            // moved 2 seeds from germinating to not-ready
+            totalLossCandidates = 52,
             modifiedTime = updateTime,
             version = 2),
         after)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -102,9 +102,28 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
   @Test
   fun `species summary is updated to reflect deleted batch`() {
     // This batch is not deleted
-    insertBatch(germinatingQuantity = 100, notReadyQuantity = 200, readyQuantity = 300)
+    insertBatch(
+        germinatingQuantity = 100,
+        germinationRate = 50,
+        totalGerminationCandidates = 50,
+        totalGerminated = 25,
+        lossRate = 25,
+        totalLossCandidates = 100,
+        totalLost = 25,
+        notReadyQuantity = 200,
+        readyQuantity = 300)
 
-    val batchId = insertBatch(germinatingQuantity = 1, notReadyQuantity = 2, readyQuantity = 3)
+    val batchId =
+        insertBatch(
+            germinatingQuantity = 1,
+            germinationRate = 100,
+            totalGerminationCandidates = 10,
+            totalGerminated = 10,
+            lossRate = 0,
+            totalLossCandidates = 100,
+            totalLost = 0,
+            notReadyQuantity = 2,
+            readyQuantity = 3)
     insertWithdrawal(purpose = WithdrawalPurpose.Dead)
     insertBatchWithdrawal(
         germinatingQuantityWithdrawn = 10,
@@ -114,9 +133,10 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
     val summaryBeforeDelete =
         SpeciesSummary(
             germinatingQuantity = 101,
+            germinationRate = 58,
             notReadyQuantity = 202,
             readyQuantity = 303,
-            lossRate = 9,
+            lossRate = 13,
             nurseries = listOf(FacilitiesRow(id = facilityId, name = "Nursery")),
             speciesId = speciesId,
             totalDead = 50,
@@ -130,9 +150,10 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
     assertEquals(
         SpeciesSummary(
             germinatingQuantity = 100,
+            germinationRate = 50,
             notReadyQuantity = 200,
             readyQuantity = 300,
-            lossRate = 0,
+            lossRate = 25,
             nurseries = summaryBeforeDelete.nurseries,
             speciesId = speciesId,
             totalDead = 0,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
@@ -23,14 +23,20 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
             speciesId = speciesId,
             germinatingQuantity = 1,
             notReadyQuantity = 2,
-            readyQuantity = 3)
+            readyQuantity = 3,
+            totalGerminated = 100,
+            totalGerminationCandidates = 200,
+            totalLost = 300,
+            totalLossCandidates = 400)
     val batchId2 =
         insertBatch(
             facilityId = facilityId,
             speciesId = speciesId2,
             germinatingQuantity = 4,
             notReadyQuantity = 5,
-            readyQuantity = 6)
+            readyQuantity = 6,
+            totalLost = 500,
+            totalLossCandidates = 600)
 
     insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.OutPlant)
     insertBatchWithdrawal(
@@ -75,7 +81,11 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
         speciesId = speciesId,
         germinatingQuantity = 7,
         notReadyQuantity = 8,
-        readyQuantity = 9)
+        readyQuantity = 9,
+        totalGerminated = 700,
+        totalGerminationCandidates = 800,
+        totalLost = 900,
+        totalLossCandidates = 1000)
     insertWithdrawal(facilityId = otherNurseryId, purpose = WithdrawalPurpose.OutPlant)
     insertBatchWithdrawal(
         germinatingQuantityWithdrawn = 28,
@@ -91,6 +101,8 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
     val expected =
         NurseryStats(
             facilityId = facilityId,
+            germinationRate = 50,
+            lossRate = 80,
             totalGerminating = 1 + 4,
             totalNotReady = 2 + 5,
             totalReady = 3 + 6,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -25,35 +24,12 @@ internal class BatchStoreSpeciesSummaryTest : BatchStoreTest() {
   }
 
   @Test
-  fun `does not include germinating quantities in loss rate`() {
-    insertBatch(
-        germinatingQuantity = 10,
-        notReadyQuantity = 1,
-        readyQuantity = 1,
-        speciesId = speciesId,
-    )
-    insertWithdrawal(purpose = WithdrawalPurpose.Dead)
-    insertBatchWithdrawal(
-        germinatingQuantityWithdrawn = 20,
-        notReadyQuantityWithdrawn = 2,
-        readyQuantityWithdrawn = 3,
-    )
-
-    val summary = store.getSpeciesSummary(speciesId)
-
-    // 5 dead withdrawals / 7 total past + current seedlings = 71.4%
-    assertEquals(71, summary.lossRate, "Loss rate")
-  }
-
-  @Test
   fun `rounds loss rate to nearest integer`() {
-    insertBatch(speciesId = speciesId, readyQuantity = 197)
-    insertWithdrawal(purpose = WithdrawalPurpose.Dead)
-    insertBatchWithdrawal(notReadyQuantityWithdrawn = 3)
+    insertBatch(readyQuantity = 197, totalLost = 306, totalLossCandidates = 1000)
 
     val summary = store.getSpeciesSummary(speciesId)
 
-    assertEquals(2, summary.lossRate, "Should round 1.5% up to 2%")
+    assertEquals(31, summary.lossRate, "Should round 30.6% up to 31%")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
@@ -46,6 +46,8 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
             latestObservedReadyQuantity = 3,
             latestObservedTime = updateTime,
             modifiedTime = updateTime,
+            totalLost = 0,
+            totalLossCandidates = 5,
             version = 2),
         after)
   }
@@ -69,6 +71,8 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
             germinatingQuantity = 1,
             notReadyQuantity = 2,
             readyQuantity = 3,
+            totalLost = 0,
+            totalLossCandidates = 5,
             modifiedTime = updateTime,
             version = 2),
         after)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -46,21 +46,27 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
         batchNumber = "21-2-1-011",
         germinatingQuantity = 10,
         notReadyQuantity = 20,
-        readyQuantity = 30)
+        readyQuantity = 30,
+        totalLost = 0,
+        totalLossCandidates = 20 + 30)
     insertBatch(
         id = species1Batch2Id,
         speciesId = speciesId,
         batchNumber = "21-2-1-012",
         germinatingQuantity = 40,
         notReadyQuantity = 50,
-        readyQuantity = 60)
+        readyQuantity = 60,
+        totalLost = 0,
+        totalLossCandidates = 50 + 60)
     insertBatch(
         id = species2Batch1Id,
         speciesId = speciesId2,
         batchNumber = "21-2-1-021",
         germinatingQuantity = 70,
         notReadyQuantity = 80,
-        readyQuantity = 90)
+        readyQuantity = 90,
+        totalLost = 0,
+        totalLossCandidates = 80 + 90)
   }
 
   @Test
@@ -103,23 +109,26 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
           assertEquals(
               listOf(
                   species1Batch1.copy(
-                      germinatingQuantity = 9,
-                      notReadyQuantity = 18,
-                      readyQuantity = 27,
+                      germinatingQuantity = 10 - 1,
+                      notReadyQuantity = 20 - 2,
+                      readyQuantity = 30 - 3,
+                      totalLossCandidates = 20 + 30 - 2 - 3,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
                   species1Batch2.copy(
-                      germinatingQuantity = 36,
-                      notReadyQuantity = 45,
-                      readyQuantity = 54,
+                      germinatingQuantity = 40 - 4,
+                      notReadyQuantity = 50 - 5,
+                      readyQuantity = 60 - 6,
+                      totalLossCandidates = 50 + 60 - 5 - 6,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
                   species2Batch1.copy(
-                      germinatingQuantity = 63,
-                      notReadyQuantity = 72,
-                      readyQuantity = 81,
+                      germinatingQuantity = 70 - 7,
+                      notReadyQuantity = 80 - 8,
+                      readyQuantity = 90 - 9,
+                      totalLossCandidates = 80 + 90 - 8 - 9,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
@@ -287,9 +296,10 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
               species1Batch1.copy(
                   version = 2,
                   modifiedTime = withdrawalTime,
-                  germinatingQuantity = 9,
-                  notReadyQuantity = 18,
-                  readyQuantity = 27,
+                  germinatingQuantity = 10 - 1,
+                  notReadyQuantity = 20 - 2,
+                  readyQuantity = 30 - 3,
+                  totalLossCandidates = 20 + 30 - 2 - 3,
               ),
               batchesDao.fetchOneById(species1Batch1Id),
               "Should have deducted withdrawn quantities from batch")
@@ -347,6 +357,17 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   // implementation detail, not part of the API contract.
   @Test
   fun `updates species summary to reflect withdrawn quantities`() {
+    batchQuantityHistoryDao.insert(
+        BatchQuantityHistoryRow(
+            batchId = species1Batch1Id,
+            historyTypeId = BatchQuantityHistoryType.Observed,
+            createdBy = user.userId,
+            createdTime = Instant.EPOCH,
+            germinatingQuantity = 10,
+            notReadyQuantity = 20,
+            readyQuantity = 30,
+            version = 1))
+
     val initialSummary = store.getSpeciesSummary(speciesId)
 
     store.withdraw(
@@ -535,6 +556,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       germinatingQuantity = 10 - 1,
                       notReadyQuantity = 20 - 2,
                       readyQuantity = 30 - 3,
+                      totalLossCandidates = 20 + 30 - 2 - 3,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
@@ -542,6 +564,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       germinatingQuantity = 40 - 4,
                       notReadyQuantity = 50 - 5,
                       readyQuantity = 60 - 6,
+                      totalLossCandidates = 50 + 60 - 5 - 6,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
@@ -549,6 +572,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       germinatingQuantity = 70 - 10,
                       notReadyQuantity = 80 - 11,
                       readyQuantity = 90 - 12,
+                      totalLossCandidates = 80 + 90 - 11 - 12,
                       modifiedTime = withdrawalTime,
                       version = 2,
                   ),
@@ -824,6 +848,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                   germinatingQuantity = 10 - 1 - 4,
                   notReadyQuantity = 20 - 2 - 5,
                   readyQuantity = 30 - 3 - 6,
+                  totalLossCandidates = 20 + 30 - 2 - 5 - 3 - 6,
                   modifiedTime = secondWithdrawalTime,
                   version = 3,
               ),


### PR DESCRIPTION
Return the aggregate germination and loss rates in the summary data for species
and for nursery facilities. This replaces the existing aggregate loss rate
calculation, which was less sophisticated than the current one.

To support calculating the aggregate numbers without having to walk through the
quantity history of every batch, the batches table now stores the numerators and
denominators of the batch-level rate calculations, such that the SQL query that
reads the aggregate stats can simply add them up and divide to get the aggregate
rates.