### PR TITLE
Move site validation from controller to model

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -358,17 +358,7 @@ data class CreatePlantingSiteRequestPayload(
       throw IllegalArgumentException("Exclusion area must be Polygon or MultiPolygon")
     }
 
-    if (!plantingZones.isNullOrEmpty()) {
-      if (boundary == null) {
-        throw IllegalArgumentException("Boundary is required if planting zones are defined")
-      }
-
-      plantingZones.forEach { it.validate() }
-    }
-
-    if (exclusion != null && boundary == null) {
-      throw IllegalArgumentException("Boundary is required if exclusion is defined")
-    }
+    plantingZones?.forEach { it.validate() }
   }
 
   fun toModel(): NewPlantingSiteModel {

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -110,6 +110,13 @@ data class PlantingSiteModel<
 
         problems.addAll(zone.validate(this))
       }
+    } else {
+      if (exclusion != null) {
+        problems.add(PlantingSiteValidationFailure.exclusionWithoutBoundary())
+      }
+      if (plantingZones.isNotEmpty()) {
+        problems.add(PlantingSiteValidationFailure.zonesWithoutSiteBoundary())
+      }
     }
 
     return problems.ifEmpty { null }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteValidationFailure.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteValidationFailure.kt
@@ -31,6 +31,9 @@ data class PlantingSiteValidationFailure(
     fun duplicateZoneName(zoneName: String) =
         PlantingSiteValidationFailure(PlantingSiteValidationFailureType.DuplicateZoneName, zoneName)
 
+    fun exclusionWithoutBoundary() =
+        PlantingSiteValidationFailure(PlantingSiteValidationFailureType.ExclusionWithoutBoundary)
+
     fun siteTooLarge() =
         PlantingSiteValidationFailure(PlantingSiteValidationFailureType.SiteTooLarge)
 
@@ -73,6 +76,9 @@ data class PlantingSiteValidationFailure(
 
     fun zoneNotInSite(zoneName: String) =
         PlantingSiteValidationFailure(PlantingSiteValidationFailureType.ZoneNotInSite, zoneName)
+
+    fun zonesWithoutSiteBoundary() =
+        PlantingSiteValidationFailure(PlantingSiteValidationFailureType.ZonesWithoutSiteBoundary)
 
     fun zoneTooSmall(zoneName: String) =
         PlantingSiteValidationFailure(PlantingSiteValidationFailureType.ZoneTooSmall, zoneName)

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteValidationFailureType.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteValidationFailureType.kt
@@ -6,6 +6,7 @@ enum class PlantingSiteValidationFailureType {
   CannotSplitZone,
   DuplicateSubzoneName,
   DuplicateZoneName,
+  ExclusionWithoutBoundary,
   SiteTooLarge,
   SubzoneBoundaryChanged,
   SubzoneBoundaryOverlaps,
@@ -16,4 +17,5 @@ enum class PlantingSiteValidationFailureType {
   ZoneHasNoSubzones,
   ZoneNotInSite,
   ZoneTooSmall,
+  ZonesWithoutSiteBoundary,
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -108,6 +108,19 @@ class PlantingSiteModelTest {
           "Site is big enough for 5 plots but not a permanent cluster")
     }
 
+    @Test
+    fun `checks that site has boundary if it has exclusion`() {
+      assertHasProblem(
+          newSite().copy(boundary = null, exclusion = rectangle(1)),
+          PlantingSiteValidationFailure.exclusionWithoutBoundary())
+    }
+
+    @Test
+    fun `checks that site has boundary if it has zones`() {
+      assertHasProblem(
+          newSite().copy(boundary = null), PlantingSiteValidationFailure.zonesWithoutSiteBoundary())
+    }
+
     private fun assertHasProblem(
         site: PlantingSiteModel<*, *, *>,
         problem: PlantingSiteValidationFailure,


### PR DESCRIPTION
`PlantingSitesController` validates that geometries are of acceptable types
since the request is syntactically invalid and can't be turned into a
`PlantingSiteModel` otherwise.

It was also doing a little structural validation of the site, but those validation
checks had nothing to do with whether the payload was well-formed. Move those
checks to `PlantingSiteModel`.