### PR TITLE
Add DSL for constructing planting sites in tests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -135,6 +135,20 @@ data class PlantingSiteModel<
         gridOrigin.equalsOrBothNull(other.gridOrigin)
   }
 
+  fun toNew(): NewPlantingSiteModel =
+      create(
+          areaHa,
+          boundary,
+          description,
+          exclusion,
+          gridOrigin,
+          name,
+          organizationId,
+          plantingSeasons,
+          plantingZones.map { it.toNew() },
+          projectId,
+          timeZone)
+
   companion object {
     /**
      * Maximum percentage of a zone or subzone that can overlap with a neighboring one before

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -31,6 +31,9 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
         boundary.equalsExact(other.boundary, tolerance)
   }
 
+  fun toNew(): NewPlantingSubzoneModel =
+      create(boundary, fullName, name, areaHa, plantingCompletedTime, monitoringPlots)
+
   companion object {
     fun create(
         boundary: MultiPolygon,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -389,6 +389,20 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
         boundary.equalsExact(other.boundary, tolerance)
   }
 
+  fun toNew(): NewPlantingZoneModel =
+      create(
+          boundary,
+          name,
+          plantingSubzones.map { it.toNew() },
+          areaHa,
+          errorMargin,
+          extraPermanentClusters,
+          numPermanentClusters,
+          numTemporaryPlots,
+          studentsT,
+          targetPlantingDensity,
+          variance)
+
   companion object {
     // Default values of the three parameters that determine how many monitoring plots should be
     // required in each observation. The "Student's t" value is a constant based on an 80%

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.util.Turtle
+import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.locationtech.jts.geom.Coordinate
@@ -78,6 +80,37 @@ fun multiPolygon(polygon: Polygon): MultiPolygon {
 fun multiPolygon(scale: Number): MultiPolygon {
   return multiPolygon(polygon(scale))
 }
+
+/** Returns a rectangular MultiPolygon with position and size in meters. */
+fun rectangle(
+    width: Number,
+    height: Number = width,
+    x: Number = 0,
+    y: Number = 0,
+): MultiPolygon =
+    Turtle(point(1))
+        .makeMultiPolygon {
+          north(y)
+          east(x)
+          rectangle(width, height)
+        }
+        .norm()
+        .toMultiPolygon()
+
+/** Returns a rectangular Polygon with position and size in meters. */
+fun rectanglePolygon(
+    width: Number,
+    height: Number = width,
+    x: Number = 0,
+    y: Number = 0,
+): Polygon =
+    Turtle(point(1))
+        .makePolygon {
+          north(y)
+          east(x)
+          rectangle(width, height)
+        }
+        .norm() as Polygon
 
 /**
  * Returns dummy information about Keycloak. This can be used to test code that generates

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -121,8 +121,8 @@ private constructor(
   fun zone(
       x: Int = nextZoneX,
       y: Int = 0,
-      width: Int = this.width + this.x - x,
-      height: Int = this.height + this.y - y,
+      width: Int = this.width - (x - this.x),
+      height: Int = this.height - (y - this.y),
       name: String? = null,
       func: ZoneBuilder.() -> Unit = {}
   ): ExistingPlantingZoneModel {
@@ -168,8 +168,8 @@ private constructor(
     fun subzone(
         x: Int = nextSubzoneX,
         y: Int = 0,
-        width: Int = this.width + this.x - x,
-        height: Int = this.height + this.y - y,
+        width: Int = this.width - (x - this.x),
+        height: Int = this.height - (y - this.y),
         name: String? = null,
         func: SubzoneBuilder.() -> Unit = {},
     ): ExistingPlantingSubzoneModel {

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -47,14 +47,18 @@ import org.locationtech.jts.geom.PrecisionModel
  *
  * Returns a planting site with:
  * - A boundary of 1000 by 500 meters
- * - Zone Z1 with a boundary of 400 by 500 meters on the west edge of the site
- *     - Subzone S1 with a boundary of 150 by 500 meters on the west edge of the zone
+ * - Zone Z1 with a boundary of 400 by 500 meters whose southwest corner is the southwest corner of
+ *   the site's boundary
+ *     - Subzone S1 with a boundary of 150 by 500 meters whose southwest corner is the southwest
+ *       corner of the zone (and thus of the site)
  *         - Cluster 1 with plots 1, 2, 3, 4 arranged counterclockwise starting at the southwest
- *           corner of the subzone
- *         - Plot 5 immediately to the east of plot 2 (50 meters east of the subzone's SW corner)
+ *           corner of the subzone, that is, at coordinates (0,0), (25,0), (25,25), and (0,25) in
+ *           meters relative to the subzone's southwest corner
+ *         - Plot 5 immediately to the east of plot 2, that is, at coordinates (50,0) relative to
+ *           the subzone's southwest corner
  *     - Subzone S2 with a boundary of 250 by 500 meters, filling the remaining space in Z1
  * - Zone Z2 with a boundary of 600 by 500 meters (filling the remaining space in the site)
- *   immediately east of Z1
+ *   immediately east of Z1, that is at coordinates (400,0) relative to the zone's southwest corner
  *     - Subzone S3 with the same boundary as Z2
  */
 class PlantingSiteBuilder

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -1,0 +1,270 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.SRID
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.rectangle
+import com.terraformation.backend.rectanglePolygon
+import com.terraformation.backend.util.calculateAreaHectares
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.PrecisionModel
+
+/**
+ * DSL for building planting site models with simple maps to test operations on site/zone/subzone
+ * geometry. The different layers of the map are all rectangular and are laid out horizontally
+ * starting at the southwest corner of the parent area.
+ *
+ * The DSL aims for succinctness and will try to build a simple but complete site if the caller
+ * doesn't specify otherwise.
+ *
+ * By default, each layer fills the remaining area of its parent. If a site has no zones, one is
+ * created by default, and if a zone has no subzones, one is created by default.
+ *
+ * Intended usage is to import the [existingSite] and/or [newSite] functions and optionally pass
+ * lambda functions to them to configure the child areas. Simple usage:
+ *
+ *     existingSite()
+ *
+ * Returns a planting site 500 by 500 meters, with a single zone 500 by 500 meters, with a single
+ * subzone 500 by 500 meters.
+ *
+ * More complex usage:
+ *
+ *     existingSite(width = 1000) {
+ *       zone(width = 400) {
+ *         subzone(width = 150) {
+ *           cluster()
+ *           plot()
+ *         }
+ *         subzone()
+ *       }
+ *       zone()
+ *     }
+ *
+ * Returns a planting site with:
+ * - A boundary of 1000 by 500 meters
+ * - Zone Z1 with a boundary of 400 by 500 meters on the west edge of the site
+ *     - Subzone S1 with a boundary of 150 by 500 meters on the west edge of the zone
+ *         - Cluster 1 with plots 1, 2, 3, 4 arranged counterclockwise starting at the southwest
+ *           corner of the subzone
+ *         - Plot 5 immediately to the east of plot 2 (50 meters east of the subzone's SW corner)
+ *     - Subzone S2 with a boundary of 250 by 500 meters, filling the remaining space in Z1
+ * - Zone Z2 with a boundary of 600 by 500 meters (filling the remaining space in the site)
+ *   immediately east of Z1
+ *     - Subzone S3 with the same boundary as Z2
+ */
+class PlantingSiteBuilder
+private constructor(
+    private val x: Int,
+    private val y: Int,
+    private val width: Int,
+    private val height: Int,
+) {
+  companion object {
+    /**
+     * Returns a planting site where all the component parts have non-null IDs. See
+     * [PlantingSiteBuilder] for usage.
+     */
+    fun existingSite(
+        x: Int = 0,
+        y: Int = 0,
+        width: Int = 500,
+        height: Int = 500,
+        func: PlantingSiteBuilder.() -> Unit = {},
+    ): ExistingPlantingSiteModel {
+      val builder = PlantingSiteBuilder(x, y, width, height)
+      builder.func()
+      return builder.build()
+    }
+
+    /**
+     * Returns a planting site where all of the component parts have null IDs. Monitoring plots are
+     * discarded. See [PlantingSiteBuilder] for usage.
+     */
+    fun newSite(
+        x: Int = 0,
+        y: Int = 0,
+        width: Int = 500,
+        height: Int = 500,
+        func: PlantingSiteBuilder.() -> Unit = {}
+    ): NewPlantingSiteModel = existingSite(x, y, width, height, func).toNew()
+  }
+
+  var boundary: MultiPolygon = rectangle(width, height, x, y)
+  var exclusion: MultiPolygon? = null
+  var name: String = "Site"
+
+  private var currentSubzoneId: Long = 0
+  private var currentZoneId: Long = 0
+  private val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+  private var nextMonitoringPlotId: Long = 1
+  private var nextZoneX = x
+  private val plantingZones = mutableListOf<ExistingPlantingZoneModel>()
+
+  fun build(): ExistingPlantingSiteModel {
+    return ExistingPlantingSiteModel(
+        areaHa = boundary.calculateAreaHectares(),
+        boundary = boundary,
+        exclusion = exclusion,
+        gridOrigin = geometryFactory.createPoint(boundary.envelope.coordinates[0]),
+        id = PlantingSiteId(1),
+        name = name,
+        organizationId = OrganizationId(1),
+        plantingZones = plantingZones.ifEmpty { listOf(zone()) },
+    )
+  }
+
+  fun zone(
+      x: Int = nextZoneX,
+      y: Int = 0,
+      width: Int = this.width + this.x - x,
+      height: Int = this.height + this.y - y,
+      name: String? = null,
+      func: ZoneBuilder.() -> Unit = {}
+  ): ExistingPlantingZoneModel {
+    ++currentZoneId
+
+    val builder = ZoneBuilder(x, y, width, height, name ?: "Z$currentZoneId")
+    builder.func()
+
+    nextZoneX = x + width
+
+    val newZone = builder.build()
+    plantingZones.add(newZone)
+    return newZone
+  }
+
+  inner class ZoneBuilder(
+      private val x: Int,
+      private val y: Int,
+      private val width: Int,
+      private val height: Int,
+      val name: String,
+  ) {
+    var numPermanentClusters: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS
+    var numTemporaryPlots: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS
+
+    private val boundary: MultiPolygon = rectangle(width, height, x, y)
+    private var nextPermanentCluster = 1
+    private var nextSubzoneX = x
+    private val plantingSubzones = mutableListOf<ExistingPlantingSubzoneModel>()
+
+    fun build(): ExistingPlantingZoneModel {
+      return ExistingPlantingZoneModel(
+          areaHa = boundary.calculateAreaHectares(),
+          boundary = boundary,
+          name = name,
+          id = PlantingZoneId(currentZoneId),
+          numPermanentClusters = numPermanentClusters,
+          numTemporaryPlots = numTemporaryPlots,
+          plantingSubzones = plantingSubzones.ifEmpty { listOf(subzone()) },
+      )
+    }
+
+    fun subzone(
+        x: Int = nextSubzoneX,
+        y: Int = 0,
+        width: Int = this.width + this.x - x,
+        height: Int = this.height + this.y - y,
+        name: String? = null,
+        func: SubzoneBuilder.() -> Unit = {},
+    ): ExistingPlantingSubzoneModel {
+      ++currentSubzoneId
+
+      val builder = SubzoneBuilder(x, y, width, height, name ?: "S$currentSubzoneId", this.name)
+      builder.func()
+
+      nextSubzoneX = x + width
+
+      val newSubzone = builder.build()
+      plantingSubzones.add(newSubzone)
+      return newSubzone
+    }
+
+    inner class SubzoneBuilder(
+        x: Int,
+        private val y: Int,
+        width: Int,
+        height: Int,
+        val name: String,
+        zoneName: String,
+    ) {
+      private val boundary: MultiPolygon = rectangle(width, height, x, y)
+      private val fullName: String = "$zoneName-$name"
+      private var lastCluster: Int? = null
+      private val monitoringPlots = mutableListOf<MonitoringPlotModel>()
+      private var nextMonitoringPlotX: Int = x
+      private var nextSubplot: Int = 1
+
+      fun build(): ExistingPlantingSubzoneModel {
+        return ExistingPlantingSubzoneModel(
+            areaHa = boundary.calculateAreaHectares(),
+            boundary = boundary,
+            fullName = fullName,
+            id = PlantingSubzoneId(currentSubzoneId),
+            monitoringPlots = monitoringPlots,
+            name = name,
+        )
+      }
+
+      fun plot(
+          x: Int = nextMonitoringPlotX,
+          y: Int = this.y,
+          cluster: Int? = null,
+          subplot: Int? =
+              when (cluster) {
+                null -> null
+                lastCluster -> nextSubplot
+                else -> 1
+              },
+          isAvailable: Boolean = true,
+          name: String = "$nextMonitoringPlotId",
+      ): MonitoringPlotModel {
+        lastCluster = cluster
+        nextMonitoringPlotX = x + MONITORING_PLOT_SIZE.toInt()
+
+        if (subplot != null) {
+          nextSubplot = subplot + 1
+        }
+
+        val plot =
+            MonitoringPlotModel(
+                boundary = rectanglePolygon(MONITORING_PLOT_SIZE, MONITORING_PLOT_SIZE, x, y),
+                id = MonitoringPlotId(nextMonitoringPlotId++),
+                isAvailable = isAvailable,
+                fullName = "$fullName-$name",
+                name = name,
+                permanentCluster = cluster,
+                permanentClusterSubplot = subplot,
+            )
+
+        monitoringPlots.add(plot)
+        return plot
+      }
+
+      fun cluster(
+          x: Int = nextMonitoringPlotX,
+          y: Int = this.y,
+          cluster: Int = nextPermanentCluster++,
+          isAvailable: Boolean = true,
+      ): List<MonitoringPlotModel> {
+        val plotSize = MONITORING_PLOT_SIZE.toInt()
+        val plots =
+            listOf(
+                plot(x, y, cluster, isAvailable = isAvailable),
+                plot(x + plotSize, y, cluster, isAvailable = isAvailable),
+                plot(x + plotSize, y + plotSize, cluster, isAvailable = isAvailable),
+                plot(x, y + plotSize, cluster, isAvailable = isAvailable),
+            )
+
+        nextMonitoringPlotX = x + plotSize * 2
+
+        return plots
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -1,152 +1,83 @@
 package com.terraformation.backend.tracking.model
 
-import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.point
-import com.terraformation.backend.util.Turtle
-import com.terraformation.backend.util.calculateAreaHectares
-import com.terraformation.backend.util.toMultiPolygon
+import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.newSite
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryFactory
-import org.locationtech.jts.geom.MultiPolygon
-import org.locationtech.jts.geom.PrecisionModel
 
 class PlantingSiteModelTest {
   @Nested
   inner class Validate {
     @Test
     fun `checks for maximum envelope area`() {
-      val hugeRectangle = makeMultiPolygon { rectangle(200000, 100000) }
-
-      val site = newPlantingSite(boundary = hugeRectangle)
+      val site = newSite(width = 200000, height = 100000)
 
       assertHasProblem(site, "Site must be contained within an envelope.*actual envelope")
     }
 
     @Test
     fun `checks for duplicate zone names`() {
-      val siteBoundary = makeMultiPolygon { square(100) }
-      val zone1Boundary = makeMultiPolygon { rectangle(50, 100) }
-      val zone2Boundary = makeMultiPolygon {
-        east(50)
-        square(50)
+      val site = newSite {
+        zone(width = 250, name = "Duplicate")
+        zone(width = 250, name = "Duplicate")
       }
-
-      val site =
-          newPlantingSite(
-              boundary = siteBoundary,
-              plantingZones =
-                  listOf(
-                      newPlantingZone(boundary = zone1Boundary, name = "Duplicate"),
-                      newPlantingZone(boundary = zone2Boundary, name = "Duplicate"),
-                  ))
 
       assertHasProblem(site, "Zone name Duplicate appears 2 times")
     }
 
     @Test
     fun `checks for zones not covered by site`() {
-      val siteBoundary = makeMultiPolygon { square(100) }
-      val zoneBoundary = makeMultiPolygon { square(200) }
-
-      val site =
-          newPlantingSite(
-              boundary = siteBoundary,
-              plantingZones = listOf(newPlantingZone(boundary = zoneBoundary)))
+      val site = newSite(width = 100, height = 100) { zone(width = 200, height = 200) }
 
       assertHasProblem(site, "75\\.00% of planting zone .* is not contained")
     }
 
     @Test
     fun `checks for overlapping zone boundaries`() {
-      val siteBoundary = makeMultiPolygon { square(200) }
-      val zone1Boundary = makeMultiPolygon { rectangle(100, 200) }
-      val zone2Boundary = makeMultiPolygon {
-        east(50)
-        rectangle(150, 200)
-      }
-
       val site =
-          newPlantingSite(
-              boundary = siteBoundary,
-              plantingZones =
-                  listOf(
-                      newPlantingZone(boundary = zone1Boundary),
-                      newPlantingZone(boundary = zone2Boundary)))
+          newSite(width = 200) {
+            zone(width = 100)
+            zone(x = 50, width = 150)
+          }
 
-      assertHasProblem(site, "50\\.00% of planting zone Zone 1 overlaps with zone Zone 2")
+      assertHasProblem(site, "50\\.00% of planting zone Z1 overlaps with zone Z2")
     }
 
     @Test
     fun `checks that zones have subzones`() {
-      val boundary = makeMultiPolygon { square(100) }
+      val site = newSite()
+      val siteWithoutSubzones =
+          site.copy(
+              plantingZones = site.plantingZones.map { it.copy(plantingSubzones = emptyList()) })
 
-      val site =
-          newPlantingSite(
-              boundary = boundary, plantingZones = listOf(newPlantingZone(boundary = boundary)))
-
-      assertHasProblem(site, "Planting zone Zone 1 has no subzones")
+      assertHasProblem(siteWithoutSubzones, "Planting zone Z1 has no subzones")
     }
 
     @Test
     fun `checks that zones are big enough for observations`() {
-      val boundary = makeMultiPolygon { square(50) }
+      val site = newSite(width = 50, height = 50)
 
-      val site =
-          newPlantingSite(
-              boundary = boundary,
-              plantingZones =
-                  listOf(
-                      newPlantingZone(
-                          boundary = boundary,
-                          plantingSubzones = listOf(newPlantingSubzone(boundary = boundary)))))
-
-      assertHasProblem(site, "Planting zone Zone 1 is too small")
+      assertHasProblem(site, "Planting zone Z1 is too small")
     }
 
     @Test
     fun `checks for subzones not covered by zone`() {
-      val siteBoundary = makeMultiPolygon { square(100) }
-      val subzoneBoundary = makeMultiPolygon { square(200) }
-
-      val site =
-          newPlantingSite(
-              boundary = siteBoundary,
-              plantingZones =
-                  listOf(
-                      newPlantingZone(
-                          boundary = siteBoundary,
-                          plantingSubzones =
-                              listOf(newPlantingSubzone(boundary = subzoneBoundary)))))
+      val site = newSite(width = 100, height = 100) { zone { subzone(width = 200, height = 200) } }
 
       assertHasProblem(site, "75\\.00% of planting subzone .* is not contained")
     }
 
     @Test
     fun `checks for overlapping subzone boundaries`() {
-      val siteBoundary = makeMultiPolygon { square(200) }
-      val subzone1Boundary = makeMultiPolygon { rectangle(100, 200) }
-      val subzone2Boundary = makeMultiPolygon {
-        east(50)
-        rectangle(150, 200)
-      }
-
       val site =
-          newPlantingSite(
-              boundary = siteBoundary,
-              plantingZones =
-                  listOf(
-                      newPlantingZone(
-                          boundary = siteBoundary,
-                          plantingSubzones =
-                              listOf(
-                                  newPlantingSubzone(boundary = subzone1Boundary),
-                                  newPlantingSubzone(boundary = subzone2Boundary)))))
+          newSite(width = 200) {
+            zone {
+              subzone(width = 100)
+              subzone(x = 50, width = 150)
+            }
+          }
 
-      assertHasProblem(
-          site, "50\\.00% of subzone Subzone 1 in zone Zone 1 overlaps with subzone Subzone 2")
+      assertHasProblem(site, "50\\.00% of subzone S1 in zone Z1 overlaps with subzone S2")
     }
 
     private fun assertHasProblem(site: PlantingSiteModel<*, *, *>, problemRegex: String) {
@@ -159,54 +90,5 @@ class PlantingSiteModelTest {
         assertEquals(listOf(problemRegex), problems, "Expected problems list to contain entry")
       }
     }
-  }
-
-  private fun makeMultiPolygon(func: Turtle.() -> Unit): MultiPolygon {
-    return Turtle(point(0)).makeMultiPolygon(func)
-  }
-
-  private var nextZoneNumber = 1
-  private var nextSubzoneNumber = 1
-
-  private fun newPlantingSite(
-      boundary: Geometry,
-      plantingZones: List<NewPlantingZoneModel> = emptyList(),
-  ): NewPlantingSiteModel {
-    val gridOrigin =
-        GeometryFactory(PrecisionModel(), boundary.srid)
-            .createPoint(boundary.envelope.coordinates[0])
-
-    return PlantingSiteModel.create(
-        areaHa = boundary.calculateAreaHectares(),
-        boundary = boundary.toMultiPolygon(),
-        gridOrigin = gridOrigin,
-        name = "Site",
-        organizationId = OrganizationId(1),
-        plantingZones = plantingZones,
-    )
-  }
-
-  fun newPlantingZone(
-      boundary: Geometry,
-      name: String = "Zone ${nextZoneNumber++}",
-      plantingSubzones: List<NewPlantingSubzoneModel> = emptyList(),
-  ): NewPlantingZoneModel {
-    return PlantingZoneModel.create(
-        boundary = boundary.toMultiPolygon(),
-        name = name,
-        plantingSubzones = plantingSubzones,
-    )
-  }
-
-  fun newPlantingSubzone(
-      boundary: Geometry,
-      name: String = "Subzone ${nextSubzoneNumber++}",
-      fullName: String = "Zone $nextZoneNumber-$name",
-  ): NewPlantingSubzoneModel {
-    return PlantingSubzoneModel.create(
-        boundary = boundary.toMultiPolygon(),
-        fullName = fullName,
-        name = name,
-    )
   }
 }


### PR DESCRIPTION
To support tests that need to construct planting site maps in specific
configurations, add a builder class that acts as a planting site DSL.
This allows site maps to be specified succinctly, which makes the test cases
easier to follow.

This is mainly motivated by the upcoming support for planting site map
editing, the tests for which require constructing lots of site maps. But it
also applies to some existing tests. `PlantingSiteModelTest` is updated to
use it.