### PR TITLE
SW-5188 Make nursery withdrawal undo endpoint functional

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -168,6 +168,8 @@ class WithdrawalsController(
               "plants will be removed from the planting site's plant totals. This does not " +
               "delete the original withdrawal.")
   fun undoBatchWithdrawal(@PathVariable withdrawalId: WithdrawalId): SimpleSuccessResponsePayload {
+    batchService.undoWithdrawal(withdrawalId)
+
     return SimpleSuccessResponsePayload()
   }
 }


### PR DESCRIPTION
The "undo withdrawal" endpoint will now actually undo a withdrawal rather than
just returning a success response.