### PR TITLE
Stop using deprecated Jackson API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/GeometryDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/GeometryDeserializer.kt
@@ -24,7 +24,7 @@ class GeometryDeserializer : JsonDeserializer<Geometry>() {
   private fun readGeometry(jp: JsonParser, tree: JsonNode, expectedType: String?): Geometry {
     val type =
         tree.findValuesAsText("type").getOrNull(0)
-            ?: throw JsonParseException(jp, "Missing geometry type", jp.currentLocation)
+            ?: throw JsonParseException(jp, "Missing geometry type", jp.currentLocation())
     if (expectedType != null && expectedType != type) {
       throw JsonParseException(jp, "Expected type $expectedType, was $type")
     }
@@ -62,7 +62,7 @@ class GeometryDeserializer : JsonDeserializer<Geometry>() {
         throw JsonParseException(
             jp,
             "Expected geometry type ${subclass.simpleName}, was ${geom.geometryType}",
-            jp.currentLocation)
+            jp.currentLocation())
       }
     }
   }


### PR DESCRIPTION
Our custom deserializer for geometry objects throws an exception when a GeoJSON
value has an unexpected or missing geometry type. The exception includes the
location in the JSON object where the failure happened.

We were using an old Jackson API method to retrieve the location. In the next
Jackson version, that method is marked as deprecated, which will cause a build
failure when we upgrade. Switch to the newer version of the method.