### PR TITLE
SW-4731 Move permanent plot selection to PlantingZoneModel

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -92,9 +92,7 @@ class ObservationService(
         plantingSite.plantingZones.forEach { plantingZone ->
           log.withMDC("plantingZoneId" to plantingZone.id) {
             if (plantingZone.plantingSubzones.any { it.id in plantedSubzoneIds }) {
-              val permanentPlotIds =
-                  plantingSiteStore.fetchPermanentPlotIds(
-                      plantingZone.id, plantingZone.numPermanentClusters)
+              val permanentPlotIds = plantingZone.choosePermanentPlots(plantedSubzoneIds)
               val temporaryPlotIds =
                   plantingZone.chooseTemporaryPlots(permanentPlotIds, plantedSubzoneIds)
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -224,44 +224,6 @@ class PlantingSiteStore(
         ?: PlantingSiteReportedPlantTotals(plantingSiteId, zoneTotals, 0, 0, 0)
   }
 
-  /**
-   * Returns a set of permanent monitoring plots for a planting zone. Only plots in subzones that
-   * are known to have been planted are returned, meaning there may be fewer plots than requested
-   * (or even none at all). If a cluster of permanent plots includes plots in more than one subzone,
-   * all the subzones must be planted for the cluster to be selected.
-   */
-  fun fetchPermanentPlotIds(
-      plantingZoneId: PlantingZoneId,
-      maxPermanentCluster: Int,
-      minPermanentCluster: Int = 1,
-  ): Set<MonitoringPlotId> {
-    requirePermissions { readPlantingZone(plantingZoneId) }
-
-    val clusters =
-        dslContext
-            .select(MONITORING_PLOTS.PERMANENT_CLUSTER, MONITORING_PLOTS.ID)
-            .from(MONITORING_PLOTS)
-            .where(MONITORING_PLOTS.plantingSubzones.PLANTING_ZONE_ID.eq(plantingZoneId))
-            .and(
-                MONITORING_PLOTS.PERMANENT_CLUSTER.between(
-                    minPermanentCluster, maxPermanentCluster))
-            .and(
-                MONITORING_PLOTS.PLANTING_SUBZONE_ID.`in`(
-                    DSL.select(PLANTING_SUBZONES.ID)
-                        .from(PLANTING_SUBZONES)
-                        .join(PLANTINGS)
-                        .on(PLANTING_SUBZONES.ID.eq(PLANTINGS.PLANTING_SUBZONE_ID))
-                        .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(plantingZoneId))
-                        .groupBy(PLANTING_SUBZONES.ID)
-                        .having(DSL.sum(PLANTINGS.NUM_PLANTS).gt(BigDecimal.ZERO))))
-            .fetchGroups(MONITORING_PLOTS.PERMANENT_CLUSTER, MONITORING_PLOTS.ID.asNonNullable())
-
-    // Only return clusters where all four plots are in planted subzones. Non-planted ones will have
-    // been filtered out by the query, so this is just all clusters where the query returned four
-    // plot IDs.
-    return clusters.filterValues { it.size == 4 }.values.flatten().toSet()
-  }
-
   fun createPlantingSite(
       organizationId: OrganizationId,
       name: String,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -1194,46 +1194,6 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
-  inner class FetchPermanentPlotIds {
-    @Test
-    fun `filters out permanent clusters whose subzones are not all planted`() {
-      insertFacility(type = FacilityType.Nursery)
-      insertSpecies()
-      insertPlantingSite()
-      val plantingZoneId = insertPlantingZone()
-      val plantedSubzoneId = insertPlantingSubzone()
-      insertWithdrawal()
-      insertDelivery()
-      insertPlanting(plantingSiteId = inserted.plantingSiteId, plantingSubzoneId = plantedSubzoneId)
-      val clusterInPlantedSubzone =
-          (1..4).map { insertMonitoringPlot(permanentCluster = 1, permanentClusterSubplot = it) }
-
-      // Cluster that straddles a planted and an unplanted subzone
-      (1..2).map { insertMonitoringPlot(permanentCluster = 2, permanentClusterSubplot = it) }
-      insertPlantingSubzone()
-      (3..4).map { insertMonitoringPlot(permanentCluster = 2, permanentClusterSubplot = it) }
-
-      // Cluster in unplanted subzone
-      (1..4).map { insertMonitoringPlot(permanentCluster = 3, permanentClusterSubplot = it) }
-
-      val expected = clusterInPlantedSubzone.toSet()
-      val actual = store.fetchPermanentPlotIds(plantingZoneId, 3)
-
-      assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `throws exception if no permission to read planting zone`() {
-      insertPlantingSite()
-      val plantingZoneId = insertPlantingZone()
-
-      every { user.canReadPlantingZone(plantingZoneId) } returns false
-
-      assertThrows<PlantingZoneNotFoundException> { store.fetchPermanentPlotIds(plantingZoneId, 1) }
-    }
-  }
-
-  @Nested
   inner class CountReportedPlants {
     @Test
     fun `returns zero total for sites without plants`() {


### PR DESCRIPTION
In preparation for supporting on-demand creation of monitoring plots, move the
logic for selecting permanent clusters for an observation to `PlantingZoneModel`.
Cluster selection is now done completely in the application code rather than via
a database query.

No change in behavior is introduced here; the plot selection logic is already
covered by `ObservationServiceTest` and `PlotAssignmentTest` which continue to
pass.