### PR TITLE
Fix `ProjectAcceleratorDetailsStore.fetchOneById`

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -48,6 +48,7 @@ class ProjectAcceleratorDetailsStore(
         .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
         .leftJoin(COUNTRIES)
         .on(PROJECTS.COUNTRY_CODE.eq(COUNTRIES.CODE))
+        .where(PROJECTS.ID.eq(projectId))
         .fetchOne { ProjectAcceleratorDetailsModel.of(it, landUseModelTypesMultiset) }
         ?: throw ProjectNotFoundException(projectId)
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -42,6 +42,9 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 
+      // To ensure that the fetchOne works as expected when there are multiple rows
+      insertProject(countryCode = "ZW")
+
       val detailsRow =
           insertProjectAcceleratorDetails(
               abbreviatedName = "abbreviated",


### PR DESCRIPTION
- `ProjectAcceleratorDetailsStore.fetchOneById` was selecting multiple rows and causing the query to fail