### PR TITLE
SW-5188 Implement undo of nursery withdrawals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -193,6 +193,12 @@ class ParentStore(private val dslContext: DSLContext) {
           DSL.coalesce(BATCHES.facilities.TIME_ZONE, BATCHES.facilities.organizations.TIME_ZONE))
           ?: ZoneOffset.UTC
 
+  fun getEffectiveTimeZone(facilityId: FacilityId): ZoneId =
+      fetchFieldById(
+          facilityId,
+          FACILITIES.ID,
+          DSL.coalesce(FACILITIES.TIME_ZONE, FACILITIES.organizations.TIME_ZONE)) ?: ZoneOffset.UTC
+
   fun getEffectiveTimeZone(plantingSiteId: PlantingSiteId): ZoneId =
       fetchFieldById(
           plantingSiteId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -24,5 +24,15 @@ class CrossOrganizationNurseryTransferNotAllowedException(
         "Cannot transfer from facility $facilityId to facility $destinationFacilityId because " +
             "they are in different organizations")
 
+class UndoOfNurseryTransferNotAllowedException(val withdrawalId: WithdrawalId) :
+    MismatchedStateException("Cannot undo nursery transfer withdrawal $withdrawalId")
+
+class UndoOfUndoNotAllowedException(val withdrawalId: WithdrawalId) :
+    MismatchedStateException(
+        "Cannot undo withdrawal $withdrawalId that was an undo of another withdrawal")
+
+class WithdrawalAlreadyUndoneException(val withdrawalId: WithdrawalId) :
+    MismatchedStateException("Withdrawal $withdrawalId has already been undone")
+
 class WithdrawalNotFoundException(val withdrawalId: WithdrawalId) :
     EntityNotFoundException("Withdrawal $withdrawalId not found")

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -20,14 +20,6 @@ data class BatchWithdrawalModel(
     val notReadyQuantityWithdrawn: Int,
     val readyQuantityWithdrawn: Int,
 ) {
-  init {
-    if (germinatingQuantityWithdrawn < 0 ||
-        notReadyQuantityWithdrawn < 0 ||
-        readyQuantityWithdrawn < 0) {
-      throw IllegalArgumentException("Withdrawal quantities may not be negative")
-    }
-  }
-
   val totalWithdrawn: Int
     get() = germinatingQuantityWithdrawn + notReadyQuantityWithdrawn + readyQuantityWithdrawn
 }
@@ -49,10 +41,16 @@ data class WithdrawalModel<ID : WithdrawalId?>(
     val notes: String? = null,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
+    val undoesWithdrawalId: WithdrawalId? = null,
 ) {
   init {
     if (batchWithdrawals.isEmpty()) {
       throw IllegalArgumentException("Withdrawals must come from at least one batch")
+    }
+
+    if (undoesWithdrawalId != null && purpose != WithdrawalPurpose.Undo ||
+        undoesWithdrawalId == null && purpose == WithdrawalPurpose.Undo) {
+      throw IllegalArgumentException("Must specify original withdrawal ID if purpose is Undo")
     }
   }
 }
@@ -81,4 +79,5 @@ fun WithdrawalsRow.toModel(batchWithdrawals: List<BatchWithdrawalsRow>): Existin
         notes = notes,
         purpose = purposeId!!,
         withdrawnDate = withdrawnDate!!,
+        undoesWithdrawalId = undoesWithdrawalId,
     )

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
@@ -98,6 +98,23 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
         notReadyQuantityWithdrawn = 32,
         readyQuantityWithdrawn = 33)
 
