### PR TITLE
SW-4573 Nursery species projects search table

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -274,6 +274,10 @@ val EMBEDDABLES =
             .withTables("nursery.facility_inventories")
             .withColumns("facility_id", "species_id"),
         EmbeddableDefinitionType()
+            .withName("nursery_species_project_id")
+            .withTables("nursery.species_projects")
+            .withColumns("species_id", "project_id"),
+        EmbeddableDefinitionType()
             .withName("organization_user_id")
             .withTables("public.organization_users")
             .withColumns("organization_id", "user_id"),

--- a/src/main/kotlin/com/terraformation/backend/search/table/InventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/InventoriesTable.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
+import com.terraformation.backend.db.nursery.tables.references.SPECIES_PROJECTS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -27,6 +28,8 @@ class InventoriesTable(private val tables: SearchTables) : SearchTable() {
           species.asSingleValueSublist("species", INVENTORIES.SPECIES_ID.eq(SPECIES.ID)),
           organizations.asSingleValueSublist(
               "organization", INVENTORIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
+          nurserySpeciesProjects.asMultiValueSublist(
+              "projects", INVENTORIES.SPECIES_ID.eq(SPECIES_PROJECTS.SPECIES_ID)),
           facilityInventories.asMultiValueSublist(
               "facilityInventories",
               INVENTORIES.ORGANIZATION_ID.eq(FACILITY_INVENTORIES.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/search/table/NurserySpeciesProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/NurserySpeciesProjectsTable.kt
@@ -1,0 +1,44 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.nursery.tables.references.SPECIES_PROJECTS
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
+import org.jooq.OrderField
+import org.jooq.Record
+import org.jooq.TableField
+
+class NurserySpeciesProjectsTable(private val tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = SPECIES_PROJECTS.NURSERY_SPECIES_PROJECT_ID
+
+  override val defaultOrderFields: List<OrderField<*>>
+    get() = listOf(SPECIES_PROJECTS.SPECIES_ID, SPECIES_PROJECTS.PROJECT_ID)
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          projects.asSingleValueSublist("project", SPECIES_PROJECTS.PROJECT_ID.eq(PROJECTS.ID)),
+          species.asSingleValueSublist("species", SPECIES_PROJECTS.SPECIES_ID.eq(SPECIES.ID)),
+          organizations.asSingleValueSublist(
+              "organization", SPECIES_PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> = emptyList()
+
+  override fun conditionForVisibility(): Condition {
+    return SPECIES_PROJECTS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
+  }
+
+  override fun conditionForOrganization(organizationId: OrganizationId): Condition {
+    return SPECIES_PROJECTS.ORGANIZATION_ID.eq(organizationId)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -37,6 +37,7 @@ class SearchTables(clock: Clock) {
   val geolocations = GeolocationsTable(this)
   val inventories = InventoriesTable(this)
   val monitoringPlots = MonitoringPlotsTable(this)
+  val nurserySpeciesProjects = NurserySpeciesProjectsTable(this)
   val nurseryWithdrawals = NurseryWithdrawalsTable(this)
   val organizations = OrganizationsTable(this)
   val organizationUsers = OrganizationUsersTable(this)

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
+import com.terraformation.backend.db.nursery.tables.references.SPECIES_PROJECTS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -24,6 +25,8 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
       listOf(
           speciesEcosystemTypes.asMultiValueSublist(
               "ecosystemTypes", SPECIES.ID.eq(SPECIES_ECOSYSTEM_TYPES.SPECIES_ID)),
+          nurserySpeciesProjects.asMultiValueSublist(
+              "nurseryProjects", SPECIES.ID.eq(SPECIES_PROJECTS.SPECIES_ID)),
           organizations.asSingleValueSublist(
               "organization", SPECIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           speciesProblems.asMultiValueSublist(

--- a/src/main/resources/db/migration/0200/V234__NurserySpeciesProjects.sql
+++ b/src/main/resources/db/migration/0200/V234__NurserySpeciesProjects.sql
@@ -1,0 +1,12 @@
+CREATE VIEW nursery.species_projects AS
+    SELECT DISTINCT
+        organization_id,
+        species_id,
+        project_id
+    FROM nursery.batches
+    WHERE project_id IS NOT NULL
+    AND (
+        germinating_quantity > 0
+        OR not_ready_quantity > 0
+        OR ready_quantity > 0
+    );

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -285,6 +285,8 @@ COMMENT ON COLUMN nursery.batches.total_loss_candidates IS 'Total number of non-
 COMMENT ON COLUMN nursery.batches.total_lost IS 'Total number of non-germinating (Not Ready and Ready) seedlings that have been withdrawn as Dead. This is the numerator for the loss rate calculation.';
 COMMENT ON COLUMN nursery.batches.version IS 'Increases by 1 each time the batch is modified. Used to detect when clients have stale data about batches.';
 
+COMMENT ON VIEW nursery.species_projects IS 'Which species have active batches associated with which projects.';
+
 COMMENT ON TABLE nursery.withdrawal_photos IS 'Linking table between `withdrawals` and `files`.';
 
 COMMENT ON TABLE nursery.withdrawal_purposes IS '(Enum) Reasons that someone can withdraw seedlings from a nursery.';


### PR DESCRIPTION
Add a new search table so clients can query which projects have active batches of
a particular species. This differs from the existing ability to query the project
for each batch in that a given project is only returned once even if it is
associated with multiple batches. Empty batches are not counted.

Example `POST /api/v1/search` request payload to return the list of project names
and IDs for species 123 along with its inventory totals:

    {
      "prefix": "inventories",
      "fields": [
        "germinatingQuantity",
        "notReadyQuantity",
        "readyQuantity",
        "totalQuantity",
        "projects.id"
        "projects.name"
      ],
      "search": {
        "operation": "field",
        "field": "species_id",
        "values": ["123"]
      }
    }