### PR TITLE
SW-5228 Make shapefile importer site models accessible

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -325,7 +325,9 @@ class AdminPlantingSitesController(
   ): String {
     try {
       val boundaryPolygon = objectMapper.readValue<Polygon>(boundary)
-      val siteFile = Shapefile.fromBoundary(boundaryPolygon, emptyMap())
+      val siteFile =
+          Shapefile.fromBoundary(
+              boundaryPolygon, mapOf(PlantingSiteImporter.siteNameProperties.first() to siteName))
 
       val siteId =
           if (siteType == "detailed") {
@@ -340,8 +342,8 @@ class AdminPlantingSitesController(
                         PlantingSiteImporter.zoneNameProperties.first() to "Zone",
                         PlantingSiteImporter.subzoneNameProperties.first() to "Subzone"))
 
-            plantingSiteImporter.importShapefiles(
-                siteName, null, organizationId, siteFile, zonesFile, subzonesFile, null)
+            plantingSiteImporter.import(
+                siteName, null, organizationId, listOf(siteFile, zonesFile, subzonesFile))
           } else {
             plantingSiteStore
                 .createPlantingSite(

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -189,13 +189,15 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
       exclusionFeature: ShapefileFeature? = null,
   ): ExistingPlantingSiteModel {
     val plantingSiteId =
-        plantingSiteImporter.importShapefiles(
+        plantingSiteImporter.import(
             name = "Test Site ${nextPlantingSiteNumber++}",
             organizationId = organizationId,
-            siteFile = Shapefile(listOf(siteFeature)),
-            zonesFile = Shapefile(zoneFeatures),
-            subzonesFile = Shapefile(subzoneFeatures),
-            exclusionsFile = exclusionFeature?.let { Shapefile(listOf(it)) })
+            shapefiles =
+                listOfNotNull(
+                    Shapefile(listOf(siteFeature)),
+                    Shapefile(zoneFeatures),
+                    Shapefile(subzoneFeatures),
+                    exclusionFeature?.let { Shapefile(listOf(it)) }))
 
     val plantingSite = plantingSiteStore.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -139,13 +139,15 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
         exclusions: List<ShapefileFeature>? = null,
     ) {
       assertHasProblem(expected) {
-        importer.importShapefiles(
+        importer.import(
             name = "Test Site",
             organizationId = organizationId,
-            siteFile = Shapefile(siteFeatures),
-            zonesFile = Shapefile(zoneFeatures),
-            subzonesFile = Shapefile(subzoneFeatures),
-            exclusionsFile = exclusions?.let { Shapefile(it) },
+            shapefiles =
+                listOfNotNull(
+                    Shapefile(siteFeatures),
+                    Shapefile(zoneFeatures),
+                    Shapefile(subzoneFeatures),
+                    exclusions?.let { Shapefile(it) }),
         )
       }
     }


### PR DESCRIPTION
Refactor the shapefile import code so there's a public method to turn a list of
shapefiles into a `NewPlantingSiteModel`. This will be used by the admin UI
when it supports uploading revised shapefiles for an existing planting site.