### PR TITLE
Update coding conventions docs

### DIFF
--- a/src/main/resources/db/migration/README.md
+++ b/src/main/resources/db/migration/README.md
@@ -6,9 +6,15 @@ The server uses [Flyway](https://flywaydb.org) to create and modify the database
 * Numbered migrations, whose filenames are prefixed with `V`, are run in numeric order. Once run, a numbered migration is never run again.
 * Replayable migrations, whose filenames are prefixed with `R`, are run whenever they are modified or created. They should be idempotent. They are run after numbered migrations.
 
+## Migration subdirectories
+
 The migrations for production systems all live under this directory. Numbered migrations should be organized in groups of 50 in subdirectories; when you add a new migration, put it in the correct subdirectory (creating the subdirectory if necessary).
 
-The server runs on PostgreSQL and there are no plans to support multiple database engines. It is fine to use PostgreSQL-only syntax in migrations.
+## Database features
+
+The server runs on PostgreSQL and there are no plans to support multiple database engines.
+
+It is fine to use PostgreSQL-only syntax in migrations. However, note that the production environment uses a hosted database which is generally not the latest PostgreSQL version. If you are using PostgreSQL-specific features, make sure they exist in the production PostgreSQL version.
 
 ## Development-only migrations
 


### PR DESCRIPTION
We've been updating the Kotlin coding conventions page in Confluence but haven't
been pulling those changes into the conventions docs in the actual code base.
Bring the docs in the repo up to date.