### PR TITLE
Update Gradle-License-Report to v2.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
   id("com.github.johnrengelman.processes") version "0.5.0"
   id("org.springdoc.openapi-gradle-plugin") version "1.8.0"
 
-  id("com.github.jk1.dependency-license-report") version "2.1"
+  id("com.github.jk1.dependency-license-report") version "2.8"
 
   id("terraware-jooq")
 }


### PR DESCRIPTION
For some reason Renovate hasn't been detecting updates to the license report
generator; upgrade to the latest version.