### PR TITLE
SW-5061 Require document storage settings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminParticipantsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminParticipantsController.kt
@@ -179,10 +179,14 @@ class AdminParticipantsController(
   fun addParticipantProject(
       @RequestParam participantId: ParticipantId,
       @RequestParam projectId: ProjectId,
+      @RequestParam fileNaming: String,
+      @RequestParam googleFolderUrl: URI,
+      @RequestParam dropboxFolderPath: String,
       redirectAttributes: RedirectAttributes
   ): String {
     try {
       projectStore.updateParticipant(projectId, participantId)
+      projectStore.updateDocumentSettings(projectId, fileNaming, googleFolderUrl, dropboxFolderPath)
       redirectAttributes.successMessage = "Added project to participant."
     } catch (e: Exception) {
       log.error("Failed to add project $projectId to participant $participantId", e)

--- a/src/main/resources/templates/admin/participant.html
+++ b/src/main/resources/templates/admin/participant.html
@@ -118,7 +118,7 @@
     </table>
 </th:block>
 
-<th:block th:if="${canUpdateParticipant && !availableProjects.isEmpty()}">
+<th:block th:if="${canUpdateParticipant}">
     <h3>Add Project to Participant</h3>
 
     <p>
@@ -126,7 +126,11 @@
         projects that are already assigned to participants are not included.
     </p>
 
-    <form action="/admin/addParticipantProject" method="POST">
+    <p th:if="${availableProjects.isEmpty()}">
+        No additional projects are available to add.
+    </p>
+
+    <form th:if="${!availableProjects.isEmpty()}" action="/admin/addParticipantProject" method="POST">
         <input type="hidden" name="participantId" th:value="${participant.id}"/>
         <select name="projectId" required>
             <option disabled selected style="display: none"></option>
@@ -140,6 +144,19 @@
                 </option>
             </optgroup>
         </select>
+        <label>
+            File Naming
+            <input type="text" name="fileNaming" required/>
+        </label>
+        <label>
+            Google Folder URL
+            <input type="url" name="googleFolderUrl" required/>
+        </label>
+        <label>
+            Dropbox Folder Path
+            <input type="text" name="dropboxFolderPath" required/>
+        </label>
+
         <input type="submit" value="Add"/>
     </form>
 </th:block>


### PR DESCRIPTION
When adding a project to a participant in the admin UI, require the admin to
configure the project's document storage settings. This guards against cases
where users upload documents to a project that doesn't have storage settings yet.

The settings might still be wrong, and it's still possible to delete them at the
database level, but requiring them in the admin UI should make it harder to
misconfigure a project by mistake.