### PR TITLE
Add 'where' to project update query

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -210,7 +210,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
       store.update(projectId) {
         ExistingProjectModel(
             description = "New description",
-            id = projectId,
+            id = ProjectId(-1),
             name = "New name",
             organizationId = OrganizationId(-1),
         )


### PR DESCRIPTION
Fixes a bug which occurred during project update. Since there is no `where` it was attempting to insert a new row, which conflicted with the pre-existing row due to a constraint on the project name.