### PR TITLE
SW-4412 Include old and new time zones in events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -193,7 +193,8 @@ class OrganizationStore(
     }
 
     if (existingRow?.timeZone != row.timeZone) {
-      publisher.publishEvent(OrganizationTimeZoneChangedEvent(organizationId))
+      publisher.publishEvent(
+          OrganizationTimeZoneChangedEvent(organizationId, existingRow?.timeZone, row.timeZone))
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationTimeZoneChangedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationTimeZoneChangedEvent.kt
@@ -1,6 +1,11 @@
 package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
+import java.time.ZoneId
 
 /** Published when an organization's time zone has been changed. */
-data class OrganizationTimeZoneChangedEvent(val organizationId: OrganizationId)
+data class OrganizationTimeZoneChangedEvent(
+    val organizationId: OrganizationId,
+    val oldTimeZone: ZoneId?,
+    val newTimeZone: ZoneId?,
+)

--- a/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
@@ -1,10 +1,16 @@
 package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.tracking.model.PlantingSiteModel
+import java.time.ZoneId
 
 /**
  * Published when a planting site's time zone has changed, either because it was individually
  * updated or because its organization's time zone was changed and the planting site doesn't have a
  * time zone of its own.
  */
-data class PlantingSiteTimeZoneChangedEvent(val plantingSite: PlantingSiteModel)
+data class PlantingSiteTimeZoneChangedEvent(
+    val plantingSite: PlantingSiteModel,
+    val oldTimeZone: ZoneId?,
+    /** The new effective time zone; this might be inherited from the organization. */
+    val newTimeZone: ZoneId?,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
@@ -21,6 +21,9 @@ class PlantingSiteService(
     plantingSiteStore
         .fetchSitesByOrganizationId(event.organizationId)
         .filter { it.timeZone == null }
-        .forEach { site -> eventPublisher.publishEvent(PlantingSiteTimeZoneChangedEvent(site)) }
+        .forEach { site ->
+          eventPublisher.publishEvent(
+              PlantingSiteTimeZoneChangedEvent(site, event.oldTimeZone, event.newTimeZone))
+        }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -295,6 +295,9 @@ class PlantingSiteStore(
       }
     }
 
+    val initialTimeZone = initial.timeZone ?: parentStore.getEffectiveTimeZone(plantingSiteId)
+    val editedTimeZone = edited.timeZone ?: parentStore.getEffectiveTimeZone(plantingSiteId)
+
     dslContext.transaction { _ ->
       with(PLANTING_SITES) {
         dslContext
@@ -315,8 +318,9 @@ class PlantingSiteStore(
             .execute()
       }
 
-      if (initial.timeZone != edited.timeZone) {
-        eventPublisher.publishEvent(PlantingSiteTimeZoneChangedEvent(edited))
+      if (initialTimeZone != editedTimeZone) {
+        eventPublisher.publishEvent(
+            PlantingSiteTimeZoneChangedEvent(edited, initialTimeZone, editedTimeZone))
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/FacilityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/FacilityServiceTest.kt
@@ -24,6 +24,7 @@ import io.mockk.verify
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 
 class FacilityServiceTest {
@@ -57,7 +58,7 @@ class FacilityServiceTest {
     every { facilityStore.fetchByOrganizationId(organizationId) } returns
         listOf(facilityWithoutTimeZone, facilityWithTimeZone)
 
-    service.on(OrganizationTimeZoneChangedEvent(organizationId))
+    service.on(OrganizationTimeZoneChangedEvent(organizationId, null, ZoneOffset.UTC))
 
     publisher.assertExactEventsPublished(
         listOf(FacilityTimeZoneChangedEvent(facilityWithoutTimeZone)))

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -301,7 +301,8 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     publisher.assertEventNotPublished<OrganizationTimeZoneChangedEvent>()
 
     store.update(existing.copy(timeZone = newTimeZone))
-    publisher.assertEventPublished(OrganizationTimeZoneChangedEvent(organizationId))
+    publisher.assertEventPublished(
+        OrganizationTimeZoneChangedEvent(organizationId, null, newTimeZone))
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -57,12 +57,14 @@ class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
       organizationsDao.update(
           organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = newTimeZone))
 
-      service.on(OrganizationTimeZoneChangedEvent(organizationId))
+      service.on(OrganizationTimeZoneChangedEvent(organizationId, oldTimeZone, newTimeZone))
 
       eventPublisher.assertExactEventsPublished(
           setOf(
-              PlantingSiteTimeZoneChangedEvent(plantingSiteWithoutTimeZone1),
-              PlantingSiteTimeZoneChangedEvent(plantingSiteWithoutTimeZone2)))
+              PlantingSiteTimeZoneChangedEvent(
+                  plantingSiteWithoutTimeZone1, oldTimeZone, newTimeZone),
+              PlantingSiteTimeZoneChangedEvent(
+                  plantingSiteWithoutTimeZone2, oldTimeZone, newTimeZone)))
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -441,7 +441,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       store.updatePlantingSite(plantingSiteId) { it.copy(timeZone = newTimeZone) }
 
       val expectedEvent =
-          PlantingSiteTimeZoneChangedEvent(initialModel.copy(timeZone = newTimeZone))
+          PlantingSiteTimeZoneChangedEvent(
+              initialModel.copy(timeZone = newTimeZone), timeZone, newTimeZone)
 
       eventPublisher.assertEventPublished(expectedEvent)
     }


### PR DESCRIPTION
Add fields to the "time zone changed" events for organizations and planting sites
so listeners can tell what the change was.

Currently, nothing uses this, but it will be needed for planting season
notification scheduling.