### PR TITLE
Use site models in PlantingSiteEdit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
@@ -1,10 +1,9 @@
 package com.terraformation.backend.tracking.edit
 
-import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.util.equalsIgnoreScale
-import com.terraformation.backend.util.equalsOrBothNull
 import java.math.BigDecimal
-import org.locationtech.jts.geom.MultiPolygon
 
 /**
  * Represents the changes that need to be made to an existing planting site to make it match an
@@ -16,9 +15,6 @@ import org.locationtech.jts.geom.MultiPolygon
  * be applied to the site.
  */
 data class PlantingSiteEdit(
-    /** Usable area in the new version of the site. */
-    val areaHa: BigDecimal,
-
     /**
      * Difference in usable area between the old version of the site (if any) and the new one. A
      * positive value means the site has grown; a negative value means it has shrunk. Note that it
@@ -27,14 +23,11 @@ data class PlantingSiteEdit(
      */
     val areaHaDifference: BigDecimal,
 
-    /** New site boundary. May intersect with [exclusion]. */
-    val boundary: MultiPolygon,
+    /** Desired planting site model. The intended end result after edits are applied. */
+    val desiredModel: AnyPlantingSiteModel,
 
-    /** New site exclusion areas, if any. */
-    val exclusion: MultiPolygon?,
-
-    /** ID of existing site. */
-    val plantingSiteId: PlantingSiteId,
+    /** Existing planting site model. Edits are based on this version of the site. */
+    val existingModel: ExistingPlantingSiteModel,
 
     /** Edits to this site's planting zones. */
     val plantingZoneEdits: List<PlantingZoneEdit>,
@@ -47,11 +40,9 @@ data class PlantingSiteEdit(
 ) {
   fun equalsExact(other: PlantingSiteEdit, tolerance: Double = 0.0000001): Boolean =
       javaClass == other.javaClass &&
-          areaHa.equalsIgnoreScale(other.areaHa) &&
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
-          boundary.equalsOrBothNull(other.boundary, tolerance) &&
-          exclusion.equalsOrBothNull(other.exclusion, tolerance) &&
-          plantingSiteId == other.plantingSiteId &&
+          desiredModel.equals(other.desiredModel, tolerance) &&
+          existingModel.equals(other.existingModel, tolerance) &&
           plantingZoneEdits.size == other.plantingZoneEdits.size &&
           plantingZoneEdits.zip(other.plantingZoneEdits).all { (edit, otherEdit) ->
             edit.equalsExact(otherEdit, tolerance)

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -38,11 +38,9 @@ class PlantingSiteEditCalculator(
         }
 
     return PlantingSiteEdit(
-        areaHa = desiredSite.boundary.calculateAreaHectares(),
         areaHaDifference = calculateAreaHaDifference(existingSite.boundary, desiredSite.boundary),
-        boundary = desiredSite.boundary,
-        exclusion = desiredSite.exclusion,
-        plantingSiteId = existingSite.id,
+        desiredModel = desiredSite,
+        existingModel = existingSite,
         plantingZoneEdits = zoneEdits,
         problems = problems,
     )

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.tracking.edit
 
 import com.terraformation.backend.db.tracking.MonitoringPlotId
-import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
@@ -27,11 +26,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("12.5"),
-            boundary = rectangle(width = 750, height = 500),
-            exclusion = null,
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Create(
@@ -48,7 +45,6 @@ class PlantingSiteEditCalculatorTest {
   @Test
   fun `returns zone update and subzone create for expansion of zone with new subzone`() {
     val newSubzoneBoundary = rectangle(x = 500, width = 250, height = 500)
-    val newSiteBoundary = rectangle(width = 750, height = 500)
 
     val existing = existingSite(width = 500)
     val desired =
@@ -61,11 +57,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("12.5"),
-            boundary = newSiteBoundary,
-            exclusion = null,
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
@@ -92,11 +86,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("30.0"),
             areaHaDifference = BigDecimal("5.0"),
-            boundary = desired.boundary!!,
-            exclusion = null,
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
@@ -132,11 +124,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("50.0"),
             areaHaDifference = BigDecimal("10.0"),
-            boundary = desired.boundary!!,
-            exclusion = rectangle(width = 100, height = 500),
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
@@ -172,11 +162,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("-12.5"),
-            boundary = desired.boundary!!,
-            exclusion = null,
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Delete(
@@ -209,11 +197,9 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            areaHa = BigDecimal("37.5"),
             areaHaDifference = BigDecimal("-12.5"),
-            boundary = desired.boundary!!,
-            exclusion = null,
-            plantingSiteId = existing.id,
+            desiredModel = desired,
+            existingModel = existing,
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
@@ -327,19 +313,17 @@ class PlantingSiteEditCalculatorTest {
 
   @Test
   fun `returns empty list of edits if nothing changed`() {
-    val site = existingSite()
+    val existing = existingSite()
+    val desired = existing.toNew()
 
     assertEditResult(
         PlantingSiteEdit(
-            BigDecimal("25.0"),
-            BigDecimal("0.0"),
-            site.boundary!!,
-            null,
-            PlantingSiteId(1),
-            emptyList(),
-            emptyList()),
-        site,
-        site.toNew())
+            areaHaDifference = BigDecimal("0.0"),
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits = emptyList()),
+        existing,
+        desired)
   }
 
   @Test
@@ -360,47 +344,46 @@ class PlantingSiteEditCalculatorTest {
 
     assertEditResult(
         PlantingSiteEdit(
-            BigDecimal("27.5"),
-            BigDecimal("2.5"),
-            desired.boundary!!,
-            null,
-            PlantingSiteId(1),
-            listOf(
-                PlantingZoneEdit.Delete(
-                    existingModel = existing.plantingZones[0],
-                    monitoringPlotsRemoved = emptySet(),
-                    plantingSubzoneEdits =
-                        listOf(
-                            PlantingSubzoneEdit.Delete(
-                                existing.plantingZones[0].plantingSubzones[0])),
+            areaHaDifference = BigDecimal("2.5"),
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Delete(
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotsRemoved = emptySet(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Delete(
+                                    existing.plantingZones[0].plantingSubzones[0])),
+                    ),
+                    PlantingZoneEdit.Delete(
+                        existingModel = existing.plantingZones[1],
+                        monitoringPlotsRemoved = emptySet(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Delete(
+                                    existing.plantingZones[1].plantingSubzones[0])),
+                    ),
+                    PlantingZoneEdit.Create(
+                        desiredModel = desired.plantingZones[0],
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desired.plantingZones[0].plantingSubzones[0]))),
+                    PlantingZoneEdit.Create(
+                        desiredModel = desired.plantingZones[1],
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desired.plantingZones[1].plantingSubzones[0]))),
+                    PlantingZoneEdit.Create(
+                        desiredModel = desired.plantingZones[2],
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desired.plantingZones[2].plantingSubzones[0]))),
                 ),
-                PlantingZoneEdit.Delete(
-                    existingModel = existing.plantingZones[1],
-                    monitoringPlotsRemoved = emptySet(),
-                    plantingSubzoneEdits =
-                        listOf(
-                            PlantingSubzoneEdit.Delete(
-                                existing.plantingZones[1].plantingSubzones[0])),
-                ),
-                PlantingZoneEdit.Create(
-                    desiredModel = desired.plantingZones[0],
-                    plantingSubzoneEdits =
-                        listOf(
-                            PlantingSubzoneEdit.Create(
-                                desired.plantingZones[0].plantingSubzones[0]))),
-                PlantingZoneEdit.Create(
-                    desiredModel = desired.plantingZones[1],
-                    plantingSubzoneEdits =
-                        listOf(
-                            PlantingSubzoneEdit.Create(
-                                desired.plantingZones[1].plantingSubzones[0]))),
-                PlantingZoneEdit.Create(
-                    desiredModel = desired.plantingZones[2],
-                    plantingSubzoneEdits =
-                        listOf(
-                            PlantingSubzoneEdit.Create(
-                                desired.plantingZones[2].plantingSubzones[0]))),
-            ),
         ),
         existing,
         desired,


### PR DESCRIPTION
Commit ce51d3cd introduced "existing" and "desired" models to the planting zone
and subzone edit classes, replacing fields that pulled values from those models.
Do the same for the top-level edit class for the site as a whole.