### PR TITLE
SW-4732 Use more precise grid points for plots

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -416,7 +416,7 @@ class PlantingZoneModelTest {
       val square = zone.findUnusedSquare(siteOrigin, 25)
       assertNotNull(square, "Unused square")
 
-      if (!square!!.coveredBy(targetArea)) {
+      if (square!!.intersection(targetArea).area < square.area * 0.99999) {
         assertEquals(targetArea, square, "Should be contained in hole")
       }
     }


### PR DESCRIPTION
The initial iteration of plot selection used a meter-based coordinate system
to calculate the grid positions of monitoring plots. Depending on the size and
location of a site, this could result in adjacent plots having a tiny amount
of overlap (on the order of 0.1% of their area) or a tiny gap in between them.
This wouldn't have meaningfully affected survey results, but it was visually
obvious when zooming in on the map.

In addition, the initial iteration was using `GeodeticCalculator` to trace the
edges of plots by moving along cardinal compass directions. That caused slight
inconsistencies because `GeodeticCalculator` calculates great-circle paths
rather than rhumb-line paths, meaning that moving "east" could cause both the
longitude and the latitude to change.

Get rid of the meter-based coordinate system in favor of `GeodeticCalculator`
for north-south calculations (where there is no difference between rhumb-line
and great-circle paths) and directly computing the longitude delta for
east-west calculations based on latitude.