### PR TITLE
SW-4796 Add monitoring plot read permission

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -43,6 +43,7 @@ import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -50,6 +51,7 @@ import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
 import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
@@ -114,6 +116,12 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(facilityId: FacilityId): OrganizationId? =
       fetchFieldById(facilityId, FACILITIES.ID, FACILITIES.ORGANIZATION_ID)
+
+  fun getOrganizationId(monitoringPlotId: MonitoringPlotId): OrganizationId? =
+      fetchFieldById(
+          monitoringPlotId,
+          MONITORING_PLOTS.ID,
+          MONITORING_PLOTS.plantingSubzones.plantingSites.ORGANIZATION_ID)
 
   fun getOrganizationId(observationId: ObservationId): OrganizationId? =
       fetchFieldById(observationId, OBSERVATIONS.ID, OBSERVATIONS.plantingSites.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -277,6 +278,8 @@ data class DeviceManagerUser(
   override fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean = false
 
   override fun canReadInternalTags(): Boolean = false
+
+  override fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean = false
 
   override fun canReadNotification(notificationId: NotificationId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -31,6 +31,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -350,6 +351,9 @@ data class IndividualUser(
       parentStore.getUserId(notificationId) == userId
 
   override fun canReadInternalTags() = isReadOnlyOrHigher()
+
+  override fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId) =
+      isMember(parentStore.getOrganizationId(monitoringPlotId))
 
   override fun canReadObservation(observationId: ObservationId) =
       isMember(parentStore.getOrganizationId(observationId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -46,6 +46,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -60,6 +61,7 @@ import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSubzoneNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
+import com.terraformation.backend.tracking.db.PlotNotFoundException
 import org.springframework.security.access.AccessDeniedException
 
 /**
@@ -575,6 +577,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readInternalTags() {
     if (!user.canReadInternalTags()) {
       throw AccessDeniedException("No permission to read internal tags")
+    }
+  }
+
+  fun readMonitoringPlot(monitoringPlotId: MonitoringPlotId) {
+    if (!user.canReadMonitoringPlot(monitoringPlotId)) {
+      throw PlotNotFoundException(monitoringPlotId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -29,6 +29,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -275,6 +276,8 @@ class SystemUser(
   override fun canReadGlobalRoles(): Boolean = true
 
   override fun canReadInternalTags(): Boolean = true
+
+  override fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean = true
 
   override fun canReadNotification(notificationId: NotificationId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -229,6 +230,8 @@ interface TerrawareUser : Principal {
   fun canReadGlobalRoles(): Boolean
 
   fun canReadInternalTags(): Boolean
+
+  fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean
 
   fun canReadNotification(notificationId: NotificationId): Boolean
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -817,7 +817,10 @@ class PlantingSiteStore(
             ?: throw PlantingSubzoneNotFoundException(plotsRow.plantingSubzoneId!!)
     val plantingZoneId = subzonesRow.plantingZoneId!!
 
-    requirePermissions { updatePlantingSite(subzonesRow.plantingSiteId!!) }
+    requirePermissions {
+      readMonitoringPlot(monitoringPlotId)
+      updatePlantingSite(subzonesRow.plantingSiteId!!)
+    }
 
     val permanentCluster =
         plotsRow.permanentCluster ?: return ReplacementResult(emptySet(), emptySet())

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -43,6 +43,7 @@ import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -57,6 +58,7 @@ import com.terraformation.backend.tracking.db.PlantingNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSubzoneNotFoundException
 import com.terraformation.backend.tracking.db.PlantingZoneNotFoundException
+import com.terraformation.backend.tracking.db.PlotNotFoundException
 import io.mockk.MockKMatcherScope
 import io.mockk.every
 import io.mockk.mockk
@@ -122,6 +124,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(DraftPlantingSiteNotFoundException::class) { canReadDraftPlantingSite(it) }
   private val facilityId: FacilityId by
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
+  private val monitoringPlotId: MonitoringPlotId by
+      readableId(PlotNotFoundException::class) { canReadMonitoringPlot(it) }
   private val notificationUserId = UserId(2)
   private val notificationId: NotificationId by
       readableId(NotificationNotFoundException::class) { canReadNotification(it) }
@@ -538,6 +542,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readGlobalRoles() = allow { readGlobalRoles() } ifUser { canReadGlobalRoles() }
 
   @Test fun readInternalTags() = allow { readInternalTags() } ifUser { canReadInternalTags() }
+
+  @Test fun readMonitoringPlot() = testRead { readMonitoringPlot(monitoringPlotId) }
 
   @Test fun readNotification() = testRead { readNotification(notificationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -54,6 +54,7 @@ import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
@@ -138,6 +139,7 @@ internal class PermissionTest : DatabaseTest() {
 
   private val facilityIds = listOf(1000, 1001, 3000).map { FacilityId(it.toLong()) }
   private val draftPlantingSiteIds = facilityIds.map { DraftPlantingSiteId(it.value) }
+  private val monitoringPlotIds = facilityIds.map { MonitoringPlotId(it.value) }
   private val plantingSiteIds = facilityIds.map { PlantingSiteId(it.value) }
   private val plantingSubzoneIds = facilityIds.map { PlantingSubzoneId(it.value) }
   private val plantingZoneIds = facilityIds.map { PlantingZoneId(it.value) }
@@ -305,6 +307,14 @@ internal class PermissionTest : DatabaseTest() {
           id = plantingSubzoneId,
           plantingSiteId = PlantingSiteId(plantingSubzoneId.value),
           plantingZoneId = PlantingZoneId(plantingSubzoneId.value),
+      )
+    }
+
+    monitoringPlotIds.forEach { monitoringPlotId ->
+      insertMonitoringPlot(
+          createdBy = userId,
+          id = monitoringPlotId,
+          plantingSubzoneId = PlantingSubzoneId(monitoringPlotId.value),
       )
     }
 
@@ -480,6 +490,11 @@ internal class PermissionTest : DatabaseTest() {
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
         updatePlantingZone = true,
+    )
+
+    permissions.expect(
+        *monitoringPlotIds.forOrg1(),
+        readMonitoringPlot = true,
     )
 
     permissions.expect(
@@ -709,6 +724,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *monitoringPlotIds.forOrg1(),
+        readMonitoringPlot = true,
+    )
+
+    permissions.expect(
         *draftPlantingSiteIds.forOrg1(),
         deleteDraftPlantingSite = true,
         readDraftPlantingSite = true,
@@ -861,6 +881,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *monitoringPlotIds.forOrg1(),
+        readMonitoringPlot = true,
+    )
+
+    permissions.expect(
         *draftPlantingSiteIds.forOrg1(),
         readDraftPlantingSite = true,
     )
@@ -988,6 +1013,11 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
+    )
+
+    permissions.expect(
+        *monitoringPlotIds.forOrg1(),
+        readMonitoringPlot = true,
     )
 
     permissions.expect(
@@ -1232,6 +1262,11 @@ internal class PermissionTest : DatabaseTest() {
         *plantingZoneIds.toTypedArray(),
         readPlantingZone = true,
         updatePlantingZone = true,
+    )
+
+    permissions.expect(
+        *monitoringPlotIds.toTypedArray(),
+        readMonitoringPlot = true,
     )
 
     permissions.expect(
@@ -1961,6 +1996,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedDevices = deviceIds.toMutableSet()
     private val uncheckedDraftPlantingSites = draftPlantingSiteIds.toMutableSet()
     private val uncheckedFacilities = facilityIds.toMutableSet()
+    private val uncheckedMonitoringPlots = monitoringPlotIds.toMutableSet()
     private val uncheckedObservations = observationIds.toMutableSet()
     private val uncheckedOrgs = organizationIds.toMutableSet()
     private val uncheckedPlantings = plantingIds.toMutableSet()
@@ -2500,6 +2536,20 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     fun expect(
+        vararg monitoringPlotIds: MonitoringPlotId,
+        readMonitoringPlot: Boolean = false,
+    ) {
+      monitoringPlotIds.forEach { monitoringPlotId ->
+        assertEquals(
+            readMonitoringPlot,
+            user.canReadMonitoringPlot(monitoringPlotId),
+            "Can read monitoring plot $monitoringPlotId")
+
+        uncheckedMonitoringPlots.remove(monitoringPlotId)
+      }
+    }
+
+    fun expect(
         vararg draftPlantingSiteIds: DraftPlantingSiteId,
         deleteDraftPlantingSite: Boolean = false,
         readDraftPlantingSite: Boolean = false,
@@ -2721,6 +2771,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedDevices.toTypedArray())
       expect(*uncheckedDraftPlantingSites.toTypedArray())
       expect(*uncheckedFacilities.toTypedArray())
+      expect(*uncheckedMonitoringPlots.toTypedArray())
       expect(*uncheckedObservations.toTypedArray())
       expect(*uncheckedOrgs.toTypedArray())
       expect(*uncheckedPlantings.toTypedArray())

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -138,6 +138,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true
+    every { user.canReadMonitoringPlot(any()) } returns true
     every { user.canReadObservation(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
     every { user.canReadPlantingZone(any()) } returns true


### PR DESCRIPTION
To avoid the monitoring plot replacement code potentially leaking the planting
site ID for a monitoring plot the user doesn't have permission to read, add a
separate read permission for monitoring plots.