### PR TITLE
SW-4796 Create replacement plots if needed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -152,6 +152,10 @@ class ParentStore(private val dslContext: DSLContext) {
   fun getOrganizationId(submissionId: SubmissionId): OrganizationId? =
       fetchFieldById(submissionId, SUBMISSIONS.ID, SUBMISSIONS.projects.ORGANIZATION_ID)
 
+  fun getPlantingSiteId(monitoringPlotId: MonitoringPlotId): PlantingSiteId? =
+      fetchFieldById(
+          monitoringPlotId, MONITORING_PLOTS.ID, MONITORING_PLOTS.plantingSubzones.PLANTING_SITE_ID)
+
   fun getUserId(notificationId: NotificationId): UserId? =
       fetchFieldById(notificationId, NOTIFICATIONS.ID, NOTIFICATIONS.USER_ID)
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -16,20 +16,8 @@ data class PlantingSubzoneModel(
     val plantingCompletedTime: Instant?,
     val monitoringPlots: List<MonitoringPlotModel>,
 ) {
-  fun chooseTemporaryPlots(
-      excludePlotIds: Set<MonitoringPlotId>,
-      count: Int
-  ): List<MonitoringPlotId> {
-    return monitoringPlots
-        .asSequence()
-        .filter { it.id !in excludePlotIds }
-        .filter { it.isAvailable }
-        .filter { it.boundary.coveredBy(boundary) }
-        .map { it.id }
-        .shuffled()
-        .take(count)
-        .toList()
-  }
+  fun findMonitoringPlot(monitoringPlotId: MonitoringPlotId): MonitoringPlotModel? =
+      monitoringPlots.find { it.id == monitoringPlotId }
 
   fun equals(other: Any?, tolerance: Double): Boolean {
     return other is PlantingSubzoneModel &&


### PR DESCRIPTION
Update the monitoring plot replacement code to work whether or not the full
grid of potential monitoring plots has been created up front. It creates new
monitoring plots as needed.