### PR TITLE
Return user ID from DatabaseTest.insertUser()

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -373,15 +373,10 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store report created notification for admins and owners`() {
-    val admin = UserId(100)
-    val owner = UserId(101)
-    val manager = UserId(102)
-    val contributor = UserId(103)
-
-    insertUser(admin)
-    insertUser(owner)
-    insertUser(manager)
-    insertUser(contributor)
+    val admin = insertUser(100)
+    val owner = insertUser(101)
+    val manager = insertUser(102)
+    val contributor = insertUser(103)
 
     insertOrganizationUser(admin, role = Role.Admin)
     insertOrganizationUser(owner, role = Role.Owner)

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -104,10 +104,9 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization throws exception if organization has users other than the current one`() {
-    val otherUserId = UserId(100)
+    val otherUserId = insertUser(100)
 
     insertUser(user.userId)
-    insertUser(otherUserId)
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
     insertOrganizationUser(otherUserId)
@@ -138,9 +137,8 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization removes Terraformation Contact user from organization`() {
-    val tfContactUserId = UserId(5)
+    val tfContactUserId = insertUser(5, email = "tfcontact@terraformation.com")
     insertUser()
-    insertUser(userId = tfContactUserId, email = "tfcontact@terraformation.com")
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
     insertOrganizationUser(userId = tfContactUserId, role = Role.TerraformationContact)
@@ -165,14 +163,13 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `UserDeletionStartedEvent handler removes user from all their organizations`() {
-    val otherUserId = UserId(100)
     val soloOrganizationId1 = OrganizationId(1)
     val soloOrganizationId2 = OrganizationId(2)
     val sharedOrganizationId = OrganizationId(3)
     val unrelatedOrganizationId = OrganizationId(4)
 
     insertUser(user.userId)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(100)
 
     insertOrganization(soloOrganizationId1)
     insertOrganization(soloOrganizationId2)
@@ -256,11 +253,10 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `UserAddedToOrganization event is published when existing user is added to an organization`() {
-    val otherUserId = UserId(100)
     val organizationId = OrganizationId(1)
 
     insertUser(user.userId)
-    insertUser(otherUserId, email = "existingUser@email.com")
+    val otherUserId = insertUser(100, email = "existingUser@email.com")
 
     insertOrganization(organizationId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -19,7 +19,6 @@ import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SubLocationId
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SubLocationsRow
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
@@ -190,8 +189,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateSubLocation updates correct values`() {
-    val otherUserId = UserId(10)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(10)
     insertSubLocation(subLocationId, createdBy = otherUserId)
 
     val newTime = Instant.EPOCH.plusSeconds(30)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -225,8 +225,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should throw an error when reading notifications belonging to another user`() {
-    val otherUserId = UserId(3)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(3)
     assertThrows<NotificationNotFoundException> {
       val notification = notificationModel(userId = otherUserId)
       store.create(notification, organizationId)
@@ -236,8 +235,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should delete user notifications when user is deleted`() {
-    val otherUserId = UserId(3)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(3)
 
     store.create(notificationModel(userId = otherUserId), organizationId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -364,8 +364,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     val newTime = clock.instant().plusSeconds(1000)
     clock.instant = newTime
 
-    val newUserId = UserId(101)
-    insertUser(newUserId)
+    val newUserId = insertUser(101)
 
     val updates =
         OrganizationsRow(
@@ -503,8 +502,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `addUser sets user role`() {
-    val newUserId = UserId(3)
-    insertUser(newUserId)
+    val newUserId = insertUser(3)
 
     store.addUser(organizationId, newUserId, Role.Contributor)
 
@@ -532,8 +530,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `addUser throws exception adding Terraformation Contact with non-terraformation email`() {
     every { user.canAddTerraformationContact(organizationId) } returns true
 
-    val newUserId = UserId(3)
-    insertUser(newUserId, email = "user@nonterraformation.com")
+    val newUserId = insertUser(3, email = "user@nonterraformation.com")
 
     assertThrows<InvalidTerraformationContactEmail> {
       store.addUser(organizationId, newUserId, Role.TerraformationContact)
@@ -544,8 +541,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `addUser adds Terraformation Contact when permitted`() {
     every { user.canAddTerraformationContact(organizationId) } returns true
 
-    val newUserId = UserId(3)
-    insertUser(newUserId)
+    val newUserId = insertUser(3)
 
     store.addUser(organizationId, newUserId, Role.TerraformationContact)
 
@@ -557,8 +553,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `addUser adds Terraformation Contact regardless of terraformation domain email case`() {
     every { user.canAddTerraformationContact(organizationId) } returns true
 
-    val newUserId = UserId(3)
-    insertUser(userId = newUserId, email = "$newUserId@TerraFormation.COM")
+    val newUserId = insertUser(3, email = "newUser@TerraFormation.COM")
 
     store.addUser(organizationId, newUserId, Role.TerraformationContact)
 
@@ -570,10 +565,8 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   fun `addUser throws exception adding a second Terraformation Contact when permitted`() {
     every { user.canAddTerraformationContact(organizationId) } returns true
 
-    val newUserId = UserId(3)
-    val anotherUserId = UserId(4)
-    insertUser(newUserId)
-    insertUser(anotherUserId)
+    val newUserId = insertUser(3)
+    val anotherUserId = insertUser(4)
 
     store.addUser(organizationId, newUserId, Role.TerraformationContact)
     assertThrows<RuntimeException> {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -434,8 +434,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetchPreferences returns null if no preferences for user`() {
-      val otherUserId = UserId(50)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(50)
 
       insertPreferences(otherUserId)
       insertPreferences(user.userId, organizationId)
@@ -645,16 +644,14 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns opted-in users`() {
       val otherOrganizationId = OrganizationId(2)
-      val optedInNonMember = UserId(100)
-      val optedInMember = UserId(101)
-      val optedOutMember = UserId(102)
+
+      val optedInNonMember =
+          insertUser(100, email = "optedInNonMember@x.com", emailNotificationsEnabled = true)
+      val optedInMember =
+          insertUser(101, email = "optedInMember@x.com", emailNotificationsEnabled = true)
+      val optedOutMember = insertUser(102, email = "optedOutMember@x.com")
 
       insertOrganization(otherOrganizationId)
-
-      insertUser(
-          optedInNonMember, email = "optedInNonMember@x.com", emailNotificationsEnabled = true)
-      insertUser(optedInMember, email = "optedInMember@x.com", emailNotificationsEnabled = true)
-      insertUser(optedOutMember, email = "optedOutMember@x.com")
 
       insertOrganizationUser(optedInNonMember, otherOrganizationId)
       insertOrganizationUser(optedInMember, organizationId)
@@ -668,15 +665,10 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `returns users with requested roles`() {
-      val admin1 = UserId(100)
-      val admin2 = UserId(101)
-      val manager = UserId(102)
-      val owner = UserId(103)
-
-      insertUser(admin1, email = "admin1@x.com", emailNotificationsEnabled = true)
-      insertUser(admin2, email = "admin2@x.com", emailNotificationsEnabled = true)
-      insertUser(manager, email = "manager@x.com", emailNotificationsEnabled = true)
-      insertUser(owner, email = "owner@x.com", emailNotificationsEnabled = true)
+      val admin1 = insertUser(100, email = "admin1@x.com", emailNotificationsEnabled = true)
+      val admin2 = insertUser(101, email = "admin2@x.com", emailNotificationsEnabled = true)
+      val manager = insertUser(102, email = "manager@x.com", emailNotificationsEnabled = true)
+      val owner = insertUser(103, email = "owner@x.com", emailNotificationsEnabled = true)
 
       insertOrganizationUser(admin1, role = Role.Admin)
       insertOrganizationUser(admin2, role = Role.Admin)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -30,7 +30,6 @@ import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.REPORTS
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
@@ -903,8 +902,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by another user`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
       val reportId = insertReport(lockedBy = otherUserId)
 
       assertThrows<ReportLockedException> { service.update(reportId) { it } }

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -21,7 +21,6 @@ import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.REPORTS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.report.ReportNotCompleteException
@@ -245,8 +244,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `overwrites existing lock if force is true`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(lockedBy = otherUserId, lockedTime = Instant.EPOCH)
 
@@ -272,8 +270,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already locked and force is not true`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -282,8 +279,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already submitted`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -330,8 +326,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by someone else`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -340,8 +335,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already submitted`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -407,8 +401,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is already submitted`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -428,8 +421,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by someone else`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -562,8 +554,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by another user`() {
-      val otherUserId = UserId(10)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(10)
       val reportId = insertReport(lockedBy = otherUserId)
 
       assertThrows<ReportLockedException> { store.submit(reportId) }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.UserNotFoundException
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
@@ -79,8 +78,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetches existing withdrawals`() {
-    val otherUserId = UserId(10)
-    insertUser(otherUserId, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(10, firstName = "Other", lastName = "User")
 
     val pojos =
         listOf(
@@ -189,8 +187,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `allows new withdrawals to be attributed to other organization users`() {
-    val otherUserId = UserId(20)
-    insertUser(otherUserId, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(20, firstName = "Other", lastName = "User")
     insertOrganizationUser(otherUserId, organizationId)
 
     val newWithdrawal =
@@ -230,8 +227,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `throws exception if user sets withdrawn by to another user and has no permission to read user`() {
-    val otherUserId = UserId(20)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(20)
 
     every { user.canReadOrganizationUser(organizationId, otherUserId) } returns false
 
@@ -253,8 +249,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `ignores withdrawnByUserId on new withdrawal if user has no permission to set withdrawal users`() {
-    val otherUserId = UserId(20)
-    insertUser(otherUserId)
+    val otherUserId = insertUser(20)
 
     every { user.canSetWithdrawalUser(any()) } returns false
 
@@ -429,8 +424,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update ignores withdrawnByUserId if user has no permission to set withdrawal users`() {
-    val otherUserId = UserId(20)
-    insertUser(otherUserId, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(20, firstName = "Other", lastName = "User")
 
     val initial =
         WithdrawalModel(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryId
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
@@ -115,17 +114,11 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     val secondWithdrawalTime = firstWithdrawalTime.plus(1, ChronoUnit.DAYS)
     val backdatedWithdrawalTime = secondWithdrawalTime.plus(1, ChronoUnit.DAYS)
 
-    val createUserId = UserId(20)
-    val checkInUserId = UserId(30)
-    val processUserId = UserId(40)
-    val firstWithdrawerUserId = UserId(50)
-    val viabilityTesterUserId = UserId(60)
-
-    insertUser(createUserId, firstName = "First", lastName = "Last")
-    insertUser(checkInUserId, firstName = null, lastName = null)
-    insertUser(processUserId, firstName = "Bono", lastName = null)
-    insertUser(firstWithdrawerUserId, firstName = "First", lastName = "Withdrawer")
-    insertUser(viabilityTesterUserId, firstName = "Viability", lastName = "Tester")
+    val createUserId = insertUser(20, firstName = "First", lastName = "Last")
+    val checkInUserId = insertUser(30, firstName = null, lastName = null)
+    val processUserId = insertUser(40, firstName = "Bono", lastName = null)
+    val firstWithdrawerUserId = insertUser(50, firstName = "First", lastName = "Withdrawer")
+    val viabilityTesterUserId = insertUser(60, firstName = "Viability", lastName = "Tester")
 
     clock.instant = createTime
     every { user.userId } returns createUserId

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
@@ -144,10 +143,8 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchObservationPlotDetails {
     @Test
     fun `calculates correct values from related tables`() {
-      val userId1 = UserId(101)
-      val userId2 = UserId(102)
-      insertUser(userId1, firstName = "First", lastName = "Person")
-      insertUser(userId2, firstName = "Second", lastName = "Human")
+      val userId1 = insertUser(101, firstName = "First", lastName = "Person")
+      val userId2 = insertUser(102, firstName = "Second", lastName = "Human")
 
       insertPlantingZone(name = "Z1")
       val plantingSubzoneId1 = insertPlantingSubzone(fullName = "Z1-S1", name = "S1")
@@ -833,8 +830,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if plot is claimed by someone else`() {
-      val otherUserId = UserId(100)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(100)
 
       insertObservationPlot(claimedBy = otherUserId, claimedTime = Instant.EPOCH)
 
@@ -890,8 +886,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if plot is claimed by someone else`() {
-      val otherUserId = UserId(100)
-      insertUser(otherUserId)
+      val otherUserId = insertUser(100)
 
       insertObservationPlot(claimedBy = otherUserId, claimedTime = Instant.EPOCH)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.NotificationType
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingType
@@ -1073,10 +1072,9 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `updatePlantingZone updates editable values`() {
     val createdTime = Instant.ofEpochSecond(1000)
-    val createdBy = UserId(100)
+    val createdBy = insertUser(100)
     val plantingSiteId = insertPlantingSite()
 
-    insertUser(createdBy)
     val initialRow =
         PlantingZonesRow(
             areaHa = BigDecimal.ONE,


### PR DESCRIPTION
Allow tests to insert users more succinctly when they need the user IDs
afterwards. Update existing tests to get the user IDs from the insert function
rather than declaring them separately.

`insertUser()` now allows passing in a null user ID to let the database
allocate a new one, but existing tests don't use that feature yet in order to
avoid potential problems with ID collisions. The default is still to use the
user ID from the active security context.