### PR TITLE
SW-3937 Delete reports when project is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletionStartedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.ProjectId
+
+/**
+ * Published when we start deleting all the data related to a project, but before the project has
+ * actually been deleted from the database.
+ */
+data class ProjectDeletionStartedEvent(val projectId: ProjectId)

--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.db.FacilityStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
@@ -12,6 +13,7 @@ import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
+import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.db.BatchStore
@@ -122,6 +124,14 @@ class ReportService(
     reportStore.fetchMetadataByOrganization(event.organizationId).forEach { report ->
       reportStore.delete(report.id)
     }
+  }
+
+  @EventListener
+  fun on(event: ProjectDeletionStartedEvent) {
+    reportStore
+        .fetchMetadataByProject(event.projectId)
+        .filter { it.status != ReportStatus.Submitted }
+        .forEach { reportStore.delete(it.id) }
   }
 
   @EventListener

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
@@ -256,6 +257,18 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<ProjectNameInUseException> {
         store.update(projectId2) { it.copy(name = "Existing name") }
       }
+    }
+  }
+
+  @Nested
+  inner class Delete {
+    @Test
+    fun `publishes ProjectDeletionStartedEvent`() {
+      val projectId = insertProject()
+
+      store.delete(projectId)
+
+      eventPublisher.assertEventPublished(ProjectDeletionStartedEvent(projectId))
     }
   }
 }


### PR DESCRIPTION
When a project is deleted, it no longer makes sense for people to submit
project-level reports for them, but we want to keep any reports that have already
been submitted.