### PR TITLE
SW-5264 Move detailed site creation to PlantingSiteStore

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -51,13 +51,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         plantingZonesDao)
   }
   private val plantingSiteImporter: PlantingSiteImporter by lazy {
-    PlantingSiteImporter(
-        clock,
-        dslContext,
-        plantingSiteStore,
-        plantingZonesDao,
-        plantingSubzonesDao,
-    )
+    PlantingSiteImporter(plantingSiteStore)
   }
   private val observationService: ObservationService by lazy {
     ObservationService(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -31,8 +31,6 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
   private val importer: PlantingSiteImporter by lazy {
     PlantingSiteImporter(
-        clock,
-        dslContext,
         PlantingSiteStore(
             clock,
             dslContext,
@@ -42,9 +40,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
             plantingSeasonsDao,
             plantingSitesDao,
             plantingSubzonesDao,
-            plantingZonesDao),
-        plantingZonesDao,
-        plantingSubzonesDao)
+            plantingZonesDao))
   }
 
   private val resourcesDir = "src/test/resources/tracking"


### PR DESCRIPTION
`PlantingSiteStore.createPlantingSite()` now accepts detailed planting site 
models, validates them, and inserts the zones and subzones.

`PlantingSiteImporter` no longer interacts directly with the database; it just
constructs models from shapefiles.

This will allow us to support user-drawn detailed planting sites created via
API calls with the same behavior as shapefile import.