### PR TITLE
SW-4515 Add API functionality to return species that are used in the org

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -67,11 +67,16 @@ class SpeciesController(
   fun listSpecies(
       @RequestParam
       @Schema(description = "Organization whose species should be listed.")
-      organizationId: OrganizationId
+      organizationId: OrganizationId,
+      @RequestParam
+      @Schema(
+          description =
+              "Only list species that are currently used in the organization's inventory, accessions or planting sites.")
+      inUse: Boolean?,
   ): ListSpeciesResponsePayload {
     val problems = speciesStore.findAllProblems(organizationId)
     val elements =
-        speciesStore.findAllSpecies(organizationId).map {
+        speciesStore.findAllSpecies(organizationId, inUse ?: false).map {
           SpeciesResponseElement(it, problems[it.id])
         }
     return ListSpeciesResponsePayload(elements)

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -62,25 +62,13 @@ class SpeciesStore(
           }
 
   private val usedInAccessions: Condition =
-      DSL.exists(
-          DSL.selectOne()
-              .from(ACCESSIONS)
-              .where(ACCESSIONS.SPECIES_ID.eq(SPECIES.ID))
-              .and(ACCESSIONS.facilities.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
+      DSL.exists(DSL.selectOne().from(ACCESSIONS).where(ACCESSIONS.SPECIES_ID.eq(SPECIES.ID)))
 
   private val usedInBatches: Condition =
-      DSL.exists(
-          DSL.selectOne()
-              .from(BATCHES)
-              .where(BATCHES.SPECIES_ID.eq(SPECIES.ID))
-              .and(BATCHES.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
+      DSL.exists(DSL.selectOne().from(BATCHES).where(BATCHES.SPECIES_ID.eq(SPECIES.ID)))
 
   private val usedInPlantings: Condition =
-      DSL.exists(
-          DSL.selectOne()
-              .from(PLANTINGS)
-              .where(PLANTINGS.SPECIES_ID.eq(SPECIES.ID))
-              .and(PLANTINGS.plantingSites.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
+      DSL.exists(DSL.selectOne().from(PLANTINGS).where(PLANTINGS.SPECIES_ID.eq(SPECIES.ID)))
 
   fun fetchSpeciesById(speciesId: SpeciesId): ExistingSpeciesModel {
     requirePermissions { readSpecies(speciesId) }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -22,6 +22,8 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
@@ -31,6 +33,7 @@ import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.NewSpeciesModel
 import jakarta.inject.Named
 import java.time.Clock
+import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.impl.DSL
@@ -57,6 +60,27 @@ class SpeciesStore(
                 .mapNotNull { record -> record[SPECIES_ECOSYSTEM_TYPES.ECOSYSTEM_TYPE_ID] }
                 .toSet()
           }
+
+  private val usedInAccessions: Condition =
+      DSL.exists(
+          DSL.selectOne()
+              .from(ACCESSIONS)
+              .where(ACCESSIONS.SPECIES_ID.eq(SPECIES.ID))
+              .and(ACCESSIONS.facilities.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
+
+  private val usedInBatches: Condition =
+      DSL.exists(
+          DSL.selectOne()
+              .from(BATCHES)
+              .where(BATCHES.SPECIES_ID.eq(SPECIES.ID))
+              .and(BATCHES.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
+
+  private val usedInPlantings: Condition =
+      DSL.exists(
+          DSL.selectOne()
+              .from(PLANTINGS)
+              .where(PLANTINGS.SPECIES_ID.eq(SPECIES.ID))
+              .and(PLANTINGS.plantingSites.ORGANIZATION_ID.eq(SPECIES.ORGANIZATION_ID)))
 
   fun fetchSpeciesById(speciesId: SpeciesId): ExistingSpeciesModel {
     requirePermissions { readSpecies(speciesId) }
@@ -116,14 +140,25 @@ class SpeciesStore(
         ?: 0
   }
 
-  fun findAllSpecies(organizationId: OrganizationId): List<ExistingSpeciesModel> {
+  fun findAllSpecies(
+      organizationId: OrganizationId,
+      inUse: Boolean = false
+  ): List<ExistingSpeciesModel> {
     requirePermissions { readOrganization(organizationId) }
+
+    val condition =
+        if (inUse == true) {
+          DSL.or(usedInAccessions, usedInBatches, usedInPlantings)
+        } else {
+          DSL.noCondition()
+        }
 
     return dslContext
         .select(SPECIES.asterisk(), speciesEcosystemTypesMultiset)
         .from(SPECIES)
         .where(SPECIES.ORGANIZATION_ID.eq(organizationId))
         .and(SPECIES.DELETED_TIME.isNull)
+        .and(condition)
         .orderBy(SPECIES.ID)
         .fetch { ExistingSpeciesModel.of(it, speciesEcosystemTypesMultiset) }
   }

--- a/src/main/resources/db/migration/R__Indexes.sql
+++ b/src/main/resources/db/migration/R__Indexes.sql
@@ -8,7 +8,6 @@ CREATE INDEX IF NOT EXISTS accessions__facility_id_ix ON seedbank.accessions (fa
 CREATE INDEX IF NOT EXISTS accessions__species_id_ix ON seedbank.accessions (species_id);
 CREATE INDEX IF NOT EXISTS batches__species_id_ix ON nursery.batches (species_id);
 CREATE INDEX IF NOT EXISTS geolocation__accession_id_ix ON seedbank.geolocations (accession_id);
-CREATE INDEX IF NOT EXISTS plantings__species_id_ix ON tracking.plantings (species_id);
 CREATE INDEX IF NOT EXISTS viability_test_results__test_id_ix ON seedbank.viability_test_results (test_id);
 CREATE INDEX IF NOT EXISTS viability_test__accession_id_ix ON seedbank.viability_tests (accession_id);
 CREATE INDEX IF NOT EXISTS withdrawal__accession_id_ix ON seedbank.withdrawals (accession_id);

--- a/src/main/resources/db/migration/R__Indexes.sql
+++ b/src/main/resources/db/migration/R__Indexes.sql
@@ -5,8 +5,10 @@
 -- Foreign key columns. Not all foreign keys are indexed, just ones where the index was observed
 -- to make a difference in actual query execution.
 CREATE INDEX IF NOT EXISTS accessions__facility_id_ix ON seedbank.accessions (facility_id);
+CREATE INDEX IF NOT EXISTS accessions__species_id_ix ON seedbank.accessions (species_id);
 CREATE INDEX IF NOT EXISTS batches__species_id_ix ON nursery.batches (species_id);
 CREATE INDEX IF NOT EXISTS geolocation__accession_id_ix ON seedbank.geolocations (accession_id);
+CREATE INDEX IF NOT EXISTS plantings__species_id_ix ON tracking.plantings (species_id);
 CREATE INDEX IF NOT EXISTS viability_test_results__test_id_ix ON seedbank.viability_test_results (test_id);
 CREATE INDEX IF NOT EXISTS viability_test__accession_id_ix ON seedbank.viability_tests (accession_id);
 CREATE INDEX IF NOT EXISTS withdrawal__accession_id_ix ON seedbank.withdrawals (accession_id);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -809,7 +809,6 @@ abstract class DatabaseTest {
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       number: String? = row.number ?: id?.let { "$it" },
       receivedDate: LocalDate? = row.receivedDate,
-      speciesId: SpeciesId? = null,
       stateId: AccessionState = row.stateId ?: AccessionState.Processing,
       treesCollectedFrom: Int? = row.treesCollectedFrom,
   ): AccessionId {
@@ -824,7 +823,6 @@ abstract class DatabaseTest {
             modifiedTime = modifiedTime,
             number = number,
             receivedDate = receivedDate,
-            speciesId = speciesId,
             stateId = stateId,
             treesCollectedFrom = treesCollectedFrom,
         )

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -809,6 +809,7 @@ abstract class DatabaseTest {
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       number: String? = row.number ?: id?.let { "$it" },
       receivedDate: LocalDate? = row.receivedDate,
+      speciesId: SpeciesId? = null,
       stateId: AccessionState = row.stateId ?: AccessionState.Processing,
       treesCollectedFrom: Int? = row.treesCollectedFrom,
   ): AccessionId {
@@ -823,6 +824,7 @@ abstract class DatabaseTest {
             modifiedTime = modifiedTime,
             number = number,
             receivedDate = receivedDate,
+            speciesId = speciesId,
             stateId = stateId,
             treesCollectedFrom = treesCollectedFrom,
         )

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesEcosystemTypesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
+import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.NewSpeciesModel
@@ -541,7 +542,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     // create an accession with 'other' species
     insertFacility(id = FacilityId(200))
-    insertAccession(speciesId = created)
+    insertAccession(row = AccessionsRow(speciesId = created))
 
     // create another org accession
     val otherOrgId = insertOrganization(id = OrganizationId(2))
@@ -549,7 +550,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         store.createSpecies(
             NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
     insertFacility(id = FacilityId(300))
-    insertAccession(speciesId = other)
+    insertAccession(row = AccessionsRow(speciesId = other))
 
     val expected = listOf(store.fetchSpeciesById(created))
     val actual = store.findAllSpecies(organizationId, true)


### PR DESCRIPTION
- Enhanced SpeciesStore findAllSpecies to return in-use species controlled by an input arg
- Similar enhancement in SpeciesController list all species API
- Added tests
- I had originally separated out this functionality, seemed wasteful to have extra API/functions when we could extend the list all species API