### PR TITLE
SW-5188 Implement undo of planting site deliveries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -106,6 +107,14 @@ class ReassignmentOfReassignmentNotAllowedException(val plantingId: PlantingId) 
     MismatchedStateException(
         "Cannot reassign from planting $plantingId because it is a reassignment")
 
+class ReassignmentOfUndoneWithdrawalNotAllowedException(val deliveryId: DeliveryId) :
+    MismatchedStateException(
+        "Cannot reassign delivery $deliveryId because its withdrawal has been undone")
+
+class ReassignmentOfUndoNotAllowedException(val deliveryId: DeliveryId) :
+    MismatchedStateException(
+        "Cannot reassign delivery $deliveryId because it is an undo of another delivery")
+
 class ReassignmentTooLargeException(val plantingId: PlantingId) :
     MismatchedStateException(
         "Cannot reassign more plants from planting $plantingId than were originally delivered")
@@ -119,3 +128,6 @@ class ObservationRescheduleStateException(val observationId: ObservationId) :
 class ScheduleObservationWithoutPlantsException(val plantingSiteId: PlantingSiteId) :
     IllegalArgumentException(
         "Cannot schedule observation in planting site $plantingSiteId which has no reported plants in subzones")
+
+class WithdrawalNotUndoException(val withdrawalId: WithdrawalId) :
+    MismatchedStateException("Withdrawal $withdrawalId is not an undo withdrawal")

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/DeliveryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/DeliveryModel.kt
@@ -4,10 +4,12 @@ import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
+import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
 
 data class DeliveryModel(
+    val createdTime: Instant,
     val id: DeliveryId,
     val plantings: List<PlantingModel>,
     val plantingSiteId: PlantingSiteId,
@@ -17,6 +19,7 @@ data class DeliveryModel(
       record: Record,
       plantingsMultisetField: Field<List<PlantingModel>>
   ) : this(
+      record[DELIVERIES.CREATED_TIME]!!,
       record[DELIVERIES.ID]!!,
       record[plantingsMultisetField],
       record[DELIVERIES.PLANTING_SITE_ID]!!,


### PR DESCRIPTION
When an outplanting withdrawal is undone, we also need to undo the changes to the
plant totals at the destination planting site. Implement the logic for that.