### PR TITLE
SW-4991 Wait for more documents before notifying

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
+import com.terraformation.backend.accelerator.event.DeliverableReadyForReviewEvent
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import java.time.Duration
+import java.time.InstantSource
+import org.jobrunr.scheduling.JobScheduler
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Lazy
+import org.springframework.context.event.EventListener
+
+@Named
+class SubmissionNotifier(
+    private val clock: InstantSource,
+    private val deliverableStore: DeliverableStore,
+    private val eventPublisher: ApplicationEventPublisher,
+    @Lazy private val scheduler: JobScheduler,
+    private val systemUser: SystemUser,
+) {
+  companion object {
+    /**
+     * Wait this long before notifying about new submissions to give the user time to submit
+     * additional items for a deliverable. This is the delay after the _last_ submission, that is,
+     * the countdown resets each time something new is submitted for a deliverable.
+     */
+    private val notificationDelay = Duration.ofMinutes(5)
+
+    private val log = perClassLogger()
+  }
+
+  /** Schedules a "ready for review" notification when a document is uploaded. */
+  @EventListener
+  fun on(event: DeliverableDocumentUploadedEvent) {
+    scheduler.schedule<SubmissionNotifier>(clock.instant().plus(notificationDelay)) {
+      notifyIfNoNewerUploads(event)
+    }
+  }
+
+  /**
+   * Publishes [DeliverableReadyForReviewEvent] if no documents have been uploaded for a submission
+   * since the one referenced by the event.
+   */
+  fun notifyIfNoNewerUploads(event: DeliverableDocumentUploadedEvent) {
+    systemUser.run {
+      val deliverable =
+          deliverableStore
+              .fetchDeliverableSubmissions(
+                  projectId = event.projectId, deliverableId = event.deliverableId)
+              .firstOrNull()
+
+      if (deliverable != null) {
+        val maxDocumentId = deliverable.documents.map { it.id }.maxBy { it.value }
+
+        if (maxDocumentId == event.documentId) {
+          eventPublisher.publishEvent(
+              DeliverableReadyForReviewEvent(event.deliverableId, event.projectId))
+        }
+      } else {
+        log.error("Deliverable ${event.deliverableId} not found for project ${event.projectId}")
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
@@ -25,7 +25,8 @@ class SubmissionNotifier(
     /**
      * Wait this long before notifying about new submissions to give the user time to submit
      * additional items for a deliverable. This is the delay after the _last_ submission, that is,
-     * the countdown resets each time something new is submitted for a deliverable.
+     * the user-visible behavior is that the countdown resets each time something new is submitted
+     * for a deliverable.
      */
     private val notificationDelay = Duration.ofMinutes(5)
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.accelerator.db.SubmissionDocumentNotFoundExcep
 import com.terraformation.backend.accelerator.document.DropboxReceiver
 import com.terraformation.backend.accelerator.document.GoogleDriveReceiver
 import com.terraformation.backend.accelerator.document.SubmissionDocumentReceiver
-import com.terraformation.backend.accelerator.event.DeliverableReadyForReviewEvent
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.DeliverableId
@@ -189,9 +189,12 @@ class SubmissionService(
         receiver.rename(storedFile, submissionDocument.name!!)
       }
 
-      eventPublisher.publishEvent(DeliverableReadyForReviewEvent(deliverableId, projectId))
+      val documentId = submissionDocument.id!!
 
-      return submissionDocument.id!!
+      eventPublisher.publishEvent(
+          DeliverableDocumentUploadedEvent(deliverableId, documentId, projectId))
+
+      return documentId
     } catch (e: Exception) {
       log.error("Error while recording uploaded document", e)
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadedEvent.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.default_schema.ProjectId
+
+/** Published when a new document is uploladed for a deliverable. */
+data class DeliverableDocumentUploadedEvent(
+    val deliverableId: DeliverableId,
+    val documentId: SubmissionDocumentId,
+    val projectId: ProjectId,
+)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
@@ -1,0 +1,79 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
+import com.terraformation.backend.accelerator.event.DeliverableReadyForReviewEvent
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.mockUser
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SubmissionNotifierTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val eventPublisher = TestEventPublisher()
+
+  private val notifier: SubmissionNotifier by lazy {
+    SubmissionNotifier(
+        TestClock(),
+        DeliverableStore(dslContext),
+        eventPublisher,
+        mockk(),
+        SystemUser(usersDao),
+    )
+  }
+
+  private lateinit var deliverableId: DeliverableId
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertModule()
+    insertCohort()
+    insertCohortModule()
+    insertParticipant(cohortId = inserted.cohortId)
+
+    projectId = insertProject(participantId = inserted.participantId)
+    deliverableId = insertDeliverable()
+  }
+
+  @Nested
+  inner class NotifyIfNoNewerUploads {
+    @Test
+    fun `does not publish event if there are newer documents`() {
+      insertSubmission()
+
+      val documentId = insertSubmissionDocument()
+      insertSubmissionDocument()
+
+      notifier.notifyIfNoNewerUploads(
+          DeliverableDocumentUploadedEvent(deliverableId, documentId, projectId))
+
+      eventPublisher.assertEventNotPublished(DeliverableReadyForReviewEvent::class.java)
+    }
+
+    @Test
+    fun `publishes event if this is the latest document`() {
+      insertSubmission()
+
+      insertSubmissionDocument()
+      val documentId = insertSubmissionDocument()
+
+      notifier.notifyIfNoNewerUploads(
+          DeliverableDocumentUploadedEvent(deliverableId, documentId, projectId))
+
+      eventPublisher.assertEventPublished(DeliverableReadyForReviewEvent(deliverableId, projectId))
+    }
+  }
+}


### PR DESCRIPTION
To avoid flooding accelerator admins with notifications when users upload multiple
documents in rapid succession to satisfy deliverables, defer the "deliverable
ready for review" notification until 5 minutes have passed without a new upload
for the deliverable.