### PR TITLE
SW-4716 Improve monitoring plot placement tests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/SRID.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/SRID.kt
@@ -17,6 +17,14 @@ object SRID {
    */
   const val SPHERICAL_MERCATOR = 3857
 
+  /**
+   * Universal Transverse Mercator zone 20S (in South America). Like all UTM zones, this has the
+   * property that 1 unit in the coordinate space is 1 meter on the ground. We use this SRID for
+   * testing; other UTM zones are looked up dynamically since a zone only covers a small slice of
+   * the planet.
+   */
+  const val UTM_20S = 32620
+
   val mapping: Map<String, Int> by lazy { loadMapping() }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -49,6 +49,10 @@ class PlantingSiteImporter(
     val targetPlantingDensityProperties = setOf("plan_dens", "density")
     val zoneNameProperties = setOf("planting_z", "zone")
 
+    // Optional zone-level properties to set initial plot counts; mostly for testing
+    val permanentClusterCountProperties = setOf("permanent")
+    val temporaryPlotCountProperies = setOf("temporary")
+
     /**
      * Minimum percentage of a zone or subzone that has to overlap with a neighboring one in order
      * to trip the validation check for overlapping areas. This fuzz factor is needed to account for
@@ -237,6 +241,13 @@ class PlantingSiteImporter(
               zoneFeature.geometry
             }
 
+        val numPermanentClusters =
+            zoneFeature.getProperty(permanentClusterCountProperties)?.toIntOrNull()
+                ?: min(DEFAULT_NUM_PERMANENT_CLUSTERS, totalPermanentClusters)
+        val numTemporaryPlots =
+            zoneFeature.getProperty(temporaryPlotCountProperies)?.toIntOrNull()
+                ?: min(DEFAULT_NUM_TEMPORARY_PLOTS, totalPlots - numPermanentClusters * 4)
+
         val zonesRow =
             PlantingZonesRow(
                 areaHa = scale(zoneFeature.calculateAreaHectares()),
@@ -248,9 +259,8 @@ class PlantingSiteImporter(
                 modifiedBy = userId,
                 modifiedTime = now,
                 name = zoneName,
-                numPermanentClusters = min(DEFAULT_NUM_PERMANENT_CLUSTERS, totalPermanentClusters),
-                numTemporaryPlots =
-                    min(DEFAULT_NUM_TEMPORARY_PLOTS, totalPlots - totalPermanentClusters * 4),
+                numPermanentClusters = numPermanentClusters,
+                numTemporaryPlots = numTemporaryPlots,
                 plantingSiteId = siteId,
                 studentsT = DEFAULT_STUDENTS_T,
                 targetPlantingDensity = targetPlantingDensity,

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -1,0 +1,218 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteImporter
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.Shapefile
+import com.terraformation.backend.tracking.model.ShapefileFeature
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.fail
+
+class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val plantingSiteImporter: PlantingSiteImporter by lazy {
+    PlantingSiteImporter(
+        clock,
+        dslContext,
+        monitoringPlotsDao,
+        plantingSitesDao,
+        plantingZonesDao,
+        plantingSubzonesDao,
+    )
+  }
+  private val observationStore: ObservationStore by lazy {
+    ObservationStore(
+        clock,
+        dslContext,
+        observationsDao,
+        observationPlotConditionsDao,
+        observationPlotsDao,
+        recordedPlantsDao)
+  }
+  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
+  private val plantingSiteStore: PlantingSiteStore by lazy {
+    PlantingSiteStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        monitoringPlotsDao,
+        parentStore,
+        plantingSeasonsDao,
+        plantingSitesDao,
+        plantingSubzonesDao,
+        plantingZonesDao)
+  }
+  private val observationService: ObservationService by lazy {
+    ObservationService(
+        clock,
+        dslContext,
+        eventPublisher,
+        mockk(),
+        observationPhotosDao,
+        observationStore,
+        plantingSiteStore,
+        parentStore)
+  }
+
+  private val gen = ShapefileGenerator(defaultPermanentClusters = 1, defaultTemporaryPlots = 2)
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertFacility(type = FacilityType.Nursery)
+    insertSpecies()
+
+    every { user.canCreatePlantingSite(any()) } returns true
+    every { user.canManageObservation(any()) } returns true
+    every { user.canReadObservation(any()) } returns true
+    every { user.canReadOrganization(any()) } returns true
+    every { user.canReadPlantingSite(any()) } returns true
+    every { user.canReadPlantingSubzone(any()) } returns true
+    every { user.canReadPlantingZone(any()) } returns true
+    every { user.canUpdateObservation(any()) } returns true
+  }
+
+  // Run test 10 times to exercise different random selections. 10 is somewhat arbitrary but given
+  // the small size of the planting site, should be enough that a typical test run will fail at
+  // least once if there's a bug.
+  @RepeatedTest(10)
+  fun `assigns plots to correct locations based on planting status of subzones`() {
+    // Import a planting site with this structure, with 1m margin to account for rounding during
+    // coordinate system conversion:
+    //
+    //                    Zone 1                      Zone 2
+    //     +-------------------------------------|-------------+
+    //     |                    |                |             |
+    //     | Subzone 1          | Subzone 2      | Subzone 3   | 100m tall
+    //     | (planted)          | (no plants)    | (no plants) |
+    //     |                    |                |             |
+    //     +-------------------------------------|-------------+
+    //     |   |   |   |   |   |   |   |   |   |   |   |   |   | (plot borders)
+    //     |       |       |       |       |       |       |     (cluster borders)
+
+    val siteBoundary = gen.multiRectangle(0 to 0, 326 to 101)
+    val zone1Boundary = gen.multiRectangle(0 to 0, 230 to 101)
+    val subzone1Boundary = gen.multiRectangle(0 to 0, 130 to 101)
+    val subzone2Boundary = gen.multiRectangle(130 to 0, 230 to 101)
+    val zone2Boundary = gen.multiRectangle(230 to 0, 326 to 101)
+
+    val siteFeature = gen.siteFeature(siteBoundary)
+    val zone1Feature = gen.zoneFeature(zone1Boundary, permanentClusters = 2, temporaryPlots = 3)
+    val subzone1Feature = gen.subzoneFeature(subzone1Boundary)
+    val subzone2Feature = gen.subzoneFeature(subzone2Boundary)
+    val zone2Feature = gen.zoneFeature(zone2Boundary, permanentClusters = 2, temporaryPlots = 2)
+    val subzone3Feature = gen.subzoneFeature(zone2Boundary)
+
+    val plantingSite =
+        importSite(
+            siteFeature,
+            listOf(zone1Feature, zone2Feature),
+            listOf(subzone1Feature, subzone2Feature, subzone3Feature))
+    val subzone1 =
+        plantingSite.plantingZones
+            .first { it.name == "Z1" }
+            .plantingSubzones
+            .first { it.name == "S1" }
+
+    insertWithdrawal()
+    insertDelivery()
+    insertPlanting(plantingSubzoneId = subzone1.id)
+
+    val observationId =
+        insertObservation(plantingSiteId = plantingSite.id, state = ObservationState.Upcoming)
+    observationService.startObservation(observationId)
+
+    val observationPlots = observationStore.fetchObservationPlotDetails(observationId)
+
+    observationPlots.forEach { plot ->
+      assertEquals(subzone1.fullName, plot.plantingSubzoneName, "Plot in unexpected subzone")
+      if (!plot.boundary.coveredBy(subzone1.boundary)) {
+        fail("Plot boundary ${plot.boundary} not within subzone boundary ${subzone1.boundary}")
+      }
+    }
+
+    // Subzones 1 and 2 will always get one temporary plot each. The third temporary plot could
+    // go in either one of them depending on where the permanent plots ended up. Any temporary
+    // plots that ended up in subzone 2 will be discarded because subzone 2 has no plants.
+
+    val numPermanentClusters = observationPlots.count { it.model.isPermanent } / 4
+    val numTemporaryPlots = observationPlots.count { !it.model.isPermanent }
+
+    when (numPermanentClusters) {
+      0 -> {
+        // Subzone 1 has no clusters, so it should get the extra plot; either subzone 2 has more
+        // clusters or all the clusters were disqualified for being partially in an unplanted
+        // subzone, in which case subzone 1 gets the extra plot because it's planted.
+        assertEquals(2, numTemporaryPlots, "Temporary plots with 0 clusters")
+      }
+      1 -> {
+        // Subzone 1 has one cluster, but we can't tell if the other cluster would have been in
+        // subzone 2 (in which case the extra plot would go to subzone 1 since it's planted) or
+        // straddles the subzone boundary (in which case it'd be eliminated and the extra plot
+        // would go to subzone 2 for having fewer clusters).
+        if (numTemporaryPlots < 1 || numTemporaryPlots > 2) {
+          // This will always fail but will give a nice assertion failure message.
+          assertEquals("either 1 or 2", "$numTemporaryPlots", "Temporary plots with 1 cluster")
+        }
+      }
+      2 -> {
+        // Subzone 1 has both clusters, so subzone 2 will get the extra plot.
+        assertEquals(1, numTemporaryPlots, "Temporary plots with 2 clusters")
+      }
+      else -> {
+        assertEquals("between 0 and 2", "$numPermanentClusters", "Number of permanent clusters")
+      }
+    }
+  }
+
+  /**
+   * Imports a site from shapefile data. Records the site, zone, and subzone IDs in [DatabaseTest]'s
+   * list of inserted IDs so they will be used as default values by [insertDelivery] and such.
+   */
+  private fun importSite(
+      siteFeature: ShapefileFeature,
+      zoneFeatures: List<ShapefileFeature>,
+      subzoneFeatures: List<ShapefileFeature>,
+      exclusionFeature: ShapefileFeature? = null,
+  ): PlantingSiteModel {
+    val plantingSiteId =
+        plantingSiteImporter.importShapefiles(
+            name = "Test Site ${nextPlantingSiteNumber++}",
+            organizationId = organizationId,
+            siteFile = Shapefile("site", listOf(siteFeature)),
+            zonesFile = Shapefile("zone", zoneFeatures),
+            subzonesFile = Shapefile("subzone", subzoneFeatures),
+            exclusionsFile = exclusionFeature?.let { Shapefile("exclusion", listOf(it)) })
+
+    val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
+
+    inserted.plantingSiteIds.add(plantingSiteId)
+    plantingSite.plantingZones.forEach { zone ->
+      inserted.plantingZoneIds.add(zone.id)
+      zone.plantingSubzones.forEach { subzone ->
+        inserted.plantingSubzoneIds.add(subzone.id)
+        subzone.monitoringPlots.forEach { plot -> inserted.monitoringPlotIds.add(plot.id) }
+      }
+    }
+
+    return plantingSite
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
@@ -1,0 +1,101 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.db.SRID
+import com.terraformation.backend.tracking.model.ShapefileFeature
+import org.geotools.referencing.CRS
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
+
+/** Helper class to generate shapefiles for testing planting site behavior with imported maps. */
+class ShapefileGenerator(
+    /** Coordinate system to use for polygons. */
+    srid: Int = SRID.UTM_20S,
+    /**
+     * Number of permanent clusters to specify in zone shapefile features by default. Null means
+     * ShapefileImporter will calculate the number of clusters.
+     */
+    private val defaultPermanentClusters: Int? = null,
+    /**
+     * Number of temporary plots to specify in zone shapefile features by default. Null means
+     * ShapefileImporter will calculate the number of plots.
+     */
+    private val defaultTemporaryPlots: Int? = null,
+) {
+  private val crs = CRS.decode("EPSG:$srid")
+  private val geometryFactory = GeometryFactory(PrecisionModel(), srid)
+
+  private var nextSubzoneNumber = 1
+  private var nextZoneNumber = 1
+
+  private lateinit var lastZoneName: String
+
+  fun siteFeature(boundary: MultiPolygon): ShapefileFeature =
+      ShapefileFeature(boundary, mapOf("site" to "Test Site"), crs)
+
+  fun zoneFeature(
+      boundary: MultiPolygon,
+      name: String = "Z${nextZoneNumber++}",
+      permanentClusters: Int? = defaultPermanentClusters,
+      temporaryPlots: Int? = defaultTemporaryPlots,
+  ): ShapefileFeature {
+    lastZoneName = name
+
+    val properties =
+        listOfNotNull(
+                "zone" to name,
+                "density" to "1200",
+                permanentClusters?.let { "permanent" to "$it" },
+                temporaryPlots?.let { "temporary" to "$it" },
+            )
+            .toMap()
+
+    return ShapefileFeature(boundary, properties, crs)
+  }
+
+  fun subzoneFeature(
+      boundary: MultiPolygon,
+      name: String = "S${nextSubzoneNumber++}",
+      zone: String = lastZoneName
+  ): ShapefileFeature {
+    return ShapefileFeature(boundary, mapOf("zone" to zone, "subzone" to name), crs)
+  }
+
+  fun exclusionFeature(boundary: MultiPolygon): ShapefileFeature {
+    return ShapefileFeature(boundary, emptyMap(), crs)
+  }
+
+  /**
+   * Returns a multipolygon containing a single rectangular polygon in UTM 20S coordinate space with
+   * the specified corners.
+   */
+  fun multiRectangle(southwest: Pair<Int, Int>, northeast: Pair<Int, Int>): MultiPolygon {
+    return multiPolygon(
+        southwest,
+        northeast.first to southwest.second,
+        northeast,
+        southwest.first to northeast.second)
+  }
+
+  /**
+   * Returns a polygon in UTM 20S coordinate space with the listed vertices. There is no need to
+   * close the list (the first point will be added to the list of coordinates automatically).
+   */
+  fun polygon(vararg points: Pair<Int, Int>): Polygon {
+    val coordinates =
+        points.map { Coordinate(it.first.toDouble(), it.second.toDouble()) } +
+            Coordinate(points[0].first.toDouble(), points[0].second.toDouble())
+    return geometryFactory.createPolygon(coordinates.toTypedArray())
+  }
+
+  /**
+   * Returns a multipolygon containing a single polygon in UTM 20S coordinate space with the listed
+   * vertices. There is no need to close the list (the first point will be added to the list of
+   * coordinates automatically).
+   */
+  fun multiPolygon(vararg points: Pair<Int, Int>): MultiPolygon {
+    return geometryFactory.createMultiPolygon(arrayOf(polygon(*points)))
+  }
+}


### PR DESCRIPTION
In preparation for changing how monitoring plot allocation works such that plots
are no longer generated all at once at site creation time, add a new test that
checks that a site imported from a given set of shapefiles will result in an
observation whose monitoring plots obey the plot selection rules.

To further verify the existing plot creation behavior, add tests to confirm that
the existing shapefile import code creates the correct number of monitoring plots;
previously there was no test coverage for that part of the import process.