### PR TITLE
SW-5035 Implement project score logic

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
@@ -1,14 +1,21 @@
 package com.terraformation.backend.accelerator.api
 
+import com.terraformation.backend.accelerator.db.ProjectScoreStore
+import com.terraformation.backend.accelerator.model.NewProjectScoreModel
+import com.terraformation.backend.accelerator.model.ProjectScoreModel
 import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.default_schema.ProjectId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import java.math.BigDecimal
 import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,68 +28,77 @@ import org.springframework.web.bind.annotation.RestController
 @AcceleratorEndpoint
 @RequestMapping("/api/v1/accelerator/projects/{projectId}/scores")
 @RestController
-class ProjectScoresController() {
+class ProjectScoresController(
+    private val projectScoreStore: ProjectScoreStore,
+) {
   @ApiResponse200
   @ApiResponse404
   @GetMapping
-  @Operation(summary = "Gets vote selections for a single project.")
+  @Operation(summary = "Gets score selections for a single project.")
   fun getProjectScores(
       @PathVariable("projectId") projectId: ProjectId,
   ): GetProjectScoresResponsePayload {
-    return GetProjectScoresResponsePayload(projectId, "testProject", emptyList())
+    val scoresByPhase = projectScoreStore.fetchScores(projectId)
+
+    val phaseScores =
+        scoresByPhase.map { (phase, scoreModels) ->
+          PhaseScores(
+              phase,
+              scoreModels.map { Score(it.category, it.modifiedTime, it.qualitative, it.score) },
+              ProjectScoreModel.totalScore(scoreModels))
+        }
+
+    return GetProjectScoresResponsePayload(phaseScores)
   }
 
   @ApiResponse200
   @ApiResponse404
   @PutMapping
   @Operation(
-      summary = "Upserts vote selections for a single project.",
+      summary = "Upserts score selections for a single project.",
       description =
           "Update the scores for the project phase. If the (project, phase, category) does not " +
               "exist, a new entry is created. Setting a `score` to `null` removes the score.")
   fun upsertProjectScores(
       @PathVariable("projectId") projectId: ProjectId,
-      @RequestBody payload: UpsertProjectScoresRequestPayload,
-  ): UpsertProjectScoresResponsePayload {
-    return UpsertProjectScoresResponsePayload(projectId, payload.phase, emptyList())
+      @RequestBody @Valid payload: UpsertProjectScoresRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    projectScoreStore.updateScores(projectId, payload.phase, payload.scores.map { it.toModel() })
+
+    return SimpleSuccessResponsePayload()
   }
 }
 
 data class Score(
     val category: ScoreCategory,
-    @Schema(description = "Must be between -2 to 2. If `null`, a score has not been selected.")
-    val value: Int? = null,
+    val modifiedTime: Instant,
     val qualitative: String? = null,
-    val modifiedTime: Instant = Instant.now(),
+    @Schema(
+        description = "If `null`, a score has not been selected.", minimum = "-2", maximum = "2")
+    val value: Int? = null,
 )
 
 data class UpsertScore(
     val category: ScoreCategory,
-    @Schema(description = "Must be between -2 to 2. If set to `null`, remove the selected score.")
-    val value: Int? = null,
     val qualitative: String? = null,
-)
+    @field:Min(-2)
+    @field:Max(2)
+    @Schema(
+        description = "If set to `null`, remove the selected score.", minimum = "-2", maximum = "2")
+    val value: Int? = null,
+) {
+  fun toModel() = NewProjectScoreModel(category, null, qualitative, value)
+}
 
 data class PhaseScores(
     val phase: CohortPhase,
     val scores: List<Score>,
-    val systemScore: BigDecimal? = null,
+    val totalScore: BigDecimal? = null,
 )
 
 data class UpsertProjectScoresRequestPayload(
     val phase: CohortPhase,
-    val scores: List<UpsertScore>,
+    @field:Valid val scores: List<UpsertScore>,
 )
 
