### PR TITLE
SW-5472 Allow plot replacement in non-completed subzones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -278,6 +278,8 @@ class ObservationService(
       val observationPlot =
           observationPlots.firstOrNull { it.model.monitoringPlotId == monitoringPlotId }
               ?: throw PlotNotInObservationException(observationId, monitoringPlotId)
+      val plantedSubzoneIds =
+          plantingSiteStore.countReportedPlantsInSubzones(observation.plantingSiteId).keys
 
       if (!allowCompleted && observationPlot.model.completedTime != null) {
         throw PlotAlreadyCompletedException(monitoringPlotId)
@@ -317,7 +319,7 @@ class ObservationService(
                         it.id in replacementResult.addedMonitoringPlotIds
                       }
                     }
-                if (subzones.all { it.plantingCompletedTime != null }) {
+                if (subzones.all { it.id in plantedSubzoneIds }) {
                   log.info(
                       "Replacement permanent cluster's plots are all in subzones that have " +
                           "completed planting; including the cluster in this observation.")

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -1398,7 +1398,10 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `replaces entire permanent cluster if this is the first observation and there are no completed plots`() {
       insertPlantingZone(numPermanentClusters = 1, width = 2, height = 4)
-      insertPlantingSubzone(width = 2, height = 4, plantingCompletedTime = Instant.EPOCH)
+      insertPlantingSubzone(width = 2, height = 4)
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting()
       val cluster1 = insertCluster(1, isPermanent = true)
       val cluster2 = insertCluster(2)
 
@@ -1424,8 +1427,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `removes permanent cluster if replacement cluster is in an unplanted subzone`() {
       insertPlantingZone(numPermanentClusters = 1, width = 2, height = 4)
-      insertPlantingSubzone(width = 2, height = 2, plantingCompletedTime = Instant.EPOCH)
+      insertPlantingSubzone(width = 2, height = 2)
+      insertWithdrawal()
+      insertDelivery()
+      insertPlanting()
       val cluster1 = insertCluster(1, isPermanent = true)
+
       insertPlantingSubzone(y = 2, width = 2, height = 2)
       val cluster2 = insertCluster(2)
 


### PR DESCRIPTION
When we're starting an observation, any subzone that has reported plants is
eligible to have monitoring plots. We use the same criterion when replacing a
monitoring plot due to a site map edit.

But when the user requested a plot replacement, we were instead looking at
whether the subzone was marked as having _completed_ planting.

Update the plot replacement code to make it behave consistently with plot
selection in other contexts.