### PR TITLE
Add convenience method for attached records

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCEL
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.file.DropboxWriter
 import com.terraformation.backend.file.GoogleDriveWriter
@@ -144,7 +145,7 @@ class SubmissionService(
                 originalName = originalName,
                 projectId = projectId,
             )
-            .also { it.attach(dslContext.configuration()) }
+            .attach(dslContext)
 
     try {
       try {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.tables.records.SubmissionsRecor
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ProjectId
 import jakarta.inject.Named
 import java.time.InstantSource
@@ -57,7 +58,7 @@ class SubmissionStore(
                     createdBy = currentUser().userId,
                     createdTime = now,
                 )
-                .also { it.attach(dslContext.configuration()) }
+                .attach(dslContext)
 
     val oldStatus = submission.submissionStatusId!!
 

--- a/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Extensions.kt
@@ -2,7 +2,9 @@ package com.terraformation.backend.db
 
 import java.util.Locale
 import org.jooq.Collation
+import org.jooq.DSLContext
 import org.jooq.Field
+import org.jooq.Record
 import org.jooq.impl.DSL
 
 /**
@@ -69,3 +71,13 @@ val Locale.collation: Collation
 
 /** Wraps a field in the "unaccent" function which removes diacritics. */
 fun Field<String?>.unaccent() = DSL.function("unaccent", String::class.java, this)
+
+/**
+ * Attaches a jOOQ Record to the default configuration of a DSL context and returns the Record. This
+ * can be used to create an attached record in one expression rather than needing to attach in a
+ * separate statement or use an `also` block.
+ */
+fun <T : Record> T.attach(dslContext: DSLContext): T {
+  attach(dslContext.configuration())
+  return this
+}


### PR DESCRIPTION
To make it a tiny bit less cumbersome to move away from DAO classes, add an
extension method to attach a jOOQ context to a `Record` object and return the
object, so it can be called as part of the expression that creates the object.