### PR TITLE
Remove unused code block from admin UI

### DIFF
--- a/src/main/resources/templates/admin/participant.html
+++ b/src/main/resources/templates/admin/participant.html
@@ -7,16 +7,6 @@
             padding-left: 0;
         }
     </style>
-
-    <th:block th:fragment="additionalScript">
-        <script th:inline="javascript">
-            /*<![CDATA[*/
-            const organizationNames = /*[[${organizationNames}]]*/;
-            const projectNames = /*[[${projectNames}]]*/;
-            const projectIdsByOrganization = /*[[${projectIdsByOrganization}]]*/;
-            /*]]>*/
-        </script>
-    </th:block>
 </head>
 <body>
 


### PR DESCRIPTION
The participant page in the admin UI had a block of JavaScript code left over from
an early stab at building a dynamic list of available projects.