+    // Withdrawal that is undone should not affect stats.
+    insertWithdrawal(facilityId = facilityId, purpose = WithdrawalPurpose.Dead)
+    insertBatchWithdrawal(
+        batchId = batchId1,
+        germinatingQuantityWithdrawn = 34,
+        notReadyQuantityWithdrawn = 35,
+        readyQuantityWithdrawn = 36)
+    insertWithdrawal(
+        facilityId = facilityId,
+        purpose = WithdrawalPurpose.Undo,
+        undoesWithdrawalId = inserted.withdrawalId)
+    insertBatchWithdrawal(
+        batchId = batchId1,
+        germinatingQuantityWithdrawn = -34,
+        notReadyQuantityWithdrawn = -35,
+        readyQuantityWithdrawn = -36)
+
     val expected =
         NurseryStats(
             facilityId = facilityId,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
@@ -1,0 +1,193 @@
+package com.terraformation.backend.nursery.db.batchStore
+
+import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
+import com.terraformation.backend.db.nursery.WithdrawalId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.nursery.db.UndoOfNurseryTransferNotAllowedException
+import com.terraformation.backend.nursery.db.UndoOfUndoNotAllowedException
+import com.terraformation.backend.nursery.db.WithdrawalAlreadyUndoneException
+import com.terraformation.backend.nursery.model.BatchWithdrawalModel
+import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
+import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import io.mockk.every
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
+  private val batch1Id = BatchId(11)
+  private val batch2Id = BatchId(12)
+
+  @BeforeEach
+  fun insertInitialBatches() {
+    insertBatch(
+        id = batch1Id,
+        speciesId = speciesId,
+        batchNumber = "21-2-1-011",
+        germinatingQuantity = 10,
+        notReadyQuantity = 20,
+        readyQuantity = 30,
+        totalLost = 0,
+        totalLossCandidates = 20 + 30)
+    insertBatch(
+        id = batch2Id,
+        speciesId = speciesId,
+        batchNumber = "21-2-1-012",
+        germinatingQuantity = 40,
+        notReadyQuantity = 50,
+        readyQuantity = 60,
+        totalLost = 0,
+        totalLossCandidates = 50 + 60)
+
+    every { user.canReadWithdrawal(any()) } returns true
+  }
+
+  @Test
+  fun `updates quantities of batches without more recent observed quantities than the original withdrawal date`() {
+    val batch1BeforeWithdrawal = store.fetchOneById(batch1Id)
+
+    clock.instant = clock.instant.plus(2, ChronoUnit.DAYS)
+
+    val withdrawalId =
+        makeInitialWithdrawal(
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(batch1Id, null, 1, 2, 3),
+                    BatchWithdrawalModel(batch2Id, null, 4, 5, 6)))
+
+    clock.instant = clock.instant.plus(2, ChronoUnit.DAYS)
+
+    store.updateQuantities(
+        batchId = batch2Id,
+        version = 2,
+        germinating = 100,
+        notReady = 110,
+        ready = 120,
+        historyType = BatchQuantityHistoryType.Observed)
+
+    val batch2AfterQuantityEdit = store.fetchOneById(batch2Id)
+
+    clock.instant = clock.instant.plus(2, ChronoUnit.DAYS)
+
+    val undoWithdrawal = store.undoWithdrawal(withdrawalId)
+
+    assertEquals(
+        ExistingWithdrawalModel(
+            batchWithdrawals =
+                listOf(
+                    BatchWithdrawalModel(batch1Id, null, -1, -2, -3),
+                    BatchWithdrawalModel(batch2Id, null, -4, -5, -6),
+                ),
+            facilityId = facilityId,
+            id = undoWithdrawal.id,
+            purpose = WithdrawalPurpose.Undo,
+            withdrawnDate = LocalDate.ofInstant(clock.instant, ZoneOffset.UTC),
+            undoesWithdrawalId = withdrawalId,
+        ),
+        undoWithdrawal)
+
+    val batch1AfterUndo = store.fetchOneById(batch1Id)
+    val batch2AfterUndo = store.fetchOneById(batch2Id)
+
+    assertEquals(
+        batch1BeforeWithdrawal.copy(version = 3),
+        batch1AfterUndo,
+        "Should have updated batch without recent observed quantities")
+    assertEquals(
+        batch2AfterQuantityEdit.copy(totalWithdrawn = 0, version = 4),
+        batch2AfterUndo,
+        "Should not have updated batch with recent observed quantities")
+
+    val quantityHistories = batchQuantityHistoryDao.findAll().onEach { it.id = null }
+
+    assertEquals(
+        listOf(
+            BatchQuantityHistoryRow(
+                batchId = batch1Id,
+                historyTypeId = BatchQuantityHistoryType.Computed,
+                createdBy = user.userId,
+                createdTime = clock.instant,
+                germinatingQuantity = 10,
+                notReadyQuantity = 20,
+                readyQuantity = 30,
+                withdrawalId = undoWithdrawal.id,
+                version = 3,
+            )),
+        quantityHistories.filter { it.batchId == batch1Id && it.withdrawalId == undoWithdrawal.id },
+        "Should have created quantity history entry for undo on batch whose quantity was updated")
+
+    assertEquals(
+        emptyList<BatchQuantityHistoryRow>(),
+        quantityHistories.filter { it.batchId == batch2Id && it.withdrawalId == undoWithdrawal.id },
+        "Should not have created quantity history entry for undo on batch with more recent observed quantity")
+  }
+
+  @Test
+  fun `throws exception if undoing nursery transfer`() {
+    val otherFacilityId = insertFacility(id = 3, type = FacilityType.Nursery)
+
+    val withdrawalId =
+        makeInitialWithdrawal(
+            destinationFacilityId = otherFacilityId, purpose = WithdrawalPurpose.NurseryTransfer)
+
+    assertThrows<UndoOfNurseryTransferNotAllowedException> { store.undoWithdrawal(withdrawalId) }
+  }
+
+  @Test
+  fun `throws exception if undoing a withdrawal that has already been undone`() {
+    val withdrawalId = makeInitialWithdrawal()
+    store.undoWithdrawal(withdrawalId)
+
+    assertThrows<WithdrawalAlreadyUndoneException> { store.undoWithdrawal(withdrawalId) }
+  }
+
+  @Test
+  fun `throws exception if undoing an undo withdrawal`() {
+    val undoWithdrawal = store.undoWithdrawal(makeInitialWithdrawal())
+
+    assertThrows<UndoOfUndoNotAllowedException> { store.undoWithdrawal(undoWithdrawal.id) }
+  }
+
+  @Test
+  fun `throws exception if no permission to update batches`() {
+    val withdrawalId = makeInitialWithdrawal()
+    store.undoWithdrawal(withdrawalId)
+
+    every { user.canUpdateBatch(any()) } returns false
+
+    assertThrows<AccessDeniedException> { store.undoWithdrawal(withdrawalId) }
+  }
+
+  private fun makeInitialWithdrawal(
+      batchWithdrawals: List<BatchWithdrawalModel> =
+          listOf(
+              BatchWithdrawalModel(
+                  batchId = batch1Id,
+                  germinatingQuantityWithdrawn = 1,
+                  notReadyQuantityWithdrawn = 2,
+                  readyQuantityWithdrawn = 3)),
+      destinationFacilityId: Any? = null,
+      purpose: WithdrawalPurpose = WithdrawalPurpose.Other,
+      withdrawnDate: LocalDate = LocalDate.EPOCH,
+  ): WithdrawalId {
+    return store
+        .withdraw(
+            NewWithdrawalModel(
+                batchWithdrawals = batchWithdrawals,
+                destinationFacilityId = destinationFacilityId?.toIdWrapper { FacilityId(it) },
+                facilityId = facilityId,
+                id = null,
+                purpose = purpose,
+                withdrawnDate = withdrawnDate))
+        .id
+  }
+}


### PR DESCRIPTION
Add an `undoWithdrawal` method to `BatchStore` that reverses the effects of a
previous withdrawal on seedling batches.

Take undo withdrawals into account in the nursery stats calculations.

Currently, there is no way for an end user to use this code; it will be hooked
up to the API in a later change.