### PR TITLE
[Do Not Merge] SW-4671 Update webapp urls for nursery seedlings batch ready notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -147,7 +147,7 @@ class AppNotificationService(
 
   @EventListener
   fun on(event: NurserySeedlingBatchReadyEvent) {
-    val batchUrl = webAppUrls.batch(event.batchNumber, event.speciesId)
+    val batchUrl = webAppUrls.batch(event.batchId, event.speciesId)
     val renderMessage = {
       messages.nurserySeedlingBatchReadyNotification(event.batchNumber, event.nurseryName)
     }

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -235,8 +235,7 @@ class EmailNotificationService(
   fun on(event: NurserySeedlingBatchReadyEvent) {
     val facilityId = parentStore.getFacilityId(event.batchId)!!
     val organizationId = parentStore.getOrganizationId(facilityId)!!
-    val batchUrl =
-        webAppUrls.fullBatch(organizationId, event.batchNumber, event.speciesId).toString()
+    val batchUrl = webAppUrls.fullBatch(organizationId, event.batchId, event.speciesId).toString()
 
     log.info("Creating email notifications for batchId ${event.batchId.value} ready.")
     getRecipients(facilityId).forEach { user ->

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
+import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.ViabilityTestType
@@ -107,17 +108,15 @@ class WebAppUrls(
     return URI.create("/inventory")
   }
 
-  fun fullBatch(organizationId: OrganizationId, batchNumber: String, speciesId: SpeciesId): URI {
+  fun fullBatch(organizationId: OrganizationId, batchId: BatchId, speciesId: SpeciesId): URI {
     return UriBuilder.fromUri(config.webAppUrl)
-        .path("/inventory/${speciesId.value}")
-        .queryParam("batch", batchNumber)
+        .path("/inventory/species/${speciesId.value}/batch/${batchId.value}")
         .queryParam("organizationId", organizationId)
         .build()
   }
 
-  fun batch(batchNumber: String, speciesId: SpeciesId): URI {
-    return UriBuilder.fromPath("/inventory/${speciesId.value}")
-        .queryParam("batch", batchNumber)
+  fun batch(batchId: BatchId, speciesId: SpeciesId): URI {
+    return UriBuilder.fromPath("/inventory/species/${speciesId.value}/batch/${batchId.value}")
         .build()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -282,7 +282,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         organizationId = organizationId,
         title = "nursery title",
         body = "nursery body",
-        localUrl = webAppUrls.batch(batchNumber, speciesId))
+        localUrl = webAppUrls.batch(batchId, speciesId))
   }
 
   @Test


### PR DESCRIPTION
- use new url format /inventory/species/<speciesId>/batch/<batchId>
- client will redirect older urls to the new format automatically
- this will be merged after FE with nursery v2 udpates is deployed in production