### PR TITLE
Add nursery inventory summary endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/NurseryFacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/NurseryFacilitiesController.kt
@@ -1,0 +1,80 @@
+package com.terraformation.backend.nursery.api
+
+import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.model.NurseryStats
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@NurseryEndpoint
+@RequestMapping("/api/v1/nursery/facilities")
+@RestController
+class NurseryFacilitiesController(
+    private val batchStore: BatchStore,
+) {
+  @GetMapping("/{facilityId}/summary")
+  @Operation(summary = "Gets a summary of the numbers of plants in a nursery.")
+  fun getNurserySummary(
+      @PathVariable facilityId: FacilityId,
+  ): GetNurserySummaryResponsePayload {
+    val stats = batchStore.getNurseryStats(facilityId)
+    val species = batchStore.getActiveSpecies(facilityId)
+
+    return GetNurserySummaryResponsePayload(NurserySummaryPayload(stats, species))
+  }
+}
+
+data class NurserySummarySpeciesPayload(
+    val id: SpeciesId,
+    val scientificName: String,
+) {
+  constructor(row: SpeciesRow) : this(row.id!!, row.scientificName!!)
+}
+
+data class NurserySummaryPayload(
+    val germinatingQuantity: Long,
+    val germinationRate: Int?,
+    @Schema(
+        description = "Percentage of current and past inventory that was withdrawn due to death.",
+        minimum = "0",
+        maximum = "100")
+    val lossRate: Int?,
+    val notReadyQuantity: Long,
+    val readyQuantity: Long,
+    @ArraySchema(arraySchema = Schema(description = "Species currently present in the nursery."))
+    val species: List<NurserySummarySpeciesPayload>,
+    @Schema(description = "Total number of plants that have been withdrawn due to death.")
+    val totalDead: Long,
+    @Schema(description = "Total number of germinated plants currently in inventory.")
+    val totalQuantity: Long,
+    @Schema(description = "Total number of plants that have been withdrawn in the past.")
+    val totalWithdrawn: Long,
+) {
+  constructor(
+      stats: NurseryStats,
+      species: List<SpeciesRow>,
+  ) : this(
+      germinatingQuantity = stats.totalGerminating,
+      germinationRate = stats.germinationRate,
+      lossRate = stats.lossRate,
+      notReadyQuantity = stats.totalNotReady,
+      readyQuantity = stats.totalReady,
+      species = species.map { NurserySummarySpeciesPayload(it) },
+      totalDead = stats.totalWithdrawnByPurpose[WithdrawalPurpose.Dead] ?: 0L,
+      totalQuantity = stats.totalInventory,
+      totalWithdrawn = stats.totalWithdrawn,
+  )
+}
+
+data class GetNurserySummaryResponsePayload(val summary: NurserySummaryPayload) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
@@ -32,9 +32,12 @@ data class NurseryStats(
     }
 
   /** The total number of plants currently in inventory. */
-  private val totalInventory: Long
+  val totalInventory: Long
     get() = totalNotReady + totalReady
 
   val totalPlantsPropagated: Long
     get() = (totalWithdrawnByPurpose[WithdrawalPurpose.OutPlant] ?: 0L) + totalInventory
+
+  val totalWithdrawn: Long
+    get() = totalWithdrawnByPurpose.values.sum()
 }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class BatchStoreGetActiveSpeciesTest : BatchStoreTest() {
+  @Test
+  fun `does not include species with no current inventory`() {
+    every { user.canReadFacility(facilityId) } returns true
+
+    insertBatch(speciesId = speciesId, germinatingQuantity = 1)
+    val speciesId2 = insertSpecies()
+    insertBatch(speciesId = speciesId2, notReadyQuantity = 1)
+    val speciesId3 = insertSpecies()
+    insertBatch(speciesId = speciesId3, readyQuantity = 1)
+
+    val expected = speciesDao.findAll().sortedBy { it.id!!.value }
+
+    val speciesId4 = insertSpecies()
+    insertBatch(speciesId = speciesId4)
+
+    val actual = store.getActiveSpecies(facilityId)
+
+    assertEquals(expected, actual)
+  }
+}


### PR DESCRIPTION
Commit 5cebebf added calculations of facility-level stats such as loss rate, but
didn't expoise the results in the API. Add an endpoint clients can call to get a
summary of the plants at a nursery.