### PR TITLE
SW-4934 Define read endpoints for deliverables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -1,0 +1,206 @@
+package com.terraformation.backend.accelerator.api
+
+import com.terraformation.backend.api.AcceleratorEndpoint
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.DocumentStore
+import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.headers.Header
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import java.net.URI
+import java.time.Instant
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@AcceleratorEndpoint
+@RequestMapping("/api/v1/accelerator/deliverables")
+@RestController
+class DeliverablesController {
+  @ApiResponse200
+  @GetMapping
+  @Operation(
+      summary = "Lists the deliverables for accelerator projects",
+      description =
+          "The list may optionally be filtered based on certain criteria as specified in the " +
+              "query string. If no filter parameters are supplied, lists all the deliverables " +
+              "in all the participants and projects that are visible to the user. For users with " +
+              "accelerator admin privileges, this will be the full list of all deliverables for " +
+              "all accelerator projects.")
+  fun listDeliverables(
+      @Parameter(
+          description =
+              "List deliverables for projects belonging to this organization. Ignored if " +
+                  "participantId or projectId is specified.")
+      organizationId: OrganizationId? = null,
+      @Parameter(
+          description =
+              "List deliverables for all projects in this participant. Ignored if projectId is " +
+                  "specified.")
+      participantId: ParticipantId? = null,
+      @Parameter(description = "List deliverables for this project only.")
+      projectId: ProjectId? = null,
+  ): ListDeliverablesResponsePayload {
+    return ListDeliverablesResponsePayload(
+        listOf(
+            ListDeliverablesElement(
+                category = DeliverableCategory.LegalEligibility,
+                descriptionHtml = "<p>A description</p>",
+                id = DeliverableId(1),
+                name = "Incorporation Documents",
+                numDocuments = 2,
+                organizationId = OrganizationId(1),
+                organizationName = "Test Org",
+                participantId = ParticipantId(2),
+                participantName = "Random Participant",
+                projectId = ProjectId(3),
+                projectName = "Omega Project",
+                status = SubmissionStatus.Rejected,
+                type = DeliverableType.Document,
+            ),
+            ListDeliverablesElement(
+                category = DeliverableCategory.FinancialViability,
+                descriptionHtml = "<p>All about money!</p>",
+                id = DeliverableId(1),
+                name = "Budget",
+                numDocuments = 0,
+                organizationId = OrganizationId(1),
+                organizationName = "Test Org",
+                participantId = ParticipantId(2),
+                participantName = "Random Participant",
+                projectId = ProjectId(3),
+                projectName = "Omega Project",
+                status = SubmissionStatus.NotSubmitted,
+                type = DeliverableType.Document,
+            ),
+        ))
+  }
+
+  @ApiResponse200
+  @ApiResponse404
+  @GetMapping("/{deliverableId}")
+  @Operation(
+      summary = "Gets the details of a single deliverable and its submission documents, if any.")
+  fun getDeliverable(@PathVariable deliverableId: DeliverableId): GetDeliverableResponsePayload {
+    return GetDeliverableResponsePayload(
+        DeliverablePayload(
+            category = DeliverableCategory.LegalEligibility,
+            descriptionHtml = "<p>A description</p>",
+            documents =
+                listOf(
+                    SubmissionDocumentPayload(
+                        Instant.now(),
+                        "Project's articles of incorporation",
+                        DocumentStore.Google,
+                        SubmissionDocumentId(13974),
+                        "Incorporation Documents_2024-02-28_Omega_Projects articles of incorporation.doc",
+                    )),
+            feedback = "Is this a joke? This is a bunch of cat photos, not a legal document.",
+            id = deliverableId,
+            internalComment = "These guys are real jokers.",
+            name = "Incorporation Documents",
+            organizationId = OrganizationId(1),
+            organizationName = "Test Org",
+            participantId = ParticipantId(2),
+            participantName = "Random Participant",
+            projectId = ProjectId(3),
+            projectName = "Omega Project",
+            status = SubmissionStatus.Rejected,
+            type = DeliverableType.Document,
+        ))
+  }
+
+  @ApiResponse(
+      responseCode = "307",
+      description =
+          "If the current user has permission to view the document, redirects to the document " +
+              "on the document store. Depending on the document store, the redirect URL may or " +
+              "may not be valid for only a limited time.",
+      headers = [Header(name = "Location", description = "URL of document in document store.")])
+  @ApiResponse404
+  @GetMapping("/{deliverableId}/documents/{documentId}")
+  @Operation(summary = "Gets a single submission document from a deliverable.")
+  fun getDeliverableDocument(
+      @PathVariable deliverableId: DeliverableId,
+      @PathVariable documentId: SubmissionDocumentId
+  ): ResponseEntity<String> {
+    val url = URI("https://dropbox.com/")
+
+    return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT).location(url).build()
+  }
+}
+
+data class ListDeliverablesElement(
+    val category: DeliverableCategory,
+    @Schema(description = "Optional description of the deliverable in HTML form.")
+    val descriptionHtml: String?,
+    val id: DeliverableId,
+    val name: String,
+    @Schema(
+        description =
+            "Number of documents submitted for this deliverable. Only valid for deliverables of " +
+                "type Document.")
+    val numDocuments: Int?,
+    val organizationId: OrganizationId,
+    val organizationName: String,
+    val participantId: ParticipantId,
+    val participantName: String,
+    val projectId: ProjectId,
+    val projectName: String,
+    val status: SubmissionStatus,
+    val type: DeliverableType,
+)
+
+data class SubmissionDocumentPayload(
+    val createdTime: Instant,
+    val description: String,
+    val documentStore: DocumentStore,
+    val id: SubmissionDocumentId,
+    val name: String,
+)
+
+data class DeliverablePayload(
+    val category: DeliverableCategory,
+    @Schema(description = "Optional description of the deliverable in HTML form.")
+    val descriptionHtml: String?,
+    val documents: List<SubmissionDocumentPayload>,
+    @Schema(
+        description =
+            "If the deliverable has been reviewed, the user-visible feedback from the review.")
+    val feedback: String?,
+    val id: DeliverableId,
+    @Schema(
+        description =
+            "Internal-only comment on the submission. Only present if the current user has accelerator admin privileges.")
+    val internalComment: String?,
+    val name: String,
+    val organizationId: OrganizationId,
+    val organizationName: String,
+    val participantId: ParticipantId,
+    val participantName: String,
+    val projectId: ProjectId,
+    val projectName: String,
+    val status: SubmissionStatus,
+    val type: DeliverableType,
+)
+
+data class GetDeliverableResponsePayload(
+    val deliverable: DeliverablePayload,
+) : SuccessResponsePayload
+
+data class ListDeliverablesResponsePayload(val deliverables: List<ListDeliverablesElement>) :
+    SuccessResponsePayload

--- a/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/OpenApiAnnotationTest.kt
@@ -48,7 +48,7 @@ class OpenApiAnnotationTest {
             .toList()
 
     assertTrue(
-        responseCodes.isEmpty() || responseCodes.any { it in 200..299 },
+        responseCodes.isEmpty() || responseCodes.any { it in 200..399 },
         "No response declared for HTTP 2xx response code on $name")
   }
 


### PR DESCRIPTION
To allow clients to start coding against the API, define the endpoints for listing
and fetching deliverable data.

Currently, these endpoints all return dummy responses.