### PR TITLE
SW-4649 Backfill batch ID into seedbank withdrawals

### DIFF
--- a/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
+++ b/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
@@ -1,6 +1,6 @@
 UPDATE seedbank.withdrawals withdrawals
 SET batch_id = (
-    SELECT batchHistory.batch_id
+    SELECT MIN(batchHistory.batch_id)
     FROM nursery.batch_quantity_history batchHistory
     INNER JOIN nursery.batches batches
         ON batches.id = batchHistory.batch_id

--- a/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
+++ b/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
@@ -1,0 +1,14 @@
+UPDATE seedbank.withdrawals
+SET
+    batch_id = joined.batch_id
+FROM (
+    SELECT withdrawals.id withdrawalId, batches.batch_id
+     FROM nursery.batch_quantity_history batches
+        INNER JOIN seedbank.withdrawals withdrawals
+            ON batches.germinating_quantity = withdrawals.withdrawn_quantity
+            AND batches.created_by = withdrawals.created_by
+            AND date_trunc('second', withdrawals.created_time)
+                BETWEEN (date_trunc('second', batches.created_time) - '1 second'::interval)
+                AND (date_trunc('second', batches.created_time) + '1 second'::interval)
+) as joined
+WHERE joined.withdrawalId = seedbank.withdrawals.id;

--- a/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
+++ b/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
@@ -11,7 +11,7 @@ SET batch_id = (
         AND batchHistory.created_by = withdrawals.created_by
         AND batchHistory.created_time
             BETWEEN withdrawals.created_time
-            AND (withdrawals.created_time::date + '1 second'::interval)
+            AND (withdrawals.created_time + '1 second'::interval)
 )
 WHERE withdrawals.batch_id IS NULL
     AND withdrawals.purpose_id = 9;

--- a/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
+++ b/src/main/resources/db/migration/0200/V240__BackfillSeedbankWithdrawalsBatchId.sql
@@ -1,14 +1,17 @@
-UPDATE seedbank.withdrawals
-SET
-    batch_id = joined.batch_id
-FROM (
-    SELECT withdrawals.id withdrawalId, batches.batch_id
-     FROM nursery.batch_quantity_history batches
-        INNER JOIN seedbank.withdrawals withdrawals
-            ON batches.germinating_quantity = withdrawals.withdrawn_quantity
-            AND batches.created_by = withdrawals.created_by
-            AND date_trunc('second', withdrawals.created_time)
-                BETWEEN (date_trunc('second', batches.created_time) - '1 second'::interval)
-                AND (date_trunc('second', batches.created_time) + '1 second'::interval)
-) as joined
-WHERE joined.withdrawalId = seedbank.withdrawals.id;
+UPDATE seedbank.withdrawals withdrawals
+SET batch_id = (
+    SELECT batchHistory.batch_id
+    FROM nursery.batch_quantity_history batchHistory
+    INNER JOIN nursery.batches batches
+        ON batches.id = batchHistory.batch_id
+    INNER JOIN seedbank.accessions accessions
+        ON accessions.id = withdrawals.accession_id
+    WHERE batches.species_id = accessions.species_id
+        AND batchHistory.germinating_quantity = withdrawals.withdrawn_quantity
+        AND batchHistory.created_by = withdrawals.created_by
+        AND batchHistory.created_time
+            BETWEEN withdrawals.created_time
+            AND (withdrawals.created_time::date + '1 second'::interval)
+)
+WHERE withdrawals.batch_id IS NULL
+    AND withdrawals.purpose_id = 9;

--- a/src/main/resources/db/migration/0200/V241__WithdrawalsBatchIdIndex.sql
+++ b/src/main/resources/db/migration/0200/V241__WithdrawalsBatchIdIndex.sql
@@ -1,0 +1,9 @@
+CREATE INDEX ON seedbank.withdrawals (batch_id);
+
+ALTER TABLE seedbank.withdrawals
+    DROP CONSTRAINT withdrawals_batch_id_fkey;
+
+ALTER TABLE seedbank.withdrawals
+    ADD FOREIGN KEY (batch_id)
+        REFERENCES nursery.batches
+        ON DELETE SET NULL;


### PR DESCRIPTION
Migration to backfill the `batch_id` into the accession withdrawals table hinges on the `created_time` check, which I have truncated to seconds and given it a 2 second window since they are not created at the exact same time. 

@sgrimm let me know what you think, I think 2 seconds might be too high but there is a chance that the withdrawal was created at the end of the previous second and the batch at the beginning of the next second. Hopefully the other checks are sufficient to make the chance that an incorrect batch ID is applied impossible.