### PR TITLE
SW-5230 Ignore exclusions in site/zone/subzone areas

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -295,9 +295,10 @@ data class NewPlantingSubzonePayload(
     }
   }
 
-  fun toModel(zoneName: String): NewPlantingSubzoneModel {
+  fun toModel(zoneName: String, exclusion: MultiPolygon?): NewPlantingSubzoneModel {
     return PlantingSubzoneModel.create(
         boundary = boundary.toMultiPolygon(),
+        exclusion = exclusion,
         fullName = "$zoneName-$name",
         name = name,
     )
@@ -319,13 +320,14 @@ data class NewPlantingZonePayload(
     plantingSubzones?.forEach { it.validate() }
   }
 
-  fun toModel(): NewPlantingZoneModel {
+  fun toModel(exclusion: MultiPolygon?): NewPlantingZoneModel {
     return PlantingZoneModel.create(
         boundary = boundary.toMultiPolygon(),
+        exclusion = exclusion,
         name = name,
         targetPlantingDensity =
             targetPlantingDensity ?: PlantingZoneModel.DEFAULT_TARGET_PLANTING_DENSITY,
-        plantingSubzones = plantingSubzones?.map { it.toModel(name) } ?: emptyList(),
+        plantingSubzones = plantingSubzones?.map { it.toModel(name, exclusion) } ?: emptyList(),
     )
   }
 }
@@ -370,15 +372,17 @@ data class CreatePlantingSiteRequestPayload(
   }
 
   fun toModel(): NewPlantingSiteModel {
+    val exclusionMultiPolygon = exclusion?.toMultiPolygon()
+
     return PlantingSiteModel.create(
         boundary = boundary?.toMultiPolygon(),
         description = description,
-        exclusion = exclusion?.toMultiPolygon(),
+        exclusion = exclusionMultiPolygon,
         name = name,
         organizationId = organizationId,
+        plantingZones = plantingZones?.map { it.toModel(exclusionMultiPolygon) } ?: emptyList(),
         projectId = projectId,
         timeZone = timeZone,
-        plantingZones = plantingZones?.map { it.toModel() } ?: emptyList(),
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -273,14 +273,9 @@ class PlantingSiteStore(
       throw PlantingSiteMapInvalidException(problems)
     }
 
-    // Simple planting sites can be arbitrarily small; if their areas would round down to zero,
-    // treat them as not having areas at all so we don't try to calculate area-based statistics.
-    val areaHa: BigDecimal? =
-        newModel.boundary?.calculateAreaHectares()?.let { if (it.signum() > 0) it else null }
-
     val plantingSitesRow =
         PlantingSitesRow(
-            areaHa = areaHa,
+            areaHa = newModel.areaHa,
             boundary = newModel.boundary,
             createdBy = currentUser().userId,
             createdTime = now,
@@ -578,7 +573,7 @@ class PlantingSiteStore(
 
     val zonesRow =
         PlantingZonesRow(
-            areaHa = zone.boundary.calculateAreaHectares(),
+            areaHa = zone.areaHa,
             boundary = zone.boundary,
             createdBy = userId,
             createdTime = now,
@@ -610,7 +605,7 @@ class PlantingSiteStore(
 
     val plantingSubzonesRow =
         PlantingSubzonesRow(
-            areaHa = subzone.boundary.calculateAreaHectares(),
+            areaHa = subzone.areaHa,
             boundary = subzone.boundary,
             createdBy = userId,
             createdTime = now,

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
 import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.coveragePercent
+import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -334,9 +335,6 @@ class PlantingSiteEditCalculator(
         .groupBy({ it.value!! }, { it.key })
         .filter { it.value.size > 1 }
   }
-
-  private fun Geometry.differenceNullable(other: Geometry?): Geometry =
-      if (other != null) difference(other) else this
 
   private fun MultiPolygon.orEmpty(): MultiPolygon =
       if (isEmpty) factory.createMultiPolygon() else this

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.equalsIgnoreScale
 import java.math.BigDecimal
 import java.time.Instant
@@ -32,17 +33,27 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
   }
 
   fun toNew(): NewPlantingSubzoneModel =
-      create(boundary, fullName, name, areaHa, plantingCompletedTime, monitoringPlots)
+      NewPlantingSubzoneModel(
+          areaHa = areaHa,
+          boundary = boundary,
+          id = null,
+          fullName = fullName,
+          name = name,
+          plantingCompletedTime = plantingCompletedTime,
+          monitoringPlots = monitoringPlots,
+      )
 
   companion object {
     fun create(
         boundary: MultiPolygon,
         fullName: String,
         name: String,
-        areaHa: BigDecimal = boundary.calculateAreaHectares(),
+        exclusion: MultiPolygon? = null,
         plantingCompletedTime: Instant? = null,
         monitoringPlots: List<MonitoringPlotModel> = emptyList(),
     ): NewPlantingSubzoneModel {
+      val areaHa: BigDecimal = boundary.differenceNullable(exclusion).calculateAreaHectares()
+
       return NewPlantingSubzoneModel(
           areaHa = areaHa,
           boundary = boundary,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.coveragePercent
+import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.equalsIgnoreScale
 import com.terraformation.backend.util.nearlyCoveredBy
 import com.terraformation.backend.util.toMultiPolygon
@@ -388,18 +389,20 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 
   fun toNew(): NewPlantingZoneModel =
-      create(
-          boundary,
-          name,
-          plantingSubzones.map { it.toNew() },
-          areaHa,
-          errorMargin,
-          extraPermanentClusters,
-          numPermanentClusters,
-          numTemporaryPlots,
-          studentsT,
-          targetPlantingDensity,
-          variance)
+      NewPlantingZoneModel(
+          areaHa = areaHa,
+          boundary = boundary,
+          errorMargin = errorMargin,
+          extraPermanentClusters = extraPermanentClusters,
+          id = null,
+          name = name,
+          numPermanentClusters = numPermanentClusters,
+          numTemporaryPlots = numTemporaryPlots,
+          plantingSubzones = plantingSubzones.map { it.toNew() },
+          studentsT = studentsT,
+          targetPlantingDensity = targetPlantingDensity,
+          variance = variance,
+      )
 
   companion object {
     // Default values of the three parameters that determine how many monitoring plots should be
@@ -420,7 +423,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
         boundary: MultiPolygon,
         name: String,
         plantingSubzones: List<NewPlantingSubzoneModel>,
-        areaHa: BigDecimal = boundary.calculateAreaHectares(),
+        exclusion: MultiPolygon? = null,
         errorMargin: BigDecimal = DEFAULT_ERROR_MARGIN,
         extraPermanentClusters: Int = 0,
         numPermanentClusters: Int = DEFAULT_NUM_PERMANENT_CLUSTERS,
@@ -429,6 +432,8 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
         targetPlantingDensity: BigDecimal = DEFAULT_TARGET_PLANTING_DENSITY,
         variance: BigDecimal = DEFAULT_VARIANCE,
     ): NewPlantingZoneModel {
+      val areaHa: BigDecimal = boundary.differenceNullable(exclusion).calculateAreaHectares()
+
       return NewPlantingZoneModel(
           areaHa = areaHa,
           boundary = boundary,

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -163,6 +163,10 @@ fun Geometry.fixIfNeeded(): Geometry {
  * @throws FactoryException The geometry couldn't be converted to UTM.
  */
 fun Geometry.calculateAreaHectares(originalCrs: CoordinateReferenceSystem? = null): BigDecimal {
+  if (isEmpty) {
+    return BigDecimal.ZERO.setScale(1)
+  }
+
   val crs = originalCrs ?: CRS.decode("EPSG:$srid", true)
 
   // Transform to UTM if it isn't already.
@@ -209,3 +213,10 @@ fun Geometry.coveragePercent(other: Geometry): Double {
 fun Geometry.nearlyCoveredBy(other: Geometry, minCoveragePercent: Double = 99.99): Boolean {
   return coveredBy(other) || coveragePercent(other) >= minCoveragePercent
 }
+
+/**
+ * Returns the difference between this geometry and another geometry, or this geometry if the other
+ * one is null.
+ */
+fun Geometry.differenceNullable(other: Geometry?): Geometry =
+    if (other != null) difference(other) else this

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -156,7 +156,6 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
               plantingZones =
                   listOf(
                       PlantingZoneModel.create(
-                          areaHa = BigDecimal.ZERO,
                           boundary = zone1Boundary,
                           errorMargin = BigDecimal(1),
                           extraPermanentClusters = 2,
@@ -166,7 +165,6 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
                           plantingSubzones =
                               listOf(
                                   PlantingSubzoneModel.create(
-                                      areaHa = BigDecimal.ZERO,
                                       boundary = subzone11Boundary,
                                       fullName = "Zone 1-Subzone 1",
                                       name = "Subzone 1",
@@ -347,11 +345,13 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
                       listOf(
                           PlantingZoneModel.create(
                               boundary = zoneBoundary,
+                              exclusion = exclusion,
                               name = "zone",
                               plantingSubzones =
                                   listOf(
                                       PlantingSubzoneModel.create(
                                           boundary = subzoneBoundary,
+                                          exclusion = exclusion,
                                           fullName = "zone-subzone",
                                           name = "subzone"))))))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.rectanglePolygon
 import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.PrecisionModel
@@ -111,7 +112,7 @@ private constructor(
 
   fun build(): ExistingPlantingSiteModel {
     return ExistingPlantingSiteModel(
-        areaHa = boundary.calculateAreaHectares(),
+        areaHa = boundary.differenceNullable(exclusion).calculateAreaHectares(),
         boundary = boundary,
         exclusion = exclusion,
         gridOrigin = geometryFactory.createPoint(boundary.envelope.coordinates[0]),
@@ -159,10 +160,10 @@ private constructor(
 
     fun build(): ExistingPlantingZoneModel {
       return ExistingPlantingZoneModel(
-          areaHa = boundary.calculateAreaHectares(),
+          areaHa = boundary.differenceNullable(exclusion).calculateAreaHectares(),
           boundary = boundary,
-          name = name,
           id = PlantingZoneId(currentZoneId),
+          name = name,
           numPermanentClusters = numPermanentClusters,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = plantingSubzones.ifEmpty { listOf(subzone()) },
@@ -206,7 +207,7 @@ private constructor(
 
       fun build(): ExistingPlantingSubzoneModel {
         return ExistingPlantingSubzoneModel(
-            areaHa = boundary.calculateAreaHectares(),
+            areaHa = boundary.differenceNullable(exclusion).calculateAreaHectares(),
             boundary = boundary,
             fullName = fullName,
             id = PlantingSubzoneId(currentSubzoneId),


### PR DESCRIPTION
In the upcoming changes to support planting site editing, we're supposed to update
the site/zone/subzone area in hectares if an exclusion grows or shrinks. But we
were disregarding exclusions in the initial area calculations at site creation
time, which would have been inconsistent with the new behavior.

Internally, areas were being calculated as part of writing the site data to the
database, and the site/zone/subzone models were being intentionally constructed
with dummy values for their areas, meaning that newly-constructed models weren't
representative of the actual site data.

Move the area calculations into the model classes (or rather, the `create`
functions we use to construct new models) and make them take exclusions into
account.