### PR TITLE
Show success details in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/Extensions.kt
@@ -26,3 +26,16 @@ var RedirectAttributes.successMessage: String?
   set(value) {
     addFlashAttribute("successMessage", value)
   }
+
+var RedirectAttributes.successDetails: List<String>?
+  get() {
+    val attribute = flashAttributes["successDetails"]
+    return if (attribute is List<*>) {
+      attribute.map { "$it" }
+    } else {
+      null
+    }
+  }
+  set(value) {
+    addFlashAttribute("successDetails", value)
+  }

--- a/src/main/resources/templates/admin/header.html
+++ b/src/main/resources/templates/admin/header.html
@@ -30,12 +30,16 @@
 
 <h1>Placeholder Admin UI</h1>
 
-<p style="background-color: lightgreen;" th:if="${!#strings.isEmpty(successMessage)}"
-   th:text="${successMessage}"></p>
+<div style="background-color: lightgreen;" th:if="${!#strings.isEmpty(successMessage)}">
+    <th:block th:text="${successMessage}"/>
+    <th:ul th:if="${!#lists.isEmpty(successDetails)}">
+        <li th:each="detail : ${successDetails}" th:text="${detail}">Detail</li>
+    </th:ul>
+</div>
 <div style="background-color: red;" th:if="${!#strings.isEmpty(failureMessage)}">
     <th:block th:text="${failureMessage}"/>
     <th:ul th:if="${!#lists.isEmpty(failureDetails)}">
-            <li th:each="detail : ${failureDetails}" th:text="${detail}">Detail</li>
+        <li th:each="detail : ${failureDetails}" th:text="${detail}">Detail</li>
     </th:ul>
 </div>
 </span>


### PR DESCRIPTION
The page header template for the admin UI can show a bullet list of failure
details in addition to a failure message. Add the same functionality for
success details. This will be used to show the results of planting site map
edit dry runs.