### PR TITLE
Upgrade to jOOQ 3.19.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   // Uncomment the kapt line in the dependencies block if you enable this.
   // kotlin("kapt")
 
-  id("dev.monosoul.jooq-docker") version "6.0.4"
+  id("dev.monosoul.jooq-docker") version "6.0.5"
   id("com.diffplug.spotless") version "6.19.0"
   id("org.jetbrains.dokka") version "1.9.10"
   id("org.springframework.boot") version "3.2.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@ org.gradle.kotlin.dsl.allWarningsAsErrors=true
 # directly in build.gradle.kts.
 
 awsSdkVersion=2.21.35
-flywayVersion=10.2.0
+flywayVersion=10.3.0
 geoToolsVersion=30.1
-jooqVersion=3.18.7
+jooqVersion=3.19.0
 jtsVersion=1.19.0
 kotlinVersion=1.9.20
 ktfmtVersion=0.42

--- a/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/TimeZonePopulator.kt
@@ -37,8 +37,8 @@ class TimeZonePopulator(private val dslContext: DSLContext) {
     val timeZonesInserted =
         if (valuesToInsert.isNotEmpty()) {
           dslContext
-              .insertInto(TIME_ZONES, TIME_ZONES.TIME_ZONE)
-              .valuesOfRecords(valuesToInsert.map { TimeZonesRecord(it) })
+              .insertInto(TIME_ZONES)
+              .set(valuesToInsert.map { TimeZonesRecord(it) })
               .onConflictDoNothing()
               .execute()
         } else {

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -230,10 +230,7 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
 
     val timestamps = (0L..999L).map { Instant.ofEpochSecond(it) }
     val records = timestamps.map { TimeseriesValuesRecord(timeseriesRow.id, it, "1") }
-    dslContext
-        .insertInto(TIMESERIES_VALUES)
-        .set(records)
-        .execute()
+    dslContext.insertInto(TIMESERIES_VALUES).set(records).execute()
 
     assertEquals(timestamps.toSet(), store.checkExistingValues(timeseriesRow.id!!, timestamps))
   }

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -231,12 +231,8 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
     val timestamps = (0L..999L).map { Instant.ofEpochSecond(it) }
     val records = timestamps.map { TimeseriesValuesRecord(timeseriesRow.id, it, "1") }
     dslContext
-        .insertInto(
-            TIMESERIES_VALUES,
-            TIMESERIES_VALUES.TIMESERIES_ID,
-            TIMESERIES_VALUES.CREATED_TIME,
-            TIMESERIES_VALUES.VALUE)
-        .valuesOfRecords(records)
+        .insertInto(TIMESERIES_VALUES)
+        .set(records)
         .execute()
 
     assertEquals(timestamps.toSet(), store.checkExistingValues(timeseriesRow.id!!, timestamps))


### PR DESCRIPTION
Switch to the latest open-source jOOQ release and to the Gradle plugin that
supports it by default.

3.19.0 includes a breaking API change related to inserting lists of records;
update the code accordingly.