### PR TITLE
SW-4411 Detect when no planting season scheduled

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
@@ -2,22 +2,29 @@ package com.terraformation.backend.daily
 
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.time.ClockAdvancedEvent
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.event.PlantingSeasonSchedulingNotificationEvent
+import com.terraformation.backend.tracking.model.NotificationCriteria
 import jakarta.inject.Inject
 import jakarta.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.jobrunr.scheduling.cron.Cron
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
 @Named
 class PlantingSeasonScheduler(
     private val config: TerrawareServerConfig,
+    private val eventPublisher: ApplicationEventPublisher,
     private val plantingSiteStore: PlantingSiteStore,
     private val systemUser: SystemUser,
 ) {
+  private val log = perClassLogger()
+
   @Inject
   fun schedule(scheduler: JobScheduler) {
     if (config.dailyTasks.enabled) {
@@ -28,13 +35,57 @@ class PlantingSeasonScheduler(
     }
   }
 
-  @Suppress("MemberVisibilityCanBePrivate") // Called by JobRunr
   fun transitionPlantingSeasons() {
-    systemUser.run { plantingSiteStore.transitionPlantingSeasons() }
+    systemUser.run {
+      plantingSiteStore.transitionPlantingSeasons()
+      sendNotifications()
+    }
   }
 
   @EventListener
   fun on(@Suppress("UNUSED_PARAMETER") event: ClockAdvancedEvent) {
     transitionPlantingSeasons()
+  }
+
+  private fun sendNotifications() {
+    NotificationCriteria.FirstPlantingSeasonNotScheduled.notifications.forEach { criteria ->
+      plantingSiteStore
+          .fetchPartiallyPlantedDetailedSitesWithNoPlantingSeasons(
+              criteria.weeksSinceCreation, criteria.notificationNotCompletedCondition())
+          .forEach { plantingSiteId ->
+            sendNotification(criteria, criteria.notificationEvent(plantingSiteId))
+          }
+    }
+
+    NotificationCriteria.NextPlantingSeasonNotScheduled.notifications.forEach { criteria ->
+      plantingSiteStore
+          .fetchPartiallyPlantedDetailedSitesWithNoUpcomingPlantingSeasons(
+              criteria.weeksSinceLastSeason, criteria.notificationNotCompletedCondition())
+          .forEach { plantingSiteId ->
+            sendNotification(criteria, criteria.notificationEvent(plantingSiteId))
+          }
+    }
+  }
+
+  private fun sendNotification(
+      criteria: NotificationCriteria,
+      event: PlantingSeasonSchedulingNotificationEvent
+  ) {
+    try {
+      // Mark the notification complete first to guard against concurrent attempts to send the
+      // same notification, which will cause all but one of the attempts to fail with an integrity
+      // constraint violation.
+      plantingSiteStore.markNotificationComplete(
+          event.plantingSiteId, criteria.notificationType, criteria.notificationNumber)
+    } catch (e: Exception) {
+      log.warn(
+          "Failed to mark notification complete for planting site ${event.plantingSiteId}; " +
+              "not sending it",
+          e)
+
+      return
+    }
+
+    eventPublisher.publishEvent(event)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -221,7 +221,7 @@ class ObservationService(
         criteria.completedTimeElapsedWeeks,
         criteria.firstPlantingElapsedWeeks,
         plantingSiteStore.fetchSitesWithSubzonePlantings(
-            criteria.notificationNotCompletedCondition))
+            criteria.notificationNotCompletedCondition(requirePrevious = true)))
   }
 
   /** Mark notification to schedule observations as complete */

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -58,6 +58,7 @@ import java.time.Instant
 import java.time.InstantSource
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Field
@@ -636,6 +637,59 @@ class PlantingSiteStore(
         .fetch(PLANTING_SITES.ID.asNonNullable())
   }
 
