### PR TITLE
Minor deliverable data model changes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -72,7 +72,7 @@ class DeliverablesController {
     return ListDeliverablesResponsePayload(
         listOf(
             ListDeliverablesElement(
-                category = DeliverableCategory.LegalEligibility,
+                category = DeliverableCategory.Compliance,
                 descriptionHtml = "<p>A description</p>",
                 id = DeliverableId(1),
                 name = "Incorporation Documents",
@@ -112,16 +112,18 @@ class DeliverablesController {
   fun getDeliverable(@PathVariable deliverableId: DeliverableId): GetDeliverableResponsePayload {
     return GetDeliverableResponsePayload(
         DeliverablePayload(
-            category = DeliverableCategory.LegalEligibility,
+            category = DeliverableCategory.Compliance,
             descriptionHtml = "<p>A description</p>",
             documents =
                 listOf(
                     SubmissionDocumentPayload(
-                        Instant.now(),
-                        "Project's articles of incorporation",
-                        DocumentStore.Google,
-                        SubmissionDocumentId(13974),
-                        "Incorporation Documents_2024-02-28_Omega_Projects articles of incorporation.doc",
+                        createdTime = Instant.now(),
+                        description = "Project's articles of incorporation",
+                        documentStore = DocumentStore.Google,
+                        id = SubmissionDocumentId(13974),
+                        name =
+                            "Incorporation Documents_2024-02-28_Omega_Projects articles of incorporation.doc",
+                        originalName = "corp.doc",
                     )),
             feedback = "Is this a joke? This is a bunch of cat photos, not a legal document.",
             id = deliverableId,
@@ -211,6 +213,7 @@ data class SubmissionDocumentPayload(
     val documentStore: DocumentStore,
     val id: SubmissionDocumentId,
     val name: String,
+    val originalName: String?,
 )
 
 data class DeliverablePayload(

--- a/src/main/resources/db/migration/0200/V247__DeliverableTweaks.sql
+++ b/src/main/resources/db/migration/0200/V247__DeliverableTweaks.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accelerator.deliverables DROP COLUMN subtitle;
+
+ALTER TABLE accelerator.deliverable_documents ADD PRIMARY KEY (deliverable_id);
+
+ALTER TABLE accelerator.submission_documents ADD COLUMN original_name TEXT;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -463,8 +463,9 @@ COMMENT ON TABLE accelerator.modules IS 'Possible steps in the workflow of a coh
 COMMENT ON TABLE accelerator.participants IS 'Accelerator participant details.';
 
 COMMENT ON TABLE accelerator.submission_documents IS 'Information about documents uploaded by users to satisfy deliverables. A deliverable can have multiple documents.';
-COMMENT ON COLUMN accelerator.submission_documents.name IS 'System-generated filename. This includes several elements such as the date and description.';
+COMMENT ON COLUMN accelerator.submission_documents.name IS 'System-generated filename. The file is stored using this name in the document store. This includes several elements such as the date and description.';
 COMMENT ON COLUMN accelerator.submission_documents.location IS 'Location of file in the document store identified by `document_store_id`. This is used by the system to generate download links and includes whatever information is needed to generate a link for a given document store; if the document store supports permalinks then this may be a simple URL.';
+COMMENT ON COLUMN accelerator.submission_documents.original_name IS 'Original filename as supplied by the client when the document was uploaded. Not required to be unique since the user can upload revised versions of documents.';
 
 COMMENT ON TABLE accelerator.submission_statuses IS '(Enum) Statuses of submissions of deliverables by specific projects.';
 

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -66,13 +66,13 @@ VALUES (1, 'Web'),
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO accelerator.deliverable_categories (id, name)
-VALUES (1, 'Legal Eligibility'),
+VALUES (1, 'Compliance'),
        (2, 'Financial Viability'),
        (3, 'GIS'),
        (4, 'Carbon Eligibility'),
-       (5, 'Stakeholders and Co-Benefits'),
+       (5, 'Stakeholders and Community Impact'),
        (6, 'Proposed Restoration Activities'),
-       (7, 'Media'),
+       (7, 'Verra Non-Permanence Risk Tool (NPRT)'),
        (8, 'Supplemental Files')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -3,15 +3,16 @@ accelerator.CohortPhase.Phase1FeasibilityStudy=Phase 1 - Feasibility Study
 accelerator.CohortPhase.Phase2PlanAndScale=Phase 2 - Plan and Scale
 accelerator.CohortPhase.Phase3ImplementAndMonitor=Phase 3 - Implement and Monitor
 accelerator.DeliverableCategory.CarbonEligibility=Carbon Eligibility
+# As in compliance with legal requirements
+accelerator.DeliverableCategory.Compliance=Compliance
 accelerator.DeliverableCategory.FinancialViability=Financial Viability
 # Geographic Information System (maps, etc.)
 accelerator.DeliverableCategory.GIS=GIS
-accelerator.DeliverableCategory.LegalEligibility=Legal Eligibility
-# "Media" as in photos, videos, and audio recordings.
-accelerator.DeliverableCategory.Media=Media
 accelerator.DeliverableCategory.ProposedRestorationActivities=Proposed Restoration Activities
-accelerator.DeliverableCategory.StakeholdersAndCoBenefits=Stakeholders and Co-Benefits
+accelerator.DeliverableCategory.StakeholdersAndCommunityImpact=Stakeholders and Community Impact
 accelerator.DeliverableCategory.SupplementalFiles=Supplemental Files
+# "Verra" and the "NPRT" acronym should not be translated.
+accelerator.DeliverableCategory.VerraNonPermanenceRiskToolNPRT=Verra Non-Permanence Risk Tool (NPRT)
 # Noun, as in a legal document
 accelerator.DeliverableType.Document=Document
 accelerator.SubmissionStatus.Approved=Approved


### PR DESCRIPTION
Update the data model based on requirements changes/clarifications:

- Deliverables no longer have subtitles.
- We need to store the original filenames of submission documents.
- The initial list of deliverable categories was a placeholder; use the list
  that will be used in the deliverables spreadsheet.

Also add a missing primary key constraint to `deliverable_documents`.