### PR TITLE
Reduce Dokka resource consumption

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 
   id("dev.monosoul.jooq-docker") version "6.0.3"
   id("com.diffplug.spotless") version "6.19.0"
-  id("org.jetbrains.dokka") version "1.9.0"
+  id("org.jetbrains.dokka") version "1.9.10"
   id("org.springframework.boot") version "3.2.0"
   id("io.spring.dependency-management") version "1.1.4"
 
@@ -335,7 +335,15 @@ tasks.withType<DokkaTask>().configureEach {
     named("main") {
       outputDirectory = file("docs/dokka")
       moduleName = "Terraware Server"
+      moduleVersion = "latest"
       includes.from(fileTree("src/main/kotlin") { include("**/Package.md") })
+      perPackageOption {
+        // Suppress docs for the generated jOOQ classes; the docs aren't useful and they cause
+        // Dokka to chew tons of memory.
+        matchingRegex =
+            "^com\\.terraformation\\.backend\\.db\\.(default_schema|nursery|seedbank|tracking).*"
+        suppress = true
+      }
       sourceLink {
         localDirectory = file("src/main/kotlin")
         remoteUrl =


### PR DESCRIPTION
CI docs jobs started timing out because Dokka's memory consumption grew to the
point where it was stuck doing constant full GCs.

Dokka's memory usage, unsurprisingly, goes up the more classes/functions it's
generating docs for.

We were generating HTML docs for all the Kotlin code including jOOQ-generated
classes, but the docs for those classes aren't really useful since they never have
any human-written comments.

Dokka docs include a version identifier, and by default it uses the module version
from the Gradle config. In our Gradle setup, this includes a git commit hash,
meaning that on every code commit, all the Dokka files were being modified. This
caused the revision history on the `gh-pages` branch to be less useful; every
commit touches every Dokka-generated file.

Update the Dokka config to exclude the packages with the bulk of the generated
classes and to use a hardwired module version.

With the reduced set of source files, the increased memory usage in Dokka 1.9.10
shouldn't cause our CI builds to fail any more, so upgrade Dokka as well.