### PR TITLE
Use imported assertion functions in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -53,7 +53,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -163,7 +163,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
             .first { it.parameters.size == 1 && it.parameters[0].type == typeOf<Long>() }
             .call(1L)
     readChecks.add { operation ->
-      Assertions.assertThrows(exceptionClass.java, operation)
+      assertThrows(exceptionClass.java, operation)
       grant { grantBlock.invoke(user, id) }
     }
     id

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -38,7 +38,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -324,8 +323,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
       val unlockedReport = store.fetchOneById(reportId)
 
-      Assertions.assertNull(unlockedReport.metadata.lockedBy, "Locked by")
-      Assertions.assertNull(unlockedReport.metadata.lockedTime, "Locked time")
+      assertNull(unlockedReport.metadata.lockedBy, "Locked by")
+      assertNull(unlockedReport.metadata.lockedTime, "Locked time")
       assertEquals(ReportStatus.InProgress, unlockedReport.metadata.status, "Status")
     }
 
@@ -337,8 +336,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
       val unlockedReport = store.fetchOneById(reportId)
 
-      Assertions.assertNull(unlockedReport.metadata.lockedBy, "Locked by")
-      Assertions.assertNull(unlockedReport.metadata.lockedTime, "Locked time")
+      assertNull(unlockedReport.metadata.lockedBy, "Locked by")
+      assertNull(unlockedReport.metadata.lockedTime, "Locked time")
       assertEquals(ReportStatus.InProgress, unlockedReport.metadata.status, "Status")
     }
 


### PR DESCRIPTION
Our convention is to import JUnit assertion functions individually rather than
importing their containing class.