### PR TITLE
Add Spring Boot Actuator dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
   // kapt("org.springframework.boot:spring-boot-configuration-processor")
 
   implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-jersey")
   implementation("org.springframework.boot:spring-boot-starter-jooq")
   implementation("org.springframework.boot:spring-boot-starter-mail")


### PR DESCRIPTION
JobRunr 7 removed the dependency on Spring Boot's starter bundle for
Actuator, which is used for load balancer health checks; we were relying on that
transitive dependency. Add it as an explicit dependency.