### PR TITLE
SW-4593 DO NOT MERGE: Enable planting season notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -250,9 +250,6 @@ class TerrawareServerConfig(
        * enabled.
        */
       @DefaultValue("30") val retentionDays: Long = 30,
-
-      /** If true, generate notifications about planting seasons needing to be scheduled. */
-      val plantingSeasonsEnabled: Boolean = false,
   )
 
   class SupportConfig(

--- a/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/PlantingSeasonScheduler.kt
@@ -38,10 +38,7 @@ class PlantingSeasonScheduler(
   fun transitionPlantingSeasons() {
     systemUser.run {
       plantingSiteStore.transitionPlantingSeasons()
-
-      if (config.notifications.plantingSeasonsEnabled) {
-        sendNotifications()
-      }
+      sendNotifications()
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledNotificationEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledSupportNotificationEvent
 import com.terraformation.backend.util.toInstant
-import io.mockk.every
 import io.mockk.mockk
 import java.time.LocalDate
 import java.time.ZoneId
@@ -60,9 +59,6 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
     insertOrganization(timeZone = timeZone)
 
     clock.instant = initialInstant
-
-    every { config.notifications } returns
-        TerrawareServerConfig.NotificationsConfig(plantingSeasonsEnabled = true)
   }
 
   @Nested
@@ -138,16 +134,6 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
           6, PlantingSeasonNotScheduledSupportNotificationEvent(plantingSiteId, 1))
       assertEventsAtWeekNumber(
           14, PlantingSeasonNotScheduledSupportNotificationEvent(plantingSiteId, 2))
-      assertNoEventsAtWeekNumber(52)
-    }
-
-    @Test
-    fun `honors feature flag`() {
-      every { config.notifications } returns
-          TerrawareServerConfig.NotificationsConfig(plantingSeasonsEnabled = false)
-
-      insertPlantingSiteWithSubzone()
-
       assertNoEventsAtWeekNumber(52)
     }
   }


### PR DESCRIPTION
Remove the feature flag for notifications about scheduling planting seasons, which
will enable them in all environments.