### PR TITLE
Use zone and subzone models in edits

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
@@ -16,6 +16,9 @@ import org.locationtech.jts.geom.MultiPolygon
  * be applied to the site.
  */
 data class PlantingSiteEdit(
+    /** Usable area in the new version of the site. */
+    val areaHa: BigDecimal,
+
     /**
      * Difference in usable area between the old version of the site (if any) and the new one. A
      * positive value means the site has grown; a negative value means it has shrunk. Note that it
@@ -44,6 +47,7 @@ data class PlantingSiteEdit(
 ) {
   fun equalsExact(other: PlantingSiteEdit, tolerance: Double = 0.0000001): Boolean =
       javaClass == other.javaClass &&
+          areaHa.equalsIgnoreScale(other.areaHa) &&
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
           boundary.equalsOrBothNull(other.boundary, tolerance) &&
           exclusion.equalsOrBothNull(other.exclusion, tolerance) &&

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -72,12 +72,7 @@ class PlantingSiteEditCalculator(
                   numPermanentClustersToAdd = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
                   plantingSubzoneEdits =
                       newZone.plantingSubzones.map { newSubzone ->
-                        PlantingSubzoneEdit.Create(
-                            addedRegion = newSubzone.boundary,
-                            boundary = newSubzone.boundary,
-                            areaHaDifference = newSubzone.areaHa,
-                            newName = newSubzone.name,
-                        )
+                        PlantingSubzoneEdit.Create(newSubzone)
                       })
             }
 
@@ -85,12 +80,7 @@ class PlantingSiteEditCalculator(
         existingSite.plantingZones.toSet().minus(existingZonesInUse).map { existingZone ->
           val plantingSubzoneEdits =
               existingZone.plantingSubzones.map { existingSubzone ->
-                PlantingSubzoneEdit.Delete(
-                    areaHaDifference = existingSubzone.areaHa.negate(),
-                    oldName = existingSubzone.name,
-                    plantingSubzoneId = existingSubzone.id,
-                    removedRegion = existingSubzone.boundary,
-                )
+                PlantingSubzoneEdit.Delete(existingSubzone)
               }
 
           checkPlantedSubzoneDeletions(existingZone, plantingSubzoneEdits)
@@ -209,23 +199,11 @@ class PlantingSiteEditCalculator(
         subzoneMappings
             .filterValues { it == null }
             .keys
-            .map { newSubzone ->
-              PlantingSubzoneEdit.Create(
-                  addedRegion = newSubzone.boundary,
-                  boundary = newSubzone.boundary,
-                  areaHaDifference = newSubzone.areaHa,
-                  newName = newSubzone.name,
-              )
-            }
+            .map { newSubzone -> PlantingSubzoneEdit.Create(newSubzone) }
 
     val deleteEdits =
         existingZone.plantingSubzones.toSet().minus(existingSubzonesInUse).map { existingSubzone ->
-          PlantingSubzoneEdit.Delete(
-              areaHaDifference = existingSubzone.areaHa.negate(),
-              oldName = existingSubzone.name,
-              plantingSubzoneId = existingSubzone.id,
-              removedRegion = existingSubzone.boundary,
-          )
+          PlantingSubzoneEdit.Delete(existingSubzone)
         }
 
     val updateEdits =
@@ -282,12 +260,7 @@ class PlantingSiteEditCalculator(
               plantingZoneId = existingZone.id,
               plantingSubzoneEdits =
                   existingZone.plantingSubzones.map { existingSubzone ->
-                    PlantingSubzoneEdit.Delete(
-                        areaHaDifference = existingSubzone.areaHa.negate(),
-                        oldName = existingSubzone.name,
-                        plantingSubzoneId = existingSubzone.id,
-                        removedRegion = existingSubzone.boundary,
-                    )
+                    PlantingSubzoneEdit.Delete(existingSubzone)
                   },
               removedRegion = existingZone.boundary,
           )
@@ -303,12 +276,7 @@ class PlantingSiteEditCalculator(
               numPermanentClustersToAdd = 0,
               plantingSubzoneEdits =
                   desiredZone.plantingSubzones.map { desiredSubzone ->
-                    PlantingSubzoneEdit.Create(
-                        addedRegion = desiredSubzone.boundary,
-                        boundary = desiredSubzone.boundary,
-                        areaHaDifference = desiredSubzone.areaHa,
-                        newName = desiredSubzone.name,
-                    )
+                    PlantingSubzoneEdit.Create(desiredSubzone)
                   })
         }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.tracking.edit
 
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.tracking.model.AnyPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
 import com.terraformation.backend.util.equalsIgnoreScale
 import com.terraformation.backend.util.equalsOrBothNull
 import java.math.BigDecimal
@@ -64,6 +66,10 @@ interface PlantingSubzoneEdit {
       override val areaHaDifference: BigDecimal,
       override val newName: String,
   ) : PlantingSubzoneEdit {
+    constructor(
+        model: AnyPlantingSubzoneModel
+    ) : this(model.boundary, model.boundary, model.areaHa, model.name)
+
     override val oldName: String?
       get() = null
 
@@ -80,6 +86,10 @@ interface PlantingSubzoneEdit {
       override val plantingSubzoneId: PlantingSubzoneId,
       override val removedRegion: MultiPolygon,
   ) : PlantingSubzoneEdit {
+    constructor(
+        model: ExistingPlantingSubzoneModel
+    ) : this(model.areaHa.negate(), model.name, model.id, model.boundary)
+
     override val addedRegion: MultiPolygon?
       get() = null
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking.edit
 
-import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.tracking.model.AnyPlantingSubzoneModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
 import com.terraformation.backend.util.equalsIgnoreScale
@@ -14,7 +13,7 @@ import org.locationtech.jts.geom.MultiPolygon
  * in existing zones or in newly-added zones), can be missing existing subzones, or can have changes
  * to existing subzones; these are modeled as create, delete, and update operations.
  */
-interface PlantingSubzoneEdit {
+sealed interface PlantingSubzoneEdit {
   /**
    * Usable region that is being added to this subzone. Does not include any areas that are covered
    * by the updated site's exclusion areas.
@@ -29,20 +28,11 @@ interface PlantingSubzoneEdit {
    */
   val areaHaDifference: BigDecimal
 
-  /**
-   * New subzone boundary, or null if the subzone is being removed. May intersect with the updated
-   * site's exclusion areas.
-   */
-  val boundary: MultiPolygon?
+  /** Desired subzone model, or null if the subzone is being removed. */
+  val desiredModel: AnyPlantingSubzoneModel?
 
-  /** New subzone name, or null if the subzone is being removed. May be the same as the old name. */
-  val newName: String?
-
-  /** Old subzone name, or null if the subzone is being newly created. */
-  val oldName: String?
-
-  /** The subzone's ID if it already exists, or null if it is being newly created. */
-  val plantingSubzoneId: PlantingSubzoneId?
+  /** Existing subzone model, or null if the subzone is being created. */
+  val existingModel: ExistingPlantingSubzoneModel?
 
   /**
    * Usable region that is being removed from this subzone. Does not include any areas that are
@@ -54,26 +44,20 @@ interface PlantingSubzoneEdit {
       javaClass == other.javaClass &&
           addedRegion.equalsOrBothNull(other.addedRegion, tolerance) &&
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
-          boundary.equalsOrBothNull(other.boundary, tolerance) &&
-          newName == other.newName &&
-          oldName == other.oldName &&
-          plantingSubzoneId == other.plantingSubzoneId &&
+          desiredModel == other.desiredModel &&
+          existingModel == other.existingModel &&
           removedRegion.equalsOrBothNull(other.removedRegion, tolerance)
 
   data class Create(
-      override val addedRegion: MultiPolygon,
-      override val boundary: MultiPolygon,
-      override val areaHaDifference: BigDecimal,
-      override val newName: String,
+      override val desiredModel: AnyPlantingSubzoneModel,
   ) : PlantingSubzoneEdit {
-    constructor(
-        model: AnyPlantingSubzoneModel
-    ) : this(model.boundary, model.boundary, model.areaHa, model.name)
+    override val addedRegion: MultiPolygon
+      get() = desiredModel.boundary
 
-    override val oldName: String?
-      get() = null
+    override val areaHaDifference: BigDecimal
+      get() = desiredModel.areaHa
 
-    override val plantingSubzoneId: PlantingSubzoneId?
+    override val existingModel: ExistingPlantingSubzoneModel?
       get() = null
 
     override val removedRegion: MultiPolygon?
@@ -81,32 +65,26 @@ interface PlantingSubzoneEdit {
   }
 
   data class Delete(
-      override val areaHaDifference: BigDecimal,
-      override val oldName: String,
-      override val plantingSubzoneId: PlantingSubzoneId,
-      override val removedRegion: MultiPolygon,
+      override val existingModel: ExistingPlantingSubzoneModel,
   ) : PlantingSubzoneEdit {
-    constructor(
-        model: ExistingPlantingSubzoneModel
-    ) : this(model.areaHa.negate(), model.name, model.id, model.boundary)
-
     override val addedRegion: MultiPolygon?
       get() = null
 
-    override val boundary: MultiPolygon?
+    override val areaHaDifference: BigDecimal
+      get() = existingModel.areaHa.negate()
+
+    override val desiredModel: AnyPlantingSubzoneModel?
       get() = null
 
-    override val newName: String?
-      get() = null
+    override val removedRegion: MultiPolygon
+      get() = existingModel.boundary
   }
 
   data class Update(
       override val addedRegion: MultiPolygon,
       override val areaHaDifference: BigDecimal,
-      override val boundary: MultiPolygon,
-      override val newName: String,
-      override val oldName: String,
-      override val plantingSubzoneId: PlantingSubzoneId,
+      override val desiredModel: AnyPlantingSubzoneModel,
+      override val existingModel: ExistingPlantingSubzoneModel,
       override val removedRegion: MultiPolygon,
   ) : PlantingSubzoneEdit
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -395,10 +395,7 @@ class PlantingSiteEditCalculatorTest {
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Delete(
-                                areaHaDifference = existing.plantingZones[0].areaHa.negate(),
-                                oldName = "S1",
-                                plantingSubzoneId = PlantingSubzoneId(1),
-                                removedRegion = existing.plantingZones[0].boundary)),
+                                existing.plantingZones[0].plantingSubzones[0])),
                     removedRegion = existing.plantingZones[0].boundary,
                 ),
                 PlantingZoneEdit.Delete(
@@ -409,10 +406,7 @@ class PlantingSiteEditCalculatorTest {
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Delete(
-                                areaHaDifference = existing.plantingZones[1].areaHa.negate(),
-                                oldName = "S2",
-                                plantingSubzoneId = PlantingSubzoneId(2),
-                                removedRegion = existing.plantingZones[1].boundary)),
+                                existing.plantingZones[1].plantingSubzones[0])),
                     removedRegion = existing.plantingZones[1].boundary,
                 ),
                 PlantingZoneEdit.Create(
@@ -424,10 +418,7 @@ class PlantingSiteEditCalculatorTest {
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(
-                                addedRegion = desired.plantingZones[0].boundary,
-                                boundary = desired.plantingZones[0].boundary,
-                                areaHaDifference = desired.plantingZones[0].areaHa,
-                                newName = "S1"))),
+                                desired.plantingZones[0].plantingSubzones[0]))),
                 PlantingZoneEdit.Create(
                     addedRegion = desired.plantingZones[1].boundary,
                     areaHaDifference = desired.plantingZones[1].areaHa,
@@ -437,10 +428,7 @@ class PlantingSiteEditCalculatorTest {
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(
-                                addedRegion = desired.plantingZones[1].boundary,
-                                boundary = desired.plantingZones[1].boundary,
-                                areaHaDifference = desired.plantingZones[1].areaHa,
-                                newName = "S2"))),
+                                desired.plantingZones[1].plantingSubzones[0]))),
                 PlantingZoneEdit.Create(
                     addedRegion = desired.plantingZones[2].boundary,
                     areaHaDifference = desired.plantingZones[2].areaHa,
@@ -450,10 +438,7 @@ class PlantingSiteEditCalculatorTest {
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(
-                                addedRegion = desired.plantingZones[2].boundary,
-                                boundary = desired.plantingZones[2].boundary,
-                                areaHaDifference = desired.plantingZones[2].areaHa,
-                                newName = "S3"))),
+                                desired.plantingZones[2].plantingSubzones[0]))),
             ),
         ),
         existing,

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.tracking.edit
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
-import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
@@ -19,8 +18,6 @@ import org.junit.jupiter.api.assertThrows
 class PlantingSiteEditCalculatorTest {
   @Test
   fun `returns create edits for newly added zone and subzone`() {
-    val newZoneBoundary = rectangle(x = 500, width = 250, height = 500)
-
     val existing = existingSite(width = 500)
     val desired =
         newSite(width = 750) {
@@ -30,6 +27,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("12.5"),
             boundary = rectangle(width = 750, height = 500),
             exclusion = null,
@@ -37,19 +35,12 @@ class PlantingSiteEditCalculatorTest {
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Create(
-                        addedRegion = newZoneBoundary,
-                        areaHaDifference = BigDecimal("12.5"),
-                        boundary = newZoneBoundary,
-                        newName = "Z2",
-                        numPermanentClustersToAdd =
-                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                        desiredModel = desired.plantingZones[1],
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
-                                    addedRegion = newZoneBoundary,
-                                    boundary = newZoneBoundary,
-                                    areaHaDifference = BigDecimal("12.5"),
-                                    newName = "S2"))))),
+                                    desiredModel =
+                                        desired.plantingZones[1].plantingSubzones[0]))))),
         existing,
         desired)
   }
@@ -70,6 +61,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("12.5"),
             boundary = newSiteBoundary,
             exclusion = null,
@@ -78,22 +70,17 @@ class PlantingSiteEditCalculatorTest {
                 listOf(
                     PlantingZoneEdit.Update(
                         addedRegion = newSubzoneBoundary,
-                        boundary = newSiteBoundary,
                         areaHaDifference = BigDecimal("12.5"),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
                         monitoringPlotsRemoved = emptySet(),
-                        newName = "Z1",
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * (750 - 500) / 500,
-                        oldName = "Z1",
-                        plantingZoneId = PlantingZoneId(1),
-                        removedRegion = rectangle(0),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
-                                    addedRegion = newSubzoneBoundary,
-                                    boundary = newSubzoneBoundary,
-                                    areaHaDifference = BigDecimal("12.5"),
-                                    newName = "S2"))))),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[1])),
+                        removedRegion = rectangle(0)))),
         existing,
         desired)
   }
@@ -105,6 +92,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("30.0"),
             areaHaDifference = BigDecimal("5.0"),
             boundary = desired.boundary!!,
             exclusion = null,
@@ -114,25 +102,21 @@ class PlantingSiteEditCalculatorTest {
                     PlantingZoneEdit.Update(
                         addedRegion = rectangle(x = 500, width = 200, height = 500),
                         areaHaDifference = BigDecimal("5.0"),
-                        boundary = desired.boundary!!,
-                        newName = "Z1",
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
-                        oldName = "Z1",
-                        removedRegion = rectangle(x = 0, width = 100, height = 500),
-                        monitoringPlotsRemoved = emptySet(),
-                        plantingZoneId = PlantingZoneId(1),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Update(
                                     addedRegion = rectangle(x = 500, width = 200, height = 500),
                                     areaHaDifference = BigDecimal("5.0"),
-                                    boundary = desired.boundary!!,
-                                    newName = "S1",
-                                    oldName = "S1",
-                                    plantingSubzoneId = PlantingSubzoneId(1),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
                                     removedRegion = rectangle(x = 0, width = 100, height = 500),
-                                ))))),
+                                )),
+                        removedRegion = rectangle(x = 0, width = 100, height = 500)))),
         existing,
         desired)
   }
@@ -148,6 +132,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("50.0"),
             areaHaDifference = BigDecimal("10.0"),
             boundary = desired.boundary!!,
             exclusion = rectangle(width = 100, height = 500),
@@ -157,25 +142,21 @@ class PlantingSiteEditCalculatorTest {
                     PlantingZoneEdit.Update(
                         addedRegion = rectangle(x = 100, width = 200, height = 500),
                         areaHaDifference = BigDecimal("10.0"),
-                        boundary = desired.boundary!!,
-                        newName = "Z1",
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
-                        oldName = "Z1",
-                        removedRegion = rectangle(0),
-                        monitoringPlotsRemoved = emptySet(),
-                        plantingZoneId = PlantingZoneId(1),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Update(
                                     addedRegion = rectangle(x = 100, width = 200, height = 500),
                                     areaHaDifference = BigDecimal("10.0"),
-                                    boundary = desired.boundary!!,
-                                    newName = "S1",
-                                    oldName = "S1",
-                                    plantingSubzoneId = PlantingSubzoneId(1),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
                                     removedRegion = rectangle(0),
-                                ))))),
+                                )),
+                        removedRegion = rectangle(0)))),
         existing,
         desired)
   }
@@ -191,6 +172,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("-12.5"),
             boundary = desired.boundary!!,
             exclusion = null,
@@ -198,18 +180,12 @@ class PlantingSiteEditCalculatorTest {
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Delete(
-                        areaHaDifference = BigDecimal("-12.5"),
-                        oldName = "Z2",
-                        removedRegion = rectangle(x = 750, width = 250, height = 500),
+                        existingModel = existing.plantingZones[1],
                         monitoringPlotsRemoved = emptySet(),
-                        plantingZoneId = PlantingZoneId(2),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(
-                                    areaHaDifference = BigDecimal("-12.5"),
-                                    oldName = "S2",
-                                    plantingSubzoneId = PlantingSubzoneId(2),
-                                    removedRegion = rectangle(x = 750, width = 250, height = 500),
+                                    existingModel = existing.plantingZones[1].plantingSubzones[0],
                                 ))))),
         existing,
         desired)
@@ -233,6 +209,7 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("-12.5"),
             boundary = desired.boundary!!,
             exclusion = null,
@@ -242,21 +219,16 @@ class PlantingSiteEditCalculatorTest {
                     PlantingZoneEdit.Update(
                         addedRegion = rectangle(0),
                         areaHaDifference = BigDecimal("-12.5"),
-                        boundary = desired.plantingZones[1].boundary,
-                        newName = "Z2",
-                        numPermanentClustersToAdd = 0,
-                        oldName = "Z2",
-                        removedRegion = rectangle(x = 750, width = 250, height = 500),
+                        desiredModel = desired.plantingZones[1],
+                        existingModel = existing.plantingZones[1],
                         monitoringPlotsRemoved = emptySet(),
-                        plantingZoneId = PlantingZoneId(2),
+                        numPermanentClustersToAdd = 0,
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(
-                                    areaHaDifference = BigDecimal("-12.5"),
-                                    oldName = "S3",
-                                    plantingSubzoneId = PlantingSubzoneId(3),
-                                    removedRegion = rectangle(x = 750, width = 250, height = 500),
-                                ))))),
+                                    existingModel = existing.plantingZones[1].plantingSubzones[1],
+                                )),
+                        removedRegion = rectangle(x = 750, width = 250, height = 500)))),
         existing,
         desired)
   }
@@ -359,7 +331,13 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            BigDecimal("0.0"), site.boundary!!, null, PlantingSiteId(1), emptyList(), emptyList()),
+            BigDecimal("25.0"),
+            BigDecimal("0.0"),
+            site.boundary!!,
+            null,
+            PlantingSiteId(1),
+            emptyList(),
+            emptyList()),
         site,
         site.toNew())
   }
@@ -382,59 +360,42 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
+            BigDecimal("27.5"),
             BigDecimal("2.5"),
             desired.boundary!!,
             null,
             PlantingSiteId(1),
             listOf(
                 PlantingZoneEdit.Delete(
-                    areaHaDifference = existing.plantingZones[0].areaHa.negate(),
+                    existingModel = existing.plantingZones[0],
                     monitoringPlotsRemoved = emptySet(),
-                    oldName = "Z1",
-                    plantingZoneId = PlantingZoneId(1),
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Delete(
                                 existing.plantingZones[0].plantingSubzones[0])),
-                    removedRegion = existing.plantingZones[0].boundary,
                 ),
                 PlantingZoneEdit.Delete(
-                    areaHaDifference = existing.plantingZones[1].areaHa.negate(),
+                    existingModel = existing.plantingZones[1],
                     monitoringPlotsRemoved = emptySet(),
-                    oldName = "Z2",
-                    plantingZoneId = PlantingZoneId(2),
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Delete(
                                 existing.plantingZones[1].plantingSubzones[0])),
-                    removedRegion = existing.plantingZones[1].boundary,
                 ),
                 PlantingZoneEdit.Create(
-                    addedRegion = desired.plantingZones[0].boundary,
-                    areaHaDifference = desired.plantingZones[0].areaHa,
-                    boundary = desired.plantingZones[0].boundary,
-                    newName = "Z1",
-                    numPermanentClustersToAdd = 0,
+                    desiredModel = desired.plantingZones[0],
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(
                                 desired.plantingZones[0].plantingSubzones[0]))),
                 PlantingZoneEdit.Create(
-                    addedRegion = desired.plantingZones[1].boundary,
-                    areaHaDifference = desired.plantingZones[1].areaHa,
-                    boundary = desired.plantingZones[1].boundary,
-                    newName = "Z2",
-                    numPermanentClustersToAdd = 0,
+                    desiredModel = desired.plantingZones[1],
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(
                                 desired.plantingZones[1].plantingSubzones[0]))),
                 PlantingZoneEdit.Create(
-                    addedRegion = desired.plantingZones[2].boundary,
-                    areaHaDifference = desired.plantingZones[2].areaHa,
-                    boundary = desired.plantingZones[2].boundary,
-                    newName = "Z3",
-                    numPermanentClustersToAdd = 0,
+                    desiredModel = desired.plantingZones[2],
                     plantingSubzoneEdits =
                         listOf(
                             PlantingSubzoneEdit.Create(


### PR DESCRIPTION
Zone and subzone creation and deletion edits always pull all their values from
a single model, and update edits pull many of their values from the "existing"
and "desired" models; include those models directly in the edit classes rather
than copying the relevant values.