### PR TITLE
Implement API endpoint to download a submission snapshot

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator
 
 import com.opencsv.CSVWriter
 import com.terraformation.backend.accelerator.db.ParticipantProjectSpeciesStore
+import com.terraformation.backend.accelerator.db.SubmissionForProjectDeliverableNotFoundException
 import com.terraformation.backend.accelerator.db.SubmissionSnapshotNotFoundException
 import com.terraformation.backend.accelerator.db.SubmissionStore
 import com.terraformation.backend.accelerator.event.DeliverableStatusUpdatedEvent
@@ -25,7 +26,6 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import jakarta.inject.Named
-import jakarta.ws.rs.NotFoundException
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.OutputStreamWriter
@@ -212,14 +212,14 @@ class ParticipantProjectSpeciesService(
     val submissionRecord =
         with(SUBMISSIONS) {
           dslContext.fetchOne(this, PROJECT_ID.eq(projectId).and(DELIVERABLE_ID.eq(deliverableId)))
-              ?: throw NotFoundException()
+              ?: throw SubmissionForProjectDeliverableNotFoundException(deliverableId, projectId)
         }
 
     val submissionId = submissionRecord.id!!
 
     requirePermissions { readSubmission(submissionId) }
 
-    // Make sure the file belongs to the submission
+    // Get the snapshot that belongs to the submission
     val snapshotRow =
         submissionSnapshotsDao.fetchOne(SUBMISSION_SNAPSHOTS.SUBMISSION_ID, submissionId)
             ?: throw SubmissionSnapshotNotFoundException(submissionId)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -16,8 +16,6 @@ import com.terraformation.backend.customer.api.ProjectPayload
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
-import com.terraformation.backend.db.accelerator.tables.daos.SubmissionsDao
-import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
@@ -48,7 +46,6 @@ import org.springframework.web.bind.annotation.RestController
 class ParticipantProjectSpeciesController(
     private val participantProjectSpeciesService: ParticipantProjectSpeciesService,
     private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore,
-    private val submissionsDao: SubmissionsDao
 ) {
   @ApiResponse200
   @PostMapping("/projects/species/assign")
@@ -119,16 +116,9 @@ class ParticipantProjectSpeciesController(
       @PathVariable projectId: ProjectId,
       @PathVariable deliverableId: DeliverableId
   ): ResponseEntity<InputStreamResource> {
-    val submissionRow =
-        submissionsDao
-            .fetch(
-                SUBMISSIONS.PROJECT_ID.eq(projectId)
-                    .and(SUBMISSIONS.DELIVERABLE_ID.eq(deliverableId)))
-            .firstOrNull() ?: throw NotFoundException()
-
     return try {
       participantProjectSpeciesService
-          .readSubmissionSnapshotFile(submissionRow.id!!)
+          .readSubmissionSnapshotFile(projectId, deliverableId)
           .toResponseEntity { contentDisposition = ContentDisposition.attachment().build() }
     } catch (e: NoSuchFileException) {
       throw NotFoundException()

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -129,12 +129,7 @@ class ParticipantProjectSpeciesController(
     return try {
       participantProjectSpeciesService
           .readSubmissionSnapshotFile(submissionRow.id!!)
-          .toResponseEntity {
-            contentDisposition =
-                ContentDisposition.attachment()
-                    .filename("submission-snapshot-${submissionRow.id}")
-                    .build()
-          }
+          .toResponseEntity { contentDisposition = ContentDisposition.attachment().build() }
     } catch (e: NoSuchFileException) {
       throw NotFoundException()
     }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -65,6 +65,13 @@ class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
 class SubmissionNotFoundException(id: SubmissionId) :
     EntityNotFoundException("Submission $id not found")
 
+class SubmissionForProjectDeliverableNotFoundException(
+    deliverableId: DeliverableId,
+    projectId: ProjectId
+) :
+    EntityNotFoundException(
+        "Submission not found for deliverable $deliverableId and project $projectId")
+
 class SubmissionSnapshotNotFoundException(id: SubmissionId) :
     EntityNotFoundException(
         "Participant Project Species snapshot data for submission $id not found")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -64,3 +64,7 @@ class SubmissionDocumentNotFoundException(id: SubmissionDocumentId) :
 
 class SubmissionNotFoundException(id: SubmissionId) :
     EntityNotFoundException("Submission $id not found")
+
+class SubmissionSnapshotNotFoundException(id: SubmissionId) :
+    EntityNotFoundException(
+        "Participant Project Species snapshot data for submission $id not found")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -62,7 +62,6 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
         eventPublisher,
         fileService,
         participantProjectSpeciesStore,
-        submissionSnapshotsDao,
         submissionStore)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -62,6 +62,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
         eventPublisher,
         fileService,
         participantProjectSpeciesStore,
+        submissionSnapshotsDao,
         submissionStore)
   }
 


### PR DESCRIPTION
- Add GET endpoint that takes `projectId` and `deliverableId` and returns the CSV bytes back if the snapshot exists.
- Remove the `submissionSnapshotsDao` from the service that reads the snapshot and replace with a `dslContext` fetch