### PR TITLE
Support tiny simple planting site maps

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -267,9 +267,14 @@ class PlantingSiteStore(
       throw PlantingSiteMapInvalidException(problems)
     }
 
+    // Simple planting sites can be arbitrarily small; if their areas would round down to zero,
+    // treat them as not having areas at all so we don't try to calculate area-based statistics.
+    val areaHa: BigDecimal? =
+        newModel.boundary?.calculateAreaHectares()?.let { if (it.signum() > 0) it else null }
+
     val plantingSitesRow =
         PlantingSitesRow(
-            areaHa = newModel.boundary?.calculateAreaHectares(),
+            areaHa = areaHa,
             boundary = newModel.boundary,
             createdBy = currentUser().userId,
             createdTime = now,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStoreTest.kt
@@ -423,6 +423,18 @@ internal class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `does not store area for simple site with tiny boundary`() {
+      val boundary = Turtle(point(1)).makeMultiPolygon { square(5) }
+
+      val model =
+          store.createPlantingSite(
+              PlantingSiteModel.create(
+                  boundary = boundary, name = "name", organizationId = organizationId))
+
+      assertNull(plantingSitesDao.fetchOneById(model.id)!!.areaHa, "Planting site area")
+    }
+
+    @Test
     fun `inserts detailed planting site`() {
       val gridOrigin = point(1)
       val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { rectangle(200, 150) }


### PR DESCRIPTION
The planting sites table has a constraint that requires the site's area in
hectares to be greater than 0, because we divide by the site area when
calculating certain statistics.

Previously, we didn't calculate the areas of simple planting sites at all, so
site maps could be arbitrarily tiny without violating the constraint. Commit
af1e716b started calculating areas for all sites, not just detailed ones, and
this caused creation of tiny simple sites to bomb out because their areas were
rounded down to 0.

Restore the previous behavior if a simple site's boundary is tiny: the area is
not stored at all. For larger simple sites, we continue to store it.