### PR TITLE
Simplify Turtle API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -204,11 +204,9 @@ data class PlantingZoneModel(
 
     /** Returns a rectangle with corners a specified number of meters from the grid origin. */
     fun meterOffsetRectangle(southwest: Coordinate, northeast: Coordinate): Polygon {
-      return Turtle.makePolygon(gridOrigin, boundaryCrs) {
-        moveStartingPoint {
-          north(southwest.y)
-          east(southwest.x)
-        }
+      return Turtle(gridOrigin, boundaryCrs).makePolygon {
+        north(southwest.y)
+        east(southwest.x)
 
         rectangle(northeast.x - southwest.x, northeast.y - southwest.y)
       }
@@ -219,11 +217,9 @@ data class PlantingZoneModel(
      * [gridInterval] meters from the grid origin.
      */
     fun gridAlignedSquare(westEdge: Double, southEdge: Double): Polygon {
-      return Turtle.makePolygon(gridOrigin, boundaryCrs) {
-        moveStartingPoint {
-          north(roundToGrid(southEdge))
-          east(roundToGrid(westEdge))
-        }
+      return Turtle(gridOrigin, boundaryCrs).makePolygon {
+        north(roundToGrid(southEdge))
+        east(roundToGrid(westEdge))
 
         square(sizeMeters)
       }

--- a/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
@@ -22,34 +22,42 @@ import org.locationtech.jts.geom.PrecisionModel
  * Constructs polygons using a sequence of movements. The movement distances are always in meters.
  *
  * The term "turtle" is from [turtle graphics](https://en.wikipedia.org/wiki/Turtle_graphics).
+ *
+ * Initially, the various movement functions only move the turtle but don't add edges to the
+ * in-progress polygon. In turtle-graphics terminology, the turtle's pen is up initially. Move the
+ * turtle to the initial vertex of the polygon then call [startDrawing] to put the pen down and
+ * start drawing the polygon. The [square] and [rectangle] methods automatically start drawing.
  */
 class Turtle(
     start: Point,
-    private val crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
+    crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
 ) {
   private var startPosition = JTS.toDirectPosition(start.coordinate, crs)
   private val calculator = GeodeticCalculator(crs)
-  private val coordinates = mutableListOf(getCoordinate(startPosition))
+  private val coordinates = mutableListOf<Coordinate>()
   private val geometryFactory = GeometryFactory(PrecisionModel(), start.srid)
+  private var drawing: Boolean = false
 
   init {
     calculator.startingPosition = startPosition
   }
 
-  /** Clears the accumulated polygon points and starts over at the current turtle position. */
-  fun clear() {
-    startPosition = calculator.startingPosition
-    coordinates.clear()
-    coordinates.add(getCoordinate(startPosition))
-  }
-
-  fun toPolygon(): Polygon {
+  /**
+   * Returns the polygon formed by a series of turtle moves from a starting point. Automatically
+   * closes the polygon; you don't need to move back to the starting point explicitly.
+   */
+  fun makePolygon(func: Turtle.() -> Unit): Polygon {
+    this.func()
     moveTo(startPosition)
     return geometryFactory.createPolygon(coordinates.toTypedArray())
   }
 
-  fun toMultiPolygon(): MultiPolygon {
-    return geometryFactory.createMultiPolygon(arrayOf(toPolygon()))
+  /**
+   * Returns a one-polygon multipolygon formed by a series of turtle moves from a starting point.
+   * Automatically closes the polygon; you don't need to move back to the starting point explicitly.
+   */
+  fun makeMultiPolygon(func: Turtle.() -> Unit): MultiPolygon {
+    return geometryFactory.createMultiPolygon(arrayOf(makePolygon(func)))
   }
 
   fun north(meters: Number) {
@@ -68,10 +76,17 @@ class Turtle(
     moveHorizontally(meters, false)
   }
 
+  fun startDrawing() {
+    drawing = true
+    coordinates.clear()
+    startPosition = calculator.startingPosition
+    coordinates.add(getCoordinate())
+  }
+
   /**
    * Traces the south, east, and north sides of a rectangle whose southwest corner is the turtle's
-   * current position. Leaves the turtle at the northwest corner such that [toPolygon] will close
-   * the rectangle.
+   * current position. Leaves the turtle at the northwest corner such that returning to the start
+   * position will close the rectangle.
    *
    * The rectangle's south edge will have the specified width, but due to the curvature of the
    * earth, its north edge will be slightly shorter or longer depending on which hemisphere it's in.
@@ -80,6 +95,7 @@ class Turtle(
     calculator.setDirection(AZIMUTH_NORTH, heightMeters.toDouble())
     val northwest = calculator.destinationPosition
 
+    startDrawing()
     east(widthMeters)
     north(heightMeters)
     moveTo(northwest)
@@ -87,31 +103,29 @@ class Turtle(
 
   /**
    * Traces the south, east, and north sides of a square whose southwest corner is the turtle's
-   * current position. Leaves the turtle at the northeast corner such that [toPolygon] will close
-   * the square.
+   * current position. Leaves the turtle at the northeast corner such that returning to start
+   * position will close the square.
    */
   fun square(meters: Number) {
     rectangle(meters, meters)
   }
 
-  fun moveStartingPoint(func: Turtle.() -> Unit) {
-    this.func()
-    clear()
-  }
-
   private fun moveTo(position: Position) {
-    coordinates.add(getCoordinate(position))
     calculator.startingPosition = position
+
+    if (drawing) {
+      coordinates.add(getCoordinate())
+    }
   }
 
-  private fun getCoordinate(position: Position = calculator.destinationPosition): Coordinate {
-    return Coordinate(position.getOrdinate(0), position.getOrdinate(1))
+  private fun getCoordinate(): Coordinate {
+    return Coordinate(
+        calculator.startingPosition.getOrdinate(0), calculator.startingPosition.getOrdinate(1))
   }
 
   private fun move(azimuth: Double, meters: Number) {
     calculator.setDirection(azimuth, meters.toDouble())
-    coordinates.add(getCoordinate())
-    calculator.startingPosition = calculator.destinationPosition
+    moveTo(calculator.destinationPosition)
   }
 
   private fun moveHorizontally(meters: Number, isEast: Boolean) {
@@ -135,7 +149,9 @@ class Turtle(
     calculator.startingGeographicPoint =
         Point2D.Double(normalizedLongitude, calculator.startingGeographicPoint.y)
 
-    coordinates.add(getCoordinate(calculator.startingPosition))
+    if (drawing) {
+      coordinates.add(getCoordinate())
+    }
   }
 
   /**
@@ -163,36 +179,5 @@ class Turtle(
         (ELLIPSOID_SEMI_MAJOR_METERS * ELLIPSOID_SEMI_MAJOR_METERS -
             ELLIPSOID_SEMI_MINOR_METERS * ELLIPSOID_SEMI_MINOR_METERS) /
             (ELLIPSOID_SEMI_MAJOR_METERS * ELLIPSOID_SEMI_MAJOR_METERS)
-
-    /**
-     * Returns the polygon formed by a series of turtle moves from a starting point. Automatically
-     * closes the polygon; you don't need to move back to the starting point explicitly.
-     */
-    fun makePolygon(
-        start: Point,
-        crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
-        func: Turtle.() -> Unit
-    ): Polygon {
-      val turtle = Turtle(start, crs)
-      turtle.func()
-
-      return turtle.toPolygon()
-    }
-
-    /**
-     * Returns a one-polygon multipolygon formed by a series of turtle moves from a starting point.
-     * Automatically closes the polygon; you don't need to move back to the starting point
-     * explicitly.
-     */
-    fun makeMultiPolygon(
-        start: Point,
-        crs: CoordinateReferenceSystem = CRS.decode("EPSG:${SRID.LONG_LAT}", true),
-        func: Turtle.() -> Unit
-    ): MultiPolygon {
-      val turtle = Turtle(start, crs)
-      turtle.func()
-
-      return turtle.toMultiPolygon()
-    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -1480,7 +1480,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
   inner class EnsurePermanentClustersExist {
     @Test
     fun `creates all clusters in empty planting site`() {
-      val siteBoundary = Turtle.makeMultiPolygon(point(0.0, 0.0)) { square(101) }
+      val siteBoundary = Turtle(point(0.0, 0.0)).makeMultiPolygon { square(101) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0.0, 0.0))
       insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
@@ -1499,7 +1499,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates as many clusters as there is room for`() {
-      val siteBoundary = Turtle.makeMultiPolygon(point(0.0, 0.0)) { rectangle(101, 51) }
+      val siteBoundary = Turtle(point(0.0, 0.0)).makeMultiPolygon { rectangle(101, 51) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0.0, 0.0))
       insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
@@ -1520,8 +1520,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `only creates nonexistent permanent clusters`() {
       val gridOrigin = point(0.0, 0.0)
-      val siteBoundary = Turtle.makeMultiPolygon(gridOrigin) { square(201) }
-      val existingPlotBoundary = Turtle.makePolygon(gridOrigin) { square(25) }
+      val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { square(201) }
+      val existingPlotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
       insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 3)
@@ -1542,12 +1542,12 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `can use temporary plot from previous observation as part of cluster`() {
       val gridOrigin = point(0.0, 0.0)
-      val siteBoundary = Turtle.makeMultiPolygon(gridOrigin) { square(51) }
+      val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { square(51) }
 
       // Temporary plot is in the southeast corner of the cluster.
       val existingPlotBoundary =
-          Turtle.makePolygon(gridOrigin) {
-            moveStartingPoint { east(25) }
+          Turtle(gridOrigin).makePolygon {
+            east(25)
             square(25)
           }
 
@@ -1573,8 +1573,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `does nothing if required clusters already exist`() {
       val gridOrigin = point(0.0, 0.0)
-      val siteBoundary = Turtle.makeMultiPolygon(gridOrigin) { square(201) }
-      val plotBoundary = Turtle.makePolygon(gridOrigin) { square(25) }
+      val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { square(201) }
+      val plotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
       insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
@@ -1596,8 +1596,8 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `uses plot number after existing highest number even if lower numbers are unused`() {
       val gridOrigin = point(0.0, 0.0)
-      val siteBoundary = Turtle.makeMultiPolygon(gridOrigin) { rectangle(101, 51) }
-      val existingPlotBoundary = Turtle.makePolygon(gridOrigin) { square(25) }
+      val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { rectangle(101, 51) }
+      val existingPlotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
       insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -74,21 +74,21 @@ class PlantingZoneModelTest {
       // Zone is 76 meters by 26 meters, split into two 38x26 subzones such that there are three
       // plot locations but the middle one sits on the subzone boundary. Only subzone 1 is planted.
       val zoneBoundary = plantingZoneBoundary(3)
-      val subzone1Boundary = Turtle.makeMultiPolygon(siteOrigin) { rectangle(38, 26) }
+      val subzone1Boundary = Turtle(siteOrigin).makeMultiPolygon { rectangle(38, 26) }
       val subzone2Boundary =
-          Turtle.makeMultiPolygon(siteOrigin) {
-            moveStartingPoint { east(38) }
+          Turtle(siteOrigin).makeMultiPolygon {
+            east(38)
             rectangle(38, 26)
           }
-      val subzone1PlotBoundary = Turtle.makePolygon(siteOrigin) { square(25) }
+      val subzone1PlotBoundary = Turtle(siteOrigin).makePolygon { square(25) }
       val bothSubzonesPlotBoundary =
-          Turtle.makePolygon(siteOrigin) {
-            moveStartingPoint { east(25) }
+          Turtle(siteOrigin).makePolygon {
+            east(25)
             square(25)
           }
       val subzone2PlotBoundary =
-          Turtle.makePolygon(siteOrigin) {
-            moveStartingPoint { east(50) }
+          Turtle(siteOrigin).makePolygon {
+            east(50)
             square(25)
           }
 
@@ -277,7 +277,8 @@ class PlantingZoneModelTest {
       // +-----------+
 
       val sitePolygon =
-          Turtle.makePolygon(siteOrigin) {
+          Turtle(siteOrigin).makePolygon {
+            startDrawing()
             east(76)
             north(26)
             west(25)
@@ -292,7 +293,7 @@ class PlantingZoneModelTest {
               boundary = siteBoundary,
               subzones = listOf(plantingSubzoneModel(boundary = siteBoundary, plots = emptyList())))
 
-      val expected = Turtle.makePolygon(siteOrigin) { square(50) }
+      val expected = Turtle(siteOrigin).makePolygon { square(50) }
 
       val actual = zone.findUnusedSquare(siteOrigin, 50)
 
@@ -304,8 +305,8 @@ class PlantingZoneModelTest {
     @Test
     fun `excludes permanent monitoring plots`() {
       // Boundary is a 51x26m square, and there is an existing plot in the southwestern 25x25m.
-      val siteBoundary = Turtle.makeMultiPolygon(siteOrigin) { rectangle(51, 26) }
-      val existingPlotPolygon = Turtle.makePolygon(siteOrigin) { square(25) }
+      val siteBoundary = Turtle(siteOrigin).makeMultiPolygon { rectangle(51, 26) }
+      val existingPlotPolygon = Turtle(siteOrigin).makePolygon { square(25) }
 
       val zone =
           plantingZoneModel(
@@ -320,8 +321,8 @@ class PlantingZoneModelTest {
                                       boundary = existingPlotPolygon, permanentCluster = 1)))))
 
       val expected =
-          Turtle.makePolygon(siteOrigin) {
-            moveStartingPoint { east(25) }
+          Turtle(siteOrigin).makePolygon {
+            east(25)
             square(25)
           }
 
@@ -353,7 +354,7 @@ class PlantingZoneModelTest {
       val allowedVariance = (expectedCount * allowedVariancePercent / 100.0).toInt()
       val allowedRange = IntRange(expectedCount - allowedVariance, expectedCount + allowedVariance)
 
-      val siteBoundary = Turtle.makeMultiPolygon(siteOrigin) { square(21) }
+      val siteBoundary = Turtle(siteOrigin).makeMultiPolygon { square(21) }
 
       val zone =
           plantingZoneModel(
@@ -388,22 +389,20 @@ class PlantingZoneModelTest {
 
       val triangles =
           (1..20).map {
-            Turtle.makePolygon(siteOrigin) {
-              moveStartingPoint {
-                east(Random.nextInt(edgeMeters - 10))
-                north(Random.nextInt(edgeMeters - 10))
-              }
+            Turtle(siteOrigin).makePolygon {
+              east(Random.nextInt(edgeMeters - 10))
+              north(Random.nextInt(edgeMeters - 10))
+
+              startDrawing()
               east(10)
               north(10)
             }
           }
 
       val targetArea =
-          Turtle.makePolygon(siteOrigin) {
-            moveStartingPoint {
-              east(Random.nextInt(edgeMeters - 51))
-              north(Random.nextInt(edgeMeters - 51))
-            }
+          Turtle(siteOrigin).makePolygon {
+            east(Random.nextInt(edgeMeters - 51))
+            north(Random.nextInt(edgeMeters - 51))
             square(51)
           }
 
@@ -448,21 +447,19 @@ class PlantingZoneModelTest {
     val subzoneId = id / 10
     val plotNumber = id.rem(10)
 
-    return Turtle.makePolygon(siteOrigin) {
-      moveStartingPoint {
-        // Subzone corner
-        east(subzoneId * 51)
-        when (plotNumber) {
-          0 -> Unit
-          1 -> east(25)
-          2 -> {
-            east(25)
-            north(25)
-          }
-          3 -> north(25)
-          4 -> north(50)
-          else -> throw IllegalArgumentException("Invalid last digit $plotNumber of test plot")
+    return Turtle(siteOrigin).makePolygon {
+      // Subzone corner
+      east(subzoneId * 51)
+      when (plotNumber) {
+        0 -> Unit
+        1 -> east(25)
+        2 -> {
+          east(25)
+          north(25)
         }
+        3 -> north(25)
+        4 -> north(50)
+        else -> throw IllegalArgumentException("Invalid last digit $plotNumber of test plot")
       }
 
       square(25)
@@ -502,8 +499,10 @@ class PlantingZoneModelTest {
    * plus a 1-meter margin to account for floating-point inaccuracy.
    */
   private fun plantingSubzoneBoundary(id: Int): MultiPolygon {
-    return Turtle.makeMultiPolygon(siteOrigin) {
-      moveStartingPoint { east(id * 51) }
+    return Turtle(siteOrigin).makeMultiPolygon {
+      east(id * 51)
+
+      startDrawing()
       east(51)
       north(51)
       west(25)


### PR DESCRIPTION
Replace the "move starting point" concept with a "start drawing" concept and
change `makePolygon` and `makeMultiPolygon` to instance methods since it wasn't
making the call sites any simpler to have them on the companion object.