### PR TITLE
SW-4835 Add permissions for ability to set specific global roles

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -337,9 +337,10 @@ class UserStore(
   }
 
   fun updateGlobalRoles(userId: UserId, roles: Set<GlobalRole>) {
-    requirePermissions { updateSpecificGlobalRoles(roles) }
     if (roles.isEmpty()) {
       requirePermissions { updateGlobalRoles() }
+    } else {
+      requirePermissions { updateSpecificGlobalRoles(roles) }
     }
 
     val user = fetchOneById(userId)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -337,7 +337,10 @@ class UserStore(
   }
 
   fun updateGlobalRoles(userId: UserId, roles: Set<GlobalRole>) {
-    requirePermissions { updateGlobalRoles() }
+    requirePermissions { updateSpecificGlobalRoles(roles) }
+    if (roles.isEmpty()) {
+      requirePermissions { updateGlobalRoles() }
+    }
 
     val user = fetchOneById(userId)
     if (user !is IndividualUser || !user.email.endsWith("@terraformation.com", ignoreCase = true)) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -335,7 +335,9 @@ data class DeviceManagerUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false
 
   override fun canUpdateGlobalRoles(): Boolean = false
+
   override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = false
+
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
 
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -335,7 +335,7 @@ data class DeviceManagerUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = false
 
   override fun canUpdateGlobalRoles(): Boolean = false
-
+  override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = false
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
 
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -459,10 +459,10 @@ data class IndividualUser(
   override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean =
       globalRoles.all {
         when (it) {
-          GlobalRole.SuperAdmin -> isSuperAdmin()
           GlobalRole.AcceleratorAdmin -> isAcceleratorAdmin()
-          GlobalRole.TFExpert -> isAcceleratorAdmin()
           GlobalRole.ReadOnly -> isAcceleratorAdmin()
+          GlobalRole.SuperAdmin -> isSuperAdmin()
+          GlobalRole.TFExpert -> isAcceleratorAdmin()
         }
       }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -456,6 +456,16 @@ data class IndividualUser(
 
   override fun canUpdateGlobalRoles(): Boolean = isSuperAdmin()
 
+  override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean =
+      globalRoles.all {
+        when (it) {
+          GlobalRole.SuperAdmin -> isSuperAdmin()
+          GlobalRole.AcceleratorAdmin -> isAcceleratorAdmin()
+          GlobalRole.TFExpert -> isAcceleratorAdmin()
+          GlobalRole.ReadOnly -> isAcceleratorAdmin()
+        }
+      }
+
   override fun canUpdateNotification(notificationId: NotificationId) =
       canReadNotification(notificationId)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -890,6 +891,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateSpecies(speciesId)) {
       readSpecies(speciesId)
       throw AccessDeniedException("No permission to update species $speciesId")
+    }
+  }
+
+  fun updateSpecificGlobalRoles(globalRoles: Set<GlobalRole>) {
+    if (!user.canUpdateSpecificGlobalRoles(globalRoles)) {
+      throw AccessDeniedException("No permission to update the provided global roles")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -345,7 +345,7 @@ class SystemUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
 
   override fun canUpdateGlobalRoles(): Boolean = true
-
+  override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = true
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
 
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -345,7 +345,9 @@ class SystemUser(
   override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
 
   override fun canUpdateGlobalRoles(): Boolean = true
+
   override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = true
+
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
 
   override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -296,7 +296,7 @@ interface TerrawareUser : Principal {
   fun canUpdateFacility(facilityId: FacilityId): Boolean
 
   fun canUpdateGlobalRoles(): Boolean
-
+  fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean
   fun canUpdateNotification(notificationId: NotificationId): Boolean
 
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -296,7 +296,9 @@ interface TerrawareUser : Principal {
   fun canUpdateFacility(facilityId: FacilityId): Boolean
 
   fun canUpdateGlobalRoles(): Boolean
+
   fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean
+
   fun canUpdateNotification(notificationId: NotificationId): Boolean
 
   fun canUpdateNotifications(organizationId: OrganizationId?): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -107,6 +107,8 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadOrganization(organizationId) } returns true
     every { user.canRemoveOrganizationUser(organizationId, any()) } returns true
     every { user.canSetOrganizationUserRole(organizationId, Role.Contributor) } returns true
+    every { user.canUpdateGlobalRoles() } returns true
+    every { user.canUpdateSpecificGlobalRoles(setOf()) } returns true
 
     val engine = MockEngine {
       respond(content = responseContent, status = responseStatusCode, headers = responseHeaders)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -108,7 +108,6 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canRemoveOrganizationUser(organizationId, any()) } returns true
     every { user.canSetOrganizationUserRole(organizationId, Role.Contributor) } returns true
     every { user.canUpdateGlobalRoles() } returns true
-    every { user.canUpdateSpecificGlobalRoles(setOf()) } returns true
 
     val engine = MockEngine {
       respond(content = responseContent, status = responseStatusCode, headers = responseHeaders)
@@ -726,7 +725,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
   inner class UpdateGlobalRoles {
     @BeforeEach
     fun setUp() {
-      every { user.canUpdateGlobalRoles() } returns true
+      every { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)) } returns true
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -716,12 +716,16 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateSpecies() = allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
 
-  @Test fun updateSpecificGlobalRoles() {
+  @Test
+  fun updateSpecificGlobalRoles() {
     assertThrows<AccessDeniedException> {
       requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
     }
 
-    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly)) }
+    grant {
+      user.canUpdateSpecificGlobalRoles(
+          setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
+    }
     assertThrows<AccessDeniedException> {
       requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
     }
@@ -729,8 +733,12 @@ internal class PermissionRequirementsTest : RunsAsUser {
     grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)) }
     requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
 
-    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly)) }
-    requirements.updateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
+    grant {
+      user.canUpdateSpecificGlobalRoles(
+          setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
+    }
+    requirements.updateSpecificGlobalRoles(
+        setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -714,6 +715,23 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun updateSpecies() = allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
+
+  @Test fun updateSpecificGlobalRoles() {
+    assertThrows<AccessDeniedException> {
+      requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
+    }
+
+    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly)) }
+    assertThrows<AccessDeniedException> {
+      requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
+    }
+
+    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)) }
+    requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
+
+    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly)) }
+    requirements.updateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
+  }
 
   @Test
   fun updateSubLocation() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -25,7 +25,6 @@ import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
