### PR TITLE
Add PostgreSQL JDBC driver to database dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,9 +25,10 @@
             "matchPackagePatterns": [
                 "flyway",
                 "jooq",
+                "postgresql",
                 "testcontainers",
             ],
-            "groupName": "Database dependencies"
+            "groupName": "database dependencies"
         },
         {
             "description": "Group Spring dependencies",


### PR DESCRIPTION
Add the driver to the "database dependencies" Renovate group so it's upgraded
together with other database-related libraries if they change at the same time.