### PR TITLE
SW-4655: Added exportable check to SearchField.

### DIFF
--- a/KEYCLOAK.md
+++ b/KEYCLOAK.md
@@ -143,7 +143,7 @@ If you're launching the server from an IDE such as IntelliJ IDEA, you can set th
 1. In the drop-down menu of run configurations in the toolbar at the top of the IntelliJ window, choose "Edit Configurations..."
 2. Select "Application" under "Spring Boot" if it's not already selected.
 3. Click the little icon at the end of the "Environment Variables" text field to pop up a dialog that shows the current set of environment variables.
-4. Add all the environment variables listed above, or set to the absolute path to `docker/.env`.
+4. Add all the environment variables listed above, or set the absolute path to `docker/.env`.
 5. Click OK on the environment variable dialog and the run configurations dialog.
 
 #### Using a profile-specific properties file for local development

--- a/src/main/kotlin/com/terraformation/backend/search/SearchExceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchExceptions.kt
@@ -5,4 +5,5 @@ import jakarta.ws.rs.core.Response
 
 /** An exception thrown when a non-exportable search field is requested for export to CSV. */
 class SearchFieldNotExportableException(fieldName: String) :
-    ClientErrorException("The search field $fieldName is not exportable", Response.Status.BAD_REQUEST)
+    ClientErrorException(
+        "The search field $fieldName is not exportable", Response.Status.BAD_REQUEST)

--- a/src/main/kotlin/com/terraformation/backend/search/SearchExceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchExceptions.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.search
+
+import jakarta.ws.rs.ClientErrorException
+import jakarta.ws.rs.core.Response
+
+/** An exception thrown when a non-exportable search field is requested for export to CSV. */
+class SearchFieldNotExportableException(fieldName: String) :
+    ClientErrorException("The search field $fieldName is not exportable", Response.Status.BAD_REQUEST)

