### PR TITLE
SW-5188 Include undo information in withdrawal payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -209,6 +209,10 @@ data class NurseryWithdrawalPayload(
     val notes: String?,
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
+    @Schema(description = "If purpose is \"Undo\", the ID of the withdrawal this one undoes.")
+    val undoesWithdrawalId: WithdrawalId?,
+    @Schema(description = "If this withdrawal was undone, the ID of the withdrawal that undid it.")
+    val undoneByWithdrawalId: WithdrawalId?,
 ) {
   constructor(
       model: ExistingWithdrawalModel
@@ -220,6 +224,8 @@ data class NurseryWithdrawalPayload(
       model.notes,
       model.purpose,
       model.withdrawnDate,
+      model.undoesWithdrawalId,
+      model.undoneByWithdrawalId,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -138,8 +138,14 @@ class BatchStore(
     val batchWithdrawalsRows = batchWithdrawalsDao.fetchByWithdrawalId(withdrawalId)
     val withdrawalsRow =
         withdrawalsDao.fetchOneById(withdrawalId) ?: throw WithdrawalNotFoundException(withdrawalId)
+    val undoneByWithdrawalId =
+        dslContext
+            .select(WITHDRAWALS.ID)
+            .from(WITHDRAWALS)
+            .where(WITHDRAWALS.UNDOES_WITHDRAWAL_ID.eq(withdrawalId))
+            .fetchOne(WITHDRAWALS.ID)
 
-    return withdrawalsRow.toModel(batchWithdrawalsRows)
+    return withdrawalsRow.toModel(batchWithdrawalsRows, undoneByWithdrawalId)
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -42,6 +42,7 @@ data class WithdrawalModel<ID : WithdrawalId?>(
     val purpose: WithdrawalPurpose,
     val withdrawnDate: LocalDate,
     val undoesWithdrawalId: WithdrawalId? = null,
+    val undoneByWithdrawalId: WithdrawalId? = null,
 ) {
   init {
     if (batchWithdrawals.isEmpty()) {
@@ -70,7 +71,10 @@ fun BatchWithdrawalsRow.toModel(): BatchWithdrawalModel =
         readyQuantityWithdrawn = readyQuantityWithdrawn!!,
     )
 
-fun WithdrawalsRow.toModel(batchWithdrawals: List<BatchWithdrawalsRow>): ExistingWithdrawalModel =
+fun WithdrawalsRow.toModel(
+    batchWithdrawals: List<BatchWithdrawalsRow>,
+    undoneByWithdrawalId: WithdrawalId? = null
+): ExistingWithdrawalModel =
     ExistingWithdrawalModel(
         batchWithdrawals = batchWithdrawals.map { it.toModel() },
         destinationFacilityId = destinationFacilityId,
@@ -80,4 +84,5 @@ fun WithdrawalsRow.toModel(batchWithdrawals: List<BatchWithdrawalsRow>): Existin
         purpose = purposeId!!,
         withdrawnDate = withdrawnDate!!,
         undoesWithdrawalId = undoesWithdrawalId,
+        undoneByWithdrawalId = undoneByWithdrawalId,
     )


### PR DESCRIPTION
To allow the web app to link between original withdrawals and the withdrawals that
undo them, return "undoes" and "undone by" withdrawal IDs in the withdrawal GET
API payload.