### PR TITLE
SW-5228 Calculate changes to site maps

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
@@ -1,0 +1,56 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.util.equalsIgnoreScale
+import com.terraformation.backend.util.equalsOrBothNull
+import java.math.BigDecimal
+import org.locationtech.jts.geom.MultiPolygon
+
+/**
+ * Represents the changes that need to be made to an existing planting site to make it match an
+ * updated version supplied by the user. The emphasis here is on changes to the site's structure;
+ * simple changes like edits to the site name aren't included.
+ *
+ * This may include a list of [problems] encountered while calculating the differences between the
+ * two versions of the site. If so, the edit should be considered invalid and the changes shouldn't
+ * be applied to the site.
+ */
+data class PlantingSiteEdit(
+    /**
+     * Difference in usable area between the old version of the site (if any) and the new one. A
+     * positive value means the site has grown; a negative value means it has shrunk. Note that it
+     * is possible for a site to gain area in some places and lose it in others; this value is the
+     * net difference when all those changes are added up.
+     */
+    val areaHaDifference: BigDecimal,
+
+    /** New site boundary. May intersect with [exclusion]. */
+    val boundary: MultiPolygon,
+
+    /** New site exclusion areas, if any. */
+    val exclusion: MultiPolygon?,
+
+    /** ID of existing site. */
+    val plantingSiteId: PlantingSiteId,
+
+    /** Edits to this site's planting zones. */
+    val plantingZoneEdits: List<PlantingZoneEdit>,
+
+    /**
+     * List of problems that prevent the edit from being performed. If this is nonempty, the edit
+     * should be considered invalid.
+     */
+    val problems: List<PlantingSiteEditProblem> = emptyList(),
+) {
+  fun equalsExact(other: PlantingSiteEdit, tolerance: Double = 0.0000001): Boolean =
+      javaClass == other.javaClass &&
+          areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
+          boundary.equalsOrBothNull(other.boundary, tolerance) &&
+          exclusion.equalsOrBothNull(other.exclusion, tolerance) &&
+          plantingSiteId == other.plantingSiteId &&
+          plantingZoneEdits.size == other.plantingZoneEdits.size &&
+          plantingZoneEdits.zip(other.plantingZoneEdits).all { (edit, otherEdit) ->
+            edit.equalsExact(otherEdit, tolerance)
+          } &&
+          problems == other.problems
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -1,0 +1,321 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
+import com.terraformation.backend.tracking.model.AnyPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.AnyPlantingZoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
+import com.terraformation.backend.tracking.model.PlantingZoneModel
+import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.coveragePercent
+import com.terraformation.backend.util.toMultiPolygon
+import java.math.BigDecimal
+import java.math.RoundingMode
+import kotlin.math.max
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.MultiPolygon
+
+class PlantingSiteEditCalculator(
+    private val existingSite: ExistingPlantingSiteModel,
+    private val desiredSite: AnyPlantingSiteModel,
+) {
+  private val problems = mutableListOf<PlantingSiteEditProblem>()
+
+  fun calculateSiteEdit(): PlantingSiteEdit {
+    if (desiredSite.boundary == null) {
+      throw IllegalArgumentException("Cannot remove map from site")
+    }
+
+    val zoneEdits = calculateZoneEdits()
+
+    return PlantingSiteEdit(
+        areaHaDifference = calculateAreaHaDifference(existingSite.boundary, desiredSite.boundary),
+        boundary = desiredSite.boundary,
+        exclusion = desiredSite.exclusion,
+        plantingSiteId = existingSite.id,
+        plantingZoneEdits = zoneEdits,
+        problems = problems,
+    )
+  }
+
+  private fun calculateZoneEdits(): List<PlantingZoneEdit> {
+    val zoneMappings: Map<AnyPlantingZoneModel, ExistingPlantingZoneModel?> =
+        desiredSite.plantingZones.associateWith { findExistingZone(it) }
+    val existingZonesInUse = zoneMappings.values.filterNotNull().toSet()
+
+    // If more than one desired zone maps to the same existing zone, it's an attempt to split.
+    findDuplicateValues(zoneMappings).forEach { (existingZone, desiredZones) ->
+      problems.add(
+          PlantingSiteEditProblem.CannotSplitZone(
+              conflictsWith = desiredZones.map { it.name }.toSet(), zoneName = existingZone.name))
+    }
+
+    val createEdits =
+        zoneMappings
+            .filterValues { it == null }
+            .keys
+            .map { newZone ->
+              PlantingZoneEdit.Create(
+                  addedRegion = newZone.boundary,
+                  areaHaDifference = newZone.areaHa,
+                  boundary = newZone.boundary,
+                  newName = newZone.name,
+                  numPermanentClustersToAdd = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                  plantingSubzoneEdits =
+                      newZone.plantingSubzones.map { newSubzone ->
+                        PlantingSubzoneEdit.Create(
+                            addedRegion = newSubzone.boundary,
+                            boundary = newSubzone.boundary,
+                            areaHaDifference = newSubzone.areaHa,
+                            newName = newSubzone.name,
+                        )
+                      })
+            }
+
+    val deleteEdits =
+        existingSite.plantingZones.toSet().minus(existingZonesInUse).map { existingZone ->
+          PlantingZoneEdit.Delete(
+              areaHaDifference = existingZone.areaHa.negate(),
+              boundary = existingZone.boundary,
+              monitoringPlotsRemoved =
+                  existingZone.plantingSubzones
+                      .flatMap { it.monitoringPlots.map { plot -> plot.id } }
+                      .toSet(),
+              oldName = existingZone.name,
+              plantingZoneId = existingZone.id,
+              plantingSubzoneEdits =
+                  existingZone.plantingSubzones.map { existingSubzone ->
+                    PlantingSubzoneEdit.Delete(
+                        areaHaDifference = existingSubzone.areaHa,
+                        boundary = existingSubzone.boundary,
+                        oldName = existingSubzone.name,
+                        plantingSubzoneId = existingSubzone.id,
+                        removedRegion = existingSubzone.boundary,
+                    )
+                  },
+              removedRegion = existingZone.boundary,
+          )
+        }
+
+    val updateEdits =
+        zoneMappings
+            .filterValues { it != null }
+            .mapNotNull { (desiredZone, existingZone) ->
+              val subzoneEdits = calculateSubzoneEdits(existingZone!!, desiredZone)
+
+              val existingUsableBoundary =
+                  existingZone.boundary.differenceNullable(existingSite.exclusion)
+              val desiredUsableBoundary =
+                  desiredZone.boundary.differenceNullable(desiredSite.exclusion)
+
+              if (subzoneEdits.isEmpty() &&
+                  existingZone.name == desiredZone.name &&
+                  existingUsableBoundary.equalsExact(
+                      desiredZone.boundary.differenceNullable(desiredSite.exclusion), 0.000001)) {
+                null
+              } else {
+                val areaHaDifference =
+                    calculateAreaHaDifference(existingUsableBoundary, desiredUsableBoundary)
+
+                // Number of permanent clusters to add is:
+                //   (current number of clusters) * (size of added region) / (size of existing zone)
+                // rounded down with a minimum of 1, but only as many as the added region can fit.
+                val addedRegion =
+                    desiredUsableBoundary
+                        .difference(existingUsableBoundary)
+                        .toNormalizedMultiPolygon()
+                val newClustersThatFitInAddedRegion =
+                    if (!addedRegion.isEmpty && areaHaDifference > BigDecimal.ZERO) {
+                      val addedRegionArea = addedRegion.calculateAreaHectares()
+                      val existingArea = existingUsableBoundary.calculateAreaHectares()
+                      val addedRegionAreaRatio = addedRegionArea / existingArea
+                      val newClustersBasedOnAreaRatio =
+                          addedRegionAreaRatio
+                              .multiply(existingZone.numPermanentClusters.toBigDecimal())
+                              .setScale(0, RoundingMode.DOWN)
+                              .toInt()
+                      val newClustersWithMinimum = max(newClustersBasedOnAreaRatio, 1)
+                      desiredZone
+                          .findUnusedSquares(
+                              existingSite.gridOrigin!!,
+                              count = newClustersWithMinimum,
+                              exclusion = desiredSite.exclusion,
+                              searchBoundary = addedRegion)
+                          .size
+                    } else {
+                      0
+                    }
+
+                val removedRegion =
+                    existingUsableBoundary
+                        .difference(desiredUsableBoundary)
+                        .toNormalizedMultiPolygon()
+                val monitoringPlotsRemoved: Set<MonitoringPlotId> =
+                    existingZone.plantingSubzones
+                        .flatMap { it.monitoringPlots }
+                        .filter { it.boundary.coveragePercent(removedRegion) > 0.00001 }
+                        .map { it.id }
+                        .toSet()
+
+                PlantingZoneEdit.Update(
+                    addedRegion = addedRegion,
+                    areaHaDifference = areaHaDifference,
+                    boundary = desiredZone.boundary,
+                    monitoringPlotsRemoved = monitoringPlotsRemoved,
+                    newName = desiredZone.name,
+                    numPermanentClustersToAdd = newClustersThatFitInAddedRegion,
+                    oldName = existingZone.name,
+                    plantingZoneId = existingZone.id,
+                    plantingSubzoneEdits = subzoneEdits,
+                    removedRegion = removedRegion,
+                )
+              }
+            }
+
+    return createEdits + deleteEdits + updateEdits
+  }
+
+  private fun calculateSubzoneEdits(
+      existingZone: ExistingPlantingZoneModel,
+      desiredZone: AnyPlantingZoneModel
+  ): List<PlantingSubzoneEdit> {
+    val subzoneMappings: Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel?> =
+        desiredZone.plantingSubzones.associateWith {
+          findExistingSubzone(existingZone, desiredZone, it)
+        }
+    val existingSubzonesInUse = subzoneMappings.values.filterNotNull().toSet()
+
+    // If more than one desired subzone maps to the same existing subzone, it's an attempt to split.
+    findDuplicateValues(subzoneMappings).forEach { (existingSubzone, desiredSubzones) ->
+      problems.add(
+          PlantingSiteEditProblem.CannotSplitSubzone(
+              conflictsWith = desiredSubzones.map { it.name }.toSet(),
+              subzoneName = existingSubzone.name,
+              zoneName = existingZone.name))
+    }
+
+    val createEdits =
+        subzoneMappings
+            .filterValues { it == null }
+            .keys
+            .map { newSubzone ->
+              PlantingSubzoneEdit.Create(
+                  addedRegion = newSubzone.boundary,
+                  boundary = newSubzone.boundary,
+                  areaHaDifference = newSubzone.areaHa,
+                  newName = newSubzone.name,
+              )
+            }
+
+    val deleteEdits =
+        existingZone.plantingSubzones.toSet().minus(existingSubzonesInUse).map { existingSubzone ->
+          PlantingSubzoneEdit.Delete(
+              areaHaDifference = existingSubzone.areaHa.negate(),
+              boundary = existingSubzone.boundary,
+              oldName = existingSubzone.name,
+              plantingSubzoneId = existingSubzone.id,
+              removedRegion = existingSubzone.boundary,
+          )
+        }
+
+    val updateEdits =
+        subzoneMappings
+            .filterValues { it != null }
+            .mapNotNull { (desiredSubzone, existingSubzone) ->
+              if (existingSubzone!!.name == desiredSubzone.name &&
+                  existingSubzone.boundary
+                      .differenceNullable(existingSite.exclusion)
+                      .equalsExact(
+                          desiredSubzone.boundary.differenceNullable(desiredSite.exclusion),
+                          0.00001)) {
+                null
+              } else {
+                PlantingSubzoneEdit.Update(
+                    addedRegion =
+                        desiredSubzone.boundary
+                            .difference(existingSubzone.boundary)
+                            .toNormalizedMultiPolygon(),
+                    areaHaDifference =
+                        calculateAreaHaDifference(
+                            existingSubzone.boundary, desiredSubzone.boundary),
+                    boundary = desiredSubzone.boundary,
+                    oldName = existingSubzone.name,
+                    newName = desiredSubzone.name,
+                    plantingSubzoneId = existingSubzone.id,
+                    removedRegion =
+                        existingSubzone.boundary
+                            .difference(desiredSubzone.boundary)
+                            .toNormalizedMultiPolygon(),
+                )
+              }
+            }
+
+    return createEdits + deleteEdits + updateEdits
+  }
+
+  private fun findExistingZone(desiredZone: AnyPlantingZoneModel): ExistingPlantingZoneModel? {
+    val overlappingZones =
+        existingSite.plantingZones.filter {
+          it.boundary.coveragePercent(desiredZone.boundary) > 0.1
+        }
+
+    return if (overlappingZones.isEmpty()) {
+      null
+    } else if (overlappingZones.size == 1) {
+      overlappingZones.first()
+    } else {
+      problems.add(
+          PlantingSiteEditProblem.ZoneBoundaryChanged(
+              overlappingZones.map { it.name }.toSet(), desiredZone.name))
+      null
+    }
+  }
+
+  private fun findExistingSubzone(
+      existingZone: ExistingPlantingZoneModel,
+      desiredZone: AnyPlantingZoneModel,
+      desiredSubzone: AnyPlantingSubzoneModel
+  ): ExistingPlantingSubzoneModel? {
+    val overlappingSubzones =
+        existingZone.plantingSubzones.filter {
+          it.boundary.coveragePercent(desiredSubzone.boundary) > 0.1
+        }
+
+    return if (overlappingSubzones.isEmpty()) {
+      null
+    } else if (overlappingSubzones.size == 1) {
+      overlappingSubzones.first()
+    } else {
+      problems.add(
+          PlantingSiteEditProblem.SubzoneBoundaryChanged(
+              overlappingSubzones.map { it.name }.toSet(), desiredSubzone.name, desiredZone.name))
+      null
+    }
+  }
+
+  private fun calculateAreaHaDifference(existing: Geometry?, desired: Geometry): BigDecimal {
+    val desiredArea = desired.differenceNullable(desiredSite.exclusion).calculateAreaHectares()
+    return if (existing != null) {
+      desiredArea - existing.differenceNullable(existingSite.exclusion).calculateAreaHectares()
+    } else {
+      desiredArea
+    }
+  }
+
+  private fun <A, B> findDuplicateValues(original: Map<A, B?>): Map<B, List<A>> {
+    return original.entries
+        .filter { it.value != null }
+        .groupBy({ it.value!! }, { it.key })
+        .filter { it.value.size > 1 }
+  }
+
+  private fun Geometry.differenceNullable(other: Geometry?): Geometry =
+      if (other != null) difference(other) else this
+
+  private fun MultiPolygon.orEmpty(): MultiPolygon =
+      if (isEmpty) factory.createMultiPolygon() else this
+
+  private fun Geometry.toNormalizedMultiPolygon() = norm().toMultiPolygon().orEmpty()
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
@@ -27,8 +27,11 @@ interface PlantingSubzoneEdit {
    */
   val areaHaDifference: BigDecimal
 
-  /** New subzone boundary. May intersect with the updated site's exclusion areas. */
-  val boundary: MultiPolygon
+  /**
+   * New subzone boundary, or null if the subzone is being removed. May intersect with the updated
+   * site's exclusion areas.
+   */
+  val boundary: MultiPolygon?
 
   /** New subzone name, or null if the subzone is being removed. May be the same as the old name. */
   val newName: String?
@@ -73,12 +76,14 @@ interface PlantingSubzoneEdit {
 
   data class Delete(
       override val areaHaDifference: BigDecimal,
-      override val boundary: MultiPolygon,
       override val oldName: String,
       override val plantingSubzoneId: PlantingSubzoneId,
       override val removedRegion: MultiPolygon,
   ) : PlantingSubzoneEdit {
     override val addedRegion: MultiPolygon?
+      get() = null
+
+    override val boundary: MultiPolygon?
       get() = null
 
     override val newName: String?

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
@@ -1,0 +1,97 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.util.equalsIgnoreScale
+import com.terraformation.backend.util.equalsOrBothNull
+import java.math.BigDecimal
+import org.locationtech.jts.geom.MultiPolygon
+
+/**
+ * Represents the changes that need to be made to a planting subzone to make it match the subzones
+ * in an updated version of a planting site. An updated planting site can have new subzones (either
+ * in existing zones or in newly-added zones), can be missing existing subzones, or can have changes
+ * to existing subzones; these are modeled as create, delete, and update operations.
+ */
+interface PlantingSubzoneEdit {
+  /**
+   * Usable region that is being added to this subzone. Does not include any areas that are covered
+   * by the updated site's exclusion areas.
+   */
+  val addedRegion: MultiPolygon?
+
+  /**
+   * Difference in usable area between the old version of the subzone (if any) and the new one. A
+   * positive value means the subzone has grown or is being created; a negative value means it has
+   * shrunk or is being deleted. Note that it is possible for a subzone to gain area in some places
+   * and lose it in others; this value is the net difference when all those changes are added up.
+   */
+  val areaHaDifference: BigDecimal
+
+  /** New subzone boundary. May intersect with the updated site's exclusion areas. */
+  val boundary: MultiPolygon
+
+  /** New subzone name, or null if the subzone is being removed. May be the same as the old name. */
+  val newName: String?
+
+  /** Old subzone name, or null if the subzone is being newly created. */
+  val oldName: String?
+
+  /** The subzone's ID if it already exists, or null if it is being newly created. */
+  val plantingSubzoneId: PlantingSubzoneId?
+
+  /**
+   * Usable region that is being removed from this subzone. Does not include any areas that are
+   * covered by the existing site's exclusion areas.
+   */
+  val removedRegion: MultiPolygon?
+
+  fun equalsExact(other: PlantingSubzoneEdit, tolerance: Double = 0.0000001): Boolean =
+      javaClass == other.javaClass &&
+          addedRegion.equalsOrBothNull(other.addedRegion, tolerance) &&
+          areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
+          boundary.equalsOrBothNull(other.boundary, tolerance) &&
+          newName == other.newName &&
+          oldName == other.oldName &&
+          plantingSubzoneId == other.plantingSubzoneId &&
+          removedRegion.equalsOrBothNull(other.removedRegion, tolerance)
+
+  data class Create(
+      override val addedRegion: MultiPolygon,
+      override val boundary: MultiPolygon,
+      override val areaHaDifference: BigDecimal,
+      override val newName: String,
+  ) : PlantingSubzoneEdit {
+    override val oldName: String?
+      get() = null
+
+    override val plantingSubzoneId: PlantingSubzoneId?
+      get() = null
+
+    override val removedRegion: MultiPolygon?
+      get() = null
+  }
+
+  data class Delete(
+      override val areaHaDifference: BigDecimal,
+      override val boundary: MultiPolygon,
+      override val oldName: String,
+      override val plantingSubzoneId: PlantingSubzoneId,
+      override val removedRegion: MultiPolygon,
+  ) : PlantingSubzoneEdit {
+    override val addedRegion: MultiPolygon?
+      get() = null
+
+    override val newName: String?
+      get() = null
+  }
+
+  data class Update(
+      override val addedRegion: MultiPolygon,
+      override val areaHaDifference: BigDecimal,
+      override val boundary: MultiPolygon,
+      override val newName: String,
+      override val oldName: String,
+      override val plantingSubzoneId: PlantingSubzoneId,
+      override val removedRegion: MultiPolygon,
+  ) : PlantingSubzoneEdit
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -1,0 +1,132 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.util.equalsIgnoreScale
+import com.terraformation.backend.util.equalsOrBothNull
+import java.math.BigDecimal
+import org.locationtech.jts.geom.MultiPolygon
+
+/**
+ * Represents the changes that need to be made to a planting zone to make it match the zones in an
+ * updated version of a planting site. An updated planting site can have new zones, can be missing
+ * existing zones, or can have changes to existing zones; these are modeled as create, delete, and
+ * update operations.
+ */
+interface PlantingZoneEdit {
+  /**
+   * Usable region that is being added to this zone. Does not include any areas that are covered by
+   * the updated site's exclusion areas.
+   */
+  val addedRegion: MultiPolygon?
+
+  /**
+   * Difference in usable area between the old version of the zone (if any) and the new one. A
+   * positive value means the zone has grown or is being created; a negative value means it has
+   * shrunk or is being deleted. Note that it is possible for a zone to gain area in some places and
+   * lose it in others; this value is the net difference when all those changes are added up.
+   */
+  val areaHaDifference: BigDecimal
+
+  /** New zone boundary. May intersect with the updated site's exclusion areas. */
+  val boundary: MultiPolygon
+
+  /**
+   * IDs of existing monitoring plots that are no longer contained in the zone's usable area and
+   * should be removed.
+   */
+  val monitoringPlotsRemoved: Set<MonitoringPlotId>
+
+  /** New zone name, or null if the zone is being removed. May be the same as the old name. */
+  val newName: String?
+
+  /**
+   * Number of permanent clusters to add to the zone. These clusters must all be located in
+   * [addedRegion].
+   */
+  val numPermanentClustersToAdd: Int?
+
+  /** Old zone name, or null if the zone is being newly created. */
+  val oldName: String?
+
+  /** Edits to this zone's subzones. */
+  val plantingSubzoneEdits: List<PlantingSubzoneEdit>
+
+  /** The zone's ID if it already exists, or null if it is being newly created. */
+  val plantingZoneId: PlantingZoneId?
+
+  /**
+   * Usable region that is being removed from this zone. Does not include any areas that are covered
+   * by the existing site's exclusion areas.
+   */
+  val removedRegion: MultiPolygon?
+
+  fun equalsExact(other: PlantingZoneEdit, tolerance: Double = 0.0000001): Boolean =
+      javaClass == other.javaClass &&
+          addedRegion.equalsOrBothNull(other.addedRegion, tolerance) &&
+          areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
+          boundary.equalsOrBothNull(other.boundary, tolerance) &&
+          monitoringPlotsRemoved == other.monitoringPlotsRemoved &&
+          newName == other.newName &&
+          numPermanentClustersToAdd == other.numPermanentClustersToAdd &&
+          oldName == other.oldName &&
+          plantingSubzoneEdits.size == other.plantingSubzoneEdits.size &&
+          plantingSubzoneEdits.zip(other.plantingSubzoneEdits).all { (edit, otherEdit) ->
+            edit.equalsExact(otherEdit, tolerance)
+          } &&
+          plantingZoneId == other.plantingZoneId &&
+          removedRegion.equalsOrBothNull(other.removedRegion, tolerance)
+
+  data class Create(
+      override val addedRegion: MultiPolygon,
+      override val areaHaDifference: BigDecimal,
+      override val boundary: MultiPolygon,
+      override val newName: String,
+      override val numPermanentClustersToAdd: Int,
+      override val plantingSubzoneEdits: List<PlantingSubzoneEdit.Create>,
+  ) : PlantingZoneEdit {
+    override val monitoringPlotsRemoved: Set<MonitoringPlotId>
+      get() = emptySet()
+
+    override val oldName: String?
+      get() = null
+
+    override val plantingZoneId: PlantingZoneId?
+      get() = null
+
+    override val removedRegion: MultiPolygon?
+      get() = null
+  }
+
+  data class Delete(
+      override val areaHaDifference: BigDecimal,
+      override val boundary: MultiPolygon,
+      override val monitoringPlotsRemoved: Set<MonitoringPlotId>,
+      override val oldName: String,
+      override val plantingZoneId: PlantingZoneId,
+      override val plantingSubzoneEdits: List<PlantingSubzoneEdit.Delete>,
+      override val removedRegion: MultiPolygon,
+  ) : PlantingZoneEdit {
+    override val addedRegion: MultiPolygon?
+      get() = null
+
+    override val newName: String?
+      get() = null
+
+    override val numPermanentClustersToAdd: Int
+      get() = 0
+  }
+
+  data class Update(
+      override val addedRegion: MultiPolygon,
+      override val areaHaDifference: BigDecimal,
+      override val boundary: MultiPolygon,
+      override val monitoringPlotsRemoved: Set<MonitoringPlotId>,
+      override val newName: String,
+      override val numPermanentClustersToAdd: Int,
+      override val oldName: String,
+      override val plantingSubzoneEdits: List<PlantingSubzoneEdit>,
+      override val plantingZoneId: PlantingZoneId,
+      override val removedRegion: MultiPolygon,
+  ) : PlantingZoneEdit
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -28,8 +28,11 @@ interface PlantingZoneEdit {
    */
   val areaHaDifference: BigDecimal
 
-  /** New zone boundary. May intersect with the updated site's exclusion areas. */
-  val boundary: MultiPolygon
+  /**
+   * New zone boundary, or null if the zone is being removed. May intersect with the updated site's
+   * exclusion areas.
+   */
+  val boundary: MultiPolygon?
 
   /**
    * IDs of existing monitoring plots that are no longer contained in the zone's usable area and
@@ -100,7 +103,6 @@ interface PlantingZoneEdit {
 
   data class Delete(
       override val areaHaDifference: BigDecimal,
-      override val boundary: MultiPolygon,
       override val monitoringPlotsRemoved: Set<MonitoringPlotId>,
       override val oldName: String,
       override val plantingZoneId: PlantingZoneId,
@@ -108,6 +110,9 @@ interface PlantingZoneEdit {
       override val removedRegion: MultiPolygon,
   ) : PlantingZoneEdit {
     override val addedRegion: MultiPolygon?
+      get() = null
+
+    override val boundary: MultiPolygon?
       get() = null
 
     override val newName: String?

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/Problems.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/Problems.kt
@@ -1,0 +1,31 @@
+package com.terraformation.backend.tracking.edit
+
+interface PlantingSiteEditProblem {
+  val conflictsWith: Set<String>?
+  val subzoneName: String?
+    get() = null
+
+  val zoneName: String?
+
+  data class CannotSplitSubzone(
+      override val conflictsWith: Set<String>,
+      override val subzoneName: String,
+      override val zoneName: String,
+  ) : PlantingSiteEditProblem
+
+  data class CannotSplitZone(
+      override val conflictsWith: Set<String>,
+      override val zoneName: String,
+  ) : PlantingSiteEditProblem
+
+  data class SubzoneBoundaryChanged(
+      override val conflictsWith: Set<String>,
+      override val subzoneName: String,
+      override val zoneName: String,
+  ) : PlantingSiteEditProblem
+
+  data class ZoneBoundaryChanged(
+      override val conflictsWith: Set<String>,
+      override val zoneName: String,
+  ) : PlantingSiteEditProblem
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -207,6 +207,9 @@ data class PlantingSiteModel<
   }
 }
 
+typealias AnyPlantingSiteModel =
+    PlantingSiteModel<out PlantingSiteId?, out PlantingZoneId?, out PlantingSubzoneId?>
+
 typealias ExistingPlantingSiteModel =
     PlantingSiteModel<PlantingSiteId, PlantingZoneId, PlantingSubzoneId>
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -56,6 +56,8 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
   }
 }
 
+typealias AnyPlantingSubzoneModel = PlantingSubzoneModel<out PlantingSubzoneId?>
+
 typealias ExistingPlantingSubzoneModel = PlantingSubzoneModel<PlantingSubzoneId>
 
 typealias NewPlantingSubzoneModel = PlantingSubzoneModel<Nothing?>

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -449,6 +449,8 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 }
 
+typealias AnyPlantingZoneModel = PlantingZoneModel<out PlantingZoneId?, out PlantingSubzoneId?>
+
 typealias ExistingPlantingZoneModel = PlantingZoneModel<PlantingZoneId, PlantingSubzoneId>
 
 typealias NewPlantingZoneModel = PlantingZoneModel<Nothing?, Nothing?>

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -87,7 +87,10 @@ fun rectangle(
     height: Number = width,
     x: Number = 0,
     y: Number = 0,
-): MultiPolygon =
+): MultiPolygon {
+  return if (width == 0) {
+    GeometryFactory(PrecisionModel(), SRID.LONG_LAT).createMultiPolygon(emptyArray())
+  } else {
     Turtle(point(1))
         .makeMultiPolygon {
           north(y)
@@ -96,6 +99,8 @@ fun rectangle(
         }
         .norm()
         .toMultiPolygon()
+  }
+}
 
 /** Returns a rectangular Polygon with position and size in meters. */
 fun rectanglePolygon(

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -262,10 +262,10 @@ class PlantingSiteEditCalculatorTest {
           }
 
       assertHasProblem(
-          existing,
-          desired,
           PlantingSiteEditProblem.ZoneBoundaryChanged(
-              conflictsWith = setOf("Z1", "Z2"), zoneName = "Z1"))
+              conflictsWith = setOf("Z1", "Z2"), zoneName = "Z1"),
+          existing,
+          desired)
     }
 
     @Test
@@ -286,10 +286,10 @@ class PlantingSiteEditCalculatorTest {
           }
 
       assertHasProblem(
-          existing,
-          desired,
           PlantingSiteEditProblem.SubzoneBoundaryChanged(
-              conflictsWith = setOf("S1", "S2"), subzoneName = "S1", zoneName = "Z1"))
+              conflictsWith = setOf("S1", "S2"), subzoneName = "S1", zoneName = "Z1"),
+          existing,
+          desired)
     }
 
     @Test
@@ -302,10 +302,10 @@ class PlantingSiteEditCalculatorTest {
           }
 
       assertHasProblem(
-          existing,
-          desired,
           PlantingSiteEditProblem.CannotSplitZone(
-              conflictsWith = setOf("N1", "N2"), zoneName = "Z1"))
+              conflictsWith = setOf("N1", "N2"), zoneName = "Z1"),
+          existing,
+          desired)
     }
 
     @Test
