### PR TITLE
SW-5318 Participant Project Species permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -6,10 +6,12 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.EVENT_PROJECTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.default_schema.AutomationId
 import com.terraformation.backend.db.default_schema.DeviceId
@@ -130,6 +132,12 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun getOrganizationId(observationId: ObservationId): OrganizationId? =
       fetchFieldById(observationId, OBSERVATIONS.ID, OBSERVATIONS.plantingSites.ORGANIZATION_ID)
+
+  fun getOrganizationId(participantProjectSpeciesId: ParticipantProjectSpeciesId): OrganizationId? =
+      fetchFieldById(
+          participantProjectSpeciesId,
+          PARTICIPANT_PROJECT_SPECIES.ID,
+          PARTICIPANT_PROJECT_SPECIES.projects.ORGANIZATION_ID)
 
   fun getOrganizationId(plantingId: PlantingId): OrganizationId? =
       fetchFieldById(plantingId, PLANTINGS.ID, PLANTINGS.plantingSites.ORGANIZATION_ID)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -193,6 +194,8 @@ data class DeviceManagerUser(
 
   override fun canCreateParticipant(): Boolean = false
 
+  override fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean = false
+
   override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = false
 
   override fun canCreateProject(organizationId: OrganizationId): Boolean = false
@@ -227,6 +230,10 @@ data class DeviceManagerUser(
   override fun canDeleteParticipantProject(
       participantId: ParticipantId,
       projectId: ProjectId
+  ): Boolean = false
+
+  override fun canDeleteParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
   ): Boolean = false
 
   override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
@@ -309,6 +316,10 @@ data class DeviceManagerUser(
       false
 
   override fun canReadParticipant(participantId: ParticipantId): Boolean = false
+
+  override fun canReadParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean = false
 
   override fun canReadPlanting(plantingId: PlantingId): Boolean = false
 
@@ -403,6 +414,10 @@ data class DeviceManagerUser(
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = false
 
   override fun canUpdateParticipant(participantId: ParticipantId): Boolean = false
+
+  override fun canUpdateParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean = false
 
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -215,6 +216,9 @@ data class IndividualUser(
 
   override fun canCreateParticipant() = isAcceleratorAdmin()
 
+  override fun canCreateParticipantProjectSpecies(projectId: ProjectId) =
+      isTFExpertOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
+
   override fun canCreatePlantingSite(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
 
@@ -259,6 +263,12 @@ data class IndividualUser(
 
   override fun canDeleteParticipantProject(participantId: ParticipantId, projectId: ProjectId) =
       isAcceleratorAdmin()
+
+  override fun canDeleteParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ) =
+      isTFExpertOrHigher() ||
+          isManagerOrHigher(parentStore.getOrganizationId(participantProjectSpeciesId))
 
   override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId) = isSuperAdmin()
 
@@ -397,6 +407,10 @@ data class IndividualUser(
   }
 
   override fun canReadParticipant(participantId: ParticipantId) = isReadOnlyOrHigher()
+
+  override fun canReadParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ) = isReadOnlyOrHigher() || isMember(parentStore.getOrganizationId(participantProjectSpeciesId))
 
   override fun canReadPlanting(plantingId: PlantingId): Boolean =
       isMember(parentStore.getOrganizationId(plantingId))
@@ -553,6 +567,12 @@ data class IndividualUser(
       isAdminOrHigher(organizationId)
 
   override fun canUpdateParticipant(participantId: ParticipantId) = isAcceleratorAdmin()
+
+  override fun canUpdateParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ) =
+      isTFExpertOrHigher() ||
+          isManagerOrHigher(parentStore.getOrganizationId(participantProjectSpeciesId))
 
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId) =
       isAdminOrHigher(parentStore.getOrganizationId(plantingSiteId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -173,6 +174,8 @@ class SystemUser(
 
   override fun canCreateParticipant(): Boolean = true
 
+  override fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean = true
+
   override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = true
 
   override fun canCreateProject(organizationId: OrganizationId): Boolean = true
@@ -207,6 +210,10 @@ class SystemUser(
   override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
 
   override fun canDeleteParticipant(participantId: ParticipantId): Boolean = true
+
+  override fun canDeleteParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean = true
 
   override fun canDeleteParticipantProject(
       participantId: ParticipantId,
@@ -309,6 +316,10 @@ class SystemUser(
       true
 
   override fun canReadParticipant(participantId: ParticipantId): Boolean = true
+
+  override fun canReadParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean = true
 
   override fun canReadPlanting(plantingId: PlantingId): Boolean = true
 
@@ -413,6 +424,10 @@ class SystemUser(
   override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
 
   override fun canUpdateParticipant(participantId: ParticipantId): Boolean = true
+
+  override fun canUpdateParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean = true
 
   override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -133,6 +134,8 @@ interface TerrawareUser : Principal {
 
   fun canCreateParticipant(): Boolean
 
+  fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean
+
   fun canCreatePlantingSite(organizationId: OrganizationId): Boolean
 
   fun canCreateProject(organizationId: OrganizationId): Boolean
@@ -166,6 +169,10 @@ interface TerrawareUser : Principal {
   fun canDeleteParticipant(participantId: ParticipantId): Boolean
 
   fun canDeleteParticipantProject(participantId: ParticipantId, projectId: ProjectId): Boolean
+
+  fun canDeleteParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean
 
   fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean
 
@@ -262,6 +269,10 @@ interface TerrawareUser : Principal {
   fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
 
   fun canReadParticipant(participantId: ParticipantId): Boolean
+
+  fun canReadParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean
 
   fun canReadPlanting(plantingId: PlantingId): Boolean
 
@@ -364,6 +375,10 @@ interface TerrawareUser : Principal {
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean
 
   fun canUpdateParticipant(participantId: ParticipantId): Boolean
+
+  fun canUpdateParticipantProjectSpecies(
+      participantProjectSpeciesId: ParticipantProjectSpeciesId
+  ): Boolean
 
   fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1421,7 +1421,7 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *participantProjectSpeciesIds.forOrg1(),
+        *participantProjectSpeciesIds.toTypedArray(),
         deleteParticipantProjectSpecies = true,
         readParticipantProjectSpecies = true,
         updateParticipantProjectSpecies = true,
@@ -1429,8 +1429,8 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *projectIds.toTypedArray(),
-        createSubmission = true,
         createParticipantProjectSpecies = true,
+        createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
         readProject = true,
@@ -3078,6 +3078,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedMonitoringPlots.toTypedArray())
       expect(*uncheckedObservations.toTypedArray())
       expect(*uncheckedOrgs.toTypedArray())
+      expect(*uncheckedParticipantProjectSpecies.toTypedArray())
       expect(*uncheckedPlantings.toTypedArray())
       expect(*uncheckedPlantingSites.toTypedArray())
       expect(*uncheckedPlantingSubzones.toTypedArray())

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventId
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
@@ -181,6 +182,8 @@ internal class PermissionTest : DatabaseTest() {
   private val moduleIds = listOf(1000, 1001, 3000, 4000).map { ModuleId(it.toLong()) }
   private val deliverableIds = listOf(DeliverableId(1000))
   private val submissionIds = projectIds.map { SubmissionId(it.value) }
+  private val participantProjectSpeciesIds =
+      projectIds.map { ParticipantProjectSpeciesId(it.value) }
 
   private inline fun <reified T> List<T>.filterToArray(func: (T) -> Boolean): Array<T> =
       filter(func).toTypedArray()
@@ -393,6 +396,12 @@ internal class PermissionTest : DatabaseTest() {
       )
       insertEventProject(eventId, ProjectId(eventId.value))
     }
+
+    participantProjectSpeciesIds.forEach { participantProjectSpeciesId ->
+      insertParticipantProjectSpecies(
+          id = participantProjectSpeciesId.value,
+          projectId = ProjectId(participantProjectSpeciesId.value))
+    }
   }
 
   @Test
@@ -568,7 +577,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         deleteProject = true,
         readProject = true,
@@ -804,7 +821,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         deleteProject = true,
         readProject = true,
@@ -961,8 +986,16 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
         createSubmission = true,
+        createParticipantProjectSpecies = true,
         readProject = true,
         readProjectDeliverables = true,
         readProjectModules = true,
@@ -1099,6 +1132,11 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.forOrg1(),
         readObservation = true,
         updateObservation = true,
+    )
+
+    permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        readParticipantProjectSpecies = true,
     )
 
     permissions.expect(
@@ -1383,8 +1421,16 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.toTypedArray(),
         createSubmission = true,
+        createParticipantProjectSpecies = true,
         deleteProject = true,
         readDefaultVoters = true,
         readProject = true,
@@ -1484,7 +1530,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
@@ -1516,6 +1570,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(3000),
         ProjectId(4000),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         readDefaultVoters = true,
         readProject = true,
@@ -1651,7 +1706,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
@@ -1684,6 +1747,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         ProjectId(3000),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         readDefaultVoters = true,
         readProjectAcceleratorDetails = true,
@@ -1815,7 +1879,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        deleteParticipantProjectSpecies = true,
+        readParticipantProjectSpecies = true,
+        updateParticipantProjectSpecies = true,
+    )
+
+    permissions.expect(
         *projectIds.forOrg1(),
+        createParticipantProjectSpecies = true,
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
@@ -1841,6 +1913,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         ProjectId(4000),
+        createParticipantProjectSpecies = true,
         readDefaultVoters = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
@@ -1978,6 +2051,11 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *submissionDocumentIds.toTypedArray(),
         readSubmissionDocument = true,
+    )
+
+    permissions.expect(
+        *participantProjectSpeciesIds.forOrg1(),
+        readParticipantProjectSpecies = true,
     )
 
     permissions.expect(
@@ -2143,6 +2221,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedMonitoringPlots = monitoringPlotIds.toMutableSet()
     private val uncheckedObservations = observationIds.toMutableSet()
     private val uncheckedOrgs = organizationIds.toMutableSet()
+    private val uncheckedParticipantProjectSpecies = participantProjectSpeciesIds.toMutableSet()
     private val uncheckedPlantings = plantingIds.toMutableSet()
     private val uncheckedPlantingSites = plantingSiteIds.toMutableSet()
     private val uncheckedPlantingSubzones = plantingSubzoneIds.toMutableSet()
@@ -2812,6 +2891,7 @@ internal class PermissionTest : DatabaseTest() {
 
     fun expect(
         vararg projectIds: ProjectId,
+        createParticipantProjectSpecies: Boolean = false,
         createSubmission: Boolean = false,
         deleteProject: Boolean = false,
         readDefaultVoters: Boolean = false,
@@ -2834,6 +2914,10 @@ internal class PermissionTest : DatabaseTest() {
             createSubmission,
             user.canCreateSubmission(projectId),
             "Can create submission for project $projectId")
+        assertEquals(
+            createParticipantProjectSpecies,
+            user.canCreateParticipantProjectSpecies(projectId),
+            "Can create participant project species for project $projectId")
         assertEquals(
             deleteProject, user.canDeleteProject(projectId), "Can delete project $projectId")
         assertEquals(readDefaultVoters, user.canReadDefaultVoters(), "Can read default voters")
@@ -2912,6 +2996,32 @@ internal class PermissionTest : DatabaseTest() {
             "Can read module details $moduleId")
 
         uncheckedModules.remove(moduleId)
+      }
+    }
+
+    fun expect(
+        vararg participantProjectSpeciesIds: ParticipantProjectSpeciesId,
+        deleteParticipantProjectSpecies: Boolean = false,
+        readParticipantProjectSpecies: Boolean = false,
+        updateParticipantProjectSpecies: Boolean = false,
+    ) {
+      participantProjectSpeciesIds.forEach { participantProjectSpeciesId ->
+        assertEquals(
+            deleteParticipantProjectSpecies,
+            user.canDeleteParticipantProjectSpecies(participantProjectSpeciesId),
+            "Can delete participant project species $participantProjectSpeciesId")
+
+        assertEquals(
+            readParticipantProjectSpecies,
+            user.canReadParticipantProjectSpecies(participantProjectSpeciesId),
+            "Can read participant project species $participantProjectSpeciesId")
+
+        assertEquals(
+            updateParticipantProjectSpecies,
+            user.canUpdateParticipantProjectSpecies(participantProjectSpeciesId),
+            "Can update participant project species $participantProjectSpeciesId")
+
+        uncheckedParticipantProjectSpecies.remove(participantProjectSpeciesId)
       }
     }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
@@ -33,6 +34,7 @@ import com.terraformation.backend.db.accelerator.tables.daos.DeliverablesDao
 import com.terraformation.backend.db.accelerator.tables.daos.EventProjectsDao
 import com.terraformation.backend.db.accelerator.tables.daos.EventsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ModulesDao
+import com.terraformation.backend.db.accelerator.tables.daos.ParticipantProjectSpeciesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectAcceleratorDetailsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectScoresDao
@@ -48,6 +50,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.DeliverablesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.EventProjectsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.EventsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ModulesRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectAcceleratorDetailsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
@@ -432,6 +435,7 @@ abstract class DatabaseTest {
   protected val organizationsDao: OrganizationsDao by lazyDao()
   protected val organizationUsersDao: OrganizationUsersDao by lazyDao()
   protected val participantsDao: ParticipantsDao by lazyDao()
+  protected val participantProjectSpeciesDao: ParticipantProjectSpeciesDao by lazyDao()
   protected val plantingsDao: PlantingsDao by lazyDao()
   protected val plantingSeasonsDao: PlantingSeasonsDao by lazyDao()
   protected val plantingSiteHistoriesDao: PlantingSiteHistoriesDao by lazyDao()
@@ -2093,6 +2097,30 @@ abstract class DatabaseTest {
     return row.id!!.also { inserted.participantIds.add(it) }
   }
 
+  private var nextParticipantProjectSpeciesNumber = 1
+
+  fun insertParticipantProjectSpecies(
+      feedback: String? = null,
+      id: Any? = null,
+      projectId: Any = inserted.projectId,
+      rationale: String? = null,
+      speciesId: Any = inserted.speciesId,
+      submissionStatus: SubmissionStatus = SubmissionStatus.NotSubmitted,
+  ): ParticipantProjectSpeciesId {
+    val row =
+        ParticipantProjectSpeciesRow(
+            feedback = feedback,
+            id = id?.toIdWrapper { ParticipantProjectSpeciesId(it) },
+            projectId = projectId.toIdWrapper { ProjectId(it) },
+            rationale = rationale,
+            speciesId = speciesId.toIdWrapper { SpeciesId(it) },
+            submissionStatusId = submissionStatus)
+
+    participantProjectSpeciesDao.insert(row)
+
+    return row.id!!.also { inserted.participantProjectSpeciesIds.add(it) }
+  }
+
   private var nextCohortNumber = 1
 
   fun insertCohort(
@@ -2248,6 +2276,7 @@ abstract class DatabaseTest {
     val observationIds = mutableListOf<ObservationId>()
     val organizationIds = mutableListOf<OrganizationId>()
     val participantIds = mutableListOf<ParticipantId>()
+    val participantProjectSpeciesIds = mutableListOf<ParticipantProjectSpeciesId>()
     val plantingIds = mutableListOf<PlantingId>()
     val plantingSeasonIds = mutableListOf<PlantingSeasonId>()
     val plantingSiteIds = mutableListOf<PlantingSiteId>()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -2097,8 +2097,6 @@ abstract class DatabaseTest {
     return row.id!!.also { inserted.participantIds.add(it) }
   }
 
-  private var nextParticipantProjectSpeciesNumber = 1
-
   fun insertParticipantProjectSpecies(
       feedback: String? = null,
       id: Any? = null,
@@ -2343,6 +2341,9 @@ abstract class DatabaseTest {
 
     val participantId
       get() = participantIds.last()
+
+    val participantProjectSpeciesId
+      get() = participantProjectSpeciesIds.last()
 
     val plantingId
       get() = plantingIds.last()


### PR DESCRIPTION
- Adds 4 new permissions: 
  - `canCreateParticipantProjectSpecies`
  - `canDeleteParticipantProjectSpecies`
  - `canReadParticipantProjectSpecies`
  - `canUpdateParticipantProjectSpecies`


