### PR TITLE
SW-5000 Don't notify about "Needs Translation" status

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableStatusUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableStatusUpdatedEvent.kt
@@ -1,10 +1,33 @@
 package com.terraformation.backend.accelerator.event
 
 import com.terraformation.backend.db.accelerator.DeliverableId
-import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.default_schema.ProjectId
 
 /** Published when a deliverable status is updated */
 data class DeliverableStatusUpdatedEvent(
     val deliverableId: DeliverableId,
-    val organizationId: OrganizationId,
-)
+    val projectId: ProjectId,
+    val oldStatus: SubmissionStatus,
+    val newStatus: SubmissionStatus,
+) {
+  /**
+   * Returns true if the transition is visible to end users, or false if it is a transition between
+   * internally-visible statuses that are presented as the same status to users.
+   */
+  fun isUserVisible(): Boolean {
+    return when (oldStatus) {
+      SubmissionStatus.InReview ->
+          when (newStatus) {
+            SubmissionStatus.NeedsTranslation -> false
+            else -> true
+          }
+      SubmissionStatus.NeedsTranslation ->
+          when (newStatus) {
+            SubmissionStatus.InReview -> false
+            else -> true
+          }
+      else -> true
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -310,16 +310,19 @@ class AppNotificationService(
 
   @EventListener
   fun on(event: DeliverableStatusUpdatedEvent) {
-    val deliverableUrl = webAppUrls.deliverable(event.deliverableId)
-    val renderMessage = { messages.deliverableStatusUpdated() }
+    if (event.isUserVisible()) {
+      val organizationId = parentStore.getOrganizationId(event.projectId)!!
+      val deliverableUrl = webAppUrls.deliverable(event.deliverableId)
+      val renderMessage = { messages.deliverableStatusUpdated() }
 
-    log.info("Creating app notifications for deliverable ${event.deliverableId} status updated")
-    insertOrganizationNotifications(
-        event.organizationId,
-        NotificationType.DeliverableStatusUpdated,
-        renderMessage,
-        deliverableUrl,
-        setOf(Role.Owner, Role.Admin, Role.Manager))
+      log.info("Creating app notifications for deliverable ${event.deliverableId} status updated")
+      insertOrganizationNotifications(
+          organizationId,
+          NotificationType.DeliverableStatusUpdated,
+          renderMessage,
+          deliverableUrl,
+          setOf(Role.Owner, Role.Admin, Role.Manager))
+    }
   }
 
   private fun insertFacilityNotifications(

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -530,12 +530,14 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: DeliverableStatusUpdatedEvent) {
-    emailService.sendOrganizationNotification(
-        event.organizationId,
-        DeliverableStatusUpdated(
-            config,
-            webAppUrls.fullDeliverable(event.organizationId, event.deliverableId).toString()),
-        roles = setOf(Role.Admin, Role.Manager, Role.Owner))
+    if (event.isUserVisible()) {
+      val organizationId = parentStore.getOrganizationId(event.projectId)!!
+      emailService.sendOrganizationNotification(
+          organizationId,
+          DeliverableStatusUpdated(
+              config, webAppUrls.fullDeliverable(organizationId, event.deliverableId).toString()),
+          roles = setOf(Role.Admin, Role.Manager, Role.Owner))
+    }
   }
 
   @EventListener


### PR DESCRIPTION
When a submission goes from "In Review" to "Needs Translation" or back, the change
isn't visible to end users. Suppress the notifications in that case.

Include the project ID in the application event since there can be multiple
projects in the same organization that submit the same deliverable.