### PR TITLE
SW-5230 Update recorded plant totals on site map edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -40,6 +40,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
@@ -674,6 +675,83 @@ class ObservationStore(
     }
   }
 
+  fun removePlotFromTotals(monitoringPlotId: MonitoringPlotId) {
+    val (plantingSiteId, plantingZoneId) =
+        dslContext
+            .select(
+                PLANTING_ZONES.PLANTING_SITE_ID.asNonNullable(), PLANTING_ZONES.ID.asNonNullable())
+            .from(MONITORING_PLOTS)
+            .join(PLANTING_SUBZONES)
+            .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+            .join(PLANTING_ZONES)
+            .on(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
+            .where(MONITORING_PLOTS.ID.eq(monitoringPlotId))
+            .fetchOne() ?: throw PlotNotFoundException(monitoringPlotId)
+
+    val negativeCountField = DSL.count().neg()
+    val negativeCounts:
+        Map<Pair<ObservationId, Boolean>, Map<RecordedSpeciesKey, Map<RecordedPlantStatus, Int>>> =
+        dslContext
+            .select(
+                OBSERVATION_PLOTS.OBSERVATION_ID,
+                OBSERVATION_PLOTS.IS_PERMANENT,
+                RECORDED_PLANTS.CERTAINTY_ID,
+                RECORDED_PLANTS.SPECIES_ID,
+                RECORDED_PLANTS.SPECIES_NAME,
+                RECORDED_PLANTS.STATUS_ID,
+                negativeCountField,
+            )
+            .from(OBSERVATION_PLOTS)
+            .join(MONITORING_PLOTS)
+            .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+            .join(PLANTING_SUBZONES)
+            .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+            .join(PLANTING_ZONES)
+            .on(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(PLANTING_ZONES.ID))
+            .join(RECORDED_PLANTS)
+            .on(OBSERVATION_PLOTS.OBSERVATION_ID.eq(RECORDED_PLANTS.OBSERVATION_ID))
+            .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(RECORDED_PLANTS.MONITORING_PLOT_ID))
+            .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(monitoringPlotId))
+            .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull)
+            .groupBy(
+                OBSERVATION_PLOTS.OBSERVATION_ID,
+                OBSERVATION_PLOTS.IS_PERMANENT,
+                RECORDED_PLANTS.CERTAINTY_ID,
+                RECORDED_PLANTS.SPECIES_ID,
+                RECORDED_PLANTS.SPECIES_NAME,
+                RECORDED_PLANTS.STATUS_ID,
+            )
+            .fetch()
+            .groupBy {
+              it[OBSERVATION_PLOTS.OBSERVATION_ID]!! to it[OBSERVATION_PLOTS.IS_PERMANENT]!!
+            }
+            .mapValues { (_, groups) ->
+              groups
+                  .groupBy {
+                    RecordedSpeciesKey(
+                        it[RECORDED_PLANTS.CERTAINTY_ID]!!,
+                        it[RECORDED_PLANTS.SPECIES_ID],
+                        it[RECORDED_PLANTS.SPECIES_NAME])
+                  }
+                  .mapValues { (_, statusTotals) ->
+                    statusTotals.associate {
+                      it[RECORDED_PLANTS.STATUS_ID]!! to it[negativeCountField]!!
+                    }
+                  }
+            }
+
+    negativeCounts.forEach { (observationIdAndIsPermanent, plantCountsBySpecies) ->
+      val (observationId, isPermanent) = observationIdAndIsPermanent
+
+      log.debug(
+          "Subtracting plant counts for plot $monitoringPlotId from site $plantingSiteId and " +
+              "zone $plantingZoneId in observation $observationId: $plantCountsBySpecies")
+
+      updateSpeciesTotals(
+          observationId, plantingSiteId, plantingZoneId, null, isPermanent, plantCountsBySpecies)
+    }
+  }
+
   /**
    * Fetches last completed observation for a planting site if there are no other upcoming or in
    * progress observations, otherwise returns most recently updated observation.
@@ -1063,8 +1141,41 @@ class ObservationStore(
                 .execute()
 
         if (rowsInserted == 0) {
-          val mortalityRateDenominatorField =
-              permanentLiveField.plus(cumulativeDeadField).plus(permanentDead + permanentLive)
+          val scopeIdAndSpeciesCondition =
+              scopeIdField
+                  .eq(scopeId)
+                  .and(
+                      if (speciesKey.id != null) speciesIdField.eq(speciesKey.id)
+                      else speciesIdField.isNull)
+                  .and(
+                      if (speciesKey.name != null) speciesNameField.eq(speciesKey.name)
+                      else speciesNameField.isNull)
+
+          // If we are updating a past observation (e.g., when removing a plot due to a map edit),
+          // the cumulative dead counts for the current observation as well as any subsequent ones
+          // need to be updated, as do their mortality rates.
+          if (permanentLive != 0 || permanentDead != 0) {
+            val mortalityRateDenominatorField =
+                permanentLiveField.plus(cumulativeDeadField).plus(permanentDead + permanentLive)
+
+            dslContext
+                .update(table)
+                .set(cumulativeDeadField, cumulativeDeadField.plus(permanentDead))
+                .set(
+                    mortalityRateField,
+                    DSL.case_()
+                        .`when`(mortalityRateDenominatorField.eq(0), 0)
+                        .else_(
+                            (cumulativeDeadField
+                                    .cast(SQLDataType.NUMERIC)
+                                    .plus(permanentDead)
+                                    .times(100)
+                                    .div(mortalityRateDenominatorField))
+                                .cast(SQLDataType.INTEGER)))
+                .where(observationIdField.ge(observationId))
+                .and(scopeIdAndSpeciesCondition)
+                .execute()
+          }
 
           val rowsUpdated =
               dslContext
@@ -1072,27 +1183,9 @@ class ObservationStore(
                   .set(totalLiveField, totalLiveField.plus(totalLive))
                   .set(totalDeadField, totalDeadField.plus(totalDead))
                   .set(totalExistingField, totalExistingField.plus(totalExisting))
-                  .set(cumulativeDeadField, cumulativeDeadField.plus(permanentDead))
                   .set(permanentLiveField, permanentLiveField.plus(permanentLive))
-                  .set(
-                      mortalityRateField,
-                      DSL.case_()
-                          .`when`(mortalityRateDenominatorField.eq(0), 0)
-                          .else_(
-                              (cumulativeDeadField
-                                      .cast(SQLDataType.NUMERIC)
-                                      .plus(permanentDead)
-                                      .times(100)
-                                      .div(mortalityRateDenominatorField))
-                                  .cast(SQLDataType.INTEGER)))
                   .where(observationIdField.eq(observationId))
-                  .and(scopeIdField.eq(scopeId))
-                  .and(
-                      if (speciesKey.id != null) speciesIdField.eq(speciesKey.id)
-                      else speciesIdField.isNull)
-                  .and(
-                      if (speciesKey.name != null) speciesNameField.eq(speciesKey.name)
-                      else speciesNameField.isNull)
+                  .and(scopeIdAndSpeciesCondition)
                   .execute()
 
           if (rowsUpdated != 1) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -35,6 +35,9 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SP
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.polygon
+import com.terraformation.backend.tracking.db.ObservationTestHelper.ObservationPlot
+import com.terraformation.backend.tracking.db.ObservationTestHelper.ObservationZone
+import com.terraformation.backend.tracking.db.ObservationTestHelper.PlantTotals
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.NewObservationModel
@@ -1869,6 +1872,171 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
               ObservationPlotPosition.SoutheastCorner to point(2, 2)),
           observedPlotCoordinatesDao.findAll().associate { it.positionId!! to it.gpsCoordinates!! },
           "Coordinates after update")
+    }
+  }
+
+  @Nested
+  inner class RemovePlotFromTotals {
+    @Test
+    fun `updates observed species totals across all observations`() {
+      val speciesId1 = insertSpecies()
+      val speciesId2 = insertSpecies()
+      val speciesId3 = insertSpecies()
+
+      val zoneId1 = insertPlantingZone()
+      insertPlantingSubzone()
+      val zone1PlotId1 = insertMonitoringPlot()
+      val zone1PlotId2 = insertMonitoringPlot()
+      val zoneId2 = insertPlantingZone()
+      insertPlantingSubzone()
+      val zone2PlotId1 = insertMonitoringPlot()
+
+      val observationId1 = insertObservation(completedTime = Instant.ofEpochSecond(1))
+
+      helper.insertObservationScenario(
+          ObservationZone(
+              zoneId = zoneId1,
+              plots =
+                  listOf(
+                      ObservationPlot(
+                          zone1PlotId1,
+                          listOf(
+                              PlantTotals(speciesId1, live = 2, dead = 1, existing = 1),
+                              PlantTotals(speciesId2, live = 1),
+                              PlantTotals("fern", live = 1, dead = 1),
+                          ),
+                      ),
+                      ObservationPlot(
+                          zone1PlotId2,
+                          listOf(
+                              PlantTotals(speciesId2, live = 1, dead = 1),
+                          )))),
+          ObservationZone(
+              zoneId = zoneId2,
+              plots =
+                  listOf(
+                      ObservationPlot(
+                          zone2PlotId1,
+                          listOf(
+                              PlantTotals(speciesId1, live = 1),
+                              PlantTotals(speciesId3, live = 1),
+                          )))))
+
+      val observationId2 = insertObservation(completedTime = Instant.ofEpochSecond(2))
+
+      helper.insertObservationScenario(
+          ObservationZone(
+              zoneId = zoneId1,
+              plots =
+                  listOf(
+                      ObservationPlot(
+                          zone1PlotId1,
+                          listOf(
+                              PlantTotals(speciesId1, live = 1, dead = 1, existing = 1),
+                              PlantTotals(speciesId2, live = 1),
+                              PlantTotals("fern", live = 2),
+                          ),
+                      ),
+                      ObservationPlot(
+                          zone1PlotId2,
+                          listOf(
+                              PlantTotals(speciesId2, live = 1),
+                          ))),
+          ))
+
+      store.removePlotFromTotals(zone1PlotId1)
+
+      helper.assertTotals(
+          setOf(
+              ObservedPlotSpeciesTotalsRow(
+                  observationId = observationId1,
+                  monitoringPlotId = zone1PlotId1,
+                  speciesId = speciesId1,
+                  speciesName = null,
+                  certaintyId = Known,
+                  totalLive = 2,
+                  totalDead = 1,
+                  totalExisting = 1,
+                  mortalityRate = 33,
+                  cumulativeDead = 1,
+                  permanentLive = 2),
+              // Parameter names omitted after this to keep the test method size manageable.
+              ObservedPlotSpeciesTotalsRow(
+                  observationId1, zone1PlotId1, speciesId2, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId1, zone1PlotId1, null, "fern", Other, 1, 1, 0, 50, 1, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId1, zone1PlotId2, speciesId2, null, Known, 1, 1, 0, 50, 1, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId1, zone2PlotId1, speciesId1, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId1, zone2PlotId1, speciesId3, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId1, zoneId1, speciesId1, null, Known, 0, 0, 0, 0, 0, 0),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId1, zoneId1, speciesId2, null, Known, 1, 1, 0, 50, 1, 1),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId1, zoneId1, null, "fern", Other, 0, 0, 0, 0, 0, 0),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId1, zoneId2, speciesId1, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId1, zoneId2, speciesId3, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId1, plantingSiteId, speciesId1, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId1, plantingSiteId, speciesId2, null, Known, 1, 1, 0, 50, 1, 1),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId1, plantingSiteId, speciesId3, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId1, plantingSiteId, null, "fern", Other, 0, 0, 0, 0, 0, 0),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId2, zone1PlotId1, speciesId1, null, Known, 1, 1, 1, 67, 2, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId2, zone1PlotId1, speciesId2, null, Known, 1, 0, 0, 0, 0, 1),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId2, zone1PlotId1, null, "fern", Other, 2, 0, 0, 33, 1, 2),
+              ObservedPlotSpeciesTotalsRow(
+                  observationId2, zone1PlotId2, speciesId2, null, Known, 1, 0, 0, 50, 1, 1),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId2, zoneId1, speciesId1, null, Known, 0, 0, 0, 0, 0, 0),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId2, zoneId1, speciesId2, null, Known, 1, 0, 0, 50, 1, 1),
+              ObservedZoneSpeciesTotalsRow(
+                  observationId2, zoneId1, null, "fern", Other, 0, 0, 0, 0, 0, 0),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId2, plantingSiteId, speciesId1, null, Known, 0, 0, 0, 0, 0, 0),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId2, plantingSiteId, speciesId2, null, Known, 1, 0, 0, 50, 1, 1),
+              ObservedSiteSpeciesTotalsRow(
+                  observationId2, plantingSiteId, null, "fern", Other, 0, 0, 0, 0, 0, 0),
+          ),
+          "Totals after plot removal")
+    }
+
+    @Test
+    fun `does not modify totals if plot has no recorded plants`() {
+      helper.insertPlantedSite()
+      val plotWithPlants = insertMonitoringPlot()
+      insertObservation(completedTime = Instant.EPOCH)
+      helper.insertObservationScenario(
+          ObservationZone(
+              zoneId = inserted.plantingZoneId,
+              plots =
+                  listOf(
+                      ObservationPlot(
+                          plotWithPlants,
+                          listOf(
+                              PlantTotals(inserted.speciesId, live = 3, dead = 2, existing = 1))))))
+
+      val totalsBeforeRemoval = helper.fetchAllTotals()
+
+      val plotWithoutPlants = insertMonitoringPlot()
+      insertObservation()
+      insertObservationPlot(completedTime = Instant.EPOCH)
+
+      store.removePlotFromTotals(plotWithoutPlants)
+
+      helper.assertTotals(totalsBeforeRemoval, "Totals after plot removal")
     }
   }
 }


### PR DESCRIPTION
When a planting site map is edited and monitoring plots are removed, subtract the
plots' plants from the recorded plant totals.