### PR TITLE
Add config option to keep invalid photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -62,6 +62,12 @@ class TerrawareServerConfig(
      */
     val useTestClock: Boolean = false,
 
+    /**
+     * Retain uploaded files that fail file validation. This may be set in test environments so we
+     * can examine the files and see why they failed.
+     */
+    val keepInvalidUploads: Boolean = false,
+
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -49,7 +49,12 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
   private val thumbnailStore: ThumbnailStore = mockk()
   private val fileService: FileService by lazy {
     FileService(
-        dslContext, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), filesDao, fileStore, thumbnailStore)
+        dslContext,
+        Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+        mockk(),
+        filesDao,
+        fileStore,
+        thumbnailStore)
   }
   private val service: BatchPhotoService by lazy {
     BatchPhotoService(batchPhotosDao, clock, dslContext, fileService, ImageUtils(fileStore))

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -42,7 +42,12 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
   private val thumbnailStore: ThumbnailStore = mockk()
   private val fileService: FileService by lazy {
     FileService(
-        dslContext, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), filesDao, fileStore, thumbnailStore)
+        dslContext,
+        Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+        mockk(),
+        filesDao,
+        fileStore,
+        thumbnailStore)
   }
   private val service: WithdrawalPhotoService by lazy {
     WithdrawalPhotoService(dslContext, fileService, ImageUtils(fileStore), withdrawalPhotosDao)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
@@ -47,7 +47,7 @@ class ReportFileServiceTest : DatabaseTest(), RunsAsUser {
   private val fileStore: FileStore = mockk()
   private val thumbnailStore: ThumbnailStore = mockk()
   private val fileService: FileService by lazy {
-    FileService(dslContext, clock, filesDao, fileStore, thumbnailStore)
+    FileService(dslContext, clock, mockk(), filesDao, fileStore, thumbnailStore)
   }
   private val reportStore: ReportStore by lazy {
     ReportStore(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -98,7 +98,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     every { user.canReadAccession(any()) } returns true
     every { user.canUploadPhoto(any()) } returns true
 
-    fileService = FileService(dslContext, clock, filesDao, fileStore, thumbnailStore)
+    fileService = FileService(dslContext, clock, mockk(), filesDao, fileStore, thumbnailStore)
     repository = PhotoRepository(accessionPhotosDao, dslContext, fileService, ImageUtils(fileStore))
 
     insertSiteData()

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -82,7 +82,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val fileService: FileService by lazy {
     FileService(
-        dslContext, Clock.fixed(Instant.EPOCH, ZoneOffset.UTC), filesDao, fileStore, thumbnailStore)
+        dslContext,
+        Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
+        mockk(),
+        filesDao,
+        fileStore,
+        thumbnailStore)
   }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(


### PR DESCRIPTION
For debugging photo format issues in the mobile app, it'll be helpful to be
able to examine files that failed the format validation check. Add a config
option to skip deleting invalid files.

We'll enable the option in staging but keep the default behavior in prod.