### PR TITLE
Enable ktfmt for buildSrc and jooq modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -276,11 +276,11 @@ spotless {
   val ktfmtVersion: String by project
   kotlin {
     ktfmt(ktfmtVersion)
-    target("**/*.kt")
+    target("src/**/*.kt", "buildSrc/**/*.kt", "jooq/**/*.kt")
   }
   kotlinGradle {
     ktfmt(ktfmtVersion)
-    target("**/*.gradle.kts")
+    target("*.gradle.kts", "buildSrc/*.gradle.kts", "jooq/*.gradle.kts")
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -276,11 +276,11 @@ spotless {
   val ktfmtVersion: String by project
   kotlin {
     ktfmt(ktfmtVersion)
-    targetExclude("build/**")
+    target("**/*.kt")
   }
   kotlinGradle {
     ktfmt(ktfmtVersion)
-    target("*.gradle.kts", "buildSrc/*.gradle.kts")
+    target("**/*.gradle.kts")
   }
 }
 

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/PostgresDockerConfigTask.kt
@@ -1,6 +1,5 @@
 package com.terraformation.gradle
 
-import java.io.File
 import java.nio.file.Files
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -20,10 +19,8 @@ abstract class PostgresDockerConfigTask : DefaultTask() {
 
   @get:OutputFile
   val outputFile =
-      project
-          .layout
-          .buildDirectory
-          .file("generated-test/kotlin/com/terraformation/backend/db/DockerImage.kt")
+      project.layout.buildDirectory.file(
+          "generated-test/kotlin/com/terraformation/backend/db/DockerImage.kt")
 
   @TaskAction
   fun generate() {
@@ -34,6 +31,7 @@ abstract class PostgresDockerConfigTask : DefaultTask() {
         """package com.terraformation.backend.db
           |const val POSTGRES_DOCKER_REPOSITORY = "$postgresDockerRepository"
           |const val POSTGRES_DOCKER_TAG = "$postgresDockerTag"
-        """.trimMargin())
+        """
+            .trimMargin())
   }
 }

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderGibberishTask.kt
@@ -24,10 +24,7 @@ abstract class RenderGibberishTask : DefaultTask() {
   @get:InputFiles
   @get:SkipWhenEmpty
   val propertiesFiles =
-      project.files(
-          project.fileTree("src/main/resources/i18n") {
-            include("**/*_en.properties")
-          })
+      project.files(project.fileTree("src/main/resources/i18n") { include("**/*_en.properties") })
 
   @get:OutputFiles val outputFiles = propertiesFiles.files.map { getTargetFile(it) }
 
@@ -63,11 +60,9 @@ abstract class RenderGibberishTask : DefaultTask() {
 
     englishProperties.forEach { name, english ->
       gibberishProperties[name] =
-          "$english"
-              .split('\n')
-              .joinToString("\n") { line ->
-                line.split(' ').asReversed().joinToString(" ") { encodeWord(it) }
-              }
+          "$english".split('\n').joinToString("\n") { line ->
+            line.split(' ').asReversed().joinToString(" ") { encodeWord(it) }
+          }
     }
 
     targetFile.writer().use { gibberishProperties.store(it, null) }
@@ -76,9 +71,8 @@ abstract class RenderGibberishTask : DefaultTask() {
   /**
    * Encodes a word as gibberish, preserving template variables and link text.
    *
-   * Square-bracket-delimited links in strings are a bit subtle because we reverse the word order
-   * in gibberish. So we need to flip the link markers around if the link is multiple words:
-   *
+   * Square-bracket-delimited links in strings are a bit subtle because we reverse the word order in
+   * gibberish. So we need to flip the link markers around if the link is multiple words:
    * - `a` -> `YQ`
    * - `b` -> `Yg`
    * - `[a]` -> `[YQ]` (square bracket prefix/suffix are retained on a single-word link)
@@ -122,10 +116,8 @@ abstract class RenderGibberishTask : DefaultTask() {
             .resolve(targetFilename)
             .relativeTo(project.projectDir.resolve("src/main/resources"))
 
-    return project
-        .layout
-        .buildDirectory
-        .dir("resources/main")
-        .map { it.file(targetRelativeToResourcesDir.toString()) }
+    return project.layout.buildDirectory.dir("resources/main").map {
+      it.file(targetRelativeToResourcesDir.toString())
+    }
   }
 }

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
@@ -30,8 +30,8 @@ abstract class RenderMjmlTask : DefaultTask() {
       project.files(
           project.fileTree("src/main/resources/templates/email") { include("**/body.ftlh.mjml") })
 
-  @get:OutputDirectory val outputDir =
-      project.layout.buildDirectory.dir("resources/main/templates/email")
+  @get:OutputDirectory
+  val outputDir = project.layout.buildDirectory.dir("resources/main/templates/email")
 
   @get:Inject abstract val objects: ObjectFactory
 
@@ -95,9 +95,7 @@ abstract class RenderMjmlTask : DefaultTask() {
         File(change.file.path.substring(0, change.file.path.length - mjmlExtension.length))
             .relativeTo(project.projectDir.resolve("src/main/resources"))
 
-    return project
-        .layout
-        .buildDirectory
+    return project.layout.buildDirectory
         .get()
         .asFile
         .resolve("resources/main")

--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/VersionFileTask.kt
@@ -1,6 +1,5 @@
 package com.terraformation.gradle
 
-import java.io.File
 import java.nio.file.Files
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -41,8 +41,9 @@ val ENUM_TABLES =
                 EnumTable("facility_connection_states", "facilities\\.connection_state_id"),
                 EnumTable("facility_types", "facilities\\.type_id"),
                 EnumTable("growth_forms", listOf("growth_forms\\.id", ".*\\.growth_form_id")),
-                EnumTable("managed_location_types", listOf("managed_location_types\\.id",
-                    ".*\\.managed_location_type_id")),
+                EnumTable(
+                    "managed_location_types",
+                    listOf("managed_location_types\\.id", ".*\\.managed_location_type_id")),
                 EnumTable(
                     "notification_criticalities",
                     listOf(".*\\.notification_criticality_id"),
@@ -58,7 +59,9 @@ val ENUM_TABLES =
                                 "NotificationCriticality",
                                 true,
                             ))),
-                EnumTable("organization_types", listOf("organization_types\\.id", ".*\\.organization_type_id")),
+                EnumTable(
+                    "organization_types",
+                    listOf("organization_types\\.id", ".*\\.organization_type_id")),
                 EnumTable("report_statuses", listOf("reports\\.status_id"), "ReportStatus"),
                 EnumTable("roles", ".*\\.role_id"),
                 EnumTable(
@@ -103,8 +106,11 @@ val ENUM_TABLES =
         "tracking" to
             listOf(
                 EnumTable("observable_conditions", "observation_plot_conditions\\.condition_id"),
-                EnumTable("observation_plot_positions",
-                    listOf("observation_photos\\.position_id", "observed_plot_coordinates\\.position_id")),
+                EnumTable(
+                    "observation_plot_positions",
+                    listOf(
+                        "observation_photos\\.position_id",
+                        "observed_plot_coordinates\\.position_id")),
                 EnumTable("observation_states", "observations\\.state_id"),
                 EnumTable("planting_types", ".*\\.planting_type_id"),
                 EnumTable(
@@ -166,9 +172,7 @@ val ID_WRAPPERS =
                 IdWrapper("ReportId", listOf("reports\\.id", ".*\\.report_id")),
                 IdWrapper("SpeciesId", listOf("species\\.id", ".*\\.species_id")),
                 IdWrapper("SpeciesProblemId", listOf("species_problems\\.id")),
-                IdWrapper(
-                    "SubLocationId",
-                    listOf("sub_locations\\.id", ".*\\.sub_location_id")),
+                IdWrapper("SubLocationId", listOf("sub_locations\\.id", ".*\\.sub_location_id")),
                 IdWrapper("ThumbnailId", listOf("thumbnails\\.id")),
                 IdWrapper("TimeseriesId", listOf("timeseries\\.id", ".*\\.timeseries_id")),
                 IdWrapper("UploadId", listOf("uploads\\.id", ".*\\.upload_id")),
@@ -203,7 +207,8 @@ val ID_WRAPPERS =
         "tracking" to
             listOf(
                 IdWrapper("DeliveryId", listOf("deliveries\\.id", ".*\\.delivery_id")),
-                IdWrapper("MonitoringPlotId", listOf("monitoring_plots\\.id", ".*\\.monitoring_plot_id")),
+                IdWrapper(
+                    "MonitoringPlotId", listOf("monitoring_plots\\.id", ".*\\.monitoring_plot_id")),
                 IdWrapper("ObservationId", listOf("observations\\.id", ".*\\.observation_id")),
                 IdWrapper("ObservedPlotCoordinatesId", listOf("observed_plot_coordinates\\.id")),
                 IdWrapper("PlantingId", listOf("plantings\\.id")),
@@ -216,7 +221,9 @@ val ID_WRAPPERS =
                         ".*\\.planting_site_id")),
                 IdWrapper("PlantingSiteNotificationId", listOf("planting_site_notifications\\.id")),
                 IdWrapper("PlantingZoneId", listOf("planting_zones\\.id", ".*\\.planting_zone_id")),
-                IdWrapper("PlantingSubzoneId", listOf("planting_subzones\\.id", ".*\\.planting_subzone_id")),
+                IdWrapper(
+                    "PlantingSubzoneId",
+                    listOf("planting_subzones\\.id", ".*\\.planting_subzone_id")),
                 IdWrapper("RecordedPlantId", listOf("recorded_plants\\.id")),
             ),
     )

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/PluralPojoStrategy.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/PluralPojoStrategy.kt
@@ -6,8 +6,8 @@ import org.jooq.meta.Definition
 import org.jooq.meta.EmbeddableDefinition
 
 /**
- * Generate less-awkward names for POJO classes for tables with plural names. For example, if
- * we have a table "automobiles", the default jOOQ behavior is to generate a POJO class called
+ * Generate less-awkward names for POJO classes for tables with plural names. For example, if we
+ * have a table "automobiles", the default jOOQ behavior is to generate a POJO class called
  * `Automobiles`, but that class name implies that it's a collection of some kind. This strategy
  * causes the class to be called `AutomobilesRow` instead.
  */

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -71,7 +71,8 @@ class TerrawareGenerator : KotlinGenerator() {
             // Capitalize each word of multi-word values and concatenate them without spaces or
             // punctuation.
             val capitalizedName =
-                name.split(Regex("[-,/ ]"))
+                name
+                    .split(Regex("[-,/ ]"))
                     .joinToString("") { word -> word.replaceFirstChar { it.uppercaseChar() } }
                     .replace(Regex("[^0-9A-Za-z]"), "")
             val jsonValue = if (table.useIdAsJsonValue) "$id" else name
@@ -87,11 +88,14 @@ class TerrawareGenerator : KotlinGenerator() {
                         })
                     .joinToString()
 
-            val idLiteral = when (id) {
-              is Int -> "$id"
-              is String -> "\"$id\""
-              else -> throw IllegalArgumentException("Don't know what to do with ID type ${id?.javaClass?.name}")
-            }
+            val idLiteral =
+                when (id) {
+                  is Int -> "$id"
+                  is String -> "\"$id\""
+                  else ->
+                      throw IllegalArgumentException(
+                          "Don't know what to do with ID type ${id?.javaClass?.name}")
+                }
 
             values.add("$capitalizedName($idLiteral, $properties)")
           }
@@ -114,11 +118,14 @@ class TerrawareGenerator : KotlinGenerator() {
           val propertyType = it.columnDataType
           "val $propertyName: $propertyType"
         }
-    val idType = when (id) {
-      is Int -> "Int"
-      is String -> "String"
-      else -> throw IllegalArgumentException("Don't know what to do with ID type ${id?.javaClass?.name}")
-    }
+    val idType =
+        when (id) {
+          is Int -> "Int"
+          is String -> "String"
+          else ->
+              throw IllegalArgumentException(
+                  "Don't know what to do with ID type ${id?.javaClass?.name}")
+        }
     val properties =
         (listOf(
                 "override val id: $idType",


### PR DESCRIPTION
Previously, the `spotlessApply` and `spotlessCheck` tasks only looked at the
source files in the main module. Configure it to look at all the files in the
project including the ones in `buildSrc` and `jooq`.