### PR TITLE
Rename exception to be less shapefile-centric

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -21,8 +21,8 @@ import com.terraformation.backend.time.DatabaseBackedClock
 import com.terraformation.backend.tracking.ObservationService
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteImporter
+import com.terraformation.backend.tracking.db.PlantingSiteMapInvalidException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
-import com.terraformation.backend.tracking.db.PlantingSiteUploadProblemsException
 import com.terraformation.backend.tracking.mapbox.MapboxService
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewObservationModel
@@ -303,7 +303,7 @@ class AdminPlantingSitesController(
 
         redirectAttributes.successMessage = "Planting site $siteId imported successfully."
       }
-    } catch (e: PlantingSiteUploadProblemsException) {
+    } catch (e: PlantingSiteMapInvalidException) {
       log.warn("Shapefile import failed validation: ${e.problems}")
       redirectAttributes.failureMessage = "Uploaded file failed validation checks"
       redirectAttributes.failureDetails = e.problems
@@ -356,7 +356,7 @@ class AdminPlantingSitesController(
       redirectAttributes.successMessage = "Planting site $siteId imported successfully."
 
       return redirectToPlantingSite(siteId)
-    } catch (e: PlantingSiteUploadProblemsException) {
+    } catch (e: PlantingSiteMapInvalidException) {
       log.warn("Site creation failed", e)
       redirectAttributes.failureMessage = "Creation failed: ${e.problems.joinToString()}"
     } catch (e: Exception) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -74,8 +74,8 @@ class PlantingSubzoneNotFoundException(val plantingSubzoneId: PlantingSubzoneId)
 class PlantingZoneNotFoundException(val plantingZoneId: PlantingZoneId) :
     EntityNotFoundException("Planting zone $plantingZoneId not found")
 
-class PlantingSiteUploadProblemsException(val problems: List<String>) :
-    RuntimeException("Found problems in uploaded planting site file") {
+class PlantingSiteMapInvalidException(val problems: List<String>) :
+    RuntimeException("Found problems in planting site map data") {
   constructor(problem: String) : this(listOf(problem))
 }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -58,7 +58,7 @@ class PlantingSiteImporter(
     requirePermissions { createPlantingSite(organizationId) }
 
     if (shapefiles.size != 3 && shapefiles.size != 4) {
-      throw PlantingSiteUploadProblemsException(
+      throw PlantingSiteMapInvalidException(
           "Expected 3 or 4 shapefiles (site, zones, subzones, and optionally exclusions) but " +
               "found ${shapefiles.size}")
     }
@@ -70,7 +70,7 @@ class PlantingSiteImporter(
 
     shapefiles.forEach { shapefile ->
       if (shapefile.features.isEmpty()) {
-        throw PlantingSiteUploadProblemsException("Shapefiles must contain geometries")
+        throw PlantingSiteMapInvalidException("Shapefiles must contain geometries")
       }
 
       when {
@@ -87,15 +87,15 @@ class PlantingSiteImporter(
         description,
         organizationId,
         siteFile
-            ?: throw PlantingSiteUploadProblemsException(
+            ?: throw PlantingSiteMapInvalidException(
                 "Planting site shapefile must contain exactly one geometry and one of these properties: " +
                     siteNameProperties.joinToString()),
         zonesFile
-            ?: throw PlantingSiteUploadProblemsException(
+            ?: throw PlantingSiteMapInvalidException(
                 "Planting zones shapefile features must include one of these properties: " +
                     zoneNameProperties.joinToString()),
         subzonesFile
-            ?: throw PlantingSiteUploadProblemsException(
+            ?: throw PlantingSiteMapInvalidException(
                 "Subzones shapefile features must include one of these properties: " +
                     subzoneNameProperties.joinToString()),
         exclusionsFile)
@@ -135,7 +135,7 @@ class PlantingSiteImporter(
     problems.addAll(newModel.validate() ?: emptyList())
 
     if (problems.isNotEmpty()) {
-      throw PlantingSiteUploadProblemsException(problems)
+      throw PlantingSiteMapInvalidException(problems)
     }
 
     val now = clock.instant()
@@ -213,7 +213,7 @@ class PlantingSiteImporter(
       }
 
       if (problems.isNotEmpty()) {
-        throw PlantingSiteUploadProblemsException(problems)
+        throw PlantingSiteMapInvalidException(problems)
       }
 
       log.info("Imported planting site $siteId for organization $organizationId")
@@ -226,8 +226,7 @@ class PlantingSiteImporter(
       problems: MutableList<String>
   ): ShapefileFeature {
     if (siteFile.features.isEmpty()) {
-      throw PlantingSiteUploadProblemsException(
-          "Planting site shapefile does not contain a boundary")
+      throw PlantingSiteMapInvalidException("Planting site shapefile does not contain a boundary")
     }
 
     if (siteFile.features.size > 1) {
@@ -259,7 +258,7 @@ class PlantingSiteImporter(
                     (0 ..< geometry.numGeometries).map { geometry.getGeometryN(it) as Polygon }
                 else -> {
                   problems.add("Exclusion geometries must all be Polygon or MultiPolygon.")
-                  throw PlantingSiteUploadProblemsException(problems)
+                  throw PlantingSiteMapInvalidException(problems)
                 }
               }
             }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -116,7 +116,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       try {
         importFunc()
         fail("Should have throw exception for validation failure")
-      } catch (e: PlantingSiteUploadProblemsException) {
+      } catch (e: PlantingSiteMapInvalidException) {
         if (e.problems.none { it == expected }) {
           // Assertion failure message will include the list of problems we actually got back.
           assertEquals(


### PR DESCRIPTION
`PlantingSiteUploadProblemsException` implies that a site has been uploaded,
but it's the exception we throw for map validation errors no matter where the
map data comes from. Rename it to `PlantingSiteMapInvalidException`.