### PR TITLE
SW-3937 Add project-only total plants and seeds

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -221,9 +221,14 @@ class ReportService(
     val nurseryBodies =
         nurseryModels
             .map { facility ->
-              val stats = batchStore.getNurseryStats(facility.id)
-              body?.nurseries?.find { it.id == facility.id }?.populate(facility, stats)
-                  ?: ReportBodyModelV1.Nursery(facility, stats)
+              val orgStats = batchStore.getNurseryStats(facility.id)
+              val projectStats = projectId?.let { batchStore.getNurseryStats(facility.id, it) }
+
+              body
+                  ?.nurseries
+                  ?.find { it.id == facility.id }
+                  ?.populate(facility, orgStats, projectStats)
+                  ?: ReportBodyModelV1.Nursery(facility, orgStats, projectStats)
             }
             .sortedBy { it.id.value }
 
@@ -231,6 +236,7 @@ class ReportService(
         plantingSiteModels
             .map { plantingSiteModel ->
               val speciesModels = speciesStore.fetchSpeciesByPlantingSiteId(plantingSiteModel.id)
+
               body
                   ?.plantingSites
                   ?.find { it.id == plantingSiteModel.id }
@@ -242,12 +248,14 @@ class ReportService(
     val seedBankBodies =
         seedBankModels
             .map { facility ->
-              val accessionDataForSeedbank = accessionStore.getSummaryStatistics(facility.id)
-              val totalSeedsStored =
-                  accessionDataForSeedbank.totalSeedsRemaining +
-                      accessionDataForSeedbank.seedsWithdrawn
-              body?.seedBanks?.find { it.id == facility.id }?.populate(facility, totalSeedsStored)
-                  ?: ReportBodyModelV1.SeedBank(facility, totalSeedsStored)
+              val orgStats = accessionStore.getSummaryStatistics(facility.id)
+              val projectStats = projectId?.let { accessionStore.getSummaryStatistics(it) }
+
+              body
+                  ?.seedBanks
+                  ?.find { it.id == facility.id }
+                  ?.populate(facility, orgStats, projectStats)
+                  ?: ReportBodyModelV1.SeedBank(facility, orgStats, projectStats)
             }
             .sortedBy { it.id.value }
 

--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
@@ -176,6 +176,7 @@ data class GetReportPayloadV1(
       val operationStartedDateEditable: Boolean,
       override val selected: Boolean,
       val totalPlantsPropagated: Long,
+      val totalPlantsPropagatedForProject: Long?,
       override val workers: WorkersPayloadV1,
   ) : EditableReportFieldsV1.Nursery {
     constructor(
@@ -194,6 +195,7 @@ data class GetReportPayloadV1(
         operationStartedDateEditable = model.operationStartedDateEditable,
         selected = model.selected,
         totalPlantsPropagated = model.totalPlantsPropagated,
+        totalPlantsPropagatedForProject = model.totalPlantsPropagatedForProject,
         workers = WorkersPayloadV1(model.workers),
     )
   }
@@ -254,6 +256,7 @@ data class GetReportPayloadV1(
       val operationStartedDateEditable: Boolean,
       override val selected: Boolean,
       val totalSeedsStored: Long,
+      val totalSeedsStoredForProject: Long?,
       override val workers: WorkersPayloadV1,
   ) : EditableReportFieldsV1.SeedBank {
     constructor(
@@ -270,6 +273,7 @@ data class GetReportPayloadV1(
         operationStartedDateEditable = model.operationStartedDateEditable,
         selected = model.selected,
         totalSeedsStored = model.totalSeedsStored,
+        totalSeedsStoredForProject = model.totalSeedsStoredForProject,
         workers = WorkersPayloadV1(model.workers),
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.nursery.model.NurseryStats
 import com.terraformation.backend.report.ReportNotCompleteException
+import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.tracking.model.PlantingSiteModel
 import java.time.LocalDate
@@ -52,11 +53,13 @@ data class ReportBodyModelV1(
       val operationStartedDateEditable: Boolean = true,
       val selected: Boolean = true,
       val totalPlantsPropagated: Long,
+      val totalPlantsPropagatedForProject: Long? = null,
       val workers: Workers = Workers(),
   ) {
     constructor(
         model: FacilityModel,
-        stats: NurseryStats,
+        orgStats: NurseryStats,
+        projectStats: NurseryStats?,
     ) : this(
         buildCompletedDate = model.buildCompletedDate,
         buildCompletedDateEditable = model.buildCompletedDate == null,
@@ -64,25 +67,31 @@ data class ReportBodyModelV1(
         buildStartedDateEditable = model.buildStartedDate == null,
         capacity = model.capacity,
         id = model.id,
-        mortalityRate = stats.mortalityRate,
+        mortalityRate = orgStats.mortalityRate,
         name = model.name,
         operationStartedDate = model.operationStartedDate,
         operationStartedDateEditable = model.operationStartedDate == null,
-        totalPlantsPropagated = stats.totalPlantsPropagated,
+        totalPlantsPropagated = orgStats.totalPlantsPropagated,
+        totalPlantsPropagatedForProject = projectStats?.totalPlantsPropagated,
     )
 
-    fun populate(model: FacilityModel, stats: NurseryStats): Nursery {
+    fun populate(
+        model: FacilityModel,
+        orgStats: NurseryStats,
+        projectStats: NurseryStats?,
+    ): Nursery {
       return copy(
           buildCompletedDate = model.buildCompletedDate ?: buildCompletedDate,
           buildCompletedDateEditable = model.buildCompletedDate == null,
           buildStartedDate = model.buildStartedDate ?: buildStartedDate,
           buildStartedDateEditable = model.buildStartedDate == null,
           capacity = model.capacity ?: capacity,
-          mortalityRate = stats.mortalityRate,
+          mortalityRate = orgStats.mortalityRate,
           name = model.name,
           operationStartedDate = model.operationStartedDate ?: operationStartedDate,
           operationStartedDateEditable = model.operationStartedDate == null,
-          totalPlantsPropagated = stats.totalPlantsPropagated,
+          totalPlantsPropagated = orgStats.totalPlantsPropagated,
+          totalPlantsPropagatedForProject = projectStats?.totalPlantsPropagated,
       )
     }
 
@@ -187,11 +196,13 @@ data class ReportBodyModelV1(
       val operationStartedDateEditable: Boolean = true,
       val selected: Boolean = true,
       val totalSeedsStored: Long = 0,
+      val totalSeedsStoredForProject: Long? = null,
       val workers: Workers = Workers(),
   ) {
     constructor(
         model: FacilityModel,
-        totalSeedsStored: Long
+        orgStats: AccessionSummaryStatistics,
+        projectStats: AccessionSummaryStatistics?,
     ) : this(
         buildCompletedDate = model.buildCompletedDate,
         buildCompletedDateEditable = model.buildCompletedDate == null,
@@ -201,10 +212,15 @@ data class ReportBodyModelV1(
         name = model.name,
         operationStartedDate = model.operationStartedDate,
         operationStartedDateEditable = model.operationStartedDate == null,
-        totalSeedsStored = totalSeedsStored,
+        totalSeedsStored = orgStats.totalSeedsStored,
+        totalSeedsStoredForProject = projectStats?.totalSeedsStored,
     )
 
-    fun populate(model: FacilityModel, totalSeedsStored: Long): SeedBank {
+    fun populate(
+        model: FacilityModel,
+        orgStats: AccessionSummaryStatistics,
+        projectStats: AccessionSummaryStatistics?,
+    ): SeedBank {
       return copy(
           buildCompletedDate = model.buildCompletedDate ?: buildCompletedDate,
           buildCompletedDateEditable = model.buildCompletedDate == null,
@@ -213,7 +229,8 @@ data class ReportBodyModelV1(
           name = model.name,
           operationStartedDate = model.operationStartedDate ?: operationStartedDate,
           operationStartedDateEditable = model.operationStartedDate == null,
-          totalSeedsStored = totalSeedsStored,
+          totalSeedsStored = orgStats.totalSeedsStored,
+          totalSeedsStoredForProject = projectStats?.totalSeedsStored,
       )
     }
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -936,6 +936,16 @@ class AccessionStore(
             .and(ACCESSIONS.STATE_ID.`in`(AccessionState.activeValues)))
   }
 
+  fun getSummaryStatistics(projectId: ProjectId): AccessionSummaryStatistics {
+    requirePermissions { readProject(projectId) }
+
+    return getSummaryStatistics(
+        DSL.select(ACCESSIONS.ID)
+            .from(ACCESSIONS)
+            .where(ACCESSIONS.PROJECT_ID.eq(projectId))
+            .and(ACCESSIONS.STATE_ID.`in`(AccessionState.activeValues)))
+  }
+
   fun getSummaryStatistics(subquery: Select<Record1<AccessionId?>>): AccessionSummaryStatistics {
     val seedsRemaining =
         DSL.sum(

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/AccessionSummaryStatistics.kt
@@ -28,6 +28,9 @@ data class AccessionSummaryStatistics(
       unknownQuantityAccessions = unknownQuantityAccessions.toInt(),
   )
 
+  val totalSeedsStored: Long
+    get() = totalSeedsRemaining + seedsWithdrawn
+
   /** Returns true if any of the fields have nonzero values. */
   fun isNonZero(): Boolean {
     return accessions != 0 ||


### PR DESCRIPTION
Add server-populated fields to the nursery and seed bank report body models to
hold the number of plants propagated and the number of seeds stored for a
project. The existing fields with the overall totals remain unchanged, and for
org-level reports, the new fields have null values.