### PR TITLE
SW-4474 Add user API to delete a planting site, with restrictions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.WithdrawalId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import java.io.IOException
 import org.springframework.security.access.AccessDeniedException
 
@@ -132,6 +133,9 @@ class OrganizationHasOtherUsersException(val organizationId: OrganizationId) :
 
 class OrganizationNotFoundException(val organizationId: OrganizationId) :
     EntityNotFoundException("Organization $organizationId not found")
+
+class PlantingSiteInUseException(val plantingSiteId: PlantingSiteId) :
+    MismatchedStateException("Planting site $plantingSiteId is in use")
 
 class ProjectNameInUseException(val name: String) :
     DuplicateEntityException("Project name $name already in use")

--- a/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/PlantingSiteService.kt
@@ -2,6 +2,9 @@ package com.terraformation.backend.tracking
 
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.PlantingSiteInUseException
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import jakarta.inject.Named
 import org.springframework.context.ApplicationEventPublisher
@@ -12,6 +15,21 @@ class PlantingSiteService(
     private val eventPublisher: ApplicationEventPublisher,
     private val plantingSiteStore: PlantingSiteStore,
 ) {
+
+  /**
+   * Deletes a planting site if it has no plantings. throws [PlantingSiteInUseException] if planting
+   * site has plantings
+   */
+  fun deletePlantingSite(plantingSiteId: PlantingSiteId) {
+    requirePermissions { deletePlantingSite(plantingSiteId) }
+
+    if (plantingSiteStore.hasPlantings(plantingSiteId)) {
+      throw PlantingSiteInUseException(plantingSiteId)
+    }
+
+    plantingSiteStore.deletePlantingSite(plantingSiteId)
+  }
+
   /**
    * Publishes [PlantingSiteTimeZoneChangedEvent]s for any planting sites whose time zones have
    * changed implicitly thanks to a change of their owning organization's time zone.

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.tracking.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse409
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
@@ -9,6 +11,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.tracking.PlantingSiteService
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.PlantingSiteModel
@@ -21,6 +24,7 @@ import java.math.BigDecimal
 import java.time.Instant
 import java.time.ZoneId
 import org.locationtech.jts.geom.MultiPolygon
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -35,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController
 @TrackingEndpoint
 class PlantingSitesController(
     private val plantingSiteStore: PlantingSiteStore,
+    private val plantingSiteService: PlantingSiteService,
 ) {
   @GetMapping
   @Operation(
@@ -104,6 +109,18 @@ class PlantingSitesController(
       @RequestBody payload: UpdatePlantingSiteRequestPayload
   ): SimpleSuccessResponsePayload {
     plantingSiteStore.updatePlantingSite(id, payload::applyTo)
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse409(
+      description = "The planting site is in use, e.g., there are plantings allocated to the site.")
+  @Operation(
+      summary = "Deletes a planting site.",
+      description = "Planting site should not have any plantings.")
+  @DeleteMapping("/{id}")
+  fun deletePlantingSite(@PathVariable("id") id: PlantingSiteId): SimpleSuccessResponsePayload {
+    plantingSiteService.deletePlantingSite(id)
     return SimpleSuccessResponsePayload()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -476,6 +476,15 @@ class PlantingSiteStore(
     )
   }
 
+  fun hasPlantings(plantingSiteId: PlantingSiteId): Boolean {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext.fetchExists(
+        PLANTINGS,
+        PLANTINGS.PLANTING_SITE_ID.eq(plantingSiteId),
+    )
+  }
+
   fun fetchOldestPlantingTime(plantingSiteId: PlantingSiteId): Instant? {
     return dslContext
         .select(DSL.min(PLANTINGS.CREATED_TIME))

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -901,6 +901,44 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
+  inner class HasPlantings {
+    private val plantingSiteId = PlantingSiteId(1)
+
+    @BeforeEach
+    fun setUp() {
+      every { user.canReadPlantingSite(plantingSiteId) } returns true
+    }
+
+    @Test
+    fun `throws exception when no permission to read the planting site`() {
+      insertPlantingSite(id = plantingSiteId)
+
+      every { user.canReadPlantingSite(plantingSiteId) } returns false
+
+      assertThrows<PlantingSiteNotFoundException> { store.hasPlantings(plantingSiteId) }
+    }
+
+    @Test
+    fun `returns false when there are no plantings in the site`() {
+      insertPlantingSite(id = plantingSiteId)
+
+      assertFalse(store.hasPlantings(plantingSiteId))
+    }
+
+    @Test
+    fun `returns true when there are plantings in the site`() {
+      insertFacility(type = FacilityType.Nursery)
+      insertSpecies()
+      insertPlantingSite(id = plantingSiteId)
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting()
+
+      assertTrue(store.hasPlantings(plantingSiteId))
+    }
+  }
+
+  @Nested
   inner class DeletePlantingSite {
     @Test
     fun `deletes detailed map data and observations`() {


### PR DESCRIPTION
- planting site can be deleted if it has no plantings
- introduced user-facing deletePlantingSite in PlantingSiteService to differentiate from default implementation in PlantingSiteStore
- added tests