### PR TITLE
SW-4732 Create missing temporary plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -101,7 +101,10 @@ class ObservationService(
               val temporaryPlotIds =
                   plantingZone
                       .chooseTemporaryPlots(plantedSubzoneIds, gridOrigin, plantingSite.exclusion)
-                      .mapNotNull { plantingZone.findMonitoringPlot(it)?.id }
+                      .map { plotBoundary ->
+                        plantingSiteStore.createTemporaryPlot(
+                            plantingSite.id, plantingZone.id, plotBoundary)
+                      }
 
               observationStore.addPlotsToObservation(
                   observationId, permanentPlotIds, isPermanent = true)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingType
+import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
@@ -1473,6 +1474,87 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val plantingSiteId = insertPlantingSite()
 
       assertThrows<AccessDeniedException> { store.deletePlantingSite(plantingSiteId) }
+    }
+  }
+
+  @Nested
+  inner class CreateTemporaryPlot {
+    @Test
+    fun `creates new plot with correct details`() {
+      val siteBoundary = Turtle(point(0)).makeMultiPolygon { square(51) }
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0))
+      val plantingZoneId = insertPlantingZone(boundary = siteBoundary)
+      val plantingSubzoneId = insertPlantingSubzone(boundary = siteBoundary)
+
+      insertMonitoringPlot(
+          boundary =
+              Turtle(point(0)).makePolygon {
+                north(25)
+                square(25)
+              },
+          name = "17")
+
+      val plotBoundary = Turtle(point(0)).makePolygon { square(25) }
+      val newPlotId = store.createTemporaryPlot(plantingSiteId, plantingZoneId, plotBoundary)
+
+      val expected =
+          MonitoringPlotsRow(
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              fullName = "Z1-1-18",
+              id = newPlotId,
+              isAvailable = true,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+              name = "18",
+              plantingSubzoneId = plantingSubzoneId,
+          )
+
+      val actual = monitoringPlotsDao.fetchOneById(newPlotId)!!
+
+      assertEquals(expected, actual.copy(boundary = null))
+
+      // PostGIS geometry representation isn't identical to GeoTools in-memory representation; do a
+      // fuzzy comparison with a very small tolerance.
+      if (!plotBoundary.equalsExact(actual.boundary!!, 0.00000000001)) {
+        assertEquals(plotBoundary, actual.boundary!!, "Plot boundary")
+      }
+    }
+
+    @Test
+    fun `returns existing ID if plot boundary already exists`() {
+      val siteBoundary = Turtle(point(0)).makeMultiPolygon { square(51) }
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0))
+      val plantingZoneId = insertPlantingZone(boundary = siteBoundary)
+      insertPlantingSubzone(boundary = siteBoundary)
+
+      val existingPlotBoundary = Turtle(point(0)).makePolygon { square(25) }
+      val existingPlotId = insertMonitoringPlot(boundary = existingPlotBoundary)
+
+      val newPlotBoundary =
+          Turtle(point(0)).makePolygon {
+            east(1)
+            north(1)
+            square(25)
+          }
+      val newPlotId = store.createTemporaryPlot(plantingSiteId, plantingZoneId, newPlotBoundary)
+
+      assertEquals(existingPlotId, newPlotId, "Should have returned existing plot ID")
+    }
+
+    @Test
+    fun `throws exception if no permission to update planting site`() {
+      every { user.canUpdatePlantingSite(any()) } returns false
+
+      val siteBoundary = Turtle(point(0)).makeMultiPolygon { square(101) }
+      val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0))
+      val plantingZoneId = insertPlantingZone(boundary = siteBoundary)
+      insertPlantingSubzone(boundary = siteBoundary)
+
+      assertThrows<AccessDeniedException> {
+        store.createTemporaryPlot(
+            plantingSiteId, plantingZoneId, Turtle(point(0)).makePolygon { square(25) })
+      }
     }
   }
 


### PR DESCRIPTION
When an observation starts and temporary plot boundaries are selected on the site
map, create new monitoring plots in the database for any boundaries that aren't
already there.

For existing planting sites, this is a no-op because all possible plot boundaries
are inserted into the database at shapefile import time. But future updates will
get rid of the import-time plot creation to better support editing maps after site
creation.

This is analogous to commit 14d90e78c which added on-demand cration of permanent
clusters.