### PR TITLE
Remove explicit Jackson dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,6 @@ repositories {
 dependencies {
   val awsSdkVersion: String by project
   val geoToolsVersion: String by project
-  val jacksonVersion: String by project
   val jooqVersion: String by project
   val jtsVersion: String by project
   val ktorVersion: String by project
@@ -92,8 +91,6 @@ dependencies {
   implementation("org.springframework.session:spring-session-jdbc")
 
   implementation("com.drewnoakes:metadata-extractor:2.18.0")
-  implementation("com.fasterxml.jackson:jackson-bom:$jacksonVersion")
-  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
   implementation("com.google.api-client:google-api-client:2.2.0")
   implementation("com.google.auth:google-auth-library-oauth2-http:1.20.0")
   implementation("com.google.apis:google-api-services-drive:v3-rev20230822-2.0.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,6 @@ org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 awsSdkVersion=2.21.13
 geoToolsVersion=30.0
-jacksonVersion=2.15.3
 jooqVersion=3.18.7
 jtsVersion=1.19.0
 kotlinVersion=1.9.20


### PR DESCRIPTION
Let Spring Boot's web starter pull in the version of Jackson it's compatible with.
This will prevent Renovate from attempting to upgrade Jackson to new versions that
aren't supported by Spring yet.