### PR TITLE
SW-5069 Only notify TF Experts about deliverables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
@@ -408,7 +409,7 @@ class AppNotificationService(
       organizationId: OrganizationId,
       renderMessage: () -> NotificationMessage,
   ) {
-    val recipients = HashSet(userStore.fetchWithGlobalRoles())
+    val recipients = userStore.fetchWithGlobalRoles(setOf(GlobalRole.TFExpert)).toMutableSet()
     val tfContact = userStore.getTerraformationContactUser(organizationId)
 
     if (tfContact != null) {

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.daily.NotificationJobSucceededEvent
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -617,7 +618,7 @@ class EmailNotificationService(
    * require user opt-in.
    */
   private fun sendToAccelerator(organizationId: OrganizationId, model: EmailTemplateModel) {
-    val recipients = HashSet(userStore.fetchWithGlobalRoles())
+    val recipients = userStore.fetchWithGlobalRoles(setOf(GlobalRole.TFExpert)).toMutableSet()
     val tfContact = userStore.getTerraformationContactUser(organizationId)
 
     // The TF contact will not have access to the accelerator console, this email notification

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -560,7 +560,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store deliverable ready for review notification`() {
-    insertUserGlobalRole(user.userId, GlobalRole.AcceleratorAdmin)
+    insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val cohortId = insertCohort()
     val participantId = insertParticipant(name = "participant1", cohortId = cohortId)
     val projectId = insertProject(participantId = participantId)
@@ -581,7 +581,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store deliverable ready for review notification with TF contact`() {
-    insertUserGlobalRole(user.userId, GlobalRole.AcceleratorAdmin)
+    insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val tfContact = insertUser(UserId(5), email = "tfcontact@terraformation.com")
     insertOrganizationUser(tfContact, role = Role.TerraformationContact)
 
@@ -615,10 +615,10 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should not over-notify deliverable ready for review notification with TF contact that is also an accelerator admin`() {
-    insertUserGlobalRole(user.userId, GlobalRole.AcceleratorAdmin)
+    insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
     val tfContact = insertUser(UserId(5), email = "tfcontact@terraformation.com")
     insertOrganizationUser(tfContact, role = Role.TerraformationContact)
-    insertUserGlobalRole(tfContact, role = GlobalRole.SuperAdmin)
+    insertUserGlobalRole(tfContact, role = GlobalRole.TFExpert)
 
     val cohortId = insertCohort()
     val participantId = insertParticipant(name = "participant1", cohortId = cohortId)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -264,6 +264,25 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
         "IDs of users with global roles")
   }
 
+  @Test
+  fun `fetchWithGlobalRoles can search for specific global roles`() {
+    val superAdminUser = insertUser(10)
+    val acceleratorAdminUser = insertUser(11)
+    val readOnlyUser = insertUser(12)
+
+    insertUserGlobalRole(superAdminUser, GlobalRole.SuperAdmin)
+    insertUserGlobalRole(acceleratorAdminUser, GlobalRole.AcceleratorAdmin)
+    insertUserGlobalRole(readOnlyUser, GlobalRole.ReadOnly)
+
+    assertEquals(
+        setOf(acceleratorAdminUser, readOnlyUser),
+        userStore
+            .fetchWithGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.ReadOnly))
+            .map { it.userId }
+            .toSet(),
+        "Users with specific global roles")
+  }
+
   @Nested
   inner class DeviceManagerTest {
     @BeforeEach

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -34,6 +34,7 @@ import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
@@ -266,7 +267,8 @@ internal class EmailNotificationServiceTest {
     every { userStore.fetchOneById(adminUser.userId) } returns adminUser
     every { userStore.fetchOneById(user.userId) } returns user
     every { userStore.fetchOneById(tfContactUserId) } returns tfContactUser
-    every { userStore.fetchWithGlobalRoles() } returns listOf(acceleratorUser)
+    every { userStore.fetchWithGlobalRoles(setOf(GlobalRole.TFExpert)) } returns
+        listOf(acceleratorUser)
 
     every { sender.send(capture(mimeMessageSlot)) } answers
         { answer ->


### PR DESCRIPTION
Only send notifications about deliverables being ready for review to users with
the TF Expert global role.

A user with a Super Admin or Accelerator Admin global role can still receive
notifications if they also have the TF Expert global role.