### PR TITLE
SW-5264 Use PlantingSiteStore to create site in importer

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -1,10 +1,12 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.util.SQUARE_METERS_PER_HECTARE
+
+/** Number of digits after the decimal point to retain in area (hectares) calculations. */
+const val HECTARES_SCALE = 1
+
 /** Monitoring plot width and height in meters. */
 const val MONITORING_PLOT_SIZE: Double = 25.0
-
-/** Number of square meters in a hectare. */
-const val SQUARE_METERS_PER_HECTARE: Double = 10000.0
 
 /** Number of square meters in a monitoring plot. */
 const val SQUARE_METERS_PER_MONITORING_PLOT: Double = MONITORING_PLOT_SIZE * MONITORING_PLOT_SIZE

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
@@ -1,14 +1,11 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.util.calculateAreaHectares
+import java.math.BigDecimal
 import org.geotools.api.feature.simple.SimpleFeature
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
-import org.geotools.geometry.jts.JTS
-import org.geotools.referencing.CRS
-import org.geotools.referencing.crs.DefaultGeographicCRS
-import org.geotools.referencing.operation.projection.TransverseMercator
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.Point
 
 /** Simplified representation of the data about a single feature from a shapefile. */
 data class ShapefileFeature(
@@ -30,30 +27,8 @@ data class ShapefileFeature(
    *
    * @throws FactoryException The geometry couldn't be converted to UTM.
    */
-  fun calculateAreaHectares(geom: Geometry = this.geometry): Double {
-    // Transform to UTM if it isn't already.
-    val utmGeometry =
-        if (CRS.getProjectedCRS(coordinateReferenceSystem) is TransverseMercator) {
-          geom
-        } else {
-          // To use the "look up the right UTM for a location" feature of GeoTools, we need to
-          // know the location in WGS84 (EPSG:4326) longitude and latitude; transform the feature's
-          // centroid coordinates to WGS84.
-          val wgs84Centroid =
-              if (CRS.lookupEpsgCode(coordinateReferenceSystem, false) == SRID.LONG_LAT) {
-                geom.centroid
-              } else {
-                val wgs84Transform =
-                    CRS.findMathTransform(coordinateReferenceSystem, DefaultGeographicCRS.WGS84)
-                JTS.transform(geom.centroid, wgs84Transform) as Point
-              }
-
-          val utmCrs = CRS.decode("AUTO2:42001,${wgs84Centroid.x},${wgs84Centroid.y}")
-
-          JTS.transform(geom, CRS.findMathTransform(coordinateReferenceSystem, utmCrs))
-        }
-
-    return utmGeometry.area / SQUARE_METERS_PER_HECTARE
+  fun calculateAreaHectares(geom: Geometry = this.geometry): BigDecimal {
+    return geom.calculateAreaHectares(coordinateReferenceSystem)
   }
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/util/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Constants.kt
@@ -1,0 +1,4 @@
+package com.terraformation.backend.util
+
+/** Number of square meters in a hectare. */
+const val SQUARE_METERS_PER_HECTARE: Double = 10000.0

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -53,7 +53,6 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     PlantingSiteImporter(
         clock,
         dslContext,
-        plantingSitesDao,
         plantingSiteStore,
         plantingZonesDao,
         plantingSubzonesDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -34,7 +34,6 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
     PlantingSiteImporter(
         clock,
         dslContext,
-        plantingSitesDao,
         PlantingSiteStore(
             clock,
             dslContext,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileFeatureTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/ShapefileFeatureTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.SRID
+import java.math.BigDecimal
 import org.geotools.referencing.CRS
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.junit.jupiter.api.Assertions.*
@@ -29,7 +30,7 @@ class ShapefileFeatureTest {
                           CoordinateXY(373929.1743, 662471.6669)))))
       val feature = ShapefileFeature(geometry, emptyMap(), CRS.decode("EPSG:$srid"))
 
-      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+      assertEquals(BigDecimal("101.8"), feature.calculateAreaHectares())
     }
 
     @Test
@@ -47,7 +48,7 @@ class ShapefileFeatureTest {
                           CoordinateXY(-76.13567116641384, 5.989357251936355)))))
       val feature = ShapefileFeature(geometry, emptyMap(), DefaultGeographicCRS.WGS84)
 
-      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+      assertEquals(BigDecimal("101.8"), feature.calculateAreaHectares())
     }
 
     @Test
@@ -66,7 +67,7 @@ class ShapefileFeatureTest {
       val feature =
           ShapefileFeature(geometry, emptyMap(), CRS.decode("EPSG:${SRID.SPHERICAL_MERCATOR}"))
 
-      assertEquals(101.8, feature.calculateAreaHectares(), 0.05)
+      assertEquals(BigDecimal("101.8"), feature.calculateAreaHectares())
     }
   }
 }


### PR DESCRIPTION
In preparation for keeping a history of planting site map updates, change
`PlantingSiteImporter` to create sites via `PlantingSiteStore` rather than by
directly inserting them into the database. The logic to maintain the map
history will then only need to exist in one place.

One difference between the two classes was that only `PlantingSiteImporter`
populated the area and grid origin fields. Move the calculations of those
values into `PlantingSiteStore` as well, which has the added benefit that
they'll be populated for site maps that aren't created via shapefile import.