### PR TITLE
Ensure a species deliverable submission when a species are added to a project

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.ParticipantProjectSpeciesStore
+import com.terraformation.backend.accelerator.db.SubmissionStore
+import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
+import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import jakarta.inject.Named
+
+@Named
+class ParticipantProjectSpeciesService(
+    private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore,
+    private val submissionStore: SubmissionStore,
+) {
+  /** Creates a new participant project species, possibly creating a deliverable submission. */
+  fun create(model: NewParticipantProjectSpeciesModel): ExistingParticipantProjectSpeciesModel {
+    val existingModel = participantProjectSpeciesStore.create(model)
+
+    // If a submission doesn't exist for the deliverable, create one
+    val deliverableSubmission =
+        submissionStore.fetchActiveSpeciesDeliverableSubmission(model.projectId)
+    if (deliverableSubmission.submissionId == null) {
+      submissionStore.createSubmission(deliverableSubmission.deliverableId, model.projectId)
+    }
+
+    return existingModel
+  }
+
+  /**
+   * Creates a participant project species for each projectId - speciesId combination and create a
+   * species deliverable submission for each project that doesn't have one
+   */
+  fun create(projectIds: Set<ProjectId>, speciesIds: Set<SpeciesId>): Unit {
+    participantProjectSpeciesStore.create(projectIds, speciesIds)
+
+    projectIds.forEach {
+      // A submission must exist for every project that is getting a new species assigned
+      val deliverableSubmission = submissionStore.fetchActiveSpeciesDeliverableSubmission(it)
+      if (deliverableSubmission.submissionId == null) {
+        submissionStore.createSubmission(deliverableSubmission.deliverableId, it)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -35,8 +35,8 @@ class ParticipantProjectSpeciesService(
    * Creates a participant project species for each projectId - speciesId combination and create a
    * species deliverable submission for each project that doesn't have one
    */
-  fun create(projectIds: Set<ProjectId>, speciesIds: Set<SpeciesId>): Unit {
-    return dslContext.transaction { _ ->
+  fun create(projectIds: Set<ProjectId>, speciesIds: Set<SpeciesId>) {
+    dslContext.transaction { _ ->
       participantProjectSpeciesStore.create(projectIds, speciesIds)
 
       projectIds.forEach {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -36,7 +36,7 @@ class ParticipantProjectSpeciesController(
   fun assignParticipantProjectSpecies(
       @RequestBody payload: AssignParticipantProjectSpeciesPayload
   ): SimpleSuccessResponsePayload {
-    participantProjectSpeciesStore.createMany(payload.projectIds, payload.speciesIds)
+    participantProjectSpeciesStore.create(payload.projectIds, payload.speciesIds)
     return SimpleSuccessResponsePayload()
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.api
 
+import com.terraformation.backend.accelerator.ParticipantProjectSpeciesService
 import com.terraformation.backend.accelerator.db.ParticipantProjectSpeciesStore
 import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
 import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/accelerator/projects/species")
 @RestController
 class ParticipantProjectSpeciesController(
+    private val participantProjectSpeciesService: ParticipantProjectSpeciesService,
     private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore,
 ) {
   @ApiResponse200
@@ -36,7 +38,7 @@ class ParticipantProjectSpeciesController(
   fun assignParticipantProjectSpecies(
       @RequestBody payload: AssignParticipantProjectSpeciesPayload
   ): SimpleSuccessResponsePayload {
-    participantProjectSpeciesStore.create(payload.projectIds, payload.speciesIds)
+    participantProjectSpeciesService.create(payload.projectIds, payload.speciesIds)
     return SimpleSuccessResponsePayload()
   }
 
@@ -47,7 +49,7 @@ class ParticipantProjectSpeciesController(
       @RequestBody payload: CreateParticipantProjectSpeciesPayload
   ): GetParticipantProjectSpeciesResponsePayload {
     val model =
-        participantProjectSpeciesStore.create(
+        participantProjectSpeciesService.create(
             NewParticipantProjectSpeciesModel(
                 id = null,
                 projectId = payload.projectId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -33,6 +33,9 @@ class ParticipantNotFoundException(id: ParticipantId) :
 class ParticipantProjectSpeciesNotFoundException(id: ParticipantProjectSpeciesId) :
     EntityNotFoundException("Participant Project Species $id not found")
 
+class ParticipantProjectSpeciesProjectNotFoundException(id: ProjectId) :
+    EntityNotFoundException("Participant Project Species for project $id not found")
+
 class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
     MismatchedStateException("Project $id document upload settings have not been configured")
 
@@ -52,6 +55,9 @@ class ProjectVoteNotFoundException(
 ) :
     EntityNotFoundException(
         "Vote not found for project $projectId, phase ${phase?.id}, user $userId")
+
+class SpeciesDeliverableNotFoundException(id: ProjectId) :
+    EntityNotFoundException("Species Deliverable for project $id not found")
 
 class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
     EntityNotFoundException("Submission document $id not found")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -80,8 +80,6 @@ class SubmissionStore(
             .on(
                 DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID),
                 PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
-            .join(ORGANIZATIONS)
-            .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
             .where(COHORT_MODULES.START_DATE.lessOrEqual(today))
             .and(COHORT_MODULES.END_DATE.greaterOrEqual(today))
             .and(PROJECTS.ID.eq(projectId))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -76,7 +76,7 @@ class SubmissionStore(
             .on(COHORT_MODULES.COHORT_ID.eq(PARTICIPANTS.COHORT_ID))
             .join(PROJECTS)
             .on(PARTICIPANTS.ID.eq(PROJECTS.PARTICIPANT_ID))
-            .fullOuterJoin(SUBMISSIONS)
+            .leftOuterJoin(SUBMISSIONS)
             .on(
                 DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID),
                 PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
@@ -86,7 +86,6 @@ class SubmissionStore(
             .and(COHORT_MODULES.END_DATE.greaterOrEqual(today))
             .and(PROJECTS.ID.eq(projectId))
             .and(DELIVERABLES.DELIVERABLE_TYPE_ID.eq(DeliverableType.Species))
-            .orderBy(DELIVERABLES.ID, PROJECTS.ID)
             .fetchOne { ExistingSpeciesDeliverableSubmissionModel.of(it) }
             ?: throw SpeciesDeliverableNotFoundException(projectId)
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.i18n.TimeZones
 import jakarta.inject.Named

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesDeliverableSubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesDeliverableSubmissionModel.kt
@@ -12,14 +12,9 @@ data class ExistingSpeciesDeliverableSubmissionModel(
 ) {
   companion object {
     fun of(record: Record): ExistingSpeciesDeliverableSubmissionModel {
-      if (record[SUBMISSIONS.ID] == null) {
-        return ExistingSpeciesDeliverableSubmissionModel(
-            deliverableId = record[DELIVERABLES.ID]!!, submissionId = null)
-      }
-
       return ExistingSpeciesDeliverableSubmissionModel(
           deliverableId = record[DELIVERABLES.ID]!!,
-          submissionId = record[SUBMISSIONS.ID]!!,
+          submissionId = record[SUBMISSIONS.ID],
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesDeliverableSubmissionModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesDeliverableSubmissionModel.kt
@@ -1,0 +1,26 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
+import org.jooq.Record
+
+data class ExistingSpeciesDeliverableSubmissionModel(
+    val deliverableId: DeliverableId,
+    val submissionId: SubmissionId? = null
+) {
+  companion object {
+    fun of(record: Record): ExistingSpeciesDeliverableSubmissionModel {
+      if (record[SUBMISSIONS.ID] == null) {
+        return ExistingSpeciesDeliverableSubmissionModel(
+            deliverableId = record[DELIVERABLES.ID]!!, submissionId = null)
+      }
+
+      return ExistingSpeciesDeliverableSubmissionModel(
+          deliverableId = record[DELIVERABLES.ID]!!,
+          submissionId = record[SUBMISSIONS.ID]!!,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesServiceTest.kt
@@ -1,0 +1,160 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.ParticipantProjectSpeciesService
+import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
+import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+
+  private val service: ParticipantProjectSpeciesService by lazy {
+    ParticipantProjectSpeciesService(
+        ParticipantProjectSpeciesStore(dslContext, participantProjectSpeciesDao, projectsDao),
+        SubmissionStore(clock, dslContext, eventPublisher))
+  }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+
+    every { user.canCreateParticipantProjectSpecies(any()) } returns true
+    every { user.canCreateSubmission(any()) } returns true
+    every { user.canReadProject(any()) } returns true
+    every { user.canReadProjectDeliverables(any()) } returns true
+  }
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `creates a submission for the project and deliverable if one does not exist for the active module when a species is added to a project`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+      val speciesId = insertSpecies()
+      val moduleId = insertModule()
+      val deliverableId =
+          insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
+
+      val participantProjectSpecies =
+          service.create(
+              NewParticipantProjectSpeciesModel(
+                  feedback = "feedback",
+                  id = null,
+                  projectId = projectId,
+                  rationale = "rationale",
+                  speciesId = speciesId))
+
+      assertEquals(
+          ParticipantProjectSpeciesRow(
+              feedback = "feedback",
+              id = participantProjectSpecies.id,
+              projectId = projectId,
+              rationale = "rationale",
+              speciesId = speciesId,
+              submissionStatusId = SubmissionStatus.NotSubmitted),
+          participantProjectSpeciesDao.fetchOneById(participantProjectSpecies.id))
+
+      val userId = currentUser().userId
+      val now = clock.instant
+
+      assertEquals(
+          listOf(
+              SubmissionsRow(
+                  createdBy = userId,
+                  createdTime = now,
+                  deliverableId = deliverableId,
+                  modifiedBy = userId,
+                  modifiedTime = now,
+                  projectId = projectId,
+                  submissionStatusId = SubmissionStatus.NotSubmitted)),
+          submissionsDao.fetchByDeliverableId(deliverableId).map { it.copy(id = null) })
+    }
+
+    @Test
+    fun `creates an entity for each project ID and species ID pairing and ensures there is a submission for each project deliverable`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val moduleId = insertModule()
+      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
+      val deliverableId =
+          insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+
+      val projectId1 = insertProject(participantId = participantId)
+      val projectId2 = insertProject(participantId = participantId)
+      val speciesId1 = insertSpecies()
+      val speciesId2 = insertSpecies()
+
+      service.create(setOf(projectId1, projectId2), setOf(speciesId1, speciesId2))
+
+      assertEquals(
+          listOf(
+              ParticipantProjectSpeciesRow(
+                  feedback = null,
+                  projectId = projectId1,
+                  rationale = null,
+                  speciesId = speciesId1,
+                  submissionStatusId = SubmissionStatus.NotSubmitted),
+              ParticipantProjectSpeciesRow(
+                  feedback = null,
+                  projectId = projectId1,
+                  rationale = null,
+                  speciesId = speciesId2,
+                  submissionStatusId = SubmissionStatus.NotSubmitted),
+              ParticipantProjectSpeciesRow(
+                  feedback = null,
+                  projectId = projectId2,
+                  rationale = null,
+                  speciesId = speciesId1,
+                  submissionStatusId = SubmissionStatus.NotSubmitted),
+              ParticipantProjectSpeciesRow(
+                  feedback = null,
+                  projectId = projectId2,
+                  rationale = null,
+                  speciesId = speciesId2,
+                  submissionStatusId = SubmissionStatus.NotSubmitted)),
+          participantProjectSpeciesDao.findAll().map { it.copy(id = null) })
+
+      val userId = currentUser().userId
+      val now = clock.instant
+
+      assertEquals(
+          listOf(
+              SubmissionsRow(
+                  createdBy = userId,
+                  createdTime = now,
+                  deliverableId = deliverableId,
+                  modifiedBy = userId,
+                  modifiedTime = now,
+                  projectId = projectId1,
+                  submissionStatusId = SubmissionStatus.NotSubmitted),
+              SubmissionsRow(
+                  createdBy = userId,
+                  createdTime = now,
+                  deliverableId = deliverableId,
+                  modifiedBy = userId,
+                  modifiedTime = now,
+                  projectId = projectId2,
+                  submissionStatusId = SubmissionStatus.NotSubmitted)),
+          submissionsDao.fetchByDeliverableId(deliverableId).map { it.copy(id = null) })
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesServiceTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.SubmissionStatus
-import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -54,24 +53,13 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
       insertCohortModule(cohortId = cohortId, moduleId = moduleId)
 
-      val participantProjectSpecies =
-          service.create(
-              NewParticipantProjectSpeciesModel(
-                  feedback = "feedback",
-                  id = null,
-                  projectId = projectId,
-                  rationale = "rationale",
-                  speciesId = speciesId))
-
-      assertEquals(
-          ParticipantProjectSpeciesRow(
+      service.create(
+          NewParticipantProjectSpeciesModel(
               feedback = "feedback",
-              id = participantProjectSpecies.id,
+              id = null,
               projectId = projectId,
               rationale = "rationale",
-              speciesId = speciesId,
-              submissionStatusId = SubmissionStatus.NotSubmitted),
-          participantProjectSpeciesDao.fetchOneById(participantProjectSpecies.id))
+              speciesId = speciesId))
 
       val userId = currentUser().userId
       val now = clock.instant
@@ -104,34 +92,6 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val speciesId2 = insertSpecies()
 
       service.create(setOf(projectId1, projectId2), setOf(speciesId1, speciesId2))
-
-      assertEquals(
-          listOf(
-              ParticipantProjectSpeciesRow(
-                  feedback = null,
-                  projectId = projectId1,
-                  rationale = null,
-                  speciesId = speciesId1,
-                  submissionStatusId = SubmissionStatus.NotSubmitted),
-              ParticipantProjectSpeciesRow(
-                  feedback = null,
-                  projectId = projectId1,
-                  rationale = null,
-                  speciesId = speciesId2,
-                  submissionStatusId = SubmissionStatus.NotSubmitted),
-              ParticipantProjectSpeciesRow(
-                  feedback = null,
-                  projectId = projectId2,
-                  rationale = null,
-                  speciesId = speciesId1,
-                  submissionStatusId = SubmissionStatus.NotSubmitted),
-              ParticipantProjectSpeciesRow(
-                  feedback = null,
-                  projectId = projectId2,
-                  rationale = null,
-                  speciesId = speciesId2,
-                  submissionStatusId = SubmissionStatus.NotSubmitted)),
-          participantProjectSpeciesDao.findAll().map { it.copy(id = null) })
 
       val userId = currentUser().userId
       val now = clock.instant

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -358,41 +358,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
         store.update(participantProjectSpeciesId) { it.copy(feedback = "Needs some work") }
       }
     }
-
-    //    @Test
-    //    fun `publishes event if status has changed`() {
-    //      val cohortId = insertCohort()
-    //      val participantId = insertParticipant(cohortId = cohortId)
-    //      val projectId = insertProject(participantId = participantId)
-    //      val speciesId = insertSpecies()
-    //      val participantProjectSpeciesId =
-    //          insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
-    //      val moduleId = insertModule()
-    //      val deliverableId = insertDeliverable(moduleId = moduleId)
-    //      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
-    //
-    //      every { user.canUpdateParticipantProjectSpecies(participantProjectSpeciesId) } returns
-    // true
-    //
-    //      store.update(participantProjectSpeciesId) {
-    //        it.copy(submissionStatus = SubmissionStatus.Approved)
-    //      }
-    //
-    //      eventPublisher.assertEventPublished(
-    //          ParticipantProjectSpeciesEditedEvent(deliverableId, projectId))
-    //    }
-
-    //    @Test
-    //    fun `does not publish event if status has not changed`() {
-    //      val projectId = insertProject()
-    //      val deliverableId = insertDeliverable()
-    //      insertSubmission(submissionStatus = SubmissionStatus.InReview)
-    //
-    //      store.updateSubmissionStatus(
-    //          deliverableId, projectId, SubmissionStatus.InReview, null, "This is amazing")
-    //
-    //      eventPublisher.assertNoEventsPublished()
-    //    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -42,7 +42,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     every { user.canCreateParticipantProjectSpecies(any()) } returns true
     every { user.canCreateSubmission(any()) } returns true
-    every { user.canDeleteParticipantProjectSpecies(any()) } returns true
     every { user.canReadParticipantProjectSpecies(any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectDeliverables(any()) } returns true
@@ -401,7 +400,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val participantProjectSpeciesId2 =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId2)
 
-      every { user.canDeleteParticipantProjectSpecies(any()) } returns false
+      every { user.canDeleteParticipantProjectSpecies(participantProjectSpeciesId1) } returns true
+      every { user.canDeleteParticipantProjectSpecies(participantProjectSpeciesId2) } returns false
 
       assertThrows<AccessDeniedException> {
         store.delete(setOf(participantProjectSpeciesId1, participantProjectSpeciesId2))

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -375,6 +375,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val participantProjectSpeciesId3 =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId3)
 
+      every { user.canDeleteParticipantProjectSpecies(any()) } returns true
+
       store.delete(setOf(participantProjectSpeciesId1, participantProjectSpeciesId2))
 
       assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProject
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -30,9 +29,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   private val store: ParticipantProjectSpeciesStore by lazy {
     ParticipantProjectSpeciesStore(
-        clock,
         dslContext,
-        eventPublisher,
         participantProjectSpeciesDao,
         projectsDao,
         SubmissionStore(clock, dslContext, eventPublisher))
@@ -70,7 +67,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           ExistingParticipantProjectSpeciesModel(
               feedback = "feedback",
               id = participantProjectSpeciesId,
-              modifiedTime = Instant.EPOCH,
               projectId = projectId,
               rationale = "rationale",
               speciesId = speciesId,
@@ -153,7 +149,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           ParticipantProjectSpeciesRow(
               feedback = "feedback",
               id = participantProjectSpecies.id,
-              modifiedTime = Instant.EPOCH,
               projectId = projectId,
               rationale = "rationale",
               speciesId = speciesId,
@@ -185,7 +180,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           ParticipantProjectSpeciesRow(
               feedback = "feedback",
               id = participantProjectSpecies.id,
-              modifiedTime = Instant.EPOCH,
               projectId = projectId,
               rationale = "rationale",
               speciesId = speciesId,
@@ -264,28 +258,24 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           listOf(
               ParticipantProjectSpeciesRow(
                   feedback = null,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId1,
                   rationale = null,
                   speciesId = speciesId1,
                   submissionStatusId = SubmissionStatus.NotSubmitted),
               ParticipantProjectSpeciesRow(
                   feedback = null,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId1,
                   rationale = null,
                   speciesId = speciesId2,
                   submissionStatusId = SubmissionStatus.NotSubmitted),
               ParticipantProjectSpeciesRow(
                   feedback = null,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId2,
                   rationale = null,
                   speciesId = speciesId1,
                   submissionStatusId = SubmissionStatus.NotSubmitted),
               ParticipantProjectSpeciesRow(
                   feedback = null,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId2,
                   rationale = null,
                   speciesId = speciesId2,
@@ -339,7 +329,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
           ParticipantProjectSpeciesRow(
               feedback = "Looks good",
               id = participantProjectSpeciesId,
-              modifiedTime = Instant.EPOCH,
               projectId = projectId,
               speciesId = speciesId,
               submissionStatusId = SubmissionStatus.Approved),
@@ -429,7 +418,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ParticipantProjectSpeciesRow(
                   feedback = null,
                   id = participantProjectSpeciesId3,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId,
                   rationale = null,
                   speciesId = speciesId3,
@@ -461,7 +449,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ParticipantProjectSpeciesRow(
                   feedback = null,
                   id = participantProjectSpeciesId1,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId,
                   rationale = null,
                   speciesId = speciesId1,
@@ -469,7 +456,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ParticipantProjectSpeciesRow(
                   feedback = null,
                   id = participantProjectSpeciesId2,
-                  modifiedTime = Instant.EPOCH,
                   projectId = projectId,
                   rationale = null,
                   speciesId = speciesId2,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -60,8 +61,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
       insertCohortModule(cohortId = cohortId, moduleId = moduleIdFuture)
       insertDeliverable(moduleId = moduleIdFuture, deliverableTypeId = DeliverableType.Species)
 
-      // epoch + 7 days
-      clock.instant = Instant.EPOCH.plusSeconds(60 * 60 * 24 * 7)
+      clock.instant = Instant.EPOCH.plus(7, ChronoUnit.DAYS)
 
       assertEquals(
           ExistingSpeciesDeliverableSubmissionModel(
@@ -99,8 +99,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
           insertDeliverable(moduleId = moduleIdFuture, deliverableTypeId = DeliverableType.Species)
       insertSubmission(deliverableId = deliverableIdFuture, projectId = projectId)
 
-      // epoch + 7 days
-      clock.instant = Instant.EPOCH.plusSeconds(60 * 60 * 24 * 7)
+      clock.instant = Instant.EPOCH.plus(7, ChronoUnit.DAYS)
 
       assertEquals(
           ExistingSpeciesDeliverableSubmissionModel(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -110,17 +110,6 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
           ),
           store.fetchActiveSpeciesDeliverableSubmission(projectId))
     }
-
-    //    @Test
-    //    fun `throws exception if no permission to read submissions`() {
-    //      insertProject()
-    //      insertDeliverable()
-    //      val submissionId = insertSubmission()
-    //
-    //      every { user.canReadSubmission(submissionId) } returns false
-    //
-    //      assertThrows<SubmissionNotFoundException> { store.fetchOneById(submissionId) }
-    //    }
   }
 
   @Nested


### PR DESCRIPTION
- Adds a function to get the active species deliverable for a project if it exists
- Added service class `ParticipantProjectSpeciesService` which ensures a deliverable submission exists for the project when a species is added to a project with an active species deliverable
