### PR TITLE
Reduce mandatory arguments to insertObservationPlot

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2006,11 +2006,11 @@ abstract class DatabaseBackedTest {
 
   fun insertObservationPlot(
       row: ObservationPlotsRow = ObservationPlotsRow(),
-      claimedBy: UserId? = row.claimedBy,
-      claimedTime: Instant? = row.claimedTime ?: if (claimedBy != null) Instant.EPOCH else null,
       completedBy: UserId? = row.completedBy,
       completedTime: Instant? =
           row.completedTime ?: if (completedBy != null) Instant.EPOCH else null,
+      claimedBy: UserId? = row.claimedBy ?: completedBy,
+      claimedTime: Instant? = row.claimedTime ?: if (claimedBy != null) Instant.EPOCH else null,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       isPermanent: Boolean = row.isPermanent ?: false,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -1665,8 +1665,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
         val observationId1 = insertObservation()
         insertObservationPlot(monitoringPlotId = plotId1, claimedBy = user.userId)
         insertObservationPlot(monitoringPlotId = plotId2, claimedBy = user.userId)
-        insertObservationPlot(
-            monitoringPlotId = plotId3, claimedBy = user.userId, completedBy = user.userId)
+        insertObservationPlot(monitoringPlotId = plotId3, completedBy = user.userId)
         insertObservationPlot(monitoringPlotId = plotId4)
         insertObservationPlot(monitoringPlotId = plotId5)
 
@@ -1734,8 +1733,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
         val observationId = insertObservation()
         insertObservationPlot(monitoringPlotId = plotId1, claimedBy = user.userId)
         insertObservationPlot(monitoringPlotId = plotId2, claimedBy = user.userId)
-        insertObservationPlot(
-            monitoringPlotId = plotId3, claimedBy = user.userId, completedBy = user.userId)
+        insertObservationPlot(monitoringPlotId = plotId3, completedBy = user.userId)
         insertObservationPlot(monitoringPlotId = plotId4)
         insertObservationPlot(monitoringPlotId = plotId5)
 
@@ -1782,10 +1780,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
         val observationId1 = insertObservation()
         insertObservationPlot(monitoringPlotId = insertMonitoringPlot(), claimedBy = user.userId)
         insertObservationPlot(monitoringPlotId = insertMonitoringPlot(), claimedBy = user.userId)
-        insertObservationPlot(
-            monitoringPlotId = insertMonitoringPlot(),
-            claimedBy = user.userId,
-            completedBy = user.userId)
+        insertObservationPlot(monitoringPlotId = insertMonitoringPlot(), completedBy = user.userId)
         insertObservationPlot(monitoringPlotId = insertMonitoringPlot())
         insertObservationPlot(monitoringPlotId = insertMonitoringPlot())
 
@@ -1852,7 +1847,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       insertPlantingSubzone()
       insertMonitoringPlot()
       insertObservation()
-      insertObservationPlot(claimedBy = user.userId, completedBy = user.userId)
+      insertObservationPlot(completedBy = user.userId)
       insertObservedCoordinates(
           gpsCoordinates = point(1), position = ObservationPlotPosition.NorthwestCorner)
 


### PR DESCRIPTION
To reduce test clutter slightly, don't require the user ID to be passed twice when
inserting a completed plot.