### PR TITLE
Add two new endpoints for Participant Project Species 

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -99,7 +99,7 @@ class ParticipantProjectSpeciesController(
       @RequestParam organizationId: OrganizationId
   ): GetParticipantProjectsForSpeciesResponsePayload {
     val results =
-        participantProjectSpeciesStore.fetchParticipantProjectsForSpeciesDeliverables(
+        participantProjectSpeciesStore.fetchParticipantProjectsForSpecies(
             organizationId, speciesId)
 
     return GetParticipantProjectsForSpeciesResponsePayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -99,8 +99,7 @@ class ParticipantProjectSpeciesController(
       @RequestParam organizationId: OrganizationId
   ): GetParticipantProjectsForSpeciesResponsePayload {
     val results =
-        participantProjectSpeciesStore.fetchParticipantProjectsForSpecies(
-            organizationId, speciesId)
+        participantProjectSpeciesStore.fetchParticipantProjectsForSpecies(organizationId, speciesId)
 
     return GetParticipantProjectsForSpeciesResponsePayload(
         results.map {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -132,7 +132,7 @@ class ParticipantProjectSpeciesStore(
         .execute()
   }
 
-  fun fetchParticipantProjectsForSpeciesDeliverables(
+  fun fetchParticipantProjectsForSpecies(
       organizationId: OrganizationId,
       speciesId: SpeciesId
   ): List<ParticipantProjectsForSpecies> {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -4,21 +4,34 @@ import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesEdi
 import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
 import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
 import com.terraformation.backend.accelerator.model.ParticipantProjectSpeciesModel
+import com.terraformation.backend.accelerator.model.ParticipantProjectsForSpecies
+import com.terraformation.backend.accelerator.model.SpeciesForParticipantProject
 import com.terraformation.backend.accelerator.model.toModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.daos.ParticipantProjectSpeciesDao
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
 import com.terraformation.backend.db.accelerator.tables.records.ParticipantProjectSpeciesRecord
+import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.MODULES
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.daos.ProjectsDao
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.i18n.TimeZones
 import jakarta.inject.Named
 import java.time.Instant
 import java.time.InstantSource
+import java.time.LocalDate
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.TableField
@@ -117,6 +130,79 @@ class ParticipantProjectSpeciesStore(
         .deleteFrom(PARTICIPANT_PROJECT_SPECIES)
         .where(PARTICIPANT_PROJECT_SPECIES.ID.`in`(participantProjectSpeciesIds))
         .execute()
+  }
+
+  fun fetchParticipantProjectsForSpeciesDeliverables(
+      organizationId: OrganizationId,
+      speciesId: SpeciesId
+  ): List<ParticipantProjectsForSpecies> {
+    val today = LocalDate.ofInstant(clock.instant(), TimeZones.UTC)
+    val user = currentUser()
+
+    return dslContext
+        .select(
+            DELIVERABLES.ID,
+            PROJECTS.NAME,
+            PROJECTS.ID,
+            PARTICIPANT_PROJECT_SPECIES.ID,
+            PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID,
+            SPECIES.ID)
+        .from(SPECIES)
+        .join(PARTICIPANT_PROJECT_SPECIES)
+        .on(SPECIES.ID.eq(PARTICIPANT_PROJECT_SPECIES.SPECIES_ID))
+        .join(PROJECTS)
+        .on(PARTICIPANT_PROJECT_SPECIES.PROJECT_ID.eq(PROJECTS.ID))
+        .join(ORGANIZATIONS)
+        .on(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
+        .join(PARTICIPANTS)
+        .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+        .leftOuterJoin(COHORT_MODULES)
+        .on(
+            COHORT_MODULES.COHORT_ID.eq(PARTICIPANTS.COHORT_ID),
+            COHORT_MODULES.END_DATE.greaterOrEqual(today),
+            COHORT_MODULES.START_DATE.lessOrEqual(today))
+        .leftOuterJoin(MODULES)
+        .on(COHORT_MODULES.MODULE_ID.eq(MODULES.ID))
+        .leftOuterJoin(DELIVERABLES)
+        .on(
+            DELIVERABLES.MODULE_ID.eq(MODULES.ID),
+            DELIVERABLES.DELIVERABLE_TYPE_ID.eq(DeliverableType.Species))
+        .where(ORGANIZATIONS.ID.eq(organizationId))
+        .and(SPECIES.ID.eq(speciesId))
+        .fetch {
+          if (user.canReadProjectDeliverables(it[PROJECTS.ID]!!)) {
+            ParticipantProjectsForSpecies.of(it)
+          } else {
+            it[DELIVERABLES.ID] = null
+            ParticipantProjectsForSpecies.of(it)
+          }
+        }
+        .filter { user.canReadProject(it.projectId) }
+  }
+
+  fun fetchSpeciesForParticipantProjects(projectId: ProjectId): List<SpeciesForParticipantProject> {
+    val user = currentUser()
+
+    return dslContext
+        .select(
+            PROJECTS.NAME,
+            PROJECTS.ID,
+            PARTICIPANT_PROJECT_SPECIES.ID,
+            PARTICIPANT_PROJECT_SPECIES.RATIONALE,
+            PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID,
+            SPECIES.ID,
+            SPECIES.COMMON_NAME,
+            SPECIES.SCIENTIFIC_NAME)
+        .from(SPECIES)
+        .join(PARTICIPANT_PROJECT_SPECIES)
+        .on(SPECIES.ID.eq(PARTICIPANT_PROJECT_SPECIES.SPECIES_ID))
+        .join(PROJECTS)
+        .on(PARTICIPANT_PROJECT_SPECIES.PROJECT_ID.eq(PROJECTS.ID))
+        .join(PARTICIPANTS)
+        .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+        .where(PROJECTS.ID.eq(projectId))
+        .fetch { SpeciesForParticipantProject.of(it) }
+        .filter { user.canReadProject(it.projectId) }
   }
 
   fun fetchLastCreatedSpeciesTime(projectId: ProjectId): Instant =

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantProjectForSpecies.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ParticipantProjectForSpecies.kt
@@ -1,0 +1,35 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import org.jooq.Record
+
+data class ParticipantProjectsForSpecies(
+    val activeDeliverableId: DeliverableId? = null,
+    val participantProjectSpeciesId: ParticipantProjectSpeciesId,
+    val participantProjectSpeciesSubmissionStatus: SubmissionStatus,
+    val projectId: ProjectId,
+    val projectName: String,
+    val speciesId: SpeciesId,
+) {
+  companion object {
+    fun of(record: Record): ParticipantProjectsForSpecies {
+      return ParticipantProjectsForSpecies(
+          activeDeliverableId = record[DELIVERABLES.ID],
+          participantProjectSpeciesId = record[PARTICIPANT_PROJECT_SPECIES.ID]!!,
+          projectId = record[PROJECTS.ID]!!,
+          projectName = record[PROJECTS.NAME]!!,
+          participantProjectSpeciesSubmissionStatus =
+              record[PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID]!!,
+          speciesId = record[SPECIES.ID]!!,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesForParticipantProject.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesForParticipantProject.kt
@@ -1,0 +1,35 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import org.jooq.Record
+
+data class SpeciesForParticipantProject(
+    val participantProjectSpeciesId: ParticipantProjectSpeciesId,
+    val participantProjectSpeciesRationale: String?,
+    val participantProjectSpeciesSubmissionStatus: SubmissionStatus,
+    val projectId: ProjectId,
+    val speciesId: SpeciesId,
+    val speciesCommonName: String?,
+    val speciesScientificName: String,
+) {
+  companion object {
+    fun of(record: Record): SpeciesForParticipantProject {
+      return SpeciesForParticipantProject(
+          participantProjectSpeciesId = record[PARTICIPANT_PROJECT_SPECIES.ID]!!,
+          participantProjectSpeciesRationale = record[PARTICIPANT_PROJECT_SPECIES.RATIONALE],
+          participantProjectSpeciesSubmissionStatus =
+              record[PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID]!!,
+          projectId = record[PROJECTS.ID]!!,
+          speciesId = record[SPECIES.ID]!!,
+          speciesCommonName = record[SPECIES.COMMON_NAME],
+          speciesScientificName = record[SPECIES.SCIENTIFIC_NAME]!!,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -219,7 +219,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
     }
 
     @Test
@@ -259,7 +259,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
     }
 
     @Test
@@ -297,7 +297,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
     }
 
     @Test
@@ -317,7 +317,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           emptyList<ParticipantProjectsForSpecies>(),
-          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -219,7 +219,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(speciesId))
     }
 
     @Test
@@ -259,7 +259,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(speciesId))
     }
 
     @Test
@@ -297,7 +297,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId2,
                   projectName = "Project 2",
                   speciesId = speciesId)),
-          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(speciesId))
     }
 
     @Test
@@ -317,7 +317,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           emptyList<ParticipantProjectsForSpecies>(),
-          store.fetchParticipantProjectsForSpecies(inserted.organizationId, speciesId))
+          store.fetchParticipantProjectsForSpecies(speciesId))
     }
   }
 
@@ -330,7 +330,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject(participantId = participantId)
 
       val speciesId1 = insertSpecies(scientificName = "Acacia Kochi")
-      val speciesId2 = insertSpecies(scientificName = "Acacia Koa")
+      val speciesId2 = insertSpecies(scientificName = "Juniperus scopulorum")
       val participantProjectSpeciesId1 =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId1)
       val participantProjectSpeciesId2 =
