### PR TITLE
SW-5228 Move planting site validation to model classes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -1,9 +1,13 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.util.SQUARE_METERS_PER_HECTARE
+import java.math.BigDecimal
 
 /** Number of digits after the decimal point to retain in area (hectares) calculations. */
 const val HECTARES_SCALE = 1
+
+/** The maximum size of the envelope (bounding box) of a site. */
+val MAX_SITE_ENVELOPE_AREA_HA = BigDecimal(20000)
 
 /** Monitoring plot width and height in meters. */
 const val MONITORING_PLOT_SIZE: Double = 25.0

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -227,8 +227,8 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.polygon
 import com.terraformation.backend.toBigDecimal
-import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
+import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.toInstant
 import jakarta.ws.rs.NotFoundException
@@ -1454,7 +1454,7 @@ abstract class DatabaseTest {
               },
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
-      errorMargin: BigDecimal = row.errorMargin ?: PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
+      errorMargin: BigDecimal = row.errorMargin ?: PlantingZoneModel.DEFAULT_ERROR_MARGIN,
       extraPermanentClusters: Int = row.extraPermanentClusters ?: 0,
       id: Any? = row.id,
       plantingSiteId: Any = row.plantingSiteId ?: inserted.plantingSiteId,
@@ -1462,12 +1462,12 @@ abstract class DatabaseTest {
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: id?.let { "Z$id" } ?: "Z${nextPlantingZoneNumber++}",
       numPermanentClusters: Int =
-          row.numPermanentClusters ?: PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
+          row.numPermanentClusters ?: PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
       numTemporaryPlots: Int =
-          row.numTemporaryPlots ?: PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
-      studentsT: BigDecimal = row.studentsT ?: PlantingSiteImporter.DEFAULT_STUDENTS_T,
+          row.numTemporaryPlots ?: PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
+      studentsT: BigDecimal = row.studentsT ?: PlantingZoneModel.DEFAULT_STUDENTS_T,
       targetPlantingDensity: BigDecimal? = row.targetPlantingDensity,
-      variance: BigDecimal = row.variance ?: PlantingSiteImporter.DEFAULT_VARIANCE,
+      variance: BigDecimal = row.variance ?: PlantingZoneModel.DEFAULT_VARIANCE,
   ): PlantingZoneId {
     val rowWithDefaults =
         row.copy(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -165,16 +165,11 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                     PlantingZoneModel(
                         areaHa = BigDecimal.TEN,
                         boundary = multiPolygon(2.0),
-                        errorMargin = PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
                         extraPermanentClusters = 1,
                         id = plantingZoneId,
                         name = "Z1",
-                        numPermanentClusters = PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
-                        numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
                         plantingSubzones = emptyList(),
-                        studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
                         targetPlantingDensity = BigDecimal.ONE,
-                        variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                     ),
                 ))
 
