### PR TITLE
SW-4603 Accelerator admins can read internal tags

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
@@ -82,13 +82,13 @@ class InternalTagStore(
   }
 
   fun findAllTags(): List<InternalTagsRow> {
-    requirePermissions { manageInternalTags() }
+    requirePermissions { readInternalTags() }
 
     return internalTagsDao.findAll().sortedBy { it.id!!.value }
   }
 
   fun fetchOrganizationsByTagId(tagId: InternalTagId): Collection<OrganizationsRow> {
-    requirePermissions { manageInternalTags() }
+    requirePermissions { readInternalTags() }
 
     return dslContext
         .select(ORGANIZATIONS.asterisk())
@@ -100,7 +100,7 @@ class InternalTagStore(
   }
 
   fun fetchAllOrganizationTagIds(): Map<OrganizationId, Set<InternalTagId>> {
-    requirePermissions { manageInternalTags() }
+    requirePermissions { readInternalTags() }
 
     return with(ORGANIZATION_INTERNAL_TAGS) {
       dslContext
@@ -113,7 +113,7 @@ class InternalTagStore(
   }
 
   fun fetchTagsByOrganization(organizationId: OrganizationId): Set<InternalTagId> {
-    requirePermissions { manageInternalTags() }
+    requirePermissions { readInternalTags() }
 
     return with(ORGANIZATION_INTERNAL_TAGS) {
       dslContext

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -172,6 +172,7 @@ data class DeviceManagerUser(
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
   override fun canReadBatch(batchId: BatchId): Boolean = false
   override fun canReadDelivery(deliveryId: DeliveryId): Boolean = false
+  override fun canReadInternalTags(): Boolean = false
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
   override fun canReadObservation(observationId: ObservationId): Boolean = false
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -298,6 +298,8 @@ data class IndividualUser(
   override fun canReadNotification(notificationId: NotificationId) =
       parentStore.getUserId(notificationId) == userId
 
+  override fun canReadInternalTags() = isAcceleratorAdmin()
+
   override fun canReadObservation(observationId: ObservationId) =
       isMember(parentStore.getOrganizationId(observationId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -455,6 +455,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readInternalTags() {
+    if (!user.canReadInternalTags()) {
+      throw AccessDeniedException("No permission to read internal tags")
+    }
+  }
+
   fun readNotification(notificationId: NotificationId) {
     if (!user.canReadNotification(notificationId)) {
       throw NotificationNotFoundException(notificationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -178,6 +178,7 @@ class SystemUser(
   override fun canReadDevice(deviceId: DeviceId): Boolean = true
   override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
   override fun canReadFacility(facilityId: FacilityId): Boolean = true
+  override fun canReadInternalTags(): Boolean = true
   override fun canReadNotification(notificationId: NotificationId): Boolean = true
   override fun canReadObservation(observationId: ObservationId): Boolean = true
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -137,6 +137,7 @@ interface TerrawareUser : Principal {
   fun canReadDevice(deviceId: DeviceId): Boolean
   fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
   fun canReadFacility(facilityId: FacilityId): Boolean
+  fun canReadInternalTags(): Boolean
   fun canReadNotification(notificationId: NotificationId): Boolean
   fun canReadObservation(observationId: ObservationId): Boolean
   fun canReadOrganization(organizationId: OrganizationId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -447,6 +447,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun readFacility() = testRead { readFacility(facilityId) }
 
+  @Test fun readInternalTags() = allow { readInternalTags() } ifUser { canReadInternalTags() }
+
   @Test fun readNotification() = testRead { readNotification(notificationId) }
 
   @Test fun readObservation() = testRead { readObservation(observationId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1080,6 +1080,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipant = true,
         deleteParticipantProject = true,
         manageNotifications = true,
+        readInternalTags = true,
         readParticipant = true,
         setTestClock = true,
         updateAppVersions = true,
@@ -1201,6 +1202,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         importGlobalSpeciesData = true,
         manageInternalTags = true,
+        readInternalTags = true,
         readParticipant = true,
         regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
@@ -1603,6 +1605,7 @@ internal class PermissionTest : DatabaseTest() {
         importGlobalSpeciesData: Boolean = false,
         manageInternalTags: Boolean = false,
         manageNotifications: Boolean = false,
+        readInternalTags: Boolean = false,
         readParticipant: Boolean = false,
         regenerateAllDeviceManagerTokens: Boolean = false,
         setTestClock: Boolean = false,
@@ -1632,6 +1635,7 @@ internal class PermissionTest : DatabaseTest() {
           "Can import global species data")
       assertEquals(manageInternalTags, user.canManageInternalTags(), "Can manage internal tags")
       assertEquals(manageNotifications, user.canManageNotifications(), "Can manage notifications")
+      assertEquals(readInternalTags, user.canReadInternalTags(), "Can read internal tags")
       assertEquals(readParticipant, user.canReadParticipant(participantId), "Can read participant")
       assertEquals(
           regenerateAllDeviceManagerTokens,


### PR DESCRIPTION
To show the list of available projects that can be added to a participant in the
admin UI, accelerator admins need to be able to query the list of organizations
with the "Accelerator" internal tag. Add a separate read permission for internal
tags.