### PR TITLE
SW-4958 Add per-project document storage settings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -354,6 +354,8 @@ data class DeviceManagerUser(
 
   override fun canUpdateProject(projectId: ProjectId): Boolean = false
 
+  override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
+
   override fun canUpdateReport(reportId: ReportId): Boolean = false
 
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -482,6 +482,8 @@ data class IndividualUser(
   override fun canUpdateProject(projectId: ProjectId) =
       isAdminOrHigher(parentStore.getOrganizationId(projectId))
 
+  override fun canUpdateProjectDocumentSettings(projectId: ProjectId) = isAcceleratorAdmin()
+
   override fun canUpdateReport(reportId: ReportId) =
       isAdminOrHigher(parentStore.getOrganizationId(reportId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -872,6 +872,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateProjectDocumentSettings(projectId: ProjectId) {
+    if (!user.canUpdateProjectDocumentSettings(projectId)) {
+      readProject(projectId)
+      throw AccessDeniedException("No permission to update project document settings $projectId")
+    }
+  }
+
   fun updateReport(reportId: ReportId) {
     if (!user.canUpdateReport(reportId)) {
       readReport(reportId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -364,6 +364,8 @@ class SystemUser(
 
   override fun canUpdateProject(projectId: ProjectId): Boolean = true
 
+  override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
+
   override fun canUpdateReport(reportId: ReportId): Boolean = true
 
   override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -315,6 +315,8 @@ interface TerrawareUser : Principal {
 
   fun canUpdateProject(projectId: ProjectId): Boolean
 
+  fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean
+
   fun canUpdateReport(reportId: ReportId): Boolean
 
   fun canUpdateSpecies(speciesId: SpeciesId): Boolean

--- a/src/main/resources/db/migration/0200/V248__ProjectDocumentSettings.sql
+++ b/src/main/resources/db/migration/0200/V248__ProjectDocumentSettings.sql
@@ -1,0 +1,6 @@
+CREATE TABLE accelerator.project_document_settings (
+    project_id BIGINT PRIMARY KEY REFERENCES projects ON DELETE CASCADE,
+    file_naming TEXT NOT NULL,
+    google_folder_url TEXT NOT NULL,
+    dropbox_folder_path TEXT NOT NULL
+);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -462,6 +462,9 @@ COMMENT ON TABLE accelerator.modules IS 'Possible steps in the workflow of a coh
 
 COMMENT ON TABLE accelerator.participants IS 'Accelerator participant details.';
 
+COMMENT ON TABLE accelerator.project_document_settings IS 'Per-project configuration for storage of submitted documents.';
+COMMENT ON COLUMN accelerator.project_document_settings.file_naming IS 'Identifier that is included in generated filenames. This is often, but not necessarily, the same as the project name.';
+
 COMMENT ON TABLE accelerator.submission_documents IS 'Information about documents uploaded by users to satisfy deliverables. A deliverable can have multiple documents.';
 COMMENT ON COLUMN accelerator.submission_documents.name IS 'System-generated filename. The file is stored using this name in the document store. This includes several elements such as the date and description.';
 COMMENT ON COLUMN accelerator.submission_documents.location IS 'Location of file in the document store identified by `document_store_id`. This is used by the system to generate download links and includes whatever information is needed to generate a link for a given document store; if the document store supports permalinks then this may be a simple URL.';

--- a/src/main/resources/templates/admin/participant.html
+++ b/src/main/resources/templates/admin/participant.html
@@ -49,6 +49,9 @@
             <th>ID</th>
             <th>Organization</th>
             <th>Name</th>
+            <th>File Naming</th>
+            <th>Google Folder URL</th>
+            <th>Dropbox Folder Path</th>
             <th></th>
         </tr>
         </thead>
@@ -59,9 +62,40 @@
             <td th:text="${organizationsById[project.organizationId].name}">My Org</td>
             <td th:text="${project.name}">My Project</td>
             <td>
+                <input type="text"
+                       name="fileNaming"
+                       required
+                       th:form="|updateProject-${project.id}|"
+                       th:value="${projectDocumentSettings[project.id]?.fileNaming}"/>
+            </td>
+            <td>
+                <input type="url"
+                       name="googleFolderUrl"
+                       required
+                       th:form="|updateProject-${project.id}|"
+                       th:value="${projectDocumentSettings[project.id]?.googleFolderUrl}"/>
+            </td>
+            <td>
+                <input type="text"
+                       name="dropboxFolderPath"
+                       required
+                       th:form="|updateProject-${project.id}|"
+                       th:value="${projectDocumentSettings[project.id]?.dropboxFolderPath}"/>
+            </td>
+            <td>
+                <form th:if="${canUpdateParticipant}"
+                      th:id="|updateProject-${project.id}|"
+                      action="/admin/updateProjectDocumentSettings"
+                      method="POST"
+                      style="display: inline">
+                    <input type="hidden" name="participantId" th:value="${participant.id}"/>
+                    <input type="hidden" name="projectId" th:value="${project.id}"/>
+                    <input type="submit" value="Update Settings"/>
+                </form>
                 <form th:if="${canUpdateParticipant}"
                       action="/admin/deleteParticipantProject"
-                      method="POST">
+                      method="POST"
+                      style="display: inline">
                     <input type="hidden" name="participantId" th:value="${participant.id}"/>
                     <input type="hidden" name="projectId" th:value="${project.id}"/>
                     <input type="submit" value="Remove"/>

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -14,12 +14,14 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNameInUseException
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.tables.pojos.ProjectDocumentSettingsRow
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
+import java.net.URI
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -48,6 +50,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadOrganization(any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canUpdateProject(any()) } returns true
+    every { user.canUpdateProjectDocumentSettings(any()) } returns true
 
     insertSiteData()
   }
@@ -312,6 +315,64 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
 
       assertThrows<AccessDeniedException> {
         store.updateParticipant(projectIdWithParticipant, null)
+      }
+    }
+  }
+
+  @Nested
+  inner class UpdateDocumentSettings {
+    @Test
+    fun `saves initial settings`() {
+      val projectId = insertProject()
+
+      val fileNaming = "naming"
+      val googleFolderUrl = URI("https://google.com/")
+      val dropboxFolderPath = "/x/y/z"
+
+      store.updateDocumentSettings(projectId, fileNaming, googleFolderUrl, dropboxFolderPath)
+
+      assertEquals(
+          listOf(
+              ProjectDocumentSettingsRow(
+                  projectId, fileNaming, googleFolderUrl, dropboxFolderPath)),
+          projectDocumentSettingsDao.findAll())
+    }
+
+    @Test
+    fun `updates existing settings`() {
+      val projectId = insertProject()
+
+      projectDocumentSettingsDao.insert(
+          ProjectDocumentSettingsRow(projectId, "old naming", URI("https://old"), "/old/path"))
+
+      val fileNaming = "naming"
+      val googleFolderUrl = URI("https://google.com/")
+      val dropboxFolderPath = "/x/y/z"
+
+      store.updateDocumentSettings(projectId, fileNaming, googleFolderUrl, dropboxFolderPath)
+
+      assertEquals(
+          listOf(
+              ProjectDocumentSettingsRow(
+                  projectId, fileNaming, googleFolderUrl, dropboxFolderPath)),
+          projectDocumentSettingsDao.findAll())
+    }
+
+    @Test
+    fun `throws exception if project does not exist`() {
+      assertThrows<ProjectNotFoundException> {
+        store.updateDocumentSettings(ProjectId(5000L), "naming", URI("file:///"), "/path")
+      }
+    }
+
+    @Test
+    fun `throws exception if no permission`() {
+      val projectId = insertProject()
+
+      every { user.canUpdateProjectDocumentSettings(projectId) } returns false
+
+      assertThrows<AccessDeniedException> {
+        store.updateDocumentSettings(projectId, "naming", URI("file:///"), "/path")
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -703,6 +703,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateProject() = allow { updateProject(projectId) } ifUser { canUpdateProject(projectId) }
 
+  @Test
+  fun updateProjectDocumentSettings() =
+      allow { updateProjectDocumentSettings(projectId) } ifUser
+          {
+            canUpdateProjectDocumentSettings(projectId)
+          }
+
   @Test fun updateReport() = allow { updateReport(reportId) } ifUser { canUpdateReport(reportId) }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1246,6 +1246,20 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *projectIds.forOrg1(),
+        deleteProject = true,
+        readProject = true,
+        updateProject = true,
+        updateProjectDocumentSettings = true,
+    )
+
+    // Not an admin of this org but can still update document settings.
+    permissions.expect(
+        ProjectId(3000),
+        updateProjectDocumentSettings = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = true,
         addCohortParticipant = true,
         addParticipantProject = true,
@@ -1300,6 +1314,20 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+    )
+
+    permissions.expect(
+        *projectIds.forOrg1(),
+        deleteProject = true,
+        readProject = true,
+        updateProject = true,
+        updateProjectDocumentSettings = true,
+    )
+
+    // Not an admin of this org but can still update document settings.
+    permissions.expect(
+        ProjectId(3000),
+        updateProjectDocumentSettings = true,
     )
 
     permissions.expect(
@@ -2156,6 +2184,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteProject: Boolean = false,
         readProject: Boolean = false,
         updateProject: Boolean = false,
+        updateProjectDocumentSettings: Boolean = false,
     ) {
       projectIds.forEach { projectId ->
         assertEquals(
@@ -2163,6 +2192,10 @@ internal class PermissionTest : DatabaseTest() {
         assertEquals(readProject, user.canReadProject(projectId), "Can read project $projectId")
         assertEquals(
             updateProject, user.canUpdateProject(projectId), "Can update project $projectId")
+        assertEquals(
+            updateProjectDocumentSettings,
+            user.canUpdateProjectDocumentSettings(projectId),
+            "Can update project $projectId document settings")
 
         uncheckedProjects.remove(projectId)
       }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.tables.daos.CohortsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantsDao
+import com.terraformation.backend.db.accelerator.tables.daos.ProjectDocumentSettingsDao
 import com.terraformation.backend.db.accelerator.tables.pojos.CohortsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantsRow
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -378,6 +379,7 @@ abstract class DatabaseTest {
   protected val plantingSubzonesDao: PlantingSubzonesDao by lazyDao()
   protected val plantingZonePopulationsDao: PlantingZonePopulationsDao by lazyDao()
   protected val plantingZonesDao: PlantingZonesDao by lazyDao()
+  protected val projectDocumentSettingsDao: ProjectDocumentSettingsDao by lazyDao()
   protected val projectReportSettingsDao: ProjectReportSettingsDao by lazyDao()
   protected val projectsDao: ProjectsDao by lazyDao()
   protected val recordedPlantsDao: RecordedPlantsDao by lazyDao()

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -137,6 +137,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "document_stores" to setOf(ALL, ACCELERATOR),
                   "modules" to setOf(ALL, ACCELERATOR),
                   "participants" to setOf(ALL, ACCELERATOR),
+                  "project_document_settings" to setOf(ALL, ACCELERATOR),
                   "submission_documents" to setOf(ALL, ACCELERATOR),
                   "submission_statuses" to setOf(ALL, ACCELERATOR),
                   "submissions" to setOf(ALL, ACCELERATOR),


### PR DESCRIPTION
When documents are uploaded for accelerator projects, they need to be stored in
project-specific locations and have a project-specific element added to their
filenames. Add a table to store those settings, and allow them to be edited from
the list of a participant's projects in the admin UI.