### PR TITLE
SW-4413 Notify on planting season scheduling

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -320,3 +320,27 @@ class MissingContact(
   override val templateDir: String
     get() = "organization/missingContact"
 }
+
+class PlantingSeasonRescheduled(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+    val oldStartDate: LocalDate,
+    val oldEndDate: LocalDate,
+    val newStartDate: LocalDate,
+    val newEndDate: LocalDate,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "plantingSeason/rescheduled"
+}
+
+class PlantingSeasonScheduled(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "plantingSeason/scheduled"
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -1,9 +1,11 @@
 package com.terraformation.backend.tracking.event
 
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
+import java.time.LocalDate
 
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
 data class ObservationPlotReplacedEvent(
@@ -55,3 +57,19 @@ data class ObservationNotScheduledNotificationEvent(
 ) : ObservationSchedulingNotificationEvent
 
 data class PlantingSiteDeletionStartedEvent(val plantingSiteId: PlantingSiteId)
+
+data class PlantingSeasonRescheduledEvent(
+    val plantingSiteId: PlantingSiteId,
+    val plantingSeasonId: PlantingSeasonId,
+    val oldStartDate: LocalDate,
+    val oldEndDate: LocalDate,
+    val newStartDate: LocalDate,
+    val newEndDate: LocalDate,
+)
+
+data class PlantingSeasonScheduledEvent(
+    val plantingSiteId: PlantingSiteId,
+    val plantingSeasonId: PlantingSeasonId,
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+)

--- a/src/main/resources/templates/email/plantingSeason/rescheduled/body.ftlh.mjml
+++ b/src/main/resources/templates/email/plantingSeason/rescheduled/body.ftlh.mjml
@@ -1,0 +1,25 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonRescheduled" -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03">
+                    The planting site ${plantingSiteName} has had a planting season rescheduled.
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                    Previously it was scheduled for ${oldStartDate} through ${oldEndDate}.
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                    Now the next planting season is scheduled for ${newStartDate} through ${newEndDate}.
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/plantingSeason/rescheduled/body.txt.ftl
+++ b/src/main/resources/templates/email/plantingSeason/rescheduled/body.txt.ftl
@@ -1,0 +1,10 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonRescheduled" -->
+The planting site ${plantingSiteName} has had a planting season rescheduled.
+
+Previously it was scheduled for ${oldStartDate} through ${oldEndDate}.
+
+Now the next planting season is scheduled for ${newStartDate} through ${newEndDate}.
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/plantingSeason/rescheduled/subject.ftl
+++ b/src/main/resources/templates/email/plantingSeason/rescheduled/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonRescheduled" -->
+Organization ${organizationName} has rescheduled a planting season of planting site ${plantingSiteName}

--- a/src/main/resources/templates/email/plantingSeason/scheduled/body.ftlh.mjml
+++ b/src/main/resources/templates/email/plantingSeason/scheduled/body.ftlh.mjml
@@ -1,0 +1,20 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonScheduled" -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03">
+                    The planting site ${plantingSiteName} has had a planting season scheduled for
+                    ${startDate} through ${endDate}.
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/plantingSeason/scheduled/body.txt.ftl
+++ b/src/main/resources/templates/email/plantingSeason/scheduled/body.txt.ftl
@@ -1,0 +1,7 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonScheduled" -->
+The planting site ${plantingSiteName} has had a planting season scheduled for
+${startDate} through ${endDate}.
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/plantingSeason/scheduled/subject.ftl
+++ b/src/main/resources/templates/email/plantingSeason/scheduled/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonScheduled" -->
+Organization ${organizationName} has scheduled a planting season of planting site ${plantingSiteName}


### PR DESCRIPTION
When a planting season is scheduled or rescheduled, send an email notification to
the organization's Terraformation contact, if any.

Unlike other notifications that go to organization contacts, these do not fall
back on the support mailing list if there is no contact.