### PR TITLE
Document producer cleanup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -45,6 +45,7 @@ class AdminController(
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
     model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
+    model.addAttribute("canManageDocumentProducer", currentUser().canManageDocumentProducer())
     model.addAttribute(
         "canManageModules",
         currentUser().canManageModules() || currentUser().canManageDeliverables())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentController.kt
@@ -1,5 +1,7 @@
 package com.terraformation.backend.admin
 
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.docprod.DocumentTemplateId
 import com.terraformation.backend.db.docprod.tables.daos.DocumentTemplatesDao
 import com.terraformation.backend.db.docprod.tables.pojos.DocumentTemplatesRow
@@ -22,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 
 @Controller
+@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin])
 @RequestMapping("/admin/document-producer")
 class AdminDocumentController(
     private val manifestImporter: ManifestImporter,

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.parameters.RequestBody
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -24,16 +23,16 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 
 @Controller
-@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin])
+@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert])
 @RequestMapping("/admin/document-producer")
-class AdminDocumentController(
+class AdminDocumentProducerController(
     private val manifestImporter: ManifestImporter,
     private val documentTemplatesDao: DocumentTemplatesDao,
 ) {
   /** Redirects /admin to /admin/ so relative URLs in the UI will work. */
   @GetMapping
   fun redirectToTrailingSlash(): String {
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   @GetMapping("/")
@@ -41,7 +40,7 @@ class AdminDocumentController(
     model.addAttribute(
         "documentTemplates", documentTemplatesDao.findAll().sortedBy { it.id?.value })
 
-    return "/admin/index"
+    return "/admin/documentProducer"
   }
 
   @PostMapping("/createDocumentTemplate")
@@ -59,7 +58,7 @@ class AdminDocumentController(
       redirectAttributes.failureMessage = "Failed to add document template: ${e.message}"
     }
 
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   @Operation(
@@ -101,7 +100,7 @@ class AdminDocumentController(
       redirectAttributes.failureMessage = "Error attempting to import manifest: $e"
     }
 
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   private var RedirectAttributes.failureMessage: String?
@@ -134,5 +133,5 @@ class AdminDocumentController(
 
   // Convenience methods to redirect to the GET endpoint for each kind of thing.
 
-  private fun adminHome() = redirect("/")
+  private fun documentProducerAdminHome() = redirect("/document-producer/")
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -271,6 +271,8 @@ data class DeviceManagerUser(
 
   override fun canManageDeliverables(): Boolean = false
 
+  override fun canManageDocumentProducer(): Boolean = false
+
   override fun canManageInternalTags(): Boolean = false
 
   override fun canManageModuleEvents(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -199,7 +199,7 @@ data class IndividualUser(
 
   override fun canCreateDeviceManager() = isSuperAdmin()
 
-  override fun canCreateDocument() = true
+  override fun canCreateDocument() = isAcceleratorAdmin()
 
   override fun canCreateDraftPlantingSite(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
@@ -232,7 +232,7 @@ data class IndividualUser(
   // Reports are normally created by the system, but can be created manually by super-admins.
   override fun canCreateReport(organizationId: OrganizationId) = isSuperAdmin()
 
-  override fun canCreateSavedVersion(documentId: DocumentId) = true
+  override fun canCreateSavedVersion(documentId: DocumentId) = isAcceleratorAdmin()
 
   override fun canCreateSpecies(organizationId: OrganizationId) = isManagerOrHigher(organizationId)
 
@@ -372,7 +372,7 @@ data class IndividualUser(
     }
   }
 
-  override fun canReadDocument(documentId: DocumentId) = true
+  override fun canReadDocument(documentId: DocumentId) = isAcceleratorAdmin()
 
   override fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId) =
       isManagerOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
@@ -551,7 +551,7 @@ data class IndividualUser(
 
   override fun canUpdateDeviceTemplates() = isSuperAdmin()
 
-  override fun canUpdateDocument(documentId: DocumentId) = true
+  override fun canUpdateDocument(documentId: DocumentId) = isAcceleratorAdmin()
 
   override fun canUpdateDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId) =
       userId == parentStore.getUserId(draftPlantingSiteId) &&

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -322,6 +322,8 @@ data class IndividualUser(
 
   override fun canManageDeliverables() = isAcceleratorAdmin()
 
+  override fun canManageDocumentProducer() = isTFExpertOrHigher()
+
   override fun canManageInternalTags() = isSuperAdmin()
 
   override fun canManageModuleEvents() = isAcceleratorAdmin()

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -199,7 +199,7 @@ data class IndividualUser(
 
   override fun canCreateDeviceManager() = isSuperAdmin()
 
-  override fun canCreateDocument() = isAcceleratorAdmin()
+  override fun canCreateDocument() = isTFExpertOrHigher()
 
   override fun canCreateDraftPlantingSite(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
@@ -232,7 +232,7 @@ data class IndividualUser(
   // Reports are normally created by the system, but can be created manually by super-admins.
   override fun canCreateReport(organizationId: OrganizationId) = isSuperAdmin()
 
-  override fun canCreateSavedVersion(documentId: DocumentId) = isAcceleratorAdmin()
+  override fun canCreateSavedVersion(documentId: DocumentId) = isTFExpertOrHigher()
 
   override fun canCreateSpecies(organizationId: OrganizationId) = isManagerOrHigher(organizationId)
 
@@ -372,7 +372,7 @@ data class IndividualUser(
     }
   }
 
-  override fun canReadDocument(documentId: DocumentId) = isAcceleratorAdmin()
+  override fun canReadDocument(documentId: DocumentId) = isTFExpertOrHigher()
 
   override fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId) =
       isManagerOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
@@ -551,7 +551,7 @@ data class IndividualUser(
 
   override fun canUpdateDeviceTemplates() = isSuperAdmin()
 
-  override fun canUpdateDocument(documentId: DocumentId) = isAcceleratorAdmin()
+  override fun canUpdateDocument(documentId: DocumentId) = isTFExpertOrHigher()
 
   override fun canUpdateDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId) =
       userId == parentStore.getUserId(draftPlantingSiteId) &&

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -257,6 +257,8 @@ class SystemUser(
 
   override fun canManageDeliverables(): Boolean = false
 
+  override fun canManageDocumentProducer(): Boolean = false
+
   override fun canManageInternalTags(): Boolean = false
 
   override fun canManageModuleEvents(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -211,6 +211,8 @@ interface TerrawareUser : Principal {
 
   fun canManageDeliverables(): Boolean
 
+  fun canManageDocumentProducer(): Boolean
+
   fun canManageInternalTags(): Boolean
 
   fun canManageModuleEvents(): Boolean

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentHistoryPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentHistoryPayloads.kt
@@ -13,45 +13,45 @@ import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
-enum class PddHistoryPayloadType {
+enum class DocumentHistoryPayloadType {
   Created,
   Edited,
   Saved
 }
 
 @JsonSubTypes(
-    JsonSubTypes.Type(value = PddHistoryCreatedPayload::class, name = "Created"),
-    JsonSubTypes.Type(value = PddHistoryEditedPayload::class, name = "Edited"),
-    JsonSubTypes.Type(value = PddHistorySavedPayload::class, name = "Saved"),
+    JsonSubTypes.Type(value = DocumentHistoryCreatedPayload::class, name = "Created"),
+    JsonSubTypes.Type(value = DocumentHistoryEditedPayload::class, name = "Edited"),
+    JsonSubTypes.Type(value = DocumentHistorySavedPayload::class, name = "Saved"),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @Schema(
     discriminatorMapping =
         [
-            DiscriminatorMapping(schema = PddHistoryCreatedPayload::class, value = "Created"),
-            DiscriminatorMapping(schema = PddHistoryEditedPayload::class, value = "Edited"),
-            DiscriminatorMapping(schema = PddHistorySavedPayload::class, value = "Saved"),
+            DiscriminatorMapping(schema = DocumentHistoryCreatedPayload::class, value = "Created"),
+            DiscriminatorMapping(schema = DocumentHistoryEditedPayload::class, value = "Edited"),
+            DiscriminatorMapping(schema = DocumentHistorySavedPayload::class, value = "Saved"),
         ],
     discriminatorProperty = "type")
-sealed interface PddHistoryPayload {
+sealed interface DocumentHistoryPayload {
   val createdBy: UserId
   val createdTime: Instant
-  val type: PddHistoryPayloadType
+  val type: DocumentHistoryPayloadType
 }
 
 @Schema(
     description =
         "History entry about the creation of the document. This is always the last element in " +
             "the reverse-chronological list of history events. It has the same information as " +
-            "the createdBy and createdTime fields in PddPayload.")
-data class PddHistoryCreatedPayload(
+            "the createdBy and createdTime fields in DocumentPayload.")
+data class DocumentHistoryCreatedPayload(
     override val createdBy: UserId,
     override val createdTime: Instant,
-) : PddHistoryPayload {
+) : DocumentHistoryPayload {
   constructor(row: DocumentsRow) : this(row.createdBy!!, row.createdTime!!)
 
-  override val type: PddHistoryPayloadType
-    get() = PddHistoryPayloadType.Created
+  override val type: DocumentHistoryPayloadType
+    get() = DocumentHistoryPayloadType.Created
 }
 
 @Schema(
@@ -59,21 +59,21 @@ data class PddHistoryCreatedPayload(
         "History entry about a document being edited. This represents the most recent edit by " +
             "the given user; if the same user edits the document multiple times in a row, only " +
             "the last edit will be listed in the history.")
-data class PddHistoryEditedPayload(
+data class DocumentHistoryEditedPayload(
     override val createdBy: UserId,
     override val createdTime: Instant,
-) : PddHistoryPayload {
+) : DocumentHistoryPayload {
   constructor(model: EditHistoryModel) : this(model.createdBy, model.createdTime)
 
-  override val type: PddHistoryPayloadType
-    get() = PddHistoryPayloadType.Edited
+  override val type: DocumentHistoryPayloadType
+    get() = DocumentHistoryPayloadType.Edited
 }
 
 @Schema(
     description =
         "History entry about a saved version of a document. The maxVariableValueId and " +
             "variableManifestId may be used to retrieve the contents of the saved version.")
-data class PddHistorySavedPayload(
+data class DocumentHistorySavedPayload(
     override val createdBy: UserId,
     override val createdTime: Instant,
     val isSubmitted: Boolean,
@@ -81,7 +81,7 @@ data class PddHistorySavedPayload(
     val name: String,
     val variableManifestId: VariableManifestId,
     val versionId: DocumentSavedVersionId,
-) : PddHistoryPayload {
+) : DocumentHistoryPayload {
   constructor(
       model: ExistingSavedVersionModel
   ) : this(
@@ -94,6 +94,6 @@ data class PddHistorySavedPayload(
       versionId = model.id,
   )
 
-  override val type: PddHistoryPayloadType
-    get() = PddHistoryPayloadType.Saved
+  override val type: DocumentHistoryPayloadType
+    get() = DocumentHistoryPayloadType.Saved
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
-@RequestMapping("/api/v1/document-producer/document-templates")
+@RequestMapping("/api/v1/document-producer/templates")
 @RestController
 class DocumentTemplatesController(
     val documentTemplatesDao: DocumentTemplatesDao,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
-@RequestMapping("/api/v1/document-templates")
+@RequestMapping("/api/v1/document-producer/document-templates")
 @RestController
 class DocumentTemplatesController(
     val documentTemplatesDao: DocumentTemplatesDao,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
-@RequestMapping("/api/v1/pdds")
+@RequestMapping("/api/v1/document-producer/documents")
 @RestController
 class DocumentsController(
     private val documentStore: DocumentStore,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -50,7 +50,9 @@ class DocumentsController(
 
   @Operation(summary = "Creates a new document.")
   @PostMapping
-  fun createDocument(@RequestBody payload: CreateDocumentRequestPayload): CreateDocumentResponsePayload {
+  fun createDocument(
+      @RequestBody payload: CreateDocumentRequestPayload
+  ): CreateDocumentResponsePayload {
     val model = documentStore.create(payload.toModel())
 
     return CreateDocumentResponsePayload(DocumentPayload(model))
@@ -272,4 +274,5 @@ data class GetSavedDocumentVersionResponsePayload(
     val version: DocumentSavedVersionPayload,
 ) : SuccessResponsePayload
 
-data class ListDocumentsResponsePayload(val documents: List<DocumentPayload>) : SuccessResponsePayload
+data class ListDocumentsResponsePayload(val documents: List<DocumentPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 @InternalEndpoint
-@RequestMapping("/api/v1/pdds/{pddId}/images")
+@RequestMapping("/api/v1/document-producer/documents/{pddId}/images")
 @RestController
 class ImagesController(
     private val documentFileService: DocumentFileService,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 @InternalEndpoint
-@RequestMapping("/api/v1/document-producer/documents/{pddId}/images")
+@RequestMapping("/api/v1/document-producer/documents/{documentId}/images")
 @RestController
 class ImagesController(
     private val documentFileService: DocumentFileService,
@@ -47,7 +47,7 @@ class ImagesController(
               "supplied, the other dimension will be computed based on the original image's " +
               "aspect ratio.")
   fun getImageValue(
-      @PathVariable pddId: DocumentId,
+      @PathVariable documentId: DocumentId,
       @PathVariable valueId: VariableValueId,
       @RequestParam
       @Schema(
@@ -67,14 +67,14 @@ class ImagesController(
       maxHeight: Int? = null,
   ): ResponseEntity<InputStreamResource> {
     return documentFileService
-        .readImageValue(pddId, valueId, maxWidth, maxHeight)
+        .readImageValue(documentId, valueId, maxWidth, maxHeight)
         .toResponseEntity()
   }
 
   @Operation(summary = "Save an image to a new variable value.")
   @PostMapping
   fun uploadImageValue(
-      @PathVariable pddId: DocumentId,
+      @PathVariable documentId: DocumentId,
       @RequestPart file: MultipartFile,
       @RequestPart(required = false) caption: String?,
       @RequestPart(required = false) citation: String?,
@@ -109,7 +109,7 @@ class ImagesController(
     val base =
         BaseVariableValueProperties(
             citation = citation,
-            documentId = pddId,
+            documentId = documentId,
             id = null,
             // If list position isn't specified, the value here will be ignored because isAppend
             // will be true.

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
-@RequestMapping("/api/v1/pdds/{pddId}/values")
+@RequestMapping("/api/v1/document-producer/documents/{pddId}/values")
 @RestController
 class ValuesController(
     private val variableValueStore: VariableValueStore,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
-@RequestMapping("/api/v1/variables")
+@RequestMapping("/api/v1/document-producer/variables")
 @RestController
 class VariablesController(
     private val variableStore: VariableStore,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -65,63 +65,6 @@ COMMENT ON TABLE device_templates IS 'Canned device configurations for use in ca
 
 COMMENT ON TABLE devices IS 'Hardware devices managed by the device manager at a facility.';
 
-COMMENT ON TABLE docprod.document_saved_versions IS 'Saved versions of document variable values. A saved version is conceptually just a reference to a particular point in the edit history of the document; to restore that version, we ignore any later edits.';
-
-COMMENT ON TABLE docprod.document_statuses IS '(Enum) Current stage of a document''s lifecycle.';
-
-COMMENT ON TABLE docprod.document_templates IS 'Templates for the different types of documents this system can produce.';
-
-COMMENT ON TABLE docprod.documents IS 'Top-level information about documents.';
-
-COMMENT ON TABLE docprod.variable_image_values IS 'Linking table that defines which image files are values of which variables.';
-
-COMMENT ON TABLE docprod.variable_injection_display_styles IS '(Enum) For injected variables, whether to render them as text fragments that are suitable for including in paragraphs or as separate items on the page. Analogous to the inline/block display styles in CSS. Not applicable to all variable types.';
-
-COMMENT ON TABLE docprod.variable_link_values IS 'Type-specific details of the values of link variables.';
-
-COMMENT ON TABLE docprod.variable_manifest_entries IS 'Linking table that defines which variables appear in which manifests and in what order.';
-
-COMMENT ON TABLE docprod.variable_manifests IS 'A collection of the definitions of the variables for a document template. This is how we do versioning of variable definitions. Each revision of the variable definitions is represented as a new manifest.';
-
-COMMENT ON TABLE docprod.variable_numbers IS 'Information about number variables that is not relevant for other variable types.';
-
-COMMENT ON TABLE docprod.variable_section_recommendations IS 'Which sections recommend using which other variables. Can vary between manifests.';
-
-COMMENT ON TABLE docprod.variable_section_values IS 'Fragments of the contents of document sections. Each fragment is either a block of text or a usage of a variable; they are assembled in order to render the contents of the section.';
-
-COMMENT ON TABLE docprod.variable_sections IS 'Hierarchy of sections that define the structure of the rendered document.';
-COMMENT ON COLUMN docprod.variable_sections.render_heading IS 'If false, the title is not included in the rendered document. False in cases where we want a single section to have multiple content blocks; in that case, we add them as child sections with this flag set to false.';
-
-COMMENT ON TABLE docprod.variable_select_option_values IS 'The options of a select variable that are selected in a document. Options that are not selected do not appear in this table.';
-
-COMMENT ON TABLE docprod.variable_select_options IS 'Available options for select variables.';
-COMMENT ON COLUMN docprod.variable_select_options.rendered_text IS 'What text should be rendered in the document when this option is selected. Null if the option''s name should be rendered.';
-
-COMMENT ON TABLE docprod.variable_selects IS 'Information about select variables that is not relevant for other variable types. This table only has information about the variable as a whole; the options are in `variable_select_options`.';
-COMMENT ON COLUMN docprod.variable_selects.is_multiple IS 'If true, allow multiple options to be selected. The list of selected options is considered a single value; do not set `variables.is_list` to true unless you want a list of multiple-select variables.';
-
-COMMENT ON TABLE docprod.variable_table_columns IS 'The order of the columns in a table. Each column must be a variable whose parent is the table.';
-
-COMMENT ON TABLE docprod.variable_table_styles IS '(Enum) How a table should be rendered visually in the document.';
-
-COMMENT ON TABLE docprod.variable_tables IS 'Information about tables that is not relevant for other variable types.';
-
-COMMENT ON TABLE docprod.variable_text_types IS '(Enum) Types of text stored in a text variable field.';
-
-COMMENT ON TABLE docprod.variable_texts IS 'Information about text variables that is not relevant for other variable types.';
-
-COMMENT ON TABLE docprod.variable_types IS '(Enum) Data types that can be assigned to variables.';
-
-COMMENT ON TABLE docprod.variable_usage_types IS '(Enum) When a variable is used in a section, whether to inject the value of the variable or the location where the value is injected elsewhere in the doc.';
-
-COMMENT ON TABLE docprod.variable_value_table_rows IS 'Linking table that defines which variable values are in which rows of a table.';
-
-COMMENT ON TABLE docprod.variable_values IS 'Insert-only table with all historical and current values of all inputs.';
-
-COMMENT ON TABLE docprod.variables IS 'variables that can be supplied by the user. This table stores the variables themselves, not the values of the variables in a particular document. Type-specific information is in child tables such as `variable_numbers`.';
-COMMENT ON COLUMN docprod.variables.is_list IS 'True if this variable is a list of values rather than a single value. If the variable is a table, true if the table can contain multiple rows.';
-COMMENT ON COLUMN docprod.variables.replaces_variable_id IS 'If this is a new version of a variable that existed in a previous manifest version, the ID of the previous version of the variable. This allows the system to automatically migrate values from older variable versions when a document is updated to a new manifest version.';
-
 COMMENT ON TABLE ecosystem_types IS '(Enum) Types of ecosystems in which plants can be found. Based on the World Wildlife Federation''s "Terrestrial Ecoregions of the World" report.';
 
 COMMENT ON TABLE facilities IS 'Physical locations at a site. For example, each seed bank and each nursery is a facility.';
@@ -597,5 +540,62 @@ COMMENT ON TABLE accelerator.submission_statuses IS '(Enum) Statuses of submissi
 COMMENT ON TABLE accelerator.submissions IS 'Information about the current states of the information supplied by specific projects in response to deliverables.';
 
 COMMENT ON TABLE accelerator.vote_options IS '(Enum) Available vote options.';
+
+COMMENT ON TABLE docprod.document_saved_versions IS 'Saved versions of document variable values. A saved version is conceptually just a reference to a particular point in the edit history of the document; to restore that version, we ignore any later edits.';
+
+COMMENT ON TABLE docprod.document_statuses IS '(Enum) Current stage of a document''s lifecycle.';
+
+COMMENT ON TABLE docprod.document_templates IS 'Templates for the different types of documents this system can produce.';
+
+COMMENT ON TABLE docprod.documents IS 'Top-level information about documents.';
+
+COMMENT ON TABLE docprod.variable_image_values IS 'Linking table that defines which image files are values of which variables.';
+
+COMMENT ON TABLE docprod.variable_injection_display_styles IS '(Enum) For injected variables, whether to render them as text fragments that are suitable for including in paragraphs or as separate items on the page. Analogous to the inline/block display styles in CSS. Not applicable to all variable types.';
+
+COMMENT ON TABLE docprod.variable_link_values IS 'Type-specific details of the values of link variables.';
+
+COMMENT ON TABLE docprod.variable_manifest_entries IS 'Linking table that defines which variables appear in which manifests and in what order.';
+
+COMMENT ON TABLE docprod.variable_manifests IS 'A collection of the definitions of the variables for a document template. This is how we do versioning of variable definitions. Each revision of the variable definitions is represented as a new manifest.';
+
+COMMENT ON TABLE docprod.variable_numbers IS 'Information about number variables that is not relevant for other variable types.';
+
+COMMENT ON TABLE docprod.variable_section_recommendations IS 'Which sections recommend using which other variables. Can vary between manifests.';
+
+COMMENT ON TABLE docprod.variable_section_values IS 'Fragments of the contents of document sections. Each fragment is either a block of text or a usage of a variable; they are assembled in order to render the contents of the section.';
+
+COMMENT ON TABLE docprod.variable_sections IS 'Hierarchy of sections that define the structure of the rendered document.';
+COMMENT ON COLUMN docprod.variable_sections.render_heading IS 'If false, the title is not included in the rendered document. False in cases where we want a single section to have multiple content blocks; in that case, we add them as child sections with this flag set to false.';
+
+COMMENT ON TABLE docprod.variable_select_option_values IS 'The options of a select variable that are selected in a document. Options that are not selected do not appear in this table.';
+
+COMMENT ON TABLE docprod.variable_select_options IS 'Available options for select variables.';
+COMMENT ON COLUMN docprod.variable_select_options.rendered_text IS 'What text should be rendered in the document when this option is selected. Null if the option''s name should be rendered.';
+
+COMMENT ON TABLE docprod.variable_selects IS 'Information about select variables that is not relevant for other variable types. This table only has information about the variable as a whole; the options are in `variable_select_options`.';
+COMMENT ON COLUMN docprod.variable_selects.is_multiple IS 'If true, allow multiple options to be selected. The list of selected options is considered a single value; do not set `variables.is_list` to true unless you want a list of multiple-select variables.';
+
+COMMENT ON TABLE docprod.variable_table_columns IS 'The order of the columns in a table. Each column must be a variable whose parent is the table.';
+
+COMMENT ON TABLE docprod.variable_table_styles IS '(Enum) How a table should be rendered visually in the document.';
+
+COMMENT ON TABLE docprod.variable_tables IS 'Information about tables that is not relevant for other variable types.';
+
+COMMENT ON TABLE docprod.variable_text_types IS '(Enum) Types of text stored in a text variable field.';
+
+COMMENT ON TABLE docprod.variable_texts IS 'Information about text variables that is not relevant for other variable types.';
+
+COMMENT ON TABLE docprod.variable_types IS '(Enum) Data types that can be assigned to variables.';
+
+COMMENT ON TABLE docprod.variable_usage_types IS '(Enum) When a variable is used in a section, whether to inject the value of the variable or the location where the value is injected elsewhere in the doc.';
+
+COMMENT ON TABLE docprod.variable_value_table_rows IS 'Linking table that defines which variable values are in which rows of a table.';
+
+COMMENT ON TABLE docprod.variable_values IS 'Insert-only table with all historical and current values of all inputs.';
+
+COMMENT ON TABLE docprod.variables IS 'variables that can be supplied by the user. This table stores the variables themselves, not the values of the variables in a particular document. Type-specific information is in child tables such as `variable_numbers`.';
+COMMENT ON COLUMN docprod.variables.is_list IS 'True if this variable is a list of values rather than a single value. If the variable is a table, true if the table can contain multiple rows.';
+COMMENT ON COLUMN docprod.variables.replaces_variable_id IS 'If this is a new version of a variable that existed in a previous manifest version, the ID of the previous version of the variable. This allows the system to automatically migrate values from older variable versions when a document is updated to a new manifest version.';
 
 -- When adding new tables, put them in alphabetical (ASCII) order.

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<h2>Document Templates</h2>
+
+<table>
+    <tr>
+        <th>ID</th>
+        <th>Name</th>
+    </tr>
+    <tr th:each="documentTemplate: ${documentTemplates}">
+        <td th:text="${documentTemplate.id}">1</td>
+        <td th:text="${documentTemplate.name}">Name</td>
+    </tr>
+</table>
+
+<form method="POST" action="/admin/document-producer/createDocumentTemplate">
+    <label for="newDocumentTemplateName">Name</label>
+    <input type="text" id="newDocumentTemplateName" name="name" minlength="1"/>
+    <input type="submit" value="Create Document Template"/>
+</form>
+
+<h2>Import Variable Manifest CSV</h2>
+
+<form method="POST" action="/admin/document-producer/uploadManifest" enctype="multipart/form-data">
+    <label for="uploadManifestCsv">CSV</label>
+    <input type="file" id="uploadManifestCsv" name="file" minlength="1"/>
+    <br>
+    <label for="uploadManifestDocumentTemplateName">Document Template ID</label>
+    <select id="uploadManifestDocumentTemplateName" name="documentTemplateId">
+        <option th:each="documentTemplate: ${documentTemplates}" th:value="${documentTemplate.id}"
+                th:text="${documentTemplate.name}"/>
+    </select>
+    <br>
+    <input type="submit" value="Import"/>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -139,5 +139,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canManageDocumentProducer}">
+    <h2>Document Producer</h2>
+
+    <p>
+        <a href="/admin/document-producer">Manage Document Templates and Variables</a>
+    </p>
+</th:block>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.get
 
 class DocumentTemplatesControllerTest : ControllerIntegrationTest() {
-  private val path = "/api/v1/document-templates"
+  private val path = "/api/v1/document-producer/document-templates"
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.get
 
 class DocumentTemplatesControllerTest : ControllerIntegrationTest() {
-  private val path = "/api/v1/document-producer/document-templates"
+  private val path = "/api/v1/document-producer/templates"
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -559,7 +559,8 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
   @Nested
   inner class UpgradeManifest {
-    private fun path(documentId: Any = inserted.documentId) = "/api/v1/document-producer/documents/$documentId/upgrade"
+    private fun path(documentId: Any = inserted.documentId) =
+        "/api/v1/document-producer/documents/$documentId/upgrade"
 
     private fun payload(manifestId: Any) = """{ "variableManifestId": $manifestId }"""
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -70,7 +70,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
           .andExpectJson(
               """
                 {
-                  "pdd": {
+                  "document": {
                     "createdBy": ${inserted.userId},
                     "createdTime": "${Instant.EPOCH}",
                     "id": 1,
@@ -117,7 +117,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
           .andExpectJson(
               """
                 {
-                  "pdds": [
+                  "documents": [
                     {
                       "createdBy": ${inserted.userId},
                       "createdTime": "${Instant.EPOCH}",
@@ -163,7 +163,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
           .andExpectJson(
               """
                 {
-                  "pdd": {
+                  "document": {
                     "createdBy": ${inserted.userId},
                     "createdTime": "${Instant.EPOCH}",
                     "id": ${inserted.documentId},

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -93,7 +93,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       val otherDocumentTemplateId = insertDocumentTemplate()
       val otherVariableManifestId =
           insertVariableManifest(documentTemplateId = otherDocumentTemplateId)
-      val otherUserId = insertUser(UserId(101))
+      val otherUserId = insertUser(101)
       val otherCreatedTime = Instant.EPOCH.plusSeconds(100)
       val otherModifiedTime = otherCreatedTime.plusSeconds(1)
       val documentId1 = insertDocument()
@@ -199,7 +199,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       val otherDocumentTemplateId = insertDocumentTemplate()
       val otherVariableManifestId =
           insertVariableManifest(documentTemplateId = otherDocumentTemplateId)
-      val otherUserId = insertUser(UserId(101))
+      val otherUserId = insertUser(101)
       val otherCreatedTime = Instant.EPOCH.plusSeconds(100)
       val otherModifiedTime = otherCreatedTime.plusSeconds(1)
       val documentId =
@@ -397,8 +397,8 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       var timestamp = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
       lateinit var lastValueId: VariableValueId
 
-      val userId1 = insertUser(UserId(101))
-      val userId2 = insertUser(UserId(102))
+      val userId1 = insertUser(101)
+      val userId2 = insertUser(102)
       val documentId = insertDocument(createdBy = userId1)
       val variableManifestId1 = insertVariableManifest()
       val variableId = insertVariableManifestEntry(insertTextVariable())

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.put
 class DocumentsControllerTest : ControllerIntegrationTest() {
   override val tablesToResetSequences = listOf(DOCUMENTS)
 
-  private val path = "/api/v1/pdds"
+  private val path = "/api/v1/document-producer/documents"
 
   @BeforeEach
   fun setUp() {
@@ -293,7 +293,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
   @Nested
   inner class GetSavedVersion {
     private fun versionsPath(versionId: Any, documentId: Any = inserted.documentId) =
-        "/api/v1/pdds/$documentId/versions/$versionId"
+        "/api/v1/document-producer/documents/$documentId/versions/$versionId"
 
     @Test
     fun `returns saved version details`() {
@@ -344,7 +344,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
   @Nested
   inner class UpdateSavedVersion {
     private fun versionsPath(versionId: Any, documentId: Any = inserted.documentId) =
-        "/api/v1/pdds/$documentId/versions/$versionId"
+        "/api/v1/document-producer/documents/$documentId/versions/$versionId"
 
     @Test
     fun `updates saved version details`() {
@@ -392,7 +392,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
   @Nested
   inner class GetDocumentHistory {
     private fun historyPath(documentId: Any = inserted.documentId) =
-        "/api/v1/pdds/$documentId/history"
+        "/api/v1/document-producer/documents/$documentId/history"
 
     @Test
     fun `returns correct sequence of edits and saved versions`() {
@@ -559,7 +559,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
   @Nested
   inner class UpgradeManifest {
-    private fun path(documentId: Any = inserted.documentId) = "/api/v1/pdds/$documentId/upgrade"
+    private fun path(documentId: Any = inserted.documentId) = "/api/v1/document-producer/documents/$documentId/upgrade"
 
     private fun payload(manifestId: Any) = """{ "variableManifestId": $manifestId }"""
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentStatus
@@ -29,7 +30,8 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
+    val userId = insertUser()
+    insertUserGlobalRole(userId = userId, GlobalRole.TFExpert)
     insertDocumentTemplate()
     insertVariableManifest()
   }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
@@ -44,7 +44,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
 
       val imageValueId = insertImageValue(imageVariableId, fileId)
 
-      mockMvc.get("/api/v1/pdds/${inserted.documentId}/images/$imageValueId").andExpect {
+      mockMvc.get("/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId").andExpect {
         status { isOk() }
         content { bytes(contents) }
       }
@@ -63,7 +63,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val imageValueId = insertImageValue(imageVariableId, fileId)
 
       mockMvc
-          .get("/api/v1/pdds/${inserted.documentId}/images/$imageValueId?maxWidth=320")
+          .get("/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId?maxWidth=320")
           .andExpect {
             status { isOk() }
             content { bytes(contents) }
@@ -83,14 +83,14 @@ class ImagesControllerTest : ControllerIntegrationTest() {
 
       val otherDocumentId = insertDocument()
 
-      mockMvc.get("/api/v1/pdds/$otherDocumentId/images/$imageValueId").andExpect {
+      mockMvc.get("/api/v1/document-producer/documents/$otherDocumentId/images/$imageValueId").andExpect {
         status { isNotFound() }
       }
     }
 
     @Test
     fun `cannot get nonexistent image`() {
-      mockMvc.get("/api/v1/pdds/${inserted.documentId}/images/1").andExpect {
+      mockMvc.get("/api/v1/document-producer/documents/${inserted.documentId}/images/1").andExpect {
         status { isNotFound() }
       }
     }
@@ -107,7 +107,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val filename = "test.jpg"
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/pdds/${inserted.documentId}/images") {
+          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
             file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
             part(MockPart("caption", caption.toByteArray()))
             part(MockPart("variableId", "$imageVariableId".toByteArray()))
@@ -149,7 +149,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val listPosition = 1
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/pdds/${inserted.documentId}/images") {
+          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
             file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
             part(MockPart("caption", caption.toByteArray()))
             part(MockPart("variableId", "$imageVariableId".toByteArray()))
@@ -189,7 +189,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val filename = "test.jpg"
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/pdds/${inserted.documentId}/images") {
+          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
             file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
             part(MockPart("caption", caption.toByteArray()))
             part(MockPart("variableId", "$imageVariableId".toByteArray()))
@@ -212,7 +212,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val textVariableId = insertVariableManifestEntry(insertTextVariable())
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/pdds/${inserted.documentId}/images") {
+          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
             file(MockMultipartFile("file", "dummy", MediaType.IMAGE_JPEG_VALUE, byteArrayOf(1)))
             part(MockPart("caption", "dummy".toByteArray()))
             part(MockPart("variableId", "$textVariableId".toByteArray()))

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
@@ -44,10 +44,12 @@ class ImagesControllerTest : ControllerIntegrationTest() {
 
       val imageValueId = insertImageValue(imageVariableId, fileId)
 
-      mockMvc.get("/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId").andExpect {
-        status { isOk() }
-        content { bytes(contents) }
-      }
+      mockMvc
+          .get("/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId")
+          .andExpect {
+            status { isOk() }
+            content { bytes(contents) }
+          }
     }
 
     @Test
@@ -63,7 +65,8 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val imageValueId = insertImageValue(imageVariableId, fileId)
 
       mockMvc
-          .get("/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId?maxWidth=320")
+          .get(
+              "/api/v1/document-producer/documents/${inserted.documentId}/images/$imageValueId?maxWidth=320")
           .andExpect {
             status { isOk() }
             content { bytes(contents) }
@@ -83,9 +86,9 @@ class ImagesControllerTest : ControllerIntegrationTest() {
 
       val otherDocumentId = insertDocument()
 
-      mockMvc.get("/api/v1/document-producer/documents/$otherDocumentId/images/$imageValueId").andExpect {
-        status { isNotFound() }
-      }
+      mockMvc
+          .get("/api/v1/document-producer/documents/$otherDocumentId/images/$imageValueId")
+          .andExpect { status { isNotFound() } }
     }
 
     @Test
@@ -107,12 +110,14 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val filename = "test.jpg"
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
-            file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
-            part(MockPart("caption", caption.toByteArray()))
-            part(MockPart("variableId", "$imageVariableId".toByteArray()))
-            part(MockPart("listPosition", "0".toByteArray()))
-          }
+          .multipart(
+              HttpMethod.POST,
+              "/api/v1/document-producer/documents/${inserted.documentId}/images") {
+                file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
+                part(MockPart("caption", caption.toByteArray()))
+                part(MockPart("variableId", "$imageVariableId".toByteArray()))
+                part(MockPart("listPosition", "0".toByteArray()))
+              }
           .andExpectJson(
               """
                 {
@@ -149,13 +154,15 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val listPosition = 1
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
-            file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
-            part(MockPart("caption", caption.toByteArray()))
-            part(MockPart("variableId", "$imageVariableId".toByteArray()))
-            part(MockPart("listPosition", "$listPosition".toByteArray()))
-            part(MockPart("rowValueId", "$rowValueId".toByteArray()))
-          }
+          .multipart(
+              HttpMethod.POST,
+              "/api/v1/document-producer/documents/${inserted.documentId}/images") {
+                file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
+                part(MockPart("caption", caption.toByteArray()))
+                part(MockPart("variableId", "$imageVariableId".toByteArray()))
+                part(MockPart("listPosition", "$listPosition".toByteArray()))
+                part(MockPart("rowValueId", "$rowValueId".toByteArray()))
+              }
           .andExpectJson(
               """
                 {
@@ -189,11 +196,13 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val filename = "test.jpg"
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
-            file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
-            part(MockPart("caption", caption.toByteArray()))
-            part(MockPart("variableId", "$imageVariableId".toByteArray()))
-          }
+          .multipart(
+              HttpMethod.POST,
+              "/api/v1/document-producer/documents/${inserted.documentId}/images") {
+                file(MockMultipartFile("file", filename, MediaType.IMAGE_JPEG_VALUE, fileData))
+                part(MockPart("caption", caption.toByteArray()))
+                part(MockPart("variableId", "$imageVariableId".toByteArray()))
+              }
           .andExpectJson(
               """
                 {
@@ -212,12 +221,14 @@ class ImagesControllerTest : ControllerIntegrationTest() {
       val textVariableId = insertVariableManifestEntry(insertTextVariable())
 
       mockMvc
-          .multipart(HttpMethod.POST, "/api/v1/document-producer/documents/${inserted.documentId}/images") {
-            file(MockMultipartFile("file", "dummy", MediaType.IMAGE_JPEG_VALUE, byteArrayOf(1)))
-            part(MockPart("caption", "dummy".toByteArray()))
-            part(MockPart("variableId", "$textVariableId".toByteArray()))
-            part(MockPart("listPosition", "0".toByteArray()))
-          }
+          .multipart(
+              HttpMethod.POST,
+              "/api/v1/document-producer/documents/${inserted.documentId}/images") {
+                file(MockMultipartFile("file", "dummy", MediaType.IMAGE_JPEG_VALUE, byteArrayOf(1)))
+                part(MockPart("caption", "dummy".toByteArray()))
+                part(MockPart("variableId", "$textVariableId".toByteArray()))
+                part(MockPart("listPosition", "0".toByteArray()))
+              }
           .andExpect { status { isConflict() } }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -26,7 +26,8 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     insertDocument()
   }
 
-  private fun path(documentId: DocumentId = inserted.documentId) = "/api/v1/document-producer/documents/$documentId/values"
+  private fun path(documentId: DocumentId = inserted.documentId) =
+      "/api/v1/document-producer/documents/$documentId/values"
 
   @Nested
   inner class ListVariableValues {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -26,7 +26,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     insertDocument()
   }
 
-  private fun path(documentId: DocumentId = inserted.documentId) = "/api/v1/pdds/$documentId/values"
+  private fun path(documentId: DocumentId = inserted.documentId) = "/api/v1/document-producer/documents/$documentId/values"
 
   @Nested
   inner class ListVariableValues {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableValueId
@@ -18,7 +19,8 @@ import org.springframework.test.web.servlet.post
 class ValuesControllerTest : ControllerIntegrationTest() {
   @BeforeEach
   fun setUp() {
-    insertUser()
+    val userId = insertUser()
+    insertUserGlobalRole(userId = userId, GlobalRole.TFExpert)
     insertDocumentTemplate()
     insertVariableManifest()
     insertDocument()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
@@ -22,7 +22,7 @@ class VariablesControllerTest : ControllerIntegrationTest() {
   @Nested
   inner class ListVariables {
     private fun path(manifestId: VariableManifestId = inserted.variableManifestId) =
-        "/api/v1/variables?manifestId=$manifestId"
+        "/api/v1/document-producer/variables?manifestId=$manifestId"
 
     @Test
     fun `only lists variables for requested manifest`() {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -80,8 +80,6 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
     @BeforeEach
     fun setUp() {
       every { user.canCreateVariableManifest() } returns true
-      // TODO is this needed?
-      // every { requirePermissions.invoke(any()) } answers { nothing }
     }
 
     @AfterEach


### PR DESCRIPTION
- Reorganize `docprod` schema comments in `src/main/resources/db/migration/R__Comments.sql`
- Clean up superfluous user ID arguments in test insertions
- Fix permissions for document related actions, all of them are set to TF Expert or higher
