### PR TITLE
SW-4876 Implement Dropbox submission document storage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
   implementation("org.springframework.session:spring-session-jdbc")
 
   implementation("com.drewnoakes:metadata-extractor:2.19.0")
+  implementation("com.dropbox.core:dropbox-core-sdk:6.0.0")
   implementation("com.google.api-client:google-api-client:2.3.0")
   implementation("com.google.auth:google-auth-library-oauth2-http:1.23.0")
   implementation("com.google.apis:google-api-services-drive:v3-rev20240123-2.0.0")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.db.DeliverableNotFoundException
 import com.terraformation.backend.accelerator.db.ProjectDocumentSettingsNotConfiguredException
+import com.terraformation.backend.accelerator.document.DropboxReceiver
 import com.terraformation.backend.accelerator.document.GoogleDriveReceiver
 import com.terraformation.backend.accelerator.document.SubmissionDocumentReceiver
 import com.terraformation.backend.auth.currentUser
@@ -16,6 +17,7 @@ import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.file.DropboxWriter
 import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.log.perClassLogger
 import jakarta.inject.Named
@@ -30,6 +32,7 @@ import org.springframework.dao.DuplicateKeyException
 @Named
 class SubmissionService(
     private val clock: InstantSource,
+    private val dropboxWriter: DropboxWriter,
     private val dslContext: DSLContext,
     private val googleDriveWriter: GoogleDriveWriter,
 ) {
@@ -84,7 +87,7 @@ class SubmissionService(
 
     val receiver: SubmissionDocumentReceiver =
         if (deliverableRecord.isSensitive == true) {
-          throw RuntimeException("Dropbox uploads not supported yet")
+          DropboxReceiver(dropboxWriter, projectDocumentSettings.dropboxFolderPath!!)
         } else {
           GoogleDriveReceiver(googleDriveWriter, projectDocumentSettings.googleFolderUrl!!)
         }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/document/DropboxReceiver.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/document/DropboxReceiver.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.accelerator.document
+
+import com.terraformation.backend.db.accelerator.DocumentStore
+import com.terraformation.backend.file.DropboxWriter
+import java.io.InputStream
+
+class DropboxReceiver(
+    private val dropboxWriter: DropboxWriter,
+    private val folderPath: String,
+) : SubmissionDocumentReceiver {
+  override val documentStore: DocumentStore
+    get() = DocumentStore.Dropbox
+
+  override fun upload(inputStream: InputStream, fileName: String, contentType: String): StoredFile {
+    val storedName = dropboxWriter.uploadFile(folderPath, fileName, inputStream)
+
+    return StoredFile(storedName, "$folderPath/$storedName")
+  }
+
+  override fun rename(storedFile: StoredFile, newName: String) {
+    dropboxWriter.rename(storedFile.location, "$folderPath/$newName")
+  }
+
+  override fun delete(storedFile: StoredFile) {
+    dropboxWriter.delete(storedFile.location)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -90,6 +90,9 @@ class TerrawareServerConfig(
     /** Configures how the server interacts with the Balena cloud service to manage sensor kits. */
     val balena: BalenaConfig = BalenaConfig(),
 
+    /** Configures how the server interacts with Dropbox. */
+    val dropbox: DropboxConfig = DropboxConfig(),
+
     /** Configures how the server interacts with the Mapbox service. */
     val mapbox: MapboxConfig = MapboxConfig(),
 
@@ -235,6 +238,23 @@ class TerrawareServerConfig(
 
     companion object {
       const val BALENA_API_URL = "https://api.balena-cloud.com"
+    }
+  }
+
+  class DropboxConfig(
+      val appKey: String? = null,
+      val appSecret: String? = null,
+      @DefaultValue("terraware-server") val clientId: String? = "terraware-server",
+      @DefaultValue("false") val enabled: Boolean = false,
+      val refreshToken: String? = null,
+  ) {
+    init {
+      if (enabled) {
+        if (appKey == null || appSecret == null || refreshToken == null) {
+          throw IllegalArgumentException(
+              "App key, app secret, and refresh token are required if Dropbox is enabled")
+        }
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/file/DropboxWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/DropboxWriter.kt
@@ -1,0 +1,92 @@
+package com.terraformation.backend.file
+
+import com.dropbox.core.DbxRequestConfig
+import com.dropbox.core.oauth.DbxCredential
+import com.dropbox.core.v2.DbxClientV2
+import com.dropbox.core.v2.common.PathRoot
+import com.dropbox.core.v2.files.WriteMode
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import java.io.InputStream
+
+/**
+ * Writes files to Dropbox. API credentials must be configured in [TerrawareServerConfig]. The
+ * following Dropbox permissions are required:
+ * - files.metadata.write
+ * - files.content.write
+ * - sharing.read
+ */
+@Named
+class DropboxWriter(
+    private val config: TerrawareServerConfig,
+) {
+  private val log = perClassLogger()
+
+  private val dbxClient: DbxClientV2 by lazy { createClient() }
+
+  /**
+   * Uploads a file to Dropbox at a specified path. If there is already a file with the same path,
+   * allows Dropbox to pick a different filename. If the folder doesn't exist yet, it is created
+   * automatically.
+   *
+   * @return The actual filename that was created on Dropbox.
+   */
+  fun uploadFile(folderPath: String, name: String, inputStream: InputStream): String {
+    val metadata =
+        dbxClient
+            .files()
+            .uploadBuilder("$folderPath/$name")
+            .withMode(WriteMode.ADD)
+            .withAutorename(true)
+            .withStrictConflict(true)
+            .uploadAndFinish(inputStream)
+
+    log.info("Uploaded file ${metadata.pathDisplay}")
+
+    return metadata.name
+  }
+
+  /** Creates a folder. Any missing parent folders will also be created. */
+  fun createFolder(path: String) {
+    dbxClient.files().createFolderV2(path)
+
+    log.info("Created folder $path")
+  }
+
+  fun rename(oldPath: String, newPath: String) {
+    dbxClient.files().moveV2(oldPath, newPath)
+  }
+
+  /**
+   * Deletes a file or folder. If [path] is a folder, all the files in the folder are deleted too.
+   */
+  fun delete(path: String) {
+    dbxClient.files().deleteV2(path)
+
+    log.info("Deleted file/folder $path")
+  }
+
+  private fun createClient(): DbxClientV2 {
+    val dbxConfig = DbxRequestConfig.newBuilder(config.dropbox.clientId).build()
+    val credential =
+        DbxCredential(
+            // Access token; must be non-null but won't be used.
+            "",
+            // Access token expiration time; we set this to 0 to force a new access token to be
+            // generated from the refresh token.
+            0,
+            config.dropbox.refreshToken,
+            config.dropbox.appKey,
+            config.dropbox.appSecret)
+
+    val client = DbxClientV2(dbxConfig, credential)
+
+    // We want paths to be relative to the account's root folder, not its home folder, so that
+    // team folders are addressable. Without this setting, the path "/foo" will actually point to
+    // "/(username)/foo" and the files won't be accessible by other users on the team.
+    val rootNamespaceId = client.users().currentAccount.rootInfo.rootNamespaceId
+
+    return client.withPathRoot(PathRoot.root(rootNamespaceId))
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
@@ -1,0 +1,90 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import java.net.URI
+import java.util.UUID
+import org.junit.Assume.assumeNotNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DropboxWriterExternalTest {
+  private lateinit var writer: DropboxWriter
+
+  /** Folder in which the temporary folders for test runs will be created. */
+  private val parentFolder = "/Engineering/Automated Tests"
+
+  private var scratchFolderCreated: Boolean = false
+  private val scratchFolder: String by lazy {
+    val path = "$parentFolder/${javaClass.simpleName}-${UUID.randomUUID()}"
+    writer.createFolder(path)
+    scratchFolderCreated = true
+    path
+  }
+
+  @BeforeEach
+  fun setUp() {
+    val appKey = getEnvOrSkipTest("TERRAWARE_DROPBOX_APPKEY")
+    val appSecret = getEnvOrSkipTest("TERRAWARE_DROPBOX_APPSECRET")
+    val refreshToken = getEnvOrSkipTest("TERRAWARE_DROPBOX_REFRESHTOKEN")
+
+    val config =
+        TerrawareServerConfig(
+            webAppUrl = URI("https://terraware.io"),
+            dropbox =
+                TerrawareServerConfig.DropboxConfig(
+                    enabled = true,
+                    appKey = appKey,
+                    appSecret = appSecret,
+                    refreshToken = refreshToken,
+                ),
+            keycloak =
+                TerrawareServerConfig.KeycloakConfig(
+                    apiClientId = "test",
+                    apiClientGroupName = "test",
+                    apiClientUsernamePrefix = "test"))
+
+    writer = DropboxWriter(config)
+  }
+
+  @AfterEach
+  fun deleteScratchFolder() {
+    if (scratchFolderCreated) {
+      writer.delete(scratchFolder)
+    }
+  }
+
+  @Test
+  fun `can create folders`() {
+    // Lazy evaluation will create the folder; this is really checking whether the lazy init
+    // function throws an exception.
+    assertNotNull(scratchFolder)
+  }
+
+  @Test
+  fun `uploading file with same name as existing file uses new filename`() {
+    val name = "test file"
+
+    val uploadedName1 = writer.uploadFile(scratchFolder, name, "a".byteInputStream())
+    val uploadedName2 = writer.uploadFile(scratchFolder, name, "b".byteInputStream())
+
+    assertEquals(name, uploadedName1, "First upload should have used requested name")
+    assertNotEquals(uploadedName1, uploadedName2, "Second upload should have used new name")
+  }
+
+  @Test
+  fun `implicitly creates missing folders`() {
+    val name = "test file"
+
+    val uploadedName = writer.uploadFile("$scratchFolder/subdir", name, "a".byteInputStream())
+
+    assertEquals(name, uploadedName)
+  }
+
+  private fun getEnvOrSkipTest(name: String): String {
+    val value = System.getenv(name)
+    assumeNotNull(value, "$name not set; skipping test")
+    return value
+  }
+}


### PR DESCRIPTION
Add support for uploading submitted documents for sensitive deliverables to
Dropbox instead of Google Drive.

Requires valid Dropbox API credentials with the appropriate permissions.