### PR TITLE
Add Spotless rules for SQL and Markdown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Fetch tip of main branch to support diffing
+      run: git fetch --depth 1 origin main
+
     - name: Set environment
       run: ./.github/scripts/set-environment.sh
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
   // kotlin("kapt")
 
   id("dev.monosoul.jooq-docker") version "6.0.24"
-  id("com.diffplug.spotless") version "6.19.0"
+  id("com.diffplug.spotless") version "6.25.0"
   id("org.jetbrains.dokka") version "1.9.20"
   id("org.springframework.boot") version "3.3.0"
   id("io.spring.dependency-management") version "1.1.5"
@@ -285,6 +285,19 @@ spotless {
   kotlinGradle {
     ktfmt(ktfmtVersion)
     target("*.gradle.kts", "buildSrc/*.gradle.kts", "jooq/*.gradle.kts")
+  }
+  flexmark {
+    target("*.md", "buildSrc/*.md", "docs/*.md", "src/**/*.md")
+    flexmark()
+  }
+  format("sql") {
+    // Only apply to newly-added SQL files since editing existing ones will cause the checksums
+    // to change which Flyway will detect as invalid edits of already-applied migrations.
+    ratchetFrom("origin/main")
+
+    target("src/**/*.sql")
+    endWithNewline()
+    trimTrailingWhitespace()
   }
 }
 

--- a/docs/ATLASSIAN.md
+++ b/docs/ATLASSIAN.md
@@ -1,6 +1,6 @@
 # Configuring support tickets with Atlassian
 
-Feature requests and bug reports submitted are triaged as Jira service issues on Atlassian. This requires configuring terraware-server with the right Atlassian API credentials. 
+Feature requests and bug reports submitted are triaged as Jira service issues on Atlassian. This requires configuring terraware-server with the right Atlassian API credentials.
 
 ## Prerequisites
 
@@ -20,6 +20,7 @@ The service desk tag is the project to hold support issues.
 ### Step 3: Add environmental variables
 
 A local application yaml file:
+
 ```
 terraware:
   atlassian:

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -43,7 +43,6 @@ Payload classes often live in the same file as the controller classes that use t
 
 Generally, if a class has a significant amount of code, it’ll live in its own file.
 
-
 ## Database access
 
 We use a schema-first, code-generation approach, as opposed to a code-first approach where the database gets created based on class structure.

--- a/docs/DROPBOX.md
+++ b/docs/DROPBOX.md
@@ -2,7 +2,7 @@
 
 Sensitive documents submitted in response to deliverables are uploaded to Dropbox rather than to Google Drive. This requires configuring terraware-server with the right Dropbox API credentials.
 
-These instructions can be used to set up a 
+These instructions can be used to set up a
 
 ## Prerequisites
 
@@ -44,7 +44,7 @@ Click the "Submit" link.
 
 This will require manually constructing an OAuth2 URL to get a code. The URL should look like:
 
-    https://www.dropbox.com/oauth2/authorize?client_id=APP_KEY&response_type=code&token_access_type=offline
+        https://www.dropbox.com/oauth2/authorize?client_id=APP_KEY&response_type=code&token_access_type=offline
 
 where `APP_KEY` is the app key from the "Settings" tab of the app's details (from step 2).
 
@@ -56,7 +56,7 @@ After granting permission to the app, you'll get a page with a temporary code, w
 
 This requires sending a POST request to Dropbox. Easiest is to do it from the command line:
 
-     curl -d 'grant_type=authorization_code&client_id=APP_KEY&client_secret=APP_SECRET&code=CODE' https://api.dropbox.com/oauth2/token
+        curl -d 'grant_type=authorization_code&client_id=APP_KEY&client_secret=APP_SECRET&code=CODE' https://api.dropbox.com/oauth2/token
 
 Where `APP_KEY` and `APP_SECRET` are the app key and secret from the settings page (from step 2) and `CODE` is the code from the end of step 4.
 
@@ -81,3 +81,4 @@ For deployment or if you're running terraware-server with a Docker image, you'll
 - `TERRAWARE_DROPBOX_APPSECRET`
 - `TERRAWARE_DROPBOX_ENABLED` (set this to `true`)
 - `TERRAWARE_DROPBOX_REFRESHTOKEN`
+

--- a/docs/KEYCLOAK.md
+++ b/docs/KEYCLOAK.md
@@ -54,9 +54,9 @@ These steps apply to a local instance of Keycloak, and also to an existing one t
    9. Click the "Service Account Roles" tab.
    10. Click "Assign Roles."
    11. Select each of the following roles and click the "Add selected" button (note that the list of roles in the dialog is paginated, so search for them or navigate to the appropriate pages):
-      - manage-users
-      - view-realm
-      - view-users
+   - manage-users
+   - view-realm
+   - view-users
    12. Click the "Assign" button.
    13. Click the "Credentials" tab.
    14. Copy the value of the "client secret" field; you'll be using it later.
@@ -124,15 +124,15 @@ There are two main ways to supply these settings: in environment variables or in
 
 If you work at Terraformation then ask a fellow developer for the values of these settings (likely in the Terraformation 1Password Eng Infra Vault).
 
-| Property | Environment Variable | Description
-| --- | --- | ---
-| `spring.security.oauth2.client.provider.keycloak.issuer-uri` | `SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI` | The base URL of the Terraware realm on your Keycloak server. If you are running Keycloak locally, this will be `http://localhost:8081/realms/terraware`. Otherwise, it will be the URL of your Keycloak server including the realm prefix for the Terraware realm, which is usually `/realms/terraware`.
-| `spring.security.oauth2.client.registration.keycloak.client-id` | `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_CLIENTID` | The client ID terraware-server will use to make Keycloak API requests. If you followed the instructions to create a local Keycloak instance, then this will be `dev-terraware-server`.
-| `spring.security.oauth2.client.registration.keycloak.client-secret` | `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET` | The secret associated with the client ID.
-| `spring.security.oauth2.resourceserver.jwt.issuer-uri` | `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI` | Set this to the same value as the other issuer URI.
-| `terraware.keycloak.api-client-id` | `TERRAWARE_KEYCLOAK_API_CLIENT_ID` | The Keycloak client ID that terraware-server API clients will use to generate access tokens. If you followed the instructions to create a local Keycloak instance, then this will be `api`.
-| `terraware.keycloak.api-client-group-name` | `TERRAWARE_KEYCLOAK_API_CLIENT_GROUP_NAME` | The name of the Keycloak group to add newly-created API client users to. The default is `/api-clients`. If you chose a different group name when you were setting up Keycloak, you'll need to set this. Note that because Keycloak group names are hierarchical, the value must start with `/`.
-| `terraware.keycloak.api-client-username-prefix` | `TERRAWARE_KEYCLOAK_API_CLIENT_USERNAME_PREFIX` | A prefix to put at the beginning of the Keycloak usernames of API client users. The default is `api-`. This is to make the users easy to identify in the Keycloak admin console.
+|                              Property                               |                        Environment Variable                        |                                                                                                                                               Description                                                                                                                                                |
+|---------------------------------------------------------------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `spring.security.oauth2.client.provider.keycloak.issuer-uri`        | `SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI`        | The base URL of the Terraware realm on your Keycloak server. If you are running Keycloak locally, this will be `http://localhost:8081/realms/terraware`. Otherwise, it will be the URL of your Keycloak server including the realm prefix for the Terraware realm, which is usually `/realms/terraware`. |
+| `spring.security.oauth2.client.registration.keycloak.client-id`     | `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_CLIENTID`              | The client ID terraware-server will use to make Keycloak API requests. If you followed the instructions to create a local Keycloak instance, then this will be `dev-terraware-server`.                                                                                                                   |
+| `spring.security.oauth2.client.registration.keycloak.client-secret` | `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET` | The secret associated with the client ID.                                                                                                                                                                                                                                                                |
+| `spring.security.oauth2.resourceserver.jwt.issuer-uri`              | `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI`              | Set this to the same value as the other issuer URI.                                                                                                                                                                                                                                                      |
+| `terraware.keycloak.api-client-id`                                  | `TERRAWARE_KEYCLOAK_API_CLIENT_ID`                                 | The Keycloak client ID that terraware-server API clients will use to generate access tokens. If you followed the instructions to create a local Keycloak instance, then this will be `api`.                                                                                                              |
+| `terraware.keycloak.api-client-group-name`                          | `TERRAWARE_KEYCLOAK_API_CLIENT_GROUP_NAME`                         | The name of the Keycloak group to add newly-created API client users to. The default is `/api-clients`. If you chose a different group name when you were setting up Keycloak, you'll need to set this. Note that because Keycloak group names are hierarchical, the value must start with `/`.          |
+| `terraware.keycloak.api-client-username-prefix`                     | `TERRAWARE_KEYCLOAK_API_CLIENT_USERNAME_PREFIX`                    | A prefix to put at the beginning of the Keycloak usernames of API client users. The default is `api-`. This is to make the users easy to identify in the Keycloak admin console.                                                                                                                         |
 
 #### Using environment variables
 
