### PR TITLE
SW-5058 Auto-assign default voters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VoteService.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.CohortStore
+import com.terraformation.backend.accelerator.db.ParticipantStore
+import com.terraformation.backend.accelerator.db.VoteStore
+import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
+import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectAddedEvent
+import com.terraformation.backend.accelerator.model.CohortDepth
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
+
+@Named
+class VoteService(
+    private val cohortStore: CohortStore,
+    private val dslContext: DSLContext,
+    private val participantStore: ParticipantStore,
+    private val voteStore: VoteStore,
+) {
+  @EventListener
+  fun on(event: ParticipantProjectAddedEvent) {
+    voteStore.assignVoters(event.projectId)
+  }
+
+  @EventListener
+  fun on(event: CohortParticipantAddedEvent) {
+    val participant = participantStore.fetchOneById(event.participantId)
+
+    dslContext.transaction { _ -> participant.projectIds.forEach { voteStore.assignVoters(it) } }
+  }
+
+  @EventListener
+  fun on(event: CohortPhaseUpdatedEvent) {
+    val cohort = cohortStore.fetchOneById(event.cohortId, CohortDepth.Participant)
+
+    dslContext.transaction { _ ->
+      cohort.participantIds.forEach { participantId ->
+        val participant = participantStore.fetchOneById(participantId)
+
+        participant.projectIds.forEach { voteStore.assignVoters(it) }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortParticipantAddedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortParticipantAddedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.CohortId
+import com.terraformation.backend.db.accelerator.ParticipantId
+
+/** Published when a participant's cohort association is changed. */
+data class CohortParticipantAddedEvent(
+    val cohortId: CohortId,
+    val participantId: ParticipantId,
+)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortPhaseUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortPhaseUpdatedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.CohortId
+import com.terraformation.backend.db.accelerator.CohortPhase
+
+/** Published when a cohort moves from one phase to another. */
+data class CohortPhaseUpdatedEvent(
+    val cohortId: CohortId,
+    val newPhase: CohortPhase,
+)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -1,0 +1,193 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.CohortStore
+import com.terraformation.backend.accelerator.db.ParticipantStore
+import com.terraformation.backend.accelerator.db.PhaseChecker
+import com.terraformation.backend.accelerator.db.VoteStore
+import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
+import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectAddedEvent
+import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.VoteOption
+import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVotesRow
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class VoteServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val service: VoteService by lazy {
+    VoteService(
+        CohortStore(clock, cohortModulesDao, cohortsDao, dslContext, eventPublisher, modulesDao),
+        dslContext,
+        ParticipantStore(clock, dslContext, eventPublisher, participantsDao),
+        VoteStore(clock, dslContext, PhaseChecker(dslContext)))
+  }
+
+  private val voter1 = UserId(101)
+  private val voter2 = UserId(102)
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertUser(voter1)
+    insertUser(voter2)
+    insertDefaultVoter(voter1)
+    insertDefaultVoter(voter2)
+
+    every { user.canReadCohort(any()) } returns true
+    every { user.canReadParticipant(any()) } returns true
+    every { user.canUpdateProjectVotes(any()) } returns true
+  }
+
+  @Nested
+  inner class ParticipantProjectAdded {
+    @Test
+    fun `inserts voters`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      insertProject(participantId = participantId) // Should be ignored
+      val projectId = insertProject(participantId = participantId)
+
+      service.on(ParticipantProjectAddedEvent(user.userId, participantId, projectId))
+
+      assertEquals(setOf(votesRow(voter1), votesRow(voter2)), projectVotesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `does not modify existing voter information`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+
+      insertVote(user = voter1, voteOption = VoteOption.No, conditionalInfo = "cond")
+
+      clock.instant = Instant.ofEpochSecond(30)
+
+      service.on(ParticipantProjectAddedEvent(user.userId, participantId, projectId))
+
+      assertEquals(
+          setOf(
+              votesRow(
+                  userId = voter1,
+                  createdTime = Instant.EPOCH,
+                  voteOption = VoteOption.No,
+                  conditionalInfo = "cond"),
+              votesRow(voter2)),
+          projectVotesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `listens for event`() {
+      assertIsEventListener<ParticipantProjectAddedEvent>(service)
+    }
+  }
+
+  @Nested
+  inner class CohortParticipantAdded {
+    @Test
+    fun `inserts voters`() {
+      val cohortId1 = insertCohort()
+      val participantId1 = insertParticipant(cohortId = cohortId1)
+      val projectId1 = insertProject(participantId = participantId1)
+      val projectId2 = insertProject(participantId = participantId1)
+
+      // Should leave these alone
+      val otherParticipantId = insertParticipant(cohortId = cohortId1)
+      insertProject(participantId = otherParticipantId)
+      val otherCohortId = insertCohort()
+      val otherCohortParticipantId = insertParticipant(cohortId = otherCohortId)
+      insertProject(participantId = otherCohortParticipantId)
+
+      service.on(CohortParticipantAddedEvent(cohortId1, participantId1))
+
+      assertEquals(
+          setOf(
+              votesRow(userId = voter1, projectId = projectId1),
+              votesRow(userId = voter2, projectId = projectId1),
+              votesRow(userId = voter1, projectId = projectId2),
+              votesRow(userId = voter2, projectId = projectId2),
+          ),
+          projectVotesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `listens for event`() {
+      assertIsEventListener<CohortParticipantAddedEvent>(service)
+    }
+  }
+
+  @Nested
+  inner class CohortPhaseUpdated {
+    @Test
+    fun `inserts voters`() {
+      val phase = CohortPhase.Phase1FeasibilityStudy
+      val cohortId1 = insertCohort(phase = phase)
+      val participantId1 = insertParticipant(cohortId = cohortId1)
+      val projectId1 = insertProject(participantId = participantId1)
+      val participantId2 = insertParticipant(cohortId = cohortId1)
+      val projectId2 = insertProject(participantId = participantId2)
+
+      // Should leave these alone
+      val otherCohortId = insertCohort()
+      val otherCohortParticipantId = insertParticipant(cohortId = otherCohortId)
+      insertProject(participantId = otherCohortParticipantId)
+      insertVote(projectId1, user = voter1)
+
+      service.on(CohortPhaseUpdatedEvent(cohortId1, phase))
+
+      assertEquals(
+          setOf(
+              // First row is inserted by test, not by service
+              votesRow(
+                  userId = voter1, projectId = projectId1, phase = CohortPhase.Phase0DueDiligence),
+              votesRow(userId = voter1, projectId = projectId1, phase = phase),
+              votesRow(userId = voter2, projectId = projectId1, phase = phase),
+              votesRow(userId = voter1, projectId = projectId2, phase = phase),
+              votesRow(userId = voter2, projectId = projectId2, phase = phase),
+          ),
+          projectVotesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `listens for event`() {
+      assertIsEventListener<CohortPhaseUpdatedEvent>(service)
+    }
+  }
+
+  private fun votesRow(
+      userId: UserId,
+      projectId: ProjectId = inserted.projectId,
+      phase: CohortPhase = CohortPhase.Phase0DueDiligence,
+      createdTime: Instant = clock.instant,
+      voteOption: VoteOption? = null,
+      conditionalInfo: String? = null,
+  ): ProjectVotesRow {
+    return ProjectVotesRow(
+        conditionalInfo = conditionalInfo,
+        createdBy = user.userId,
+        createdTime = createdTime,
+        modifiedBy = user.userId,
+        modifiedTime = createdTime,
+        phaseId = phase,
+        projectId = projectId,
+        userId = userId,
+        voteOptionId = voteOption,
+    )
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
 import com.terraformation.backend.accelerator.model.CohortDepth
 import com.terraformation.backend.accelerator.model.CohortModel
 import com.terraformation.backend.accelerator.model.ExistingCohortModel
@@ -25,8 +27,9 @@ class CohortStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: CohortStore by lazy {
-    CohortStore(clock, dslContext, cohortsDao, modulesDao, cohortModulesDao)
+    CohortStore(clock, cohortModulesDao, cohortsDao, dslContext, eventPublisher, modulesDao)
   }
 
   @BeforeEach
@@ -226,6 +229,9 @@ class CohortStoreTest : DatabaseTest(), RunsAsUser {
               name = "New Name",
               phaseId = CohortPhase.Phase1FeasibilityStudy),
           cohortsDao.fetchOneById(cohortId))
+
+      eventPublisher.assertEventPublished(
+          CohortPhaseUpdatedEvent(cohortId, CohortPhase.Phase1FeasibilityStudy))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantStoreTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
 import com.terraformation.backend.accelerator.model.ExistingParticipantModel
 import com.terraformation.backend.accelerator.model.ParticipantModel
 import com.terraformation.backend.db.DatabaseTest
@@ -21,8 +23,9 @@ class ParticipantStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: ParticipantStore by lazy {
-    ParticipantStore(clock, dslContext, participantsDao)
+    ParticipantStore(clock, dslContext, eventPublisher, participantsDao)
   }
 
   @BeforeEach
@@ -176,6 +179,8 @@ class ParticipantStoreTest : DatabaseTest(), RunsAsUser {
               name = "New Name",
           ),
           participantsDao.fetchOneById(participantId))
+
+      eventPublisher.assertEventPublished(CohortParticipantAddedEvent(cohortId, participantId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -117,7 +117,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     notificationStore = NotificationStore(dslContext, clock)
     organizationStore = OrganizationStore(clock, dslContext, organizationsDao, publisher)
     parentStore = ParentStore(dslContext)
-    participantStore = ParticipantStore(clock, dslContext, participantsDao)
+    participantStore = ParticipantStore(clock, dslContext, publisher, participantsDao)
     accessionStore =
         AccessionStore(
             dslContext,


### PR DESCRIPTION
We want the list of voters to automatically be populated for the participant
projects that are eligible for voting in a particular phase.

Add logic to automatically populate the projects' voter rosters with the list
of default voters when:

- A project is added to a participant that is already in a cohort.
- A participant that already has projects is added to a cohort.
- A cohort moves to a new phase.