@@ -352,7 +352,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
                   projectId = projectId,
                   speciesId = speciesId2,
-                  speciesScientificName = "Acacia Koa",
+                  speciesScientificName = "Juniperus scopulorum",
                   speciesCommonName = null)),
           store.fetchSpeciesForParticipantProjects(projectId))
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -6,8 +6,11 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesEditedEvent
 import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
 import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
+import com.terraformation.backend.accelerator.model.ParticipantProjectsForSpecies
+import com.terraformation.backend.accelerator.model.SpeciesForParticipantProject
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
@@ -15,6 +18,7 @@ import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -174,6 +178,199 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<ParticipantProjectSpeciesNotFoundException> {
         store.fetchOneById(participantProjectSpeciesId)
       }
+    }
+  }
+
+  @Nested
+  inner class FetchParticipantProjectsForSpecies {
+    @Test
+    fun `fetches the projects a species is associated to by species ID with an active deliverable`() {
+      val cohortId = insertCohort()
+      val moduleId = insertModule()
+      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
+      val deliverableId =
+          insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+      // This one should not be returned because it is not a species type deliverable
+      insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Document)
+
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId1 = insertProject(participantId = participantId)
+      val projectId2 = insertProject(participantId = participantId)
+
+      val speciesId = insertSpecies()
+      val participantProjectSpeciesId1 =
+          insertParticipantProjectSpecies(projectId = projectId1, speciesId = speciesId)
+      val participantProjectSpeciesId2 =
+          insertParticipantProjectSpecies(projectId = projectId2, speciesId = speciesId)
+
+      assertEquals(
+          listOf(
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = deliverableId,
+                  participantProjectSpeciesId = participantProjectSpeciesId1,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId1,
+                  projectName = "Project 1",
+                  speciesId = speciesId),
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = deliverableId,
+                  participantProjectSpeciesId = participantProjectSpeciesId2,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId2,
+                  projectName = "Project 2",
+                  speciesId = speciesId)),
+          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+    }
+
+    @Test
+    fun `fetches the projects a species is associated to by species ID without an active deliverable`() {
+      val cohortId = insertCohort()
+
+      val moduleIdOld = insertModule()
+      insertCohortModule(cohortId = cohortId, moduleId = moduleIdOld)
+      insertDeliverable(moduleId = moduleIdOld, deliverableTypeId = DeliverableType.Species)
+
+      // Ensure the previously created module is in the past, so there is no active deliverable
+      clock.instant = Instant.EPOCH.plus(7, ChronoUnit.DAYS)
+
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId1 = insertProject(participantId = participantId)
+      val projectId2 = insertProject(participantId = participantId)
+
+      val speciesId = insertSpecies()
+      val participantProjectSpeciesId1 =
+          insertParticipantProjectSpecies(projectId = projectId1, speciesId = speciesId)
+      val participantProjectSpeciesId2 =
+          insertParticipantProjectSpecies(projectId = projectId2, speciesId = speciesId)
+
+      assertEquals(
+          listOf(
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = null,
+                  participantProjectSpeciesId = participantProjectSpeciesId1,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId1,
+                  projectName = "Project 1",
+                  speciesId = speciesId),
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = null,
+                  participantProjectSpeciesId = participantProjectSpeciesId2,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId2,
+                  projectName = "Project 2",
+                  speciesId = speciesId)),
+          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+    }
+
+    @Test
+    fun `does not include active deliverable ID if the user does not have permission to view project deliverables`() {
+      val cohortId = insertCohort()
+      val moduleId = insertModule()
+      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
+      insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId1 = insertProject(participantId = participantId)
+      val projectId2 = insertProject(participantId = participantId)
+
+      val speciesId = insertSpecies()
+      val participantProjectSpeciesId1 =
+          insertParticipantProjectSpecies(projectId = projectId1, speciesId = speciesId)
+      val participantProjectSpeciesId2 =
+          insertParticipantProjectSpecies(projectId = projectId2, speciesId = speciesId)
+
+      every { user.canReadProjectDeliverables(any()) } returns false
+
+      assertEquals(
+          listOf(
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = null,
+                  participantProjectSpeciesId = participantProjectSpeciesId1,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId1,
+                  projectName = "Project 1",
+                  speciesId = speciesId),
+              ParticipantProjectsForSpecies(
+                  activeDeliverableId = null,
+                  participantProjectSpeciesId = participantProjectSpeciesId2,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId2,
+                  projectName = "Project 2",
+                  speciesId = speciesId)),
+          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+    }
+
+    @Test
+    fun `returns an empty list of the user does not have permission to read the project`() {
+      val cohortId = insertCohort()
+      val moduleId = insertModule()
+      insertCohortModule(cohortId = cohortId, moduleId = moduleId)
+      insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+
+      val speciesId = insertSpecies()
+      insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
+
+      every { user.canReadProject(any()) } returns false
+
+      assertEquals(
+          emptyList<ParticipantProjectsForSpecies>(),
+          store.fetchParticipantProjectsForSpeciesDeliverables(inserted.organizationId, speciesId))
+    }
+  }
+
+  @Nested
+  inner class FetchSpeciesForParticipantProject {
+    @Test
+    fun `fetches the species and participant project species data associated to a participant project`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+
+      val speciesId1 = insertSpecies(scientificName = "Acacia Kochi")
+      val speciesId2 = insertSpecies(scientificName = "Acacia Koa")
+      val participantProjectSpeciesId1 =
+          insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId1)
+      val participantProjectSpeciesId2 =
+          insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId2)
+
+      assertEquals(
+          listOf(
+              SpeciesForParticipantProject(
+                  participantProjectSpeciesId = participantProjectSpeciesId1,
+                  participantProjectSpeciesRationale = null,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId,
+                  speciesId = speciesId1,
+                  speciesScientificName = "Acacia Kochi",
+                  speciesCommonName = null),
+              SpeciesForParticipantProject(
+                  participantProjectSpeciesId = participantProjectSpeciesId2,
+                  participantProjectSpeciesRationale = null,
+                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
+                  projectId = projectId,
+                  speciesId = speciesId2,
+                  speciesScientificName = "Acacia Koa",
+                  speciesCommonName = null)),
+          store.fetchSpeciesForParticipantProjects(projectId))
+    }
+
+    @Test
+    fun `returns an empty list of the user does not have permission to read the project`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+
+      val speciesId = insertSpecies()
+      insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
+
+      every { user.canReadProject(any()) } returns false
+
+      assertEquals(
+          emptyList<SpeciesForParticipantProject>(),
+          store.fetchSpeciesForParticipantProjects(projectId))
     }
   }
 


### PR DESCRIPTION
Add two new endpoints (in lieu of using the Search API) for:
- Retrieving projects associated to species through the Participant Project Species (PPS)
  - An active deliverable ID (according to the cohort module dates) will be included if it exists
- Retrieving species associated to a project through PPS
