### PR TITLE
SW-5269 - Add species_growth_forms table

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -340,4 +340,8 @@ val EMBEDDABLES =
             .withName("species_ecosystem_id")
             .withTables("public.species_ecosystem_types")
             .withColumns("species_id", "ecosystem_type_id"),
+        EmbeddableDefinitionType()
+            .withName("species_growth_form_id")
+            .withTables("public.species_growth_forms")
+            .withColumns("species_id", "growth_form_id"),
     )

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
@@ -157,7 +157,7 @@ data class ReportBodyModelV1(
     }
 
     data class Species(
-        val growthForm: GrowthForm? = null,
+        val growthForms: Set<GrowthForm> = emptySet(),
         val id: SpeciesId,
         val mortalityRateInField: Int? = null,
         val scientificName: String,
@@ -166,13 +166,13 @@ data class ReportBodyModelV1(
       constructor(
           model: ExistingSpeciesModel
       ) : this(
-          growthForm = model.growthForm,
+          growthForms = model.growthForms,
           id = model.id,
           scientificName = model.scientificName,
       )
 
       fun freshen(model: ExistingSpeciesModel): Species {
-        return copy(growthForm = model.growthForm, scientificName = model.scientificName)
+        return copy(growthForms = model.growthForms, scientificName = model.scientificName)
       }
 
       internal fun validate(context: Validator) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -60,6 +60,7 @@ class SearchTables(clock: Clock) {
   val reports = ReportsTable(this)
   val species = SpeciesTable(this)
   val speciesEcosystemTypes = SpeciesEcosystemTypesTable(this)
+  val speciesGrowthForms = SpeciesGrowthFormsTable(this)
   val speciesProblems = SpeciesProblemsTable(this)
   val subLocations = SubLocationsTable(this)
   val users = UsersTable(this)

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import org.jooq.Record
+import org.jooq.SelectJoinStep
+import org.jooq.TableField
+
+class SpeciesGrowthFormsTable(private val tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = SPECIES_GROWTH_FORMS.SPECIES_ID
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          species.asSingleValueSublist("species", SPECIES_GROWTH_FORMS.SPECIES_ID.eq(SPECIES.ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      listOf(
+          idWrapperField("species_id", SPECIES_GROWTH_FORMS.SPECIES_ID) { SpeciesId(it) },
+          enumField("growth_form", SPECIES_GROWTH_FORMS.GROWTH_FORM_ID),
+      )
+
+  override val inheritsVisibilityFrom: SearchTable
+    get() = tables.species
+
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
+    return query.join(SPECIES).on(SPECIES_GROWTH_FORMS.SPECIES_ID.eq(SPECIES.ID))
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
 import com.terraformation.backend.search.SearchTable
@@ -24,8 +23,7 @@ class SpeciesGrowthFormsTable(private val tables: SearchTables) : SearchTable() 
 
   override val fields: List<SearchField> =
       listOf(
-          idWrapperField("species_id", SPECIES_GROWTH_FORMS.SPECIES_ID) { SpeciesId(it) },
-          enumField("growth_form", SPECIES_GROWTH_FORMS.GROWTH_FORM_ID),
+          enumField("growthForm", SPECIES_GROWTH_FORMS.GROWTH_FORM_ID),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesGrowthFormsTable.kt
@@ -11,7 +11,7 @@ import org.jooq.TableField
 
 class SpeciesGrowthFormsTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = SPECIES_GROWTH_FORMS.SPECIES_ID
+    get() = SPECIES_GROWTH_FORMS.SPECIES_GROWTH_FORM_ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.SPECIES_PROJECTS
@@ -30,6 +31,8 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
               "organization", SPECIES.ORGANIZATION_ID.eq(ORGANIZATIONS.ID)),
           speciesProblems.asMultiValueSublist(
               "problems", SPECIES.ID.eq(SPECIES_PROBLEMS.SPECIES_ID)),
+          speciesGrowthForms.asMultiValueSublist(
+              "growthForms", SPECIES.ID.eq(SPECIES_GROWTH_FORMS.SPECIES_ID)),
           inventories.asSingleValueSublist(
               "inventory",
               SPECIES.ORGANIZATION_ID.eq(INVENTORIES.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -48,7 +48,6 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
           textField("commonName", SPECIES.COMMON_NAME),
           enumField("conservationCategory", SPECIES.CONSERVATION_CATEGORY_ID, localize = false),
           textField("familyName", SPECIES.FAMILY_NAME, nullable = false),
-          enumField("growthForm", SPECIES.GROWTH_FORM_ID),
           idWrapperField("id", SPECIES.ID) { SpeciesId(it) },
           booleanField("rare", SPECIES.RARE),
           textField("scientificName", SPECIES.SCIENTIFIC_NAME, nullable = false),

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesController.kt
@@ -221,7 +221,7 @@ data class SpeciesResponseElement(
             ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"))
     val conservationCategory: ConservationCategory?,
     val familyName: String?,
-    val growthForm: GrowthForm?,
+    val growthForms: Set<GrowthForm>?,
     val id: SpeciesId,
     val problems: List<SpeciesProblemElement>?,
     val rare: Boolean?,
@@ -236,7 +236,7 @@ data class SpeciesResponseElement(
       commonName = model.commonName,
       conservationCategory = model.conservationCategory,
       familyName = model.familyName,
-      growthForm = model.growthForm,
+      growthForms = model.growthForms,
       id = model.id,
       problems = problems?.map { SpeciesProblemElement(it) }?.ifEmpty { null },
       rare = model.rare,
@@ -254,7 +254,7 @@ data class SpeciesRequestPayload(
             ExternalDocumentation(url = "https://en.wikipedia.org/wiki/IUCN_Red_List#Categories"))
     val conservationCategory: ConservationCategory?,
     val familyName: String?,
-    val growthForm: GrowthForm?,
+    val growthForms: Set<GrowthForm>?,
     @Schema(description = "Which organization's species list to update.")
     val organizationId: OrganizationId,
     val rare: Boolean?,
@@ -267,7 +267,7 @@ data class SpeciesRequestPayload(
           conservationCategory = conservationCategory,
           ecosystemTypes = ecosystemTypes ?: emptySet(),
           familyName = familyName,
-          growthForm = growthForm,
+          growthForms = growthForms ?: emptySet(),
           id = id,
           initialScientificName = scientificName,
           rare = rare,

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -128,7 +128,8 @@ class SpeciesImporter(
                       ConservationCategory.forJsonValue(it.trim().uppercase(Locale.ENGLISH))
                     },
                 rare = values[4]?.let { it in trueValues },
-                growthForm = values[5]?.let { GrowthForm.forDisplayName(it, locale) },
+                growthForms =
+                    values[5]?.let { setOf(GrowthForm.forDisplayName(it, locale)) } ?: emptySet(),
                 seedStorageBehavior =
                     values[6]?.let { SeedStorageBehavior.forDisplayName(it, locale) },
                 ecosystemTypes =

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -18,7 +18,7 @@ data class SpeciesModel<ID : SpeciesId?>(
     val deletedTime: Instant? = null,
     val ecosystemTypes: Set<EcosystemType> = emptySet(),
     val familyName: String? = null,
-    val growthForm: GrowthForm? = null,
+    val growthForms: Set<GrowthForm> = emptySet(),
     val id: ID,
     val organizationId: OrganizationId,
     val rare: Boolean? = null,
@@ -29,7 +29,8 @@ data class SpeciesModel<ID : SpeciesId?>(
   companion object {
     fun of(
         record: Record,
-        ecosystemTypesMultiset: Field<Set<EcosystemType>>
+        ecosystemTypesMultiset: Field<Set<EcosystemType>>,
+        growthFormsMultiset: Field<Set<GrowthForm>>
     ): ExistingSpeciesModel =
         ExistingSpeciesModel(
             checkedTime = record[SPECIES.CHECKED_TIME],
@@ -38,7 +39,7 @@ data class SpeciesModel<ID : SpeciesId?>(
             deletedTime = record[SPECIES.DELETED_TIME],
             ecosystemTypes = record[ecosystemTypesMultiset] ?: emptySet(),
             familyName = record[SPECIES.FAMILY_NAME],
-            growthForm = record[SPECIES.GROWTH_FORM_ID],
+            growthForms = record[growthFormsMultiset] ?: emptySet(),
             id = record[SPECIES.ID]!!,
             initialScientificName = record[SPECIES.INITIAL_SCIENTIFIC_NAME]!!,
             organizationId = record[SPECIES.ORGANIZATION_ID]!!,

--- a/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
+++ b/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
@@ -6,3 +6,11 @@ CREATE TABLE public.species_growth_forms (
 );
 
 CREATE INDEX ON public.species_growth_forms (species_id);
+
+INSERT INTO public.species_growth_forms (species_id, growth_form_id)
+SELECT id, growth_form_id
+FROM public.species
+WHERE growth_form_id IS NOT null
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.species DROP COLUMN growth_form_id;

--- a/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
+++ b/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
@@ -1,0 +1,8 @@
+CREATE TABLE public.species_growth_forms (
+    species_id INTEGER REFERENCES public.species ON DELETE CASCADE,
+    growth_form_id INTEGER REFERENCES public.growth_forms,
+
+    PRIMARY KEY (species_id, growth_form_id)
+);
+
+CREATE INDEX ON public.species_growth_forms (species_id);

--- a/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
+++ b/src/main/resources/db/migration/0250/V265__SpeciesGrowthForm.sql
@@ -1,5 +1,5 @@
 CREATE TABLE public.species_growth_forms (
-    species_id INTEGER REFERENCES public.species ON DELETE CASCADE,
+    species_id BIGINT REFERENCES public.species ON DELETE CASCADE,
     growth_form_id INTEGER REFERENCES public.growth_forms,
 
     PRIMARY KEY (species_id, growth_form_id)

--- a/src/main/resources/db/migration/0250/V266__MigrateSpeciesGrowthForm.sql
+++ b/src/main/resources/db/migration/0250/V266__MigrateSpeciesGrowthForm.sql
@@ -1,0 +1,7 @@
+INSERT INTO public.species_growth_forms (species_id, growth_form_id)
+SELECT id, growth_form_id
+FROM public.species
+WHERE growth_form_id IS NOT null
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.species DROP COLUMN growth_form_id;

--- a/src/main/resources/db/migration/0250/V266__MigrateSpeciesGrowthForm.sql
+++ b/src/main/resources/db/migration/0250/V266__MigrateSpeciesGrowthForm.sql
@@ -1,7 +1,0 @@
-INSERT INTO public.species_growth_forms (species_id, growth_form_id)
-SELECT id, growth_form_id
-FROM public.species
-WHERE growth_form_id IS NOT null
-ON CONFLICT DO NOTHING;
-
-ALTER TABLE public.species DROP COLUMN growth_form_id;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -161,6 +161,8 @@ COMMENT ON COLUMN species.checked_time IS 'If non-null, when the species was che
 
 COMMENT ON TABLE species_ecosystem_types IS 'Ecosystems where each species can be found.';
 
+COMMENT ON TABLE species_growth_forms IS 'Growth forms of each species';
+
 COMMENT ON TABLE species_problem_fields IS '(Enum) Species fields that can be scanned for problems.';
 
 COMMENT ON TABLE species_problem_types IS '(Enum) Specific types of problems that can be detected in species data.';

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -477,6 +477,7 @@ search.species.rare=Species is rare
 search.species.scientificName=Species scientific name
 search.species.seedStorageBehavior=Species seed storage behavior
 search.speciesEcosystemTypes.ecosystemType=Species ecosystem type
+search.speciesGrowthForms.growthForm=Species growth form
 search.speciesProblems.field=Species problem field
 search.speciesProblems.id=Species problem ID
 search.speciesProblems.suggestedValue=Species problem suggested value

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -102,6 +102,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.ReportPhotosDao
 import com.terraformation.backend.db.default_schema.tables.daos.ReportsDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesEcosystemTypesDao
+import com.terraformation.backend.db.default_schema.tables.daos.SpeciesGrowthFormsDao
 import com.terraformation.backend.db.default_schema.tables.daos.SpeciesProblemsDao
 import com.terraformation.backend.db.default_schema.tables.daos.SubLocationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.ThumbnailsDao
@@ -129,6 +130,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_ECOSYSTEM_TYPES
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES_GROWTH_FORMS
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
@@ -442,6 +444,7 @@ abstract class DatabaseTest {
   protected val reportsDao: ReportsDao by lazyDao()
   protected val speciesDao: SpeciesDao by lazyDao()
   protected val speciesEcosystemTypesDao: SpeciesEcosystemTypesDao by lazyDao()
+  protected val speciesGrowthFormsDao: SpeciesGrowthFormsDao by lazyDao()
   protected val speciesProblemsDao: SpeciesProblemsDao by lazyDao()
   protected val subLocationsDao: SubLocationsDao by lazyDao()
   protected val submissionsDao: SubmissionsDao by lazyDao()
@@ -806,7 +809,7 @@ abstract class DatabaseTest {
       initialScientificName: String = scientificName,
       commonName: String? = null,
       ecosystemTypes: Set<EcosystemType> = emptySet(),
-      growthForm: GrowthForm? = null,
+      growthForms: Set<GrowthForm> = emptySet(),
   ): SpeciesId {
     val speciesIdWrapper = speciesId?.toIdWrapper { SpeciesId(it) }
     val organizationIdWrapper = organizationId.toIdWrapper { OrganizationId(it) }
@@ -821,7 +824,6 @@ abstract class DatabaseTest {
               .set(CREATED_TIME, createdTime)
               .set(DELETED_BY, if (deletedTime != null) createdBy else null)
               .set(DELETED_TIME, deletedTime)
-              .set(GROWTH_FORM_ID, growthForm)
               .apply { speciesIdWrapper?.let { set(ID, it) } }
               .set(INITIAL_SCIENTIFIC_NAME, initialScientificName)
               .set(MODIFIED_BY, createdBy)
@@ -837,6 +839,14 @@ abstract class DatabaseTest {
           .insertInto(SPECIES_ECOSYSTEM_TYPES)
           .set(SPECIES_ECOSYSTEM_TYPES.SPECIES_ID, actualSpeciesId)
           .set(SPECIES_ECOSYSTEM_TYPES.ECOSYSTEM_TYPE_ID, ecosystemType)
+          .execute()
+    }
+
+    growthForms.forEach { growthForm ->
+      dslContext
+          .insertInto(SPECIES_GROWTH_FORMS)
+          .set(SPECIES_GROWTH_FORMS.SPECIES_ID, actualSpeciesId)
+          .set(SPECIES_GROWTH_FORMS.GROWTH_FORM_ID, growthForm)
           .execute()
     }
 

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -219,6 +219,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "spatial_ref_sys" to emptySet(),
                   "species" to setOf(ALL, SEEDBANK, SPECIES),
                   "species_ecosystem_types" to setOf(ALL, SPECIES),
+                  "species_growth_forms" to setOf(ALL, SPECIES),
                   "species_problem_fields" to setOf(ALL, SPECIES),
                   "species_problem_types" to setOf(ALL, SPECIES),
                   "species_problems" to setOf(ALL, SPECIES),

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -81,7 +81,13 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   private val messages = Messages()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val speciesStore: SpeciesStore by lazy {
-    SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao)
+    SpeciesStore(
+        clock,
+        dslContext,
+        speciesDao,
+        speciesEcosystemTypesDao,
+        speciesGrowthFormsDao,
+        speciesProblemsDao)
   }
   private val uploadStore: UploadStore by lazy {
     UploadStore(dslContext, uploadProblemsDao, uploadsDao)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -148,7 +148,13 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
         reportRenderer,
         reportStore,
         scheduler,
-        SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao),
+        SpeciesStore(
+            clock,
+            dslContext,
+            speciesDao,
+            speciesEcosystemTypesDao,
+            speciesGrowthFormsDao,
+            speciesProblemsDao),
         SystemUser(usersDao),
     )
   }
@@ -178,7 +184,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
       val nurseryId = FacilityId(1)
       val plantingSiteId = PlantingSiteId(1)
       val seedBankId = FacilityId(2)
-      val speciesId = insertSpecies(growthForm = GrowthForm.Shrub, scientificName = "My species")
+      val speciesId =
+          insertSpecies(growthForms = setOf(GrowthForm.Shrub), scientificName = "My species")
 
       insertFacility(
           nurseryId,
@@ -236,7 +243,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                               species =
                                   listOf(
                                       ReportBodyModelV1.PlantingSite.Species(
-                                          growthForm = GrowthForm.Shrub,
+                                          growthForms = setOf(GrowthForm.Shrub),
                                           id = speciesId,
                                           scientificName = "My species",
                                       ),
@@ -285,7 +292,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
       val projectId = insertProject(name = "Test Project")
       val otherProjectId = insertProject(name = "Other Project")
-      val speciesId = insertSpecies(growthForm = GrowthForm.Shrub, scientificName = "My species")
+      val speciesId =
+          insertSpecies(growthForms = setOf(GrowthForm.Shrub), scientificName = "My species")
 
       insertFacility(nonProjectNurseryId, type = FacilityType.Nursery)
       insertFacility(nonProjectSeedBankId, type = FacilityType.SeedBank)
@@ -396,7 +404,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                               species =
                                   listOf(
                                       ReportBodyModelV1.PlantingSite.Species(
-                                          growthForm = GrowthForm.Shrub,
+                                          growthForms = setOf(GrowthForm.Shrub),
                                           id = speciesId,
                                           scientificName = "My species",
                                       ),
@@ -678,7 +686,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
           ),
       )
 
-      val speciesId = insertSpecies(growthForm = GrowthForm.Forb, scientificName = "New species")
+      val speciesId =
+          insertSpecies(growthForms = setOf(GrowthForm.Forb), scientificName = "New species")
       insertBatch(
           facilityId = firstNursery,
           germinatingQuantity = 50,
@@ -741,7 +750,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                           species =
                               listOf(
                                   ReportBodyModelV1.PlantingSite.Species(
-                                      growthForm = GrowthForm.Forb,
+                                      growthForms = setOf(GrowthForm.Forb),
                                       id = speciesId,
                                       mortalityRateInField = 9,
                                       scientificName = "Old species",
@@ -840,7 +849,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                                   species =
                                       listOf(
                                           ReportBodyModelV1.PlantingSite.Species(
-                                              growthForm = GrowthForm.Forb,
+                                              growthForms = setOf(GrowthForm.Forb),
                                               id = speciesId,
                                               scientificName = "New species",
                                           ),

--- a/src/test/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1Test.kt
@@ -70,7 +70,7 @@ class ReportBodyModelV1Test {
                       species =
                           listOf(
                               ReportBodyModelV1.PlantingSite.Species(
-                                  growthForm = GrowthForm.Forb,
+                                  growthForms = setOf(GrowthForm.Forb),
                                   id = SpeciesId(1),
                                   mortalityRateInField = 9,
                                   scientificName = "Species name",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -129,7 +129,13 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val scheduler: JobScheduler = mockk()
   private val speciesStore: SpeciesStore by lazy {
-    SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao)
+    SpeciesStore(
+        clock,
+        dslContext,
+        speciesDao,
+        speciesEcosystemTypesDao,
+        speciesGrowthFormsDao,
+        speciesProblemsDao)
   }
   private val uploadService: UploadService = mockk()
   private val uploadStore: UploadStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -99,7 +99,13 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
         )
 
     speciesStore =
-        SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao)
+        SpeciesStore(
+            clock,
+            dslContext,
+            speciesDao,
+            speciesEcosystemTypesDao,
+            speciesGrowthFormsDao,
+            speciesProblemsDao)
 
     insertSiteData()
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -939,7 +939,6 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             mapOf(
                 "checkedTime" to checkedTimeString,
                 "commonName" to "Common 1",
-                "growthForm" to "Graminoid",
                 "id" to "10000",
                 "rare" to "false",
                 "scientificName" to "Kousa Dogwood",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.FacilityId
-import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -96,7 +95,6 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
             checkedTime = checkedTime,
             commonName = "Common 1",
             rare = false,
-            growthFormId = GrowthForm.Graminoid,
             createdBy = user.userId,
             createdTime = now,
             modifiedBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -27,7 +27,13 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val speciesStore: SpeciesStore by lazy {
-    SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao)
+    SpeciesStore(
+        clock,
+        dslContext,
+        speciesDao,
+        speciesEcosystemTypesDao,
+        speciesGrowthFormsDao,
+        speciesProblemsDao)
   }
   private val speciesChecker: SpeciesChecker = mockk()
   private val service: SpeciesService by lazy {

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesEcosystemTypesRow
+import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesGrowthFormsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesProblemsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
@@ -45,7 +46,13 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     store =
-        SpeciesStore(clock, dslContext, speciesDao, speciesEcosystemTypesDao, speciesProblemsDao)
+        SpeciesStore(
+            clock,
+            dslContext,
+            speciesDao,
+            speciesEcosystemTypesDao,
+            speciesGrowthFormsDao,
+            speciesProblemsDao)
 
     every { user.canCreateSpecies(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
@@ -64,7 +71,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             conservationCategory = ConservationCategory.Endangered,
             deletedTime = Instant.EPOCH,
             familyName = "family",
-            growthForm = GrowthForm.Shrub,
+            growthForms = setOf(GrowthForm.Shrub),
             id = null,
             organizationId = organizationId,
             rare = false,
@@ -85,7 +92,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                 deletedBy = null,
                 deletedTime = null,
                 familyName = "family",
-                growthFormId = GrowthForm.Shrub,
                 id = speciesId,
                 initialScientificName = "test",
                 modifiedBy = user.userId,
@@ -123,7 +129,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                 id = null,
                 organizationId = organizationId,
                 scientificName = "test",
-                growthForm = GrowthForm.Fern,
+                growthForms = setOf(GrowthForm.Fern),
                 rare = false,
                 seedStorageBehavior = SeedStorageBehavior.Orthodox,
             ))
@@ -139,7 +145,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             familyName = "edited family",
             id = null,
             organizationId = organizationId,
-            growthForm = GrowthForm.Shrub,
+            growthForms = setOf(GrowthForm.Shrub),
             rare = true,
             scientificName = "test",
             seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
@@ -159,7 +165,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             familyName = "edited family",
             id = originalSpeciesId,
             initialScientificName = "test",
-            growthFormId = GrowthForm.Shrub,
             organizationId = organizationId,
             modifiedBy = user.userId,
             modifiedTime = clock.instant(),
@@ -176,6 +181,11 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(originalSpeciesId)
     assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
+
+    val expectedGrowthForms = listOf(SpeciesGrowthFormsRow(originalSpeciesId, GrowthForm.Shrub))
+
+    val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(originalSpeciesId)
+    assertEquals(expectedGrowthForms, actualGrowthForms)
   }
 
   @Test
@@ -203,7 +213,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             conservationCategory = ConservationCategory.Extinct,
             ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
             familyName = "original family",
-            growthForm = GrowthForm.Shrub,
+            growthForms = setOf(GrowthForm.Shrub),
             id = null,
             organizationId = organizationId,
             rare = true,
@@ -225,7 +235,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             deletedTime = bogusInstant,
             ecosystemTypes = setOf(EcosystemType.BorealForestsTaiga, EcosystemType.Tundra),
             familyName = "new family",
-            growthForm = GrowthForm.Fern,
+            growthForms = setOf(GrowthForm.Fern),
             id = speciesId,
             initialScientificName = "new initial",
             organizationId = bogusOrganizationId,
@@ -243,7 +253,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             deletedBy = null,
             deletedTime = null,
             familyName = "new family",
-            growthFormId = GrowthForm.Fern,
             id = speciesId,
             initialScientificName = "original scientific",
             modifiedBy = user.userId,
@@ -267,6 +276,11 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     val actualEcosystemTypes = speciesEcosystemTypesDao.fetchBySpeciesId(speciesId).toSet()
     assertEquals(expectedEcosystemTypes, actualEcosystemTypes)
+
+    val expectedGrowthForms = setOf(SpeciesGrowthFormsRow(speciesId, GrowthForm.Fern))
+
+    val actualGrowthForms = speciesGrowthFormsDao.fetchBySpeciesId(speciesId).toSet()
+    assertEquals(expectedGrowthForms, actualGrowthForms)
   }
 
   @Test


### PR DESCRIPTION
- Adds a table `species_growth_forms`, used to create a many-to-many relationship between the `species` table and `growth_forms` enum table.
- Migrate all `species.growth_form` into this new table
- Drop the `species.growth_form` column
- Update all tests to check for the new rows when checking species growth form data
- Update all controllers to return `species.growth_forms` instead of `species.growth_form`.
- Add `growthForms` sublist to `species` search table


TODO:
- [x] Update frontend - [PR](https://github.com/terraware/terraware-web/pull/2551)
- [x] Make sure consumers of reports with species are OK with this field changing from `growthForm` to `growthForms`
- [x] Determine if this type of dependent deploy is OK, or if we want to make it backwards compatible while the frontend is done.
  - FE is done, there seem to be no mobile considerations (this is being verified), so we can deploy them simultaneously with the next release.
