### PR TITLE
Add default value to SearchResults.cursor

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchResults.kt
@@ -15,7 +15,7 @@ data class SearchResults(
      * Cursor that can be passed to [SearchService.search] to retrieve additional results. If
      * [results] contains the full set of results, this will be null.
      */
-    val cursor: String?
+    val cursor: String? = null,
 ) {
   /**
    * Turns nested field values into CRLF-delimited strings suitable for exporting to a CSV file.

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -387,9 +387,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                                 "id" to "$participantId",
                                 "projects" to listOf(mapOf("id" to "$projectId"))),
                         ),
-                ),
-            ),
-            null)
+                )))
 
     val actual = searchService.search(prefix, fields, NoConditionNode())
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -127,9 +127,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                             mapOf("landUseModelType" to "Mangroves"),
                             mapOf("landUseModelType" to "Silvopasture"),
                         ),
-                ),
-            ),
-            null)
+                )))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -153,8 +151,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
             listOf(
                 mapOf("name" to "Organization 1"),
                 mapOf("name" to "Organization 2"),
-            ),
-            null)
+            ))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -172,7 +169,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val prefix = SearchFieldPrefix(searchTables.organizations)
     val fields = listOf(prefix.resolve("name"))
 
-    val expected = SearchResults(listOf(mapOf("name" to "Organization 1")), null)
+    val expected = SearchResults(listOf(mapOf("name" to "Organization 1")))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -189,7 +186,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val prefix = SearchFieldPrefix(searchTables.projects)
     val fields = listOf(prefix.resolve("name"))
 
-    val expected = SearchResults(listOf(mapOf("name" to "Project 1")), null)
+    val expected = SearchResults(listOf(mapOf("name" to "Project 1")))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -208,7 +205,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val prefix = SearchFieldPrefix(searchTables.projects)
     val fields = listOf(prefix.resolve("name"))
 
-    val expected = SearchResults(listOf(mapOf("name" to "Project 1")), null)
+    val expected = SearchResults(listOf(mapOf("name" to "Project 1")))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -227,7 +224,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val fields = listOf(prefix.resolve("name"))
     val condition = FieldNode(prefix.resolve("internalTags_name"), listOf("Accelerator"))
 
-    val expected = SearchResults(listOf(mapOf("name" to "Organization 1")), null)
+    val expected = SearchResults(listOf(mapOf("name" to "Organization 1")))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, condition))
   }
@@ -255,8 +252,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf(
                     "id" to "${inserted.projectId}",
                     "name" to "Project 1",
-                )),
-            null)
+                )))
 
     assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
   }
@@ -280,9 +276,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf(
                     "acceleratorDetails_dealStage" to "Phase 0 (Doc Review)",
                     "landUseModelTypes_landUseModelType" to "Monoculture".toGibberish(),
-                ),
-            ),
-            null)
+                )))
 
     val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
 
@@ -345,9 +339,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                                 "name" to "Participant 3",
                             ),
                         ),
-                ),
-            ),
-            null)
+                )))
 
     val actual =
         searchService.search(prefix, fields, FieldNode(prefix.resolve("name"), listOf("Cohort 1")))

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -86,8 +86,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
                     "meetingUrl" to "https://meet.google.com",
                     "slidesUrl" to "https://slides.google.com",
                     "recordingUrl" to "https://recording.google.com",
-                )),
-            null)
+                )))
 
     val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
 
@@ -312,9 +311,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
                             mapOf("id" to "$event1"),
                             mapOf("id" to "$event2"),
                             mapOf("id" to "$event3")),
-                ),
-            ),
-            null)
+                )))
     val projectActual = searchService.search(projectPrefix, projectFields, NoConditionNode())
 
     val eventPrefix = SearchFieldPrefix(searchTables.events)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -81,8 +81,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
                     "preparationMaterials" to "<i> Preps </i>",
                     "phase" to CohortPhase.Phase1FeasibilityStudy.getDisplayName(Locales.GIBBERISH),
                     "workshopDescription" to "Workshop ideas",
-                )),
-            null)
+                )))
 
     val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
     assertJsonEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -157,9 +157,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
                     "id" to "$deliverableId",
                     "project_id" to "$projectId",
                     "module_id" to "${inserted.moduleId}",
-                ),
-            ),
-            null)
+                )))
 
     val actual = searchService.search(prefix, fields, NoConditionNode())
 
@@ -232,9 +230,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
                         listOf(
                             mapOf("id" to "$deliverableWithSubmission"),
                             mapOf("id" to "$deliverableWithoutSubmissions"),
-                        )),
-            ),
-            null)
+                        ))))
 
     val actual = searchService.search(prefix, fields, NoConditionNode())
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -200,8 +200,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                                   "totalQuantity" to number(1024 + 2048),
                               ),
                           )),
-              ),
-              null),
+              )),
           results)
     }
 
@@ -267,8 +266,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalQuantity" to number(128 + 256),
                       "totalSpecies" to number(1),
                   ),
-              ),
-              null),
+              )),
           results)
     }
 
@@ -299,9 +297,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "germinatingQuantity" to number(64),
                       "notReadyQuantity" to number(128),
                       "readyQuantity" to number(256),
-                      "totalQuantity" to number(128 + 256)),
-              ),
-              null),
+                      "totalQuantity" to number(128 + 256)))),
           results)
     }
 
@@ -401,8 +397,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "addedDate" to "2022-09-03",
                       "version" to number(1),
                   ),
-              ),
-              null),
+              )),
           results)
     }
 
@@ -431,9 +426,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
               listOf(
                   mapOf(
                       "id" to "$nonProjectBatchId",
-                  ),
-              ),
-              null),
+                  ))),
           results)
     }
 
@@ -591,8 +584,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalWithdrawn" to number(24),
                       "withdrawnDate" to "2023-03-03",
                   ),
-              ),
-              null)
+              ))
 
       val actual = searchService.search(prefix, fields, NoConditionNode(), orderBy)
 
@@ -639,8 +631,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "totalWithdrawn" to "-1",
                       "undoesWithdrawalDate" to "2024-01-15",
                       "undoesWithdrawalId" to "$withdrawalId",
-                  )),
-              null)
+                  )))
 
       val actual = searchService.search(prefix, fields, NoConditionNode(), orderBy)
 
@@ -674,8 +665,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   mapOf("project_name" to "Project 1"),
                   mapOf("project_name" to "Project 2"),
                   mapOf("project_name" to "Project 3"),
-              ),
-              null)
+              ))
 
       val actual =
           searchService.search(
@@ -703,8 +693,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
               listOf(
                   mapOf("id" to "$speciesId1"),
                   mapOf("id" to "$speciesId2"),
-              ),
-              null)
+              ))
 
       val actual =
           searchService.search(

--- a/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
@@ -57,8 +57,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "id" to "$speciesKoaAcacia",
                       "scientificName" to "Koa Acacia",
                   ),
-              ),
-              null)
+              ))
 
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koa"), SearchFilterType.Exact)
@@ -92,8 +91,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "id" to "$speciesKoaAcacia",
                       "scientificName" to "Koa Acacia",
                   ),
-              ),
-              null)
+              ))
 
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koaa"), SearchFilterType.Fuzzy)
@@ -115,8 +113,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf(""), SearchFilterType.PhraseMatch)
 
-      assertJsonEquals(
-          SearchResults(emptyList(), null), searchService.search(prefix, fields, conditions))
+      assertJsonEquals(SearchResults(emptyList()), searchService.search(prefix, fields, conditions))
     }
 
     @Test
@@ -141,8 +138,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "id" to "$speciesKoaAcacia",
                       "scientificName" to "Koa Acacia",
                   ),
-              ),
-              null)
+              ))
 
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koa"), SearchFilterType.PhraseMatch)
@@ -188,8 +184,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
                       "id" to "$brightRedAppleTreeFarm",
                       "scientificName" to "Bright Red Apple Tree Farm",
                   ),
-              ),
-              null)
+              ))
 
       val conditions =
           FieldNode(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
@@ -51,8 +51,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
                     "collectedDate" to "2019-01-01",
                 ),
                 mapOf("id" to "1102"),
-            ),
-            null)
+            ))
     val actual =
         searchService.search(
             rootPrefix,
@@ -76,8 +75,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
                 // Oldest first, meaning ascending date order
                 mapOf("id" to "1000", "ageMonths" to "0", "collectedDate" to "2020-06-01"),
                 mapOf("id" to "1001", "ageMonths" to "0", "collectedDate" to "2020-06-02"),
-            ),
-            null)
+            ))
 
     val actual =
         searchService.search(
@@ -102,8 +100,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
                 // Youngest first, meaning reverse date order
                 mapOf("id" to "1001", "ageYears" to "0", "collectedDate" to "2020-06-02"),
                 mapOf("id" to "1000", "ageYears" to "0", "collectedDate" to "2020-06-01"),
-            ),
-            null)
+            ))
 
     val actual =
         searchService.search(
@@ -121,7 +118,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
     val searchNode = FieldNode(ageMonthsField, listOf(null))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "1000")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -133,7 +130,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
     val searchNode = FieldNode(ageMonthsField, listOf("0"))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "1000")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -148,7 +145,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageYearsField, listOf("1", "2"), SearchFilterType.Range)
     val sortField = SearchSortField(ageYearsField)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001"), mapOf("id" to "1000")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001"), mapOf("id" to "1000")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode, listOf(sortField))
 
     assertEquals(expected, actual)
@@ -161,7 +158,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     // "Up to 2 months old"
     val searchNode = FieldNode(ageMonthsField, listOf(null, "2"), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -174,7 +171,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     // "At least 3 months old"
     val searchNode = FieldNode(ageMonthsField, listOf("3", null), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "1000")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
@@ -42,8 +42,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -63,8 +62,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
                     "accessionNumber" to "XYZ",
                     "plantsCollectedFromAlias" to "1",
                 ),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         searchAccessions(facilityId, listOf(plantsCollectedFromAlias), criteria = NoConditionNode())
@@ -89,8 +87,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
                     "accessionNumber" to "XYZ",
                     "alias(raw)" to "1",
                 ),
-            ),
-            cursor = null)
+            ))
 
     val actual = searchAccessions(facilityId, listOf(rawAlias), criteria = NoConditionNode())
     assertEquals(expected, actual)
@@ -100,12 +97,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
   fun `can use aliased field in search criteria`() {
     val criteria = FieldNode(plantsCollectedFromAlias, listOf("2"))
 
-    val expected =
-        SearchResults(
-            listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-            ),
-            cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     val actual = searchAccessions(facilityId, emptyList(), criteria = criteria)
     assertEquals(expected, actual)
@@ -120,8 +112,7 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         searchAccessions(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -53,8 +53,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                     "bagNumber" to "B",
                     "accessionNumber" to "XYZ",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -87,8 +86,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -119,8 +117,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                     "plantsCollectedFrom" to "1",
                     "active" to "Active",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -140,8 +137,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                 mapOf("scientificName" to "Å x"),
                 mapOf("scientificName" to "Kousa Dogwood"),
                 mapOf("scientificName" to "Other Dogwood"),
-            ),
-            cursor = null)
+            ))
 
     val swedishExpected =
         SearchResults(
@@ -150,8 +146,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                 mapOf("scientificName" to "Kousa Dogwood"),
                 mapOf("scientificName" to "Other Dogwood"),
                 mapOf("scientificName" to "Å x"),
-            ),
-            cursor = null)
+            ))
 
     val englishResult =
         Locale.ENGLISH.use {
@@ -178,8 +173,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Used Up")),
-            cursor = null)
+            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Used Up")))
 
     assertEquals(expected, result)
   }
@@ -197,8 +191,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -215,8 +208,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
               countryPrefix, listOf(countryCodeField, countryNameField), searchNode)
         }
 
-    val expected =
-        SearchResults(listOf(mapOf("code" to "US", "name" to gibberishValue)), cursor = null)
+    val expected = SearchResults(listOf(mapOf("code" to "US", "name" to gibberishValue)))
 
     assertEquals(expected, result)
   }
@@ -227,7 +219,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val result = searchService.search(countryPrefix, listOf(countryNameField), searchNode)
 
-    val expected = SearchResults(listOf(mapOf("name" to "Côte d’Ivoire")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("name" to "Côte d’Ivoire")))
 
     assertEquals(expected, result)
   }
@@ -253,8 +245,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
             listOf(
                 mapOf("name" to unitedStates),
                 mapOf("name" to togo),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -277,8 +268,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "species_checkedTime" to checkedTimeString)),
-            cursor = null)
+                    "species_checkedTime" to checkedTimeString)))
 
     assertEquals(expected, result)
   }
@@ -299,8 +289,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
@@ -25,8 +25,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("id" to "10000", "rare" to "false".toGibberish()),
-                mapOf("id" to "10001", "rare" to "true".toGibberish())),
-            cursor = null)
+                mapOf("id" to "10001", "rare" to "true".toGibberish())))
 
     assertEquals(expected, result)
   }
@@ -39,7 +38,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
 
     val result = Locales.GIBBERISH.use { searchService.search(prefix, fields, criteria) }
 
-    val expected = SearchResults(listOf(mapOf("id" to "10001")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "10001")))
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
@@ -87,8 +87,7 @@ internal class SearchServiceCompoundSearchTest : SearchServiceTest() {
               // We create accession numbers 10 through 20 and the ID sequence starts at 1
               val id = value - 9
               mapOf("id" to "$id", "accessionNumber" to "$value")
-            },
-            null)
+            })
     val actual = searchAccessions(facilityId, listOf(accessionNumberField), searchNode)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
@@ -41,9 +41,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "2",
                     "active" to "Active",
-                ),
-            ),
-            cursor = null)
+                )))
 
     val secondPage =
         searchAccessions(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceDateFieldSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceDateFieldSearchTest.kt
@@ -23,7 +23,7 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(receivedDateField, listOf("2021-01-02"), SearchFilterType.Exact)
 
-    val expected = SearchResults(listOf(mapOf("id" to "2", "accessionNumber" to "JAN2")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "2", "accessionNumber" to "JAN2")))
     val actual = searchAccessions(facilityId, fields, searchNode)
 
     assertEquals(expected, actual)
@@ -41,8 +41,7 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 mapOf("id" to "2", "accessionNumber" to "JAN2"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            null)
+            ))
     val actual = searchAccessions(facilityId, fields, searchNode)
 
     assertEquals(expected, actual)
@@ -59,8 +58,7 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("id" to "2", "accessionNumber" to "JAN2"),
-                mapOf("id" to "3", "accessionNumber" to "JAN8")),
-            null)
+                mapOf("id" to "3", "accessionNumber" to "JAN8")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)
@@ -73,7 +71,7 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val searchNode =
         FieldNode(receivedDateField, listOf("2021-01-07", null), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "3", "accessionNumber" to "JAN8")), null)
+    val expected = SearchResults(listOf(mapOf("id" to "3", "accessionNumber" to "JAN8")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)
@@ -90,8 +88,7 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("id" to "1", "accessionNumber" to "JAN1"),
-                mapOf("id" to "2", "accessionNumber" to "JAN2")),
-            null)
+                mapOf("id" to "2", "accessionNumber" to "JAN2")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -37,8 +37,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Processing"),
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "state" to "Drying"),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -52,10 +51,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(
-                mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "In Storage"),
-            ),
-            cursor = null)
+            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "In Storage")))
 
     assertEquals(expected, result)
   }
@@ -80,8 +76,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
                 mapOf("id" to "1000", "accessionNumber" to "XYZ", "viabilityTests_type" to "Lab"),
                 mapOf(
                     "id" to "1000", "accessionNumber" to "XYZ", "viabilityTests_type" to "Nursery"),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
@@ -112,8 +107,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
                     "id" to "1000",
                     "state" to gibberishAwaitingProcessing,
                     "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         Locales.GIBBERISH.use {
@@ -142,8 +136,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
                     "active" to gibberishActive,
                     "id" to "1000",
                     "state" to gibberishInStorage,
-                )),
-            cursor = null)
+                )))
 
     val actual = Locales.GIBBERISH.use { searchAccessions(facilityId, fields, criteria = search) }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFuzzySearchTest.kt
@@ -22,8 +22,7 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -42,8 +41,7 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -58,8 +56,7 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
         FieldNode(accessionNumberField, listOf("22-1-100"), SearchFilterType.ExactOrFuzzy)
 
     assertEquals(
-        SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "22-1-100")), cursor = null),
+        SearchResults(listOf(mapOf("id" to "1000", "accessionNumber" to "22-1-100"))),
         searchAccessions(facilityId, fields, searchNode),
         "Search for value with an exact match")
 
@@ -70,8 +67,7 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "22-1-101"),
                 mapOf("id" to "1000", "accessionNumber" to "22-1-102"),
-            ),
-            null),
+            )),
         searchAccessions(facilityId, fields, searchNode),
         "Search for value without an exact match")
   }
@@ -89,8 +85,7 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1000", "accessionNumber" to "22-1-10"),
                 mapOf("id" to "1001", "accessionNumber" to "22-1-100"),
-            ),
-            null),
+            )),
         searchAccessions(facilityId, fields, searchNode))
   }
 
@@ -106,9 +101,8 @@ internal class SearchServiceFuzzySearchTest : SearchServiceTest() {
     assertEquals(
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
-            ),
-            null),
+                mapOf(
+                    "id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"))),
         searchAccessions(facilityId, fields, searchNode))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
@@ -67,8 +67,7 @@ internal class SearchServiceInitializationTest : SearchServiceTest() {
                     "plantsCollectedFrom" to "2",
                     "active" to "Active",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -74,8 +74,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val result = searchService.search(rootPrefix, listOf(seedsTestedField), NoConditionNode())
 
     val expected =
-        SearchResults(
-            listOf(mapOf("viabilityTests" to listOf(mapOf("seedsTested" to "15")))), cursor = null)
+        SearchResults(listOf(mapOf("viabilityTests" to listOf(mapOf("seedsTested" to "15")))))
 
     assertEquals(expected, result)
   }
@@ -113,8 +112,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                             "bags" to
                                                 listOf(
                                                     mapOf("number" to "2"),
-                                                    mapOf("number" to "6")))))))),
-            cursor = null)
+                                                    mapOf("number" to "6")))))))))
 
     assertEquals(expected, result)
   }
@@ -138,8 +136,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                             mapOf("bagNumber" to "2"),
                             mapOf("bagNumber" to "5"),
                             mapOf("bagNumber" to "6"),
-                        ))),
-            cursor = null)
+                        ))))
 
     assertEquals(expected, result)
   }
@@ -167,8 +164,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                             mapOf("id" to "1001"),
                             mapOf("id" to "1000"),
                             mapOf("id" to "1001"),
-                        ))),
-            cursor = null)
+                        ))))
 
     assertEquals(expected, result)
   }
@@ -194,8 +190,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("viabilityTest" to sublistValues, "seedsGerminated" to "5"),
-                mapOf("viabilityTest" to sublistValues, "seedsGerminated" to "10")),
-            cursor = null)
+                mapOf("viabilityTest" to sublistValues, "seedsGerminated" to "10")))
 
     assertEquals(expected, result)
   }
@@ -218,8 +213,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(flattenedFieldName to orgName, "seedsGerminated" to "5"),
-                mapOf(flattenedFieldName to orgName, "seedsGerminated" to "10")),
-            cursor = null)
+                mapOf(flattenedFieldName to orgName, "seedsGerminated" to "10")))
 
     assertEquals(expected, result)
   }
@@ -236,7 +230,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             listOf(orgNameField),
             FieldNode(orgNameField, listOf("Non-matching organization name")))
 
-    val expected = SearchResults(emptyList(), cursor = null)
+    val expected = SearchResults(emptyList())
 
     assertEquals(expected, result)
   }
@@ -260,9 +254,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "id" to "1000",
                     "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
                     "accessionNumber" to "XYZ",
-                ),
-            ),
-            cursor = null)
+                )))
 
     assertEquals(expected, result)
   }
@@ -291,8 +283,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6")),
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -320,8 +311,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                 "viabilityTestResults" to
                                     listOf(
                                         mapOf("seedsGerminated" to "10"),
-                                        mapOf("seedsGerminated" to "5")))))),
-            cursor = null)
+                                        mapOf("seedsGerminated" to "5")))))))
 
     assertEquals(expected, result)
   }
@@ -341,8 +331,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")),
-            cursor = null)
+                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -372,8 +361,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                 "viabilityTestResults" to
                                     listOf(
                                         mapOf("seedsGerminated" to "10"),
-                                        mapOf("seedsGerminated" to "5")))))),
-            cursor = null)
+                                        mapOf("seedsGerminated" to "5")))))))
 
     assertEquals(expected, result)
   }
@@ -402,8 +390,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "bags" to listOf(mapOf("number" to "5"), mapOf("number" to "1")),
                     "accessionNumber" to "XYZ",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -439,8 +426,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -474,8 +460,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                             ),
                         ),
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -506,8 +491,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -537,8 +521,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -561,8 +544,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -611,8 +593,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                         ),
                     "receivedDate" to "2020-01-01",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -634,8 +615,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 // Bag 1
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -675,8 +655,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                         mapOf("seedsGerminated" to "10")))),
                     "viabilityTests_viabilityTestResults_seedsGerminated" to "10",
                 ),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -695,8 +674,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "facility" to mapOf("name" to "Facility $facilityId"))),
-            cursor = null)
+                    "facility" to mapOf("name" to "Facility $facilityId"))))
 
     assertEquals(expected, result)
   }
@@ -728,9 +706,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                         mapOf("viabilityTest" to mapOf("seedsTested" to "15")),
                                         mapOf("viabilityTest" to mapOf("seedsTested" to "15")),
                                     ))),
-                ),
-            ),
-            cursor = null)
+                )))
 
     assertEquals(expected, result)
   }
@@ -764,9 +740,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                         mapOf("viabilityTest" to mapOf("seedsTested" to "15")),
                                         mapOf("viabilityTest" to mapOf("seedsTested" to "15")),
                                     ))),
-                ),
-            ),
-            cursor = null)
+                )))
 
     assertEquals(expected, result)
   }
@@ -790,8 +764,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                     listOf(
                                         mapOf("active" to "Active", "state" to "Processing"),
                                         mapOf("active" to "Active", "state" to "In Storage"),
-                                    ))))),
-            cursor = null)
+                                    ))))))
 
     assertEquals(expected, result)
   }
@@ -1036,8 +1009,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "collectors.position" to "0\r\n1\r\n2",
                     "id" to "1000"),
                 mapOf("id" to "1001"),
-            ),
-            cursor = null)
+            ))
 
     val result =
         searchService.search(rootPrefix, fields, NoConditionNode(), sortFields).flattenForCsv()
@@ -1072,8 +1044,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("number" to "5", "accession" to mapOf("accessionNumber" to "XYZ"))),
-            cursor = null)
+            listOf(mapOf("number" to "5", "accession" to mapOf("accessionNumber" to "XYZ"))))
 
     val result = searchService.search(prefix, fields, criteria)
 
@@ -1087,7 +1058,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val fields = listOf(bagNumberField)
     val criteria = FieldNode(bagNumberField, listOf("5"))
 
-    val expected = SearchResults(listOf(mapOf("number" to "5")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("number" to "5")))
 
     val result = searchService.search(prefix, fields, criteria)
 
@@ -1110,8 +1081,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1000))!!.copy(facilityId = otherFacilityId))
 
-    val expected =
-        SearchResults(listOf(mapOf("number" to "2"), mapOf("number" to "6")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("number" to "2"), mapOf("number" to "6")))
 
     val result = searchService.search(prefix, fields, criteria, order)
 
@@ -1145,7 +1115,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             recordingDate = LocalDate.EPOCH,
             seedsGerminated = 8))
 
-    val expected = SearchResults(listOf(mapOf("seedsGerminated" to "8")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("seedsGerminated" to "8")))
 
     val result = searchService.search(prefix, fields, criteria, order)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -23,8 +23,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -47,8 +46,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
                 mapOf("id" to "1", "accessionNumber" to "MISSING"),
-            ),
-            cursor = null)
+            ))
 
     assertEquals(expected, result)
   }
@@ -67,8 +65,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            null),
+            )),
         searchAccessions(facilityId, fields, searchNode))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
@@ -23,8 +23,7 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
             listOf(
                 mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
                 mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-            ),
-            cursor = null)
+            ))
 
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
@@ -39,7 +38,7 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
     val fields = listOf(accessionNumberField)
     val sortOrder = fields.map { SearchSortField(it) }
 
-    val expected = SearchResults(emptyList(), cursor = null)
+    val expected = SearchResults(emptyList())
 
     val actual =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
@@ -25,8 +25,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "plantsCollectedFrom" to "500")),
-            cursor = null)
+                    "plantsCollectedFrom" to "500")))
 
     assertEquals(expected, result)
   }
@@ -42,8 +41,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "plantsCollectedFrom" to "1")),
-            cursor = null)
+            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "plantsCollectedFrom" to "1")))
 
     assertEquals(expected, result)
   }
@@ -63,8 +61,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1001",
                     "accessionNumber" to "ABCDEFG",
-                    "plantsCollectedFrom" to "500")),
-            cursor = null)
+                    "plantsCollectedFrom" to "500")))
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -22,11 +22,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
     val result = searchService.search(rootPrefix, fields, criteria)
 
     val expected =
-        SearchResults(
-            listOf(
-                mapOf("estimatedCount" to "12,000", "estimatedCount(raw)" to "12000"),
-            ),
-            cursor = null)
+        SearchResults(listOf(mapOf("estimatedCount" to "12,000", "estimatedCount(raw)" to "12000")))
 
     assertEquals(expected, result)
   }
@@ -74,9 +70,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
                     "species_rare(raw)" to "false",
                     "state(raw)" to "In Storage",
                     "totalWithdrawnWeightGrams(raw)" to "5000",
-                ),
-            ),
-            cursor = null)
+                )))
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUriFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUriFieldTest.kt
@@ -60,8 +60,8 @@ internal class SearchServiceUriFieldTest : SearchServiceTest() {
     val result3 = searchService.search(prefix, fields, criteria3)
 
     val expected1 = SearchResults(listOf(searchResult1, searchResult2), cursor = null)
-    val expected2 = SearchResults(listOf(searchResult1), cursor = null)
-    val expected3 = SearchResults(listOf(searchResult3), cursor = null)
+    val expected2 = SearchResults(listOf(searchResult1))
+    val expected3 = SearchResults(listOf(searchResult3))
 
     assertEquals(expected1, result1)
     assertEquals(expected2, result2)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -78,8 +78,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                                             listOf(
                                                 mapOf(
                                                     "organization" to
-                                                        mapOf("id" to "$organizationId")))))))),
-            null)
+                                                        mapOf("id" to "$organizationId")))))))))
 
     val actual = searchService.search(organizationsPrefix, fields, NoConditionNode(), sortOrder)
 
@@ -104,8 +103,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                 mapOf(
                     "id" to "$bothOrgsUserId",
                     "organizationMemberships_organization_id" to "$organizationId",
-                )),
-            null)
+                )))
 
     val actual = searchService.search(usersPrefix, fields, NoConditionNode(), sortOrder)
 
@@ -119,8 +117,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
     val sortOrder = fields.map { SearchSortField(it) }
 
     val expected =
-        SearchResults(
-            listOf(mapOf("id" to "${user.userId}"), mapOf("id" to "$bothOrgsUserId")), null)
+        SearchResults(listOf(mapOf("id" to "${user.userId}"), mapOf("id" to "$bothOrgsUserId")))
 
     val actual = searchService.search(usersPrefix, fields, NoConditionNode(), sortOrder)
 
@@ -154,8 +151,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                 mapOf(
                     "organization_id" to "$organizationId",
                     "roleName" to Role.Admin.getDisplayName(Locale.ENGLISH),
-                )),
-            null)
+                )))
 
     val actual = searchService.search(membersPrefix, fields, criteria, sortOrder)
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceWeightTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceWeightTest.kt
@@ -43,8 +43,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
             listOf("900000 Milligrams", "650,000.000001 Pounds"),
             SearchFilterType.Range)
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -58,8 +57,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(remainingGramsField, listOf("1000"))
 
-    val expected =
-        SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")), cursor = null)
+    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -100,8 +98,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
                     "remainingKilograms" to "1",
                     "remainingMilligrams" to "1,000,000",
                     "remainingOunces" to "35.274",
-                    "remainingPounds" to "2.20462")),
-            cursor = null)
+                    "remainingPounds" to "2.20462")))
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -119,8 +116,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
           val searchNode = FieldNode(remainingPoundsField, listOf("2.205"), SearchFilterType.Fuzzy)
 
           val expected =
-              SearchResults(
-                  listOf(mapOf("accessionNumber" to "ABCDEFG", "id" to "1001")), cursor = null)
+              SearchResults(listOf(mapOf("accessionNumber" to "ABCDEFG", "id" to "1001")))
 
           val result = searchAccessions(facilityId, emptyList(), searchNode)
 
@@ -133,8 +129,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
               SearchResults(
                   listOf(
                       mapOf("accessionNumber" to "ABCDEFG", "id" to "1001"),
-                      mapOf("accessionNumber" to "XYZ", "id" to "1000")),
-                  cursor = null)
+                      mapOf("accessionNumber" to "XYZ", "id" to "1000")))
 
           val result = searchAccessions(facilityId, emptyList(), searchNode)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -286,8 +286,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                             "id" to "$projectId",
                             "modifiedTime" to "1970-01-01T00:00:00Z",
                             "name" to "Project 1"),
-                    "totalPlants" to "6")),
-            null)
+                    "totalPlants" to "6")))
 
     val prefix = SearchFieldPrefix(searchTables.plantingSites)
     val fields =
@@ -363,7 +362,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
 
     val prefix = SearchFieldPrefix(root = searchTables.plantingSubzones)
 
-    val expected = SearchResults(emptyList(), null)
+    val expected = SearchResults(emptyList())
     val actual = searchService.search(prefix, listOf(prefix.resolve("id")), NoConditionNode())
 
     assertEquals(expected, actual)


### PR DESCRIPTION
Having to explicitly set the search results cursor to `null` adds clutter to
tests. Make the field default to null and remove the explicit null values from
all the tests. Tests that pass non-null values (to test that cursors work) are
unchanged here.