### PR TITLE
Remove unused field from Shapefile class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -296,18 +296,16 @@ class AdminPlantingSitesController(
   ): String {
     try {
       val boundaryPolygon = objectMapper.readValue<Polygon>(boundary)
-      val siteFile = Shapefile.fromBoundary("site", boundaryPolygon, emptyMap())
+      val siteFile = Shapefile.fromBoundary(boundaryPolygon, emptyMap())
 
       val siteId =
           if (siteType == "detailed") {
             val zonesFile =
                 Shapefile.fromBoundary(
-                    "zone",
                     boundaryPolygon,
                     mapOf(PlantingSiteImporter.zoneNameProperties.first() to "Zone"))
             val subzonesFile =
                 Shapefile.fromBoundary(
-                    "subzone",
                     boundaryPolygon,
                     mapOf(
                         PlantingSiteImporter.zoneNameProperties.first() to "Zone",

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
@@ -17,7 +17,6 @@ import org.locationtech.jts.geom.PrecisionModel
 
 /** Simplified representation of the geometry data from a shapefile. */
 data class Shapefile(
-    val typeName: String,
     val features: List<ShapefileFeature>,
 ) {
   companion object {
@@ -69,11 +68,10 @@ data class Shapefile(
                     .toList()
               }
 
-      return Shapefile(dataStore.typeNames[0], features)
+      return Shapefile(features)
     }
 
     fun fromBoundary(
-        typeName: String,
         boundary: Polygon,
         properties: Map<String, String>,
         crs: CoordinateReferenceSystem = DefaultGeographicCRS.WGS84
@@ -82,7 +80,7 @@ data class Shapefile(
           GeometryFactory(PrecisionModel(), SRID.LONG_LAT).createMultiPolygon(arrayOf(boundary))
       val boundaryFeature = ShapefileFeature(multiPolygonBoundary, properties, crs)
 
-      return Shapefile(typeName, listOf(boundaryFeature))
+      return Shapefile(listOf(boundaryFeature))
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -198,10 +198,10 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         plantingSiteImporter.importShapefiles(
             name = "Test Site ${nextPlantingSiteNumber++}",
             organizationId = organizationId,
-            siteFile = Shapefile("site", listOf(siteFeature)),
-            zonesFile = Shapefile("zone", zoneFeatures),
-            subzonesFile = Shapefile("subzone", subzoneFeatures),
-            exclusionsFile = exclusionFeature?.let { Shapefile("exclusion", listOf(it)) })
+            siteFile = Shapefile(listOf(siteFeature)),
+            zonesFile = Shapefile(zoneFeatures),
+            subzonesFile = Shapefile(subzoneFeatures),
+            exclusionsFile = exclusionFeature?.let { Shapefile(listOf(it)) })
 
     val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -77,9 +77,9 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.importShapefiles(
           name = "Test Site",
           organizationId = organizationId,
-          siteFile = Shapefile("site", listOf(siteFeature)),
-          zonesFile = Shapefile("zone", listOf(zoneFeature)),
-          subzonesFile = Shapefile("subzone", listOf(subzoneFeature)),
+          siteFile = Shapefile(listOf(siteFeature)),
+          zonesFile = Shapefile(listOf(zoneFeature)),
+          subzonesFile = Shapefile(listOf(subzoneFeature)),
           exclusionsFile = null,
       )
 
@@ -98,10 +98,10 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.importShapefiles(
           name = "Test Site",
           organizationId = organizationId,
-          siteFile = Shapefile("site", listOf(siteFeature)),
-          zonesFile = Shapefile("zone", listOf(zoneFeature)),
-          subzonesFile = Shapefile("subzone", listOf(subzoneFeature)),
-          exclusionsFile = Shapefile("exclusion", listOf(exclusionFeature)),
+          siteFile = Shapefile(listOf(siteFeature)),
+          zonesFile = Shapefile(listOf(zoneFeature)),
+          subzonesFile = Shapefile(listOf(subzoneFeature)),
+          exclusionsFile = Shapefile(listOf(exclusionFeature)),
       )
 
       assertPlotCounts(permanent = 28, temporary = 10)

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileTest.kt
@@ -16,16 +16,12 @@ internal class ShapefileTest {
 
     assertEquals(2, shapefiles.size, "Number of shapefiles loaded")
 
-    assertEquals(
-        setOf("PlantingSite", "PlantingZones"),
-        shapefiles.map { it.typeName }.toSet(),
-        "Shapefile type names")
-
-    val plantingSite = shapefiles.firstOrNull { it.typeName == "PlantingSite" }
+    val plantingSite = shapefiles.firstOrNull { it.features.size == 1 }
     assertNotNull(plantingSite, "Should have found site boundary shapefile")
-    assertEquals(1, plantingSite!!.features.size, "Number of features in site")
     assertEquals(
-        MultiPolygon::class.java, plantingSite.features[0].geometry.javaClass, "Site feature type")
+        MultiPolygon::class.java,
+        plantingSite!!.features[0].geometry.javaClass,
+        "Site feature type")
   }
 
   @Test


### PR DESCRIPTION
Our in-memory representation of shapefile data included a textual "data type"
value but we weren't using it for anything except to test that it was populated
correctly. Remove it.