### PR TITLE
Fix duplicate projects on voters admin page

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/AcceleratorProjectModel.kt
@@ -6,9 +6,9 @@ import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
-import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTE_DECISIONS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import org.jooq.Field
 import org.jooq.Record
 
 data class AcceleratorProjectModel(
@@ -20,11 +20,12 @@ data class AcceleratorProjectModel(
     val phaseName: String = phase.getDisplayName(null),
     val projectId: ProjectId,
     val projectName: String,
-    val voteDecision: VoteOption?
+    val voteDecisions: Map<CohortPhase, VoteOption> = emptyMap(),
 ) {
   companion object {
     fun of(
         record: Record,
+        decisionsField: Field<Map<CohortPhase, VoteOption>>,
     ): AcceleratorProjectModel {
       return AcceleratorProjectModel(
           cohortId = record[COHORTS.ID]!!,
@@ -34,7 +35,7 @@ data class AcceleratorProjectModel(
           phase = record[COHORTS.PHASE_ID]!!,
           projectId = record[PROJECTS.ID]!!,
           projectName = record[PROJECTS.NAME]!!,
-          voteDecision = record[PROJECT_VOTE_DECISIONS.VOTE_OPTION_ID],
+          voteDecisions = record[decisionsField] ?: emptyMap(),
       )
     }
   }

--- a/src/main/resources/templates/admin/voters.html
+++ b/src/main/resources/templates/admin/voters.html
@@ -119,7 +119,7 @@
     <tr th:each="project : ${projects}" class="striped">
         <td th:text="${project.projectName}">Project Name</td>
         <td th:text="${project.phaseName}">Project Phase</td>
-        <td th:text="${project.voteDecision ?: 'Incomplete'}">Yes</td>
+        <td th:text="${project.voteDecisions[project.phase] ?: 'Incomplete'}">Yes</td>
         <td>
             <form method="POST"
                   th:id="|remove-${project.projectId}|"

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -29,8 +29,18 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsUser {
     insertProject(countryCode = "KE", participantId = inserted.participantId)
     insertVoteDecision(
         projectId = inserted.projectId,
+        phase = CohortPhase.Phase0DueDiligence,
+        voteOption = VoteOption.Yes,
+    )
+    insertVoteDecision(
+        projectId = inserted.projectId,
         phase = CohortPhase.Phase1FeasibilityStudy,
         voteOption = VoteOption.No,
+    )
+    insertVoteDecision(
+        projectId = inserted.projectId,
+        phase = CohortPhase.Phase2PlanAndScale,
+        voteOption = null,
     )
 
     every { user.canReadAllAcceleratorDetails() } returns true
@@ -38,6 +48,7 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `returns accelerator projects`() {
+    val phase = cohortsDao.fetchOneById(inserted.cohortId)!!.phaseId!!
     assertEquals(
         listOf(
             AcceleratorProjectModel(
@@ -45,10 +56,14 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsUser {
                 cohortName = cohortsDao.fetchOneById(inserted.cohortId)!!.name!!,
                 participantId = inserted.participantId,
                 participantName = participantsDao.fetchOneById(inserted.participantId)!!.name!!,
-                phase = cohortsDao.fetchOneById(inserted.cohortId)!!.phaseId!!,
+                phase = phase,
                 projectId = inserted.projectId,
                 projectName = projectsDao.fetchOneById(inserted.projectId)!!.name!!,
-                voteDecision = VoteOption.No,
+                voteDecisions =
+                    mapOf(
+                        CohortPhase.Phase0DueDiligence to VoteOption.Yes,
+                        CohortPhase.Phase1FeasibilityStudy to VoteOption.No,
+                    ),
             )),
         service.listAcceleratorProjects())
   }


### PR DESCRIPTION
If a project had vote decision records for multiple phases, we were listing the
project multiple times on the voter management page in the admin UI, but only
showing the voters for the current phase.

Change the database query and the model class to be aware that there can be
multiple vote decisions for a project, and make the admin UI only show the current
phase.