### PR TITLE
Add per-species sublist to facility inventory totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoryTotalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoryTotalsTable.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORY_TOTALS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -25,6 +26,9 @@ class FacilityInventoryTotalsTable(private val tables: SearchTables) : SearchTab
       listOf(
           facilities.asSingleValueSublist(
               "facility", FACILITY_INVENTORY_TOTALS.FACILITY_ID.eq(FACILITIES.ID)),
+          facilityInventories.asMultiValueSublist(
+              "facilityInventories",
+              FACILITY_INVENTORY_TOTALS.FACILITY_ID.eq(FACILITY_INVENTORIES.FACILITY_ID)),
           organizations.asSingleValueSublist(
               "organization", FACILITY_INVENTORY_TOTALS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
       )

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -216,6 +216,8 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
               listOf(
                   prefix.resolve("facility_id"),
                   prefix.resolve("facility_name"),
+                  prefix.resolve("facilityInventories.species_id"),
+                  prefix.resolve("facilityInventories.species_scientificName"),
                   prefix.resolve("germinatingQuantity"),
                   prefix.resolve("notReadyQuantity"),
                   prefix.resolve("readyQuantity"),
@@ -234,6 +236,17 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "germinatingQuantity" to number(1 + 8 + 512),
                       "notReadyQuantity" to number(2 + 16 + 1024),
                       "readyQuantity" to number(4 + 32 + 2048),
+                      "facilityInventories" to
+                          listOf(
+                              mapOf(
+                                  "species_id" to "$speciesId1",
+                                  "species_scientificName" to "Species $speciesId1",
+                              ),
+                              mapOf(
+                                  "species_id" to "$speciesId2",
+                                  "species_scientificName" to "Species $speciesId2",
+                              ),
+                          ),
                       "totalQuantity" to number(2 + 4 + 16 + 32 + 1024 + 2048),
                       "totalSpecies" to number(2),
                   ),
@@ -243,6 +256,13 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "germinatingQuantity" to number(64),
                       "notReadyQuantity" to number(128),
                       "readyQuantity" to number(256),
+                      "facilityInventories" to
+                          listOf(
+                              mapOf(
+                                  "species_id" to "$speciesId1",
+                                  "species_scientificName" to "Species $speciesId1",
+                              ),
+                          ),
                       "totalQuantity" to number(128 + 256),
                       "totalSpecies" to number(1),
                   ),


### PR DESCRIPTION
Allow clients to query the total inventory by facility, but also get per-species
details for the inventory at each facility.

For example, to get a list of inventory totals with a list of species names, the
search request would look like:

    {
      "prefix": "facilities.facilityInventoryTotals",
      "fields": [
        "facility_id",
        "facility_name",
        "facilityInventories.species_scientificName",
        "germinatingQuantity",
        "notReadyQuantity",
        "readyQuantity",
        "totalQuantity",
        "totalSpecies"
      ],
      "search": {
        "operation": "field",
        "field": "organization_id",
        "values": [ "123" ]
      }
    }