-data class GetProjectScoresResponsePayload(
-    val projectId: ProjectId,
-    val projectName: String,
-    val phases: List<PhaseScores>
-) : SuccessResponsePayload
-
-data class UpsertProjectScoresResponsePayload(
-    val projectId: ProjectId,
-    val phaseId: CohortPhase,
-    val scores: List<Score>,
-    val systemScore: BigDecimal? = null,
-) : SuccessResponsePayload
+data class GetProjectScoresResponsePayload(val phases: List<PhaseScores>) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/PhaseChecker.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/PhaseChecker.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class PhaseChecker(private val dslContext: DSLContext) {
+  /**
+   * Ensures the project's participant's cohort is in the specified phase.
+   *
+   * @throws ProjectNotInCohortException The project is not in a participant, or its participant is
+   *   not in a cohort.
+   * @throws ProjectNotInCohortPhaseException The project's participant's cohort is in a different
+   *   phase than the specified one.
+   */
+  fun ensureProjectPhase(projectId: ProjectId, phase: CohortPhase) {
+    val currentPhase =
+        dslContext
+            .select(COHORTS.PHASE_ID)
+            .from(PROJECTS)
+            .join(PARTICIPANTS)
+            .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+            .join(COHORTS)
+            .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+            .where(PROJECTS.ID.eq(projectId))
+            .fetchOne(COHORTS.PHASE_ID) ?: throw ProjectNotInCohortException(projectId)
+
+    if (currentPhase != phase) {
+      throw ProjectNotInCohortPhaseException(projectId, phase)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStore.kt
@@ -1,0 +1,100 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.accelerator.model.ExistingProjectScoreModel
+import com.terraformation.backend.accelerator.model.NewProjectScoreModel
+import com.terraformation.backend.accelerator.model.ProjectScoreModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.DSLContext
+
+@Named
+class ProjectScoreStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  /**
+   * Returns the per-category scores for a project.
+   *
+   * @param phases If non-null, only return scores for these phases.
+   */
+  fun fetchScores(
+      projectId: ProjectId,
+      phases: Collection<CohortPhase>? = null
+  ): Map<CohortPhase, List<ExistingProjectScoreModel>> {
+    requirePermissions { readProjectScores(projectId) }
+
+    return with(PROJECT_SCORES) {
+      val conditions =
+          listOfNotNull(
+              phases?.let { PHASE_ID.`in`(it) },
+              PROJECT_ID.eq(projectId),
+          )
+
+      dslContext
+          .select(PHASE_ID, MODIFIED_TIME, QUALITATIVE, SCORE, SCORE_CATEGORY_ID)
+          .from(PROJECT_SCORES)
+          .where(conditions)
+          .orderBy(PHASE_ID, SCORE_CATEGORY_ID)
+          .fetchGroups(PHASE_ID.asNonNullable()) { ProjectScoreModel.of(it) }
+    }
+  }
+
+  fun updateScores(
+      projectId: ProjectId,
+      phase: CohortPhase,
+      scores: Collection<NewProjectScoreModel>
+  ) {
+    requirePermissions { updateProjectScores(projectId) }
+
+    val now = clock.instant()
+    val userId = currentUser().userId
+
+    val currentPhase =
+        dslContext
+            .select(COHORTS.PHASE_ID)
+            .from(PROJECTS)
+            .join(PARTICIPANTS)
+            .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+            .join(COHORTS)
+            .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+            .fetchOne(COHORTS.PHASE_ID) ?: throw ProjectNotInCohortException(projectId)
+
+    if (currentPhase != phase) {
+      throw ProjectNotInCohortPhaseException(projectId, phase)
+    }
+
+    dslContext.transaction { _ ->
+      scores.forEach { score ->
+        with(PROJECT_SCORES) {
+          dslContext
+              .insertInto(PROJECT_SCORES)
+              .set(CREATED_BY, userId)
+              .set(CREATED_TIME, now)
+              .set(MODIFIED_BY, userId)
+              .set(MODIFIED_TIME, now)
+              .set(PHASE_ID, phase)
+              .set(PROJECT_ID, projectId)
+              .set(QUALITATIVE, score.qualitative)
+              .set(SCORE, score.score)
+              .set(SCORE_CATEGORY_ID, score.category)
+              .onConflict()
+              .doUpdate()
+              .set(MODIFIED_BY, userId)
+              .set(MODIFIED_TIME, now)
+              .set(QUALITATIVE, score.qualitative)
+              .set(SCORE, score.score)
+              .execute()
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
@@ -1,0 +1,42 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.ScoreCategory
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Instant
+import org.jooq.Record
+
+data class ProjectScoreModel<INSTANT : Instant?>(
+    val category: ScoreCategory,
+    val modifiedTime: INSTANT,
+    val qualitative: String?,
+    val score: Int?,
+) {
+  companion object {
+    fun of(record: Record) =
+        ExistingProjectScoreModel(
+            category = record[PROJECT_SCORES.SCORE_CATEGORY_ID]!!,
+            modifiedTime = record[PROJECT_SCORES.MODIFIED_TIME]!!,
+            qualitative = record[PROJECT_SCORES.QUALITATIVE],
+            score = record[PROJECT_SCORES.SCORE],
+        )
+
+    /**
+     * Returns the total (average) score for a set of per-category scores, rounded to 2 decimal
+     * places.
+     */
+    fun totalScore(scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
+      val validScoreValues = scores.mapNotNull { it.score }
+      return if (validScoreValues.isNotEmpty()) {
+        validScoreValues.average().toBigDecimal().setScale(2, RoundingMode.HALF_UP)
+      } else {
+        null
+      }
+    }
+  }
+}
+
+typealias ExistingProjectScoreModel = ProjectScoreModel<Instant>
+
+typealias NewProjectScoreModel = ProjectScoreModel<Nothing?>

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -22,7 +22,9 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
-  private val store: ProjectScoreStore by lazy { ProjectScoreStore(clock, dslContext) }
+  private val store: ProjectScoreStore by lazy {
+    ProjectScoreStore(clock, dslContext, PhaseChecker(dslContext))
+  }
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -1,0 +1,272 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.accelerator.model.ExistingProjectScoreModel
+import com.terraformation.backend.accelerator.model.NewProjectScoreModel
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.ScoreCategory
+import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val store: ProjectScoreStore by lazy { ProjectScoreStore(clock, dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertCohort(phase = CohortPhase.Phase0DueDiligence)
+    insertParticipant(cohortId = inserted.cohortId)
+
+    every { user.canReadProject(any()) } returns true
+    every { user.canReadProjectScores(any()) } returns true
+    every { user.canUpdateProjectScores(any()) } returns true
+  }
+
+  @Nested
+  inner class FetchScores {
+    @Test
+    fun `returns data from all phases by default`() {
+      val time1 = Instant.ofEpochSecond(1)
+      val time2 = Instant.ofEpochSecond(2)
+      val time3 = Instant.ofEpochSecond(3)
+
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      insertProjectScore(
+          phase = CohortPhase.Phase0DueDiligence,
+          category = ScoreCategory.Legal,
+          qualitative = "q1",
+          score = 1,
+          createdTime = time1)
+      insertProjectScore(
+          phase = CohortPhase.Phase1FeasibilityStudy,
+          category = ScoreCategory.Carbon,
+          createdTime = time2)
+
+      insertProject()
+
+      insertProjectScore(
+          phase = CohortPhase.Phase0DueDiligence,
+          category = ScoreCategory.Community,
+          score = -1,
+          createdTime = time3)
+
+      val expected =
+          mapOf(
+              CohortPhase.Phase0DueDiligence to
+                  listOf(ExistingProjectScoreModel(ScoreCategory.Legal, time1, "q1", 1)),
+              CohortPhase.Phase1FeasibilityStudy to
+                  listOf(ExistingProjectScoreModel(ScoreCategory.Carbon, time2, null, null)))
+
+      val actual = store.fetchScores(projectId)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `can restrict query to specific phases`() {
+      val time1 = Instant.ofEpochSecond(1)
+      val time2 = Instant.ofEpochSecond(2)
+      val time3 = Instant.ofEpochSecond(3)
+      val time4 = Instant.ofEpochSecond(4)
+
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      insertProjectScore(
+          phase = CohortPhase.Phase0DueDiligence,
+          category = ScoreCategory.Legal,
+          qualitative = "q1",
+          score = 1,
+          createdTime = time1)
+      insertProjectScore(
+          phase = CohortPhase.Phase0DueDiligence,
+          category = ScoreCategory.Carbon,
+          score = 2,
+          createdTime = time2)
+      insertProjectScore(
+          phase = CohortPhase.Phase1FeasibilityStudy,
+          category = ScoreCategory.Carbon,
+          createdTime = time3)
+      insertProjectScore(
+          phase = CohortPhase.Phase2PlanAndScale,
+          category = ScoreCategory.Carbon,
+          score = -1,
+          createdTime = time4)
+
+      val expected =
+          mapOf(
+              CohortPhase.Phase0DueDiligence to
+                  listOf(
+                      ExistingProjectScoreModel(ScoreCategory.Carbon, time2, null, 2),
+                      ExistingProjectScoreModel(ScoreCategory.Legal, time1, "q1", 1),
+                  ),
+              CohortPhase.Phase1FeasibilityStudy to
+                  listOf(
+                      ExistingProjectScoreModel(ScoreCategory.Carbon, time3, null, null),
+                  ))
+
+      val actual =
+          store.fetchScores(
+              projectId,
+              setOf(
+                  CohortPhase.Phase0DueDiligence,
+                  CohortPhase.Phase1FeasibilityStudy,
+                  CohortPhase.Phase3ImplementAndMonitor))
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `throws exception if no permission to read scores`() {
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      every { user.canReadProjectScores(projectId) } returns false
+
+      assertThrows<AccessDeniedException> { store.fetchScores(projectId) }
+    }
+  }
+
+  @Nested
+  inner class UpdateScores {
+    @Test
+    fun `creates scores that do not exist`() {
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      clock.instant = Instant.ofEpochSecond(123)
+
+      store.updateScores(
+          projectId,
+          CohortPhase.Phase0DueDiligence,
+          listOf(
+              NewProjectScoreModel(ScoreCategory.Carbon, null, "q1", 1),
+              NewProjectScoreModel(ScoreCategory.Legal, null, null, null),
+          ))
+
+      val commonRow =
+          ProjectScoresRow(
+              projectId = projectId,
+              phaseId = CohortPhase.Phase0DueDiligence,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+
+      val expected =
+          setOf(
+              commonRow.copy(
+                  scoreCategoryId = ScoreCategory.Carbon,
+                  score = 1,
+                  qualitative = "q1",
+              ),
+              commonRow.copy(
+                  scoreCategoryId = ScoreCategory.Legal,
+                  score = null,
+                  qualitative = null,
+              ),
+          )
+
+      assertEquals(expected, projectScoresDao.findAll().toSet())
+    }
+
+    @Test
+    fun `updates scores that already exist`() {
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      insertProjectScore(phase = CohortPhase.Phase0DueDiligence, category = ScoreCategory.Legal)
+      insertProjectScore(
+          phase = CohortPhase.Phase0DueDiligence,
+          category = ScoreCategory.Forestry,
+          qualitative = "q",
+          score = 1)
+
+      clock.instant = Instant.ofEpochSecond(123)
+
+      store.updateScores(
+          projectId,
+          CohortPhase.Phase0DueDiligence,
+          listOf(
+              NewProjectScoreModel(ScoreCategory.Legal, null, "q1", 1),
+              NewProjectScoreModel(ScoreCategory.Forestry, null, null, null),
+          ))
+
+      val commonRow =
+          ProjectScoresRow(
+              projectId = projectId,
+              phaseId = CohortPhase.Phase0DueDiligence,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          )
+
+      val expected =
+          setOf(
+              commonRow.copy(
+                  scoreCategoryId = ScoreCategory.Legal,
+                  score = 1,
+                  qualitative = "q1",
+              ),
+              commonRow.copy(
+                  scoreCategoryId = ScoreCategory.Forestry,
+                  score = null,
+                  qualitative = null,
+              ),
+          )
+
+      assertEquals(expected, projectScoresDao.findAll().toSet())
+    }
+
+    @Test
+    fun `throws exception if no permission to update scores`() {
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      every { user.canUpdateProjectScores(projectId) } returns false
+
+      assertThrows<AccessDeniedException> {
+        store.updateScores(
+            projectId,
+            CohortPhase.Phase0DueDiligence,
+            listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)))
+      }
+    }
+
+    @Test
+    fun `throws exception if updating scores for a non-participant project`() {
+      val projectId = insertProject()
+
+      assertThrows<ProjectNotInCohortException> {
+        store.updateScores(
+            projectId,
+            CohortPhase.Phase0DueDiligence,
+            listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)))
+      }
+    }
+
+    @Test
+    fun `throws exception if updating scores for a different phase than the current one`() {
+      val projectId = insertProject(participantId = inserted.participantId)
+
+      assertThrows<ProjectNotInCohortPhaseException> {
+        store.updateScores(
+            projectId,
+            CohortPhase.Phase1FeasibilityStudy,
+            listOf(NewProjectScoreModel(ScoreCategory.Legal, null, null, 1)))
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -25,7 +25,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
-  private val store: VoteStore by lazy { VoteStore(clock, dslContext) }
+  private val store: VoteStore by lazy { VoteStore(clock, dslContext, PhaseChecker(dslContext)) }
 
   data class VoteKey(val userId: UserId, val projectId: ProjectId, val phase: CohortPhase)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -585,6 +585,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.readProjectDeliverables(projectId)
   }
 
+  @Test
+  fun readProjectScores() {
+    assertThrows<ProjectNotFoundException> { requirements.readProjectScores(projectId) }
+
+    grant { user.canReadProject(projectId) }
+    assertThrows<AccessDeniedException> { requirements.readProjectScores(projectId) }
+
+    grant { user.canReadProjectScores(projectId) }
+    requirements.readProjectScores(projectId)
+  }
+
   @Test fun readReport() = testRead { readReport(reportId) }
 
   @Test fun readSpecies() = testRead { readSpecies(speciesId) }
@@ -754,6 +765,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           {
             canUpdateProjectDocumentSettings(projectId)
           }
+
+  @Test
+  fun updateProjectScores() =
+      allow { updateProjectScores(projectId) } ifUser { canUpdateProjectScores(projectId) }
 
   @Test
   fun updateProjectVotes() =

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.DocumentStore
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
@@ -26,6 +27,7 @@ import com.terraformation.backend.db.accelerator.tables.daos.DeliverablesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectDocumentSettingsDao
+import com.terraformation.backend.db.accelerator.tables.daos.ProjectScoresDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectVoteDecisionsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectVotesDao
 import com.terraformation.backend.db.accelerator.tables.daos.SubmissionDocumentsDao
@@ -36,6 +38,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableDocumen
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverablesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVoteDecisionsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVotesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionDocumentsRow
@@ -410,6 +413,7 @@ abstract class DatabaseTest {
   protected val plantingZonesDao: PlantingZonesDao by lazyDao()
   protected val projectDocumentSettingsDao: ProjectDocumentSettingsDao by lazyDao()
   protected val projectReportSettingsDao: ProjectReportSettingsDao by lazyDao()
+  protected val projectScoresDao: ProjectScoresDao by lazyDao()
   protected val projectsDao: ProjectsDao by lazyDao()
   protected val projectVoteDecisionDao: ProjectVoteDecisionsDao by lazyDao()
   protected val projectVotesDao: ProjectVotesDao by lazyDao()
@@ -557,6 +561,31 @@ abstract class DatabaseTest {
     projectsDao.insert(row)
 
     return row.id!!.also { inserted.projectIds.add(it) }
+  }
+
+  protected fun insertProjectScore(
+      projectId: Any = inserted.projectId,
+      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      category: ScoreCategory = ScoreCategory.Legal,
+      score: Int? = null,
+      qualitative: String? = null,
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+  ) {
+    val row =
+        ProjectScoresRow(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            modifiedBy = createdBy,
+            modifiedTime = createdTime,
+            phaseId = phase,
+            projectId = projectId.toIdWrapper { ProjectId(it) },
+            qualitative = qualitative,
+            score = score,
+            scoreCategoryId = category,
+        )
+
+    projectScoresDao.insert(row)
   }
 
   private var nextDeliverableNumber: Int = 1


### PR DESCRIPTION
Add real implementations of the `/api/v1/accelerator/projects/*/scores`
endpoints.

This also simplifies the payload definitions, removing response fields that
wouldn't be used by clients.