@@ -166,3 +166,4 @@ spring:
         jwt:
           issuer-uri: http://your-server/realms/your-realm
 ```
+

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -24,7 +24,7 @@ The server will listen on port 8080.
 
 Fetch the API schema to confirm the server is up and running. (This doesn't require authentication.)
 
-    curl http://localhost:8080/v3/api-docs.yaml
+        curl http://localhost:8080/v3/api-docs.yaml
 
 ## Running the server via Docker
 
@@ -99,7 +99,7 @@ Depending on how you set the Keycloak-related environment variables in the initi
 If you need to change some configuration settings in your local development environment, but you don't want to fuss with environment variables, you can put the configuration in YAML files and tell the server to read them.
 
 Copy the file `src/main/resources/application-dev.yaml.sample` to `src/main/resources/application-dev.yaml`. This file will not be included when the code is packaged into a jar, and will be ignored by git.
-It has the necessary Keycloak and Postgres configuration variables stubbed out for you. 
+It has the necessary Keycloak and Postgres configuration variables stubbed out for you.
 
 See the other `application.yaml` files in [`src/main/resources`](src/main/resources) for some examples, but it'll look something like this:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,3 +38,4 @@ The database has some subject-area-specific schemas as well as a default public 
 * [Dependency license report](license-report/index.html)
 * [Git log since last release](unreleased.log)
 * [Notifications](notifications.html)
+

--- a/src/main/kotlin/com/terraformation/backend/report/api/Package.md
+++ b/src/main/kotlin/com/terraformation/backend/report/api/Package.md
@@ -35,3 +35,4 @@ This hierarchy is just to keep things consistent and maintainable on the server 
     }
 }
 ```
+


### PR DESCRIPTION
Sometimes in code review we flag things like SQL files not ending with trailing
newlines, but that should really be the job of a linter. Configure Spotless to
format (and check) Markdown files and newly-added SQL files. Existing SQL files
are left alone since they're mostly migrations, and modifying a migration
that's already applied will cause Flyway to abort at application start time.
