### PR TITLE
SW-5264 Populate planting site history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -31,6 +32,12 @@ data class PlantingSiteModel<
     val description: String? = null,
     val exclusion: MultiPolygon? = null,
     val gridOrigin: Point? = null,
+    /**
+     * If this model is associated with a particular history entry, its ID. This property is not
+     * populated when doing a simple fetch of the current site data, nor for planting sites without
+     * maps.
+     */
+    val historyId: PlantingSiteHistoryId? = null,
     val id: PSID,
     val name: String,
     val organizationId: OrganizationId,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -195,11 +195,14 @@ import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotCoordinatesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSiteHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSiteNotificationsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSitePopulationsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSubzoneHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSubzonePopulationsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSubzonesDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingZoneHistoriesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingZonePopulationsDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingZonesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingsDao
@@ -431,11 +434,14 @@ abstract class DatabaseTest {
   protected val participantsDao: ParticipantsDao by lazyDao()
   protected val plantingsDao: PlantingsDao by lazyDao()
   protected val plantingSeasonsDao: PlantingSeasonsDao by lazyDao()
+  protected val plantingSiteHistoriesDao: PlantingSiteHistoriesDao by lazyDao()
   protected val plantingSiteNotificationsDao: PlantingSiteNotificationsDao by lazyDao()
   protected val plantingSitePopulationsDao: PlantingSitePopulationsDao by lazyDao()
   protected val plantingSitesDao: PlantingSitesDao by lazyDao()
+  protected val plantingSubzoneHistoriesDao: PlantingSubzoneHistoriesDao by lazyDao()
   protected val plantingSubzonePopulationsDao: PlantingSubzonePopulationsDao by lazyDao()
   protected val plantingSubzonesDao: PlantingSubzonesDao by lazyDao()
+  protected val plantingZoneHistoriesDao: PlantingZoneHistoriesDao by lazyDao()
   protected val plantingZonePopulationsDao: PlantingZonePopulationsDao by lazyDao()
   protected val plantingZonesDao: PlantingZonesDao by lazyDao()
   protected val projectAcceleratorDetailsDao: ProjectAcceleratorDetailsDao by lazyDao()


### PR DESCRIPTION
When a planting site with map data is created, or a simple planting site with a
map is updated, record the map geometries in `planting_site_histories` and
the child tables for zones and subzones.

The server doesn't currently support updates of detailed planting site maps,
so zone and subzone history records are only inserted at creation time; updating
of detailed planting site maps will be added in upcoming changes.