### PR TITLE
Include status field in report settings response

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/report/api/ReportsSettingsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/ReportsSettingsController.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.report.api
 
 import com.terraformation.backend.api.CustomerEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.report.db.ReportStore
@@ -70,7 +71,7 @@ data class GetReportSettingsResponsePayload(
     val organizationEnabled: Boolean,
     @ArraySchema(arraySchema = Schema(description = "Per-project report settings."))
     val projects: List<ProjectReportSettingsPayload>,
-) {
+) : SuccessResponsePayload {
   constructor(
       model: ReportSettingsModel
   ) : this(


### PR DESCRIPTION
The response payload for the `GET /api/v1/reports/settings` endpoint wasn't
including the standard `status` field.