### PR TITLE
Add fields missing in the project details response, fix a bug with the data store fetch one by ID

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -13,8 +13,10 @@ import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
 import java.math.BigDecimal
+import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -62,6 +64,8 @@ data class ProjectAcceleratorDetailsPayload(
     val applicationReforestableLand: BigDecimal?,
     val confirmedReforestableLand: BigDecimal?,
     val countryCode: String?,
+    val createdBy: UserId,
+    val createdTime: Instant,
     val dealDescription: String?,
     val dealStage: DealStage?,
     val failureRisk: String?,
@@ -69,11 +73,15 @@ data class ProjectAcceleratorDetailsPayload(
     val landUseModelTypes: Set<LandUseModelType>,
     val maxCarbonAccumulation: BigDecimal?,
     val minCarbonAccumulation: BigDecimal?,
+    val modifiedBy: UserId,
+    val modifiedTime: Instant,
     val numCommunities: Int?,
     val numNativeSpecies: Int?,
+    val perHectareBudget: BigDecimal?,
     val pipeline: Pipeline?,
     val projectId: ProjectId,
     val projectLead: String?,
+    val projectName: String?,
     val region: Region?,
     val totalExpansionPotential: BigDecimal?,
     val whatNeedsToBeTrue: String?,
@@ -84,6 +92,8 @@ data class ProjectAcceleratorDetailsPayload(
       applicationReforestableLand = model.applicationReforestableLand,
       confirmedReforestableLand = model.confirmedReforestableLand,
       countryCode = model.countryCode,
+      createdBy = model.createdBy,
+      createdTime = model.createdTime,
       dealDescription = model.dealDescription,
       dealStage = model.dealStage,
       failureRisk = model.failureRisk,
@@ -91,11 +101,15 @@ data class ProjectAcceleratorDetailsPayload(
       landUseModelTypes = model.landUseModelTypes,
       maxCarbonAccumulation = model.maxCarbonAccumulation,
       minCarbonAccumulation = model.minCarbonAccumulation,
+      modifiedBy = model.modifiedBy,
+      modifiedTime = model.modifiedTime,
       numCommunities = model.numCommunities,
       numNativeSpecies = model.numNativeSpecies,
+      perHectareBudget = model.perHectareBudget,
       pipeline = model.pipeline,
       projectId = model.projectId,
       projectLead = model.projectLead,
+      projectName = model.projectName,
       region = model.region,
       totalExpansionPotential = model.totalExpansionPotential,
       whatNeedsToBeTrue = model.whatNeedsToBeTrue,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -41,13 +41,19 @@ class ProjectAcceleratorDetailsStore(
             landUseModelTypesMultiset,
             PROJECT_ACCELERATOR_DETAILS.asterisk(),
             PROJECTS.COUNTRY_CODE,
+            PROJECTS.CREATED_BY,
+            PROJECTS.CREATED_TIME,
             PROJECTS.ID,
+            PROJECTS.MODIFIED_BY,
+            PROJECTS.MODIFIED_TIME,
+            PROJECTS.NAME,
         )
         .from(PROJECTS)
         .leftJoin(PROJECT_ACCELERATOR_DETAILS)
         .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
         .leftJoin(COUNTRIES)
         .on(PROJECTS.COUNTRY_CODE.eq(COUNTRIES.CODE))
+        .where(PROJECTS.ID.eq(projectId))
         .fetchOne { ProjectAcceleratorDetailsModel.of(it, landUseModelTypesMultiset) }
         ?: throw ProjectNotFoundException(projectId)
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -6,9 +6,11 @@ import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCEL
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.COUNTRIES
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import java.math.BigDecimal
+import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
 
@@ -16,6 +18,8 @@ data class ProjectAcceleratorDetailsModel(
     val applicationReforestableLand: BigDecimal? = null,
     val confirmedReforestableLand: BigDecimal? = null,
     val countryCode: String? = null,
+    val createdBy: UserId,
+    val createdTime: Instant,
     val dealDescription: String? = null,
     val dealStage: DealStage? = null,
     val failureRisk: String? = null,
@@ -23,12 +27,15 @@ data class ProjectAcceleratorDetailsModel(
     val landUseModelTypes: Set<LandUseModelType> = emptySet(),
     val maxCarbonAccumulation: BigDecimal? = null,
     val minCarbonAccumulation: BigDecimal? = null,
+    val modifiedBy: UserId,
+    val modifiedTime: Instant,
     val numCommunities: Int? = null,
     val numNativeSpecies: Int? = null,
     val perHectareBudget: BigDecimal? = null,
     val pipeline: Pipeline? = null,
     val projectId: ProjectId,
     val projectLead: String? = null,
+    val projectName: String? = null,
     val region: Region? = null,
     val totalExpansionPotential: BigDecimal? = null,
     val whatNeedsToBeTrue: String? = null,
@@ -43,6 +50,8 @@ data class ProjectAcceleratorDetailsModel(
             applicationReforestableLand = record[APPLICATION_REFORESTABLE_LAND],
             confirmedReforestableLand = record[CONFIRMED_REFORESTABLE_LAND],
             countryCode = record[PROJECTS.COUNTRY_CODE],
+            createdBy = record[PROJECTS.CREATED_BY]!!,
+            createdTime = record[PROJECTS.CREATED_TIME]!!,
             dealDescription = record[DEAL_DESCRIPTION],
             dealStage = record[DEAL_STAGE_ID],
             failureRisk = record[FAILURE_RISK],
@@ -50,12 +59,15 @@ data class ProjectAcceleratorDetailsModel(
             landUseModelTypes = record[landUseModelTypesMultiset]?.toSet() ?: emptySet(),
             maxCarbonAccumulation = record[MAX_CARBON_ACCUMULATION],
             minCarbonAccumulation = record[MIN_CARBON_ACCUMULATION],
+            modifiedBy = record[PROJECTS.MODIFIED_BY]!!,
+            modifiedTime = record[PROJECTS.MODIFIED_TIME]!!,
             numCommunities = record[NUM_COMMUNITIES],
             numNativeSpecies = record[NUM_NATIVE_SPECIES],
             perHectareBudget = record[PER_HECTARE_BUDGET],
             pipeline = record[PIPELINE_ID],
             projectId = record[PROJECTS.ID]!!,
             projectLead = record[PROJECT_LEAD],
+            projectName = record[PROJECTS.NAME],
             region = record[COUNTRIES.REGION_ID],
             totalExpansionPotential = record[TOTAL_EXPANSION_POTENTIAL],
             whatNeedsToBeTrue = record[WHAT_NEEDS_TO_BE_TRUE],

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
@@ -11,6 +12,7 @@ import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.math.BigDecimal
+import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -67,6 +69,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               applicationReforestableLand = detailsRow.applicationReforestableLand,
               confirmedReforestableLand = detailsRow.confirmedReforestableLand,
               countryCode = "KE",
+              createdBy = currentUser().userId,
+              createdTime = Instant.EPOCH,
               dealDescription = detailsRow.dealDescription,
               dealStage = detailsRow.dealStageId,
               failureRisk = detailsRow.failureRisk,
@@ -74,12 +78,15 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               landUseModelTypes = setOf(LandUseModelType.Agroforestry, LandUseModelType.Mangroves),
               maxCarbonAccumulation = detailsRow.maxCarbonAccumulation,
               minCarbonAccumulation = detailsRow.minCarbonAccumulation,
+              modifiedBy = currentUser().userId,
+              modifiedTime = Instant.EPOCH,
               numCommunities = detailsRow.numCommunities,
               numNativeSpecies = detailsRow.numNativeSpecies,
               perHectareBudget = detailsRow.perHectareBudget,
               pipeline = detailsRow.pipelineId,
               projectId = projectId,
               projectLead = detailsRow.projectLead,
+              projectName = "Project 1",
               region = Region.SubSaharanAfrica,
               totalExpansionPotential = detailsRow.totalExpansionPotential,
               whatNeedsToBeTrue = detailsRow.whatNeedsToBeTrue,
@@ -94,7 +101,12 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(
           ProjectAcceleratorDetailsModel(
               countryCode = "US",
+              createdBy = currentUser().userId,
+              createdTime = Instant.EPOCH,
+              modifiedBy = currentUser().userId,
+              modifiedTime = Instant.EPOCH,
               projectId = projectId,
+              projectName = "Project 1",
               region = Region.NorthAmerica,
           ),
           store.fetchOneById(projectId))
@@ -121,6 +133,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               applicationReforestableLand = BigDecimal(1),
               confirmedReforestableLand = BigDecimal(2),
               countryCode = "JP",
+              createdBy = currentUser().userId,
+              createdTime = Instant.EPOCH,
               dealDescription = "description",
               dealStage = DealStage.Phase0DocReview,
               failureRisk = "failure",
@@ -128,12 +142,15 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               landUseModelTypes = setOf(LandUseModelType.Agroforestry, LandUseModelType.Mangroves),
               maxCarbonAccumulation = BigDecimal(5),
               minCarbonAccumulation = BigDecimal(4),
+              modifiedBy = currentUser().userId,
+              modifiedTime = Instant.EPOCH,
               numCommunities = 2,
               numNativeSpecies = 1,
               perHectareBudget = BigDecimal(6),
               pipeline = Pipeline.AcceleratorProjects,
               projectId = projectId,
               projectLead = "lead",
+              projectName = "Project 1",
               totalExpansionPotential = BigDecimal(3),
               whatNeedsToBeTrue = "needs",
           )
@@ -174,6 +191,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               applicationReforestableLand = BigDecimal(10),
               confirmedReforestableLand = BigDecimal(20),
               countryCode = "JP",
+              createdBy = currentUser().userId,
+              createdTime = Instant.EPOCH,
               dealDescription = "new description",
               dealStage = DealStage.Phase1,
               failureRisk = "new failure",
@@ -181,12 +200,15 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               landUseModelTypes = setOf(LandUseModelType.Mangroves, LandUseModelType.Silvopasture),
               maxCarbonAccumulation = BigDecimal(50),
               minCarbonAccumulation = BigDecimal(40),
+              modifiedBy = currentUser().userId,
+              modifiedTime = Instant.EPOCH,
               numCommunities = 20,
               numNativeSpecies = 10,
               perHectareBudget = BigDecimal(60),
               pipeline = Pipeline.AcceleratorProjects,
               projectId = projectId,
               projectLead = "new lead",
+              projectName = "Project 1",
               totalExpansionPotential = BigDecimal(30),
               whatNeedsToBeTrue = "new needs",
           )


### PR DESCRIPTION
- Added `createdBy`, `createdTime`, `modifiedBy`, `modifiedTime`, `projectName` to the `ProjectAcceleratorDetailsModel`
- Fixed a bug with `ProjectAcceleratorDetailsStore.fetchOneById`, it was returning multiple rows