### PR TITLE
Fix malformed test case

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -281,9 +281,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
-  fun createObservation() = {
-    allow { createObservation(plantingSiteId) } ifUser { canCreateObservation(plantingSiteId) }
-  }
+  fun createObservation() =
+      allow { createObservation(plantingSiteId) } ifUser { canCreateObservation(plantingSiteId) }
 
   @Test
   fun createPlantingSite() =


### PR DESCRIPTION
`PermissionRequirementsTest.createObservation` was constructing a function to run
the test case when it should directly run the test case.