@@ -320,10 +320,10 @@ class PlantingSiteEditCalculatorTest {
           }
 
       assertHasProblem(
-          existing,
-          desired,
           PlantingSiteEditProblem.CannotSplitSubzone(
-              conflictsWith = setOf("N1", "N2"), subzoneName = "S1", zoneName = "Z1"))
+              conflictsWith = setOf("N1", "N2"), subzoneName = "S1", zoneName = "Z1"),
+          existing,
+          desired)
     }
 
     @Test
@@ -355,17 +355,17 @@ class PlantingSiteEditCalculatorTest {
     }
   }
 
-  private fun assertHasProblem(edit: PlantingSiteEdit, problem: PlantingSiteEditProblem) {
+  private fun assertHasProblem(problem: PlantingSiteEditProblem, edit: PlantingSiteEdit) {
     if (edit.problems.none { it == problem }) {
       assertEquals(listOf(problem), edit.problems, "Expected problem not found")
     }
   }
 
   private fun assertHasProblem(
+      problem: PlantingSiteEditProblem,
       existing: ExistingPlantingSiteModel,
       desired: AnyPlantingSiteModel,
-      problem: PlantingSiteEditProblem
   ) {
-    assertHasProblem(calculateSiteEdit(existing, desired), problem)
+    assertHasProblem(problem, calculateSiteEdit(existing, desired))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -1,0 +1,371 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.SRID
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.rectangle
+import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.existingSite
+import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.newSite
+import com.terraformation.backend.tracking.model.PlantingZoneModel
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
+
+class PlantingSiteEditCalculatorTest {
+  private val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+
+  @Test
+  fun `returns create edits for newly added zone and subzone`() {
+    val newZoneBoundary = rectangle(x = 500, width = 250, height = 500)
+
+    val existing = existingSite(width = 500)
+    val desired =
+        newSite(width = 750) {
+          zone(width = 500)
+          zone(width = 250)
+        }
+
+    assertEditResult(
+        existing,
+        desired,
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("12.5"),
+            boundary = rectangle(width = 750, height = 500),
+            exclusion = null,
+            plantingSiteId = existing.id,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Create(
+                        addedRegion = newZoneBoundary,
+                        areaHaDifference = BigDecimal("12.5"),
+                        boundary = newZoneBoundary,
+                        newName = "Z2",
+                        numPermanentClustersToAdd =
+                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    addedRegion = newZoneBoundary,
+                                    boundary = newZoneBoundary,
+                                    areaHaDifference = BigDecimal("12.5"),
+                                    newName = "S2"))))))
+  }
+
+  @Test
+  fun `returns zone update and subzone create for expansion of zone with new subzone`() {
+    val newSubzoneBoundary = rectangle(x = 500, width = 250, height = 500)
+    val newSiteBoundary = rectangle(width = 750, height = 500)
+
+    val existing = existingSite(width = 500)
+    val desired =
+        newSite(width = 750) {
+          zone {
+            subzone(width = 500)
+            subzone()
+          }
+        }
+
+    assertEditResult(
+        existing,
+        desired,
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("12.5"),
+            boundary = newSiteBoundary,
+            exclusion = null,
+            plantingSiteId = existing.id,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = newSubzoneBoundary,
+                        boundary = newSiteBoundary,
+                        areaHaDifference = BigDecimal("12.5"),
+                        monitoringPlotsRemoved = emptySet(),
+                        newName = "Z1",
+                        numPermanentClustersToAdd =
+                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * (750 - 500) / 500,
+                        oldName = "Z1",
+                        plantingZoneId = PlantingZoneId(1),
+                        removedRegion = geometryFactory.createMultiPolygon(emptyArray<Polygon?>()),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    addedRegion = newSubzoneBoundary,
+                                    boundary = newSubzoneBoundary,
+                                    areaHaDifference = BigDecimal("12.5"),
+                                    newName = "S2"))))))
+  }
+
+  @Test
+  fun `returns updates with both added and removed regions if boundary change was not a simple expansion`() {
+    val existing = existingSite(x = 0, width = 500, height = 500)
+    val desired = newSite(x = 100, width = 600, height = 500)
+
+    assertEditResult(
+        existing,
+        desired,
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("5.0"),
+            boundary = desired.boundary!!,
+            exclusion = null,
+            plantingSiteId = existing.id,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 500, width = 200, height = 500),
+                        areaHaDifference = BigDecimal("5.0"),
+                        boundary = desired.boundary!!,
+                        newName = "Z1",
+                        numPermanentClustersToAdd =
+                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
+                        oldName = "Z1",
+                        removedRegion = rectangle(x = 0, width = 100, height = 500),
+                        monitoringPlotsRemoved = emptySet(),
+                        plantingZoneId = PlantingZoneId(1),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 500, width = 200, height = 500),
+                                    areaHaDifference = BigDecimal("5.0"),
+                                    boundary = desired.boundary!!,
+                                    newName = "S1",
+                                    oldName = "S1",
+                                    plantingSubzoneId = PlantingSubzoneId(1),
+                                    removedRegion = rectangle(x = 0, width = 100, height = 500),
+                                ))))))
+  }
+
+  @Test
+  fun `adds permanent clusters in proportion to size of added area`() {
+    val existing = existingSite(width = 10000)
+    val doubleSize = newSite(width = 20000)
+    val halfAgainSize = newSite(width = 15000)
+    val slightlyLargerSize = newSite(width = 10051)
+
+    assertEquals(
+        PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+        calculateSiteEdit(existing, doubleSize).plantingZoneEdits.first().numPermanentClustersToAdd,
+        "Number of permanent clusters to add when doubling zone size")
+    assertEquals(
+        PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS / 2,
+        calculateSiteEdit(existing, halfAgainSize)
+            .plantingZoneEdits
+            .first()
+            .numPermanentClustersToAdd,
+        "Number of permanent clusters to add when increasing zone size by half")
+    assertEquals(
+        1,
+        calculateSiteEdit(existing, slightlyLargerSize)
+            .plantingZoneEdits
+            .first()
+            .numPermanentClustersToAdd,
+        "Number of permanent clusters to add when increasing zone size slightly")
+  }
+
+  @Test
+  fun `does not add permanent cluster if there is not enough room for it in added area`() {
+    val existing = existingSite(width = 500)
+    val desired = newSite(width = 510)
+
+    assertEquals(
+        0,
+        calculateSiteEdit(existing, desired).plantingZoneEdits.first().numPermanentClustersToAdd,
+        "Number of permanent clusters to add")
+  }
+
+  @Test
+  fun `does not add permanent cluster if total usable area of zone has gone down`() {
+    val existing = existingSite(width = 10000, height = 500)
+    val desired =
+        newSite(width = 11000, height = 500) { exclusion = rectangle(width = 2000, height = 500) }
+
+    assertEquals(
+        0,
+        calculateSiteEdit(existing, desired).plantingZoneEdits.first().numPermanentClustersToAdd,
+        "Number of permanent clusters to add")
+  }
+
+  @Test
+  fun `removes monitoring plots that overlap with added exclusion area`() {
+    val existing = existingSite {
+      zone {
+        subzone {
+          plot()
+          plot()
+        }
+      }
+    }
+    val desired = newSite { exclusion = rectangle(1) }
+
+    assertEquals(
+        setOf(MonitoringPlotId(1)),
+        calculateSiteEdit(existing, desired)
+            .plantingZoneEdits
+            .firstOrNull()
+            ?.monitoringPlotsRemoved,
+        "Monitoring plots removed")
+  }
+
+  @Test
+  fun `removes monitoring plots that no longer lie in site`() {
+    val existing = existingSite {
+      zone {
+        subzone {
+          plot()
+          plot()
+        }
+      }
+    }
+    val desired = newSite(x = 1)
+
+    assertEquals(
+        setOf(MonitoringPlotId(1)),
+        calculateSiteEdit(existing, desired)
+            .plantingZoneEdits
+            .firstOrNull()
+            ?.monitoringPlotsRemoved,
+        "Monitoring plots removed")
+  }
+
+  @Test
+  fun `returns empty list of edits if nothing changed`() {
+    val site = existingSite()
+
+    assertEditResult(
+        site,
+        site.toNew(),
+        PlantingSiteEdit(
+            BigDecimal("0.0"), site.boundary!!, null, PlantingSiteId(1), emptyList(), emptyList()))
+  }
+
+  @Nested
+  inner class Validation {
+    @Test
+    fun `detects change to boundary between existing zones`() {
+      val existing =
+          existingSite(width = 1000) {
+            zone(width = 500)
+            zone(width = 500)
+          }
+      val desired =
+          newSite(width = 1000) {
+            zone(width = 600)
+            zone(width = 400)
+          }
+
+      assertHasProblem(
+          existing,
+          desired,
+          PlantingSiteEditProblem.ZoneBoundaryChanged(
+              conflictsWith = setOf("Z1", "Z2"), zoneName = "Z1"))
+    }
+
+    @Test
+    fun `detects change to boundary between existing subzones`() {
+      val existing =
+          existingSite(width = 1000) {
+            zone {
+              subzone(width = 500)
+              subzone(width = 500)
+            }
+          }
+      val desired =
+          newSite(width = 1000) {
+            zone {
+              subzone(width = 600)
+              subzone(width = 400)
+            }
+          }
+
+      assertHasProblem(
+          existing,
+          desired,
+          PlantingSiteEditProblem.SubzoneBoundaryChanged(
+              conflictsWith = setOf("S1", "S2"), subzoneName = "S1", zoneName = "Z1"))
+    }
+
+    @Test
+    fun `detects attempt to split a zone`() {
+      val existing = existingSite(width = 1000)
+      val desired =
+          newSite(width = 1000) {
+            zone(width = 500, name = "N1")
+            zone(width = 500, name = "N2")
+          }
+
+      assertHasProblem(
+          existing,
+          desired,
+          PlantingSiteEditProblem.CannotSplitZone(
+              conflictsWith = setOf("N1", "N2"), zoneName = "Z1"))
+    }
+
+    @Test
+    fun `detects attempt to split a subzone`() {
+      val existing = existingSite(width = 1000)
+      val desired =
+          newSite(width = 1000) {
+            zone {
+              subzone(width = 500, name = "N1")
+              subzone(width = 500, name = "N2")
+            }
+          }
+
+      assertHasProblem(
+          existing,
+          desired,
+          PlantingSiteEditProblem.CannotSplitSubzone(
+              conflictsWith = setOf("N1", "N2"), subzoneName = "S1", zoneName = "Z1"))
+    }
+
+    @Test
+    fun `throws exception if desired site has no boundary`() {
+      assertThrows<IllegalArgumentException> {
+        PlantingSiteEditCalculator(
+                existingSite(),
+                newSite().copy(boundary = null),
+            )
+            .calculateSiteEdit()
+      }
+    }
+  }
+
+  private fun calculateSiteEdit(
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel
+  ): PlantingSiteEdit = PlantingSiteEditCalculator(existing, desired).calculateSiteEdit()
+
+  private fun assertEditResult(
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel,
+      expected: PlantingSiteEdit
+  ) {
+    val actual = calculateSiteEdit(existing, desired)
+
+    if (!actual.equalsExact(expected)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  private fun assertHasProblem(edit: PlantingSiteEdit, problem: PlantingSiteEditProblem) {
+    if (edit.problems.none { it == problem }) {
+      assertEquals(listOf(problem), edit.problems, "Expected problem not found")
+    }
+  }
+
+  private fun assertHasProblem(
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel,
+      problem: PlantingSiteEditProblem
+  ) {
+    assertHasProblem(calculateSiteEdit(existing, desired), problem)
+  }
+}


### PR DESCRIPTION
In preparation for allowing editing of planting site maps, add logic to
calculate the differences between an existing planting site and a site map
requested by the user, and to detect edits that are disallowed according to the
product requirements.

The internal representation of a site edit will be used as the basis of both the
confirmation step in the UI ("this edit would do X, Y, and Z") and as input to
an update function that will apply the requested edits.

The code in this change only concerns itself with site geometry, not with any
of the other edit behaviors related to active observations or the presence of
planting data. Upcoming changes will cover those requirements.