### PR TITLE
SW-4414 Send accelerator planting season email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.email.model.ObservationScheduled
 import com.terraformation.backend.email.model.ObservationStarted
 import com.terraformation.backend.email.model.ObservationUpcoming
 import com.terraformation.backend.email.model.PlantingSeasonNotScheduled
+import com.terraformation.backend.email.model.PlantingSeasonNotScheduledSupport
 import com.terraformation.backend.email.model.PlantingSeasonRescheduled
 import com.terraformation.backend.email.model.PlantingSeasonScheduled
 import com.terraformation.backend.email.model.PlantingSeasonStarted
@@ -63,6 +64,7 @@ import com.terraformation.backend.tracking.event.ObservationScheduledEvent
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
 import com.terraformation.backend.tracking.event.ObservationUpcomingNotificationDueEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
+import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledSupportNotificationEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
@@ -453,6 +455,17 @@ class EmailNotificationService(
 
     emailService.sendOrganizationNotification(
         plantingSite.organizationId, model, roles = setOf(Role.Owner, Role.Admin, Role.Manager))
+  }
+
+  @EventListener
+  fun on(event: PlantingSeasonNotScheduledSupportNotificationEvent) {
+    val plantingSite = plantingSiteStore.fetchSiteById(event.plantingSiteId, PlantingSiteDepth.Site)
+    val organization =
+        organizationStore.fetchOneById(
+            plantingSite.organizationId, OrganizationStore.FetchDepth.Organization)
+    val model = PlantingSeasonNotScheduledSupport(config, organization.name, plantingSite.name)
+
+    sendToOrganizationContact(organization, model)
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -363,3 +363,12 @@ class PlantingSeasonNotScheduled(
   override val templateDir: String
     get() = "plantingSeason/notScheduled"
 }
+
+class PlantingSeasonNotScheduledSupport(
+    config: TerrawareServerConfig,
+    val organizationName: String,
+    val plantingSiteName: String,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "plantingSeason/notScheduledSupport"
+}

--- a/src/main/resources/templates/email/plantingSeason/notScheduledSupport/body.ftlh.mjml
+++ b/src/main/resources/templates/email/plantingSeason/notScheduledSupport/body.ftlh.mjml
@@ -1,0 +1,20 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonNotScheduledSupport" -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03">
+                    Planting site ${plantingSiteName} is missing a planting season, but the
+                    organization has not scheduled one.
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/plantingSeason/notScheduledSupport/body.txt.ftl
+++ b/src/main/resources/templates/email/plantingSeason/notScheduledSupport/body.txt.ftl
@@ -1,0 +1,7 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonNotScheduledSupport" -->
+Planting site ${plantingSiteName} is missing a planting season, but the
+organization has not scheduled one.
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/plantingSeason/notScheduledSupport/subject.ftl
+++ b/src/main/resources/templates/email/plantingSeason/notScheduledSupport/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSeasonNotScheduledSupport" -->
+Organization ${organizationName} has not scheduled a planting season for planting site ${plantingSiteName}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -55,6 +55,7 @@ import com.terraformation.backend.tracking.event.ObservationScheduledEvent
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
 import com.terraformation.backend.tracking.event.ObservationUpcomingNotificationDueEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
+import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledSupportNotificationEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
@@ -696,6 +697,23 @@ internal class EmailNotificationServiceTest {
     assertBodyContains("schedule", "Text")
     assertBodyContains(webAppUrls.fullPlantingSite(organization.id, plantingSite.id), "Link URL")
     assertIsEventListener<PlantingSeasonNotScheduledNotificationEvent>(service)
+  }
+
+  @Test
+  fun plantingSeasonNotScheduledSupport() {
+    every { organizationStore.fetchTerraformationContact(organization.id) } returns tfContactUserId
+
+    val event = PlantingSeasonNotScheduledSupportNotificationEvent(plantingSite.id, 1)
+
+    service.on(event)
+
+    assertSubjectContains("Test Organization")
+    assertSubjectContains("My Site")
+    assertSubjectContains("not scheduled")
+    assertBodyContains("My Site")
+    assertBodyContains("missing a planting season")
+    assertRecipientsEqual(setOf(tfContactEmail))
+    assertIsEventListener<PlantingSeasonNotScheduledSupportNotificationEvent>(service)
   }
 
   @Test


### PR DESCRIPTION
Send email (but not in-app) notifications to the organization's Terraformation
project contact, or to the support mailing list, if they haven't set up a planting
season after being reminded to do so in-app.

Since these notifications are internal-only, their English content is included
directly in the email templates rather than looked up in the string table.