### PR TITLE
SW-5354 Disallow exclusion of whole subzones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -324,6 +324,10 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
                 "zone $name")
       }
 
+      if (newModel.exclusion != null && subzone.boundary.nearlyCoveredBy(newModel.exclusion)) {
+        problems.add("Subzone ${subzone.name} in zone $name is inside exclusion area")
+      }
+
       plantingSubzones.drop(index + 1).forEach { otherSubzone ->
         val overlapPercent = subzone.boundary.coveragePercent(otherSubzone.boundary)
         if (overlapPercent > PlantingSiteModel.REGION_OVERLAP_MAX_PERCENT) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.newSite
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
@@ -78,6 +79,19 @@ class PlantingSiteModelTest {
           }
 
       assertHasProblem(site, "50\\.00% of subzone S1 in zone Z1 overlaps with subzone S2")
+    }
+
+    @Test
+    fun `checks that no subzones are completely covered by exclusion area`() {
+      val site = newSite {
+        exclusion = rectangle(width = 200, height = 500)
+        zone {
+          subzone(width = 150)
+          subzone()
+        }
+      }
+
+      assertHasProblem(site, "Subzone S1 in zone Z1 is inside exclusion area")
     }
 
     private fun assertHasProblem(site: PlantingSiteModel<*, *, *>, problemRegex: String) {


### PR DESCRIPTION
We don't allow exclusion areas to completely cover subzones; the user should
delete the subzones from the site in that case. Detect completely-excluded
subzones as part of planting site validation.