### PR TITLE
SW-5421 Update the SpeciesForParticipantProject model to include all data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -11,12 +11,14 @@ import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.api.ProjectPayload
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
+import com.terraformation.backend.species.api.SpeciesResponseElement
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -110,7 +112,7 @@ class ParticipantProjectSpeciesController(
   fun getSpeciesForProject(
       @PathVariable projectId: ProjectId
   ): GetSpeciesForParticipantProjectsResponsePayload {
-    val results = participantProjectSpeciesStore.fetchSpeciesForParticipantProjects(projectId)
+    val results = participantProjectSpeciesStore.fetchSpeciesForParticipantProject(projectId)
 
     return GetSpeciesForParticipantProjectsResponsePayload(
         results.map { SpeciesForParticipantProjectPayload(it) })
@@ -170,7 +172,19 @@ data class ParticipantProjectSpeciesPayload(
     val speciesId: SpeciesId,
     val speciesNativeCategory: SpeciesNativeCategory?,
     val submissionStatus: SubmissionStatus,
-)
+) {
+  constructor(
+      model: ExistingParticipantProjectSpeciesModel
+  ) : this(
+      feedback = model.feedback,
+      id = model.id,
+      internalComment = model.internalComment,
+      projectId = model.projectId,
+      rationale = model.rationale,
+      speciesId = model.speciesId,
+      speciesNativeCategory = model.speciesNativeCategory,
+      submissionStatus = model.submissionStatus)
+}
 
 data class GetParticipantProjectSpeciesResponsePayload(
     val participantProjectSpecies: ParticipantProjectSpeciesPayload,
@@ -200,26 +214,16 @@ data class GetParticipantProjectsForSpeciesResponsePayload(
 ) : SuccessResponsePayload
 
 data class SpeciesForParticipantProjectPayload(
-    val participantProjectSpeciesId: ParticipantProjectSpeciesId,
-    val participantProjectSpeciesRationale: String?,
-    val participantProjectSpeciesSubmissionStatus: SubmissionStatus,
-    val participantProjectSpeciesNativeCategory: SpeciesNativeCategory?,
-    val projectId: ProjectId,
-    val speciesId: SpeciesId,
-    val speciesCommonName: String?,
-    val speciesScientificName: String,
+    val participantProjectSpecies: ParticipantProjectSpeciesPayload,
+    val species: SpeciesResponseElement,
+    val project: ProjectPayload,
 ) {
   constructor(
       model: SpeciesForParticipantProject
   ) : this(
-      participantProjectSpeciesId = model.participantProjectSpeciesId,
-      participantProjectSpeciesRationale = model.participantProjectSpeciesRationale,
-      participantProjectSpeciesSubmissionStatus = model.participantProjectSpeciesSubmissionStatus,
-      participantProjectSpeciesNativeCategory = model.participantProjectSpeciesNativeCategory,
-      projectId = model.projectId,
-      speciesId = model.speciesId,
-      speciesCommonName = model.speciesCommonName,
-      speciesScientificName = model.speciesScientificName,
+      participantProjectSpecies = ParticipantProjectSpeciesPayload(model.participantProjectSpecies),
+      project = ProjectPayload(model.project),
+      species = SpeciesResponseElement(model.species, null),
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -63,7 +63,7 @@ class ParticipantProjectSpeciesController(
                 speciesId = payload.speciesId,
             ))
 
-    return makeGetResponse(model)
+    return GetParticipantProjectSpeciesResponsePayload(ParticipantProjectSpeciesPayload(model))
   }
 
   @ApiResponse200
@@ -87,7 +87,7 @@ class ParticipantProjectSpeciesController(
   ): GetParticipantProjectSpeciesResponsePayload {
     val model = participantProjectSpeciesStore.fetchOneById(participantProjectSpeciesId)
 
-    return makeGetResponse(model)
+    return GetParticipantProjectSpeciesResponsePayload(ParticipantProjectSpeciesPayload(model))
   }
 
   @ApiResponse200
@@ -130,21 +130,6 @@ class ParticipantProjectSpeciesController(
 
     return SimpleSuccessResponsePayload()
   }
-
-  private fun makeGetResponse(
-      model: ExistingParticipantProjectSpeciesModel
-  ): GetParticipantProjectSpeciesResponsePayload =
-      GetParticipantProjectSpeciesResponsePayload(
-          ParticipantProjectSpeciesPayload(
-              feedback = model.feedback,
-              id = model.id,
-              internalComment = model.internalComment,
-              projectId = model.projectId,
-              rationale = model.rationale,
-              speciesId = model.speciesId,
-              speciesNativeCategory = model.speciesNativeCategory,
-              submissionStatus = model.submissionStatus,
-          ))
 }
 
 data class AssignParticipantProjectSpeciesPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -175,20 +175,11 @@ class ParticipantProjectSpeciesStore(
         .filter { user.canReadProject(it.projectId) }
   }
 
-  fun fetchSpeciesForParticipantProjects(projectId: ProjectId): List<SpeciesForParticipantProject> {
+  fun fetchSpeciesForParticipantProject(projectId: ProjectId): List<SpeciesForParticipantProject> {
     val user = currentUser()
 
     return dslContext
-        .select(
-            PROJECTS.NAME,
-            PROJECTS.ID,
-            PARTICIPANT_PROJECT_SPECIES.ID,
-            PARTICIPANT_PROJECT_SPECIES.RATIONALE,
-            PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID,
-            PARTICIPANT_PROJECT_SPECIES.SPECIES_NATIVE_CATEGORY_ID,
-            SPECIES.ID,
-            SPECIES.COMMON_NAME,
-            SPECIES.SCIENTIFIC_NAME)
+        .select(PROJECTS.asterisk(), PARTICIPANT_PROJECT_SPECIES.asterisk(), SPECIES.asterisk())
         .from(SPECIES)
         .join(PARTICIPANT_PROJECT_SPECIES)
         .on(SPECIES.ID.eq(PARTICIPANT_PROJECT_SPECIES.SPECIES_ID))
@@ -196,7 +187,7 @@ class ParticipantProjectSpeciesStore(
         .on(PARTICIPANT_PROJECT_SPECIES.PROJECT_ID.eq(PROJECTS.ID))
         .where(PROJECTS.ID.eq(projectId))
         .fetch { SpeciesForParticipantProject.of(it) }
-        .filter { user.canReadProject(it.projectId) }
+        .filter { user.canReadProject(it.project.id) }
   }
 
   fun fetchLastCreatedSpeciesTime(projectId: ProjectId): Instant =

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesForParticipantProject.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SpeciesForParticipantProject.kt
@@ -1,38 +1,20 @@
 package com.terraformation.backend.accelerator.model
 
-import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
-import com.terraformation.backend.db.accelerator.SubmissionStatus
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
-import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
-import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
-import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.customer.model.ExistingProjectModel
+import com.terraformation.backend.species.model.ExistingSpeciesModel
 import org.jooq.Record
 
 data class SpeciesForParticipantProject(
-    val participantProjectSpeciesId: ParticipantProjectSpeciesId,
-    val participantProjectSpeciesRationale: String?,
-    val participantProjectSpeciesSubmissionStatus: SubmissionStatus,
-    val participantProjectSpeciesNativeCategory: SpeciesNativeCategory?,
-    val projectId: ProjectId,
-    val speciesId: SpeciesId,
-    val speciesCommonName: String?,
-    val speciesScientificName: String,
+    val participantProjectSpecies: ExistingParticipantProjectSpeciesModel,
+    val project: ExistingProjectModel,
+    val species: ExistingSpeciesModel,
 ) {
   companion object {
     fun of(record: Record): SpeciesForParticipantProject {
       return SpeciesForParticipantProject(
-          participantProjectSpeciesId = record[PARTICIPANT_PROJECT_SPECIES.ID]!!,
-          participantProjectSpeciesRationale = record[PARTICIPANT_PROJECT_SPECIES.RATIONALE],
-          participantProjectSpeciesSubmissionStatus =
-              record[PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID]!!,
-          participantProjectSpeciesNativeCategory =
-              record[PARTICIPANT_PROJECT_SPECIES.SPECIES_NATIVE_CATEGORY_ID],
-          projectId = record[PROJECTS.ID]!!,
-          speciesId = record[SPECIES.ID]!!,
-          speciesCommonName = record[SPECIES.COMMON_NAME],
-          speciesScientificName = record[SPECIES.SCIENTIFIC_NAME]!!,
+          participantProjectSpecies = ExistingParticipantProjectSpeciesModel.of(record),
+          species = ExistingSpeciesModel.of(record),
+          project = ExistingProjectModel.of(record),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -45,10 +45,10 @@ data class SpeciesModel<ID : SpeciesId?>(
   companion object {
     fun of(
         record: Record,
-        ecosystemTypesMultiset: Field<Set<EcosystemType>>,
-        growthFormsMultiset: Field<Set<GrowthForm>>,
-        plantMaterialSourcingMethodsMultiset: Field<Set<PlantMaterialSourcingMethod>>,
-        successionalGroupsMultiset: Field<Set<SuccessionalGroup>>,
+        ecosystemTypesMultiset: Field<Set<EcosystemType>>? = null,
+        growthFormsMultiset: Field<Set<GrowthForm>>? = null,
+        plantMaterialSourcingMethodsMultiset: Field<Set<PlantMaterialSourcingMethod>>? = null,
+        successionalGroupsMultiset: Field<Set<SuccessionalGroup>>? = null,
     ): ExistingSpeciesModel =
         ExistingSpeciesModel(
             averageWoodDensity = record[SPECIES.AVERAGE_WOOD_DENSITY],
@@ -59,9 +59,9 @@ data class SpeciesModel<ID : SpeciesId?>(
             dbhValue = record[SPECIES.DBH_VALUE],
             deletedTime = record[SPECIES.DELETED_TIME],
             ecologicalRoleKnown = record[SPECIES.ECOLOGICAL_ROLE_KNOWN],
-            ecosystemTypes = record[ecosystemTypesMultiset] ?: emptySet(),
+            ecosystemTypes = ecosystemTypesMultiset?.let { record[it] } ?: emptySet(),
             familyName = record[SPECIES.FAMILY_NAME],
-            growthForms = record[growthFormsMultiset] ?: emptySet(),
+            growthForms = growthFormsMultiset?.let { record[it] } ?: emptySet(),
             heightAtMaturitySource = record[SPECIES.HEIGHT_AT_MATURITY_SOURCE],
             heightAtMaturityValue = record[SPECIES.HEIGHT_AT_MATURITY_VALUE],
             id = record[SPECIES.ID]!!,
@@ -71,11 +71,11 @@ data class SpeciesModel<ID : SpeciesId?>(
             organizationId = record[SPECIES.ORGANIZATION_ID]!!,
             otherFacts = record[SPECIES.OTHER_FACTS],
             plantMaterialSourcingMethods =
-                record[plantMaterialSourcingMethodsMultiset] ?: emptySet(),
+                plantMaterialSourcingMethodsMultiset?.let { record[it] } ?: emptySet(),
             rare = record[SPECIES.RARE],
             scientificName = record[SPECIES.SCIENTIFIC_NAME]!!,
             seedStorageBehavior = record[SPECIES.SEED_STORAGE_BEHAVIOR_ID],
-            successionalGroups = record[successionalGroupsMultiset] ?: emptySet(),
+            successionalGroups = successionalGroupsMultiset?.let { record[it] } ?: emptySet(),
             woodDensityLevel = record[SPECIES.WOOD_DENSITY_LEVEL_ID],
         )
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -8,6 +8,8 @@ import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSp
 import com.terraformation.backend.accelerator.model.NewParticipantProjectSpeciesModel
 import com.terraformation.backend.accelerator.model.ParticipantProjectsForSpecies
 import com.terraformation.backend.accelerator.model.SpeciesForParticipantProject
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -16,6 +18,7 @@ import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.ParticipantProjectSpeciesRow
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.species.model.ExistingSpeciesModel
 import io.mockk.every
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -342,27 +345,66 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val participantProjectSpeciesId2 =
           insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId2)
 
+      val userId = currentUser().userId
+      val now = Instant.EPOCH
+
       assertEquals(
           listOf(
               SpeciesForParticipantProject(
-                  participantProjectSpeciesId = participantProjectSpeciesId1,
-                  participantProjectSpeciesRationale = null,
-                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
-                  participantProjectSpeciesNativeCategory = null,
-                  projectId = projectId,
-                  speciesId = speciesId1,
-                  speciesScientificName = "Acacia Kochi",
-                  speciesCommonName = null),
+                  participantProjectSpecies =
+                      ExistingParticipantProjectSpeciesModel(
+                          createdBy = userId,
+                          createdTime = now,
+                          id = participantProjectSpeciesId1,
+                          modifiedBy = userId,
+                          modifiedTime = now,
+                          projectId = projectId,
+                          speciesId = speciesId1,
+                          submissionStatus = SubmissionStatus.NotSubmitted),
+                  project =
+                      ExistingProjectModel(
+                          createdBy = userId,
+                          createdTime = now,
+                          id = projectId,
+                          modifiedBy = userId,
+                          modifiedTime = now,
+                          name = "Project 1",
+                          organizationId = inserted.organizationId,
+                          participantId = participantId),
+                  species =
+                      ExistingSpeciesModel(
+                          commonName = null,
+                          id = speciesId1,
+                          organizationId = inserted.organizationId,
+                          scientificName = "Acacia Kochi")),
               SpeciesForParticipantProject(
-                  participantProjectSpeciesId = participantProjectSpeciesId2,
-                  participantProjectSpeciesRationale = null,
-                  participantProjectSpeciesSubmissionStatus = SubmissionStatus.NotSubmitted,
-                  participantProjectSpeciesNativeCategory = null,
-                  projectId = projectId,
-                  speciesId = speciesId2,
-                  speciesScientificName = "Juniperus scopulorum",
-                  speciesCommonName = null)),
-          store.fetchSpeciesForParticipantProjects(projectId))
+                  participantProjectSpecies =
+                      ExistingParticipantProjectSpeciesModel(
+                          createdBy = userId,
+                          createdTime = now,
+                          id = participantProjectSpeciesId2,
+                          modifiedBy = userId,
+                          modifiedTime = now,
+                          projectId = projectId,
+                          speciesId = speciesId2,
+                          submissionStatus = SubmissionStatus.NotSubmitted),
+                  project =
+                      ExistingProjectModel(
+                          createdBy = userId,
+                          createdTime = now,
+                          id = projectId,
+                          modifiedBy = userId,
+                          modifiedTime = now,
+                          name = "Project 1",
+                          organizationId = inserted.organizationId,
+                          participantId = participantId),
+                  species =
+                      ExistingSpeciesModel(
+                          commonName = null,
+                          id = speciesId2,
+                          organizationId = inserted.organizationId,
+                          scientificName = "Juniperus scopulorum"))),
+          store.fetchSpeciesForParticipantProject(projectId))
     }
 
     @Test
@@ -378,7 +420,7 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(
           emptyList<SpeciesForParticipantProject>(),
-          store.fetchSpeciesForParticipantProjects(projectId))
+          store.fetchSpeciesForParticipantProject(projectId))
     }
   }
 


### PR DESCRIPTION
In order to more easily get all species data associated to a project, include the entirety of the `project`, `species`, and `participant_project_species` data within the model that is returned when fetching all species for a project.