### PR TITLE
Don't allow deletion of subzones with past plantings

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -413,7 +413,7 @@ class AdminPlantingSitesController(
                 existing.name,
                 existing.description,
                 existing.organizationId)
-        val plantedSubzoneIds = plantingSiteStore.countReportedPlantsInSubzones(plantingSiteId).keys
+        val plantedSubzoneIds = plantingSiteStore.fetchSubzoneIdsWithPastPlantings(plantingSiteId)
         val edit =
             PlantingSiteEditCalculator(existing, desired, plantedSubzoneIds).calculateSiteEdit()
 


### PR DESCRIPTION
We don't want to allow deletion of subzones that appear in the planting history
for a planting site, even if the plants were later reassigned to another subzone.