### PR TITLE
Function to convert LocalDates to Instants

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -5,6 +5,11 @@ import java.io.StringWriter
 import java.math.BigDecimal
 import java.net.URI
 import java.text.Normalizer
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import org.jooq.Field
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
@@ -76,3 +81,7 @@ fun String.removeDiacritics(): String {
   // Now remove all the combining characters, resulting in a string without diacritics.
   return normalized.replace(combiningMarksRegex, "")
 }
+
+/** Returns the Instant for a time of day on the date in a particular time zone. */
+fun LocalDate.toInstant(timeZone: ZoneId, time: LocalTime = LocalTime.MIDNIGHT): Instant =
+    ZonedDateTime.of(this, time, timeZone).toInstant()

--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -1,0 +1,19 @@
+package com.terraformation.backend.util
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ExtensionsTest {
+  @Test
+  fun `toInstant converts date to correct instant`() {
+    val date = LocalDate.of(2023, 1, 1)
+    val time = LocalTime.of(2, 3, 4, 0)
+    val timeZone = ZoneId.of("America/Los_Angeles")
+
+    assertEquals(Instant.ofEpochSecond(1672567384), date.toInstant(timeZone, time))
+  }
+}


### PR DESCRIPTION
For planting season notifications, we'll need to convert the start/end dates to
the correct instants in the planting sites' time zones. Add an extension function
to do the conversion.