### PR TITLE
Use correct Renovate keyword for grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,12 +12,12 @@
         },
         {
             "description": "Group Node dependencies",
-            "matchPaths": ["package.json"],
+            "matchFileNames": ["package.json"],
             "groupName": "Node dependencies"
         },
         {
             "description": "Group Python dependencies",
-            "matchPaths": ["**/requirements.txt"],
+            "matchFileNames": ["**/requirements.txt"],
             "groupName": "Python dependencies"
         },
         {
@@ -37,7 +37,10 @@
         },
         {
             "description": "Group GitHub Actions dependencies",
-            "matchPaths": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+            "matchFileNames": [
+                ".github/workflows/*.yml",
+                ".github/workflows/*.yaml"
+            ],
             "groupName": "GitHub Actions"
         },
     ],


### PR DESCRIPTION
The Renovate config file uses the keyword `matchFileNames` for rules that match
based on the name of the package file. We were using `matchPaths` which caused
our Node and Python package updates to be generated individually rather than
grouped together as intended.