### PR TITLE
SW-4625 Make annual reports start December 1

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -214,7 +214,7 @@ class ReportService(
       body: LatestReportBodyModel? = null
   ): LatestReportBodyModel {
     val organization = organizationStore.fetchOneById(organizationId)
-    val isAnnual = body?.isAnnual ?: (ZonedDateTime.now(clock).minusMonths(3).quarter == 4)
+    val isAnnual = body?.isAnnual ?: (ZonedDateTime.now(clock).minusMonths(2).quarter == 4)
     val facilities =
         if (projectId != null) {
           facilityStore.fetchByProjectId(projectId)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -440,6 +440,30 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
       assertFalse(body.isAnnual, "Is annual")
       assertNull(body.annualDetails, "Annual details")
     }
+
+    @Test
+    fun `it creates an annual report on December 1`() {
+      clock.instant = ZonedDateTime.of(2022, 12, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant()
+
+      val created = service.create(organizationId)
+
+      val body = reportStore.fetchOneById(created.id).body.toLatestVersion()
+
+      assertTrue(body.isAnnual, "Is annual")
+      assertNotNull(body.annualDetails, "Annual details")
+    }
+
+    @Test
+    fun `it does not create an annual report on November 30`() {
+      clock.instant = ZonedDateTime.of(2022, 11, 30, 0, 0, 0, 0, ZoneOffset.UTC).toInstant()
+
+      val created = service.create(organizationId)
+
+      val body = reportStore.fetchOneById(created.id).body.toLatestVersion()
+
+      assertFalse(body.isAnnual, "Is annual")
+      assertNull(body.annualDetails, "Annual details")
+    }
   }
 
   @Nested


### PR DESCRIPTION
- Make the 'isAnnual' check look a the quarter two months before the current date, allowing annual reports to be created on December 1