### PR TITLE
SW-4952 Add permission to read all deliverables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -260,6 +260,8 @@ data class DeviceManagerUser(
 
   override fun canReadAccession(accessionId: AccessionId): Boolean = false
 
+  override fun canReadAllDeliverables(): Boolean = false
+
   override fun canReadBatch(batchId: BatchId): Boolean = false
 
   override fun canReadCohort(cohortId: CohortId): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -308,6 +308,8 @@ data class IndividualUser(
   override fun canReadAccession(accessionId: AccessionId) =
       isMember(parentStore.getFacilityId(accessionId))
 
+  override fun canReadAllDeliverables() = isReadOnlyOrHigher()
+
   override fun canReadAutomation(automationId: AutomationId) =
       isMember(parentStore.getFacilityId(automationId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -494,6 +494,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readAllDeliverables() {
+    if (!user.canReadAllDeliverables()) {
+      throw AccessDeniedException("No permission to read all deliverables")
+    }
+  }
+
   fun readAutomation(automationId: AutomationId) {
     if (!user.canReadAutomation(automationId)) {
       throw AutomationNotFoundException(automationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -248,6 +248,8 @@ class SystemUser(
 
   override fun canReadAccession(accessionId: AccessionId): Boolean = true
 
+  override fun canReadAllDeliverables(): Boolean = true
+
   override fun canReadAutomation(automationId: AutomationId): Boolean = true
 
   override fun canReadBatch(batchId: BatchId): Boolean = true

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -202,6 +202,8 @@ interface TerrawareUser : Principal {
 
   fun canReadAccession(accessionId: AccessionId): Boolean
 
+  fun canReadAllDeliverables(): Boolean
+
   fun canReadAutomation(automationId: AutomationId): Boolean
 
   fun canReadBatch(batchId: BatchId): Boolean

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -501,6 +501,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun readAccession() = testRead { readAccession(accessionId) }
 
+  @Test
+  fun readAllDeliverables() = allow { readAllDeliverables() } ifUser { canReadAllDeliverables() }
+
   @Test fun readAutomation() = testRead { readAutomation(automationId) }
 
   @Test fun readBatch() = testRead { readBatch(batchId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -171,7 +171,7 @@ internal class PermissionTest : DatabaseTest() {
   private val globalRoles = setOf(GlobalRole.SuperAdmin)
 
   private val moduleId = ModuleId(1)
-  private val deliverableId = DeliverableId(10)
+  private val deliverableIds = listOf(DeliverableId(10))
   private val submissionIds = projectIds.map { SubmissionId(it.value) }
 
   private inline fun <reified T> List<T>.filterToArray(func: (T) -> Boolean): Array<T> =
@@ -333,15 +333,21 @@ internal class PermissionTest : DatabaseTest() {
         createdBy = userId,
         id = moduleId,
     )
-    insertDeliverable(createdBy = userId, id = deliverableId, moduleId = moduleId)
-
-    submissionIds.forEach { submissionId ->
-      insertSubmission(
+    deliverableIds.forEach { deliverableId ->
+      insertDeliverable(
           createdBy = userId,
-          deliverableId = deliverableId,
-          id = submissionId,
-          projectId = ProjectId(submissionId.value),
+          id = deliverableId,
+          moduleId = moduleId,
       )
+
+      submissionIds.forEach { submissionId ->
+        insertSubmission(
+            createdBy = userId,
+            deliverableId = deliverableId,
+            id = submissionId,
+            projectId = ProjectId(submissionId.value),
+        )
+      }
     }
   }
 
@@ -1174,6 +1180,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipant = true,
         deleteParticipantProject = true,
         manageNotifications = true,
+        readAllDeliverables = true,
         readCohort = true,
         readGlobalRoles = true,
         readInternalTags = true,
@@ -1353,9 +1360,10 @@ internal class PermissionTest : DatabaseTest() {
         manageDeliverables = true,
         manageInternalTags = true,
         manageModules = true,
-        readInternalTags = true,
-        readGlobalRoles = true,
+        readAllDeliverables = true,
         readCohort = true,
+        readGlobalRoles = true,
+        readInternalTags = true,
         readParticipant = true,
         regenerateAllDeviceManagerTokens = true,
         setTestClock = true,
@@ -1447,9 +1455,10 @@ internal class PermissionTest : DatabaseTest() {
         manageDeliverables = true,
         manageInternalTags = false,
         manageModules = true,
-        readInternalTags = true,
+        readAllDeliverables = true,
         readCohort = true,
         readGlobalRoles = true,
+        readInternalTags = true,
         readParticipant = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
@@ -1535,9 +1544,10 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         importGlobalSpeciesData = false,
         manageInternalTags = false,
-        readInternalTags = false,
+        readAllDeliverables = true,
         readCohort = true,
         readGlobalRoles = false,
+        readInternalTags = false,
         readParticipant = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
@@ -1608,9 +1618,10 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         importGlobalSpeciesData = false,
         manageInternalTags = false,
-        readInternalTags = false,
+        readAllDeliverables = true,
         readCohort = true,
         readGlobalRoles = false,
+        readInternalTags = false,
         readParticipant = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
@@ -2047,6 +2058,7 @@ internal class PermissionTest : DatabaseTest() {
         manageInternalTags: Boolean = false,
         manageModules: Boolean = false,
         manageNotifications: Boolean = false,
+        readAllDeliverables: Boolean = false,
         readCohort: Boolean = false,
         readGlobalRoles: Boolean = false,
         readInternalTags: Boolean = false,
@@ -2093,6 +2105,7 @@ internal class PermissionTest : DatabaseTest() {
       assertEquals(manageInternalTags, user.canManageInternalTags(), "Can manage internal tags")
       assertEquals(manageModules, user.canManageModules(), "Can manage modules")
       assertEquals(manageNotifications, user.canManageNotifications(), "Can manage notifications")
+      assertEquals(readAllDeliverables, user.canReadAllDeliverables(), "Can read all deliverables")
       assertEquals(readCohort, user.canReadCohort(cohortId), "Can read cohort")
       assertEquals(readGlobalRoles, user.canReadGlobalRoles(), "Can read global roles")
       assertEquals(readInternalTags, user.canReadInternalTags(), "Can read internal tags")
@@ -2372,7 +2385,7 @@ internal class PermissionTest : DatabaseTest() {
             "Can update project $projectId document settings")
         assertEquals(
             updateSubmissionStatus,
-            user.canUpdateSubmissionStatus(deliverableId, projectId),
+            user.canUpdateSubmissionStatus(deliverableIds.first(), projectId),
             "Can update submission status for project $projectId")
 
         uncheckedProjects.remove(projectId)


### PR DESCRIPTION
Internal users will need to be able to get an overview of all deliverables for all
projects; add a global permission for it.