### PR TITLE
SW-5230 Validate zone size in PlantingZoneModel

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -106,7 +106,7 @@ data class PlantingSiteModel<
           }
         }
 
-        problems.addAll(zone.validate())
+        problems.addAll(zone.validate(this))
       }
     }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -279,8 +279,31 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
     }
   }
 
-  fun validate(): List<String> {
+  fun validate(newModel: PlantingSiteModel<*, *, *>): List<String> {
     val problems = mutableListOf<String>()
+
+    // Find 5 squares: 4 for the cluster and one for a temporary plot.
+    val plotBoundaries =
+        findUnusedSquares(
+            count = 5,
+            exclusion = newModel.exclusion,
+            gridOrigin = newModel.gridOrigin!!,
+        )
+
+    // Make sure we have room for an actual cluster.
+    val clusterBoundaries =
+        findUnusedSquares(
+            count = 1,
+            exclusion = newModel.exclusion,
+            gridOrigin = newModel.gridOrigin,
+            sizeMeters = MONITORING_PLOT_SIZE * 2,
+        )
+
+    if (clusterBoundaries.isEmpty() || plotBoundaries.size < 5) {
+      problems.add(
+          "Planting zone $name is too small to create minimum number of monitoring plots (is the " +
+              "zone at least 150x75 meters?)")
+    }
 
     plantingSubzones
         .groupBy { it.name.lowercase() }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -91,7 +91,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       val subzoneFeature = gen.subzoneFeature(siteBoundary)
 
       assertHasProblem(
-          "Could not create enough monitoring plots in zone Z1 (is the zone at least 150x75 meters?)",
+          "Planting zone Z1 is too small to create minimum number of monitoring plots (is the zone at least 150x75 meters?)",
           listOf(siteFeature),
           listOf(zoneFeature),
           listOf(subzoneFeature))
@@ -106,7 +106,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       val subzoneFeature = gen.subzoneFeature(siteBoundary)
 
       assertHasProblem(
-          "Could not create enough monitoring plots in zone Z1 (is the zone at least 150x75 meters?)",
+          "Planting zone Z1 is too small to create minimum number of monitoring plots (is the zone at least 150x75 meters?)",
           listOf(siteFeature),
           listOf(zoneFeature),
           listOf(subzoneFeature))


### PR DESCRIPTION
Move the validation that a zone is big enough to fit a permanent cluster and a
temporary plot from `PlantingSiteImporter` to `PlantingZoneModel`.