### PR TITLE
Hardwire admin UI URL prefix

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -137,7 +137,6 @@ class AdminController(
     private val userStore: UserStore,
 ) {
   private val log = perClassLogger()
-  private val prefix = "/admin"
 
   /** Redirects /admin to /admin/ so relative URLs in the UI will work. */
   @GetMapping
@@ -160,7 +159,6 @@ class AdminController(
     model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("canUpdateGlobalRoles", currentUser().canUpdateGlobalRoles())
     model.addAttribute("organizations", organizations)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("roles", Role.entries.map { it to it.getDisplayName(Locale.ENGLISH) })
 
     return "/admin/index"
@@ -190,7 +188,6 @@ class AdminController(
     model.addAttribute(
         "plantingSiteValidationOptions", PlantingSiteImporter.ValidationOption.entries)
     model.addAttribute("plantingSites", plantingSites)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("reports", reports)
     model.addAttribute("terraformationContact", tfContact)
 
@@ -217,7 +214,6 @@ class AdminController(
     model.addAttribute("facility", facility)
     model.addAttribute("facilityTypes", FacilityType.entries)
     model.addAttribute("organization", organization)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("recipients", recipients)
     model.addAttribute("subLocations", subLocations)
 
@@ -297,7 +293,6 @@ class AdminController(
     model.addAttribute("pastPlantingSeasons", pastPlantingSeasons)
     model.addAttribute("plantCounts", plantCounts)
     model.addAttribute("plotCounts", plotCounts)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("reportedPlants", reportedPlants)
     model.addAttribute("site", plantingSite)
 
@@ -308,7 +303,6 @@ class AdminController(
   fun getPlantingSiteMap(@PathVariable plantingSiteId: PlantingSiteId, model: Model): String {
     val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Subzone)
 
-    model.addAttribute("prefix", prefix)
     model.addAttribute("site", plantingSite)
 
     if (plantingSite.boundary != null) {
@@ -415,7 +409,6 @@ class AdminController(
 
     model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("categories", DeviceTemplateCategory.entries)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("templates", templates)
 
     return "/admin/deviceTemplates"
@@ -429,7 +422,6 @@ class AdminController(
     model.addAttribute(
         "canRegenerateAllDeviceManagerTokens", currentUser().canRegenerateAllDeviceManagerTokens())
     model.addAttribute("managers", managers)
-    model.addAttribute("prefix", prefix)
 
     return "/admin/listDeviceManagers"
   }
@@ -446,7 +438,6 @@ class AdminController(
         "canUpdateDeviceManager", currentUser().canUpdateDeviceManager(deviceManagerId))
     model.addAttribute("facility", facility)
     model.addAttribute("manager", manager)
-    model.addAttribute("prefix", prefix)
 
     return "/admin/deviceManager"
   }
@@ -461,7 +452,6 @@ class AdminController(
     val now = ZonedDateTime.now(clock)
     val currentTime = DateTimeFormatter.RFC_1123_DATE_TIME.format(now)
     model.addAttribute("currentTime", currentTime)
-    model.addAttribute("prefix", prefix)
 
     return "/admin/testClock"
   }
@@ -472,7 +462,6 @@ class AdminController(
 
     val versions = appVersionStore.findAll()
     model.addAttribute("appVersions", versions)
-    model.addAttribute("prefix", prefix)
 
     return "/admin/appVersions"
   }
@@ -485,7 +474,6 @@ class AdminController(
 
     model.addAttribute("allOrganizations", allOrganizations)
     model.addAttribute("organizationTags", organizationTags)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("tags", tags)
     model.addAttribute("tagsById", tags.associateBy { it.id!! })
 
@@ -502,7 +490,6 @@ class AdminController(
     val organizations = internalTagStore.fetchOrganizationsByTagId(tagId)
 
     model.addAttribute("organizations", organizations)
-    model.addAttribute("prefix", prefix)
     model.addAttribute("tag", tag)
 
     return "/admin/internalTag"
@@ -516,7 +503,6 @@ class AdminController(
     requirePermissions { updateGlobalRoles() }
 
     model.addAttribute("globalRoles", GlobalRole.entries.sortedBy { it.jsonValue })
-    model.addAttribute("prefix", prefix)
     model.addAttribute("users", userStore.fetchWithGlobalRoles())
 
     return "/admin/globalRoles"
@@ -1509,7 +1495,7 @@ class AdminController(
   }
 
   /** Returns a redirect view name for an admin endpoint. */
-  private fun redirect(endpoint: String) = "redirect:${prefix}$endpoint"
+  private fun redirect(endpoint: String) = "redirect:/admin$endpoint"
 
   // Convenience methods to redirect to the GET endpoint for each kind of thing.
 

--- a/src/main/resources/templates/admin/appVersions.html
+++ b/src/main/resources/templates/admin/appVersions.html
@@ -5,7 +5,7 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2>App Versions</h2>
 
@@ -24,7 +24,7 @@
     <tbody>
     <tr th:each="appVersion : ${appVersions}">
         <td>
-            <form method="POST" th:action="|${prefix}/updateAppVersion|"
+            <form method="POST" action="/admin/updateAppVersion"
                   th:id="|${appVersion.appName}-${appVersion.platform}|">
                 <input type="hidden" name="originalAppName" th:value="${appVersion.appName}"/>
                 <input type="hidden" name="originalPlatform" th:value="${appVersion.platform}"/>
@@ -52,7 +52,7 @@
                    value="Update"/>
         </td>
         <td>
-            <form method="POST" th:action="|${prefix}/deleteAppVersion|">
+            <form method="POST" action="/admin/deleteAppVersion">
                 <input type="hidden" name="appName" th:value="${appVersion.appName}"/>
                 <input type="hidden" name="platform" th:value="${appVersion.platform}"/>
                 <input type="submit" value="Delete"/>
@@ -62,7 +62,7 @@
 
     <tr>
         <td>
-            <form method="POST" th:action="|${prefix}/createAppVersion|" id="create">
+            <form method="POST" action="/admin/createAppVersion" id="create">
                 <input type="text" name="appName" required/>
             </form>
         </td>

--- a/src/main/resources/templates/admin/deviceManager.html
+++ b/src/main/resources/templates/admin/deviceManager.html
@@ -19,14 +19,14 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a> -
-<a th:if="${facility} == null" th:href="|${prefix}/deviceManagers|">Device Managers</a>
-<a th:if="${facility} != null" th:href="|${prefix}/facility/${facility.id}|"
+<a href="/admin/">Home</a> -
+<a th:if="${facility} == null" href="/admin/deviceManagers">Device Managers</a>
+<a th:if="${facility} != null" th:href="|/admin/facility/${facility.id}|"
    th:text="${facility.name}">Facility</a>
 
 <h2 th:text="|Device Manager ${manager.deviceName} (${manager.id})|">Device Manager foo (1)</h2>
 
-<form th:action="|${prefix}/deviceManagers/${manager.id}|" method="POST">
+<form th:action="|/admin/deviceManagers/${manager.id}|" method="POST">
 
     <label for="sensorKitId">Sensor Kit ID</label>
     <input type="text" name="sensorKitId" id="sensorKitId" th:value="${manager.sensorKitId}"/>
@@ -97,7 +97,7 @@
 </form>
 
 <form th:if="${manager.userId} != null"
-      th:action="|${prefix}/deviceManagers/${manager.id}/generateToken|"
+      th:action="|/admin/deviceManagers/${manager.id}/generateToken|"
       method="POST">
 
     <input type="submit" value="Generate New Offline Refresh Token"/>

--- a/src/main/resources/templates/admin/deviceTemplates.html
+++ b/src/main/resources/templates/admin/deviceTemplates.html
@@ -5,7 +5,7 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2>Device Templates</h2>
 
@@ -32,7 +32,7 @@
     <tbody>
     <tr th:each="template : ${templates}">
         <td>
-            <form th:action="|${prefix}/deviceTemplates|" method="POST"
+            <form action="/admin/deviceTemplates" method="POST"
                   th:id="|template${template.id}|"
                   th:if="${canUpdateDeviceTemplates}">
                 <input type="hidden" name="id" th:value="${template.id}"/>
@@ -95,7 +95,7 @@
 
     <tr th:if="${canUpdateDeviceTemplates}">
         <td>
-            <form th:action="|${prefix}/createDeviceTemplate|" method="POST" id="createTemplate">
+            <form action="/admin/createDeviceTemplate" method="POST" id="createTemplate">
             </form>
         </td>
         <td></td>

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -62,12 +62,12 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a> -
-<a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>
+<a href="/admin/">Home</a> -
+<a th:href="|/admin/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>
 
 <h2 th:text="|Facility ${facility.name} (${facility.id})|">Facility (id)</h2>
 
-<form method="POST" th:action="|${prefix}/updateFacility|" th:if="${canUpdateFacility}">
+<form method="POST" action="/admin/updateFacility" th:if="${canUpdateFacility}">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
     <label for="name">Name</label>
     <input type="text" name="name" id="name" required th:value="${facility.name}"/>
@@ -111,13 +111,13 @@
 <h3>Devices</h3>
 
 <p th:if="${deviceManager} != null">
-    <a th:href="|${prefix}/deviceManagers/${deviceManager.id}|"
+    <a th:href="|/admin/deviceManagers/${deviceManager.id}|"
        th:text="|Device manager ${deviceManager.id} connected.|">Device manager 1 connected.</a>
 </p>
 
 <p th:if="${deviceManager} == null">
     No device manager connected.
-    <a th:href="|${prefix}/deviceManagers|">Go to device manager list</a>
+    <a href="/admin/deviceManagers">Go to device manager list</a>
 </p>
 
 <table th:if="!${devices.isEmpty()}">
@@ -144,7 +144,7 @@
 
 <h4 id="createDevices">Create Devices</h4>
 
-<form method="POST" th:action="|${prefix}/createDevices|">
+<form method="POST" action="/admin/createDevices">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
 
     <div>
@@ -208,14 +208,14 @@
 
 <ul>
     <li th:each="location : ${subLocations}">
-        <form method="POST" th:action="|${prefix}/updateSubLocation|"
+        <form method="POST" action="/admin/updateSubLocation"
               th:if="${canUpdateFacility}" style="display: inline-block;">
             <input type="hidden" name="facilityId" th:value="${facility.id}"/>
             <input type="hidden" name="subLocationId" th:value="${location.id}"/>
             <input type="text" name="name" th:value="${location.name}"/>
             <input type="submit" value=" Update "/>
         </form>
-        <form method="POST" th:action="|${prefix}/deleteSubLocation|"
+        <form method="POST" action="/admin/deleteSubLocation"
               th:if="${canUpdateFacility}" style="display: inline-block;">
             <input type="hidden" name="facilityId" th:value="${facility.id}"/>
             <input type="hidden" name="subLocationId" th:value="${location.id}"/>
@@ -228,7 +228,7 @@
     </li>
 </ul>
 
-<form method="POST" th:action="|${prefix}/createSubLocation|" th:if="${canUpdateFacility}">
+<form method="POST" action="/admin/createSubLocation" th:if="${canUpdateFacility}">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
     <label for="subLocationName">Name</label>
     <input type="text" name="name" id="subLocationName" required/>
@@ -249,7 +249,7 @@
 
 <h4>Send Test Alert</h4>
 
-<form method="POST" th:action="|${prefix}/sendAlert|">
+<form method="POST" action="/admin/sendAlert">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
     <label for="subject">Subject</label>
     <input type="text" name="subject" id="subject" value="Testing Alert Email"/>

--- a/src/main/resources/templates/admin/globalRoles.html
+++ b/src/main/resources/templates/admin/globalRoles.html
@@ -6,7 +6,7 @@
 <span th:replace="~{/admin/header :: top}"/>
 
 <p>
-    <a th:href="|${prefix}/|">Home</a>
+    <a href="/admin/">Home</a>
 </p>
 
 <h2>Global Roles</h2>
@@ -39,7 +39,7 @@
         <td>
             <form method="POST"
                   th:id="|update-${user.userId}|"
-                  th:action="|${prefix}/globalRoles|">
+                  action="/admin/globalRoles">
                 <input type="hidden" name="userId" th:value="${user.userId}"/>
                 <input type="submit" value="Update"/>
             </form>
@@ -59,7 +59,7 @@
             />
         </td>
         <td>
-            <form method="POST" id="add" th:action="|${prefix}/globalRoles|">
+            <form method="POST" id="add" action="/admin/globalRoles">
                 <input type="submit" value="Update"/>
             </form>
         </td>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -9,7 +9,7 @@
 
 <ul>
     <li th:each="organization : ${organizations}">
-        <a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">
+        <a th:href="|/admin/organization/${organization.id}|" th:text="${organization.name}">
             Org name
         </a>
         <span th:text="|(${organization.id})|">(15)</span>
@@ -20,7 +20,7 @@
     <h2>Global Roles</h2>
 
     <p>
-        <a th:href="|${prefix}/globalRoles|">Manage Global Roles</a>
+        <a href="/admin/globalRoles">Manage Global Roles</a>
     </p>
 </div>
 
@@ -44,11 +44,11 @@
     <h2>Device manager configuration</h2>
 
     <p>
-        <a th:href="|${prefix}/deviceManagers|">Device Managers</a>
+        <a href="/admin/deviceManagers">Device Managers</a>
     </p>
 
     <p th:if="${canUpdateDeviceTemplates}">
-        <a th:href="|${prefix}/deviceTemplates|">Device Templates</a>
+        <a href="/admin/deviceTemplates">Device Templates</a>
     </p>
 </th:block>
 
@@ -56,7 +56,7 @@
     <h2>App Versions</h2>
 
     <p>
-        <a th:href="|${prefix}/appVersions|">Update app versions</a>
+        <a href="/admin/appVersions">Update app versions</a>
     </p>
 </th:block>
 
@@ -64,7 +64,7 @@
     <h2>Test Utilities</h2>
 
     <p>
-        <a th:href="|${prefix}/testClock|">Test clock adjustment</a>
+        <a href="/admin/testClock">Test clock adjustment</a>
     </p>
 </th:block>
 
@@ -72,7 +72,7 @@
     <h2>Internal Tags</h2>
 
     <p>
-        <a th:href="|${prefix}/internalTags|">Manage internal tags</a>
+        <a href="/admin/internalTags">Manage internal tags</a>
     </p>
 </th:block>
 
@@ -84,7 +84,7 @@
         contact, the existing contact will be replaced by the new one.
     </p>
 
-    <form method="POST" th:action="|${prefix}/addOrganizationUser|">
+    <form method="POST" action="/admin/addOrganizationUser">
         <label for="addUserEmail">Email (user must already exist)</label>
         <input id="addUserEmail" type="email" name="email" required />
         <label for="addUserOrganizationId">Organization</label>

--- a/src/main/resources/templates/admin/internalTag.html
+++ b/src/main/resources/templates/admin/internalTag.html
@@ -21,9 +21,9 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 -
-<a th:href="|${prefix}/internalTags|">Internal Tags</a>
+<a href="/admin/internalTags">Internal Tags</a>
 
 <h2 th:text="|Internal Tag: ${tag.name} (${tag.id})|">Internal Tag Foo (123)</h2>
 
@@ -42,7 +42,7 @@
     </tr>
 </table>
 
-<form method="POST" th:action="|${prefix}/updateInternalTag/${tag.id}|" th:if="!${tag.isSystem}">
+<form method="POST" th:action="|/admin/updateInternalTag/${tag.id}|" th:if="!${tag.isSystem}">
     <table>
         <tr>
             <td><label for="name">Name</label></td>
@@ -64,7 +64,7 @@
     </table>
 </form>
 
-<form id="deleteTagForm" method="POST" th:action="|${prefix}/deleteInternalTag/${tag.id}|" th:if="!${tag.isSystem}">
+<form id="deleteTagForm" method="POST" th:action="|/admin/deleteInternalTag/${tag.id}|" th:if="!${tag.isSystem}">
     <table>
         <tr>
             <td>

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -5,7 +5,7 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2>Device Managers</h2>
 
@@ -23,13 +23,13 @@
     <tbody>
     <tr th:each="manager : ${managers}">
         <td>
-            <a th:href="|${prefix}/deviceManagers/${manager.id}|" th:text="${manager.id}">123</a>
+            <a th:href="|/admin/deviceManagers/${manager.id}|" th:text="${manager.id}">123</a>
         </td>
         <td>
-            <a th:href="|${prefix}/deviceManagers/${manager.id}|" th:text="${manager.sensorKitId}">ABCDE</a>
+            <a th:href="|/admin/deviceManagers/${manager.id}|" th:text="${manager.sensorKitId}">ABCDE</a>
         </td>
         <td th:text="${manager.facilityId}">
-            <a th:href="|${prefix}/facility/${manager.facilityId}|" th:text="${manager.facilityId}">567</a>
+            <a th:href="|/admin/facility/${manager.facilityId}|" th:text="${manager.facilityId}">567</a>
         </td>
         <td th:text="${manager.userId}">123</td>
         <td th:text="${manager.isOnline()}">true</td>
@@ -45,7 +45,7 @@
         For development use only!
     </p>
 
-    <form th:action="|${prefix}/deviceManagers|" method="POST">
+    <form action="/admin/deviceManagers" method="POST">
         <label for="sensorKitId">Sensor Kit ID</label>
         <input type="text" name="sensorKitId" id="sensorKitId"/>
         <br/>
@@ -70,7 +70,7 @@
         server logs to monitor its progress in that case.
     </p>
 
-    <form th:action="|${prefix}/deviceManagers/regenerateAllTokens|" method="POST">
+    <form action="/admin/deviceManagers/regenerateAllTokens" method="POST">
         <input type="submit" value="Regenerate All Tokens"/>
     </form>
 

--- a/src/main/resources/templates/admin/listInternalTags.html
+++ b/src/main/resources/templates/admin/listInternalTags.html
@@ -5,7 +5,7 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2>Internal Tags</h2>
 
@@ -16,7 +16,7 @@
 
 <ul>
     <li th:each="tag : ${tags}">
-        <a th:href="|${prefix}/internalTag/${tag.id}|" th:text="${tag.name}">Tag Name</a>
+        <a th:href="|/admin/internalTag/${tag.id}|" th:text="${tag.name}">Tag Name</a>
 
         <th:block th:text="|(${tag.id})|">(123)</th:block>
         <th:block th:if="${tag.isSystem()}"><b>System</b></th:block>
@@ -25,7 +25,7 @@
     </li>
 </ul>
 
-<form method="POST" th:action="|${prefix}/createInternalTag|">
+<form method="POST" action="/admin/createInternalTag">
     <label for="name">Name</label>
     <input type="text" id="name" name="name" size="15" required/>
     <label for="description">Description</label>
@@ -59,7 +59,7 @@
             <td>
                 <form method="POST"
                       th:id="|update-${organization.id}|"
-                      th:action="|${prefix}/updateOrganizationInternalTags|">
+                      action="/admin/updateOrganizationInternalTags">
                     <input type="hidden" name="organizationId" th:value="${organization.id}"/>
                     <input type="submit" value="Update"/>
                 </form>

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -190,7 +190,7 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2 th:text="|Organization ${organization.name} (${organization.id})|">Organization (name)</h2>
 
@@ -198,7 +198,7 @@
 
 <ul>
     <li th:each="facility : ${facilities}">
-        <a th:href="|${prefix}/facility/${facility.id}|">
+        <a th:href="|/admin/facility/${facility.id}|">
             <span th:text="|${facility.name}|">MySeedBank</span>
             (<span th:text="${facility.type.jsonValue}">Seed Bank</span>
             <span th:text="${facility.id}">12345</span>)
@@ -206,7 +206,7 @@
     </li>
 </ul>
 
-<form method="POST" th:action="|${prefix}/createFacility|" th:if="${canCreateFacility}">
+<form method="POST" action="/admin/createFacility" th:if="${canCreateFacility}">
     <h4>Create Facility</h4>
 
     <input type="hidden" name="organizationId" th:value="${organization.id}"/>
@@ -227,11 +227,11 @@
 
 <ol>
     <li th:value="${site.id}" th:each="site : ${plantingSites}">
-        <a th:href="|${prefix}/plantingSite/${site.id}|" th:text="${site.name}">Site Name</a>
+        <a th:href="|/admin/plantingSite/${site.id}|" th:text="${site.name}">Site Name</a>
     </li>
 </ol>
 
-<form method="POST" enctype="multipart/form-data" th:action="|${prefix}/createPlantingSite|"
+<form method="POST" enctype="multipart/form-data" action="/admin/createPlantingSite"
       th:if="${canCreatePlantingSite}">
     <h4>Create Planting Site from Shapefiles</h4>
 
@@ -252,7 +252,7 @@
     <input type="submit" value=" Create Planting Site "/>
 </form>
 
-<form method="POST" th:action="|${prefix}/createPlantingSiteFromMap|"
+<form method="POST" action="/admin/createPlantingSiteFromMap"
       th:if="${canCreatePlantingSite}">
     <h4>Create Test Planting Site from Map (for development testing)</h4>
 
@@ -310,11 +310,11 @@
     <li th:each="report : ${reports}">
         <th:block th:text="|${report.year}-Q${report.quarter} (${report.id})|"></th:block>
         -
-        <a th:href="|${prefix}/report/${report.id}/index.html|">View HTML</a>
+        <a th:href="|/admin/report/${report.id}/index.html|">View HTML</a>
         -
-        <a th:href="|${prefix}/report/${report.id}/report.csv|">View CSV</a>
+        <a th:href="|/admin/report/${report.id}/report.csv|">View CSV</a>
         <form method="POST"
-              th:action="|${prefix}/exportReport|"
+              action="/admin/exportReport"
               th:if="${canExportReport}"
               style="display: inline-block;">
             <input type="hidden" name="organizationId" th:value="${organization.id}"/>
@@ -322,7 +322,7 @@
             <input type="submit" value="Export to Google Drive"/>
         </form>
         <form method="POST"
-              th:action="|${prefix}/deleteReport|"
+              action="/admin/deleteReport"
               class="deleteReportForm"
               th:if="${canDeleteReport}"
               style="display: inline-block;">
@@ -333,7 +333,7 @@
     </li>
 </ul>
 
-<form method="POST" th:action="|${prefix}/createReport|" th:if="${canCreateReport}">
+<form method="POST" action="/admin/createReport" th:if="${canCreateReport}">
     <h4>Create Report (for development testing)</h4>
     <p>
         The report will be created for the previous quarter. Adjust the test clock if you want to

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -93,12 +93,11 @@
 
             function showMapPopup() {
                 /*<![CDATA[*/
-                const prefix = /*[[${prefix}]]*/;
                 const envelope = /*[[${envelope}]]*/;
                 const siteId = /*[[${site.id}]]*/;
                 /*]]>*/
 
-                window.open(`${prefix}/plantingSite/${siteId}/map`);
+                window.open(`/admin/plantingSite/${siteId}/map`);
             }
 
             function warnOnDelete(event) {
@@ -136,8 +135,8 @@
 
 <th:block th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a> -
-<a th:href="|${prefix}/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>
+<a href="/admin/">Home</a> -
+<a th:href="|/admin/organization/${organization.id}|" th:text="${organization.name}">Org Name</a>
 
 <h2 th:text="|Planting Site ${site.name} (${site.id})|">Planting Site Name (123)</h2>
 
@@ -153,7 +152,7 @@
     <button onclick="showMapPopup()">Click to View Map</button> (opens in new window)
 </div>
 
-<form method="POST" th:action="|${prefix}/updatePlantingSite|" th:if="${canUpdatePlantingSite}">
+<form method="POST" action="/admin/updatePlantingSite" th:if="${canUpdatePlantingSite}">
     <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
     <label for="siteName">Name</label>
     <input type="text" id="siteName" name="siteName" th:value="${site.name}" minlength="1"
@@ -173,7 +172,7 @@
         <input type="date" disabled th:value="${season.endDate}">
     </li>
     <li th:each="season : ${futurePlantingSeasons}">
-        <form method="POST" th:action="|${prefix}/updatePlantingSeason|" style="display: inline-block;">
+        <form method="POST" action="/admin/updatePlantingSeason" style="display: inline-block;">
             <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
             <input type="hidden" name="plantingSeasonId" th:value="${season.id}"/>
             <input type="date" name="startDate" required th:value="${season.startDate}"/>
@@ -181,14 +180,14 @@
             <input type="date" name="endDate" required th:value="${season.endDate}"/>
             <input type="submit" value="Update"/>
         </form>
-        <form method="POST" th:action="|${prefix}/deletePlantingSeason|" style="display: inline-block;">
+        <form method="POST" action="/admin/deletePlantingSeason" style="display: inline-block;">
             <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
             <input type="hidden" name="plantingSeasonId" th:value="${season.id}"/>
             <input type="submit" value="Delete"/>
         </form>
     </li>
     <li>
-        <form method="POST" th:action="|${prefix}/createPlantingSeason|">
+        <form method="POST" action="/admin/createPlantingSeason">
             <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
             <input type="date" name="startDate" required/>
             -
@@ -198,7 +197,7 @@
     </li>
 </ol>
 
-<form method="POST" th:action="|${prefix}/movePlantingSite|" th:if="${canMovePlantingSiteToAnyOrg}"
+<form method="POST" action="/admin/movePlantingSite" th:if="${canMovePlantingSiteToAnyOrg}"
       id="moveForm">
     <h3>Move to New Organization</h3>
 
@@ -285,7 +284,7 @@
                     </span>
                 </td>
                 <td style="padding-left: 8px;">
-                    <form method="POST" th:action="|${prefix}/updatePlantingZone|" th:id="|zone-${zone.id}|">
+                    <form method="POST" action="/admin/updatePlantingZone" th:id="|zone-${zone.id}|">
                         <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
                         <input type="hidden" name="plantingZoneId" th:value="${zone.id}"/>
                         <input type="submit" value="Update"/>
@@ -350,7 +349,7 @@
                 <th:block th:text="${observationMessages[observation.id]}"></th:block>
                 <form th:if="${canStartObservations[observation.id]}"
                       method="POST"
-                      th:action="|${prefix}/startObservation|">
+                      action="/admin/startObservation">
                     <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
                     <input type="hidden" name="observationId" th:value="${observation.id}"/>
                     <input type="submit" value="Start"/>
@@ -368,7 +367,7 @@
             </td>
             <td></td>
             <td>
-                <form method="POST" id="createObservation" th:action="|${prefix}/createObservation|">
+                <form method="POST" id="createObservation" action="/admin/createObservation">
                     <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
                     <input type="submit" value="Create Observation"/>
                 </form>
@@ -385,7 +384,7 @@
         plants that have been reported, and will delete the site's map data.
     </p>
 
-    <form id="deleteSiteForm" method="POST" th:action="|${prefix}/deletePlantingSite|">
+    <form id="deleteSiteForm" method="POST" action="/admin/deletePlantingSite">
         <input type="hidden" name="organizationId" th:value="${organization.id}"/>
         <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
         <input type="submit" value="Delete Planting Site"/>

--- a/src/main/resources/templates/admin/plantingSiteMap.html
+++ b/src/main/resources/templates/admin/plantingSiteMap.html
@@ -44,7 +44,7 @@
         /*<![CDATA[*/
         mapboxgl.accessToken = /*[[${mapboxToken}]]*/;
 
-        const prefix = /*[[${prefix}]]*/;
+        const prefix = /*[[/admin]]*/;
         const envelope = /*[[${envelope}]]*/;
         const siteId = /*[[${site.id}]]*/;
         const bounds = new mapboxgl.LngLatBounds(envelope.coordinates[0][0], envelope.coordinates[0][2]);
@@ -74,7 +74,7 @@
 
             map.addSource('plots', {
                 type: 'geojson',
-                data: `${prefix}/plantingSite/${siteId}/plots`,
+                data: `/admin/plantingSite/${siteId}/plots`,
             });
 
             map.addLayer({

--- a/src/main/resources/templates/admin/testClock.html
+++ b/src/main/resources/templates/admin/testClock.html
@@ -9,14 +9,14 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
-<a th:href="|${prefix}/|">Home</a>
+<a href="/admin/">Home</a>
 
 <h2>Test Clock Adjustment</h2>
 
 <p>Current server time is <b th:text="${currentTime}"></b>. (Will refresh every 30 seconds.)
 
 <p>
-<form method="POST" th:action="|${prefix}/advanceTestClock|">
+<form method="POST" action="/admin/advanceTestClock">
     Advance clock by
     <input name="quantity" size="3" maxlength="3" type="text" value="1"/>
     <select name="units">
@@ -29,7 +29,7 @@
 </form>
 
 <p>
-<form method="POST" th:action="|${prefix}/resetTestClock|">
+<form method="POST" action="/admin/resetTestClock">
     <input type="submit" value="Reset Clock to Current Time"/>
 </form>
 


### PR DESCRIPTION
When the admin UI was first written, we wanted to allow for the possibility that
the frontend web server would do URL rewriting to expose it at a different path.
We thus needed to be able to easily change the path that was included in links
and form actions.

This has turned out not to be needed. Passing the prefix around and using it
everywhere adds noise to the templates and the controller classes.

Update AdminController to stop including the prefix in the models that get passed
to the templates, and update the templates to directly use `/admin` in their URL
paths. In many cases, this means attributes such as `href` can be string literals
instead of Thymeleaf expressions.