### PR TITLE
SW-3937 Add project ID, name to reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.report.api
 
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -114,6 +115,8 @@ data class GetReportPayloadV1(
     override val nurseries: List<GetNurseryV1>,
     val organizationName: String,
     override val plantingSites: List<GetPlantingSiteV1>,
+    val projectId: ProjectId?,
+    val projectName: String?,
     override val quarter: Int,
     override val seedBanks: List<GetSeedBankV1>,
     override val status: ReportStatus,
@@ -144,6 +147,8 @@ data class GetReportPayloadV1(
       nurseries = body.nurseries.map { GetNurseryV1(it) },
       organizationName = body.organizationName,
       plantingSites = body.plantingSites.map { GetPlantingSiteV1(it) },
+      projectId = metadata.projectId,
+      projectName = metadata.projectName,
       quarter = metadata.quarter,
       seedBanks = body.seedBanks.map { GetSeedBankV1(it) },
       status = metadata.status,

--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -92,6 +92,8 @@ class ReportStore(
               MODIFIED_BY,
               MODIFIED_TIME,
               ORGANIZATION_ID,
+              PROJECT_ID,
+              PROJECT_NAME,
               QUARTER,
               STATUS_ID,
               SUBMITTED_BY,

--- a/src/main/kotlin/com/terraformation/backend/report/model/Reports.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/Reports.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.UserId
@@ -30,6 +31,8 @@ data class ReportMetadata(
     val modifiedBy: UserId? = null,
     val modifiedTime: Instant? = null,
     val organizationId: OrganizationId,
+    val projectId: ProjectId? = null,
+    val projectName: String? = null,
     val quarter: Int,
     val status: ReportStatus,
     val submittedBy: UserId? = null,
@@ -45,6 +48,8 @@ data class ReportMetadata(
       modifiedBy = row.modifiedBy,
       modifiedTime = row.modifiedTime,
       organizationId = row.organizationId!!,
+      projectId = row.projectId,
+      projectName = row.projectName,
       quarter = row.quarter!!,
       status = row.statusId!!,
       submittedBy = row.submittedBy,
@@ -61,6 +66,8 @@ data class ReportMetadata(
       modifiedBy = record[REPORTS.MODIFIED_BY],
       modifiedTime = record[REPORTS.MODIFIED_TIME],
       organizationId = record[REPORTS.ORGANIZATION_ID.asNonNullable()],
+      projectId = record[REPORTS.PROJECT_ID],
+      projectName = record[REPORTS.PROJECT_NAME],
       quarter = record[REPORTS.QUARTER.asNonNullable()],
       status = record[REPORTS.STATUS_ID.asNonNullable()],
       submittedBy = record[REPORTS.SUBMITTED_BY],

--- a/src/main/resources/db/migration/0200/V231__ReportProjects.sql
+++ b/src/main/resources/db/migration/0200/V231__ReportProjects.sql
@@ -1,0 +1,11 @@
+ALTER TABLE reports DROP CONSTRAINT one_report_per_quarter;
+
+ALTER TABLE reports ADD COLUMN project_id BIGINT REFERENCES projects (id) ON DELETE SET NULL;
+ALTER TABLE reports ADD COLUMN project_name TEXT;
+
+CREATE INDEX ON reports (project_id);
+
+ALTER TABLE reports ADD CONSTRAINT one_project_report_per_quarter
+    UNIQUE (organization_id, project_id, year, quarter);
+ALTER TABLE reports ADD CONSTRAINT one_org_report_per_quarter
+    EXCLUDE (organization_id WITH =, year WITH =, quarter WITH =) WHERE (project_id IS NULL);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -134,7 +134,9 @@ COMMENT ON TABLE report_photos IS 'Linking table between `reports` and `files` f
 
 COMMENT ON TABLE report_statuses IS '(Enum) Describes where in the workflow each partner report is.';
 
-COMMENT ON TABLE reports IS 'Partner-submitted reports about their projects.';
+COMMENT ON TABLE reports IS 'Partner-submitted reports about their organizations and projects.';
+COMMENT ON COLUMN reports.project_id IS 'If this report is for a specific project and the project still exists, the project ID. If the project has been deleted, this will be null but `project_name` will still be populated.';
+COMMENT ON COLUMN reports.project_name IS 'If this report is for a specific project, the name of the project as of the time the report was submitted.';
 
 COMMENT ON TABLE roles IS '(Enum) Roles a user is allowed to have in an organization.';
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -1359,6 +1359,8 @@ abstract class DatabaseTest {
       lockedBy: Any? = row.lockedBy,
       lockedTime: Instant? = row.lockedTime ?: lockedBy?.let { Instant.EPOCH },
       organizationId: Any = row.organizationId ?: this.organizationId,
+      projectId: Any? = row.projectId,
+      projectName: String? = row.projectName,
       quarter: Int = row.quarter ?: 1,
       submittedBy: Any? = row.submittedBy,
       submittedTime: Instant? = row.submittedTime ?: submittedBy?.let { Instant.EPOCH },
@@ -1371,6 +1373,10 @@ abstract class DatabaseTest {
               },
       year: Int = row.year ?: 1970,
   ): ReportId {
+    val projectIdWrapper = projectId?.toIdWrapper { ProjectId(it) }
+    val projectNameWithDefault =
+        projectName ?: projectIdWrapper?.let { projectsDao.fetchOneById(it)?.name }
+
     val rowWithDefaults =
         row.copy(
             body = JSONB.jsonb(body),
@@ -1378,6 +1384,8 @@ abstract class DatabaseTest {
             lockedBy = lockedBy?.toIdWrapper { UserId(it) },
             lockedTime = lockedTime,
             organizationId = organizationId.toIdWrapper { OrganizationId(it) },
+            projectId = projectIdWrapper,
+            projectName = projectNameWithDefault,
             quarter = quarter,
             statusId = status,
             submittedBy = submittedBy?.toIdWrapper { UserId(it) },

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -173,7 +173,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns report with deserialized body`() {
       val body = ReportBodyModelV1(organizationName = "org")
 
-      val reportId = insertReport()
+      val projectId = insertProject(name = "Test Project")
+      val reportId = insertReport(projectId = projectId)
 
       val expected =
           ReportModel(
@@ -181,6 +182,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
               ReportMetadata(
                   id = reportId,
                   organizationId = organizationId,
+                  projectId = projectId,
+                  projectName = "Test Project",
                   quarter = 1,
                   status = ReportStatus.New,
                   year = 1970,


### PR DESCRIPTION
Update the database schema to allow project-specific reports.

The logic for writing the reports and for populating them with the correct
information will follow in other changes.