### PR TITLE
SW-4673 Unassign plots when observation rescheduled

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -395,6 +395,19 @@ class ObservationStore(
           .set(OBSERVATIONS.END_DATE, endDate)
           .where(OBSERVATIONS.ID.eq(observationId))
           .execute()
+
+      // If the observation was already in progress, it will have plots, but we want to assign a
+      // fresh set on the new start date so that the observation is based on up-to-date information
+      // about which subzones are planted. Delete the existing plots. This is a no-op if the
+      // observation hadn't started yet.
+      //
+      // Rescheduling should only be allowed if there are no completed plots, but for added safety,
+      // guard against deleting completed ones.
+      dslContext
+          .deleteFrom(OBSERVATION_PLOTS)
+          .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
+          .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNull)
+          .execute()
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -730,6 +730,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
           ObservationState.Upcoming, updatedObservation.state, "State should show as Upcoming")
       assertEquals(startDate, updatedObservation.startDate, "Start date should be updated")
       assertEquals(endDate, updatedObservation.endDate, "End date should be updated")
+      assertEquals(
+          emptyList<Any>(), observationPlotsDao.findAll(), "Observation plots should be removed")
 
       eventPublisher.assertExactEventsPublished(
           setOf(ObservationRescheduledEvent(originalObservation, updatedObservation)))


### PR DESCRIPTION
If an observation is in progress but no plots are completed yet, we let admins
reschedule it for a future date. Get rid of the initial plot assignments so as
to calculate a fresh set of plots based on the state of the planting site on
the new start date.