### PR TITLE
SW-4469 Show planting seasons in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -54,14 +54,14 @@ data class PlantingSiteModel(
    *
    * The next observation starts on the first of the month after the end of the planting season.
    */
-  fun getNextObservationStart(clock: Clock = Clock.systemUTC()): LocalDate? {
-    return plantingSeasonEndMonth?.let { endMonth ->
-      val observationMonth = endMonth.plus(1)
-      val today = LocalDate.now(clock)
-      val year = if (today.month >= observationMonth) today.year + 1 else today.year
+  fun getNextObservationStart(clock: Clock): LocalDate? {
+    val now = clock.instant()
 
-      LocalDate.of(year, observationMonth.value, 1)
-    }
+    return plantingSeasons
+        .firstOrNull { it.endTime >= now }
+        ?.endDate
+        ?.plusMonths(1)
+        ?.withDayOfMonth(1)
   }
 
   /**

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -160,13 +160,43 @@
            required/>
     <label for="description">Description</label>
     <input type="text" id="description" name="description" th:value="${site.description}"/>
-    <label for="plantingSeasonStartMonth">Planting Season Start</label>
-    <select th:replace="~{::monthSelect ('plantingSeasonStartMonth', ${site.plantingSeasonStartMonth})}"/>
-    <label for="plantingSeasonEndMonth">Planting Season End</label>
-    <select th:replace="~{::monthSelect ('plantingSeasonEndMonth', ${site.plantingSeasonEndMonth})}"/>
     <br/>
     <input type="submit" value="Update"/>
 </form>
+
+<h3>Planting Seasons</h3>
+
+<ol>
+    <li th:each="season : ${pastPlantingSeasons}">
+        <input type="date" disabled th:value="${season.startDate}">
+        -
+        <input type="date" disabled th:value="${season.endDate}">
+    </li>
+    <li th:each="season : ${futurePlantingSeasons}">
+        <form method="POST" th:action="|${prefix}/updatePlantingSeason|" style="display: inline-block;">
+            <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+            <input type="hidden" name="plantingSeasonId" th:value="${season.id}"/>
+            <input type="date" name="startDate" required th:value="${season.startDate}"/>
+            -
+            <input type="date" name="endDate" required th:value="${season.endDate}"/>
+            <input type="submit" value="Update"/>
+        </form>
+        <form method="POST" th:action="|${prefix}/deletePlantingSeason|" style="display: inline-block;">
+            <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+            <input type="hidden" name="plantingSeasonId" th:value="${season.id}"/>
+            <input type="submit" value="Delete"/>
+        </form>
+    </li>
+    <li>
+        <form method="POST" th:action="|${prefix}/createPlantingSeason|">
+            <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
+            <input type="date" name="startDate" required/>
+            -
+            <input type="date" name="endDate" required/>
+            <input type="submit" value="Create"/>
+        </form>
+    </li>
+</ol>
 
 <form method="POST" th:action="|${prefix}/movePlantingSite|" th:if="${canMovePlantingSiteToAnyOrg}"
       id="moveForm">


### PR DESCRIPTION
List the planting seasons (including past ones) in the admin UI, and use the
planting season dates to prefill the default dates for the next observation.
Current and future planting seasons can be edited and new ones can be created,
but past ones can't be modified.

This replaces the planting season start/end month fields.