### PR TITLE
Put the event type in the ProjectModuleEventSession response object

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
@@ -39,28 +39,30 @@ class ProjectModulesController(
 }
 
 data class ProjectModuleEventSession(
-    val id: EventId,
-    val startTime: Instant?,
     val endTime: Instant?,
+    val id: EventId,
     val meetingUrl: URI?,
     val recordingUrl: URI?,
     val slidesUrl: URI?,
+    val startTime: Instant?,
+    val type: EventType,
 ) {
   constructor(
-      model: EventModel
+      model: EventModel,
+      type: EventType,
   ) : this(
-      id = model.id,
-      startTime = model.startTime,
       endTime = model.endTime,
+      id = model.id,
       meetingUrl = model.meetingUrl,
       recordingUrl = model.recordingUrl,
       slidesUrl = model.slidesUrl,
+      startTime = model.startTime,
+      type = type,
   )
 }
 
 data class ProjectModuleEvent(
     val description: String,
-    val type: EventType,
     val sessions: List<ProjectModuleEventSession>,
 )
 
@@ -88,9 +90,9 @@ data class ProjectModule(
           model.eventDescriptions.map {
             ProjectModuleEvent(
                 it.value,
-                it.key,
-                model.eventSessions[it.key]?.map { event -> ProjectModuleEventSession(event) }
-                    ?: emptyList(),
+                model.eventSessions[it.key]?.map { event ->
+                  ProjectModuleEventSession(event, it.key)
+                } ?: emptyList(),
             )
           })
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
@@ -59,7 +59,8 @@ data class ProjectModuleEventSession(
 }
 
 data class ProjectModuleEvent(
-    val eventDescription: String,
+    val description: String,
+    val type: EventType,
     val sessions: List<ProjectModuleEventSession>,
 )
 
@@ -71,7 +72,7 @@ data class ProjectModule(
     val additionalResources: String?,
     val overview: String?,
     val preparationMaterials: String?,
-    val events: Map<EventType, ProjectModuleEvent>,
+    val events: List<ProjectModuleEvent>,
 ) {
   constructor(
       model: ModuleModel
@@ -84,9 +85,10 @@ data class ProjectModule(
       overview = model.overview,
       preparationMaterials = model.preparationMaterials,
       events =
-          model.eventDescriptions.mapValues {
+          model.eventDescriptions.map {
             ProjectModuleEvent(
                 it.value,
+                it.key,
                 model.eventSessions[it.key]?.map { event -> ProjectModuleEventSession(event) }
                     ?: emptyList(),
             )

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectModulesController.kt
@@ -87,11 +87,11 @@ data class ProjectModule(
       overview = model.overview,
       preparationMaterials = model.preparationMaterials,
       events =
-          model.eventDescriptions.map {
+          model.eventDescriptions.map { (eventType, description) ->
             ProjectModuleEvent(
-                it.value,
-                model.eventSessions[it.key]?.map { event ->
-                  ProjectModuleEventSession(event, it.key)
+                description,
+                model.eventSessions[eventType]?.map { event ->
+                  ProjectModuleEventSession(event, eventType)
                 } ?: emptyList(),
             )
           })


### PR DESCRIPTION
- This allows the enum to be carried to the frontend
- The OpenAPI type generation was ignoring the `EventType` as the key and converting it to `string`
- The property is needed in the context of the session in the frontend, we don't ever display an "event", we display the session instead.