### PR TITLE
SW-5484 Check detected file Mime type in addition to client header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ If you're going to be contributing code:
 Setup docs for optional parts of the system, only needed if you're working on code related to these features:
 
 * [ATLASSIAN.md](ATLASSIAN.md): how to configure the server to file Jira tasks. Only needed if you're working on features related to customer support.
-* [DROPBOX.md](DROPBOX.md): how to configure Dropbox integration for storing sensitive uploaded dcocuments.
+* [DROPBOX.md](DROPBOX.md): how to configure Dropbox integration for storing sensitive uploaded documents.
 
 ## Database schema diagrams
 

--- a/src/main/kotlin/com/terraformation/backend/support/SupportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/SupportService.kt
@@ -63,13 +63,15 @@ class SupportService(
   ): List<TemporaryAttachmentModel> {
     val tikaContentType = MediaType.parseMediaType(Tika().detect(sizedInputStream))
     sizedInputStream.contentType?.let {
-      !isContentTypeSupported(it) &&
-          throw NotSupportedException(
-              "$it is not a supported content type. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
-    }
-    !isContentTypeSupported(tikaContentType) &&
+      if (!isContentTypeSupported(it)) {
         throw NotSupportedException(
-            "File detected to be $tikaContentType, which is not supported. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
+            "$it is not a supported content type. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
+      }
+    }
+    if (!isContentTypeSupported(tikaContentType)) {
+      throw NotSupportedException(
+          "File detected to be $tikaContentType, which is not supported. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
+    }
 
     return atlassianHttpClient.attachTemporaryFile(filename, sizedInputStream).temporaryAttachments
   }

--- a/src/main/kotlin/com/terraformation/backend/support/SupportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/SupportService.kt
@@ -13,6 +13,8 @@ import com.terraformation.backend.support.atlassian.model.SupportRequestType
 import com.terraformation.backend.support.atlassian.model.TemporaryAttachmentModel
 import jakarta.inject.Named
 import jakarta.ws.rs.NotSupportedException
+import org.apache.tika.Tika
+import org.springframework.http.MediaType
 
 @Named
 class SupportService(
@@ -59,11 +61,15 @@ class SupportService(
       filename: String,
       sizedInputStream: SizedInputStream,
   ): List<TemporaryAttachmentModel> {
+    val tikaContentType = MediaType.parseMediaType(Tika().detect(sizedInputStream))
     sizedInputStream.contentType?.let {
       !isContentTypeSupported(it) &&
           throw NotSupportedException(
               "$it is not a supported content type. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
     }
+    !isContentTypeSupported(tikaContentType) &&
+        throw NotSupportedException(
+            "File detected to be $tikaContentType, which is not supported. Must be one of $SUPPORTED_CONTENT_TYPES_STRING")
 
     return atlassianHttpClient.attachTemporaryFile(filename, sizedInputStream).temporaryAttachments
   }


### PR DESCRIPTION
This additional check will prevent a user from changing the file extension before uploading the file, or use an incorrect header, to bypass the request header content type check. 

The intention is that this will prevent malicious files from being uploaded to our support requests. 