### PR TITLE
SW-4412 Mark planting seasons as active/inactive

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
@@ -1,0 +1,40 @@
+package com.terraformation.backend.daily
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.time.ClockAdvancedEvent
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import org.jobrunr.scheduling.JobScheduler
+import org.jobrunr.scheduling.cron.Cron
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.event.EventListener
+
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
+@Named
+class PlantingSeasonScheduler(
+    private val config: TerrawareServerConfig,
+    private val plantingSiteStore: PlantingSiteStore,
+    private val systemUser: SystemUser,
+) {
+  @Inject
+  fun schedule(scheduler: JobScheduler) {
+    if (config.dailyTasks.enabled) {
+      scheduler.scheduleRecurrently<PlantingSeasonScheduler>(
+          javaClass.simpleName, Cron.every15minutes()) {
+            transitionPlantingSeasons()
+          }
+    }
+  }
+
+  @Suppress("MemberVisibilityCanBePrivate") // Called by JobRunr
+  fun transitionPlantingSeasons() {
+    systemUser.run { plantingSiteStore.transitionPlantingSeasons() }
+  }
+
+  @EventListener
+  fun on(@Suppress("UNUSED_PARAMETER") event: ClockAdvancedEvent) {
+    transitionPlantingSeasons()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -73,3 +73,13 @@ data class PlantingSeasonScheduledEvent(
     val startDate: LocalDate,
     val endDate: LocalDate,
 )
+
+data class PlantingSeasonStartedEvent(
+    val plantingSiteId: PlantingSiteId,
+    val plantingSeasonId: PlantingSeasonId,
+)
+
+data class PlantingSeasonEndedEvent(
+    val plantingSiteId: PlantingSiteId,
+    val plantingSeasonId: PlantingSeasonId,
+)

--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -11,66 +11,89 @@ class TestEventPublisher : ApplicationEventPublisher {
   }
 
   /**
+   * Clears the record of published events. This can be used in multi-step tests where an early step
+   * is supposed to publish an event but a later one isn't.
+   */
+  fun clear() {
+    publishedEvents.clear()
+  }
+
+  /**
    * Asserts that a list of events were published in a specific order. Ignores any additional events
    * not on the list.
    */
-  fun assertEventsPublished(events: List<Any>) {
+  fun assertEventsPublished(events: List<Any>, message: String = "Expected events not published") {
     val expectedEvents = events.toSet()
     val publishedEventsFromExpectedList = publishedEvents.filter { it in expectedEvents }
 
-    assertEquals(events, publishedEventsFromExpectedList, "Expected events not published")
+    assertEquals(events, publishedEventsFromExpectedList, message)
   }
 
   /**
    * Asserts that a set of events were published in any order. Ignores any additional events not in
    * the set.
    */
-  fun assertEventsPublished(events: Set<Any>) {
+  fun assertEventsPublished(events: Set<Any>, message: String = "Expected events not published") {
     val publishedEventsFromExpectedSet = publishedEvents.filter { it in events }.toSet()
 
-    assertEquals(events, publishedEventsFromExpectedSet, "Expected events not published")
+    assertEquals(events, publishedEventsFromExpectedSet, message)
   }
 
   /**
    * Asserts that a list of events, and only that list of events, were published in a specific
    * order.
    */
-  fun assertExactEventsPublished(events: List<Any>) {
-    assertEquals(events, publishedEvents, "Expected events not published")
+  fun assertExactEventsPublished(
+      events: List<Any>,
+      message: String = "Expected events not published"
+  ) {
+    assertEquals(events, publishedEvents, message)
   }
 
   /** Asserts that a set of events, and only that set of events, were published in any order. */
-  fun assertExactEventsPublished(events: Set<Any>) {
-    assertEquals(events, publishedEvents.toSet(), "Expected events not published")
+  fun assertExactEventsPublished(
+      events: Set<Any>,
+      message: String = "Expected events not published"
+  ) {
+    assertEquals(events, publishedEvents.toSet(), message)
   }
 
   /** Asserts that a particular event was published. */
-  fun assertEventPublished(event: Any) {
+  fun assertEventPublished(event: Any, message: String = "Expected event not published") {
     if (event !in publishedEvents) {
       // Fail with an assertion that shows which events were actually published.
-      assertEquals(listOf(event), publishedEvents, "Expected event not published")
+      assertEquals(listOf(event), publishedEvents, message)
     }
   }
 
   /** Asserts that an event matching a predicate was published. */
-  fun assertEventPublished(predicate: (Any) -> Boolean) {
+  fun assertEventPublished(
+      message: String = "Expected event not published",
+      predicate: (Any) -> Boolean
+  ) {
     if (!publishedEvents.any(predicate)) {
       // Fail with an assertion that shows which events were actually published.
-      assertEquals(
-          "Event matching predicate", publishedEvents as Any, "Expected event not published")
+      assertEquals("Event matching predicate", publishedEvents as Any, message)
     }
   }
 
   /** Asserts that no event of a particular type has been published. */
-  fun assertEventNotPublished(clazz: Class<*>) {
-    assertEquals(
-        emptyList<Any>(),
-        publishedEvents.filter { clazz.isInstance(it) },
-        "Expected no events of type ${clazz.name}")
+  fun assertEventNotPublished(
+      clazz: Class<*>,
+      message: String = "Expected no events of type ${clazz.name}"
+  ) {
+    assertEquals(emptyList<Any>(), publishedEvents.filter { clazz.isInstance(it) }, message)
+  }
+
+  /** Asserts that no events of any type have been published. */
+  fun assertNoEventsPublished(message: String = "Expected no events to be published") {
+    assertEquals(emptyList<Any>(), publishedEvents, message)
   }
 
   /** Asserts that no event of a particular type has been published. */
-  inline fun <reified T : Any> assertEventNotPublished() {
-    assertEventNotPublished(T::class.java)
+  inline fun <reified T : Any> assertEventNotPublished(
+      message: String = "Expected no events of type ${T::class.java.name}"
+  ) {
+    assertEventNotPublished(T::class.java, message)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -23,8 +23,10 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.polygon
+import com.terraformation.backend.tracking.event.PlantingSeasonEndedEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
+import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEvent
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.CannotUpdatePastPlantingSeasonException
@@ -1493,6 +1495,92 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val plantingSiteId = insertPlantingSite()
 
       assertThrows<AccessDeniedException> { store.deletePlantingSite(plantingSiteId) }
+    }
+  }
+
+  @Nested
+  inner class TransitionPlantingSeasons {
+    @Test
+    fun `marks planting season as active when its start time arrives`() {
+      val startDate = LocalDate.EPOCH.plusDays(1)
+      val endDate = startDate.plusDays(60)
+      val model =
+          store.createPlantingSite(
+              description = null,
+              name = "name",
+              organizationId = organizationId,
+              plantingSeasons =
+                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
+              projectId = null,
+              timeZone = timeZone,
+          )
+
+      assertSeasonActive(false, "Should start as inactive")
+
+      store.transitionPlantingSeasons()
+
+      assertSeasonActive(false, "Should stay inactive until start time arrives")
+      eventPublisher.assertEventNotPublished<PlantingSeasonStartedEvent>()
+
+      clock.instant = startDate.toInstant(timeZone)
+
+      store.transitionPlantingSeasons()
+
+      assertSeasonActive(true, "Should transition to active")
+      eventPublisher.assertEventPublished(
+          PlantingSeasonStartedEvent(model.id, model.plantingSeasons.first().id))
+
+      clock.instant = endDate.minusDays(1).toInstant(timeZone)
+      eventPublisher.clear()
+
+      store.transitionPlantingSeasons()
+      eventPublisher.assertNoEventsPublished(
+          "Should not publish any events if planting season already in correct state")
+    }
+
+    @Test
+    fun `marks planting season as inactive when its end time arrives`() {
+      val startDate = LocalDate.EPOCH.plusDays(1)
+      val endDate = startDate.plusDays(60)
+
+      clock.instant = startDate.toInstant(timeZone)
+
+      val model =
+          store.createPlantingSite(
+              description = null,
+              name = "name",
+              organizationId = organizationId,
+              plantingSeasons =
+                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
+              projectId = null,
+              timeZone = timeZone,
+          )
+
+      assertSeasonActive(true, "Should start as active")
+
+      store.transitionPlantingSeasons()
+
+      assertSeasonActive(true, "Should remain active until end time arrives")
+      eventPublisher.assertEventNotPublished<PlantingSeasonEndedEvent>()
+
+      clock.instant = endDate.plusDays(1).toInstant(timeZone)
+
+      store.transitionPlantingSeasons()
+
+      assertSeasonActive(false, "Should have been marked as inactive")
+      eventPublisher.assertEventPublished(
+          PlantingSeasonEndedEvent(model.id, model.plantingSeasons.first().id))
+
+      clock.instant = endDate.plusDays(2).toInstant(timeZone)
+      eventPublisher.clear()
+
+      store.transitionPlantingSeasons()
+      eventPublisher.assertNoEventsPublished(
+          "Should not publish any events if planting season already in correct state")
+    }
+
+    private fun assertSeasonActive(isActive: Boolean, message: String) {
+      assertEquals(listOf(isActive), plantingSeasonsDao.findAll().map { it.isActive }, message)
     }
   }
 }


### PR DESCRIPTION
Add a scheduled job that transitions planting seasons into and out of active state
as their start and end times arrive. Each transition generates an application
event which will be used to trigger notifications.