### PR TITLE
Parameterize planting site model IDs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -24,9 +24,9 @@ import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlantingSiteUploadProblemsException
 import com.terraformation.backend.tracking.mapbox.MapboxService
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import io.swagger.v3.oas.annotations.Hidden
@@ -178,7 +178,7 @@ class AdminPlantingSitesController(
     return plotsToGeoJson(site, plantedSubzoneIds)
   }
 
-  private fun zonesToGeoJson(site: PlantingSiteModel) =
+  private fun zonesToGeoJson(site: ExistingPlantingSiteModel) =
       mapOf(
           "type" to "FeatureCollection",
           "features" to
@@ -190,7 +190,7 @@ class AdminPlantingSitesController(
                 )
               })
 
-  private fun subzonesToGeoJson(site: PlantingSiteModel) =
+  private fun subzonesToGeoJson(site: ExistingPlantingSiteModel) =
       mapOf(
           "type" to "FeatureCollection",
           "features" to
@@ -204,7 +204,10 @@ class AdminPlantingSitesController(
                 }
               })
 
-  private fun plotsToGeoJson(site: PlantingSiteModel, plantedSubzoneIds: Set<PlantingSubzoneId>) =
+  private fun plotsToGeoJson(
+      site: ExistingPlantingSiteModel,
+      plantedSubzoneIds: Set<PlantingSubzoneId>
+  ) =
       mapOf(
           "type" to "FeatureCollection",
           "features" to

--- a/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/PlantingSiteTimeZoneChangedEvent.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.customer.event
 
-import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import java.time.ZoneId
 
 /**
@@ -9,7 +9,7 @@ import java.time.ZoneId
  * time zone of its own.
  */
 data class PlantingSiteTimeZoneChangedEvent(
-    val plantingSite: PlantingSiteModel,
+    val plantingSite: ExistingPlantingSiteModel,
     val oldTimeZone: ZoneId?,
     /** The new effective time zone; this might be inherited from the organization. */
     val newTimeZone: ZoneId?,

--- a/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/ReportBodyModelV1.kt
@@ -10,7 +10,7 @@ import com.terraformation.backend.nursery.model.NurseryStats
 import com.terraformation.backend.report.ReportNotCompleteException
 import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
 import com.terraformation.backend.species.model.ExistingSpeciesModel
-import com.terraformation.backend.tracking.model.PlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import java.time.LocalDate
 
 @JsonTypeName("1")
@@ -121,7 +121,7 @@ data class ReportBodyModelV1(
       val workers: Workers = Workers(),
   ) {
     constructor(
-        model: PlantingSiteModel,
+        model: ExistingPlantingSiteModel,
         species: List<ExistingSpeciesModel>
     ) : this(
         id = model.id,
@@ -130,7 +130,7 @@ data class ReportBodyModelV1(
     )
 
     fun populate(
-        model: PlantingSiteModel,
+        model: ExistingPlantingSiteModel,
         speciesModels: List<ExistingSpeciesModel>
     ): PlantingSite {
       return copy(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -39,6 +39,7 @@ import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
 import com.terraformation.backend.tracking.model.ExistingObservationModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NewObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.ObservationMonitoringPlotPhotoModel
@@ -51,7 +52,6 @@ import com.terraformation.backend.tracking.model.ObservationResultsModel
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
 import com.terraformation.backend.tracking.model.ObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
 import io.swagger.v3.oas.annotations.Operation
@@ -106,7 +106,7 @@ class ObservationsController(
       plantingSiteId: PlantingSiteId? = null,
   ): ListObservationsResponsePayload {
     val observations: Collection<ExistingObservationModel>
-    val plantingSites: Map<PlantingSiteId, PlantingSiteModel>
+    val plantingSites: Map<PlantingSiteId, ExistingPlantingSiteModel>
     val plotCounts: Map<ObservationId, ObservationPlotCounts>
 
     if (plantingSiteId != null) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -15,11 +15,11 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.tracking.PlantingSiteService
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.ExistingPlantingSeasonModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteReportedPlantTotals
-import com.terraformation.backend.tracking.model.PlantingSubzoneModel
-import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import com.terraformation.backend.util.toMultiPolygon
 import io.swagger.v3.oas.annotations.Operation
@@ -152,7 +152,7 @@ data class PlantingSubzonePayload(
     val plantingCompletedTime: Instant?,
 ) {
   constructor(
-      model: PlantingSubzoneModel
+      model: ExistingPlantingSubzoneModel
   ) : this(
       model.areaHa,
       model.boundary,
@@ -174,7 +174,7 @@ data class PlantingZonePayload(
     val targetPlantingDensity: BigDecimal,
 ) {
   constructor(
-      model: PlantingZoneModel
+      model: ExistingPlantingZoneModel
   ) : this(
       model.areaHa,
       model.boundary,
@@ -217,7 +217,7 @@ data class PlantingSitePayload(
     val timeZone: ZoneId?,
 ) {
   constructor(
-      model: PlantingSiteModel
+      model: ExistingPlantingSiteModel
   ) : this(
       areaHa = model.areaHa,
       boundary = model.boundary,
@@ -323,7 +323,7 @@ data class UpdatePlantingSiteRequestPayload(
     val projectId: ProjectId? = null,
     val timeZone: ZoneId?,
 ) {
-  fun applyTo(model: PlantingSiteModel) =
+  fun applyTo(model: ExistingPlantingSiteModel) =
       model.copy(
           boundary = boundary,
           description = description?.ifBlank { null },

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -7,10 +7,10 @@ import java.math.BigDecimal
 import java.time.Instant
 import org.locationtech.jts.geom.MultiPolygon
 
-data class PlantingSubzoneModel(
+data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
-    val id: PlantingSubzoneId,
+    val id: PSZID,
     val fullName: String,
     val name: String,
     val plantingCompletedTime: Instant?,
@@ -20,7 +20,7 @@ data class PlantingSubzoneModel(
       monitoringPlots.find { it.id == monitoringPlotId }
 
   fun equals(other: Any?, tolerance: Double): Boolean {
-    return other is PlantingSubzoneModel &&
+    return other is PlantingSubzoneModel<*> &&
         id == other.id &&
         fullName == other.fullName &&
         name == other.name &&
@@ -30,3 +30,7 @@ data class PlantingSubzoneModel(
         boundary.equalsExact(other.boundary, tolerance)
   }
 }
+
+typealias ExistingPlantingSubzoneModel = PlantingSubzoneModel<PlantingSubzoneId>
+
+typealias NewPlantingSubzoneModel = PlantingSubzoneModel<Nothing?>

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -75,8 +75,8 @@ import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationNotificationEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationReminderNotificationEvent
 import com.terraformation.backend.tracking.model.ExistingObservationModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import freemarker.template.Configuration
 import io.mockk.every
@@ -182,7 +182,7 @@ internal class EmailNotificationServiceTest {
   private val accessionId = AccessionId(13)
   private val accessionNumber = "202201010001"
   private val plantingSite =
-      PlantingSiteModel(
+      ExistingPlantingSiteModel(
           boundary = multiPolygon(1),
           description = null,
           id = PlantingSiteId(1),

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -11,8 +11,8 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.ShapefileFeature
 import io.mockk.every
@@ -192,7 +192,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
       zoneFeatures: List<ShapefileFeature>,
       subzoneFeatures: List<ShapefileFeature>,
       exclusionFeature: ShapefileFeature? = null,
-  ): PlantingSiteModel {
+  ): ExistingPlantingSiteModel {
     val plantingSiteId =
         plantingSiteImporter.importShapefiles(
             name = "Test Site ${nextPlantingSiteNumber++}",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -32,6 +32,7 @@ import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEven
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.CannotUpdatePastPlantingSeasonException
 import com.terraformation.backend.tracking.model.ExistingPlantingSeasonModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.tracking.model.PlantingSeasonTooFarInFutureException
 import com.terraformation.backend.tracking.model.PlantingSeasonTooLongException
@@ -126,7 +127,7 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
         insertPlantingSeason(startDate = season2StartDate, endDate = season2EndDate)
 
     val expectedWithSite =
-        PlantingSiteModel(
+        ExistingPlantingSiteModel(
             boundary = multiPolygon(3),
             description = null,
             exclusion = multiPolygon(1.5),

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -607,7 +607,7 @@ class PlantingZoneModelTest {
    * Returns the boundary for a sample planting zone that contains some number of 51x76 meter
    * subzones laid out west to east.
    */
-  private fun plantingZoneBoundary(subzones: List<PlantingSubzoneModel>): MultiPolygon {
+  private fun plantingZoneBoundary(subzones: List<ExistingPlantingSubzoneModel>): MultiPolygon {
     if (subzones.isEmpty()) {
       return multiPolygon(1)
     }
@@ -621,10 +621,10 @@ class PlantingZoneModelTest {
   private fun plantingZoneModel(
       numTemporaryPlots: Int = 1,
       numPermanentClusters: Int = 1,
-      subzones: List<PlantingSubzoneModel>,
+      subzones: List<ExistingPlantingSubzoneModel>,
       boundary: MultiPolygon = plantingZoneBoundary(subzones),
   ) =
-      PlantingZoneModel(
+      ExistingPlantingZoneModel(
           areaHa = BigDecimal.ONE,
           boundary = boundary,
           errorMargin = BigDecimal.ONE,


### PR DESCRIPTION
In preparation for adding logic to edit existing planting sites, introduce
"new" and "existing" variants of `PlantingSiteModel` similar to the pattern we
use on other model classes.

The wrinkle here is that the parameterized nullability needs to also apply to
the models for planting zones and planting subzones.

This will allow us to use the model classes to represent a site/zone/subzone
hierarchy where some of the objects haven't been inserted into the database
yet.

This is mostly replacing `PlantingSiteModel` with `ExistingPlantingSiteModel`
in the application code (same with zone and subzone models), but also required
replacing a secondary constructor with a function so as to specify its return
type.