### PR TITLE
SW-4731 Logic for random on-demand plot selection

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -171,9 +171,8 @@ data class PlantingZoneModel(
     val zoneGeometry =
         if (exclusion != null) {
           JTS.transform(boundary.difference(exclusion).difference(monitoringPlotAreas), toMeters)
-              as MultiPolygon
         } else {
-          JTS.transform(boundary.difference(monitoringPlotAreas), toMeters) as MultiPolygon
+          JTS.transform(boundary.difference(monitoringPlotAreas), toMeters)
         }
 
     fun rectangle(west: Double, south: Double, east: Double, north: Double): Polygon =

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -185,6 +185,19 @@ data class PlantingZoneModel(
                 Coordinate(west, north),
                 Coordinate(west, south)))
 
+    fun roundToGrid(value: Double): Double = Math.round(value / gridInterval) * gridInterval
+
+    /**
+     * Returns a square [sizeMeters] on a side with the coordinates snapped to multiples of
+     * [gridInterval].
+     */
+    fun gridAlignedSquare(west: Double, south: Double): Polygon {
+      val roundedWest = roundToGrid(west)
+      val roundedSouth = roundToGrid(south)
+      return rectangle(
+          roundedWest, roundedSouth, roundedWest + sizeMeters, roundedSouth + sizeMeters)
+    }
+
     /**
      * Attempts to find an available square within a rectangular region of the zone. First tries to
      * pick a few random points, and if none of them works, divides the region into four quadrants
@@ -195,26 +208,42 @@ data class PlantingZoneModel(
      * an exhaustive search for matches.
      */
     fun findInRegion(southwest: Coordinate, northeast: Coordinate): Polygon? {
-      val maxAttempts = 5
+      val regionPolygon = rectangle(southwest.x, southwest.y, northeast.x, northeast.y)
 
-      // Try a few times to find a random spot in the region. This will succeed most of the time.
-      for (attemptNumber in 1..maxAttempts) {
-        val squareWest =
-            Math.round(Random.nextDouble(southwest.x, northeast.x) / gridInterval) * gridInterval
-        val squareSouth =
-            Math.round(Random.nextDouble(southwest.y, northeast.y) / gridInterval) * gridInterval
-        val squareEast = squareWest + sizeMeters
-        val squareNorth = squareSouth + sizeMeters
+      // If all possible points in the region will round to the same point on the grid, or if the
+      // region is less than a quarter the size of a grid square, check it and return; trying random
+      // points within the region wouldn't be useful, nor would dividing the region in quarters and
+      // drilling down.
+      val minimumArea = (gridInterval * gridInterval) / 4.0
+      if (roundToGrid(southwest.x) == roundToGrid(northeast.x) &&
+          roundToGrid(southwest.y) == roundToGrid(northeast.y) ||
+          regionPolygon.area < minimumArea) {
+        val polygon = gridAlignedSquare(southwest.x, southwest.y)
 
-        val square = rectangle(squareWest, squareSouth, squareEast, squareNorth)
-
-        if (square.coveredBy(zoneGeometry)) {
-          return JTS.transform(square, toOriginalCrs) as Polygon
+        return if (polygon.coveredBy(zoneGeometry)) {
+          JTS.transform(polygon, toOriginalCrs) as Polygon
+        } else {
+          null
         }
       }
 
-      // No luck. This might be a sparse site map. Split the region into quartiles and search them
-      // in random order but with the ones that cover the most zone area more likely to come first.
+      // Try a few times to find a random spot in the region. This will succeed most of the time.
+      val maxAttempts = 5
+
+      for (attemptNumber in 1..maxAttempts) {
+        val polygon =
+            gridAlignedSquare(
+                Random.nextDouble(southwest.x, northeast.x),
+                Random.nextDouble(southwest.y, northeast.y))
+
+        if (polygon.coveredBy(zoneGeometry)) {
+          return JTS.transform(polygon, toOriginalCrs) as Polygon
+        }
+      }
+
+      // No luck. This might be a sparse site map. Split the region into equal-sized quadrants and
+      // search them in random order but with the ones that cover the most zone area more likely to
+      // come first.
       val middleX = (southwest.x + northeast.x) / 2.0
       val middleY = (southwest.y + northeast.y) / 2.0
 
@@ -226,9 +255,8 @@ data class PlantingZoneModel(
                   rectangle(middleX, middleY, northeast.x, northeast.y),
                   rectangle(southwest.x, middleY, middleX, northeast.y))
               .map { quadrant -> quadrant to zoneGeometry.intersection(quadrant).area }
-              // Stop drilling down when we get to quadrants with 4 square meters of usable area
-              // since they're unlikely to round to different grid points than their parents.
-              .filter { it.second > 16.0 }
+              // Exclude quadrants that don't cover any zone area at all.
+              .filter { it.second > 0 }
               .toMutableList()
 
       while (quadrants.isNotEmpty()) {

--- a/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
@@ -1,4 +1,4 @@
-package com.terraformation.backend
+package com.terraformation.backend.util
 
 import com.terraformation.backend.db.SRID
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem

--- a/src/test/kotlin/com/terraformation/backend/Turtle.kt
+++ b/src/test/kotlin/com/terraformation/backend/Turtle.kt
@@ -1,0 +1,113 @@
+package com.terraformation.backend
+
+import com.terraformation.backend.db.SRID
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
+import org.geotools.referencing.GeodeticCalculator
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
+
+/**
+ * Constructs polygons using a sequence of movements. The movement distances are always in meters.
+ *
+ * The term "turtle" is from [turtle graphics](https://en.wikipedia.org/wiki/Turtle_graphics).
+ */
+class Turtle(
+    start: Point,
+    private val crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
+) {
+  private val calculator = GeodeticCalculator(crs)
+  private val coordinates = mutableListOf<Coordinate>()
+  private val geometryFactory = GeometryFactory(PrecisionModel(), start.srid)
+
+  init {
+    moveTo(start)
+  }
+
+  fun toPolygon(): Polygon {
+    return geometryFactory.createPolygon(coordinates.toTypedArray())
+  }
+
+  fun toMultiPolygon(): MultiPolygon {
+    return geometryFactory.createMultiPolygon(arrayOf(toPolygon()))
+  }
+
+  fun north(meters: Number) {
+    move(AZIMUTH_NORTH, meters)
+  }
+
+  fun east(meters: Number) {
+    move(AZIMUTH_EAST, meters)
+  }
+
+  fun south(meters: Number) {
+    move(AZIMUTH_SOUTH, meters)
+  }
+
+  fun west(meters: Number) {
+    move(AZIMUTH_WEST, meters)
+  }
+
+  fun moveTo(point: Point) {
+    coordinates.add(point.coordinate)
+    calculator.startingPosition = JTS.toDirectPosition(point.coordinate, crs)
+  }
+
+  private fun move(azimuth: Double, meters: Number) {
+    calculator.setDirection(azimuth, meters.toDouble())
+    coordinates.add(
+        Coordinate(
+            calculator.destinationPosition.getOrdinate(0),
+            calculator.destinationPosition.getOrdinate(1)))
+    calculator.startingPosition = calculator.destinationPosition
+  }
+
+  companion object {
+    private const val AZIMUTH_NORTH: Double = 0.0
+    private const val AZIMUTH_EAST: Double = 90.0
+    private const val AZIMUTH_SOUTH: Double = 180.0
+    private const val AZIMUTH_WEST: Double = 270.0
+
+    /**
+     * Returns the polygon formed by a series of turtle moves from a starting point. Automatically
+     * closes the polygon; you don't need to move back to the starting point explicitly.
+     */
+    fun makePolygon(
+        start: Point,
+        crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
+        func: Turtle.() -> Unit
+    ): Polygon {
+      val turtle = Turtle(start, crs)
+      turtle.func()
+
+      // Close the polygon.
+      turtle.moveTo(start)
+
+      return turtle.toPolygon()
+    }
+
+    /**
+     * Returns a one-polygon multipolygon formed by a series of turtle moves from a starting point.
+     * Automatically closes the polygon; you don't need to move back to the starting point
+     * explicitly.
+     */
+    fun makeMultiPolygon(
+        start: Point,
+        crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
+        func: Turtle.() -> Unit
+    ): MultiPolygon {
+      val turtle = Turtle(start, crs)
+      turtle.func()
+
+      // Close the polygon.
+      turtle.moveTo(start)
+
+      return turtle.toMultiPolygon()
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -1,12 +1,12 @@
 package com.terraformation.backend.tracking.model
 
-import com.terraformation.backend.Turtle
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.polygon
+import com.terraformation.backend.util.Turtle
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull


### PR DESCRIPTION
In preparation for creating monitoring plots on demand, add logic to randomly
select an available grid-aligned square region in a planting zone.