### PR TITLE
Fix the timezone migration so it doesn't fail with real databases

### DIFF
--- a/src/main/resources/db/migration/0250/V280__TimeZones.sql
+++ b/src/main/resources/db/migration/0250/V280__TimeZones.sql
@@ -602,4 +602,5 @@ VALUES ('Africa/Abidjan'),
        ('W-SU'),
        ('WET'),
        ('Z'),
-       ('Zulu');
+       ('Zulu')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Since the real database already has timezones, the timezone migration needs to allow this. 