+  fun fetchPartiallyPlantedDetailedSitesWithNoPlantingSeasons(
+      weeksSinceCreation: Int,
+      additionalCondition: Condition
+  ): List<PlantingSiteId> {
+    requirePermissions { manageNotifications() }
+
+    val maxCreatedTime = clock.instant().minus(weeksSinceCreation * 7L, ChronoUnit.DAYS)
+
+    return dslContext
+        .select(PLANTING_SITES.ID)
+        .from(PLANTING_SITES)
+        .where(additionalCondition)
+        .and(PLANTING_SITES.CREATED_TIME.le(maxCreatedTime))
+        .andNotExists(
+            DSL.selectOne()
+                .from(PLANTING_SEASONS)
+                .where(PLANTING_SITES.ID.eq(PLANTING_SEASONS.PLANTING_SITE_ID)))
+        .andExists(
+            DSL.selectOne()
+                .from(PLANTING_SUBZONES)
+                .where(PLANTING_SITES.ID.eq(PLANTING_SUBZONES.PLANTING_SITE_ID))
+                .and(PLANTING_SUBZONES.PLANTING_COMPLETED_TIME.isNull))
+        .orderBy(PLANTING_SITES.ID)
+        .fetch(PLANTING_SITES.ID.asNonNullable())
+  }
+
+  fun fetchPartiallyPlantedDetailedSitesWithNoUpcomingPlantingSeasons(
+      weeksSinceLastSeason: Int,
+      additionalCondition: Condition
+  ): List<PlantingSiteId> {
+    requirePermissions { manageNotifications() }
+
+    val maxEndTime = clock.instant().minus(weeksSinceLastSeason * 7L, ChronoUnit.DAYS)
+
+    return dslContext
+        .select(PLANTING_SITES.ID)
+        .from(PLANTING_SITES)
+        .where(additionalCondition)
+        .and(
+            DSL.field(
+                    DSL.select(DSL.max(PLANTING_SEASONS.END_TIME))
+                        .from(PLANTING_SEASONS)
+                        .where(PLANTING_SITES.ID.eq(PLANTING_SEASONS.PLANTING_SITE_ID)))
+                .le(maxEndTime))
+        .andExists(
+            DSL.selectOne()
+                .from(PLANTING_SUBZONES)
+                .where(PLANTING_SITES.ID.eq(PLANTING_SUBZONES.PLANTING_SITE_ID))
+                .and(PLANTING_SUBZONES.PLANTING_COMPLETED_TIME.isNull))
+        .orderBy(PLANTING_SITES.ID)
+        .fetch(PLANTING_SITES.ID.asNonNullable())
+  }
+
   fun transitionPlantingSeasons() {
     endPlantingSeasons()
     startPlantingSeasons()
@@ -1042,6 +1096,7 @@ class PlantingSiteStore(
       if (rowsUpdated > 0) {
         log.info("Planting season $plantingSeasonId at site $plantingSiteId has ended")
 
+        deleteRecurringPlantingSeasonNotifications(plantingSiteId)
         eventPublisher.publishEvent(PlantingSeasonEndedEvent(plantingSiteId, plantingSeasonId))
       }
     }
@@ -1058,5 +1113,21 @@ class PlantingSiteStore(
         .forEach { (plantingSiteId, plantingSeasonId) ->
           endPlantingSeason(plantingSiteId, plantingSeasonId)
         }
+  }
+
+  /**
+   * Deletes the records about planting-season-related notifications that can be sent for each
+   * planting season. This is so that when the next planting season happens, the existing records
+   * don't cause the system to think that it has already generated the necessary notifications.
+   */
+  private fun deleteRecurringPlantingSeasonNotifications(plantingSiteId: PlantingSiteId) {
+    dslContext
+        .deleteFrom(PLANTING_SITE_NOTIFICATIONS)
+        .where(PLANTING_SITE_NOTIFICATIONS.PLANTING_SITE_ID.eq(plantingSiteId))
+        .and(
+            PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_TYPE_ID.`in`(
+                NotificationType.SchedulePlantingSeason,
+            ))
+        .execute()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -83,3 +83,13 @@ data class PlantingSeasonEndedEvent(
     val plantingSiteId: PlantingSiteId,
     val plantingSeasonId: PlantingSeasonId,
 )
+
+interface PlantingSeasonSchedulingNotificationEvent {
+  val plantingSiteId: PlantingSiteId
+  val notificationNumber: Int
+}
+
+data class PlantingSeasonNotScheduledNotificationEvent(
+    override val plantingSiteId: PlantingSiteId,
+    override val notificationNumber: Int,
+) : PlantingSeasonSchedulingNotificationEvent

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/NotificationCriteria.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/NotificationCriteria.kt
@@ -6,45 +6,51 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_NOTIFICATIONS
 import com.terraformation.backend.tracking.event.ObservationNotScheduledNotificationEvent
 import com.terraformation.backend.tracking.event.ObservationSchedulingNotificationEvent
+import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationNotificationEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationReminderNotificationEvent
 import org.jooq.Condition
 import org.jooq.impl.DSL
 
-class NotificationCriteria {
-  sealed interface ObservationScheduling {
+interface NotificationCriteria {
+  val notificationType: NotificationType
+  val notificationNumber: Int
+
+  /**
+   * Returns a query condition that evaluates to true if this notification hasn't been marked as
+   * completed yet.
+   *
+   * @param requirePrevious If true, also require the notification with the previous number to be
+   *   marked as completed if [notificationNumber] is greater than 1.
+   */
+  fun notificationNotCompletedCondition(requirePrevious: Boolean = false): Condition {
+    val thisNotificationNotSent =
+        DSL.notExists(
+            DSL.selectOne()
+                .from(PLANTING_SITE_NOTIFICATIONS)
+                .where(PLANTING_SITES.ID.eq(PLANTING_SITE_NOTIFICATIONS.PLANTING_SITE_ID))
+                .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_TYPE_ID.eq(notificationType))
+                .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_NUMBER.ge(notificationNumber)))
+
+    return if (requirePrevious && notificationNumber > 1) {
+      val previousNotificationSent =
+          DSL.exists(
+              DSL.selectOne()
+                  .from(PLANTING_SITE_NOTIFICATIONS)
+                  .where(PLANTING_SITES.ID.eq(PLANTING_SITE_NOTIFICATIONS.PLANTING_SITE_ID))
+                  .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_TYPE_ID.eq(notificationType))
+                  .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_NUMBER.eq(notificationNumber - 1)))
+
+      DSL.and(previousNotificationSent, thisNotificationNotSent)
+    } else {
+      thisNotificationNotSent
+    }
+  }
+
+  sealed interface ObservationScheduling : NotificationCriteria {
     val completedTimeElapsedWeeks: Long
     val firstPlantingElapsedWeeks: Long
-    val notificationType: NotificationType
-    val notificationNumber: Int
     fun notificationEvent(plantingSiteId: PlantingSiteId): ObservationSchedulingNotificationEvent
-
-    val notificationNotCompletedCondition: Condition
-      get() {
-        val thisNotificationNotSent =
-            DSL.notExists(
-                DSL.selectOne()
-                    .from(PLANTING_SITE_NOTIFICATIONS)
-                    .where(PLANTING_SITES.ID.eq(PLANTING_SITE_NOTIFICATIONS.PLANTING_SITE_ID))
-                    .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_TYPE_ID.eq(notificationType))
-                    .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_NUMBER.ge(notificationNumber)))
-
-        return if (notificationNumber > 1) {
-          val previousNotificationSent =
-              DSL.exists(
-                  DSL.selectOne()
-                      .from(PLANTING_SITE_NOTIFICATIONS)
-                      .where(PLANTING_SITES.ID.eq(PLANTING_SITE_NOTIFICATIONS.PLANTING_SITE_ID))
-                      .and(PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_TYPE_ID.eq(notificationType))
-                      .and(
-                          PLANTING_SITE_NOTIFICATIONS.NOTIFICATION_NUMBER.eq(
-                              notificationNumber - 1)))
-
-          DSL.and(previousNotificationSent, thisNotificationNotSent)
-        } else {
-          thisNotificationNotSent
-        }
-      }
   }
 
   data object ScheduleObservations : ObservationScheduling {
@@ -87,5 +93,47 @@ class NotificationCriteria {
 
     override fun notificationEvent(plantingSiteId: PlantingSiteId) =
         ObservationNotScheduledNotificationEvent(plantingSiteId)
+  }
+
+  data class FirstPlantingSeasonNotScheduled(
+      override val notificationNumber: Int,
+      val weeksSinceCreation: Int
+  ) : NotificationCriteria {
+    override val notificationType
+      get() = NotificationType.SchedulePlantingSeason
+
+    fun notificationEvent(plantingSiteId: PlantingSiteId) =
+        PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, notificationNumber)
+
+    companion object {
+      // These should be in descending notification number order to avoid sending multiple
+      // notifications.
+      val notifications =
+          listOf(
+              FirstPlantingSeasonNotScheduled(notificationNumber = 2, weeksSinceCreation = 4),
+              FirstPlantingSeasonNotScheduled(notificationNumber = 1, weeksSinceCreation = 0),
+          )
+    }
+  }
+
+  data class NextPlantingSeasonNotScheduled(
+      override val notificationNumber: Int,
+      val weeksSinceLastSeason: Int
+  ) : NotificationCriteria {
+    override val notificationType: NotificationType
+      get() = NotificationType.SchedulePlantingSeason
+
+    fun notificationEvent(plantingSiteId: PlantingSiteId) =
+        PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, notificationNumber)
+
+    companion object {
+      // These should be in descending notification number order to avoid sending multiple
+      // notifications.
+      val notifications =
+          listOf(
+              NextPlantingSeasonNotScheduled(notificationNumber = 2, weeksSinceLastSeason = 6),
+              NextPlantingSeasonNotScheduled(notificationNumber = 1, weeksSinceLastSeason = 2),
+          )
+    }
   }
 }

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -137,7 +137,8 @@ VALUES (1, 'User Added to Organization', 1),
        (19, 'Schedule Observation', 1),
        (20, 'Schedule Observation Reminder', 1),
        (21, 'Observation Not Scheduled (Support)', 1),
