### PR TITLE
SW-4774 Add user's global roles to the API response for GET /me

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -42,7 +42,7 @@ val ENUM_TABLES =
                 EnumTable("ecosystem_types", listOf(".*\\.ecosystem_type_id")),
                 EnumTable("facility_connection_states", listOf("facilities\\.connection_state_id")),
                 EnumTable("facility_types", listOf("facilities\\.type_id")),
-                EnumTable("global_roles", listOf(".*\\.global_role_id"), isLocalizable = false),
+                EnumTable("global_roles", listOf(".*\\.global_role_id"), isLocalizable = false, useIdAsJsonValue = true),
                 EnumTable("growth_forms", listOf("growth_forms\\.id", ".*\\.growth_form_id")),
                 EnumTable(
                     "managed_location_types",

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -42,7 +42,7 @@ val ENUM_TABLES =
                 EnumTable("ecosystem_types", listOf(".*\\.ecosystem_type_id")),
                 EnumTable("facility_connection_states", listOf("facilities\\.connection_state_id")),
                 EnumTable("facility_types", listOf("facilities\\.type_id")),
-                EnumTable("global_roles", listOf(".*\\.global_role_id"), isLocalizable = false, useIdAsJsonValue = true),
+                EnumTable("global_roles", listOf(".*\\.global_role_id"), isLocalizable = false),
                 EnumTable("growth_forms", listOf("growth_forms\\.id", ".*\\.growth_form_id")),
                 EnumTable(
                     "managed_location_types",

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
@@ -40,6 +41,7 @@ class UsersController(private val userStore: UserStore) {
               user.email,
               user.emailNotificationsEnabled,
               user.firstName,
+              user.globalRoles,
               user.lastName,
               user.locale?.toLanguageTag(),
               user.timeZone))
@@ -120,6 +122,7 @@ data class UserProfilePayload(
                 "\"You've been added to a new organization.\"")
     val emailNotificationsEnabled: Boolean,
     val firstName: String?,
+    val globalRoles: Set<GlobalRole>,
     val lastName: String?,
     @Schema(description = "IETF locale code containing user's preferred language.", example = "en")
     val locale: String?,


### PR DESCRIPTION
Return the global roles for the user in the GET /me API call response, the front end will use these roles to determine what things they can / can't see with regard to the accelerator admin area of the site.

![SCR-20240123-memp.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/wJnPX9wLZAkiGXEBFJxL/d9ebac7b-f64d-41f4-9d8e-0c6d21c9ee9b.png)

