### PR TITLE
Use compound primary key for subzone populations

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -254,9 +254,9 @@ val EMBEDDABLES =
             .withTables("tracking.planting_site_populations")
             .withColumns("planting_site_id", "species_id"),
         EmbeddableDefinitionType()
-            .withName("plot_population_id")
-            .withTables("tracking.plot_populations")
-            .withColumns("plot_id", "species_id"),
+            .withName("planting_subzone_population_id")
+            .withTables("tracking.planting_subzone_populations")
+            .withColumns("planting_subzone_id", "species_id"),
         EmbeddableDefinitionType()
             .withName("species_ecosystem_id")
             .withTables("public.species_ecosystem_types")

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonePopulationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonePopulationsTable.kt
@@ -16,7 +16,7 @@ import org.jooq.TableField
 
 class PlantingSubzonePopulationsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID
+    get() = PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_POPULATION_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {


### PR DESCRIPTION
Commit c9ae259d replaced `plot_populations` with `planting_subzone_populations`.
There was an embedded type defined for `plot_populations` to represent its
compound primary key, but it wasn't replaced with one for the new table.

Update the embedded type and use it in the subzone populations search table;
the incorrect primary key on that table could have resulted in incorrect search
results, though luckily the web app isn't currently doing any searches that
would trigger the problem.