### PR TITLE
SW-4791 Allow searching for null IDs in sublists

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
@@ -21,7 +21,10 @@ class IdWrapperField<T : Any>(
     val allValues = fieldNode.values.filterNotNull().map { fromLong(it.toLong()) }
     return when (fieldNode.type) {
       SearchFilterType.Exact ->
-          if (allValues.isNotEmpty()) databaseField.`in`(allValues) else DSL.falseCondition()
+          DSL.or(
+              listOfNotNull(
+                  if (allValues.isNotEmpty()) databaseField.`in`(allValues) else null,
+                  if (fieldNode.values.any { it == null }) databaseField.isNull else null))
       SearchFilterType.ExactOrFuzzy,
       SearchFilterType.Fuzzy -> throw RuntimeException("Fuzzy search not supported for IDs")
       SearchFilterType.Range -> throw RuntimeException("Range search not supported for IDs")

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -29,7 +29,8 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
               "accession", BATCH_SUMMARIES.ACCESSION_ID.eq(ACCESSIONS.ID), isRequired = false),
           facilities.asSingleValueSublist(
               "facility", BATCH_SUMMARIES.FACILITY_ID.eq(FACILITIES.ID)),
-          projects.asSingleValueSublist("project", BATCH_SUMMARIES.PROJECT_ID.eq(PROJECTS.ID)),
+          projects.asSingleValueSublist(
+              "project", BATCH_SUMMARIES.PROJECT_ID.eq(PROJECTS.ID), isRequired = false),
           species.asSingleValueSublist("species", BATCH_SUMMARIES.SPECIES_ID.eq(SPECIES.ID)),
           batchSubLocations.asMultiValueSublist(
               "subLocations", BATCH_SUMMARIES.ID.eq(BATCH_SUB_LOCATIONS.BATCH_ID)),


### PR DESCRIPTION
`IdWrapperField` wasn't handling null search values like the other field classes
do; it needs to ad an `IS NULL` condition if the list of exact search values
includes a null. This was causing us to be unable to search for batches that
aren't associated with projects.