### PR TITLE
SW-5230 Add email notification for site map edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -60,6 +60,7 @@ import com.terraformation.backend.email.model.PlantingSeasonNotScheduledSupport
 import com.terraformation.backend.email.model.PlantingSeasonRescheduled
 import com.terraformation.backend.email.model.PlantingSeasonScheduled
 import com.terraformation.backend.email.model.PlantingSeasonStarted
+import com.terraformation.backend.email.model.PlantingSiteMapEdited
 import com.terraformation.backend.email.model.ReportCreated
 import com.terraformation.backend.email.model.ScheduleObservation
 import com.terraformation.backend.email.model.ScheduleObservationReminder
@@ -84,6 +85,7 @@ import com.terraformation.backend.tracking.event.PlantingSeasonNotScheduledSuppo
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonStartedEvent
+import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationNotificationEvent
 import com.terraformation.backend.tracking.event.ScheduleObservationReminderNotificationEvent
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
@@ -591,6 +593,22 @@ class EmailNotificationService(
                   .toString()),
           roles = setOf(Role.Admin, Role.Manager, Role.Owner))
     }
+  }
+
+  @EventListener
+  fun on(event: PlantingSiteMapEditedEvent) {
+    val organization = organizationStore.fetchOneById(event.edit.existingModel.organizationId)
+
+    sendToOrganizationContact(
+        organization,
+        PlantingSiteMapEdited(
+            config = config,
+            addedToOrRemovedFrom =
+                if (event.edit.areaHaDifference.signum() < 0) "removed from" else "added to",
+            areaHaDifference = event.edit.areaHaDifference.abs().toPlainString(),
+            organizationName = organization.name,
+            plantingSiteName = event.edit.existingModel.name,
+        ))
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -443,3 +443,14 @@ class SupportRequestSubmitted(
   override val templateDir: String
     get() = "support/requestSubmitted"
 }
+
+class PlantingSiteMapEdited(
+    config: TerrawareServerConfig,
+    val addedToOrRemovedFrom: String,
+    val areaHaDifference: String,
+    val organizationName: String,
+    val plantingSiteName: String,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "plantingSite/mapEdited"
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.event
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import java.time.LocalDate
@@ -98,3 +99,5 @@ data class PlantingSeasonNotScheduledSupportNotificationEvent(
     override val plantingSiteId: PlantingSiteId,
     override val notificationNumber: Int,
 ) : PlantingSeasonSchedulingNotificationEvent
+
+data class PlantingSiteMapEditedEvent(val edit: PlantingSiteEdit)

--- a/src/main/resources/templates/email/plantingSite/mapEdited/body.ftlh.mjml
+++ b/src/main/resources/templates/email/plantingSite/mapEdited/body.ftlh.mjml
@@ -1,0 +1,21 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSiteMapEdited" -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03">
+                    The planting site ${plantingSiteName} has had change to its total area.
+                    ${areaHaDifference} hectares have been ${addedToOrRemovedFrom} the planting
+                    site.
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+
+        <mj-include path="../../footer.ftlh.mjml"/>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/plantingSite/mapEdited/body.txt.ftl
+++ b/src/main/resources/templates/email/plantingSite/mapEdited/body.txt.ftl
@@ -1,0 +1,7 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSiteMapEdited" -->
+The planting site ${plantingSiteName} has had change to its total area.
+${areaHaDifference} hectares have been ${addedToOrRemovedFrom} the planting site.
+
+------------------------------
+
+${strings("notification.email.text.footer", manageSettingsUrl)}

--- a/src/main/resources/templates/email/plantingSite/mapEdited/subject.ftl
+++ b/src/main/resources/templates/email/plantingSite/mapEdited/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.PlantingSiteMapEdited" -->
+Organization ${organizationName} has had a change to planting site ${plantingSiteName}

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -102,6 +102,7 @@ private constructor(
   var boundary: MultiPolygon = rectangle(width, height, x, y)
   var exclusion: MultiPolygon? = null
   var name: String = "Site"
+  var organizationId: OrganizationId = OrganizationId(1)
 
   private var currentSubzoneId: Long = 0
   private var currentZoneId: Long = 0
@@ -118,7 +119,7 @@ private constructor(
         gridOrigin = geometryFactory.createPoint(boundary.envelope.coordinates[0]),
         id = PlantingSiteId(1),
         name = name,
-        organizationId = OrganizationId(1),
+        organizationId = organizationId,
         plantingZones = plantingZones.ifEmpty { listOf(zone()) },
     )
   }


### PR DESCRIPTION
Add notification logic to send email to the organization's Terraformation contact
when a detailed planting site is edited.

Currently, nothing publishes the event that triggers the email; it will be added
in a later change.