### PR TITLE
SW-5047 API for bulk removing global roles from users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminGlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminGlobalRolesController.kt
@@ -64,7 +64,7 @@ class AdminGlobalRolesController(
         }
 
     try {
-      userStore.updateGlobalRoles(effectiveUserId, roleEnums)
+      userStore.updateGlobalRoles(setOf(effectiveUserId), roleEnums)
       redirectAttributes.successMessage = "Global roles updated."
     } catch (e: Exception) {
       log.error("Failed to update global roles", e)

--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import java.time.Instant
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -43,6 +44,18 @@ class GlobalRolesController(
 
     return SimpleSuccessResponsePayload()
   }
+
+  @ApiResponse200
+  @ApiResponse404
+  @DeleteMapping("/users/globalRoles")
+  @Operation(summary = "Remove global roles from the supplied users.")
+  fun removeGlobalRoles(
+    @RequestBody payload: RemoveGlobalRolesRequestPayload,
+  ): SuccessResponsePayload {
+//    userStore.updateGlobalRoles(userId, payload.globalRoles)
+
+    return SimpleSuccessResponsePayload()
+  }
 }
 
 data class UserWithGlobalRolesPayload(
@@ -66,6 +79,10 @@ data class UserWithGlobalRolesPayload(
 
 data class GlobalRoleUsersListResponsePayload(val users: List<UserWithGlobalRolesPayload>) :
     SuccessResponsePayload
+
+data class RemoveGlobalRolesRequestPayload(
+    val userIds: Set<UserId>,
+)
 
 data class UpdateGlobalRolesRequestPayload(
     val globalRoles: Set<GlobalRole>,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -40,7 +40,7 @@ class GlobalRolesController(
       @PathVariable("userId") userId: UserId,
       @RequestBody payload: UpdateGlobalRolesRequestPayload,
   ): SuccessResponsePayload {
-    userStore.updateGlobalRoles(userId, payload.globalRoles)
+    userStore.updateGlobalRoles(setOf(userId), payload.globalRoles)
 
     return SimpleSuccessResponsePayload()
   }
@@ -50,9 +50,9 @@ class GlobalRolesController(
   @DeleteMapping("/users/globalRoles")
   @Operation(summary = "Remove global roles from the supplied users.")
   fun removeGlobalRoles(
-    @RequestBody payload: RemoveGlobalRolesRequestPayload,
+      @RequestBody payload: RemoveGlobalRolesRequestPayload,
   ): SuccessResponsePayload {
-//    userStore.updateGlobalRoles(userId, payload.globalRoles)
+    userStore.updateGlobalRoles(payload.userIds, emptySet())
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -50,7 +50,7 @@ class GlobalRolesController(
   @DeleteMapping("/globalRoles/users")
   @Operation(summary = "Remove global roles from the supplied users.")
   fun deleteGlobalRoles(
-      @RequestBody payload: RemoveGlobalRolesRequestPayload,
+      @RequestBody payload: DeleteGlobalRolesRequestPayload,
   ): SuccessResponsePayload {
     userStore.updateGlobalRoles(payload.userIds, emptySet())
 
@@ -80,7 +80,7 @@ data class UserWithGlobalRolesPayload(
 data class GlobalRoleUsersListResponsePayload(val users: List<UserWithGlobalRolesPayload>) :
     SuccessResponsePayload
 
-data class RemoveGlobalRolesRequestPayload(
+data class DeleteGlobalRolesRequestPayload(
     val userIds: Set<UserId>,
 )
 

--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -47,9 +47,9 @@ class GlobalRolesController(
 
   @ApiResponse200
   @ApiResponse404
-  @DeleteMapping("/users/globalRoles")
+  @DeleteMapping("/globalRoles/users")
   @Operation(summary = "Remove global roles from the supplied users.")
-  fun removeGlobalRoles(
+  fun deleteGlobalRoles(
       @RequestBody payload: RemoveGlobalRolesRequestPayload,
   ): SuccessResponsePayload {
     userStore.updateGlobalRoles(payload.userIds, emptySet())

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -385,11 +385,12 @@ class UserStore(
           .execute()
 
       if (roles.isNotEmpty()) {
-        userIds.forEach { userId ->
-          val records = roles.map { UserGlobalRolesRecord(userId = userId, globalRoleId = it) }
+        val records =
+            userIds.flatMap { userId ->
+              roles.map { UserGlobalRolesRecord(userId = userId, globalRoleId = it) }
+            }
 
-          dslContext.insertInto(USER_GLOBAL_ROLES).set(records).execute()
-        }
+        dslContext.insertInto(USER_GLOBAL_ROLES).set(records).execute()
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -363,25 +363,33 @@ class UserStore(
     }
   }
 
-  fun updateGlobalRoles(userId: UserId, roles: Set<GlobalRole>) {
+  fun updateGlobalRoles(userIds: Set<UserId>, roles: Set<GlobalRole>) {
     if (roles.isEmpty()) {
       requirePermissions { updateGlobalRoles() }
     } else {
       requirePermissions { updateSpecificGlobalRoles(roles) }
     }
 
-    val user = fetchOneById(userId)
-    if (user !is IndividualUser || !user.email.endsWith("@terraformation.com", ignoreCase = true)) {
-      throw AccessDeniedException("Only Terraformation users may have global roles")
+    userIds.forEach {
+      val user = fetchOneById(it)
+      if (user !is IndividualUser ||
+          !user.email.endsWith("@terraformation.com", ignoreCase = true)) {
+        throw AccessDeniedException("Only Terraformation users may have global roles")
+      }
     }
 
     dslContext.transaction { _ ->
-      dslContext.deleteFrom(USER_GLOBAL_ROLES).where(USER_GLOBAL_ROLES.USER_ID.eq(userId)).execute()
+      dslContext
+          .deleteFrom(USER_GLOBAL_ROLES)
+          .where(USER_GLOBAL_ROLES.USER_ID.`in`(userIds))
+          .execute()
 
       if (roles.isNotEmpty()) {
-        val records = roles.map { UserGlobalRolesRecord(userId = userId, globalRoleId = it) }
+        userIds.forEach { userId ->
+          val records = roles.map { UserGlobalRolesRecord(userId = userId, globalRoleId = it) }
 
-        dslContext.insertInto(USER_GLOBAL_ROLES).set(records).execute()
+          dslContext.insertInto(USER_GLOBAL_ROLES).set(records).execute()
+        }
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -761,6 +761,22 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `overwrites existing global roles for a set of users`() {
+      val userId1 = insertUser(10)
+      val userId2 = insertUser(11)
+      insertUserGlobalRole(userId1, GlobalRole.AcceleratorAdmin)
+      insertUserGlobalRole(userId2, GlobalRole.TFExpert)
+
+      userStore.updateGlobalRoles(setOf(userId1, userId2), setOf(GlobalRole.SuperAdmin))
+
+      assertEquals(
+          listOf(
+              UserGlobalRolesRow(userId = userId1, globalRoleId = GlobalRole.SuperAdmin),
+              UserGlobalRolesRow(userId = userId2, globalRoleId = GlobalRole.SuperAdmin)),
+          userGlobalRolesDao.findAll())
+    }
+
+    @Test
     fun `can remove all global roles from a user`() {
       val userId = insertUser(10)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -777,29 +777,15 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `can remove all global roles from a user`() {
-      val userId = insertUser(10)
-
-      userStore.updateGlobalRoles(setOf(userId), emptySet())
-
-      assertEquals(emptyList<Any>(), userGlobalRolesDao.findAll())
-    }
-
-    @Test
     fun `can remove all global roles from a set of users`() {
       val userId1 = insertUser(10)
       val userId2 = insertUser(11)
+      insertUserGlobalRole(userId1, GlobalRole.SuperAdmin)
+      insertUserGlobalRole(userId2, GlobalRole.AcceleratorAdmin)
 
       userStore.updateGlobalRoles(setOf(userId1, userId2), emptySet())
 
       assertEquals(emptyList<Any>(), userGlobalRolesDao.findAll())
-    }
-
-    @Test
-    fun `throws exception if user does not have a Terraformation email address`() {
-      val userId = insertUser(10, email = "test@elsewhere.com")
-
-      assertThrows<AccessDeniedException> { userStore.updateGlobalRoles(setOf(userId), emptySet()) }
     }
 
     @Test


### PR DESCRIPTION
- Add API `DELETE /api/v1/globalRoles/users` for bulk removing global roles from a given set of user IDs
  - Receives a payload of `{"userIds: [$userId1,$userId2]}`
- Update the `UserStore.updateGlobalRoles` function to accept a list of userIds to perform the operation on.
  - The operation is considered "all or nothing", IE no users supplied in the list will be updated if there is an error with any of them (for example if some of the users are not `@terraformation.com` users)