### PR TITLE
SW-5485 Don't fail build if staging is down

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     # if the schema itself hasn't changed.
     - name: Diff OpenAPI docs against staging
       run: |
-        if curl -s https://staging.terraware.io/v3/api-docs.yaml > /tmp/staging.yaml; then
+        if curl -f -s https://staging.terraware.io/v3/api-docs.yaml > /tmp/staging.yaml; then
           for f in openapi.yaml /tmp/staging.yaml; do
             yq -i '
               .info.version = null |


### PR DESCRIPTION
The CI step that diffs the OpenAPI schema against staging was failing when staging
was down (even if just momentarily because a new build was being deployed).

Add the flag to the `curl` command that tells it to exit with nonzero status if
there's an HTTP error response.