### PR TITLE
Fix jOOQ deprecation warning

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
@@ -11,6 +11,7 @@ import org.jooq.BindingSetSQLOutputContext
 import org.jooq.BindingSetStatementContext
 import org.jooq.Converter
 import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Point
@@ -102,5 +103,8 @@ class GeometryBinding : Binding<JooqGeometry, Geometry> {
           }
       return JooqGeometry.valueOf(wkt)
     }
+
+    /** DataType that can be used when constructing custom fields in queries. */
+    val dataType = SQLDataType.GEOMETRY.asConvertedDataType(GeometryBinding())
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/db/GeometryUtil.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryUtil.kt
@@ -23,4 +23,4 @@ fun Field<Geometry?>.asGeoJson(): Field<String?> =
  * https://github.com/jOOQ/jOOQ/issues/14195.
  */
 fun Field<Geometry?>.forMultiset(): Field<Geometry?> =
-    DSL.field("substring(ST_AsEWKB(?)::text, 3)", Geometry::class.java, this)
+    DSL.field("substring(ST_AsEWKB(?)::text, 3)", GeometryBinding.dataType, this)


### PR DESCRIPTION
We use a custom class for PostGIS geometry columns, and we have a converter that
plugs into jOOQ so it uses our class when reading and writing those columns.

When we were constructing a custom jOOQ `Field` object, we were telling jOOQ to
look up the converter for our class in its global list of converters. That pattern
is being deprecated per https://github.com/jOOQ/jOOQ/issues/15286 because it can
cause undefined behavior. The existing code still works, but causes jOOQ to log
warning messages.

Update our custom field construction to explicitly specify the converter it needs.