### PR TITLE
SW-3937 Create project-level reports

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
@@ -55,10 +55,12 @@ class ReportFileServiceTest : DatabaseTest(), RunsAsUser {
         clock,
         dslContext,
         TestEventPublisher(),
+        facilitiesDao,
         jacksonObjectMapper(),
         ParentStore(dslContext),
+        projectsDao,
         reportsDao,
-        facilitiesDao)
+    )
   }
   private val service: ReportFileService by lazy {
     ReportFileService(filesDao, fileService, reportFilesDao, reportPhotosDao, reportStore)


### PR DESCRIPTION
Reports are created by the system at the start of each quarter. Add logic to
create project-level reports alongside the existing org-level ones.

The logic to only populate the project-level reports with project-level data
will follow in another change.