### PR TITLE
Rename field in PlantingSiteMapEditedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -597,17 +597,19 @@ class EmailNotificationService(
 
   @EventListener
   fun on(event: PlantingSiteMapEditedEvent) {
-    val organization = organizationStore.fetchOneById(event.edit.existingModel.organizationId)
+    val organization =
+        organizationStore.fetchOneById(event.plantingSiteEdit.existingModel.organizationId)
 
     sendToOrganizationContact(
         organization,
         PlantingSiteMapEdited(
             config = config,
             addedToOrRemovedFrom =
-                if (event.edit.areaHaDifference.signum() < 0) "removed from" else "added to",
-            areaHaDifference = event.edit.areaHaDifference.abs().toPlainString(),
+                if (event.plantingSiteEdit.areaHaDifference.signum() < 0) "removed from"
+                else "added to",
+            areaHaDifference = event.plantingSiteEdit.areaHaDifference.abs().toPlainString(),
             organizationName = organization.name,
-            plantingSiteName = event.edit.existingModel.name,
+            plantingSiteName = event.plantingSiteEdit.existingModel.name,
         ))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -100,4 +100,6 @@ data class PlantingSeasonNotScheduledSupportNotificationEvent(
     override val notificationNumber: Int,
 ) : PlantingSeasonSchedulingNotificationEvent
 
-data class PlantingSiteMapEditedEvent(val edit: PlantingSiteEdit)
+data class PlantingSiteMapEditedEvent(
+    val plantingSiteEdit: PlantingSiteEdit,
+)


### PR DESCRIPTION
In preparation for adding more fields to this event, rename the existing field for
added clarity.