### PR TITLE
SW-5007 Notify when deliverable documents are uploaded

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableReadyForReviewEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableReadyForReviewEvent.kt
@@ -1,14 +1,10 @@
 package com.terraformation.backend.accelerator.event
 
 import com.terraformation.backend.db.accelerator.DeliverableId
-import com.terraformation.backend.db.accelerator.ParticipantId
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 
 /** Published when a deliverable is ready for review */
 data class DeliverableReadyForReviewEvent(
     val deliverableId: DeliverableId,
-    val organizationId: OrganizationId,
-    val participantId: ParticipantId,
     val projectId: ProjectId,
 )

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.model
 
+import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
@@ -9,10 +10,12 @@ data class ProjectModel<ID : ProjectId?>(
     val name: String,
     val organizationId: OrganizationId,
     val description: String? = null,
+    val participantId: ParticipantId? = null,
 ) {
   companion object {
     fun of(row: ProjectsRow): ExistingProjectModel {
-      return ExistingProjectModel(row.id!!, row.name!!, row.organizationId!!, row.description)
+      return ExistingProjectModel(
+          row.id!!, row.name!!, row.organizationId!!, row.description, row.participantId)
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -519,9 +519,15 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: DeliverableReadyForReviewEvent) {
-    val participant = participantStore.fetchOneById(event.participantId)
+    val project = projectStore.fetchOneById(event.projectId)
+    if (project.participantId == null) {
+      log.error("Got deliverable ready notification for non-participant project ${event.projectId}")
+      return
+    }
+
+    val participant = participantStore.fetchOneById(project.participantId)
     sendToAccelerator(
-        event.organizationId,
+        project.organizationId,
         DeliverableReadyForReview(
             config,
             webAppUrls

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.customer.db.NotificationStore
 import com.terraformation.backend.customer.db.OrganizationStore
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.PermissionStore
+import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.event.FacilityIdleEvent
 import com.terraformation.backend.customer.event.UserAddedToOrganizationEvent
@@ -103,6 +104,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   private lateinit var parentStore: ParentStore
   private lateinit var participantStore: ParticipantStore
   private lateinit var plantingSiteStore: PlantingSiteStore
+  private lateinit var projectStore: ProjectStore
   private lateinit var userStore: UserStore
   private lateinit var service: AppNotificationService
   private lateinit var webAppUrls: WebAppUrls
@@ -153,6 +155,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             plantingSitesDao,
             plantingSubzonesDao,
             plantingZonesDao)
+    projectStore = ProjectStore(clock, dslContext, publisher, projectsDao)
     userStore =
         UserStore(
             clock,
@@ -179,6 +182,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             parentStore,
             participantStore,
             plantingSiteStore,
+            projectStore,
             SystemUser(usersDao),
             userStore,
             messages,
@@ -565,8 +569,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(
-        DeliverableReadyForReviewEvent(deliverableId, organizationId, participantId, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotification(
         type = NotificationType.DeliverableReadyForReview,
@@ -590,8 +593,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(
-        DeliverableReadyForReviewEvent(deliverableId, organizationId, participantId, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotifications(
         listOf(
@@ -626,8 +628,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(
-        DeliverableReadyForReviewEvent(deliverableId, organizationId, participantId, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotifications(
         listOf(

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -201,6 +201,7 @@ internal class EmailNotificationServiceTest {
           id = ProjectId(1),
           name = "My Project",
           organizationId = organization.id,
+          participantId = participant.id,
       )
   private val upcomingObservation =
       ExistingObservationModel(
@@ -832,9 +833,7 @@ internal class EmailNotificationServiceTest {
   fun `deliverableReadyForReview with Terraformation contact`() {
     every { userStore.getTerraformationContactUser(any()) } returns tfContactUser
 
-    val event =
-        DeliverableReadyForReviewEvent(
-            DeliverableId(1), organization.id, participant.id, project.id)
+    val event = DeliverableReadyForReviewEvent(DeliverableId(1), project.id)
 
     service.on(event)
 
@@ -850,9 +849,7 @@ internal class EmailNotificationServiceTest {
     every { userStore.getTerraformationContactUser(any()) } returns tfContactUser
     every { userStore.fetchWithGlobalRoles() } returns listOf(acceleratorUser, tfContactUser)
 
-    val event =
-        DeliverableReadyForReviewEvent(
-            DeliverableId(1), organization.id, participant.id, project.id)
+    val event = DeliverableReadyForReviewEvent(DeliverableId(1), project.id)
 
     service.on(event)
 
@@ -868,9 +865,7 @@ internal class EmailNotificationServiceTest {
 
   @Test
   fun `deliverableReadyForReview without Terraformation contact`() {
-    val event =
-        DeliverableReadyForReviewEvent(
-            DeliverableId(1), organization.id, participant.id, project.id)
+    val event = DeliverableReadyForReviewEvent(DeliverableId(1), project.id)
 
     service.on(event)
 


### PR DESCRIPTION
When a user uploads a document for a deliverable, notify the appropriate
internal users that the deliverable is ready for review.

Currently, each uploaded document will trigger a notification.