### PR TITLE
SW-5022 Allow internal users to read deliverables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -33,9 +33,9 @@ class DeliverableStore(
   ): List<DeliverableSubmissionModel> {
     requirePermissions {
       when {
-        projectId != null -> readProject(projectId)
+        projectId != null -> readProjectDeliverables(projectId)
         participantId != null -> readParticipant(participantId)
-        organizationId != null -> readOrganization(organizationId)
+        organizationId != null -> readOrganizationDeliverables(organizationId)
         else -> readAllDeliverables()
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -278,6 +278,8 @@ data class DeviceManagerUser(
 
   override fun canReadObservation(observationId: ObservationId): Boolean = false
 
+  override fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean = false
+
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       false
 
@@ -292,6 +294,8 @@ data class DeviceManagerUser(
   override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = false
 
   override fun canReadProject(projectId: ProjectId): Boolean = false
+
+  override fun canReadProjectDeliverables(projectId: ProjectId): Boolean = false
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -350,6 +350,9 @@ data class IndividualUser(
 
   override fun canReadOrganization(organizationId: OrganizationId) = isMember(organizationId)
 
+  override fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean =
+      isReadOnlyOrHigher() || isManagerOrHigher(organizationId)
+
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean {
     return if (userId == this.userId) {
       canReadOrganization(organizationId)
@@ -374,6 +377,9 @@ data class IndividualUser(
 
   override fun canReadProject(projectId: ProjectId) =
       isMember(parentStore.getOrganizationId(projectId))
+
+  override fun canReadProjectDeliverables(projectId: ProjectId): Boolean =
+      isReadOnlyOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
 
   override fun canReadProjectScores(projectId: ProjectId) = isReadOnlyOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -584,6 +584,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readOrganizationDeliverables(organizationId: OrganizationId) {
+    if (!user.canReadOrganizationDeliverables(organizationId)) {
+      readOrganization(organizationId)
+      throw AccessDeniedException(
+          "No permission to read deliverables for organization $organizationId")
+    }
+  }
+
   fun readOrganizationUser(organizationId: OrganizationId, userId: UserId) {
     if (!user.canReadOrganizationUser(organizationId, userId)) {
       readOrganization(organizationId)
@@ -624,6 +632,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readProject(projectId: ProjectId) {
     if (!user.canReadProject(projectId)) {
       throw ProjectNotFoundException(projectId)
+    }
+  }
+
+  fun readProjectDeliverables(projectId: ProjectId) {
+    if (!user.canReadProjectDeliverables(projectId)) {
+      readProject(projectId)
+      throw AccessDeniedException("No permission to read deliverables for project $projectId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -278,6 +278,8 @@ class SystemUser(
 
   override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
 
+  override fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean = true
+
   override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
       true
 
@@ -292,6 +294,8 @@ class SystemUser(
   override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
 
   override fun canReadProject(projectId: ProjectId): Boolean = true
+
+  override fun canReadProjectDeliverables(projectId: ProjectId): Boolean = true
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -232,6 +232,8 @@ interface TerrawareUser : Principal {
 
   fun canReadOrganization(organizationId: OrganizationId): Boolean
 
+  fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean
+
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
 
   fun canReadParticipant(participantId: ParticipantId): Boolean
@@ -245,6 +247,8 @@ interface TerrawareUser : Principal {
   fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean
 
   fun canReadProject(projectId: ProjectId): Boolean
+
+  fun canReadProjectDeliverables(projectId: ProjectId): Boolean
 
   fun canReadProjectScores(projectId: ProjectId): Boolean
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -32,8 +32,10 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
 
     every { user.canReadAllDeliverables() } returns true
     every { user.canReadOrganization(any()) } returns true
+    every { user.canReadOrganizationDeliverables(any()) } returns true
     every { user.canReadParticipant(any()) } returns true
     every { user.canReadProject(any()) } returns true
+    every { user.canReadProjectDeliverables(any()) } returns true
   }
 
   @Nested
@@ -325,8 +327,10 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception if no permission to read entities`() {
       every { user.canReadAllDeliverables() } returns false
       every { user.canReadOrganization(any()) } returns false
+      every { user.canReadOrganizationDeliverables(any()) } returns false
       every { user.canReadParticipant(any()) } returns false
       every { user.canReadProject(any()) } returns false
+      every { user.canReadProjectDeliverables(any()) } returns false
 
       insertOrganization()
       val participantId = insertParticipant()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -533,6 +533,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readOrganization() = testRead { readOrganization(organizationId) }
 
   @Test
+  fun readOrganizationDeliverables() {
+    assertThrows<OrganizationNotFoundException> {
+      requirements.readOrganizationDeliverables(organizationId)
+    }
+
+    grant { user.canReadOrganization(organizationId) }
+    assertThrows<AccessDeniedException> {
+      requirements.readOrganizationDeliverables(organizationId)
+    }
+
+    grant { user.canReadOrganizationDeliverables(organizationId) }
+    requirements.readOrganizationDeliverables(organizationId)
+  }
+
+  @Test
   fun readOrganizationUser() {
     assertThrows<OrganizationNotFoundException> {
       requirements.readOrganizationUser(organizationId, userId)
@@ -558,6 +573,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readPlantingZone() = testRead { readPlantingZone(plantingZoneId) }
 
   @Test fun readProject() = testRead { readProject(projectId) }
+
+  @Test
+  fun readProjectDeliverables() {
+    assertThrows<ProjectNotFoundException> { requirements.readProjectDeliverables(projectId) }
+
+    grant { user.canReadProject(projectId) }
+    assertThrows<AccessDeniedException> { requirements.readProjectDeliverables(projectId) }
+
+    grant { user.canReadProjectDeliverables(projectId) }
+    requirements.readProjectDeliverables(projectId)
+  }
 
   @Test fun readReport() = testRead { readReport(reportId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -374,6 +374,7 @@ internal class PermissionTest : DatabaseTest() {
         createDraftPlantingSite = true,
         listReports = true,
         createProject = true,
+        readOrganizationDeliverables = true,
     )
 
     permissions.expect(
@@ -512,6 +513,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         updateProject = true,
     )
 
@@ -551,6 +553,7 @@ internal class PermissionTest : DatabaseTest() {
         createDraftPlantingSite = true,
         listReports = true,
         createProject = true,
+        readOrganizationDeliverables = true,
     )
 
     permissions.expect(
@@ -597,6 +600,7 @@ internal class PermissionTest : DatabaseTest() {
         createDraftPlantingSite = true,
         listReports = true,
         createProject = true,
+        readOrganizationDeliverables = true,
     )
 
     permissions.expect(
@@ -735,6 +739,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         updateProject = true,
     )
 
@@ -765,6 +770,7 @@ internal class PermissionTest : DatabaseTest() {
         removeOrganizationSelf = true,
         createSpecies = true,
         listFacilities = true,
+        readOrganizationDeliverables = true,
     )
 
     permissions.expect(
@@ -873,6 +879,7 @@ internal class PermissionTest : DatabaseTest() {
         *projectIds.forOrg1(),
         createSubmission = true,
         readProject = true,
+        readProjectDeliverables = true,
     )
 
     permissions.expect(
@@ -1089,6 +1096,7 @@ internal class PermissionTest : DatabaseTest() {
         createReport = true,
         listReports = true,
         createProject = true,
+        readOrganizationDeliverables = true,
     )
 
     permissions.expect(
@@ -1256,6 +1264,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProject = true,
@@ -1300,6 +1309,27 @@ internal class PermissionTest : DatabaseTest() {
     val permissions = PermissionsTracker()
 
     permissions.expect(
+        *organizationIds.forOrg1(),
+        readOrganization = true,
+        updateOrganization = true,
+        listOrganizationUsers = true,
+        readOrganizationUser = true,
+        readOrganizationSelf = true,
+        addOrganizationUser = true,
+        removeOrganizationUser = true,
+        removeOrganizationSelf = true,
+        createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
+        createPlantingSite = true,
+        createDraftPlantingSite = true,
+        createReport = true,
+        listReports = true,
+        createProject = true,
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
         createObservation = true,
@@ -1324,6 +1354,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProject = true,
@@ -1337,6 +1368,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(3000),
         createSubmission = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProjectDocumentSettings = true,
@@ -1404,6 +1436,26 @@ internal class PermissionTest : DatabaseTest() {
     val permissions = PermissionsTracker()
 
     permissions.expect(
+        org1Id,
+        readOrganization = true,
+        updateOrganization = true,
+        listOrganizationUsers = true,
+        readOrganizationUser = true,
+        readOrganizationSelf = true,
+        addOrganizationUser = true,
+        removeOrganizationUser = true,
+        removeOrganizationSelf = true,
+        createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
+        createPlantingSite = true,
+        createDraftPlantingSite = true,
+        listReports = true,
+        createProject = true,
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
         createObservation = true,
@@ -1428,6 +1480,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProject = true,
@@ -1439,8 +1492,14 @@ internal class PermissionTest : DatabaseTest() {
 
     // Not an admin of this org but can still access accelerator-related functions.
     permissions.expect(
+        OrganizationId(3),
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         ProjectId(3000),
         createSubmission = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProjectDocumentSettings = true,
@@ -1507,6 +1566,26 @@ internal class PermissionTest : DatabaseTest() {
     val permissions = PermissionsTracker()
 
     permissions.expect(
+        org1Id,
+        readOrganization = true,
+        updateOrganization = true,
+        listOrganizationUsers = true,
+        readOrganizationUser = true,
+        readOrganizationSelf = true,
+        addOrganizationUser = true,
+        removeOrganizationUser = true,
+        removeOrganizationSelf = true,
+        createSpecies = true,
+        createFacility = true,
+        listFacilities = true,
+        createPlantingSite = true,
+        createDraftPlantingSite = true,
+        listReports = true,
+        createProject = true,
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = true,
         createObservation = true,
@@ -1531,6 +1610,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readProject = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProject = true,
@@ -1541,7 +1621,13 @@ internal class PermissionTest : DatabaseTest() {
 
     // Not an admin of this org but can still access accelerator-related functions.
     permissions.expect(
+        OrganizationId(3),
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         ProjectId(3000),
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
         updateProjectScores = true,
@@ -1605,6 +1691,15 @@ internal class PermissionTest : DatabaseTest() {
     givenRole(org1Id, Role.Contributor)
 
     permissions.expect(
+        org1Id,
+        readOrganization = true,
+        readOrganizationSelf = true,
+        removeOrganizationSelf = true,
+        listFacilities = true,
+        readOrganizationDeliverables = true,
+    )
+
+    permissions.expect(
         *plantingSiteIds.forOrg1(),
         createDelivery = false,
         createObservation = false,
@@ -1624,6 +1719,11 @@ internal class PermissionTest : DatabaseTest() {
         updateObservation = true,
     )
 
+    permissions.expect(
+        OrganizationId(3),
+        readOrganizationDeliverables = true,
+    )
+
     // Can read all submissions even those outside of this org
     permissions.expect(
         *submissionIds.toTypedArray(),
@@ -1638,6 +1738,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *projectIds.forOrg1(),
         readProject = true,
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
     )
@@ -1645,6 +1746,7 @@ internal class PermissionTest : DatabaseTest() {
     // Not an admin of this org but can still access accelerator-related functions.
     permissions.expect(
         ProjectId(3000),
+        readProjectDeliverables = true,
         readProjectScores = true,
         readProjectVotes = true,
     )
@@ -1817,6 +1919,7 @@ internal class PermissionTest : DatabaseTest() {
         createReport: Boolean = false,
         listReports: Boolean = false,
         createProject: Boolean = false,
+        readOrganizationDeliverables: Boolean = false,
     ) {
       organizations.forEach { organizationId ->
         assertEquals(
@@ -1887,6 +1990,10 @@ internal class PermissionTest : DatabaseTest() {
             createProject,
             user.canCreateProject(organizationId),
             "Can create project in organization $organizationId")
+        assertEquals(
+            readOrganizationDeliverables,
+            user.canReadOrganizationDeliverables(organizationId),
+            "Can read deliverables for organization $organizationId")
 
         uncheckedOrgs.remove(organizationId)
       }
@@ -2413,6 +2520,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission: Boolean = false,
         deleteProject: Boolean = false,
         readProject: Boolean = false,
+        readProjectDeliverables: Boolean = false,
         readProjectScores: Boolean = false,
         readProjectVotes: Boolean = false,
         updateProject: Boolean = false,
@@ -2429,6 +2537,10 @@ internal class PermissionTest : DatabaseTest() {
         assertEquals(
             deleteProject, user.canDeleteProject(projectId), "Can delete project $projectId")
         assertEquals(readProject, user.canReadProject(projectId), "Can read project $projectId")
+        assertEquals(
+            readProjectDeliverables,
+            user.canReadProjectDeliverables(projectId),
+            "Can read deliverables for project $projectId")
         assertEquals(
             readProjectScores,
             user.canReadProjectScores(projectId),


### PR DESCRIPTION
The permission checks for reading deliverables and submissions required the user
to be a member of the organization whose projects were being queried, and also
allowed contributor users to read deliverable data.

Add permissions for deliverable reading that allow access by internal users with
the appropriate global roles but not organization users with contributor roles.