### PR TITLE
SW-5264 Use model classes in PlantingSiteImporter

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -13,8 +13,8 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
     val id: PSZID,
     val fullName: String,
     val name: String,
-    val plantingCompletedTime: Instant?,
-    val monitoringPlots: List<MonitoringPlotModel>,
+    val plantingCompletedTime: Instant? = null,
+    val monitoringPlots: List<MonitoringPlotModel> = emptyList(),
 ) {
   fun findMonitoringPlot(monitoringPlotId: MonitoringPlotId): MonitoringPlotModel? =
       monitoringPlots.find { it.id == monitoringPlotId }


### PR DESCRIPTION
In preparation for moving planting zone/subzone validation and creation into
PlantingSiteStore, update PlantingSiteImporter to create zone and subzone
models and pass them around internally rather than using shapefile features.

Currently, the validation and database insertion still happen in
PlantingSiteImporter, so there's no caller-visible behavior change here, just
internal refactoring.