-import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -715,31 +714,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun updateSpecies() = allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
-
-  @Test
-  fun updateSpecificGlobalRoles() {
-    assertThrows<AccessDeniedException> {
-      requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
-    }
-
-    grant {
-      user.canUpdateSpecificGlobalRoles(
-          setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
-    }
-    assertThrows<AccessDeniedException> {
-      requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
-    }
-
-    grant { user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)) }
-    requirements.updateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin))
-
-    grant {
-      user.canUpdateSpecificGlobalRoles(
-          setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
-    }
-    requirements.updateSpecificGlobalRoles(
-        setOf(GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly))
-  }
 
   @Test
   fun updateSubLocation() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1289,6 +1289,12 @@ internal class PermissionTest : DatabaseTest() {
         updateParticipant = true,
         updateSpecificGlobalRoles = true,
     )
+
+    // Super admin can apply all global roles to a user
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin)))
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
   }
 
   @Test
@@ -1360,6 +1366,12 @@ internal class PermissionTest : DatabaseTest() {
         updateGlobalRoles = false,
         updateParticipant = true,
     )
+
+    // Accelerator admin can apply all global roles to a user except super admin
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin)))
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
+    assertTrue(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
   }
 
   @Test
@@ -1415,8 +1427,15 @@ internal class PermissionTest : DatabaseTest() {
         updateGlobalRoles = false,
         updateParticipant = false,
     )
+
+    // TF Expert can't apply any global roles to a user
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
   }
 
+  @Test
   fun `read only user has correct privileges`() {
     insertUserGlobalRole(userId, GlobalRole.ReadOnly)
 
@@ -1441,7 +1460,7 @@ internal class PermissionTest : DatabaseTest() {
         readObservation = true,
         replaceObservationPlot = false,
         rescheduleObservation = false,
-        updateObservation = false,
+        updateObservation = true,
     )
 
     permissions.expect(
@@ -1469,6 +1488,12 @@ internal class PermissionTest : DatabaseTest() {
         updateGlobalRoles = false,
         updateParticipant = false,
     )
+
+    // Read Only can't apply any global roles to a user
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.AcceleratorAdmin)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
+    assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1948,7 +1948,9 @@ internal class PermissionTest : DatabaseTest() {
       assertEquals(
           updateParticipant, user.canUpdateParticipant(participantId), "Can update participant")
       assertEquals(
-          updateSpecificGlobalRoles, user.canUpdateSpecificGlobalRoles(globalRoles), "Can update specific global roles")
+          updateSpecificGlobalRoles,
+          user.canUpdateSpecificGlobalRoles(globalRoles),
+          "Can update specific global roles")
 
       hasCheckedGlobalPermissions = true
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -161,6 +161,7 @@ internal class PermissionTest : DatabaseTest() {
   // For now, participant permissions are global, not per-participant, so we only need one ID.
   private val participantId = ParticipantId(1)
   private val cohortId = CohortId(1)
+  private val globalRoles = setOf(GlobalRole.SuperAdmin)
 
   private inline fun <reified T> List<T>.filterToArray(func: (T) -> Boolean): Array<T> =
       filter(func).toTypedArray()
@@ -1896,6 +1897,7 @@ internal class PermissionTest : DatabaseTest() {
         updateDeviceTemplates: Boolean = false,
         updateGlobalRoles: Boolean = false,
         updateParticipant: Boolean = false,
+        updateSpecificGlobalRoles: Boolean = false,
     ) {
       assertEquals(
           addAnyOrganizationUser, user.canAddAnyOrganizationUser(), "Can add any organization user")
@@ -1945,6 +1947,8 @@ internal class PermissionTest : DatabaseTest() {
       assertEquals(updateGlobalRoles, user.canUpdateGlobalRoles(), "Can update global roles")
       assertEquals(
           updateParticipant, user.canUpdateParticipant(participantId), "Can update participant")
+      assertEquals(
+          updateSpecificGlobalRoles, user.canUpdateSpecificGlobalRoles(globalRoles), "Can update specific global roles")
 
       hasCheckedGlobalPermissions = true
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1134,6 +1134,7 @@ internal class PermissionTest : DatabaseTest() {
         updateDeviceTemplates = true,
         updateGlobalRoles = true,
         updateParticipant = true,
+        updateSpecificGlobalRoles = true,
     )
 
     permissions.expect(
@@ -1286,6 +1287,7 @@ internal class PermissionTest : DatabaseTest() {
         updateDeviceTemplates = true,
         updateGlobalRoles = true,
         updateParticipant = true,
+        updateSpecificGlobalRoles = true,
     )
   }
 


### PR DESCRIPTION
- Add a permission check for `canUpdateSpecificGlobalRoles` which takes a set of roles. Since the permissions are based on the roles that are being updated, we check them individually against the current user's authorization.
- I left the `canUpdateGlobalRoles` permission as a "super admin fallback", in the event no roles are passed (for deleting all roles). It is also used in the admin UI for checking whether or not to show the global role UI. I think this will eventually get removed and we can decide if this permission is still needed then. 