### PR TITLE
Set and use correct factory on geometry objects

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryBinding.kt
@@ -16,6 +16,7 @@ import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
+import org.locationtech.jts.geom.PrecisionModel
 import org.locationtech.jts.io.WKBReader
 
 /**
@@ -42,7 +43,7 @@ class GeometryBinding : Binding<JooqGeometry, Geometry> {
   private val converter = GeometryConverter()
 
   class GeometryConverter : Converter<JooqGeometry, Geometry> {
-    private val geometryFactory = GeometryFactory()
+    private val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
 
     override fun from(databaseObject: JooqGeometry?): Geometry? {
       // Geometry values are returned in WKB (Well Known Binary) form, encoded in hexadecimal.

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.log.perClassLogger
@@ -15,10 +14,8 @@ import com.terraformation.backend.tracking.model.ShapefileFeature
 import com.terraformation.backend.util.toMultiPolygon
 import jakarta.inject.Named
 import java.math.BigDecimal
-import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Polygon
-import org.locationtech.jts.geom.PrecisionModel
 
 @Named
 class PlantingSiteImporter(
@@ -169,7 +166,9 @@ class PlantingSiteImporter(
               }
             }
 
-    return GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+    return exclusionsFile.features[0]
+        .geometry
+        .factory
         .createMultiPolygon(allPolygons.toTypedArray())
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -83,11 +83,9 @@ import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
 import org.jooq.impl.DSL
-import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
-import org.locationtech.jts.geom.PrecisionModel
 import org.springframework.context.ApplicationEventPublisher
 
 @Named
@@ -265,8 +263,7 @@ class PlantingSiteStore(
     // southwest corner of the envelope (bounding box) of the site boundary.
     val gridOrigin =
         if (newModel.boundary != null) {
-          GeometryFactory(PrecisionModel(), newModel.boundary.srid)
-              .createPoint(newModel.boundary.envelope.coordinates[0])
+          newModel.boundary.factory.createPoint(newModel.boundary.envelope.coordinates[0])
         } else {
           null
         }
@@ -1034,7 +1031,7 @@ class PlantingSiteStore(
       throw IllegalStateException("Planting site ${plantingSite.id} has no grid origin")
     }
 
-    val geometryFactory = GeometryFactory(PrecisionModel(), plantingSite.gridOrigin.srid)
+    val geometryFactory = plantingSite.gridOrigin.factory
 
     // List of [boundary, cluster number]
     val clusterBoundaries: List<Pair<Polygon, Int>> =

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Shapefile.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.tracking.model
 
-import com.terraformation.backend.db.SRID
 import com.terraformation.backend.file.useAndDelete
+import com.terraformation.backend.util.toMultiPolygon
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.ZipFile
@@ -10,10 +10,8 @@ import kotlin.io.path.extension
 import org.geotools.api.data.DataStoreFinder
 import org.geotools.api.filter.Filter
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem
-import org.geotools.referencing.crs.DefaultGeographicCRS
-import org.locationtech.jts.geom.GeometryFactory
+import org.geotools.referencing.CRS
 import org.locationtech.jts.geom.Polygon
-import org.locationtech.jts.geom.PrecisionModel
 
 /** Simplified representation of the geometry data from a shapefile. */
 data class Shapefile(
@@ -74,13 +72,9 @@ data class Shapefile(
     fun fromBoundary(
         boundary: Polygon,
         properties: Map<String, String>,
-        crs: CoordinateReferenceSystem = DefaultGeographicCRS.WGS84
+        crs: CoordinateReferenceSystem = CRS.decode("EPSG:${boundary.srid}", true)
     ): Shapefile {
-      val multiPolygonBoundary =
-          GeometryFactory(PrecisionModel(), SRID.LONG_LAT).createMultiPolygon(arrayOf(boundary))
-      val boundaryFeature = ShapefileFeature(multiPolygonBoundary, properties, crs)
-
-      return Shapefile(listOf(boundaryFeature))
+      return Shapefile(listOf(ShapefileFeature(boundary.toMultiPolygon(), properties, crs)))
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -12,11 +12,9 @@ import org.geotools.referencing.CRS
 import org.geotools.referencing.GeodeticCalculator
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
-import org.locationtech.jts.geom.PrecisionModel
 
 /** Finds an unused grid-aligned square within a zone boundary. */
 class UnusedSquareFinder(
@@ -26,7 +24,7 @@ class UnusedSquareFinder(
     /** Areas to exclude from the zone, or null if the whole zone is available. */
     exclusion: MultiPolygon? = null,
 ) {
-  private val geometryFactory = GeometryFactory(PrecisionModel())
+  private val geometryFactory = zoneBoundary.factory
   private val boundaryCrs = CRS.decode("EPSG:${zoneBoundary.srid}", true)
   private val calculator = GeodeticCalculator(boundaryCrs)
   private val gridInterval: Double = sizeMeters.toDouble()

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -26,7 +26,6 @@ import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
-import org.locationtech.jts.geom.PrecisionModel
 import org.locationtech.jts.geom.util.GeometryFixer
 
 // One-off extension functions for third-party classes. Extensions that are only useful in the
@@ -132,9 +131,7 @@ fun GeometryFactory.createRectangle(
  * Returns a MultiPolygon version of a polygonal geometry. If the geometry is already a
  * MultiPolygon, returns it as-is.
  */
-fun Geometry.toMultiPolygon(
-    factory: GeometryFactory = GeometryFactory(PrecisionModel(), srid)
-): MultiPolygon {
+fun Geometry.toMultiPolygon(): MultiPolygon {
   return when (this) {
     is MultiPolygon -> this
     is Polygon -> factory.createMultiPolygon(arrayOf(this))

--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -72,8 +72,7 @@ fun polygon(scale: Number): Polygon {
 
 /** Wraps a Polygon in a MultiPolygon. */
 fun multiPolygon(polygon: Polygon): MultiPolygon {
-  val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
-  return geometryFactory.createMultiPolygon(arrayOf(polygon))
+  return polygon.factory.createMultiPolygon(arrayOf(polygon))
 }
 
 /** Creates a simple rectangular MultiPolygon. */

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -615,7 +615,7 @@ class PlantingZoneModelTest {
     return subzones
         .map { it.boundary }
         .reduce { acc: Geometry, subzone: Geometry -> acc.union(subzone) }
-        .toMultiPolygon(geometryFactory)
+        .toMultiPolygon()
   }
 
   private fun plantingZoneModel(


### PR DESCRIPTION
JTS Geometry objects remember which factory created them, so we can reuse that
factory when we're creating derived geometries.

But when we were reading geometry values from the database, we were using a
geometry factory that didn't have the correct SRID to indicate that the
coordinates were longitude and latitude, so reusing those objects' factories
would produce geometries with incorrect SRIDs.

Set the correct SRID when constructing new geometries, and reuse the existing
factory when deriving new geometries from existing ones.