### PR TITLE
SW-4534 Track project renames in reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -121,6 +122,11 @@ class ReportService(
     reportStore.fetchMetadataByOrganization(event.organizationId).forEach { report ->
       reportStore.delete(report.id)
     }
+  }
+
+  @EventListener
+  fun on(event: ProjectRenamedEvent) {
+    reportStore.updateProjectName(event.projectId, event.newName)
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/ReportStore.kt
@@ -227,6 +227,16 @@ class ReportStore(
     }
   }
 
+  /** Updates the name of a project on any project-level reports that haven't been submitted yet. */
+  fun updateProjectName(projectId: ProjectId, newName: String) {
+    dslContext
+        .update(REPORTS)
+        .set(REPORTS.PROJECT_NAME, newName)
+        .where(REPORTS.PROJECT_ID.eq(projectId))
+        .and(REPORTS.STATUS_ID.notEqual(ReportStatus.Submitted))
+        .execute()
+  }
+
   /**
    * Creates an empty report for the most recent quarter. This is called automatically by the
    * system, not at the request of a user.


### PR DESCRIPTION
We want project-level reports to be labeled with the project names as of the time
the reports were submitted, even if the projects are later renamed.

Apply project renames to unsubmitted reports.