### PR TITLE
Make SearchFieldDescriptionsTest more useful

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldDescriptionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldDescriptionsTest.kt
@@ -4,8 +4,8 @@ import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.table.SearchTables
 import java.time.Clock
 import kotlin.reflect.full.memberProperties
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
 
 class SearchFieldDescriptionsTest {
   private val messages = Messages()
@@ -14,18 +14,25 @@ class SearchFieldDescriptionsTest {
   fun `all search fields have English descriptions`() {
     val tables = SearchTables(Clock.systemUTC())
 
-    assertAll(
+    val missingFields =
         SearchTables::class
             .memberProperties
-            .map { it.get(tables) as SearchTable }
+            .mapNotNull { it.get(tables) as? SearchTable }
             .flatMap { table ->
-              table.fields.map { field ->
-                ({
+              table.fields.mapNotNull { field ->
+                try {
                   // This will throw an exception if there is no entry in the strings table
                   // for the field.
                   messages.searchFieldDisplayName(table.name, field.fieldName)
-                })
+                  null
+                } catch (e: Exception) {
+                  "search.${table.name}.${field.fieldName}="
+                }
               }
-            })
+            }
+            .sorted()
+            .joinToString("\n")
+
+    assertEquals("", missingFields, "Missing search field descriptions")
   }
 }


### PR DESCRIPTION
Similar to commit ab12043c, make SearchFieldDescriptionsTest include a list of
missing properties file lines in its assertion failure message so it's easier
to fill in the missing entries.