### PR TITLE
Fix global role migration

### DIFF
--- a/src/main/resources/db/migration/0200/V233__DropSuperAdminType.sql
+++ b/src/main/resources/db/migration/0200/V233__DropSuperAdminType.sql
@@ -1,3 +1,7 @@
+INSERT INTO global_roles (id, name)
+VALUES (1, 'Super-Admin')
+ON CONFLICT DO NOTHING;
+
 INSERT INTO user_global_roles (user_id, global_role_id)
 SELECT id, 1
 FROM users


### PR DESCRIPTION
Migration 233 assumed that the global roles table was already populated, but that
won't be the case if it is deployed at the same time as migration 232 since the
roles are inserted in `R__TypeCodes.sql` after the numbered migrations.