### PR TITLE
Implement submission document redirect endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import java.net.URI
 import java.time.Instant
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -159,7 +158,7 @@ class DeliverablesController(
       @PathVariable deliverableId: DeliverableId,
       @PathVariable documentId: SubmissionDocumentId
   ): ResponseEntity<String> {
-    val url = URI("https://dropbox.com/")
+    val url = submissionService.getExternalUrl(deliverableId, documentId)
 
     return ResponseEntity.status(HttpStatus.TEMPORARY_REDIRECT).location(url).build()
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.ProjectId
 
 class CohortNotFoundException(id: CohortId) : EntityNotFoundException("Cohort $id not found")
@@ -23,3 +24,6 @@ class ParticipantNotFoundException(id: ParticipantId) :
 
 class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
     MismatchedStateException("Project $id document upload settings have not been configured")
+
+class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
+    EntityNotFoundException("Submission document $id not found")

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -291,6 +292,8 @@ data class DeviceManagerUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = false
 
   override fun canReadSubLocation(subLocationId: SubLocationId): Boolean = false
+
+  override fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = false
 
   override fun canReadUpload(uploadId: UploadId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -380,6 +381,9 @@ data class IndividualUser(
 
   override fun canReadSubLocation(subLocationId: SubLocationId) =
       isMember(parentStore.getFacilityId(subLocationId))
+
+  override fun canReadSubmissionDocument(documentId: SubmissionDocumentId) =
+      isAcceleratorAdmin() || isTFExpert() || isReadOnly()
 
   override fun canReadTimeseries(deviceId: DeviceId) = isMember(parentStore.getFacilityId(deviceId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.accelerator.db.CohortNotFoundException
 import com.terraformation.backend.accelerator.db.ParticipantNotFoundException
+import com.terraformation.backend.accelerator.db.SubmissionDocumentNotFoundException
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AutomationNotFoundException
 import com.terraformation.backend.db.DeviceManagerNotFoundException
@@ -21,6 +22,7 @@ import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -625,6 +627,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readSubLocation(subLocationId: SubLocationId) {
     if (!user.canReadSubLocation(subLocationId)) {
       throw SubLocationNotFoundException(subLocationId)
+    }
+  }
+
+  fun readSubmissionDocument(documentId: SubmissionDocumentId) {
+    if (!user.canReadSubmissionDocument(documentId)) {
+      throw SubmissionDocumentNotFoundException(documentId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.auth.CurrentUserHolder
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -291,6 +292,8 @@ class SystemUser(
   override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
 
   override fun canReadSubLocation(subLocationId: SubLocationId): Boolean = true
+
+  override fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = true
 
   override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.model
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -244,6 +245,8 @@ interface TerrawareUser : Principal {
   fun canReadSpecies(speciesId: SpeciesId): Boolean
 
   fun canReadSubLocation(subLocationId: SubLocationId): Boolean
+
+  fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean
 
   fun canReadTimeseries(deviceId: DeviceId): Boolean
 

--- a/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
@@ -203,10 +203,21 @@ class GoogleDriveWriter(
     deleteRequest.execute()
   }
 
+  /**
+   * Returns a shareable link to the file. Access is still subject to the permission settings on the
+   * file.
+   */
+  fun shareFile(googleFileId: String): URI {
+    return URI.create(getFileMetadata(googleFileId, "webViewLink").webViewLink)
+  }
+
   /** Returns the metadata for an existing file. */
-  private fun getFileMetadata(googleFileId: String): File {
+  private fun getFileMetadata(googleFileId: String, fields: String? = null): File {
     val getRequest = driveClient.files().get(googleFileId)
     getRequest.supportsAllDrives = true
+    if (fields != null) {
+      getRequest.fields = fields
+    }
 
     try {
       return getRequest.execute()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.model
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.db.CohortNotFoundException
 import com.terraformation.backend.accelerator.db.ParticipantNotFoundException
+import com.terraformation.backend.accelerator.db.SubmissionDocumentNotFoundException
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.AutomationNotFoundException
 import com.terraformation.backend.db.DeviceManagerNotFoundException
@@ -21,6 +22,7 @@ import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.ViabilityTestNotFoundException
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.DeviceManagerId
@@ -143,6 +145,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(SpeciesNotFoundException::class) { canReadSpecies(it) }
   private val subLocationId: SubLocationId by
       readableId(SubLocationNotFoundException::class) { canReadSubLocation(it) }
+  private val submissionDocumentId: SubmissionDocumentId by
+      readableId(SubmissionDocumentNotFoundException::class) { canReadSubmissionDocument(it) }
   private val uploadId: UploadId by readableId(UploadNotFoundException::class) { canReadUpload(it) }
   private val userId = UserId(1)
   private val viabilityTestId: ViabilityTestId by
@@ -553,6 +557,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readSpecies() = testRead { readSpecies(speciesId) }
 
   @Test fun readSubLocation() = testRead { readSubLocation(subLocationId) }
+
+  @Test fun readSubmissionDocument() = testRead { readSubmissionDocument(submissionDocumentId) }
 
   @Test fun readUpload() = testRead { readUpload(uploadId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.model.PermissionTest.PermissionsTrack
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.BalenaDeviceId
 import com.terraformation.backend.db.default_schema.DeviceId
@@ -133,7 +134,9 @@ internal class PermissionTest : DatabaseTest() {
   private val plantingSubzoneIds = facilityIds.map { PlantingSubzoneId(it.value) }
   private val plantingZoneIds = facilityIds.map { PlantingZoneId(it.value) }
   private val observationIds = plantingSiteIds.map { ObservationId(it.value) }
+
   private val projectIds = facilityIds.map { ProjectId(it.value) }
+  private val submissionDocumentIds = projectIds.map { SubmissionDocumentId(it.value) }
 
   private val accessionIds = facilityIds.map { AccessionId(it.value) }
   private val automationIds = facilityIds.map { AutomationId(it.value) }
@@ -1205,6 +1208,11 @@ internal class PermissionTest : DatabaseTest() {
         updateProject = true,
     )
 
+    permissions.expect(
+        *submissionDocumentIds.toTypedArray(),
+        readSubmissionDocument = true,
+    )
+
     permissions.andNothingElse()
   }
 
@@ -1266,6 +1274,11 @@ internal class PermissionTest : DatabaseTest() {
         ProjectId(3000),
         createSubmission = true,
         updateProjectDocumentSettings = true,
+    )
+
+    permissions.expect(
+        *submissionDocumentIds.toTypedArray(),
+        readSubmissionDocument = true,
     )
 
     permissions.expect(
@@ -1350,6 +1363,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *submissionDocumentIds.toTypedArray(),
+        readSubmissionDocument = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = false,
         addCohortParticipant = true,
         addParticipantProject = true,
@@ -1414,6 +1432,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *submissionDocumentIds.toTypedArray(),
+        readSubmissionDocument = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = false,
         addCohortParticipant = false,
         addParticipantProject = false,
@@ -1473,6 +1496,11 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = false,
         rescheduleObservation = false,
         updateObservation = true,
+    )
+
+    permissions.expect(
+        *submissionDocumentIds.toTypedArray(),
+        readSubmissionDocument = true,
     )
 
     permissions.expect(
@@ -1616,6 +1644,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedReports = reportIds.toMutableSet()
     private val uncheckedSpecies = speciesIds.toMutableSet()
     private val uncheckedSubLocations = subLocationIds.toMutableSet()
+    private val uncheckedSubmissionDocuments = submissionDocumentIds.toMutableSet()
     private val uncheckedViabilityTests = viabilityTestIds.toMutableSet()
     private val uncheckedWithdrawals = withdrawalIds.toMutableSet()
 
@@ -2254,6 +2283,20 @@ internal class PermissionTest : DatabaseTest() {
       }
     }
 
+    fun expect(
+        vararg documentIds: SubmissionDocumentId,
+        readSubmissionDocument: Boolean = false,
+    ) {
+      documentIds.forEach { documentId ->
+        assertEquals(
+            readSubmissionDocument,
+            user.canReadSubmissionDocument(documentId),
+            "Can read submission document $documentId")
+
+        uncheckedSubmissionDocuments.remove(documentId)
+      }
+    }
+
     fun andNothingElse() {
       expect(*uncheckedAccessions.toTypedArray())
       expect(*uncheckedAutomations.toTypedArray())
@@ -2273,6 +2316,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedReports.toTypedArray())
       expect(*uncheckedSpecies.toTypedArray())
       expect(*uncheckedSubLocations.toTypedArray())
+      expect(*uncheckedSubmissionDocuments.toTypedArray())
       expect(*uncheckedViabilityTests.toTypedArray())
       expect(*uncheckedWithdrawals.toTypedArray())
 

--- a/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
@@ -82,6 +82,18 @@ class DropboxWriterExternalTest {
     assertEquals(name, uploadedName)
   }
 
+  @Test
+  fun `can generate shared link for file`() {
+    val name = "share test"
+
+    writer.uploadFile(scratchFolder, name, "a".byteInputStream())
+
+    // Generate shared link twice to test "link already exists" logic which kicks in when the same
+    // file is shared repeatedly while a valid link still exists.
+    assertNotNull(writer.shareFile("$scratchFolder/$name"))
+    assertNotNull(writer.shareFile("$scratchFolder/$name"))
+  }
+
   private fun getEnvOrSkipTest(name: String): String {
     val value = System.getenv(name)
     assumeNotNull(value, "$name not set; skipping test")


### PR DESCRIPTION
Generate URLs for documents on Google Drive and Dropbox, and redirect to them from
`GET /api/v1/accelerator/deliverables/{deliverableId}/documents/{documentId}`.
This is only available for users with Super-Admin, Accelerator Admin, TF Expert,
or Read Only global roles.