### PR TITLE
SW-5230 Remove shapefile validation options

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.report.db.ReportStore
-import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.mapbox.MapboxService
 import jakarta.validation.constraints.NotBlank
@@ -64,8 +63,6 @@ class AdminOrganizationsController(
     model.addAttribute("facilityTypes", FacilityType.entries)
     model.addAttribute("mapboxToken", mapboxService.generateTemporaryToken())
     model.addAttribute("organization", organization)
-    model.addAttribute(
-        "plantingSiteValidationOptions", PlantingSiteImporter.ValidationOption.entries)
     model.addAttribute("plantingSites", plantingSites)
     model.addAttribute("reports", reports)
     model.addAttribute("terraformationContact", tfContact)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -288,7 +288,6 @@ class AdminPlantingSitesController(
   fun createPlantingSite(
       @RequestParam organizationId: OrganizationId,
       @RequestParam siteName: String,
-      @RequestParam validation: Set<PlantingSiteImporter.ValidationOption>,
       @RequestPart zipfile: MultipartFile,
       redirectAttributes: RedirectAttributes,
   ): String {
@@ -300,7 +299,7 @@ class AdminPlantingSitesController(
 
         val siteId =
             plantingSiteImporter.import(
-                siteName, null, organizationId, Shapefile.fromZipFile(localZipFile), validation)
+                siteName, null, organizationId, Shapefile.fromZipFile(localZipFile))
 
         redirectAttributes.successMessage = "Planting site $siteId imported successfully."
       }
@@ -342,7 +341,7 @@ class AdminPlantingSitesController(
                         PlantingSiteImporter.subzoneNameProperties.first() to "Subzone"))
 
             plantingSiteImporter.importShapefiles(
-                siteName, null, organizationId, siteFile, zonesFile, subzonesFile, null, emptySet())
+                siteName, null, organizationId, siteFile, zonesFile, subzonesFile, null)
           } else {
             plantingSiteStore
                 .createPlantingSite(

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -261,11 +261,6 @@
     Must contain either three or four shapefiles (exclusions shapefile is optional) and their
     associated supplementary datafiles.
     <br/>
-    Validation Options:
-    <div class="validationOption" th:each="option : ${plantingSiteValidationOptions}">
-        <input type="checkbox" checked name="validation" th:value="${option}"/>
-        <th:block th:text="${option.displayName}">Some option</th:block>
-    </div>
     <input type="submit" value=" Create Planting Site "/>
 </form>
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.ShapefileGenerator
-import com.terraformation.backend.tracking.db.PlantingSiteImporter.ValidationOption
 import com.terraformation.backend.tracking.model.Shapefile
 import com.terraformation.backend.tracking.model.ShapefileFeature
 import io.mockk.every
@@ -70,8 +69,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
           "name",
           "description",
           organizationId,
-          Shapefile.fromZipFile(Path("$resourcesDir/TooFewShapefiles.zip")),
-          emptySet())
+          Shapefile.fromZipFile(Path("$resourcesDir/TooFewShapefiles.zip")))
     }
   }
 
@@ -81,7 +79,6 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
     fun `detects too few shapefiles`() {
       assertHasProblem(
           "TooFewShapefiles.zip",
-          ValidationOption.ZonesContainedInSite,
           "Expected 3 or 4 shapefiles (site, zones, subzones, and optionally exclusions) but found 2")
     }
 
@@ -128,18 +125,13 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       }
     }
 
-    private fun assertHasProblem(
-        zipFile: String,
-        validationOption: ValidationOption,
-        expected: String
-    ) {
+    private fun assertHasProblem(zipFile: String, expected: String) {
       assertHasProblem(expected) {
         importer.import(
             "name",
             "description",
             organizationId,
-            Shapefile.fromZipFile(Path("$resourcesDir/$zipFile")),
-            setOf(validationOption))
+            Shapefile.fromZipFile(Path("$resourcesDir/$zipFile")))
       }
     }
 


### PR DESCRIPTION
Early on in the development of the tracking features, all our test shapefiles were
invalid in one way or another, so we needed to be able to disable the various
validation checks in order to test the code.

Now that we have shapefiles whose geometries are valid and whose only "problem" is
that they sometimes lack target planting densities for zones, there's no need to
continue supporting invalid files. Remove the concept of "validation options" from
the importer and start treating target planting density as an optional value with
a default.