### PR TITLE
SW-4586 Add BatchId to Facility Inventories Search Table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
@@ -32,7 +32,8 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
       listOf(
           facilities.asSingleValueSublist(
               "facility", FACILITY_INVENTORIES.FACILITY_ID.eq(FACILITIES.ID)),
-          batches.asSingleValueSublist("batch", FACILITY_INVENTORIES.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
+          batches.asSingleValueSublist(
+              "batch", FACILITY_INVENTORIES.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
           species.asSingleValueSublist("species", FACILITY_INVENTORIES.SPECIES_ID.eq(SPECIES.ID)),
           organizations.asSingleValueSublist(
               "organization", FACILITY_INVENTORIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -23,6 +24,7 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
         listOf(
             FACILITY_INVENTORIES.ORGANIZATION_ID,
             FACILITY_INVENTORIES.SPECIES_ID,
+            FACILITY_INVENTORIES.BATCH_ID,
             FACILITY_INVENTORIES.FACILITY_ID)
 
   override val sublists: List<SublistField> by lazy {
@@ -30,6 +32,7 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
       listOf(
           facilities.asSingleValueSublist(
               "facility", FACILITY_INVENTORIES.FACILITY_ID.eq(FACILITIES.ID)),
+          batches.asSingleValueSublist("batch", FACILITY_INVENTORIES.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
           species.asSingleValueSublist("species", FACILITY_INVENTORIES.SPECIES_ID.eq(SPECIES.ID)),
           organizations.asSingleValueSublist(
               "organization", FACILITY_INVENTORIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -24,7 +23,6 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
         listOf(
             FACILITY_INVENTORIES.ORGANIZATION_ID,
             FACILITY_INVENTORIES.SPECIES_ID,
-            FACILITY_INVENTORIES.BATCH_ID,
             FACILITY_INVENTORIES.FACILITY_ID)
 
   override val sublists: List<SublistField> by lazy {
@@ -32,8 +30,6 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
       listOf(
           facilities.asSingleValueSublist(
               "facility", FACILITY_INVENTORIES.FACILITY_ID.eq(FACILITIES.ID)),
-          batches.asSingleValueSublist(
-              "batch", FACILITY_INVENTORIES.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
           species.asSingleValueSublist("species", FACILITY_INVENTORIES.SPECIES_ID.eq(SPECIES.ID)),
           organizations.asSingleValueSublist(
               "organization", FACILITY_INVENTORIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
@@ -43,6 +39,7 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
 
   override val fields: List<SearchField> =
       listOf(
+          textField("batchIds", FACILITY_INVENTORIES.BATCH_IDS, nullable = false),
           longField(
               "germinatingQuantity", FACILITY_INVENTORIES.GERMINATING_QUANTITY, nullable = false),
           longField("notReadyQuantity", FACILITY_INVENTORIES.NOT_READY_QUANTITY, nullable = false),

--- a/src/main/resources/db/migration/0200/V232__FacilityInventoryBatchId.sql
+++ b/src/main/resources/db/migration/0200/V232__FacilityInventoryBatchId.sql
@@ -1,0 +1,14 @@
+DROP VIEW nursery.facility_inventories;
+
+CREATE OR REPLACE VIEW nursery.facility_inventories AS
+SELECT organization_id,
+       species_id,
+       facility_id,
+       id                                       AS batch_id,
+       SUM(ready_quantity)                      AS ready_quantity,
+       SUM(not_ready_quantity)                  AS not_ready_quantity,
+       SUM(germinating_quantity)                AS germinating_quantity,
+       SUM(ready_quantity + not_ready_quantity) AS total_quantity
+FROM nursery.batches
+GROUP BY organization_id, species_id, facility_id, batch_id
+HAVING SUM(ready_quantity + not_ready_quantity + germinating_quantity) > 0;

--- a/src/main/resources/db/migration/0200/V232__FacilityInventoryBatchId.sql
+++ b/src/main/resources/db/migration/0200/V232__FacilityInventoryBatchId.sql
@@ -4,11 +4,11 @@ CREATE OR REPLACE VIEW nursery.facility_inventories AS
 SELECT organization_id,
        species_id,
        facility_id,
-       id                                       AS batch_id,
+       STRING_AGG(CAST(id AS TEXT), ',')        AS batch_ids,
        SUM(ready_quantity)                      AS ready_quantity,
        SUM(not_ready_quantity)                  AS not_ready_quantity,
        SUM(germinating_quantity)                AS germinating_quantity,
        SUM(ready_quantity + not_ready_quantity) AS total_quantity
 FROM nursery.batches
-GROUP BY organization_id, species_id, facility_id, batch_id
+GROUP BY organization_id, species_id, facility_id
 HAVING SUM(ready_quantity + not_ready_quantity + germinating_quantity) > 0;


### PR DESCRIPTION
The table to show nursery batches by nursery searches the FacilityInventories
search table. In order to correctly route to the withdrawal flow the batchIds
for each returned search row is needed. These are added as a comma-
separated text aggregation field on the database view, and returned in the
search table.