### PR TITLE
Fix code docs generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -335,13 +335,15 @@ licenseReport {
 }
 
 // https://github.com/Kotlin/dokka/issues/3472
-configurations.matching { it.name.startsWith("dokka") }.configureEach {
-  resolutionStrategy.eachDependency {
-    if (requested.group.startsWith("com.fasterxml.jackson")) {
-      useVersion("2.15.3")
+configurations
+    .matching { it.name.startsWith("dokka") }
+    .configureEach {
+      resolutionStrategy.eachDependency {
+        if (requested.group.startsWith("com.fasterxml.jackson")) {
+          useVersion("2.15.3")
+        }
+      }
     }
-  }
-}
 
 tasks.withType<DokkaTask>().configureEach {
   dokkaSourceSets {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -334,6 +334,15 @@ licenseReport {
   renderers = arrayOf(InventoryHtmlReportRenderer())
 }
 
+// https://github.com/Kotlin/dokka/issues/3472
+configurations.matching { it.name.startsWith("dokka") }.configureEach {
+  resolutionStrategy.eachDependency {
+    if (requested.group.startsWith("com.fasterxml.jackson")) {
+      useVersion("2.15.3")
+    }
+  }
+}
+
 tasks.withType<DokkaTask>().configureEach {
   dokkaSourceSets {
     named("main") {


### PR DESCRIPTION
The latest Spring Boot version uses a Jackson version that's not compatible with
Kotlin's documentation generator tool (Dokka). Override the Jackson version when
generating docs, per the suggestion in the Dokka bug report about the problem.

If/when Dokka is updated to work with more recent Jackson versions, this change
can be reverted.