### PR TITLE
SW-5230 Add observation plots to replace removed ones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -89,6 +89,16 @@ class ObservationStore(
         .fetch { ObservationModel.of(it) }
   }
 
+  fun fetchInProgressObservation(plantingSiteId: PlantingSiteId): ExistingObservationModel? {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext
+        .selectFrom(OBSERVATIONS)
+        .where(OBSERVATIONS.PLANTING_SITE_ID.eq(plantingSiteId))
+        .and(OBSERVATIONS.STATE_ID.eq(ObservationState.InProgress))
+        .fetchOne { ObservationModel.of(it) }
+  }
+
   fun fetchObservationsByPlantingSite(
       plantingSiteId: PlantingSiteId
   ): List<ExistingObservationModel> {

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -5,7 +5,9 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.model.ExistingObservationModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
+import com.terraformation.backend.tracking.model.ReplacementResult
 import java.time.LocalDate
 
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
@@ -101,5 +103,7 @@ data class PlantingSeasonNotScheduledSupportNotificationEvent(
 ) : PlantingSeasonSchedulingNotificationEvent
 
 data class PlantingSiteMapEditedEvent(
+    val edited: ExistingPlantingSiteModel,
     val plantingSiteEdit: PlantingSiteEdit,
+    val monitoringPlotReplacements: ReplacementResult,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementResult.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ReplacementResult.kt
@@ -6,4 +6,13 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 data class ReplacementResult(
     val addedMonitoringPlotIds: Set<MonitoringPlotId>,
     val removedMonitoringPlotIds: Set<MonitoringPlotId>,
-)
+) {
+  companion object {
+    fun merge(results: Collection<ReplacementResult>): ReplacementResult {
+      return ReplacementResult(
+          results.flatMap { it.addedMonitoringPlotIds }.toSet(),
+          results.flatMap { it.removedMonitoringPlotIds }.toSet(),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -87,6 +87,7 @@ import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteBuilder
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
 import com.terraformation.backend.tracking.model.ReplacementDuration
+import com.terraformation.backend.tracking.model.ReplacementResult
 import freemarker.template.Configuration
 import io.mockk.every
 import io.mockk.mockk
@@ -1014,17 +1015,21 @@ internal class EmailNotificationServiceTest {
     every { userStore.fetchWithGlobalRoles() } returns listOf(acceleratorUser, tfContactUser)
 
     val siteName = "Test Site"
+    val existingModel =
+        PlantingSiteBuilder.existingSite {
+          name = siteName
+          organizationId = organization.id
+        }
+
     val event =
         PlantingSiteMapEditedEvent(
+            existingModel,
             PlantingSiteEdit(
                 areaHaDifference = BigDecimal("-13.2"),
                 desiredModel = PlantingSiteBuilder.newSite { name = siteName },
-                existingModel =
-                    PlantingSiteBuilder.existingSite {
-                      name = siteName
-                      organizationId = organization.id
-                    },
-                plantingZoneEdits = emptyList()))
+                existingModel = existingModel,
+                plantingZoneEdits = emptyList()),
+            ReplacementResult(emptySet(), emptySet()))
 
     service.on(event)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -17,6 +17,7 @@ import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewPlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.newSite
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.ReplacementResult
 import com.terraformation.backend.util.nearlyCoveredBy
 import io.mockk.every
 import java.math.BigDecimal
@@ -439,7 +440,14 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
                 }
               })
 
-      eventPublisher.assertEventPublished(PlantingSiteMapEditedEvent(results.plantingSiteEdit))
+      val monitoringPlotIds =
+          results.edited.plantingZones[0].plantingSubzones[0].monitoringPlots.map { it.id }.toSet()
+
+      eventPublisher.assertEventPublished(
+          PlantingSiteMapEditedEvent(
+              results.edited,
+              results.plantingSiteEdit,
+              ReplacementResult(monitoringPlotIds, emptySet())))
     }
 
     @Test


### PR DESCRIPTION
If a planting site edit removes part of a site that contains a monitoring plot or
permanent cluster for an in-progress observation, replace it with a new one.