### PR TITLE
SW-4534 Publish event when project is renamed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.ProjectId
+
+/** Published when a project's name is changed. */
+data class ProjectRenamedEvent(
+    val projectId: ProjectId,
+    val oldName: String,
+    val newName: String,
+)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -142,7 +142,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
             plantingSitesDao,
             plantingSubzonesDao,
             plantingZonesDao),
-        ProjectStore(clock, dslContext, projectsDao),
+        ProjectStore(clock, dslContext, publisher, projectsDao),
         reportRenderer,
         reportStore,
         scheduler,


### PR DESCRIPTION
To support freezing the project names in per-project reports when they are
submitted, but using the latest project names in reports that haven't been
submitted yet, the reports code will need to know when projects are renamed.
Publish an application event when a project is renamed.