### PR TITLE
SW-4937 Module and deliverable management permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -177,7 +177,9 @@ data class DeviceManagerUser(
   override fun canListNotifications(organizationId: OrganizationId?): Boolean = false
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = false
   override fun canListReports(organizationId: OrganizationId): Boolean = false
+  override fun canManageDeliverables(): Boolean = false
   override fun canManageInternalTags(): Boolean = false
+  override fun canManageModules(): Boolean = false
   override fun canManageNotifications(): Boolean = false
   override fun canManageObservation(observationId: ObservationId): Boolean = false
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -281,7 +281,11 @@ data class IndividualUser(
 
   override fun canListReports(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
+  override fun canManageDeliverables() = isAcceleratorAdmin()
+
   override fun canManageInternalTags() = isSuperAdmin()
+
+  override fun canManageModules() = isAcceleratorAdmin()
 
   override fun canManageNotifications() = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -437,9 +437,21 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun manageDeliverables() {
+    if (!user.canManageDeliverables()) {
+      throw AccessDeniedException("No permission to manage deliverables")
+    }
+  }
+
   fun manageInternalTags() {
     if (!user.canManageInternalTags()) {
       throw AccessDeniedException("No permission to manage internal tags")
+    }
+  }
+
+  fun manageModules() {
+    if (!user.canManageModules()) {
+      throw AccessDeniedException("No permission to manage modules")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -179,7 +179,9 @@ class SystemUser(
   override fun canListNotifications(organizationId: OrganizationId?): Boolean = true
   override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
   override fun canListReports(organizationId: OrganizationId): Boolean = true
+  override fun canManageDeliverables(): Boolean = false
   override fun canManageInternalTags(): Boolean = false
+  override fun canManageModules(): Boolean = false
   override fun canManageNotifications(): Boolean = true
   override fun canManageObservation(observationId: ObservationId): Boolean = true
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -134,7 +134,9 @@ interface TerrawareUser : Principal {
   fun canListNotifications(organizationId: OrganizationId?): Boolean
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
   fun canListReports(organizationId: OrganizationId): Boolean
+  fun canManageDeliverables(): Boolean
   fun canManageInternalTags(): Boolean
+  fun canManageModules(): Boolean
   fun canManageNotifications(): Boolean
   fun canManageObservation(observationId: ObservationId): Boolean
   fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -465,6 +465,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun listReports() =
       allow { listReports(organizationId) } ifUser { canListReports(organizationId) }
 
+  @Test fun manageDeliverables() = allow { manageDeliverables() } ifUser { canManageDeliverables() }
+
+  @Test fun manageModules() = allow { manageModules() } ifUser { canManageModules() }
+
   @Test
   fun manageObservation() =
       allow { manageObservation(observationId) } ifUser { canManageObservation(observationId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1255,7 +1255,9 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipantProject = true,
         deleteSelf = true,
         importGlobalSpeciesData = true,
+        manageDeliverables = true,
         manageInternalTags = true,
+        manageModules = true,
         readInternalTags = true,
         readCohort = true,
         readParticipant = true,
@@ -1310,7 +1312,9 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipantProject = true,
         deleteSelf = true,
         importGlobalSpeciesData = false,
+        manageDeliverables = true,
         manageInternalTags = false,
+        manageModules = true,
         readInternalTags = true,
         readCohort = true,
         readParticipant = true,
@@ -1847,7 +1851,9 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipantProject: Boolean = false,
         deleteSelf: Boolean = false,
         importGlobalSpeciesData: Boolean = false,
+        manageDeliverables: Boolean = false,
         manageInternalTags: Boolean = false,
+        manageModules: Boolean = false,
         manageNotifications: Boolean = false,
         readCohort: Boolean = false,
         readInternalTags: Boolean = false,
@@ -1889,7 +1895,9 @@ internal class PermissionTest : DatabaseTest() {
           importGlobalSpeciesData,
           user.canImportGlobalSpeciesData(),
           "Can import global species data")
+      assertEquals(manageDeliverables, user.canManageDeliverables(), "Can manage deliverables")
       assertEquals(manageInternalTags, user.canManageInternalTags(), "Can manage internal tags")
+      assertEquals(manageModules, user.canManageModules(), "Can manage modules")
       assertEquals(manageNotifications, user.canManageNotifications(), "Can manage notifications")
       assertEquals(readCohort, user.canReadCohort(cohortId), "Can read cohort")
       assertEquals(readInternalTags, user.canReadInternalTags(), "Can read internal tags")


### PR DESCRIPTION
Add permissions for managing the list of modules and the list of deliverables.
Both of them require either the Accelerator Admin or the Super-Admin global role.