### PR TITLE
SW-4595 Fix incorrect apostrophes

### DIFF
--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -100,14 +100,14 @@ notification.observation.monitoringPlotReplaced.email.subject=Organization {0} h
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduled.email.body.1=Organization {0} has not scheduled an observation of planting site {1}
 # {0} is the name of a planting site
-notification.observation.notScheduled.email.body.2=Planting site {0} is ready to have it’s next observation scheduled, but the organization has not scheduled one.
+notification.observation.notScheduled.email.body.2=Planting site {0} is ready to have its next observation scheduled, but the organization has not scheduled one.
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduled.email.subject=Organization {0} has not scheduled an observation of planting site {1}
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduledSupport.email.body.1=Organization {0} has not scheduled an observation of planting site {1}
 notification.observation.notScheduledSupport.email.body.2=There is currently no assigned Terraformation primary project contact for this organization. Please assign one and let them know of the unscheduled observation.
 # {0} is the name of a planting site
-notification.observation.notScheduledSupport.email.body.3=Planting site {0} is ready to have it’s next observation scheduled, but the organization has not scheduled one.
+notification.observation.notScheduledSupport.email.body.3=Planting site {0} is ready to have its next observation scheduled, but the organization has not scheduled one.
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduledSupport.email.subject=Organization {0} has not scheduled an observation of planting site {1}
 # {0} is the name of an organization. {1} is the name of a planting site.
@@ -120,7 +120,7 @@ notification.observation.rescheduled.email.body.3=Previously it was scheduled fo
 notification.observation.rescheduled.email.body.4=Now the next observation is scheduled for {0} through {1}.
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.rescheduled.email.subject=Organization {0} has rescheduled an observation of planting site {1}
-notification.observation.schedule.app.body=It’s time to schedule an observation for your planting site
+notification.observation.schedule.app.body=It''s time to schedule an observation for your planting site
 notification.observation.schedule.app.title=Schedule an observation
 notification.observation.schedule.email.body.1=Schedule an observation
 # {0} is the name of a planting site
@@ -164,10 +164,10 @@ notification.plantingSeason.notScheduled.2.app.title=Reminder\: Add your next pl
 notification.plantingSeason.notScheduled.2.email.body.1=Your planting site {0} is ready to have a planting season scheduled. Go to Terraware to schedule your next planting season.
 notification.plantingSeason.notScheduled.2.email.subject=Reminder\: Add your next planting season
 notification.plantingSeason.started.app.body=Planting season has begun at planting site {0}. To begin planting in the field, make sure that your nursery inventory is up-to-date and that you log your nursery withdrawals as you begin planting.
-notification.plantingSeason.started.app.title=It''’s planting season\!
+notification.plantingSeason.started.app.title=It''s planting season\!
 notification.plantingSeason.started.email.body.1=Planting season has begun at planting site {0}.
-notification.plantingSeason.started.email.body.2=It''’s time to begin making withdrawals from your nursery and planting in the field. Check out your seedling inventory in Terraware now to make sure it is up-to-date for planting.
-notification.plantingSeason.started.email.subject=It''’s planting season\!
+notification.plantingSeason.started.email.body.2=It''s time to begin making withdrawals from your nursery and planting in the field. Check out your seedling inventory in Terraware now to make sure it is up-to-date for planting.
+notification.plantingSeason.started.email.subject=It''s planting season\!
 notification.registration.email.buttonLabel=Create Terraware Account
 notification.registration.organization.email.buttonIntro=Please click the button below to create your Terraware account where you can view the organization.
 notification.registration.organization.email.linkIntro=Please click the link below to create your Terraware account where you can view the organization.

--- a/src/test/kotlin/com/terraformation/backend/i18n/PropertiesFilesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/PropertiesFilesTest.kt
@@ -1,0 +1,40 @@
+package com.terraformation.backend.i18n
+
+import java.util.Locale
+import java.util.ResourceBundle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class PropertiesFilesTest {
+  @MethodSource("getMessageBundles")
+  @ParameterizedTest
+  fun `mixed single quote styles`(bundleName: String) {
+    val bundle = ResourceBundle.getBundle(bundleName, Locale.ENGLISH)
+    val invalidKeys =
+        bundle.keys
+            .asSequence()
+            .filter { key ->
+              val value = bundle.getString(key)
+              value.contains('\'') && value.contains('’')
+            }
+            .toList()
+
+    assertEquals(
+        emptyList<String>(),
+        invalidKeys,
+        "String contains both an ASCII apostrophe and a closing single quote")
+  }
+
+  companion object {
+    @JvmStatic
+    fun getMessageBundles() =
+        listOf(
+            "i18n.Countries",
+            "i18n.CountrySubdivisions",
+            "i18n.Enums",
+            "i18n.Messages",
+            "i18n.TimeZoneWithoutCity",
+        )
+  }
+}


### PR DESCRIPTION
ASCII apostrophe characters are special in properties files and have to be doubled
to escape them. But some text editors "helpfully" detect pairs of apostrophes and
turn the second one into a closing single quote mark. Then Phrase, or other
software, notices the remaining apostrophe and doubles it again, such that we end
up with strings that have an ASCII apostophe and a single quote together.

We also had a couple sentences that should have used the word "its" but instead
used "it’s."

Remove the unnecessary single quote characters and add a test to catch the problem
in the future.