### PR TITLE
SW-4731 Create missing permanent clusters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -78,6 +78,8 @@ class ObservationService(
           throw ObservationAlreadyStartedException(observationId)
         }
 
+        plantingSiteStore.ensurePermanentClustersExist(observation.plantingSiteId)
+
         val plantingSite =
             plantingSiteStore.fetchSiteById(observation.plantingSiteId, PlantingSiteDepth.Plot)
         val plantedSubzoneIds =

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -132,7 +132,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertUser()
     insertOrganization()
-    plantingSiteId = insertPlantingSite()
+    plantingSiteId = insertPlantingSite(x = 0, width = 11, gridOrigin = point(0.0, 0.0))
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true
@@ -142,6 +142,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canRescheduleObservation(any()) } returns true
     every { user.canScheduleObservation(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
+    every { user.canUpdatePlantingSite(any()) } returns true
   }
 
   @Nested
@@ -191,7 +192,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
 
       insertFacility(type = FacilityType.Nursery)
       insertSpecies()
-      insertPlantingSite()
       insertWithdrawal()
       insertDelivery()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -88,6 +88,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     every { user.canReadPlantingSubzone(any()) } returns true
     every { user.canReadPlantingZone(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
+    every { user.canUpdatePlantingSite(any()) } returns true
   }
 
   // Run test 10 times to exercise different random selections. 10 is somewhat arbitrary but given

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -42,6 +42,7 @@ import com.terraformation.backend.tracking.model.PlantingSiteReportedPlantTotals
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
+import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.toInstant
 import io.mockk.every
 import java.math.BigDecimal
@@ -1472,6 +1473,187 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val plantingSiteId = insertPlantingSite()
 
       assertThrows<AccessDeniedException> { store.deletePlantingSite(plantingSiteId) }
+    }
+  }
+
+  @Nested
+  inner class EnsurePermanentClustersExist {
+    @Test
+    fun `creates all clusters in empty planting site`() {
+      val siteBoundary =
+          Turtle.makeMultiPolygon(point(0.0, 0.0)) {
+            east(101)
+            north(101)
+            west(101)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0.0, 0.0))
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
+      insertPlantingSubzone(boundary = siteBoundary)
+
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val plots = monitoringPlotsDao.findAll()
+
+      assertEquals(16, plots.size, "Number of monitoring plots created")
+      assertEquals(
+          setOf(1, 2, 3, 4), plots.map { it.permanentCluster }.toSet(), "Permanent cluster numbers")
+      assertEquals(1, plots.minOf { it.name!!.toInt() }, "Smallest plot number")
+      assertEquals(16, plots.maxOf { it.name!!.toInt() }, "Largest plot number")
+    }
+
+    @Test
+    fun `creates as many clusters as there is room for`() {
+      val siteBoundary =
+          Turtle.makeMultiPolygon(point(0.0, 0.0)) {
+            east(101)
+            north(51)
+            west(101)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0.0, 0.0))
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
+      insertPlantingSubzone(boundary = siteBoundary)
+
+      // Zone is configured for 4 clusters, but there's only room for 2.
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val plots = monitoringPlotsDao.findAll()
+
+      assertEquals(8, plots.size, "Number of monitoring plots created")
+      assertEquals(
+          setOf(1, 2), plots.map { it.permanentCluster }.toSet(), "Permanent cluster numbers")
+      assertEquals(1, plots.minOf { it.name!!.toInt() }, "Smallest plot number")
+      assertEquals(8, plots.maxOf { it.name!!.toInt() }, "Largest plot number")
+    }
+
+    @Test
+    fun `only creates nonexistent permanent clusters`() {
+      val gridOrigin = point(0.0, 0.0)
+      val siteBoundary =
+          Turtle.makeMultiPolygon(gridOrigin) {
+            east(201)
+            north(201)
+            west(201)
+          }
+      val existingPlotBoundary =
+          Turtle.makePolygon(gridOrigin) {
+            east(25)
+            north(25)
+            west(25)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 3)
+      insertPlantingSubzone(boundary = siteBoundary)
+      insertMonitoringPlot(
+          boundary = existingPlotBoundary, permanentCluster = 2, permanentClusterSubplot = 1)
+
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val plots = monitoringPlotsDao.findAll()
+      val plotsPerCluster = plots.groupBy { it.permanentCluster }.mapValues { it.value.size }
+
+      assertEquals(9, plots.size, "Number of monitoring plots including existing one")
+      assertEquals(
+          mapOf(1 to 4, 2 to 1, 3 to 4), plotsPerCluster, "Number of plots in each cluster")
+    }
+
+    @Test
+    fun `can use temporary plot from previous observation as part of cluster`() {
+      val gridOrigin = point(0.0, 0.0)
+      val siteBoundary =
+          Turtle.makeMultiPolygon(gridOrigin) {
+            east(51)
+            north(51)
+            west(51)
+          }
+
+      // Temporary plot is in the southeast corner of the cluster.
+      val existingPlotBoundary =
+          Turtle.makePolygon(gridOrigin) {
+            moveStartingPoint { east(25) }
+            east(25)
+            north(25)
+            west(25)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 1)
+      insertPlantingSubzone(boundary = siteBoundary)
+      val existingPlotId = insertMonitoringPlot(boundary = existingPlotBoundary)
+
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val plots = monitoringPlotsDao.findAll()
+      val existingPlot = plots.first { it.id == existingPlotId }
+
+      assertEquals(4, plots.size, "Number of monitoring plots including existing one")
+      assertEquals(1, existingPlot.permanentCluster, "Permanent cluster of existing plot")
+      assertEquals(2, existingPlot.permanentClusterSubplot, "Subplot number of existing plot")
+    }
+
+    @Test
+    fun `does nothing if required clusters already exist`() {
+      val gridOrigin = point(0.0, 0.0)
+      val siteBoundary =
+          Turtle.makeMultiPolygon(gridOrigin) {
+            east(201)
+            north(201)
+            west(201)
+          }
+      val plotBoundary =
+          Turtle.makePolygon(gridOrigin) {
+            east(25)
+            north(25)
+            west(25)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
+      insertPlantingSubzone(boundary = siteBoundary)
+      insertMonitoringPlot(
+          boundary = plotBoundary, permanentCluster = 1, permanentClusterSubplot = 1)
+      insertMonitoringPlot(
+          boundary = plotBoundary, permanentCluster = 2, permanentClusterSubplot = 1)
+
+      val before = monitoringPlotsDao.findAll().toSet()
+
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val after = monitoringPlotsDao.findAll().toSet()
+
+      assertEquals(before, after, "Should not have created or modified any plots")
+    }
+
+    @Test
+    fun `uses plot number after existing highest number even if lower numbers are unused`() {
+      val gridOrigin = point(0.0, 0.0)
+      val siteBoundary =
+          Turtle.makeMultiPolygon(gridOrigin) {
+            east(101)
+            north(51)
+            west(101)
+          }
+      val existingPlotBoundary =
+          Turtle.makePolygon(gridOrigin) {
+            east(25)
+            north(25)
+            west(25)
+          }
+
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
+      insertPlantingSubzone(boundary = siteBoundary)
+      insertMonitoringPlot(boundary = existingPlotBoundary, name = "123", permanentCluster = 1)
+
+      store.ensurePermanentClustersExist(plantingSiteId)
+
+      val plots = monitoringPlotsDao.findAll()
+      assertEquals(
+          listOf(123, 124, 125, 126, 127),
+          plots.map { it.name!!.toInt() }.sorted(),
+          "Plot numbers including existing plot")
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -1588,9 +1588,13 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val plots = monitoringPlotsDao.findAll()
       val existingPlot = plots.first { it.id == existingPlotId }
 
+      // Subplots are numbered counterclockwise starting from the southwest.
+      val southeastSubplot = 2
+
       assertEquals(4, plots.size, "Number of monitoring plots including existing one")
       assertEquals(1, existingPlot.permanentCluster, "Permanent cluster of existing plot")
-      assertEquals(2, existingPlot.permanentClusterSubplot, "Subplot number of existing plot")
+      assertEquals(
+          southeastSubplot, existingPlot.permanentClusterSubplot, "Subplot number of existing plot")
     }
 
     @Test


### PR DESCRIPTION
`PlantingSiteStore.ensurePermanentClustersExist()` will, as its name suggests,
ensure that the required number of permanent clusters exist in each of a site's
planting zones, creating new monitoring plots or adding existing temporary plots
to clusters as needed.

For existing planting sites, this is a no-op because a full set of permanent
clusters is created at shapefile import time and this function thus has no work
to do, but future updates will get rid of the import-time plot creation and will
require this logic to be in place.