### PR TITLE
Remove observation config from TerrawareServerConfig

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -90,9 +90,6 @@ class TerrawareServerConfig(
     /** Configures notifications processing. */
     val notifications: NotificationsConfig = NotificationsConfig(),
 
-    /** Configures observations options. */
-    val observations: ObservationsConfig = ObservationsConfig(),
-
     /** Configures detailed request logging. */
     val requestLog: RequestLogConfig = RequestLogConfig(),
     val report: ReportConfig = ReportConfig(),
@@ -252,19 +249,6 @@ class TerrawareServerConfig(
   class SupportConfig(
       /** Support email address to use */
       val email: String? = null,
-  )
-
-  /**
-   * This configuration is a temporary measure to avoid sending user notifications on a first
-   * planting. We don't want this in production until scheduling observations as a feature is
-   * released.
-   */
-  class ObservationsConfig(
-      /**
-       * Whether to send notifications to schedule on observation when the first planting is
-       * allocated to a planting site sub zone.
-       */
-      @DefaultValue("false") val notifyOnFirstPlanting: Boolean = false,
   )
 
   class RequestLogConfig(

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking
 
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
@@ -55,7 +54,6 @@ class ObservationService(
     private val observationStore: ObservationStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val parentStore: ParentStore,
-    private val terrawareServerConfig: TerrawareServerConfig,
 ) {
   private val log = perClassLogger()
 
@@ -394,8 +392,7 @@ class ObservationService(
       source.isBefore(clock.instant().minus(weeks * 7, ChronoUnit.DAYS).plus(1, ChronoUnit.HOURS))
 
   private fun earliestPlantingElapsedWeeks(plantingSiteId: PlantingSiteId, weeks: Long): Boolean =
-      terrawareServerConfig.observations.notifyOnFirstPlanting &&
-          !observationStore.hasObservations(plantingSiteId) &&
+      !observationStore.hasObservations(plantingSiteId) &&
           (plantingSiteStore.fetchOldestPlantingTime(plantingSiteId)?.let {
             elapsedWeeks(it, weeks)
           }

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.tracking
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -79,7 +78,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   private val clock = spyk(TestClock())
   private val eventPublisher = TestEventPublisher()
   private val fileStore: FileStore = mockk()
-  private val terrawareServerConfig: TerrawareServerConfig = mockk()
   private val thumbnailStore: ThumbnailStore = mockk()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val fileService: FileService by lazy {
@@ -115,8 +113,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
         observationPhotosDao,
         observationStore,
         plantingSiteStore,
-        parentStore,
-        terrawareServerConfig)
+        parentStore)
   }
 
   private lateinit var plantingSiteId: PlantingSiteId
@@ -721,8 +718,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUp() {
       every { user.canManageNotifications() } returns true
-      every { terrawareServerConfig.observations } returns
-          TerrawareServerConfig.ObservationsConfig(notifyOnFirstPlanting = true)
     }
 
     @Test
@@ -859,8 +854,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUp() {
       every { user.canManageNotifications() } returns true
-      every { terrawareServerConfig.observations } returns
-          TerrawareServerConfig.ObservationsConfig(notifyOnFirstPlanting = true)
     }
 
     @Test
@@ -1006,8 +999,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUp() {
       every { user.canManageNotifications() } returns true
-      every { terrawareServerConfig.observations } returns
-          TerrawareServerConfig.ObservationsConfig(notifyOnFirstPlanting = true)
     }
 
     @Test
@@ -1130,8 +1121,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUp() {
       every { user.canManageNotifications() } returns true
-      every { terrawareServerConfig.observations } returns
-          TerrawareServerConfig.ObservationsConfig(notifyOnFirstPlanting = true)
     }
 
     @Test


### PR DESCRIPTION
- config was used to support a gating flag to 'notify on first planting' for staging purposes
- we won't need this anymore, plan is to release the user scheduled notifications feature to production this week
- there will be a corresponding infra PR to remove the config value setting