### PR TITLE
SW-4962 Redo projectId type in document upload endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -161,13 +161,12 @@ class DeliverablesController {
   }
 
   @Operation(summary = "Uploads a new document to satisfy a deliverable.")
-  @PostMapping(
-      "/{deliverableId}/documents/{projectId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+  @PostMapping("/{deliverableId}/documents", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
   @io.swagger.v3.oas.annotations.parameters.RequestBody(
       content = [Content(encoding = [Encoding(name = "file", contentType = MediaType.ALL_VALUE)])])
   fun uploadDeliverableDocument(
       @PathVariable deliverableId: DeliverableId,
-      @PathVariable projectId: ProjectId,
+      @RequestPart(required = true) projectId: ProjectId,
       @RequestPart(required = true) description: String,
       @RequestPart(required = true) file: MultipartFile
   ): UploadDeliverableDocumentResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -166,7 +166,7 @@ class DeliverablesController {
       content = [Content(encoding = [Encoding(name = "file", contentType = MediaType.ALL_VALUE)])])
   fun uploadDeliverableDocument(
       @PathVariable deliverableId: DeliverableId,
-      @RequestPart(required = true) projectId: ProjectId,
+      @RequestPart(required = true) projectId: String,
       @RequestPart(required = true) description: String,
       @RequestPart(required = true) file: MultipartFile
   ): UploadDeliverableDocumentResponsePayload {


### PR DESCRIPTION
- Use String type for payload, IdWrapper supports string arguments in the constructor, here it will get converted into a ProjectId (if valid)
- Revert previous change of sticking projectId in the path