### PR TITLE
SW-4410 Update planting seasons on time zone change

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
@@ -14,7 +15,10 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.util.toInstant
 import io.mockk.every
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -116,6 +120,39 @@ class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
                   plantingSiteWithoutTimeZone1, oldTimeZone, newTimeZone),
               PlantingSiteTimeZoneChangedEvent(
                   plantingSiteWithoutTimeZone2, oldTimeZone, newTimeZone)))
+
+      assertIsEventListener<OrganizationTimeZoneChangedEvent>(service)
+    }
+
+    @Test
+    fun `updates planting seasons when planting site time zone changes`() {
+      val oldTimeZone = insertTimeZone("America/New_York")
+      val newTimeZone = insertTimeZone("Europe/Paris")
+      val startDate = LocalDate.EPOCH.plusMonths(1)
+      val endDate = startDate.plusMonths(3)
+
+      insertOrganization(timeZone = oldTimeZone)
+      insertPlantingSite(timeZone = oldTimeZone)
+      insertPlantingSeason(timeZone = oldTimeZone, startDate = startDate, endDate = endDate)
+
+      val oldSiteModel =
+          plantingSiteStore.fetchSiteById(inserted.plantingSiteId, PlantingSiteDepth.Site)
+
+      service.on(PlantingSiteTimeZoneChangedEvent(oldSiteModel, oldTimeZone, newTimeZone))
+
+      val newSiteModel =
+          plantingSiteStore.fetchSiteById(inserted.plantingSiteId, PlantingSiteDepth.Site)
+
+      assertEquals(
+          startDate.toInstant(newTimeZone),
+          newSiteModel.plantingSeasons.first().startTime,
+          "Start time")
+      assertEquals(
+          endDate.plusDays(1).toInstant(newTimeZone),
+          newSiteModel.plantingSeasons.first().endTime,
+          "End time")
+
+      assertIsEventListener<PlantingSiteTimeZoneChangedEvent>(service)
     }
   }
 }


### PR DESCRIPTION
When a planting site's time zone changes, the start and end times (which are
`Instant`s) will no longer be correct since they were computed using the old
time zone; recalculate them in the new time zone.