-       (22, 'Planting Season Started', 1)
+       (22, 'Planting Season Started', 1),
+       (23, 'Schedule Planting Season', 2)
 ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
                                notification_criticality_id = excluded.notification_criticality_id;
 

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -1,0 +1,250 @@
+package com.terraformation.backend.daily
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
+import com.terraformation.backend.util.toInstant
+import io.mockk.mockk
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val config = mockk<TerrawareServerConfig>()
+  private val eventPublisher = TestEventPublisher()
+
+  private val scheduler: PlantingSeasonScheduler by lazy {
+    PlantingSeasonScheduler(
+        config,
+        eventPublisher,
+        PlantingSiteStore(
+            clock,
+            dslContext,
+            eventPublisher,
+            monitoringPlotsDao,
+            ParentStore(dslContext),
+            plantingSeasonsDao,
+            plantingSitesDao,
+            plantingSubzonesDao,
+            plantingZonesDao,
+        ),
+        SystemUser(usersDao),
+    )
+  }
+
+  private val timeZone = ZoneId.of("America/Los_Angeles")
+  private val initialDate = LocalDate.of(2023, 1, 1)
+  private val initialInstant = initialDate.toInstant(timeZone)
+
+  @BeforeEach
+  fun setUp() {
+    insertTimeZone(timeZone)
+    insertUser()
+    insertOrganization(timeZone = timeZone)
+
+    clock.instant = initialInstant
+  }
+
+  @Nested
+  inner class FirstPlantingSeasonNotification {
+    @Test
+    fun `sends reminders after correct numbers of weeks have passed since site creation`() {
+      val plantingSiteId = insertPlantingSiteWithSubzone()
+
+      assertEventsAtWeekNumber(0, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
+      assertEventsAtWeekNumber(4, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 2))
+      assertNoEventsAtWeekNumber(52)
+    }
+
+    @Test
+    fun `does not send first-season reminders about sites that have seasons`() {
+      insertPlantingSiteWithSeason()
+
+      assertNoEventsAtWeekNumber(0)
+    }
+
+    @Test
+    fun `does not send multiple reminders if several reminder deadlines have passed`() {
+      val plantingSiteId = insertPlantingSiteWithSubzone()
+
+      clock.instant = initialDate.plusWeeks(52).toInstant(timeZone)
+      scheduler.transitionPlantingSeasons()
+
+      eventPublisher.assertExactEventsPublished(
+          listOf(PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 2)),
+          "Should have sent last notification")
+
+      clock.instant = clock.instant.plusSeconds(1)
+      eventPublisher.clear()
+      scheduler.transitionPlantingSeasons()
+
+      eventPublisher.assertNoEventsPublished()
+    }
+
+    @Test
+    fun `does not send reminders about sites without subzones`() {
+      insertPlantingSite(createdTime = initialInstant)
+
+      assertNoEventsAtWeekNumber(52)
+    }
+
+    @Test
+    fun `sends reminders about partially-planted sites`() {
+      val plantingSiteId = insertPlantingSiteWithSubzone()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+
+      assertEventsAtWeekNumber(0, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
+    }
+
+    @Test
+    fun `does not send reminders about fully-planted sites`() {
+      insertPlantingSite(createdTime = initialInstant)
+      insertPlantingZone()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+      insertPlantingZone()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+
+      assertNoEventsAtWeekNumber(52)
+    }
+  }
+
+  @Nested
+  inner class NextPlantingSeasonNotification {
+    @Test
+    fun `sends reminders after correct numbers of weeks have passed since end of prior season`() {
+      val plantingSiteId = insertPlantingSiteWithSeason()
+
+      assertEventsAtWeekNumber(2, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
+      assertEventsAtWeekNumber(6, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 2))
+      assertNoEventsAtWeekNumber(52)
+    }
+
+    @Test
+    fun `does not send reminders if there are upcoming seasons`() {
+      insertPlantingSiteWithSeason()
+      insertPlantingSeason(
+          timeZone = timeZone,
+          startDate = initialDate.plusMonths(1),
+          endDate = initialDate.plusMonths(3))
+
+      assertNoEventsAtWeekNumber(2)
+    }
+
+    @Test
+    fun `does not send multiple reminders if several reminder deadlines have passed`() {
+      val plantingSiteId = insertPlantingSiteWithSeason()
+
+      clock.instant = instantAtWeekNumber(52)
+      scheduler.transitionPlantingSeasons()
+
+      eventPublisher.assertExactEventsPublished(
+          listOf(PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 2)),
+          "Should have sent last notification")
+
+      clock.instant = clock.instant.plusSeconds(1)
+      eventPublisher.clear()
+      scheduler.transitionPlantingSeasons()
+
+      eventPublisher.assertNoEventsPublished()
+    }
+
+    @Test
+    fun `does not send reminders about sites without subzones`() {
+      insertPlantingSiteWithSeason(subzone = false)
+
+      assertNoEventsAtWeekNumber(52)
+    }
+
+    @Test
+    fun `sends reminders about partially-planted sites`() {
+      val plantingSiteId = insertPlantingSiteWithSeason()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+
+      assertEventsAtWeekNumber(2, PlantingSeasonNotScheduledNotificationEvent(plantingSiteId, 1))
+    }
+
+    @Test
+    fun `does not send reminders about fully-planted sites`() {
+      insertPlantingSite(createdTime = initialInstant)
+      insertPlantingZone()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+      insertPlantingZone()
+      insertPlantingSubzone(plantingCompletedTime = initialInstant)
+      insertPlantingSeason(
+          timeZone = timeZone,
+          startDate = initialDate.minusWeeks(6),
+          endDate = initialDate.minusDays(1),
+      )
+
+      assertNoEventsAtWeekNumber(52)
+    }
+  }
+
+  private fun instantAtWeekNumber(weeks: Int) = initialInstant.plus(weeks * 7L, ChronoUnit.DAYS)
+
+  private fun assertNoEventsAtWeekNumber(weeks: Int) {
+    clock.instant = instantAtWeekNumber(weeks)
+
+    scheduler.transitionPlantingSeasons()
+    eventPublisher.assertNoEventsPublished("Sent unexpected notifications at $weeks weeks")
+  }
+
+  private fun assertEventsAtWeekNumber(weeks: Int, vararg events: Any) {
+    val targetInstant = instantAtWeekNumber(weeks)
+
+    clock.instant = targetInstant.minusSeconds(1)
+    scheduler.transitionPlantingSeasons()
+    eventPublisher.assertNoEventsPublished("Sent $weeks-weeks notification too early")
+
+    clock.instant = targetInstant
+    scheduler.transitionPlantingSeasons()
+    eventPublisher.assertExactEventsPublished(events.toSet(), "$weeks-weeks notification")
+    eventPublisher.clear()
+
+    clock.instant = targetInstant.plusSeconds(1)
+    scheduler.transitionPlantingSeasons()
+    eventPublisher.assertNoEventsPublished("Sent duplicate $weeks-weeks notification")
+  }
+
+  private fun insertPlantingSiteWithSubzone(): PlantingSiteId {
+    val plantingSiteId = insertPlantingSite(createdTime = clock.instant)
+    insertPlantingZone()
+    insertPlantingSubzone()
+
+    return plantingSiteId
+  }
+
+  private fun insertPlantingSiteWithSeason(subzone: Boolean = true): PlantingSiteId {
+    val plantingSiteId =
+        if (subzone) {
+          insertPlantingSiteWithSubzone()
+        } else {
+          insertPlantingSite(createdTime = clock.instant)
+        }
+
+    // The end date is the day before initialDate so that calculating week numbers based on
+    // initialDate will give us weeks since the end of the last season.
+    insertPlantingSeason(
+        plantingSiteId = plantingSiteId,
+        timeZone = timeZone,
+        startDate = initialDate.minusWeeks(6),
+        endDate = initialDate.minusDays(1),
+    )
+
+    return plantingSiteId
+  }
+}


### PR DESCRIPTION
Scan for planting sites that ought to have planting seasons but don't, and publish
application events to trigger an initial notification and then a reminder 4 weeks
after that.

The timing of the initial notification varies depending on whether or not the site
has had planting seasons in the past.

This change doesn't send any actual notifications, just publishes the application
events; the notifications will be implemented in a later change.