### PR TITLE
SW-5215 Fetch organization user's created_time when querying for organization users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -278,7 +278,7 @@ class OrganizationStore(
             USERS.FIRST_NAME,
             USERS.LAST_NAME,
             USERS.USER_TYPE_ID,
-            USERS.CREATED_TIME,
+            ORGANIZATION_USERS.CREATED_TIME,
             ORGANIZATION_USERS.ORGANIZATION_ID,
             ORGANIZATION_USERS.ROLE_ID,
         )
@@ -292,7 +292,7 @@ class OrganizationStore(
           val userId = record[USERS.ID]
           val organizationId = record[ORGANIZATION_USERS.ORGANIZATION_ID]
           val userType = record[USERS.USER_TYPE_ID]
-          val createdTime = record[USERS.CREATED_TIME]
+          val createdTime = record[ORGANIZATION_USERS.CREATED_TIME]
           val email = record[USERS.EMAIL]
 
           val firstName = record[USERS.FIRST_NAME]

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -34,6 +34,7 @@ import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.Instant
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import org.jooq.JSONB
 import org.jooq.Record
 import org.jooq.Table
@@ -442,7 +443,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
                 "First1",
                 "Last1",
                 UserType.Individual,
-                clock.instant(),
+                clock.instant().plus(1, ChronoUnit.DAYS),
                 organizationId,
                 Role.Admin),
             OrganizationUserModel(
@@ -451,7 +452,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
                 "First2",
                 "Last2",
                 UserType.Individual,
-                clock.instant(),
+                clock.instant().plus(2, ChronoUnit.MINUTES),
                 organizationId,
                 Role.Contributor),
         )
@@ -866,6 +867,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   private fun configureUser(model: OrganizationUserModel) {
     insertUser(model.userId, null, model.email, model.firstName, model.lastName, model.userType)
-    insertOrganizationUser(model.userId, model.organizationId, model.role)
+    insertOrganizationUser(
+        model.userId, model.organizationId, model.role, createdTime = model.createdTime)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -957,7 +957,7 @@ abstract class DatabaseTest {
           .set(CREATED_BY, createdBy)
           .set(CREATED_TIME, createdTime)
           .set(MODIFIED_BY, createdBy)
-          .set(MODIFIED_TIME, Instant.EPOCH)
+          .set(MODIFIED_TIME, createdTime)
           .set(ORGANIZATION_ID, organizationId.toIdWrapper { OrganizationId(it) })
           .set(ROLE_ID, role)
           .set(USER_ID, userId.toIdWrapper { UserId(it) })

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -949,12 +949,13 @@ abstract class DatabaseTest {
       organizationId: Any = this.organizationId,
       role: Role = Role.Contributor,
       createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
   ) {
     with(ORGANIZATION_USERS) {
       dslContext
           .insertInto(ORGANIZATION_USERS)
           .set(CREATED_BY, createdBy)
-          .set(CREATED_TIME, Instant.EPOCH)
+          .set(CREATED_TIME, createdTime)
           .set(MODIFIED_BY, createdBy)
           .set(MODIFIED_TIME, Instant.EPOCH)
           .set(ORGANIZATION_ID, organizationId.toIdWrapper { OrganizationId(it) })


### PR DESCRIPTION
- previously was looking up the user's created time
- updated code to fetch the org user's created time (date/time when user was added to the org)
- updated existing tests to capture this scenario