### PR TITLE
Make plot-sized boundaries in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -234,13 +234,12 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
-import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
-import com.terraformation.backend.polygon
+import com.terraformation.backend.rectangle
+import com.terraformation.backend.rectanglePolygon
 import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.tracking.model.PlantingZoneModel
-import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.toInstant
 import jakarta.ws.rs.NotFoundException
 import java.math.BigDecimal
@@ -1406,8 +1405,11 @@ abstract class DatabaseTest {
         when {
           boundary != null -> boundary
           x != null && y != null ->
-              multiPolygon(
-                  polygon(x, y, x.toDouble() + width.toDouble(), y.toDouble() + height.toDouble()))
+              rectangle(
+                  width.toDouble() * MONITORING_PLOT_SIZE,
+                  height.toDouble() * MONITORING_PLOT_SIZE,
+                  x.toDouble() * MONITORING_PLOT_SIZE,
+                  y.toDouble() * MONITORING_PLOT_SIZE)
           else -> null
         }
 
@@ -1492,13 +1494,11 @@ abstract class DatabaseTest {
       height: Number = 2,
       boundary: Geometry =
           row.boundary
-              ?: Turtle(point(0)).makeMultiPolygon {
-                north(y.toDouble() * MONITORING_PLOT_SIZE)
-                east(x.toDouble() * MONITORING_PLOT_SIZE)
-                rectangle(
-                    width.toDouble() * MONITORING_PLOT_SIZE,
-                    height.toDouble() * MONITORING_PLOT_SIZE)
-              },
+              ?: rectangle(
+                  width.toDouble() * MONITORING_PLOT_SIZE,
+                  height.toDouble() * MONITORING_PLOT_SIZE,
+                  x.toDouble() * MONITORING_PLOT_SIZE,
+                  y.toDouble() * MONITORING_PLOT_SIZE),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       errorMargin: BigDecimal = row.errorMargin ?: PlantingZoneModel.DEFAULT_ERROR_MARGIN,
@@ -1553,13 +1553,11 @@ abstract class DatabaseTest {
       height: Number = 2,
       boundary: Geometry =
           row.boundary
-              ?: Turtle(point(0)).makeMultiPolygon {
-                north(y.toDouble() * MONITORING_PLOT_SIZE)
-                east(x.toDouble() * MONITORING_PLOT_SIZE)
-                rectangle(
-                    width.toDouble() * MONITORING_PLOT_SIZE,
-                    height.toDouble() * MONITORING_PLOT_SIZE)
-              },
+              ?: rectangle(
+                  width.toDouble() * MONITORING_PLOT_SIZE,
+                  height.toDouble() * MONITORING_PLOT_SIZE,
+                  x.toDouble() * MONITORING_PLOT_SIZE,
+                  y.toDouble() * MONITORING_PLOT_SIZE),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,
@@ -1640,11 +1638,11 @@ abstract class DatabaseTest {
       y: Number = 0,
       boundary: Polygon =
           (row.boundary as? Polygon)
-              ?: Turtle(point(0)).makePolygon {
-                north(y.toDouble() * MONITORING_PLOT_SIZE)
-                east(x.toDouble() * MONITORING_PLOT_SIZE)
-                square(MONITORING_PLOT_SIZE)
-              },
+              ?: rectanglePolygon(
+                  MONITORING_PLOT_SIZE,
+                  MONITORING_PLOT_SIZE,
+                  x.toDouble() * MONITORING_PLOT_SIZE,
+                  y.toDouble() * MONITORING_PLOT_SIZE),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       id: Any? = row.id,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.onePixelPng
 import com.terraformation.backend.point
+import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.db.InvalidObservationEndDateException
 import com.terraformation.backend.tracking.db.InvalidObservationStartDateException
 import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
@@ -50,7 +51,6 @@ import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NotificationCriteria
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
-import com.terraformation.backend.util.Turtle
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -134,7 +134,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertUser()
     insertOrganization()
-    plantingSiteId = insertPlantingSite(x = 0, width = 11, gridOrigin = point(0))
+    plantingSiteId = insertPlantingSite(x = 0, width = 11, gridOrigin = point(1))
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true
@@ -201,9 +201,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
       insertPlantingZone(
           x = 0, width = 8, height = 2, numPermanentClusters = 2, numTemporaryPlots = 3)
       val subzone1Boundary =
-          Turtle(point(0)).makeMultiPolygon {
-            rectangle(5 * MONITORING_PLOT_SIZE, 2 * MONITORING_PLOT_SIZE)
-          }
+          rectangle(width = 5 * MONITORING_PLOT_SIZE, height = 2 * MONITORING_PLOT_SIZE)
       insertPlantingSubzone(boundary = subzone1Boundary)
       insertPlanting()
       insertCluster(1)
@@ -295,7 +293,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
       // In zone 2, the service should create two permanent clusters, but neither of them should
       // be included in the observation since they all lie in an unplanted subzone.
 
-      plantingSiteId = insertPlantingSite(x = 0, width = 14, gridOrigin = point(0))
+      plantingSiteId = insertPlantingSite(x = 0, width = 14, gridOrigin = point(1))
       insertFacility(type = FacilityType.Nursery)
       insertSpecies()
       insertWithdrawal()
@@ -304,9 +302,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
       insertPlantingZone(
           x = 0, width = 6, height = 2, numPermanentClusters = 1, numTemporaryPlots = 3)
       val subzone1Boundary =
-          Turtle(point(0)).makeMultiPolygon {
-            rectangle(3 * MONITORING_PLOT_SIZE, 2 * MONITORING_PLOT_SIZE)
-          }
+          rectangle(width = 3 * MONITORING_PLOT_SIZE, height = 2 * MONITORING_PLOT_SIZE)
       val subzone1Id = insertPlantingSubzone(boundary = subzone1Boundary)
       insertPlanting()
 


### PR DESCRIPTION
Currently the width and height parameters for `insertPlantingSite()` and
friends just add the values to the raw coordinates in the default coordinate
system, meaning a site with a width of 5 actually has a width of 5 degrees
longitude.

Instead treat them as multiples of the monitoring plot size, which will make it
more convenient to construct test data for planting site editing tests.