--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -221,7 +221,7 @@ abstract class SearchTable {
       granularity: AgeField.AgeGranularity,
       clock: Clock,
       nullable: Boolean = true,
-  ) = AgeField(fieldName, databaseField, this, nullable, true, granularity, clock)
+  ) = AgeField(fieldName, databaseField, this, nullable, true, true, granularity, clock)
 
   fun bigDecimalField(
       fieldName: String,

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.api.SearchEndpoint
 import com.terraformation.backend.api.csvResponse
 import com.terraformation.backend.api.writeNext
 import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.search.SearchFieldNotExportableException
 import com.terraformation.backend.search.SearchFieldPrefix
 import com.terraformation.backend.search.SearchService
 import com.terraformation.backend.search.table.SearchTables
@@ -110,7 +111,8 @@ class SearchController(
 
     val columnNames =
         payload.getSearchFieldPaths(rootPrefix).map { fieldPath ->
-          fieldPath.searchField.getDisplayName(messages)
+          if (fieldPath.searchField.exportable) fieldPath.searchField.getDisplayName(messages)
+          else throw SearchFieldNotExportableException(fieldPath.searchField.fieldName)
         }
 
     return csvResponse(filename, columnNames) { csvWriter ->

--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -32,6 +32,7 @@ class AgeField(
     override val table: SearchTable,
     override val nullable: Boolean,
     override val localize: Boolean = true,
+    override val exportable: Boolean = true,
     private val granularity: AgeGranularity,
     private val clock: Clock,
 ) : SingleColumnSearchField<LocalDate>() {
@@ -87,7 +88,7 @@ class AgeField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      AgeField(rawFieldName(), databaseField, table, nullable, false, granularity, clock)
+      AgeField(rawFieldName(), databaseField, table, nullable, false, false, granularity, clock)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -45,16 +45,15 @@ private constructor(
   override val nullable: Boolean = original.nullable || targetPath.sublists.any { !it.isRequired }
 
   /**
-   *  True if the target field can be exported to a CSV file. Delegate to original field for
-   *  exportable check.
+   * True if the target field can be exported to a CSV file. Delegate to original field for
+   * exportable check.
    */
   override val exportable: Boolean = original.exportable
 
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null
-      AliasField(
-          rawFieldName(), SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
+      AliasField(rawFieldName(), SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -44,6 +44,12 @@ private constructor(
    */
   override val nullable: Boolean = original.nullable || targetPath.sublists.any { !it.isRequired }
 
+  /**
+   *  True if the target field can be exported to a CSV file. Delegate to original field for
+   *  exportable check.
+   */
+  override val exportable: Boolean = original.exportable
+
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -24,7 +24,7 @@ private constructor(
      * The underlying field. Other than the field name, all the properties on the alias delegate to
      * this.
      */
-    val original: SearchField
+    val original: SearchField,
 ) : SearchField by original {
   constructor(
       fieldName: String,
@@ -47,7 +47,8 @@ private constructor(
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null
-      AliasField(rawFieldName(), SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
+      AliasField(
+          rawFieldName(), SearchFieldPath(targetPath.prefix, rawOriginal), rawOriginal)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -44,12 +44,6 @@ private constructor(
    */
   override val nullable: Boolean = original.nullable || targetPath.sublists.any { !it.isRequired }
 
-  /**
-   * True if the target field can be exported to a CSV file. Delegate to original field for
-   * exportable check.
-   */
-  override val exportable: Boolean = original.exportable
-
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null

--- a/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BigDecimalField.kt
@@ -13,7 +13,10 @@ class BigDecimalField(
     databaseField: Field<BigDecimal?>,
     table: SearchTable,
     localize: Boolean = true,
-) : NumericSearchField<BigDecimal>(fieldName, databaseField, table, localize = localize) {
+    exportable: Boolean = true,
+) :
+    NumericSearchField<BigDecimal>(
+        fieldName, databaseField, table, localize = localize, exportable = exportable) {
   override fun fromString(value: String) = numberFormat.parseObject(value) as BigDecimal
 
   override fun makeNumberFormat(): NumberFormat {
@@ -25,7 +28,7 @@ class BigDecimalField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      BigDecimalField(rawFieldName(), databaseField, table, false)
+      BigDecimalField(rawFieldName(), databaseField, table, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -20,6 +20,7 @@ class BooleanField(
     override val table: SearchTable,
     override val nullable: Boolean = true,
     override val localize: Boolean = true,
+    override val exportable: Boolean = true,
 ) : SingleColumnSearchField<Boolean>() {
   private val trueStrings = ConcurrentHashMap<Locale, String>()
   private val falseStrings = ConcurrentHashMap<Locale, String>()
@@ -61,7 +62,7 @@ class BooleanField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      BooleanField(rawFieldName(), databaseField, table, nullable, false)
+      BooleanField(rawFieldName(), databaseField, table, nullable, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -12,7 +12,8 @@ class DoubleField(
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,
-) : NumericSearchField<Double>(fieldName, databaseField, table, nullable, localize) {
+    exportable: Boolean = true,
+) : NumericSearchField<Double>(fieldName, databaseField, table, nullable, localize, exportable) {
   override fun fromString(value: String) = numberFormat.parse(value).toDouble()
 
   override fun makeNumberFormat(): NumberFormat {
@@ -23,7 +24,7 @@ class DoubleField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      DoubleField(rawFieldName(), databaseField, table, nullable, false)
+      DoubleField(rawFieldName(), databaseField, table, nullable, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -27,6 +27,7 @@ class EnumField<E : Enum<E>, T : LocalizableEnum<E>>(
     private val enumClass: Class<T>,
     override val nullable: Boolean = true,
     override val localize: Boolean = true,
+    override val exportable: Boolean = true,
 ) : SingleColumnSearchField<T>() {
   private val byLocalizedDisplayName = ConcurrentHashMap<Locale, Map<String, T>>()
   private val orderByFields = ConcurrentHashMap<Locale, Field<Int>>()
@@ -85,7 +86,7 @@ class EnumField<E : Enum<E>, T : LocalizableEnum<E>>(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      EnumField(rawFieldName(), databaseField, table, enumClass, nullable, false)
+      EnumField(rawFieldName(), databaseField, table, enumClass, nullable, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -12,7 +12,8 @@ class IntegerField(
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,
-) : NumericSearchField<Int>(fieldName, databaseField, table, nullable, localize) {
+    exportable: Boolean = true,
+) : NumericSearchField<Int>(fieldName, databaseField, table, nullable, localize, exportable) {
   override fun fromString(value: String) =
       if (localize) numberFormat.parse(value).toInt() else value.toInt()
 
@@ -20,7 +21,7 @@ class IntegerField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      IntegerField(rawFieldName(), databaseField, table, nullable, false)
+      IntegerField(rawFieldName(), databaseField, table, nullable, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -26,6 +26,7 @@ class LocalizedTextField(
     override val table: SearchTable,
     override val nullable: Boolean = true,
     override val localize: Boolean = true,
+    override val exportable: Boolean = true,
 ) : SingleColumnSearchField<String>() {
   /**
    * Maps lower-case diacritic-free localized strings to their corresponding database field values.

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -12,14 +12,15 @@ class LongField(
     table: SearchTable,
     nullable: Boolean = true,
     localize: Boolean = true,
-) : NumericSearchField<Long>(fieldName, databaseField, table, nullable, localize) {
+    exportable: Boolean = true,
+) : NumericSearchField<Long>(fieldName, databaseField, table, nullable, localize, exportable) {
   override fun fromString(value: String) = numberFormat.parse(value).toLong()
 
   override fun makeNumberFormat(): NumberFormat = NumberFormat.getIntegerInstance(currentLocale())
 
   override fun raw(): SearchField? {
     return if (localize) {
-      LongField(rawFieldName(), databaseField, table, nullable, false)
+      LongField(rawFieldName(), databaseField, table, nullable, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -23,6 +23,7 @@ abstract class NumericSearchField<T : Number>(
     override val table: SearchTable,
     override val nullable: Boolean = true,
     override val localize: Boolean,
+    override val exportable: Boolean,
 ) : SingleColumnSearchField<T>() {
   companion object {
     const val MAXIMUM_FRACTION_DIGITS = 5

--- a/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
@@ -62,6 +62,10 @@ interface SearchField {
   val localize: Boolean
     get() = true
 
+  /** If true, values can be exported to CSV. */
+  val exportable: Boolean
+    get() = true
+
   /**
    * Returns a list of conditions to include in a WHERE clause when this field is used to filter
    * search results. This may vary based on the filter type.

--- a/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/WeightField.kt
@@ -34,6 +34,7 @@ class WeightField(
     private val desiredUnits: SeedQuantityUnits,
     override val table: SearchTable,
     override val localize: Boolean = true,
+    override val exportable: Boolean = true,
 ) : SearchField {
   private val formatRegex = Regex("(\\d|\\d.*\\d)\\s*(\\D*)")
   private val numberFormats = ConcurrentHashMap<Locale, NumberFormat>()
@@ -179,7 +180,8 @@ class WeightField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      WeightField(rawFieldName(), quantityField, unitsField, gramsField, desiredUnits, table, false)
+      WeightField(
+          rawFieldName(), quantityField, unitsField, gramsField, desiredUnits, table, false, false)
     } else {
       null
     }


### PR DESCRIPTION
Added an exportable variable the defaults to `true`. If a search field is converted to its raw form, it will set exportable to `false`.

If a raw search field is requested for a csv export, it will throw an Exception, that results in a 400 Bad Request error.

Due to the CSV text format, it may look like the following instead of a JSON:
```
"status","message"
"error","The search field is not exportable"
```



Tests not added yet. Will set up test suite for the entire Search API in a separate PR.