### PR TITLE
SW-4732 Select temporary plots using site map

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -33,6 +33,7 @@ class UnusedSquareFinder(
   /** The geometry of the zone's available area (minus exclusion and existing plots). */
   private val zoneGeometry =
       zoneBoundary
+          .fixIfNeeded()
           .let { if (exclusion != null) it.difference(exclusion.fixIfNeeded()) else it }
           .fixIfNeeded()
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.createRectangle
+import com.terraformation.backend.util.fixIfNeeded
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.random.Random
@@ -15,7 +16,6 @@ import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.PrecisionModel
-import org.locationtech.jts.geom.util.GeometryFixer
 
 /** Finds an unused grid-aligned square within a zone boundary. */
 class UnusedSquareFinder(
@@ -33,8 +33,8 @@ class UnusedSquareFinder(
   /** The geometry of the zone's available area (minus exclusion and existing plots). */
   private val zoneGeometry =
       zoneBoundary
-          .let { if (exclusion != null) it.difference(exclusion) else it }
-          .let { if (!it.isValid) GeometryFixer(it).result else it }
+          .let { if (exclusion != null) it.difference(exclusion.fixIfNeeded()) else it }
+          .fixIfNeeded()
 
   init {
     calculator.startingPosition = JTS.toDirectPosition(gridOrigin.coordinate, boundaryCrs)

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -17,6 +17,7 @@ import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.PrecisionModel
+import org.locationtech.jts.geom.util.GeometryFixer
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
 // context of a specific bit of application code should live alongside that code, but functions that
@@ -128,5 +129,22 @@ fun Geometry.toMultiPolygon(
     is MultiPolygon -> this
     is Polygon -> factory.createMultiPolygon(arrayOf(this))
     else -> throw IllegalArgumentException("Cannot convert $geometryType to MultiPolygon")
+  }
+}
+
+/**
+ * Fixes problems with invalid geometries if possible. Geometries that are calculated using
+ * operations like intersections and unions can suffer from floating-point inaccuracy which causes
+ * things like self-intersecting polygon edges. Subsequent calculations on those geometries will
+ * throw exceptions.
+ *
+ * Note that this should only be used to fix geometries that are derived from valid geometries, not
+ * as a way to avoid having to validate user-supplied geometries.
+ */
+fun Geometry.fixIfNeeded(): Geometry {
+  return if (isValid) {
+    this
+  } else {
+    GeometryFixer(this).result
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Turtle.kt
@@ -38,6 +38,9 @@ class Turtle(
   private val geometryFactory = GeometryFactory(PrecisionModel(), start.srid)
   private var drawing: Boolean = false
 
+  val currentPosition: Position
+    get() = calculator.startingPosition
+
   init {
     calculator.startingPosition = startPosition
   }
@@ -110,7 +113,7 @@ class Turtle(
     rectangle(meters, meters)
   }
 
-  private fun moveTo(position: Position) {
+  fun moveTo(position: Position) {
     calculator.startingPosition = position
 
     if (drawing) {


### PR DESCRIPTION
Currently, temporary plots are selected by picking entries from the complete list
of potential plots that gets created during shapefile import.

Switch to a geometry-based selection process instead, where plot locations are
selected on a map and then mapped to existing plot IDs if the plots have already
been inserted into the database.

Currently, we still create all the potential plots during shapefile import, so the
selected plots will always already exist. But this moves us one step closer to
being able to skip creating the plots ahead of time.