### PR TITLE
SW-4469 Stop accessing planting season months

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -53,7 +53,6 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.time.InstantSource
 import java.time.LocalDate
-import java.time.Month
 import java.time.ZoneId
 import org.jooq.Condition
 import org.jooq.DSLContext
@@ -253,8 +252,6 @@ class PlantingSiteStore(
       name: String,
       description: String?,
       timeZone: ZoneId?,
-      plantingSeasonEndMonth: Month? = null,
-      plantingSeasonStartMonth: Month? = null,
       projectId: ProjectId?,
       boundary: MultiPolygon? = null,
       plantingSeasons: Collection<UpdatedPlantingSeasonModel> = emptyList(),
@@ -280,8 +277,6 @@ class PlantingSiteStore(
             modifiedTime = now,
             name = name,
             organizationId = organizationId,
-            plantingSeasonEndMonth = plantingSeasonEndMonth,
-            plantingSeasonStartMonth = plantingSeasonStartMonth,
             projectId = projectId,
             timeZone = timeZone,
         )
@@ -328,8 +323,6 @@ class PlantingSiteStore(
             .set(MODIFIED_BY, currentUser().userId)
             .set(MODIFIED_TIME, clock.instant())
             .set(NAME, edited.name)
-            .set(PLANTING_SEASON_END_MONTH, edited.plantingSeasonEndMonth)
-            .set(PLANTING_SEASON_START_MONTH, edited.plantingSeasonStartMonth)
             .set(PROJECT_ID, edited.projectId)
             .set(TIME_ZONE, edited.timeZone)
             .apply {

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.util.equalsIgnoreScale
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.LocalDate
-import java.time.Month
 import java.time.ZoneId
 import org.jooq.Field
 import org.jooq.Record
@@ -22,9 +21,7 @@ data class PlantingSiteModel(
     val id: PlantingSiteId,
     val name: String,
     val organizationId: OrganizationId,
-    val plantingSeasonEndMonth: Month? = null,
     val plantingSeasons: List<ExistingPlantingSeasonModel> = emptyList(),
-    val plantingSeasonStartMonth: Month? = null,
     val plantingZones: List<PlantingZoneModel>,
     val projectId: ProjectId? = null,
     val timeZone: ZoneId? = null,
@@ -40,9 +37,7 @@ data class PlantingSiteModel(
       id = record[PLANTING_SITES.ID]!!,
       name = record[PLANTING_SITES.NAME]!!,
       organizationId = record[PLANTING_SITES.ORGANIZATION_ID]!!,
-      plantingSeasonEndMonth = record[PLANTING_SITES.PLANTING_SEASON_END_MONTH],
       plantingSeasons = plantingSeasonsMultiset?.let { record[it] } ?: emptyList(),
-      plantingSeasonStartMonth = record[PLANTING_SITES.PLANTING_SEASON_START_MONTH],
       plantingZones = plantingZonesMultiset?.let { record[it] } ?: emptyList(),
       projectId = record[PLANTING_SITES.PROJECT_ID],
       timeZone = record[PLANTING_SITES.TIME_ZONE],
@@ -79,8 +74,6 @@ data class PlantingSiteModel(
         id == other.id &&
         name == other.name &&
         timeZone == other.timeZone &&
-        plantingSeasonEndMonth == other.plantingSeasonEndMonth &&
-        plantingSeasonStartMonth == other.plantingSeasonStartMonth &&
         plantingZones.size == other.plantingZones.size &&
         projectId == other.projectId &&
         areaHa.equalsIgnoreScale(other.areaHa) &&

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -43,7 +43,6 @@ import io.mockk.every
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
-import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
@@ -352,8 +351,6 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
               description = "description",
               name = "name",
               organizationId = organizationId,
-              plantingSeasonEndMonth = Month.JULY,
-              plantingSeasonStartMonth = Month.APRIL,
               projectId = projectId,
               timeZone = timeZone,
           )
@@ -369,8 +366,6 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = Instant.EPOCH,
                   modifiedBy = user.userId,
                   modifiedTime = Instant.EPOCH,
-                  plantingSeasonEndMonth = Month.JULY,
-                  plantingSeasonStartMonth = Month.APRIL,
                   projectId = projectId,
                   timeZone = timeZone,
               )),
@@ -543,8 +538,6 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
             boundary = multiPolygon(2.0),
             description = "new description",
             name = "new name",
-            plantingSeasonEndMonth = Month.MARCH,
-            plantingSeasonStartMonth = Month.DECEMBER,
             timeZone = newTimeZone,
         )
       }
@@ -561,8 +554,6 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = createdTime,
                   modifiedBy = user.userId,
                   modifiedTime = now,
-                  plantingSeasonEndMonth = Month.MARCH,
-                  plantingSeasonStartMonth = Month.DECEMBER,
                   timeZone = newTimeZone,
               )),
           plantingSitesDao.findAll(),


### PR DESCRIPTION
We no longer expose the planting season start and end months in the API or the
admin UI; remove the code that accesses them in the database so we can drop the
columns.