### PR TITLE
SW-4599 Add permission for updating global roles

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -194,6 +194,7 @@ data class DeviceManagerUser(
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = false
   override fun canUpdateDeviceTemplates(): Boolean = false
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false
+  override fun canUpdateGlobalRoles(): Boolean = false
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canUpdateObservation(observationId: ObservationId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -395,6 +395,8 @@ data class IndividualUser(
 
   override fun canUpdateFacility(facilityId: FacilityId) = isAdminOrHigher(facilityId)
 
+  override fun canUpdateGlobalRoles(): Boolean = isSuperAdmin()
+
   override fun canUpdateNotification(notificationId: NotificationId) =
       canReadNotification(notificationId)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -669,6 +669,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateGlobalRoles() {
+    if (!user.canUpdateGlobalRoles()) {
+      throw AccessDeniedException("No permission to update global roles")
+    }
+  }
+
   fun updateNotification(notificationId: NotificationId) {
     if (!user.canUpdateNotification(notificationId)) {
       readNotification(notificationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -204,6 +204,7 @@ class SystemUser(
   override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canUpdateDeviceTemplates(): Boolean = true
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
+  override fun canUpdateGlobalRoles(): Boolean = true
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canUpdateObservation(observationId: ObservationId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -165,6 +165,7 @@ interface TerrawareUser : Principal {
   fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canUpdateDeviceTemplates(): Boolean
   fun canUpdateFacility(facilityId: FacilityId): Boolean
+  fun canUpdateGlobalRoles(): Boolean
   fun canUpdateNotification(notificationId: NotificationId): Boolean
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
   fun canUpdateObservation(observationId: ObservationId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -551,6 +551,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun updateGlobalNotifications() =
       allow { updateNotifications(null) } ifUser { canUpdateNotifications(null) }
 
+  @Test fun updateGlobalRoles() = allow { updateGlobalRoles() } ifUser { canUpdateGlobalRoles() }
+
   @Test
   fun updateNotification() =
       allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1074,6 +1074,7 @@ internal class PermissionTest : DatabaseTest() {
         setTestClock = true,
         updateAppVersions = true,
         updateDeviceTemplates = true,
+        updateGlobalRoles = true,
     )
 
     permissions.expect(
@@ -1189,6 +1190,7 @@ internal class PermissionTest : DatabaseTest() {
         setTestClock = true,
         updateAppVersions = true,
         updateDeviceTemplates = true,
+        updateGlobalRoles = true,
     )
   }
 
@@ -1584,6 +1586,7 @@ internal class PermissionTest : DatabaseTest() {
         setTestClock: Boolean = false,
         updateAppVersions: Boolean = false,
         updateDeviceTemplates: Boolean = false,
+        updateGlobalRoles: Boolean = false,
     ) {
       assertEquals(
           addAnyOrganizationUser, user.canAddAnyOrganizationUser(), "Can add any organization user")
@@ -1603,6 +1606,7 @@ internal class PermissionTest : DatabaseTest() {
       assertEquals(updateAppVersions, user.canUpdateAppVersions(), "Can update app versions")
       assertEquals(
           updateDeviceTemplates, user.canUpdateDeviceTemplates(), "Can update device templates")
+      assertEquals(updateGlobalRoles, user.canUpdateGlobalRoles(), "Can update global roles")
 
       hasCheckedGlobalPermissions = true
     }


### PR DESCRIPTION
Add a new `canUpdateGlobalRoles` permission, currently only true for super-admins,
to control the ability to add and remove users' global roles. Global roles will
replace the Super-Admin user type with a more flexible system.