### PR TITLE
SW-4910 Fix observation states in admin UI

### DIFF
--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -353,7 +353,7 @@
             <td th:text="${observation.id}">1</td>
             <td th:text="${observation.startDate}">2023-01-01</td>
             <td th:text="${observation.endDate}">2023-01-31</td>
-            <td th:text="${observation.state.getDisplayName(null)}">Upcoming</td>
+            <td th:text="${observation.state}">Upcoming</td>
             <td>
                 <th:block th:text="${observationMessages[observation.id]}"></th:block>
                 <form th:if="${canStartObservations[observation.id]}"


### PR DESCRIPTION
Commit c3c49c00 removed the localized display names from a bunch of enums
including observation state, but the admin UI was still trying to resolve
the localized name when showing the table of observations for a planting site.
This caused the page rendering to bomb out and return a partial page.

Show the enum's name instead.