### PR TITLE
SW-4937 Upload modules and deliverables CSVs in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
@@ -1,0 +1,184 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.ModuleId
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_DOCUMENTS
+import com.terraformation.backend.db.accelerator.tables.references.MODULES
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.importer.CsvImportFailedException
+import com.terraformation.backend.importer.processCsvFile
+import jakarta.inject.Named
+import java.io.InputStream
+import java.net.URI
+import java.time.InstantSource
+import org.jooq.DSLContext
+
+/** Imports the list of deliverables from a CSV file. */
+@Named
+class DeliverablesImporter(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  companion object {
+    private const val COLUMN_NAME = 0
+    private const val COLUMN_ID = COLUMN_NAME + 1
+    private const val COLUMN_DESCRIPTION = COLUMN_ID + 1
+    private const val COLUMN_TEMPLATE = COLUMN_DESCRIPTION + 1
+    private const val COLUMN_MODULE_ID = COLUMN_TEMPLATE + 1
+    private const val COLUMN_CATEGORY = COLUMN_MODULE_ID + 1
+    private const val COLUMN_SENSITIVE = COLUMN_CATEGORY + 1
+    private const val COLUMN_REQUIRED = COLUMN_SENSITIVE + 1
+    private const val NUM_COLUMNS = COLUMN_REQUIRED + 1
+
+    /** Values we treat as true in boolean columns. */
+    private val trueValues = setOf("y", "yes", "true", "t")
+
+    private val deliverableCategoriesByName =
+        DeliverableCategory.entries.associateBy { it.jsonValue.lowercase() }
+    private val validDeliverableCategories =
+        DeliverableCategory.entries.map { it.jsonValue }.sorted()
+  }
+
+  fun importDeliverables(inputStream: InputStream) {
+    requirePermissions { manageDeliverables() }
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    val validModuleIds =
+        dslContext.select(MODULES.ID).from(MODULES).fetchSet(MODULES.ID.asNonNullable())
+
+    dslContext.transaction { _ ->
+      // Flip the signs on the positions of all the existing deliverables so they don't conflict
+      // with the new positions if we, e.g., swap the order of two deliverables. Needed because
+      // positions are required to be unique for a given deliverable and we'd hit a unique
+      // constraint violation on whichever row we tried to update first if we were swapping
+      // positions.
+      //
+      // This is also used to detect deliverables that were deleted from the spreadsheet.
+      dslContext
+          .update(DELIVERABLES)
+          .set(DELIVERABLES.POSITION, DELIVERABLES.POSITION.neg())
+          .execute()
+
+      processCsvFile(inputStream) { values, rowNumber, addError ->
+        if (values.size != NUM_COLUMNS) {
+          addError("Expected $NUM_COLUMNS columns but found ${values.size}")
+          return@processCsvFile
+        }
+
+        val deliverableId = values[COLUMN_ID]?.toLongOrNull()?.let { DeliverableId(it) }
+        val moduleId = values[COLUMN_MODULE_ID]?.toLongOrNull()?.let { ModuleId(it) }
+        val category = values[COLUMN_CATEGORY]?.lowercase()?.let { deliverableCategoriesByName[it] }
+        val name = values[COLUMN_NAME]
+        val isRequired = values[COLUMN_REQUIRED]?.lowercase() in trueValues
+        val isSensitive = values[COLUMN_SENSITIVE]?.lowercase() in trueValues
+        val templateUrl =
+            values[COLUMN_TEMPLATE]?.let {
+              try {
+                URI.create(it)
+              } catch (e: Exception) {
+                addError("Invalid template URL $it")
+                null
+              }
+            }
+
+        if (deliverableId == null || deliverableId.value <= 0) {
+          if (values[COLUMN_ID] != null) {
+            addError("Deliverable ID \"${values[COLUMN_ID]}\" invalid")
+          } else {
+            addError("Missing deliverable ID")
+          }
+        }
+        if (moduleId == null || moduleId.value <= 0) {
+          if (values[COLUMN_MODULE_ID] != null) {
+            addError("Module ID \"${values[COLUMN_MODULE_ID]}\" invalid")
+          } else {
+            addError("Missing module ID.")
+          }
+        } else if (moduleId !in validModuleIds) {
+          addError(
+              "Unknown module ID $moduleId; if this is a new module, upload the revised module " +
+                  "list first and try again")
+        }
+        if (category == null) {
+          if (values[COLUMN_CATEGORY] != null) {
+            addError(
+                "Category \"${values[COLUMN_CATEGORY]}\" invalid. Valid categories: $validDeliverableCategories")
+          } else {
+            addError("Missing category.")
+          }
+        }
+        if (name == null) {
+          addError("Missing deliverable name")
+        }
+
+        if (deliverableId != null &&
+            moduleId != null &&
+            moduleId in validModuleIds &&
+            category != null &&
+            name != null) {
+          with(DELIVERABLES) {
+            dslContext
+                .insertInto(DELIVERABLES)
+                .set(ID, deliverableId)
+                .set(DELIVERABLE_CATEGORY_ID, category)
+                .set(DELIVERABLE_TYPE_ID, DeliverableType.Document)
+                .set(MODULE_ID, moduleId)
+                .set(POSITION, rowNumber)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .set(NAME, name)
+                .set(IS_SENSITIVE, isSensitive)
+                .set(IS_REQUIRED, isRequired)
+                .set(DESCRIPTION_HTML, values[COLUMN_DESCRIPTION])
+                .onConflict()
+                .doUpdate()
+                .set(DELIVERABLE_CATEGORY_ID, category)
+                .set(MODULE_ID, moduleId)
+                .set(POSITION, rowNumber)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .set(NAME, name)
+                .set(IS_SENSITIVE, isSensitive)
+                .set(IS_REQUIRED, isRequired)
+                .set(DESCRIPTION_HTML, values[COLUMN_DESCRIPTION])
+                .execute()
+          }
+
+          with(DELIVERABLE_DOCUMENTS) {
+            dslContext
+                .insertInto(DELIVERABLE_DOCUMENTS)
+                .set(DELIVERABLE_ID, deliverableId)
+                .set(DELIVERABLE_TYPE_ID, DeliverableType.Document)
+                .set(TEMPLATE_URL, templateUrl)
+                .onConflict()
+                .doUpdate()
+                .set(TEMPLATE_URL, templateUrl)
+                .execute()
+          }
+        }
+      }
+
+      val leftOverNegativePositions =
+          dslContext
+              .select(DELIVERABLES.ID)
+              .from(DELIVERABLES)
+              .where(DELIVERABLES.POSITION.lt(0))
+              .fetch(DELIVERABLES.ID)
+
+      if (leftOverNegativePositions.isNotEmpty()) {
+        throw CsvImportFailedException(
+            emptyList(),
+            "Deleting deliverables isn't supported yet. Missing IDs: $leftOverNegativePositions")
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
@@ -1,0 +1,69 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.ModuleId
+import com.terraformation.backend.db.accelerator.tables.references.MODULES
+import com.terraformation.backend.importer.processCsvFile
+import jakarta.inject.Named
+import java.io.InputStream
+import java.time.InstantSource
+import org.jooq.DSLContext
+
+/** Imports the list of modules from a CSV file. */
+@Named
+class ModulesImporter(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  companion object {
+    private const val COLUMN_NAME = 0
+    private const val COLUMN_ID = COLUMN_NAME + 1
+    private const val NUM_COLUMNS = COLUMN_ID + 1
+  }
+
+  fun importModules(inputStream: InputStream) {
+    requirePermissions { manageModules() }
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    dslContext.transaction { _ ->
+      processCsvFile(inputStream) { values, _, addError ->
+        if (values.size != NUM_COLUMNS) {
+          addError("Expected $NUM_COLUMNS columns but found ${values.size}")
+          return@processCsvFile
+        }
+
+        val moduleId = values[COLUMN_ID]?.toLongOrNull()?.let { ModuleId(it) }
+        val name = values[COLUMN_NAME]
+
+        if (moduleId == null) {
+          addError("Missing or invalid module ID")
+        }
+        if (name == null) {
+          addError("Missing module name")
+        }
+
+        if (moduleId != null && name != null) {
+          with(MODULES) {
+            dslContext
+                .insertInto(MODULES)
+                .set(ID, moduleId)
+                .set(NAME, name)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .onConflict()
+                .doUpdate()
+                .set(NAME, name)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .execute()
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -38,6 +38,9 @@ class AdminController(
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
     model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
+    model.addAttribute(
+        "canManageModules",
+        currentUser().canManageModules() || currentUser().canManageDeliverables())
     model.addAttribute("canManageInternalTags", currentUser().canManageInternalTags())
     model.addAttribute("canManageParticipants", currentUser().canCreateParticipant())
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminModulesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminModulesController.kt
@@ -1,0 +1,85 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.accelerator.db.DeliverablesImporter
+import com.terraformation.backend.accelerator.db.ModulesImporter
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.accelerator.tables.references.MODULES
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.importer.CsvImportFailedException
+import com.terraformation.backend.log.perClassLogger
+import org.jooq.DSLContext
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin])
+@Validated
+class AdminModulesController(
+    private val deliverablesImporter: DeliverablesImporter,
+    private val dslContext: DSLContext,
+    private val modulesImporter: ModulesImporter,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/modules")
+  fun modulesHome(model: Model): String {
+    val hasModules = dslContext.fetchExists(MODULES)
+
+    model.addAttribute("canManageDeliverables", currentUser().canManageDeliverables())
+    model.addAttribute("canManageModules", currentUser().canManageModules())
+    model.addAttribute("hasModules", hasModules)
+
+    return "/admin/modules"
+  }
+
+  @PostMapping("/uploadDeliverables")
+  fun uploadDeliverables(
+      @RequestPart file: MultipartFile,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      file.inputStream.use { inputStream -> deliverablesImporter.importDeliverables(inputStream) }
+
+      redirectAttributes.successMessage = "Deliverables imported successfully."
+    } catch (e: CsvImportFailedException) {
+      redirectAttributes.failureMessage = e.message
+      redirectAttributes.failureDetails = e.errors.map { "Row ${it.rowNumber}: ${it.message}" }
+    } catch (e: Exception) {
+      log.warn("Deliverables import failed", e)
+      redirectAttributes.failureMessage = "Import failed: ${e.message}"
+    }
+
+    return redirectToModulesHome()
+  }
+
+  @PostMapping("/uploadModules")
+  fun uploadModules(
+      @RequestPart file: MultipartFile,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      file.inputStream.use { inputStream -> modulesImporter.importModules(inputStream) }
+
+      redirectAttributes.successMessage = "Modules imported successfully."
+    } catch (e: CsvImportFailedException) {
+      redirectAttributes.failureMessage = e.message
+      redirectAttributes.failureDetails = e.errors.map { "Row ${it.rowNumber}: ${it.message}" }
+    } catch (e: Exception) {
+      log.warn("Modules import failed", e)
+      redirectAttributes.failureMessage = "Import failed: ${e.message}"
+    }
+
+    return redirectToModulesHome()
+  }
+
+  private fun redirectToModulesHome() = "redirect:/admin/modules"
+}

--- a/src/main/kotlin/com/terraformation/backend/importer/ProcessCsvFile.kt
+++ b/src/main/kotlin/com/terraformation/backend/importer/ProcessCsvFile.kt
@@ -1,0 +1,70 @@
+package com.terraformation.backend.importer
+
+import com.opencsv.CSVReader
+import java.io.InputStream
+import java.io.InputStreamReader
+
+/**
+ * Synchronously processes a CSV file. Typically this will be for admin functions where it's okay
+ * for an upload request to take an arbitrary amount of time to finish. For CSV uploads from end
+ * users, use [CsvImporter].
+ *
+ * @param maxErrors Abort processing after this many errors have been added. This should be high
+ *   enough that users won't feel like they have to keep retrying the file after fixing each problem
+ *   but low enough that a file where every row has a problem won't result in a uselessly huge list
+ *   of errors.
+ * @throws CsvImportFailedException Errors were reported during processing of the file.
+ */
+fun processCsvFile(
+    inputStream: InputStream,
+    skipHeaderRow: Boolean = true,
+    exceptionMessage: String = "CSV processing failed",
+    maxErrors: Int = 50,
+    importRow: ImportCsvRow,
+) {
+  val errors = mutableListOf<CsvImportError>()
+  var rowNumber = 0
+
+  val csvReader = CSVReader(InputStreamReader(inputStream))
+
+  if (skipHeaderRow) {
+    if (csvReader.readNext() == null) {
+      throw CsvImportFailedException(
+          listOf(CsvImportError(0, "No data found in file")), exceptionMessage)
+    }
+
+    rowNumber++
+  }
+
+  csvReader.forEach { rawValues ->
+    val values = rawValues.map { it?.trim()?.ifBlank { null } }
+
+    rowNumber++
+
+    importRow.importRow(values, rowNumber) { message ->
+      errors.add(CsvImportError(rowNumber, message))
+      if (errors.size >= maxErrors) {
+        throw CsvImportFailedException(errors, exceptionMessage)
+      }
+    }
+  }
+
+  if (errors.isNotEmpty()) {
+    throw CsvImportFailedException(errors, exceptionMessage)
+  }
+}
+
+fun interface ImportCsvRow {
+  /**
+   * Imports a row from the CSV file. This is the callback function for [processCsvFile].
+   *
+   * @param values Trimmed values of the columns. Blank values are null.
+   * @param addError Callback to add an error to the list of errors.
+   */
+  fun importRow(values: List<String?>, rowNumber: Int, addError: (String) -> Unit)
+}
+
+data class CsvImportError(val rowNumber: Int, val message: String)
+
+class CsvImportFailedException(val errors: List<CsvImportError>, message: String) :
+    RuntimeException(message)

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -115,5 +115,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canManageModules}">
+    <h2>Modules and Deliverables</h2>
+
+    <p>
+        <a href="/admin/modules">Manage modules and deliverables</a>
+    </p>
+</th:block>
+
 </body>
 </html>

--- a/src/main/resources/templates/admin/modules.html
+++ b/src/main/resources/templates/admin/modules.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<th:block th:if="${canManageModules}">
+    <h2>Modules</h2>
+
+    <form method="POST" action="/admin/uploadModules" enctype="multipart/form-data">
+        <label>
+            Modules Spreadsheet (CSV)
+            <input type="file" name="file" required/>
+        </label>
+        <input type="submit"/>
+    </form>
+</th:block>
+
+<th:block th:if="${canManageDeliverables}">
+    <h2>Deliverables</h2>
+
+    <th:block th:if="${hasModules}">
+        <form method="POST" action="/admin/uploadDeliverables" enctype="multipart/form-data">
+            <label>
+                Deliverables Spreadsheet (CSV)
+                <input type="file" name="file" required/>
+            </label>
+            <input type="submit"/>
+        </form>
+    </th:block>
+
+    <p th:if="!${hasModules}">
+        No modules defined! Upload a modules list to enable uploading deliverables.
+    </p>
+</th:block>
+
+</body>
+</html>


### PR DESCRIPTION
Add a page to the admin UI to allow admins (Accelerator Admin and Super-Admin)
to upload the spreadsheets that define the lists of modules and deliverables.