### PR TITLE
Add fetchOneById method to SubmissionStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.ProjectId
 
 class CohortNotFoundException(id: CohortId) : EntityNotFoundException("Cohort $id not found")
@@ -27,3 +28,6 @@ class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
 
 class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
     EntityNotFoundException("Submission document $id not found")
+
+class SubmissionNotFoundException(id: SubmissionId) :
+    EntityNotFoundException("Submission $id not found")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -1,13 +1,50 @@
 package com.terraformation.backend.accelerator.db
 
+import com.terraformation.backend.accelerator.model.ExistingSubmissionModel
+import com.terraformation.backend.accelerator.model.SubmissionModel
+import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.tables.daos.SubmissionsDao
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
+import com.terraformation.backend.db.asNonNullable
 import jakarta.inject.Named
 import java.time.InstantSource
+import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 
 @Named
 class SubmissionStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val submissionsDao: SubmissionsDao,
 ) {
   /** Inserts a new document for a submission. This calculates the filename */
+  fun fetchOneById(
+      submissionId: SubmissionId,
+  ): ExistingSubmissionModel {
+    return fetch(SUBMISSIONS.ID.eq(submissionId)).firstOrNull()
+        ?: throw SubmissionNotFoundException(submissionId)
+  }
+
+  private fun fetch(condition: Condition?): List<ExistingSubmissionModel> {
+    val submissionDocumentsIdsField =
+        DSL.multiset(
+                DSL.select(SUBMISSION_DOCUMENTS.ID)
+                    .from(SUBMISSION_DOCUMENTS)
+                    .where(SUBMISSION_DOCUMENTS.SUBMISSION_ID.eq(SUBMISSIONS.ID))
+                    .orderBy(SUBMISSION_DOCUMENTS.ID))
+            .convertFrom { result ->
+              result.map { it[SUBMISSION_DOCUMENTS.ID.asNonNullable()] }.toSet()
+            }
+
+    return with(SUBMISSIONS) {
+      dslContext
+          .select(SUBMISSIONS.asterisk(), submissionDocumentsIdsField)
+          .from(SUBMISSIONS)
+          .apply { condition?.let { where(it) } }
+          .orderBy(ID)
+          .fetch { SubmissionModel.of(it, submissionDocumentsIdsField) }
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.accelerator.model.ExistingSubmissionModel
 import com.terraformation.backend.accelerator.model.SubmissionModel
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.tables.daos.SubmissionsDao
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
@@ -19,7 +20,6 @@ class SubmissionStore(
     private val dslContext: DSLContext,
     private val submissionsDao: SubmissionsDao,
 ) {
-  /** Inserts a new document for a submission. This calculates the filename */
   fun fetchOneById(
       submissionId: SubmissionId,
   ): ExistingSubmissionModel {
@@ -45,6 +45,7 @@ class SubmissionStore(
           .apply { condition?.let { where(it) } }
           .orderBy(ID)
           .fetch { SubmissionModel.of(it, submissionDocumentsIdsField) }
+          .filter { currentUser().canReadSubmission(it.id) }
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
@@ -16,7 +16,7 @@ data class SubmissionModel<ID : SubmissionId?>(
     val internalComment: String? = null,
     val projectId: ProjectId,
     val submissionDocumentIds: Set<SubmissionDocumentId>,
-    val submissionStatusId: SubmissionStatus,
+    val submissionStatus: SubmissionStatus,
 ) {
   companion object {
     fun of(
@@ -30,7 +30,7 @@ data class SubmissionModel<ID : SubmissionId?>(
           internalComment = record[SUBMISSIONS.INTERNAL_COMMENT]!!,
           projectId = record[SUBMISSIONS.PROJECT_ID]!!,
           submissionDocumentIds = submissionDocumentIds?.let { record[it] } ?: emptySet(),
-          submissionStatusId = record[SUBMISSIONS.SUBMISSION_STATUS_ID]!!,
+          submissionStatus = record[SUBMISSIONS.SUBMISSION_STATUS_ID]!!,
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
@@ -26,8 +26,8 @@ data class SubmissionModel<ID : SubmissionId?>(
       return ExistingSubmissionModel(
           id = record[SUBMISSIONS.ID]!!,
           deliverableId = record[SUBMISSIONS.DELIVERABLE_ID]!!,
-          feedback = record[SUBMISSIONS.FEEDBACK]!!,
-          internalComment = record[SUBMISSIONS.INTERNAL_COMMENT]!!,
+          feedback = record[SUBMISSIONS.FEEDBACK],
+          internalComment = record[SUBMISSIONS.INTERNAL_COMMENT],
           projectId = record[SUBMISSIONS.PROJECT_ID]!!,
           submissionDocumentIds = submissionDocumentIds?.let { record[it] } ?: emptySet(),
           submissionStatus = record[SUBMISSIONS.SUBMISSION_STATUS_ID]!!,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SubmissionModel.kt
@@ -1,0 +1,39 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
+import com.terraformation.backend.db.default_schema.ProjectId
+import org.jooq.Field
+import org.jooq.Record
+
+data class SubmissionModel<ID : SubmissionId?>(
+    val id: ID,
+    val deliverableId: DeliverableId,
+    val feedback: String? = null,
+    val internalComment: String? = null,
+    val projectId: ProjectId,
+    val submissionDocumentIds: Set<SubmissionDocumentId>,
+    val submissionStatusId: SubmissionStatus,
+) {
+  companion object {
+    fun of(
+        record: Record,
+        submissionDocumentIds: Field<Set<SubmissionDocumentId>>? = null
+    ): ExistingSubmissionModel {
+      return ExistingSubmissionModel(
+          id = record[SUBMISSIONS.ID]!!,
+          deliverableId = record[SUBMISSIONS.DELIVERABLE_ID]!!,
+          feedback = record[SUBMISSIONS.FEEDBACK]!!,
+          internalComment = record[SUBMISSIONS.INTERNAL_COMMENT]!!,
+          projectId = record[SUBMISSIONS.PROJECT_ID]!!,
+          submissionDocumentIds = submissionDocumentIds?.let { record[it] } ?: emptySet(),
+          submissionStatusId = record[SUBMISSIONS.SUBMISSION_STATUS_ID]!!,
+      )
+    }
+  }
+}
+
+typealias ExistingSubmissionModel = SubmissionModel<SubmissionId>

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -4,6 +4,8 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
+import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -137,12 +139,20 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(speciesId: SpeciesId): OrganizationId? =
       fetchFieldById(speciesId, SPECIES.ID, SPECIES.ORGANIZATION_ID)
 
+  fun getOrganizationId(submissionId: SubmissionId): OrganizationId? {
+    val projectId = getProjectId(submissionId)
+    return projectId?.let { getOrganizationId(it) }
+  }
+
   fun getUserId(notificationId: NotificationId): UserId? =
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)
 
   fun getOrganizationId(accessionId: AccessionId): OrganizationId? {
     return fetchFieldById(accessionId, ACCESSIONS.ID, ACCESSIONS.facilities.ORGANIZATION_ID)
   }
+
+  fun getProjectId(submissionId: SubmissionId): ProjectId? =
+      fetchFieldById(submissionId, SUBMISSIONS.ID, SUBMISSIONS.PROJECT_ID)
 
   fun getFacilityConnectionState(deviceId: DeviceId): FacilityConnectionState {
     return fetchFieldById(deviceId, DEVICES.ID, DEVICES.facilities.CONNECTION_STATE_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -139,10 +139,8 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(speciesId: SpeciesId): OrganizationId? =
       fetchFieldById(speciesId, SPECIES.ID, SPECIES.ORGANIZATION_ID)
 
-  fun getOrganizationId(submissionId: SubmissionId): OrganizationId? {
-    val projectId = getProjectId(submissionId)
-    return projectId?.let { getOrganizationId(it) }
-  }
+  fun getOrganizationId(submissionId: SubmissionId): OrganizationId? =
+      fetchFieldById(submissionId, SUBMISSIONS.ID, SUBMISSIONS.projects.ORGANIZATION_ID)
 
   fun getUserId(notificationId: NotificationId): UserId? =
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -292,6 +293,8 @@ data class DeviceManagerUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
 
   override fun canReadSubLocation(subLocationId: SubLocationId): Boolean = false
+
+  override fun canReadSubmission(submissionId: SubmissionId): Boolean = false
 
   override fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -382,6 +383,9 @@ data class IndividualUser(
   override fun canReadSubLocation(subLocationId: SubLocationId) =
       isMember(parentStore.getFacilityId(subLocationId))
 
+  override fun canReadSubmission(submissionId: SubmissionId) =
+      isReadOnlyOrHigher() || isMember(parentStore.getOrganizationId(submissionId))
+
   override fun canReadSubmissionDocument(documentId: SubmissionDocumentId) =
       isAcceleratorAdmin() || isTFExpert() || isReadOnly()
 
@@ -526,6 +530,9 @@ data class IndividualUser(
   private fun isTFExpert() = GlobalRole.TFExpert in globalRoles || isSuperAdmin()
 
   private fun isReadOnly() = GlobalRole.ReadOnly in globalRoles || isSuperAdmin()
+
+  private fun isReadOnlyOrHigher() =
+      isAcceleratorAdmin() || isReadOnly() || isSuperAdmin() || isTFExpert()
 
   private fun isSuperAdmin() = GlobalRole.SuperAdmin in globalRoles
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.model
 import com.terraformation.backend.accelerator.db.CohortNotFoundException
 import com.terraformation.backend.accelerator.db.ParticipantNotFoundException
 import com.terraformation.backend.accelerator.db.SubmissionDocumentNotFoundException
+import com.terraformation.backend.accelerator.db.SubmissionNotFoundException
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AutomationNotFoundException
 import com.terraformation.backend.db.DeviceManagerNotFoundException
@@ -23,6 +24,7 @@ import com.terraformation.backend.db.ViabilityTestNotFoundException
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -627,6 +629,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readSubLocation(subLocationId: SubLocationId) {
     if (!user.canReadSubLocation(subLocationId)) {
       throw SubLocationNotFoundException(subLocationId)
+    }
+  }
+
+  fun readSubmission(submissionId: SubmissionId) {
+    if (!user.canReadSubmission(submissionId)) {
+      throw SubmissionNotFoundException(submissionId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -292,6 +293,8 @@ class SystemUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
 
   override fun canReadSubLocation(subLocationId: SubLocationId): Boolean = true
+
+  override fun canReadSubmission(submissionId: SubmissionId): Boolean = true
 
   override fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -245,6 +246,8 @@ interface TerrawareUser : Principal {
   fun canReadSpecies(speciesId: SpeciesId): Boolean
 
   fun canReadSubLocation(subLocationId: SubLocationId): Boolean
+
+  fun canReadSubmission(submissionId: SubmissionId): Boolean
 
   fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -36,6 +36,11 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
       val deliverableId = insertDeliverable()
       val submissionId = insertSubmission()
 
+      val submissionDocumentIds =
+          setOf(
+              insertSubmissionDocument(submissionId = submissionId),
+              insertSubmissionDocument(submissionId = submissionId))
+
       assertEquals(
           ExistingSubmissionModel(
               id = submissionId,
@@ -43,7 +48,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
               internalComment = null,
               projectId = projectId,
               deliverableId = deliverableId,
-              submissionDocumentIds = emptySet(),
+              submissionDocumentIds = submissionDocumentIds,
               submissionStatus = SubmissionStatus.NotSubmitted),
           store.fetchOneById(submissionId))
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.accelerator.model.ExistingSubmissionModel
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.mockUser
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val store: SubmissionStore by lazy { SubmissionStore(clock, dslContext, submissionsDao) }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+
+    // TODO
+    // every { user.canReadSubmission(any()) } returns true
+  }
+
+  @Nested
+  inner class FetchOneById {
+    @Test
+    fun `fetches the submission`() {
+      val organizationId = insertOrganization()
+      val projectId = insertProject(organizationId = organizationId)
+      val moduleId = insertModule()
+      val deliverableId = insertDeliverable(moduleId = moduleId)
+      val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
+
+      assertEquals(
+          ExistingSubmissionModel(
+              id = submissionId,
+              feedback = "",
+              internalComment = "",
+              projectId = projectId,
+              deliverableId = deliverableId,
+              submissionDocumentIds = emptySet(),
+              submissionStatusId = SubmissionStatus.NotSubmitted),
+          store.fetchOneById(submissionId))
+    }
+
+    //    @Test
+    //    fun `throws exception if no permission to read submissions`() {
+    //      val submissionId = insertSubmission(id = 1)
+    //
+    //      every { user.canReadSubmission(submissionId) } returns false
+    //
+    //      assertThrows<SubmissionNotFoundException> { store.fetchOneById(submissionId) }
+    //    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -20,7 +20,8 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertUser()
-
+    insertOrganization()
+    insertModule()
     // TODO
     // every { user.canReadSubmission(any()) } returns true
   }
@@ -29,11 +30,9 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchOneById {
     @Test
     fun `fetches the submission`() {
-      val organizationId = insertOrganization()
-      val projectId = insertProject(organizationId = organizationId)
-      val moduleId = insertModule()
-      val deliverableId = insertDeliverable(moduleId = moduleId)
-      val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
+      val projectId = insertProject()
+      val deliverableId = insertDeliverable()
+      val submissionId = insertSubmission()
 
       assertEquals(
           ExistingSubmissionModel(
@@ -43,7 +42,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
               projectId = projectId,
               deliverableId = deliverableId,
               submissionDocumentIds = emptySet(),
-              submissionStatusId = SubmissionStatus.NotSubmitted),
+              submissionStatus = SubmissionStatus.NotSubmitted),
           store.fetchOneById(submissionId))
     }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -39,8 +39,8 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           ExistingSubmissionModel(
               id = submissionId,
-              feedback = "",
-              internalComment = "",
+              feedback = null,
+              internalComment = null,
               projectId = projectId,
               deliverableId = deliverableId,
               submissionDocumentIds = emptySet(),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -6,10 +6,12 @@ import com.terraformation.backend.accelerator.model.ExistingSubmissionModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.mockUser
+import io.mockk.every
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -22,8 +24,8 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     insertUser()
     insertOrganization()
     insertModule()
-    // TODO
-    // every { user.canReadSubmission(any()) } returns true
+
+    every { user.canReadSubmission(any()) } returns true
   }
 
   @Nested
@@ -46,13 +48,15 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
           store.fetchOneById(submissionId))
     }
 
-    //    @Test
-    //    fun `throws exception if no permission to read submissions`() {
-    //      val submissionId = insertSubmission(id = 1)
-    //
-    //      every { user.canReadSubmission(submissionId) } returns false
-    //
-    //      assertThrows<SubmissionNotFoundException> { store.fetchOneById(submissionId) }
-    //    }
+    @Test
+    fun `throws exception if no permission to read submissions`() {
+      insertProject()
+      insertDeliverable()
+      val submissionId = insertSubmission()
+
+      every { user.canReadSubmission(submissionId) } returns false
+
+      assertThrows<SubmissionNotFoundException> { store.fetchOneById(submissionId) }
+    }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2356,8 +2356,8 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     fun expect(
-      vararg submissionIds: SubmissionId,
-      readSubmission: Boolean = false,
+        vararg submissionIds: SubmissionId,
+        readSubmission: Boolean = false,
     ) {
       submissionIds.forEach { submissionId ->
         assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -338,6 +338,7 @@ internal class PermissionTest : DatabaseTest() {
     submissionIds.forEach { submissionId ->
       insertSubmission(
           createdBy = userId,
+          deliverableId = deliverableId,
           id = submissionId,
           projectId = ProjectId(submissionId.value),
       )
@@ -508,7 +509,14 @@ internal class PermissionTest : DatabaseTest() {
         updateProject = true,
     )
 
-    permissions.expect(deleteSelf = true, readSubmission = true)
+    permissions.expect(
+        *submissionIds.forOrg1(),
+        readSubmission = true,
+    )
+
+    permissions.expect(
+        deleteSelf = true,
+    )
 
     permissions.andNothingElse()
   }
@@ -545,7 +553,9 @@ internal class PermissionTest : DatabaseTest() {
         updateDeviceManager = true,
     )
 
-    permissions.expect(deleteSelf = true, readSubmission = false)
+    permissions.expect(
+        deleteSelf = true,
+    )
 
     permissions.andNothingElse()
   }
@@ -722,7 +732,14 @@ internal class PermissionTest : DatabaseTest() {
         updateProject = true,
     )
 
-    permissions.expect(deleteSelf = true, readSubmission = true)
+    permissions.expect(
+        *submissionIds.forOrg1(),
+        readSubmission = true,
+    )
+
+    permissions.expect(
+        deleteSelf = true,
+    )
 
     permissions.andNothingElse()
   }
@@ -852,7 +869,14 @@ internal class PermissionTest : DatabaseTest() {
         readProject = true,
     )
 
-    permissions.expect(deleteSelf = true, readSubmission = true)
+    permissions.expect(
+        *submissionIds.forOrg1(),
+        readSubmission = true,
+    )
+
+    permissions.expect(
+        deleteSelf = true,
+    )
 
     permissions.andNothingElse()
   }
@@ -968,7 +992,14 @@ internal class PermissionTest : DatabaseTest() {
         readProject = true,
     )
 
-    permissions.expect(deleteSelf = true, readSubmission = true)
+    permissions.expect(
+        *submissionIds.forOrg1(),
+        readSubmission = true,
+    )
+
+    permissions.expect(
+        deleteSelf = true,
+    )
 
     permissions.andNothingElse()
   }
@@ -1147,7 +1178,6 @@ internal class PermissionTest : DatabaseTest() {
         readGlobalRoles = true,
         readInternalTags = true,
         readParticipant = true,
-        readSubmission = true,
         setTestClock = true,
         updateCohort = true,
         updateAppVersions = true,
@@ -1222,6 +1252,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *submissionIds.toTypedArray(),
+        readSubmission = true,
+    )
+
+    permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
     )
@@ -1289,6 +1324,12 @@ internal class PermissionTest : DatabaseTest() {
         updateProjectDocumentSettings = true,
     )
 
+    // Can read all submissions even those outside of this org
+    permissions.expect(
+        *submissionIds.toTypedArray(),
+        readSubmission = true,
+    )
+
     permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
@@ -1314,7 +1355,6 @@ internal class PermissionTest : DatabaseTest() {
         readGlobalRoles = true,
         readCohort = true,
         readParticipant = true,
-        readSubmission = true,
         regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
         updateAppVersions = true,
@@ -1376,6 +1416,12 @@ internal class PermissionTest : DatabaseTest() {
         updateProjectDocumentSettings = true,
     )
 
+    // Can read all submissions even those outside of this org
+    permissions.expect(
+        *submissionIds.toTypedArray(),
+        readSubmission = true,
+    )
+
     permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
@@ -1401,7 +1447,6 @@ internal class PermissionTest : DatabaseTest() {
         readCohort = true,
         readGlobalRoles = true,
         readParticipant = true,
-        readSubmission = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
         updateAppVersions = false,
@@ -1446,6 +1491,12 @@ internal class PermissionTest : DatabaseTest() {
         updateObservation = true,
     )
 
+    // Can read all submissions even those outside of this org
+    permissions.expect(
+        *submissionIds.toTypedArray(),
+        readSubmission = true,
+    )
+
     permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
@@ -1469,7 +1520,6 @@ internal class PermissionTest : DatabaseTest() {
         readCohort = true,
         readGlobalRoles = false,
         readParticipant = true,
-        readSubmission = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
         updateAppVersions = false,
@@ -1514,6 +1564,12 @@ internal class PermissionTest : DatabaseTest() {
         updateObservation = true,
     )
 
+    // Can read all submissions even those outside of this org
+    permissions.expect(
+        *submissionIds.toTypedArray(),
+        readSubmission = true,
+    )
+
     permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
@@ -1537,7 +1593,6 @@ internal class PermissionTest : DatabaseTest() {
         readCohort = true,
         readGlobalRoles = false,
         readParticipant = true,
-        readSubmission = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
         updateAppVersions = false,
@@ -1661,6 +1716,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedSpecies = speciesIds.toMutableSet()
     private val uncheckedSubLocations = subLocationIds.toMutableSet()
     private val uncheckedSubmissionDocuments = submissionDocumentIds.toMutableSet()
+    private val uncheckedSubmissions = submissionIds.toMutableSet()
     private val uncheckedViabilityTests = viabilityTestIds.toMutableSet()
     private val uncheckedWithdrawals = withdrawalIds.toMutableSet()
 
@@ -1976,7 +2032,6 @@ internal class PermissionTest : DatabaseTest() {
         readGlobalRoles: Boolean = false,
         readInternalTags: Boolean = false,
         readParticipant: Boolean = false,
-        readSubmission: Boolean = false,
         regenerateAllDeviceManagerTokens: Boolean = false,
         setTestClock: Boolean = false,
         updateAppVersions: Boolean = false,
@@ -2023,7 +2078,6 @@ internal class PermissionTest : DatabaseTest() {
       assertEquals(readGlobalRoles, user.canReadGlobalRoles(), "Can read global roles")
       assertEquals(readInternalTags, user.canReadInternalTags(), "Can read internal tags")
       assertEquals(readParticipant, user.canReadParticipant(participantId), "Can read participant")
-      assertEquals(readSubmission, user.canReadSubmission(submissionIds[0]), "Can read submission")
       assertEquals(
           regenerateAllDeviceManagerTokens,
           user.canRegenerateAllDeviceManagerTokens(),
@@ -2302,6 +2356,20 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     fun expect(
+      vararg submissionIds: SubmissionId,
+      readSubmission: Boolean = false,
+    ) {
+      submissionIds.forEach { submissionId ->
+        assertEquals(
+            readSubmission,
+            user.canReadSubmission(submissionId),
+            "Can read submission $submissionId")
+
+        uncheckedSubmissions.remove(submissionId)
+      }
+    }
+
+    fun expect(
         vararg documentIds: SubmissionDocumentId,
         readSubmissionDocument: Boolean = false,
     ) {
@@ -2335,6 +2403,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedSpecies.toTypedArray())
       expect(*uncheckedSubLocations.toTypedArray())
       expect(*uncheckedSubmissionDocuments.toTypedArray())
+      expect(*uncheckedSubmissions.toTypedArray())
       expect(*uncheckedViabilityTests.toTypedArray())
       expect(*uncheckedWithdrawals.toTypedArray())
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -551,13 +551,13 @@ abstract class DatabaseTest {
       deliverableCategoryId: DeliverableCategory = DeliverableCategory.FinancialViability,
       deliverableTypeId: DeliverableType = DeliverableType.Document,
       descriptionHtml: String? = "",
-      id: DeliverableId = nextDeliverableNumber.toIdWrapper { DeliverableId(it) },
+      id: Any? = null,
       isSensitive: Boolean = false,
       isRequired: Boolean = false,
-      moduleId: ModuleId = inserted.moduleId,
+      moduleId: Any? = inserted.moduleId,
       name: String = "Deliverable $nextDeliverableNumber",
-      position: Int = 0,
-      subtitle: String? = "",
+      position: Int = nextDeliverableNumber,
+      subtitle: String? = null,
   ): DeliverableId {
     with(DELIVERABLES) {
       nextDeliverableNumber++
@@ -569,10 +569,10 @@ abstract class DatabaseTest {
               deliverableCategoryId = deliverableCategoryId,
               deliverableTypeId = deliverableTypeId,
               descriptionHtml = descriptionHtml,
-              id = id,
+              id = id?.toIdWrapper { DeliverableId(it) },
               modifiedBy = createdBy,
               modifiedTime = createdTime,
-              moduleId = moduleId,
+              moduleId = moduleId?.toIdWrapper { ModuleId(it) },
               name = name,
               position = position,
               isSensitive = isSensitive,
@@ -700,32 +700,28 @@ abstract class DatabaseTest {
     return actualSpeciesId.also { inserted.speciesIds.add(it) }
   }
 
-  private var nextSubmissionNumber = 1
-
   fun insertSubmission(
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      deliverableId: DeliverableId = inserted.deliverableId,
-      feedback: String? = "",
-      id: SubmissionId = nextSubmissionNumber.toIdWrapper { SubmissionId(it) },
-      internalComment: String? = "",
-      projectId: ProjectId = inserted.projectId,
-      submissionStatusId: SubmissionStatus = SubmissionStatus.NotSubmitted,
+      deliverableId: Any? = inserted.deliverableId,
+      feedback: String? = null,
+      id: Any? = null,
+      internalComment: String? = null,
+      projectId: Any? = inserted.projectId,
+      submissionStatus: SubmissionStatus = SubmissionStatus.NotSubmitted,
   ): SubmissionId {
-    nextSubmissionNumber++
-
     val row =
         SubmissionsRow(
             createdBy = createdBy,
             createdTime = createdTime,
-            deliverableId = deliverableId,
+            deliverableId = deliverableId?.toIdWrapper { DeliverableId(it) },
             feedback = feedback,
-            id = id,
+            id = id?.toIdWrapper { SubmissionId(it) },
             internalComment = internalComment,
             modifiedBy = createdBy,
             modifiedTime = createdTime,
-            projectId = projectId,
-            submissionStatusId = submissionStatusId,
+            projectId = projectId?.toIdWrapper { ProjectId(it) },
+            submissionStatusId = submissionStatus,
         )
 
     submissionsDao.insert(row)
@@ -1336,7 +1332,7 @@ abstract class DatabaseTest {
   fun insertModule(
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      id: ModuleId = nextModuleNumber.toIdWrapper { ModuleId(it) },
+      id: Any? = null,
       name: String = "Module $nextModuleNumber",
   ): ModuleId {
     with(MODULES) {
@@ -1346,7 +1342,7 @@ abstract class DatabaseTest {
           ModulesRow(
               createdBy = createdBy,
               createdTime = createdTime,
-              id = id,
+              id = id?.toIdWrapper { ModuleId(it) },
               modifiedBy = createdBy,
               modifiedTime = createdTime,
               name = name,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -9,12 +9,26 @@ import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.daos.CohortsDao
+import com.terraformation.backend.db.accelerator.tables.daos.DeliverablesDao
+import com.terraformation.backend.db.accelerator.tables.daos.ModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectDocumentSettingsDao
+import com.terraformation.backend.db.accelerator.tables.daos.SubmissionsDao
 import com.terraformation.backend.db.accelerator.tables.pojos.CohortsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.DeliverablesRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.MODULES
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.EcosystemType
@@ -344,6 +358,7 @@ abstract class DatabaseTest {
   protected val cohortsDao: CohortsDao by lazyDao()
   protected val countriesDao: CountriesDao by lazyDao()
   protected val countrySubdivisionsDao: CountrySubdivisionsDao by lazyDao()
+  protected val deliverablesDao: DeliverablesDao by lazyDao()
   protected val deliveriesDao: DeliveriesDao by lazyDao()
   protected val deviceManagersDao: DeviceManagersDao by lazyDao()
   protected val devicesDao: DevicesDao by lazyDao()
@@ -353,6 +368,7 @@ abstract class DatabaseTest {
   protected val filesDao: FilesDao by lazyDao()
   protected val geolocationsDao: GeolocationsDao by lazyDao()
   protected val internalTagsDao: InternalTagsDao by lazyDao()
+  protected val modulesDao: ModulesDao by lazyDao()
   protected val monitoringPlotsDao: MonitoringPlotsDao by lazyDao()
   protected val notificationsDao: NotificationsDao by lazyDao()
   protected val nurseryWithdrawalsDao:
@@ -390,6 +406,7 @@ abstract class DatabaseTest {
   protected val speciesEcosystemTypesDao: SpeciesEcosystemTypesDao by lazyDao()
   protected val speciesProblemsDao: SpeciesProblemsDao by lazyDao()
   protected val subLocationsDao: SubLocationsDao by lazyDao()
+  protected val submissionsDao: SubmissionsDao by lazyDao()
   protected val thumbnailsDao: ThumbnailsDao by lazyDao()
   protected val timeseriesDao: TimeseriesDao by lazyDao()
   protected val timeZonesDao: TimeZonesDao by lazyDao()
@@ -526,6 +543,45 @@ abstract class DatabaseTest {
     return row.id!!.also { inserted.projectIds.add(it) }
   }
 
+  private var nextDeliverableNumber: Int = 1
+
+  protected fun insertDeliverable(
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      deliverableCategoryId: DeliverableCategory? = DeliverableCategory.FinancialViability,
+      deliverableTypeId: DeliverableType? = DeliverableType.Document,
+      descriptionHtml: String? = "",
+      id: Any? = null,
+      moduleId: Any? = null,
+      name: String = "Deliverable ${nextDeliverableNumber++}",
+      position: Int? = 0,
+      isSensitive: Boolean? = false,
+      isRequired: Boolean? = false
+  ): DeliverableId {
+    with(DELIVERABLES) {
+      val row =
+          DeliverablesRow(
+              createdBy = createdBy.toIdWrapper { UserId(it) },
+              createdTime = createdTime,
+              deliverableCategoryId = deliverableCategoryId,
+              deliverableTypeId = deliverableTypeId,
+              descriptionHtml = descriptionHtml,
+              id = id?.toIdWrapper { DeliverableId(it) },
+              modifiedBy = createdBy.toIdWrapper { UserId(it) },
+              modifiedTime = createdTime,
+              moduleId = moduleId?.toIdWrapper { ModuleId(it) },
+              name = name,
+              position = position,
+              isSensitive = isSensitive,
+              isRequired = isRequired,
+          )
+
+      deliverablesDao.insert(row)
+
+      return row.id!!.also { inserted.deliverableIds.add(it) }
+    }
+  }
+
   protected fun insertDevice(
       id: Any,
       facilityId: Any = this.facilityId,
@@ -639,6 +695,35 @@ abstract class DatabaseTest {
     }
 
     return actualSpeciesId.also { inserted.speciesIds.add(it) }
+  }
+
+  fun insertSubmission(
+      createdBy: Any = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      deliverableId: Any? = null,
+      feedback: String? = "",
+      id: Any? = null,
+      internalComment: String? = "",
+      projectId: Any? = null,
+      submissionStatusId: SubmissionStatus? = SubmissionStatus.NotSubmitted,
+  ): SubmissionId {
+    val row =
+        SubmissionsRow(
+            createdBy = createdBy.toIdWrapper { UserId(it) },
+            createdTime = createdTime,
+            deliverableId = deliverableId?.toIdWrapper { DeliverableId(it) },
+            feedback = feedback,
+            id = id?.toIdWrapper { SubmissionId(it) },
+            internalComment = internalComment,
+            modifiedBy = createdBy.toIdWrapper { UserId(it) },
+            modifiedTime = createdTime,
+            projectId = projectId?.toIdWrapper { ProjectId(it) },
+            submissionStatusId = submissionStatusId,
+        )
+
+    submissionsDao.insert(row)
+
+    return row.id!!.also { inserted.submissionIds.add(it) }
   }
 
   /** Creates a user that can be referenced by various tests. */
@@ -1239,6 +1324,31 @@ abstract class DatabaseTest {
     return rowWithDefaults.id!!.also { inserted.plantingSubzoneIds.add(it) }
   }
 
+  private var nextModuleNumber: Int = 1
+
+  fun insertModule(
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      id: Any? = null,
+      name: String = "Module ${nextModuleNumber++}",
+  ): ModuleId {
+    with(MODULES) {
+      val row =
+          ModulesRow(
+              createdBy = createdBy.toIdWrapper { UserId(it) },
+              createdTime = createdTime,
+              id = id?.toIdWrapper { ModuleId(it) },
+              modifiedBy = createdBy.toIdWrapper { UserId(it) },
+              modifiedTime = createdTime,
+              name = name,
+          )
+
+      modulesDao.insert(row)
+
+      return row.id!!.also { inserted.moduleIds.add(it) }
+    }
+  }
+
   fun insertMonitoringPlot(
       row: MonitoringPlotsRow = MonitoringPlotsRow(),
       x: Number = 0,
@@ -1767,11 +1877,13 @@ abstract class DatabaseTest {
     val automationIds = mutableListOf<AutomationId>()
     val batchIds = mutableListOf<BatchId>()
     val cohortIds = mutableListOf<CohortId>()
+    val deliverableIds = mutableListOf<DeliverableId>()
     val deliveryIds = mutableListOf<DeliveryId>()
     val deviceIds = mutableListOf<DeviceId>()
     val draftPlantingSiteIds = mutableListOf<DraftPlantingSiteId>()
     val facilityIds = mutableListOf<FacilityId>()
     val fileIds = mutableListOf<FileId>()
+    val moduleIds = mutableListOf<ModuleId>()
     val monitoringPlotIds = mutableListOf<MonitoringPlotId>()
     val notificationIds = mutableListOf<NotificationId>()
     val observationIds = mutableListOf<ObservationId>()
@@ -1787,6 +1899,7 @@ abstract class DatabaseTest {
     val reportIds = mutableListOf<ReportId>()
     val speciesIds = mutableListOf<SpeciesId>()
     val subLocationIds = mutableListOf<SubLocationId>()
+    val submissionIds = mutableListOf<SubmissionId>()
     val uploadIds = mutableListOf<UploadId>()
     val userIds = mutableListOf<UserId>()
     val withdrawalIds = mutableListOf<WithdrawalId>()
@@ -1803,6 +1916,9 @@ abstract class DatabaseTest {
     val cohortId
       get() = cohortIds.last()
 
+    val deliverableId
+      get() = deliverableIds.last()
+
     val deliveryId
       get() = deliveryIds.last()
 
@@ -1817,6 +1933,9 @@ abstract class DatabaseTest {
 
     val fileId
       get() = fileIds.last()
+
+    val moduleId
+      get() = moduleIds.last()
 
     val monitoringPlotId
       get() = monitoringPlotIds.last()
@@ -1862,6 +1981,9 @@ abstract class DatabaseTest {
 
     val subLocationId
       get() = subLocationIds.last()
+
+    val submissionId
+      get() = submissionIds.last()
 
     val uploadId
       get() = uploadIds.last()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -546,30 +546,33 @@ abstract class DatabaseTest {
   private var nextDeliverableNumber: Int = 1
 
   protected fun insertDeliverable(
-      createdBy: UserId = currentUser().userId,
-      createdTime: Instant = Instant.EPOCH,
-      deliverableCategoryId: DeliverableCategory? = DeliverableCategory.FinancialViability,
-      deliverableTypeId: DeliverableType? = DeliverableType.Document,
-      descriptionHtml: String? = "",
-      id: Any? = null,
-      moduleId: Any? = null,
-      name: String = "Deliverable ${nextDeliverableNumber++}",
-      position: Int? = 0,
-      isSensitive: Boolean? = false,
-      isRequired: Boolean? = false
+    createdBy: UserId = currentUser().userId,
+    createdTime: Instant = Instant.EPOCH,
+    deliverableCategoryId: DeliverableCategory = DeliverableCategory.FinancialViability,
+    deliverableTypeId: DeliverableType = DeliverableType.Document,
+    descriptionHtml: String? = "",
+    id: DeliverableId = nextDeliverableNumber.toIdWrapper { DeliverableId(it) },
+    isSensitive: Boolean = false,
+    isRequired: Boolean = false,
+    moduleId: ModuleId = inserted.moduleId,
+    name: String = "Deliverable $nextDeliverableNumber",
+    position: Int = 0,
+    subtitle: String? = "",
   ): DeliverableId {
     with(DELIVERABLES) {
+      nextDeliverableNumber++;
+
       val row =
           DeliverablesRow(
-              createdBy = createdBy.toIdWrapper { UserId(it) },
+              createdBy = createdBy,
               createdTime = createdTime,
               deliverableCategoryId = deliverableCategoryId,
               deliverableTypeId = deliverableTypeId,
               descriptionHtml = descriptionHtml,
-              id = id?.toIdWrapper { DeliverableId(it) },
-              modifiedBy = createdBy.toIdWrapper { UserId(it) },
+              id = id,
+              modifiedBy = createdBy,
               modifiedTime = createdTime,
-              moduleId = moduleId?.toIdWrapper { ModuleId(it) },
+              moduleId = moduleId,
               name = name,
               position = position,
               isSensitive = isSensitive,
@@ -697,27 +700,31 @@ abstract class DatabaseTest {
     return actualSpeciesId.also { inserted.speciesIds.add(it) }
   }
 
+  private var nextSubmissionNumber = 1;
+
   fun insertSubmission(
-      createdBy: Any = currentUser().userId,
+      createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      deliverableId: Any? = null,
+      deliverableId: DeliverableId = inserted.deliverableId,
       feedback: String? = "",
-      id: Any? = null,
+      id: SubmissionId = nextSubmissionNumber.toIdWrapper { SubmissionId(it) },
       internalComment: String? = "",
-      projectId: Any? = null,
-      submissionStatusId: SubmissionStatus? = SubmissionStatus.NotSubmitted,
+      projectId: ProjectId = inserted.projectId,
+      submissionStatusId: SubmissionStatus = SubmissionStatus.NotSubmitted,
   ): SubmissionId {
+    nextSubmissionNumber++;
+
     val row =
         SubmissionsRow(
-            createdBy = createdBy.toIdWrapper { UserId(it) },
+            createdBy = createdBy,
             createdTime = createdTime,
-            deliverableId = deliverableId?.toIdWrapper { DeliverableId(it) },
+            deliverableId = deliverableId,
             feedback = feedback,
-            id = id?.toIdWrapper { SubmissionId(it) },
+            id = id,
             internalComment = internalComment,
-            modifiedBy = createdBy.toIdWrapper { UserId(it) },
+            modifiedBy = createdBy,
             modifiedTime = createdTime,
-            projectId = projectId?.toIdWrapper { ProjectId(it) },
+            projectId = projectId,
             submissionStatusId = submissionStatusId,
         )
 
@@ -1329,16 +1336,18 @@ abstract class DatabaseTest {
   fun insertModule(
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      id: Any? = null,
-      name: String = "Module ${nextModuleNumber++}",
+      id: ModuleId = nextModuleNumber.toIdWrapper { ModuleId(it) },
+      name: String = "Module $nextModuleNumber",
   ): ModuleId {
     with(MODULES) {
+      nextModuleNumber++;
+
       val row =
           ModulesRow(
-              createdBy = createdBy.toIdWrapper { UserId(it) },
+              createdBy = createdBy,
               createdTime = createdTime,
-              id = id?.toIdWrapper { ModuleId(it) },
-              modifiedBy = createdBy.toIdWrapper { UserId(it) },
+              id = id,
+              modifiedBy = createdBy,
               modifiedTime = createdTime,
               name = name,
           )

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -546,21 +546,21 @@ abstract class DatabaseTest {
   private var nextDeliverableNumber: Int = 1
 
   protected fun insertDeliverable(
-    createdBy: UserId = currentUser().userId,
-    createdTime: Instant = Instant.EPOCH,
-    deliverableCategoryId: DeliverableCategory = DeliverableCategory.FinancialViability,
-    deliverableTypeId: DeliverableType = DeliverableType.Document,
-    descriptionHtml: String? = "",
-    id: DeliverableId = nextDeliverableNumber.toIdWrapper { DeliverableId(it) },
-    isSensitive: Boolean = false,
-    isRequired: Boolean = false,
-    moduleId: ModuleId = inserted.moduleId,
-    name: String = "Deliverable $nextDeliverableNumber",
-    position: Int = 0,
-    subtitle: String? = "",
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      deliverableCategoryId: DeliverableCategory = DeliverableCategory.FinancialViability,
+      deliverableTypeId: DeliverableType = DeliverableType.Document,
+      descriptionHtml: String? = "",
+      id: DeliverableId = nextDeliverableNumber.toIdWrapper { DeliverableId(it) },
+      isSensitive: Boolean = false,
+      isRequired: Boolean = false,
+      moduleId: ModuleId = inserted.moduleId,
+      name: String = "Deliverable $nextDeliverableNumber",
+      position: Int = 0,
+      subtitle: String? = "",
   ): DeliverableId {
     with(DELIVERABLES) {
-      nextDeliverableNumber++;
+      nextDeliverableNumber++
 
       val row =
           DeliverablesRow(
@@ -700,7 +700,7 @@ abstract class DatabaseTest {
     return actualSpeciesId.also { inserted.speciesIds.add(it) }
   }
 
-  private var nextSubmissionNumber = 1;
+  private var nextSubmissionNumber = 1
 
   fun insertSubmission(
       createdBy: UserId = currentUser().userId,
@@ -712,7 +712,7 @@ abstract class DatabaseTest {
       projectId: ProjectId = inserted.projectId,
       submissionStatusId: SubmissionStatus = SubmissionStatus.NotSubmitted,
   ): SubmissionId {
-    nextSubmissionNumber++;
+    nextSubmissionNumber++
 
     val row =
         SubmissionsRow(
@@ -1340,7 +1340,7 @@ abstract class DatabaseTest {
       name: String = "Module $nextModuleNumber",
   ): ModuleId {
     with(MODULES) {
-      nextModuleNumber++;
+      nextModuleNumber++
 
       val row =
           ModulesRow(


### PR DESCRIPTION
- Add a `fetchOneById` function to the `submissionStore` which fetches the submission and any associated submission documents.
- I had to add `insertSubmission`, `insertDeliverable`, and `insertModule` test database functions in order to test out the `fetchByOneId` function.
- Add `canReadSubmission` permission, available to all global roles and members of the submission's project's organization
