### PR TITLE
SW-4600 Replace Super-Admin user type with global role

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,14 +196,19 @@ terraware:
 
 ## Super-Admins
 
-Some operations are not available to regular users of the system; they must be requested by privileged administrative users. Internally, these are referred to as "super-admins".
+Some operations are not available to regular users of the system; they must be requested by privileged administrative users. Internally, these are referred to as "Super-Admins".
 
-Marking a user as a super-admin currently requires connecting to the server's database and modifying the users table directly. The exact command you'll need to run to connect to the database will vary a bit depending on where it's running (local host, Docker container, managed cloud database service, etc.). For a database running on your local host, `psql terraware` will usually work.
+Super-Admin privileges can be granted using the "Manage Global Roles" link from the admin UI if you're already logged in as a Super-Admin.
+
+Creating the initial Super-Admin user currently requires connecting to the server's database and modifying the user global roles table directly. The exact command you'll need to run to connect to the database will vary a bit depending on where it's running (local host, Docker container, managed cloud database service, etc.). For a database running on your local host, `psql terraware` will usually work.
 
 Once you're connected to the database, run the following query to change the user with a particular email address to a super-admin:
 
 ```sql
-UPDATE users SET user_type_id = 2 WHERE email = 'your_email@your.domain';
+INSERT INTO user_global_roles (user_id, global_role_id)
+SELECT id, 1
+FROM users
+WHERE email = 'your_email@your.domain';
 ```
 
 ## Importing GBIF backbone data

--- a/src/main/kotlin/com/terraformation/backend/api/SuperAdminInterceptor.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SuperAdminInterceptor.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.api
 
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.GlobalRole
 import jakarta.inject.Named
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -26,7 +26,7 @@ class SuperAdminInterceptor : HandlerInterceptor {
     if (handler is HandlerMethod &&
         (handler.hasMethodAnnotation(RequireSuperAdmin::class.java) ||
             handler.beanType.isAnnotationPresent(RequireSuperAdmin::class.java)) &&
-        currentUser().userType != UserType.SuperAdmin) {
+        GlobalRole.SuperAdmin !in currentUser().globalRoles) {
       response.sendError(HttpStatus.FORBIDDEN.value(), "Requires administrator privileges.")
       return false
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -28,7 +28,6 @@ import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UserId
-import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.DeviceTemplatesDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.db.default_schema.tables.pojos.AppVersionsRow
@@ -177,7 +176,7 @@ class AdminController(
     val reports = reportStore.fetchMetadataByOrganization(organizationId)
     val tfContactUserId = organizationStore.fetchTerraformationContact(organizationId)
     val tfContact = if (tfContactUserId != null) userStore.fetchOneById(tfContactUserId) else null
-    val isSuperAdmin = currentUser().userType == UserType.SuperAdmin
+    val isSuperAdmin = GlobalRole.SuperAdmin in currentUser().globalRoles
 
     model.addAttribute("canAssignTerraformationContact", isSuperAdmin)
     model.addAttribute("canCreateFacility", currentUser().canCreateFacility(organization.id))

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -262,7 +262,7 @@ class OrganizationStore(
 
     return queryOrganizationUsers(
         ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId)
-            .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin)))
+            .and(USERS.USER_TYPE_ID.eq(UserType.Individual)))
   }
 
   fun fetchUser(organizationId: OrganizationId, userId: UserId): OrganizationUserModel {
@@ -365,7 +365,7 @@ class OrganizationStore(
         .where(
             listOfNotNull(
                 ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId),
-                USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin),
+                USERS.USER_TYPE_ID.eq(UserType.Individual),
                 optInCondition,
                 roleCondition))
         .fetch(USERS.EMAIL.asNonNullable())

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -442,7 +442,7 @@ data class IndividualUser(
 
   override fun canUploadPhoto(accessionId: AccessionId) = canReadAccession(accessionId)
 
-  private fun isSuperAdmin() = userType == UserType.SuperAdmin
+  private fun isSuperAdmin() = GlobalRole.SuperAdmin in globalRoles
 
   private fun isOwner(organizationId: OrganizationId?) =
       organizationId != null && organizationRoles[organizationId] == Role.Owner

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -40,7 +40,7 @@ class OrganizationUsersTable(tables: SearchTables) : SearchTable() {
                 DSL.selectOne()
                     .from(USERS)
                     .where(USERS.ID.eq(ORGANIZATION_USERS.USER_ID))
-                    .and(USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin))))
+                    .and(USERS.USER_TYPE_ID.eq(UserType.Individual))))
   }
 
   override fun conditionForOrganization(organizationId: OrganizationId): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -42,7 +42,7 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
   // Users are only visible to other people in the same organizations, and device manager users are
   // not visible via this table.
   override fun conditionForVisibility(): Condition {
-    return USERS.USER_TYPE_ID.`in`(UserType.Individual, UserType.SuperAdmin)
+    return USERS.USER_TYPE_ID.eq(UserType.Individual)
         .and(
             DSL.exists(
                 DSL.selectOne()

--- a/src/main/resources/db/migration/0200/V233__DropSuperAdminType.sql
+++ b/src/main/resources/db/migration/0200/V233__DropSuperAdminType.sql
@@ -1,0 +1,11 @@
+INSERT INTO user_global_roles (user_id, global_role_id)
+SELECT id, 1
+FROM users
+WHERE user_type_id = 2
+ON CONFLICT DO NOTHING;
+
+UPDATE users
+SET user_type_id = 1
+WHERE user_type_id = 2;
+
+DELETE FROM user_types WHERE id = 2;

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -305,7 +305,7 @@ ON CONFLICT (id) DO UPDATE SET name         = excluded.name,
 
 INSERT INTO user_types (id, name)
 VALUES (1, 'Individual'),
-       (2, 'Super Admin'),
+       -- 2 was Super-Admin, which is now a global role
        (3, 'Device Manager'),
        (4, 'System')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -440,7 +440,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
                 "user2@x.com",
                 "First2",
                 "Last2",
-                UserType.SuperAdmin,
+                UserType.Individual,
                 clock.instant(),
                 organizationId,
                 Role.Contributor),

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.BalenaDeviceId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
@@ -1154,7 +1155,7 @@ internal class PermissionTest : DatabaseTest() {
 
   @Test
   fun `super admin user has elevated privileges`() {
-    usersDao.update(usersDao.fetchOneById(userId)!!.copy(userTypeId = UserType.SuperAdmin))
+    insertUserGlobalRole(userId, GlobalRole.SuperAdmin)
 
     givenRole(org1Id, Role.Admin)
 


### PR DESCRIPTION
Add the Super-Admin global role to users with the Super-Admin user type, convert
the users to regular individual users, and remove the user type.

Update all the references to the user type in the code to instead check for the
presence of the global role.