### PR TITLE
SW-4609 Fix germination rate calculation error

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -1192,7 +1192,7 @@ class BatchStore(
         currentNotReadyAndReady + totalWithdrawnNotReadyAndReady - initialNotReady - initialReady
     val totalGerminationCandidates = initialGerminating - totalNonDeadGerminating
     val germinationRate: Int? =
-        if (initialGerminating > 0 &&
+        if (totalGerminationCandidates > 0 &&
             currentGerminating == 0 &&
             !hasManualGerminatingEdit &&
             !hasManualNotReadyEdit &&

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCalculationsTest.kt
@@ -127,6 +127,16 @@ internal class BatchStoreCalculationsTest : BatchStoreTest() {
     assertNull(afterTransfer.lossRate, "Loss rate after second transfer")
   }
 
+  @Test
+  fun `germination rate not calculated if all germinating seedlings withdrawn`() {
+    runScenario(
+        initial = Quantities(10, 1, 0),
+        other = Quantities(10, 0, 0),
+        current = Quantities(0, 1, 0),
+        expectedGerminationRate = null,
+        expectedLossRate = 0)
+  }
+
   /**
    * Runs a scenario that consists of a canned sequence of operations. This is to support running
    * the example cases listed in the calculations spreadsheet that's part of the requirements doc.


### PR DESCRIPTION
If all the germinating seedlings in a batch were withdrawn with a withdrawal
purpose other than Dead, the code was trying to divide by zero when calculating
the batch's germination rate.