### PR TITLE
Allow participant to be created in a cohort

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantModel.kt
@@ -24,9 +24,12 @@ data class ParticipantModel<ID : ParticipantId?>(
       )
     }
 
-    fun create(name: String): NewParticipantModel {
+    fun create(
+        name: String,
+        cohortId: CohortId? = null,
+    ): NewParticipantModel {
       return NewParticipantModel(
-          cohortId = null,
+          cohortId = cohortId,
           id = null,
           name = name,
           projectIds = emptyList(),


### PR DESCRIPTION
Previously, ParticipantStore could only update the cohort ID after participant
creation. Change it to allow a participant to be created directly in a cohort.