### PR TITLE
Rename a few project votes API payload properties

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
@@ -37,7 +37,8 @@ class ProjectVotesController() {
   fun getProjectVotes(
       @PathVariable("projectId") projectId: ProjectId,
   ): GetProjectVotesResponsePayload {
-    return GetProjectVotesResponsePayload(projectId, "testProject", emptyList())
+    return GetProjectVotesResponsePayload(
+        ProjectVotesPayload(projectId, "testProject", emptyList()))
   }
 
   @ApiResponse200
@@ -92,7 +93,7 @@ data class VoteSelection(
 data class PhaseVotes(val phase: CohortPhase, val votes: List<VoteSelection>)
 
 data class UpsertVoteSelection(
-    val user: UserId,
+    val userId: UserId,
     @Schema(description = "If set to `null`, remove the vote the user has previously selected.")
     val voteOption: VoteOption? = null,
     val conditionalInfo: String? = null,
@@ -114,11 +115,13 @@ data class DeleteProjectVotesRequestPayload(
     val phaseDelete: Boolean? = null,
 )
 
-data class GetProjectVotesResponsePayload(
+data class ProjectVotesPayload(
     val projectId: ProjectId,
     val projectName: String,
     val phases: List<PhaseVotes>
-) : SuccessResponsePayload
+)
+
+data class GetProjectVotesResponsePayload(val votes: ProjectVotesPayload) : SuccessResponsePayload
 
 data class UpsertProjectVotesResponsePayload(
     val projectId: ProjectId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectVotesController.kt
@@ -54,7 +54,8 @@ class ProjectVotesController() {
       @PathVariable("projectId") projectId: ProjectId,
       @RequestBody payload: UpsertProjectVotesRequestPayload,
   ): UpsertProjectVotesResponsePayload {
-    return UpsertProjectVotesResponsePayload(projectId, payload.phase, emptyList())
+    return UpsertProjectVotesResponsePayload(
+        UpsertProjectVotesPayload(projectId, payload.phase, emptyList()))
   }
 
   @ApiResponse200
@@ -123,8 +124,11 @@ data class ProjectVotesPayload(
 
 data class GetProjectVotesResponsePayload(val votes: ProjectVotesPayload) : SuccessResponsePayload
 
-data class UpsertProjectVotesResponsePayload(
+data class UpsertProjectVotesPayload(
     val projectId: ProjectId,
     val phase: CohortPhase,
-    val results: List<UpsertVoteSelection>,
-) : SuccessResponsePayload
+    val results: List<UpsertVoteSelection>
+)
+
+data class UpsertProjectVotesResponsePayload(val votes: UpsertProjectVotesPayload) :
+    SuccessResponsePayload


### PR DESCRIPTION
- observed candidates for rename when I synced FE with project votes API types
- renamed user to userId for consistency
- set project votes payload in a root property so it can be extracted without cherry picking properties (consistent with existing pattern in other API)