### PR TITLE
SW-4414 Generate events for accelerator planting seasons

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -93,3 +93,8 @@ data class PlantingSeasonNotScheduledNotificationEvent(
     override val plantingSiteId: PlantingSiteId,
     override val notificationNumber: Int,
 ) : PlantingSeasonSchedulingNotificationEvent
+
+data class PlantingSeasonNotScheduledSupportNotificationEvent(
+    override val plantingSiteId: PlantingSiteId,
+    override val notificationNumber: Int,
+) : PlantingSeasonSchedulingNotificationEvent

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -138,7 +138,8 @@ VALUES (1, 'User Added to Organization', 1),
        (20, 'Schedule Observation Reminder', 1),
        (21, 'Observation Not Scheduled (Support)', 1),
        (22, 'Planting Season Started', 1),
-       (23, 'Schedule Planting Season', 2)
+       (23, 'Schedule Planting Season', 2),
+       (24, 'Planting Season Not Scheduled (Support)', 2)
 ON CONFLICT (id) DO UPDATE SET name                        = excluded.name,
                                notification_criticality_id = excluded.notification_criticality_id;
 


### PR DESCRIPTION
For accelerator participants, we want to notify their Terraformation project
contacts if they still haven't set up planting seasons 2 weeks after we send
the second in-app notification about it.

Add logic to publish the required notification events.

This doesn't actually send the notifications; those will be added in a later
change.