### PR TITLE
Hide device manager links from accelerator admins

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/AdminController.kt
@@ -156,10 +156,12 @@ class AdminController(
 
     model.addAttribute("allOrganizations", allOrganizations)
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
+    model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
     model.addAttribute("canManageInternalTags", currentUser().canManageInternalTags())
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())
     model.addAttribute("canUpdateAppVersions", currentUser().canUpdateAppVersions())
+    model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("canUpdateGlobalRoles", currentUser().canUpdateGlobalRoles())
     model.addAttribute("organizations", organizations)
     model.addAttribute("prefix", prefix)

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -40,15 +40,17 @@
     </form>
 </div>
 
-<h2>Device manager configuration</h2>
+<th:block th:if="${canCreateDeviceManager}">
+    <h2>Device manager configuration</h2>
 
-<p>
-    <a th:href="|${prefix}/deviceManagers|">Device Managers</a>
-</p>
+    <p>
+        <a th:href="|${prefix}/deviceManagers|">Device Managers</a>
+    </p>
 
-<p>
-    <a th:href="|${prefix}/deviceTemplates|">Device Templates</a>
-</p>
+    <p th:if="${canUpdateDeviceTemplates}">
+        <a th:href="|${prefix}/deviceTemplates|">Device Templates</a>
+    </p>
+</th:block>
 
 <th:block th:if="${canUpdateAppVersions}">
     <h2>App Versions</h2>


### PR DESCRIPTION
The admin UI home page has links to the pages for administering device managers.
Device managers can only be administered by super-admins, so these links are
useless for accelerator admins. Add permission checks to hide them.