### PR TITLE
SW-4832 Add draft planting sites to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import org.jooq.Condition
+import org.jooq.OrderField
+import org.jooq.Record
+import org.jooq.TableField
+
+class DraftPlantingSitesTable(tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = DRAFT_PLANTING_SITES.ID
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          users.asSingleValueSublist("createdBy", DRAFT_PLANTING_SITES.CREATED_BY.eq(USERS.ID)),
+          users.asSingleValueSublist("modifiedBy", DRAFT_PLANTING_SITES.MODIFIED_BY.eq(USERS.ID)),
+          organizations.asSingleValueSublist(
+              "organization", DRAFT_PLANTING_SITES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
+          projects.asSingleValueSublist(
+              "project", DRAFT_PLANTING_SITES.PROJECT_ID.eq(PROJECTS.ID), isRequired = false),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      listOf(
+          timestampField("createdTime", DRAFT_PLANTING_SITES.CREATED_TIME, nullable = false),
+          textField("description", DRAFT_PLANTING_SITES.DESCRIPTION),
+          idWrapperField("id", DRAFT_PLANTING_SITES.ID) { DraftPlantingSiteId(it) },
+          timestampField("modifiedTime", DRAFT_PLANTING_SITES.MODIFIED_TIME, nullable = false),
+          textField("name", DRAFT_PLANTING_SITES.NAME, nullable = false),
+          integerField("numPlantingZones", DRAFT_PLANTING_SITES.NUM_PLANTING_ZONES),
+          integerField("numPlantingSubzones", DRAFT_PLANTING_SITES.NUM_PLANTING_SUBZONES),
+          zoneIdField("timeZone", DRAFT_PLANTING_SITES.TIME_ZONE),
+      )
+
+  override fun conditionForVisibility(): Condition {
+    return DRAFT_PLANTING_SITES.ORGANIZATION_ID.`in`(
+        currentUser().organizationRoles.filter { it.value != Role.Contributor }.keys)
+  }
+
+  override fun conditionForOrganization(organizationId: OrganizationId): Condition {
+    return DRAFT_PLANTING_SITES.ORGANIZATION_ID.eq(organizationId)
+  }
+
+  override val defaultOrderFields: List<OrderField<*>>
+    get() = listOf(DRAFT_PLANTING_SITES.ID)
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
+import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -36,6 +37,8 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
               "countrySubdivision",
               ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE.eq(COUNTRY_SUBDIVISIONS.CODE),
               isRequired = false),
+          draftPlantingSites.asMultiValueSublist(
+              "draftPlantingSites", ORGANIZATIONS.ID.eq(DRAFT_PLANTING_SITES.ORGANIZATION_ID)),
           facilities.asMultiValueSublist(
               "facilities", ORGANIZATIONS.ID.eq(FACILITIES.ORGANIZATION_ID)),
           inventories.asMultiValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -25,6 +26,8 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
       listOf(
           accessions.asMultiValueSublist("accessions", PROJECTS.ID.eq(ACCESSIONS.PROJECT_ID)),
           batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCH_SUMMARIES.PROJECT_ID)),
+          draftPlantingSites.asMultiValueSublist(
+              "draftPlantingSites", PROJECTS.ID.eq(DRAFT_PLANTING_SITES.PROJECT_ID)),
           organizations.asSingleValueSublist(
               "organization", PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           plantingSites.asMultiValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -31,6 +31,7 @@ class SearchTables(clock: Clock) {
   val countries = CountriesTable(this)
   val countrySubdivisions = CountrySubdivisionsTable(this)
   val deliveries = DeliveriesTable(this)
+  val draftPlantingSites = DraftPlantingSitesTable(this)
   val facilities = FacilitiesTable(this)
   val facilityInventories = FacilityInventoriesTable(this)
   val facilityInventoryTotals = FacilityInventoryTotalsTable(this)


### PR DESCRIPTION
Allow clients to search for draft planting sites using whatever filter criteria
they need. Only the statically-defined fields are searchable; to fetch the opaque
data for a draft planting site, fetch it using the drafts `GET` endpoint.

Example payload for `POST /api/v1/search` to search for drafts in organization
12345:

    {
        "prefix": "draftPlantingSites",
        "fields": [
            "createdBy_id",
            "description",
            "id",
            "name",
            "numPlantingSubzones",
            "numPlantingZones",
            "timeZone"
        ],
        "search": {
            "operation": "field",
            "field": "organization_id",
            "values": [12345]
        }
    }