### PR TITLE
Add permission for deleting planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -142,6 +142,7 @@ data class DeviceManagerUser(
   override fun canDeleteAccession(accessionId: AccessionId): Boolean = false
   override fun canDeleteBatch(batchId: BatchId): Boolean = false
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = false
+  override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
   override fun canDeleteProject(projectId: ProjectId): Boolean = false
   override fun canDeleteReport(reportId: ReportId): Boolean = false
   override fun canDeleteSelf(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -209,6 +209,8 @@ data class IndividualUser(
 
   override fun canDeleteOrganization(organizationId: OrganizationId) = isOwner(organizationId)
 
+  override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId) = isSuperAdmin()
+
   override fun canDeleteProject(projectId: ProjectId) =
       isAdminOrHigher(parentStore.getOrganizationId(projectId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -272,6 +272,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun deletePlantingSite(plantingSiteId: PlantingSiteId) {
+    if (!user.canDeletePlantingSite(plantingSiteId)) {
+      readPlantingSite(plantingSiteId)
+      throw AccessDeniedException("No permission to delete planting site $plantingSiteId")
+    }
+  }
+
   fun deleteProject(projectId: ProjectId) {
     if (!user.canDeleteProject(projectId)) {
       readProject(projectId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -140,6 +140,7 @@ class SystemUser(
   override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
   override fun canDeleteBatch(batchId: BatchId): Boolean = true
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
+  override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
   override fun canDeleteProject(projectId: ProjectId): Boolean = true
   override fun canDeleteReport(reportId: ReportId): Boolean = false
   override fun canDeleteSelf(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -104,6 +104,7 @@ interface TerrawareUser : Principal {
   fun canDeleteAutomation(automationId: AutomationId): Boolean
   fun canDeleteBatch(batchId: BatchId): Boolean
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean
+  fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean
   fun canDeleteProject(projectId: ProjectId): Boolean
   fun canDeleteReport(reportId: ReportId): Boolean
   fun canDeleteSelf(): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -331,6 +331,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { deleteOrganization(organizationId) } ifUser { canDeleteOrganization(organizationId) }
 
   @Test
+  fun deletePlantingSite() =
+      allow { deletePlantingSite(plantingSiteId) } ifUser { canDeletePlantingSite(plantingSiteId) }
+
+  @Test
   fun deleteProject() = allow { deleteProject(projectId) } ifUser { canDeleteProject(projectId) }
 
   @Test fun deleteReport() = allow { deleteReport(reportId) } ifUser { canDeleteReport(reportId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1080,6 +1080,7 @@ internal class PermissionTest : DatabaseTest() {
         *plantingSiteIds.toTypedArray(),
         createDelivery = true,
         createObservation = true,
+        deletePlantingSite = true,
         movePlantingSiteToAnyOrg = true,
         readPlantingSite = true,
         scheduleObservation = true,
@@ -1162,6 +1163,7 @@ internal class PermissionTest : DatabaseTest() {
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
         createObservation = true,
+        deletePlantingSite = true,
         movePlantingSiteToAnyOrg = true,
         readPlantingSite = true,
         scheduleObservation = true,
@@ -1657,6 +1659,7 @@ internal class PermissionTest : DatabaseTest() {
         vararg plantingSiteIds: PlantingSiteId,
         createDelivery: Boolean = false,
         createObservation: Boolean = false,
+        deletePlantingSite: Boolean = false,
         movePlantingSiteToAnyOrg: Boolean = false,
         readPlantingSite: Boolean = false,
         scheduleObservation: Boolean = false,
@@ -1671,6 +1674,10 @@ internal class PermissionTest : DatabaseTest() {
             createObservation,
             user.canCreateObservation(plantingSiteId),
             "Can create observation of planting site $plantingSiteId")
+        assertEquals(
+            deletePlantingSite,
+            user.canDeletePlantingSite(plantingSiteId),
+            "Can delete planting site $plantingSiteId")
         assertEquals(
             movePlantingSiteToAnyOrg,
             user.canMovePlantingSiteToAnyOrg(plantingSiteId),


### PR DESCRIPTION
In preparation for adding planting site deletion to the admin UI, add a permission
for it. Initially, only super-admins will be allowed to delete planting sites.