### PR TITLE
Fix CohortStoreTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
@@ -87,13 +87,12 @@ class CohortStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           listOf(
               CohortModulesRow(
-                  id = 1,
                   cohortId = model.id,
                   moduleId = moduleId,
                   startDate = LocalDate.of(1970, 1, 1),
                   endDate = LocalDate.of(1970, 5, 1),
               )),
-          cohortModulesDao.findAll())
+          cohortModulesDao.findAll().map { it.copy(id = null) })
     }
 
     @Test


### PR DESCRIPTION
The test was checking for a specific ID being created but wasn't resetting the
ID sequence on the table, so if another earlier test inserted into the same table,
this test would fail.

We don't actually care which specific ID is used, so fix the test by ignoring the
ID entirely when asserting that the expected values were inserted into the
database.