### PR TITLE
SW-5228 Use model to create new planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.tracking.mapbox.MapboxService
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import io.swagger.v3.oas.annotations.Hidden
@@ -345,13 +346,11 @@ class AdminPlantingSitesController(
           } else {
             plantingSiteStore
                 .createPlantingSite(
-                    organizationId = organizationId,
-                    name = siteName,
-                    description = null,
-                    timeZone = null,
-                    projectId = null,
-                    boundary = siteFile.features.first().geometry as MultiPolygon,
-                )
+                    PlantingSiteModel.create(
+                        boundary = siteFile.features.first().geometry as MultiPolygon,
+                        name = siteName,
+                        organizationId = organizationId,
+                    ))
                 .id
           }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
 import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteReportedPlantTotals
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import com.terraformation.backend.util.toMultiPolygon
@@ -103,14 +104,15 @@ class PlantingSitesController(
 
     val model =
         plantingSiteStore.createPlantingSite(
-            boundary = payload.boundary?.toMultiPolygon(),
-            description = payload.description,
-            name = payload.name,
-            organizationId = payload.organizationId,
-            plantingSeasons = plantingSeasons,
-            projectId = payload.projectId,
-            timeZone = payload.timeZone,
-        )
+            PlantingSiteModel.create(
+                boundary = payload.boundary?.toMultiPolygon(),
+                description = payload.description,
+                name = payload.name,
+                organizationId = payload.organizationId,
+                projectId = payload.projectId,
+                timeZone = payload.timeZone,
+            ),
+            plantingSeasons = plantingSeasons)
     return CreatePlantingSiteResponsePayload(model.id)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.ShapefileFeature
 import com.terraformation.backend.util.toMultiPolygon
@@ -170,12 +171,13 @@ class PlantingSiteImporter(
       val siteId =
           plantingSiteStore
               .createPlantingSite(
-                  boundary = siteFeature.geometry.toMultiPolygon(),
-                  description = description,
-                  exclusion = exclusion,
-                  name = name,
-                  organizationId = organizationId,
-              )
+                  PlantingSiteModel.create(
+                      boundary = siteFeature.geometry.toMultiPolygon(),
+                      description = description,
+                      exclusion = exclusion,
+                      name = name,
+                      organizationId = organizationId,
+                  ))
               .id
 
       zonesByName.forEach { (zoneName, zoneFeature) ->

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -25,14 +25,14 @@ data class PlantingSiteModel<
 >(
     val areaHa: BigDecimal? = null,
     val boundary: MultiPolygon?,
-    val description: String?,
+    val description: String? = null,
     val exclusion: MultiPolygon? = null,
     val gridOrigin: Point? = null,
     val id: PSID,
     val name: String,
     val organizationId: OrganizationId,
     val plantingSeasons: List<ExistingPlantingSeasonModel> = emptyList(),
-    val plantingZones: List<PlantingZoneModel<PZID, PSZID>>,
+    val plantingZones: List<PlantingZoneModel<PZID, PSZID>> = emptyList(),
     val projectId: ProjectId? = null,
     val timeZone: ZoneId? = null,
 ) {
@@ -97,6 +97,34 @@ data class PlantingSiteModel<
             plantingZones = plantingZonesMultiset?.let { record[it] } ?: emptyList(),
             projectId = record[PLANTING_SITES.PROJECT_ID],
             timeZone = record[PLANTING_SITES.TIME_ZONE],
+        )
+
+    fun create(
+        areaHa: BigDecimal? = null,
+        boundary: MultiPolygon? = null,
+        description: String? = null,
+        exclusion: MultiPolygon? = null,
+        gridOrigin: Point? = null,
+        name: String,
+        organizationId: OrganizationId,
+        plantingSeasons: List<ExistingPlantingSeasonModel> = emptyList(),
+        plantingZones: List<NewPlantingZoneModel> = emptyList(),
+        projectId: ProjectId? = null,
+        timeZone: ZoneId? = null,
+    ) =
+        NewPlantingSiteModel(
+            areaHa = areaHa,
+            boundary = boundary,
+            description = description,
+            exclusion = exclusion,
+            gridOrigin = gridOrigin,
+            id = null,
+            name = name,
+            organizationId = organizationId,
+            plantingSeasons = plantingSeasons,
+            plantingZones = plantingZones,
+            projectId = projectId,
+            timeZone = timeZone,
         )
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -369,12 +369,13 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject()
       val model =
           store.createPlantingSite(
-              description = "description",
-              name = "name",
-              organizationId = organizationId,
-              projectId = projectId,
-              timeZone = timeZone,
-          )
+              PlantingSiteModel.create(
+                  description = "description",
+                  name = "name",
+                  organizationId = organizationId,
+                  projectId = projectId,
+                  timeZone = timeZone,
+              ))
 
       assertEquals(
           listOf(
@@ -403,10 +404,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       val model =
           store.createPlantingSite(
-              boundary = boundary,
-              name = "name",
-              organizationId = organizationId,
-          )
+              PlantingSiteModel.create(
+                  boundary = boundary,
+                  name = "name",
+                  organizationId = organizationId,
+              ))
 
       assertEquals(
           listOf(
@@ -439,19 +441,18 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       val model =
           store.createPlantingSite(
-              description = null,
-              name = "name",
-              organizationId = organizationId,
+              PlantingSiteModel.create(
+                  name = "name",
+                  organizationId = organizationId,
+                  timeZone = timeZone,
+              ),
               plantingSeasons =
                   listOf(
                       UpdatedPlantingSeasonModel(
                           startDate = season1StartDate, endDate = season1EndDate),
                       UpdatedPlantingSeasonModel(
                           startDate = season2StartDate, endDate = season2EndDate),
-                  ),
-              projectId = null,
-              timeZone = timeZone,
-          )
+                  ))
 
       val expected =
           listOf(
@@ -484,12 +485,10 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       assertThrows<AccessDeniedException> {
         store.createPlantingSite(
-            description = null,
-            name = "name",
-            organizationId = organizationId,
-            projectId = null,
-            timeZone = null,
-        )
+            PlantingSiteModel.create(
+                name = "name",
+                organizationId = organizationId,
+            ))
       }
     }
 
