### PR TITLE
SW-5089 Global roles grant limited read access

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.InternalTagId
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -25,6 +26,7 @@ import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.db.default_schema.tables.references.DEVICE_MANAGERS
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_INTERNAL_TAGS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.REPORTS
@@ -209,6 +211,12 @@ class ParentStore(private val dslContext: DSLContext) {
           .and(ORGANIZATION_USERS.USER_ID.eq(userId))
           .fetch()
           .isNotEmpty
+
+  fun hasInternalTag(organizationId: OrganizationId, internalTag: InternalTagId): Boolean =
+      dslContext.fetchExists(
+          ORGANIZATION_INTERNAL_TAGS,
+          ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID.eq(organizationId),
+          ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(internalTag))
 
   /**
    * Looks up a database row by an ID and returns the value of one of the columns, or null if no row

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -144,8 +144,8 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchById requires user to be in the organization`() {
-    every { user.organizationRoles } returns emptyMap()
+  fun `fetchById requires user to be able to read the organization`() {
+    every { user.canReadOrganization(organizationId) } returns false
 
     assertThrows<OrganizationNotFoundException> { store.fetchOneById(organizationId) }
   }
@@ -161,6 +161,16 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     assertEquals(expectedTotalUsers, store.fetchOneById(organizationId).totalUsers)
+  }
+
+  @Test
+  fun `fetchById does not return facility data if user has read access but is not a member`() {
+    every { user.facilityRoles } returns emptyMap()
+    every { user.organizationRoles } returns emptyMap()
+
+    assertEquals(
+        organizationModel.copy(facilities = emptyList()),
+        store.fetchOneById(organizationId, OrganizationStore.FetchDepth.Facility))
   }
 
   @Test


### PR DESCRIPTION
Allow users with the Super-Admin global role to read all organizations and all
projects, and allow users with the other global roles to read organizations with
the Accelerator internal tag and their projects.

Currently, this does not allow read access via the search API, only via the
dedicated GET endpoints for organizations and projects. It also doesn't grant
read access to other entities such as batches or accessions, just the basic
data (name, etc.) of the organizations and projects.