@@ -274,15 +269,10 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
                     PlantingZoneModel(
                         areaHa = BigDecimal.TEN,
                         boundary = zoneBoundary4326,
-                        errorMargin = PlantingSiteImporter.DEFAULT_ERROR_MARGIN,
                         extraPermanentClusters = 0,
                         id = plantingZoneId,
                         name = "Z1",
-                        numPermanentClusters = PlantingSiteImporter.DEFAULT_NUM_PERMANENT_CLUSTERS,
-                        numTemporaryPlots = PlantingSiteImporter.DEFAULT_NUM_TEMPORARY_PLOTS,
-                        studentsT = PlantingSiteImporter.DEFAULT_STUDENTS_T,
                         targetPlantingDensity = BigDecimal.ONE,
-                        variance = PlantingSiteImporter.DEFAULT_VARIANCE,
                         plantingSubzones =
                             listOf(
                                 PlantingSubzoneModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -1,0 +1,193 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.point
+import com.terraformation.backend.util.Turtle
+import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.toMultiPolygon
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.MultiPolygon
+
+class PlantingSiteModelTest {
+  @Nested
+  inner class Validate {
+    @Test
+    fun `checks for maximum envelope area`() {
+      val hugeRectangle = makeMultiPolygon { rectangle(200000, 100000) }
+
+      val site = newPlantingSite(boundary = hugeRectangle)
+
+      assertHasProblem(site, "Site must be contained within an envelope.*actual envelope")
+    }
+
+    @Test
+    fun `checks for duplicate zone names`() {
+      val siteBoundary = makeMultiPolygon { square(100) }
+      val zone1Boundary = makeMultiPolygon { rectangle(50, 100) }
+      val zone2Boundary = makeMultiPolygon {
+        east(50)
+        square(50)
+      }
+
+      val site =
+          newPlantingSite(
+              boundary = siteBoundary,
+              plantingZones =
+                  listOf(
+                      newPlantingZone(boundary = zone1Boundary, name = "Duplicate"),
+                      newPlantingZone(boundary = zone2Boundary, name = "Duplicate"),
+                  ))
+
+      assertHasProblem(site, "Zone name Duplicate appears 2 times")
+    }
+
+    @Test
+    fun `checks for zones not covered by site`() {
+      val siteBoundary = makeMultiPolygon { square(100) }
+      val zoneBoundary = makeMultiPolygon { square(200) }
+
+      val site =
+          newPlantingSite(
+              boundary = siteBoundary,
+              plantingZones = listOf(newPlantingZone(boundary = zoneBoundary)))
+
+      assertHasProblem(site, "75\\.00% of planting zone .* is not contained")
+    }
+
+    @Test
+    fun `checks for overlapping zone boundaries`() {
+      val siteBoundary = makeMultiPolygon { square(200) }
+      val zone1Boundary = makeMultiPolygon { rectangle(100, 200) }
+      val zone2Boundary = makeMultiPolygon {
+        east(50)
+        rectangle(150, 200)
+      }
+
+      val site =
+          newPlantingSite(
+              boundary = siteBoundary,
+              plantingZones =
+                  listOf(
+                      newPlantingZone(boundary = zone1Boundary),
+                      newPlantingZone(boundary = zone2Boundary)))
+
+      assertHasProblem(site, "50\\.00% of planting zone Zone 1 overlaps with zone Zone 2")
+    }
+
+    @Test
+    fun `checks that zones have subzones`() {
+      val boundary = makeMultiPolygon { square(100) }
+
+      val site =
+          newPlantingSite(
+              boundary = boundary, plantingZones = listOf(newPlantingZone(boundary = boundary)))
+
+      assertHasProblem(site, "Planting zone Zone 1 has no subzones")
+    }
+
+    @Test
+    fun `checks for subzones not covered by zone`() {
+      val siteBoundary = makeMultiPolygon { square(100) }
+      val subzoneBoundary = makeMultiPolygon { square(200) }
+
+      val site =
+          newPlantingSite(
+              boundary = siteBoundary,
+              plantingZones =
+                  listOf(
+                      newPlantingZone(
+                          boundary = siteBoundary,
+                          plantingSubzones =
+                              listOf(newPlantingSubzone(boundary = subzoneBoundary)))))
+
+      assertHasProblem(site, "75\\.00% of planting subzone .* is not contained")
+    }
+
+    @Test
+    fun `checks for overlapping subzone boundaries`() {
+      val siteBoundary = makeMultiPolygon { square(200) }
+      val subzone1Boundary = makeMultiPolygon { rectangle(100, 200) }
+      val subzone2Boundary = makeMultiPolygon {
+        east(50)
+        rectangle(150, 200)
+      }
+
+      val site =
+          newPlantingSite(
+              boundary = siteBoundary,
+              plantingZones =
+                  listOf(
+                      newPlantingZone(
+                          boundary = siteBoundary,
+                          plantingSubzones =
+                              listOf(
+                                  newPlantingSubzone(boundary = subzone1Boundary),
+                                  newPlantingSubzone(boundary = subzone2Boundary)))))
+
+      assertHasProblem(
+          site, "50\\.00% of subzone Subzone 1 in zone Zone 1 overlaps with subzone Subzone 2")
+    }
+
+    private fun assertHasProblem(site: PlantingSiteModel<*, *, *>, problemRegex: String) {
+      val regex = Regex(problemRegex)
+
+      val problems = site.validate()
+      assertNotNull(problems, "Validation returned no problems")
+
+      if (problems!!.none { it.contains(regex) }) {
+        assertEquals(listOf(problemRegex), problems, "Expected problems list to contain entry")
+      }
+    }
+  }
+
+  private fun makeMultiPolygon(func: Turtle.() -> Unit): MultiPolygon {
+    return Turtle(point(0)).makeMultiPolygon(func)
+  }
+
+  private var nextZoneNumber = 1
+  private var nextSubzoneNumber = 1
+
+  private fun newPlantingSite(
+      boundary: Geometry,
+      plantingZones: List<NewPlantingZoneModel> = emptyList(),
+  ): NewPlantingSiteModel {
+    return PlantingSiteModel.create(
+        areaHa = boundary.calculateAreaHectares(),
+        boundary = boundary.toMultiPolygon(),
+        name = "Site",
+        organizationId = OrganizationId(1),
+        plantingZones = plantingZones,
+    )
+  }
+
+  fun newPlantingZone(
+      boundary: Geometry,
+      name: String = "Zone ${nextZoneNumber++}",
+      plantingSubzones: List<NewPlantingSubzoneModel> = emptyList(),
+  ): NewPlantingZoneModel {
+    return NewPlantingZoneModel(
+        areaHa = boundary.calculateAreaHectares(),
+        boundary = boundary.toMultiPolygon(),
+        id = null,
+        name = name,
+        plantingSubzones = plantingSubzones,
+    )
+  }
+
+  fun newPlantingSubzone(
+      boundary: Geometry,
+      name: String = "Subzone ${nextSubzoneNumber++}",
+      fullName: String = "Zone $nextZoneNumber-$name",
+  ): NewPlantingSubzoneModel {
+    return NewPlantingSubzoneModel(
+        areaHa = boundary.calculateAreaHectares(),
+        boundary = boundary.toMultiPolygon(),
+        fullName = fullName,
+        id = null,
+        name = name,
+    )
+  }
+}


### PR DESCRIPTION
Currently, `PlantingSiteImporter` does two kinds of validation: checking that the
shapefiles are correctly formed (correct attribute names, etc.) and checking
that the maps in the shapefile obey our constraints on planting sites.

Move the constraint checks to `PlantingSiteModel` and `PlantingZoneModel` so we
can validate planting site maps that aren't in the form of shapefiles. This is
a step toward unifying shapefile-based and API-based detailed planting site
creation and updating, though for now, the validation is still only done during
shapefile import.