### PR TITLE
SW-4802 Move findUnusedSquare to helper class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -3,16 +3,9 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
-import com.terraformation.backend.util.Turtle
-import com.terraformation.backend.util.createRectangle
 import com.terraformation.backend.util.equalsIgnoreScale
+import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
-import kotlin.math.cos
-import kotlin.math.sin
-import kotlin.random.Random
-import org.geotools.geometry.jts.JTS
-import org.geotools.referencing.CRS
-import org.geotools.referencing.GeodeticCalculator
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
@@ -164,204 +157,20 @@ data class PlantingZoneModel(
 
   /**
    * Returns a square Polygon of the requested width/height that is completely contained in the zone
-   * and does not intersect with any existing monitoring plots.
+   * and does not intersect with an exclusion area.
    *
    * The square will be positioned a whole multiple of [gridInterval] meters from the specified
    * origin.
    *
-   * @param excludeAllPermanentPlots If true, exclude the boundaries of all permanent monitoring
-   *   plots. If false, only exclude the boundaries of permanent monitoring plots that will be
-   *   candidates for inclusion in the next observation (that is, ignore permanent plots that were
-   *   used in previous observations but won't be used in the next one).
    * @param exclusion Areas to exclude from the zone, or null if the whole zone is available.
    * @return The unused square, or null if no suitable area could be found.
    */
   fun findUnusedSquare(
       gridOrigin: Point,
       sizeMeters: Number,
-      excludeAllPermanentPlots: Boolean = true,
       exclusion: MultiPolygon? = null,
-      gridInterval: Double = sizeMeters.toDouble()
   ): Polygon? {
-    val geometryFactory = GeometryFactory(PrecisionModel())
-    val boundaryCrs = CRS.decode("EPSG:${boundary.srid}", true)
-    val calculator = GeodeticCalculator(boundaryCrs)
-    calculator.startingPosition = JTS.toDirectPosition(gridOrigin.coordinate, boundaryCrs)
-
-    // For purposes of checking whether or not a particular grid position is available, we treat
-    // existing permanent plots as part of the exclusion area.
-    val monitoringPlotAreas = getMonitoringPlotGeometry(excludeAllPermanentPlots)
-
-    // The geometry of the zone's available area (minus exclusion and existing plots).
-    val zoneGeometry =
-        if (exclusion != null) {
-          boundary.difference(exclusion).difference(monitoringPlotAreas)
-        } else {
-          boundary.difference(monitoringPlotAreas)
-        }
-
-    fun roundToGrid(value: Double): Double = Math.round(value / gridInterval) * gridInterval
-
-    /** Returns a rectangle with corners a specified number of meters from the grid origin. */
-    fun meterOffsetRectangle(southwest: Coordinate, northeast: Coordinate): Polygon {
-      return Turtle(gridOrigin, boundaryCrs).makePolygon {
-        north(southwest.y)
-        east(southwest.x)
-
-        rectangle(northeast.x - southwest.x, northeast.y - southwest.y)
-      }
-    }
-
-    /**
-     * Returns a square [sizeMeters] on a side with the coordinates snapped to multiples of
-     * [gridInterval] meters from the grid origin.
-     */
-    fun gridAlignedSquare(westEdge: Double, southEdge: Double): Polygon {
-      return Turtle(gridOrigin, boundaryCrs).makePolygon {
-        north(roundToGrid(southEdge))
-        east(roundToGrid(westEdge))
-
-        square(sizeMeters)
-      }
-    }
-
-    /**
-     * Returns the distance from the grid origin to a particular set of coordinates as an offset in
-     * meters along each axis.
-     */
-    fun getMeterOffsets(coordinate: Coordinate): Coordinate {
-      calculator.destinationPosition = JTS.toDirectPosition(coordinate, boundaryCrs)
-
-      val azimuthRadians = calculator.azimuth * Math.PI / 180.0
-      val distanceMeters = calculator.orthodromicDistance
-      val x = sin(azimuthRadians) * distanceMeters
-      val y = cos(azimuthRadians) * distanceMeters
-
-      return Coordinate(x, y)
-    }
-
-    /**
-     * Returns true if a polygon is sufficiently covered by the zone geometry. If an edge of the
-     * site geometry is axis-aligned, rounding errors can cause a polygon on the edge to test as not
-     * completely covered by the zone. So instead we test that the polygon is at least 99.999%
-     * covered.
-     */
-    fun coveredByZone(polygon: Geometry): Boolean {
-      return zoneGeometry.intersection(polygon).area >= polygon.area * 0.99999
-    }
-
-    /**
-     * Attempts to find an available square within a rectangular region of the zone. First tries to
-     * pick a few random points, and if none of them works, divides the region into four quadrants
-     * and searches them in area-weighted random order until it finds a match.
-     *
-     * The idea is that for a typical zone, the initial random probe will most likely work and we'll
-     * return a result quickly, but for an odd-shaped zone, we keep drilling down until we've done
-     * an exhaustive search for matches.
-     */
-    fun findInRegion(southwest: Coordinate, northeast: Coordinate): Polygon? {
-      val regionWidth = northeast.x - southwest.x
-      val regionHeight = northeast.y - southwest.y
-
-      // If all possible points in the region will round to the same point on the grid, or if the
-      // region is less than a quarter the size of a grid square, check it and return; trying random
-      // points within the region wouldn't be useful, nor would dividing the region in quarters and
-      // drilling down.
-      val minimumArea = (gridInterval * gridInterval) / 4.0
-      if (roundToGrid(southwest.x) == roundToGrid(northeast.x) &&
-          roundToGrid(southwest.y) == roundToGrid(northeast.y) ||
-          regionWidth * regionHeight < minimumArea) {
-        val polygon = gridAlignedSquare(southwest.x, southwest.y)
-
-        return if (coveredByZone(polygon)) {
-          polygon
-        } else {
-          null
-        }
-      }
-
-      // Try a few times to find a random spot in the region. This will succeed most of the time.
-      val maxAttempts = 5
-
-      for (attemptNumber in 1..maxAttempts) {
-        val polygon =
-            gridAlignedSquare(
-                Random.nextDouble(southwest.x, northeast.x),
-                Random.nextDouble(southwest.y, northeast.y))
-
-        if (coveredByZone(polygon)) {
-          return polygon
-        }
-      }
-
-      // No luck. This might be a sparse site map. Split the region into equal-sized quadrants and
-      // search them in random order but with the ones that cover the most zone area more likely to
-      // come first.
-      val middleX = (southwest.x + northeast.x) / 2.0
-      val middleY = (southwest.y + northeast.y) / 2.0
-
-      // List of quadrant geometry and how much usable area the quadrant has.
-      val quadrants: MutableList<Pair<Polygon, Double>> =
-          listOf(
-                  geometryFactory.createRectangle(southwest.x, southwest.y, middleX, middleY),
-                  geometryFactory.createRectangle(middleX, southwest.y, northeast.x, middleY),
-                  geometryFactory.createRectangle(middleX, middleY, northeast.x, northeast.y),
-                  geometryFactory.createRectangle(southwest.x, middleY, middleX, northeast.y))
-              .map { quadrant ->
-                val quadrantPolygon =
-                    meterOffsetRectangle(quadrant.coordinates[0], quadrant.coordinates[2])
-                quadrant to zoneGeometry.intersection(quadrantPolygon).area
-              }
-              // Exclude quadrants that don't cover any zone area at all.
-              .filter { it.second > 0 }
-              .toMutableList()
-
-      while (quadrants.isNotEmpty()) {
-        val totalIntersectionArea = quadrants.sumOf { it.second }
-        val weightedSelection = Random.nextDouble(totalIntersectionArea)
-        var totalVisitedWeight = 0.0
-
-        for (index in quadrants.indices) {
-          totalVisitedWeight += quadrants[index].second
-
-          if (totalVisitedWeight >= weightedSelection) {
-            val selectedQuadrant = quadrants.removeAt(index).first
-
-            val findResult =
-                findInRegion(selectedQuadrant.coordinates[0], selectedQuadrant.coordinates[2])
-            if (findResult != null) {
-              return findResult
-            } else {
-              break
-            }
-          }
-        }
-      }
-
-      return null
-    }
-
-    // The envelope of the zone geometry may be wider on the north edge than on the south or vice
-    // versa because degrees of longitude represent different distances depending on latitude.
-    // So we convert all 4 corners of the envelope to meter offsets from the origin, and use the
-    // minimum and maximum values to determine the meter-based search region.
-    val zoneEnvelope = zoneGeometry.envelope
-    val zoneEnvelopeMeters = zoneEnvelope.coordinates.map { getMeterOffsets(it) }
-
-    // Extend the initial search area beyond the actual zone envelope so that we're equally likely
-    // to choose an edge location as an interior location.
-    //
-    // If we don't do this, then the interior grid lines are chosen when a random position is within
-    // (sizeMeters / 2) in either direction, whereas an edge location is only chosen when the
-    // position is within (sizeMeters / 2) in one direction because the points that would round
-    // to it from the other direction would be outside the random number range.
-    val margin = sizeMeters.toDouble() / 2.0
-
-    return findInRegion(
-        Coordinate(
-            zoneEnvelopeMeters.minOf { it.x } - margin, zoneEnvelopeMeters.minOf { it.y } - margin),
-        Coordinate(
-            zoneEnvelopeMeters.maxOf { it.x } + margin, zoneEnvelopeMeters.maxOf { it.y } + margin))
+    return UnusedSquareFinder(boundary, gridOrigin, sizeMeters, exclusion).findUnusedSquare()
   }
 
   /**
@@ -385,25 +194,19 @@ data class PlantingZoneModel(
       count: Int,
       excludeAllPermanentPlots: Boolean,
       exclusion: MultiPolygon? = null,
-      gridInterval: Double = sizeMeters.toDouble()
   ): List<Polygon> {
     val factory = GeometryFactory(PrecisionModel(), boundary.srid)
 
-    val excludedPolygons = mutableListOf<Polygon>()
+    // For purposes of checking whether or not a particular grid position is available, we treat
+    // existing permanent plots as part of the exclusion area.
+    var exclusionWithAllocatedSquares = getMonitoringPlotGeometry(excludeAllPermanentPlots)
     if (exclusion != null) {
-      for (n in (0 ..< exclusion.numGeometries)) {
-        excludedPolygons.add(exclusion.getGeometryN(n) as Polygon)
-      }
+      exclusionWithAllocatedSquares =
+          exclusionWithAllocatedSquares.union(exclusion).toMultiPolygon(factory)
     }
 
     return (1..count).mapNotNull { squareNumber ->
-      val square =
-          findUnusedSquare(
-              gridOrigin,
-              sizeMeters,
-              excludeAllPermanentPlots,
-              factory.createMultiPolygon(excludedPolygons.toTypedArray()),
-              gridInterval)
+      val square = findUnusedSquare(gridOrigin, sizeMeters, exclusionWithAllocatedSquares)
 
       if (square != null && squareNumber < count) {
         // Prevent the square from being repeated by adding it to the exclusion area.
@@ -415,13 +218,16 @@ data class PlantingZoneModel(
         val height = (square.coordinates[2].y - square.coordinates[0].y) / 8.0
         val middle = square.centroid
 
-        excludedPolygons.add(
-            factory.createPolygon(
-                arrayOf(
-                    middle.coordinate,
-                    Coordinate(middle.x + width, middle.y),
-                    Coordinate(middle.x, middle.y + height),
-                    middle.coordinate)))
+        exclusionWithAllocatedSquares =
+            exclusionWithAllocatedSquares
+                .union(
+                    factory.createPolygon(
+                        arrayOf(
+                            middle.coordinate,
+                            Coordinate(middle.x + width, middle.y),
+                            Coordinate(middle.x, middle.y + height),
+                            middle.coordinate)))
+                .toMultiPolygon()
       }
 
       square

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -1,0 +1,215 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.util.Turtle
+import com.terraformation.backend.util.createRectangle
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+import org.geotools.geometry.jts.JTS
+import org.geotools.referencing.CRS
+import org.geotools.referencing.GeodeticCalculator
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
+
+/** Finds an unused grid-aligned square within a zone boundary. */
+class UnusedSquareFinder(
+    zoneBoundary: MultiPolygon,
+    private val gridOrigin: Point,
+    private val sizeMeters: Number,
+    /** Areas to exclude from the zone, or null if the whole zone is available. */
+    exclusion: MultiPolygon? = null,
+) {
+  private val geometryFactory = GeometryFactory(PrecisionModel())
+  private val boundaryCrs = CRS.decode("EPSG:${zoneBoundary.srid}", true)
+  private val calculator = GeodeticCalculator(boundaryCrs)
+  private val gridInterval: Double = sizeMeters.toDouble()
+
+  /** The geometry of the zone's available area (minus exclusion and existing plots). */
+  private val zoneGeometry =
+      if (exclusion != null) {
+        zoneBoundary.difference(exclusion)
+      } else {
+        zoneBoundary
+      }
+
+  init {
+    calculator.startingPosition = JTS.toDirectPosition(gridOrigin.coordinate, boundaryCrs)
+  }
+
+  /**
+   * Returns a square Polygon of the requested width/height that is completely contained in the zone
+   * and does not intersect with an exclusion area.
+   *
+   * The square will be positioned a whole multiple of [gridInterval] meters from the specified
+   * origin.
+   *
+   * @return The unused square, or null if no suitable area could be found.
+   */
+  fun findUnusedSquare(): Polygon? {
+    // The envelope of the zone geometry may be wider on the north edge than on the south or vice
+    // versa because degrees of longitude represent different distances depending on latitude.
+    // So we convert all 4 corners of the envelope to meter offsets from the origin, and use the
+    // minimum and maximum values to determine the meter-based search region.
+    val zoneEnvelope = zoneGeometry.envelope
+    val zoneEnvelopeMeters = zoneEnvelope.coordinates.map { getMeterOffsets(it) }
+
+    // Extend the initial search area beyond the actual zone envelope so that we're equally likely
+    // to choose an edge location as an interior location.
+    //
+    // If we don't do this, then the interior grid lines are chosen when a random position is within
+    // (sizeMeters / 2) in either direction, whereas an edge location is only chosen when the
+    // position is within (sizeMeters / 2) in one direction because the points that would round
+    // to it from the other direction would be outside the random number range.
+    val margin = sizeMeters.toDouble() / 2.0
+
+    return findInRegion(
+        Coordinate(
+            zoneEnvelopeMeters.minOf { it.x } - margin, zoneEnvelopeMeters.minOf { it.y } - margin),
+        Coordinate(
+            zoneEnvelopeMeters.maxOf { it.x } + margin, zoneEnvelopeMeters.maxOf { it.y } + margin))
+  }
+
+  private fun roundToGrid(value: Double): Double = Math.round(value / gridInterval) * gridInterval
+
+  /** Returns a rectangle with corners a specified number of meters from the grid origin. */
+  private fun meterOffsetRectangle(southwest: Coordinate, northeast: Coordinate): Polygon {
+    return Turtle(gridOrigin, boundaryCrs).makePolygon {
+      north(southwest.y)
+      east(southwest.x)
+
+      rectangle(northeast.x - southwest.x, northeast.y - southwest.y)
+    }
+  }
+
+  /**
+   * Returns a square [sizeMeters] on a side with the coordinates snapped to multiples of
+   * [gridInterval] meters from the grid origin.
+   */
+  private fun gridAlignedSquare(westEdge: Double, southEdge: Double): Polygon {
+    return Turtle(gridOrigin, boundaryCrs).makePolygon {
+      north(roundToGrid(southEdge))
+      east(roundToGrid(westEdge))
+
+      square(sizeMeters)
+    }
+  }
+  /**
+   * Returns the distance from the grid origin to a particular set of coordinates as an offset in
+   * meters along each axis.
+   */
+  private fun getMeterOffsets(coordinate: Coordinate): Coordinate {
+    calculator.destinationPosition = JTS.toDirectPosition(coordinate, boundaryCrs)
+
+    val azimuthRadians = calculator.azimuth * Math.PI / 180.0
+    val distanceMeters = calculator.orthodromicDistance
+    val x = sin(azimuthRadians) * distanceMeters
+    val y = cos(azimuthRadians) * distanceMeters
+
+    return Coordinate(x, y)
+  }
+
+  /**
+   * Returns true if a polygon is sufficiently covered by the zone geometry. If an edge of the site
+   * geometry is axis-aligned, rounding errors can cause a polygon on the edge to test as not
+   * completely covered by the zone. So instead we test that the polygon is at least 99.999%
+   * covered.
+   */
+  private fun coveredByZone(polygon: Geometry): Boolean {
+    return zoneGeometry.intersection(polygon).area >= polygon.area * 0.99999
+  }
+  /**
+   * Attempts to find an available square within a rectangular region of the zone. First tries to
+   * pick a few random points, and if none of them works, divides the region into four quadrants and
+   * searches them in area-weighted random order until it finds a match.
+   *
+   * The idea is that for a typical zone, the initial random probe will most likely work and we'll
+   * return a result quickly, but for an odd-shaped zone, we keep drilling down until we've done an
+   * exhaustive search for matches.
+   */
+  private fun findInRegion(southwest: Coordinate, northeast: Coordinate): Polygon? {
+    val regionWidth = northeast.x - southwest.x
+    val regionHeight = northeast.y - southwest.y
+
+    // If all possible points in the region will round to the same point on the grid, or if the
+    // region is less than a quarter the size of a grid square, check it and return; trying random
+    // points within the region wouldn't be useful, nor would dividing the region in quarters and
+    // drilling down.
+    val minimumArea = (gridInterval * gridInterval) / 4.0
+    if (roundToGrid(southwest.x) == roundToGrid(northeast.x) &&
+        roundToGrid(southwest.y) == roundToGrid(northeast.y) ||
+        regionWidth * regionHeight < minimumArea) {
+      val polygon = gridAlignedSquare(southwest.x, southwest.y)
+
+      return if (coveredByZone(polygon)) {
+        polygon
+      } else {
+        null
+      }
+    }
+
+    // Try a few times to find a random spot in the region. This will succeed most of the time.
+    val maxAttempts = 5
+
+    for (attemptNumber in 1..maxAttempts) {
+      val polygon =
+          gridAlignedSquare(
+              Random.nextDouble(southwest.x, northeast.x),
+              Random.nextDouble(southwest.y, northeast.y))
+
+      if (coveredByZone(polygon)) {
+        return polygon
+      }
+    }
+
+    // No luck. This might be a sparse site map. Split the region into equal-sized quadrants and
+    // search them in random order but with the ones that cover the most zone area more likely to
+    // come first.
+    val middleX = (southwest.x + northeast.x) / 2.0
+    val middleY = (southwest.y + northeast.y) / 2.0
+
+    // List of quadrant geometry and how much usable area the quadrant has.
+    val quadrants: MutableList<Pair<Polygon, Double>> =
+        listOf(
+                geometryFactory.createRectangle(southwest.x, southwest.y, middleX, middleY),
+                geometryFactory.createRectangle(middleX, southwest.y, northeast.x, middleY),
+                geometryFactory.createRectangle(middleX, middleY, northeast.x, northeast.y),
+                geometryFactory.createRectangle(southwest.x, middleY, middleX, northeast.y))
+            .map { quadrant ->
+              val quadrantPolygon =
+                  meterOffsetRectangle(quadrant.coordinates[0], quadrant.coordinates[2])
+              quadrant to zoneGeometry.intersection(quadrantPolygon).area
+            }
+            // Exclude quadrants that don't cover any zone area at all.
+            .filter { it.second > 0 }
+            .toMutableList()
+
+    while (quadrants.isNotEmpty()) {
+      val totalIntersectionArea = quadrants.sumOf { it.second }
+      val weightedSelection = Random.nextDouble(totalIntersectionArea)
+      var totalVisitedWeight = 0.0
+
+      for (index in quadrants.indices) {
+        totalVisitedWeight += quadrants[index].second
+
+        if (totalVisitedWeight >= weightedSelection) {
+          val selectedQuadrant = quadrants.removeAt(index).first
+
+          val findResult =
+              findInRegion(selectedQuadrant.coordinates[0], selectedQuadrant.coordinates[2])
+          if (findResult != null) {
+            return findResult
+          } else {
+            break
+          }
+        }
+      }
+    }
+
+    return null
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -14,7 +14,9 @@ import org.jooq.Field
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
 // context of a specific bit of application code should live alongside that code, but functions that
@@ -113,4 +115,18 @@ fun GeometryFactory.createRectangle(
           Coordinate(east, north),
           Coordinate(west, north),
           Coordinate(west, south)))
+}
+
+/**
+ * Returns a MultiPolygon version of a polygonal geometry. If the geometry is already a
+ * MultiPolygon, returns it as-is.
+ */
+fun Geometry.toMultiPolygon(
+    factory: GeometryFactory = GeometryFactory(PrecisionModel(), srid)
+): MultiPolygon {
+  return when (this) {
+    is MultiPolygon -> this
+    is Polygon -> factory.createMultiPolygon(arrayOf(this))
+    else -> throw IllegalArgumentException("Cannot convert $geometryType to MultiPolygon")
+  }
 }


### PR DESCRIPTION
For user-defined planting zone boundaries, we'll want to validate that the
boundaries are large enough to hold monitoring plots before inserting the zone
data into the database.

Ideally, we wanto to do that using the same "find a plot location" algorithm
that's used in real observations. That code is currently in `PlantingZoneModel`
which can only represent planting zones that exist in the database.

Move the zone search logic into a helper class `UnusedSquareFinder`.

This is mostly a straight copy-paste of the existing implementation, with the
following changes:

- The logic for excluding existing monitoring plots now lives in
  `findUnusedSquares` since it was only ever used via that function anyway.
  This requires changing the unit test for that functionality.
- The various functions that used to be defined inside `findUnusedSquare` are
  now just regular methods in the new class.
- Likewise, some of the local variables from `findUnusedSquare` are now
  instance variables in the new class.
- It's no longer possible to specify a grid interval thats different than the
  square size. We weren't ever doing that anyway.