@@ -501,12 +500,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       assertThrows<ProjectInDifferentOrganizationException> {
         store.createPlantingSite(
-            description = null,
-            organizationId = organizationId,
-            name = "name",
-            projectId = projectId,
-            timeZone = null,
-        )
+            PlantingSiteModel.create(
+                name = "name",
+                organizationId = organizationId,
+                projectId = projectId,
+            ))
       }
     }
 
@@ -516,11 +514,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       assertThrows<PlantingSeasonsOverlapException> {
         store.createPlantingSite(
-            description = null,
-            organizationId = organizationId,
-            name = "name",
-            projectId = null,
-            timeZone = timeZone,
+            PlantingSiteModel.create(
+                name = "name",
+                organizationId = organizationId,
+                timeZone = timeZone,
+            ),
             plantingSeasons =
                 listOf(
                     UpdatedPlantingSeasonModel(
@@ -550,11 +548,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     ) {
       assertThrows<T> {
         store.createPlantingSite(
-            description = null,
-            organizationId = organizationId,
-            name = "name",
-            projectId = null,
-            timeZone = timeZone,
+            PlantingSiteModel.create(
+                name = "name",
+                organizationId = organizationId,
+                timeZone = timeZone,
+            ),
             plantingSeasons =
                 listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)))
       }
@@ -572,14 +570,12 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     fun `updates values`() {
       val initialModel =
           store.createPlantingSite(
-              boundary = Turtle(point(0)).makeMultiPolygon { square(100) },
-              description = null,
-              name = "initial name",
-              organizationId = organizationId,
-              plantingSeasons = emptyList(),
-              projectId = null,
-              timeZone = timeZone,
-          )
+              PlantingSiteModel.create(
+                  boundary = Turtle(point(0)).makeMultiPolygon { square(100) },
+                  name = "initial name",
+                  organizationId = organizationId,
+                  timeZone = timeZone,
+              ))
 
       val createdTime = clock.instant()
       val newTimeZone = insertTimeZone("Europe/Paris")
@@ -1741,14 +1737,13 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
       val endDate = startDate.plusDays(60)
       val model =
           store.createPlantingSite(
-              description = null,
-              name = "name",
-              organizationId = organizationId,
+              PlantingSiteModel.create(
+                  name = "name",
+                  organizationId = organizationId,
+                  timeZone = timeZone,
+              ),
               plantingSeasons =
-                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
-              projectId = null,
-              timeZone = timeZone,
-          )
+                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)))
 
       assertSeasonActive(false, "Should start as inactive")
 
@@ -1782,14 +1777,13 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       val model =
           store.createPlantingSite(
-              description = null,
-              name = "name",
-              organizationId = organizationId,
+              PlantingSiteModel.create(
+                  name = "name",
+                  organizationId = organizationId,
+                  timeZone = timeZone,
+              ),
               plantingSeasons =
-                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)),
-              projectId = null,
-              timeZone = timeZone,
-          )
+                  listOf(UpdatedPlantingSeasonModel(startDate = startDate, endDate = endDate)))
 
       assertSeasonActive(true, "Should start as active")
 


### PR DESCRIPTION
`PlantingSiteStore.createPlantingSite` now takes a planting site model instead
of a set of parameters for individual fields. (Planting seasons are still a
separate parameter for now.)

This is in preparation for moving the creation of planting zones and subzones
from `PlantingSiteImporter` to `PlantingSiteStore`, which will help support
user-drawn zone and subzone boundaries (where there is no shapefile to import)
as well as giving us a consistent place to create the initial map history
records for zones and subzones.

Aside from a new convenience function for creating `NewPlantingSiteModel`
objects, there is no functional change here, just moving values from function
parameters to model fields.