### PR TITLE
SW-4962 Fix document upload endpoint API to accept projectId as a path param

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -161,12 +161,13 @@ class DeliverablesController {
   }
 
   @Operation(summary = "Uploads a new document to satisfy a deliverable.")
-  @PostMapping("/{deliverableId}/documents", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+  @PostMapping(
+      "/{deliverableId}/documents/{projectId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
   @io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [Content(encoding = [Encoding(name = "file", contentType = MediaType.ALL_VALUE)])])
   fun uploadDeliverableDocument(
       @PathVariable deliverableId: DeliverableId,
-      @RequestPart(required = true) projectId: ProjectId,
+      @PathVariable projectId: ProjectId,
       @RequestPart(required = true) description: String,
       @RequestPart(required = true) file: MultipartFile
   ): UploadDeliverableDocumentResponsePayload {


### PR DESCRIPTION
- the projectId was defined as a multipart/form-data request part but it's type was ProjectId, led to unsupported MediaType errors
- fix is to either set the schema for projectId to be "int64" and convert to ProjectId inside the function
- instead moved projectId to the path as a PathParam as this is our common practice