### PR TITLE
Document Producer Admin cleanup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -45,6 +45,7 @@ class AdminController(
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
     model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
+    model.addAttribute("canManageDocumentProducer", currentUser().canManageDocumentProducer())
     model.addAttribute(
         "canManageModules",
         currentUser().canManageModules() || currentUser().canManageDeliverables())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.parameters.RequestBody
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -24,16 +23,16 @@ import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 
 @Controller
-@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin])
+@RequireGlobalRole([GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert])
 @RequestMapping("/admin/document-producer")
-class AdminDocumentController(
+class AdminDocumentProducerController(
     private val manifestImporter: ManifestImporter,
     private val documentTemplatesDao: DocumentTemplatesDao,
 ) {
   /** Redirects /admin to /admin/ so relative URLs in the UI will work. */
   @GetMapping
   fun redirectToTrailingSlash(): String {
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   @GetMapping("/")
@@ -41,7 +40,7 @@ class AdminDocumentController(
     model.addAttribute(
         "documentTemplates", documentTemplatesDao.findAll().sortedBy { it.id?.value })
 
-    return "/admin/index"
+    return "/admin/documentProducer"
   }
 
   @PostMapping("/createDocumentTemplate")
@@ -59,7 +58,7 @@ class AdminDocumentController(
       redirectAttributes.failureMessage = "Failed to add document template: ${e.message}"
     }
 
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   @Operation(
@@ -101,7 +100,7 @@ class AdminDocumentController(
       redirectAttributes.failureMessage = "Error attempting to import manifest: $e"
     }
 
-    return adminHome()
+    return documentProducerAdminHome()
   }
 
   private var RedirectAttributes.failureMessage: String?
@@ -134,5 +133,5 @@ class AdminDocumentController(
 
   // Convenience methods to redirect to the GET endpoint for each kind of thing.
 
-  private fun adminHome() = redirect("/")
+  private fun documentProducerAdminHome() = redirect("/document-producer/")
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -271,6 +271,8 @@ data class DeviceManagerUser(
 
   override fun canManageDeliverables(): Boolean = false
 
+  override fun canManageDocumentProducer(): Boolean = false
+
   override fun canManageInternalTags(): Boolean = false
 
   override fun canManageModuleEvents(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -322,6 +322,8 @@ data class IndividualUser(
 
   override fun canManageDeliverables() = isAcceleratorAdmin()
 
+  override fun canManageDocumentProducer() = isTFExpertOrHigher()
+
   override fun canManageInternalTags() = isSuperAdmin()
 
   override fun canManageModuleEvents() = isAcceleratorAdmin()

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -257,6 +257,8 @@ class SystemUser(
 
   override fun canManageDeliverables(): Boolean = false
 
+  override fun canManageDocumentProducer(): Boolean = false
+
   override fun canManageInternalTags(): Boolean = false
 
   override fun canManageModuleEvents(): Boolean = false

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -211,6 +211,8 @@ interface TerrawareUser : Principal {
 
   fun canManageDeliverables(): Boolean
 
+  fun canManageDocumentProducer(): Boolean
+
   fun canManageInternalTags(): Boolean
 
   fun canManageModuleEvents(): Boolean

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<h2>Document Templates</h2>
+
+<table>
+    <tr>
+        <th>ID</th>
+        <th>Name</th>
+    </tr>
+    <tr th:each="documentTemplate: ${documentTemplates}">
+        <td th:text="${documentTemplate.id}">1</td>
+        <td th:text="${documentTemplate.name}">Name</td>
+    </tr>
+</table>
+
+<form method="POST" action="/admin/document-producer/createDocumentTemplate">
+    <label for="newDocumentTemplateName">Name</label>
+    <input type="text" id="newDocumentTemplateName" name="name" minlength="1"/>
+    <input type="submit" value="Create Document Template"/>
+</form>
+
+<h2>Import Variable Manifest CSV</h2>
+
+<form method="POST" action="/admin/document-producer/uploadManifest" enctype="multipart/form-data">
+    <label for="uploadManifestCsv">CSV</label>
+    <input type="file" id="uploadManifestCsv" name="file" minlength="1"/>
+    <br>
+    <label for="uploadManifestDocumentTemplateName">Document Template ID</label>
+    <select id="uploadManifestDocumentTemplateName" name="documentTemplateId">
+        <option th:each="documentTemplate: ${documentTemplates}" th:value="${documentTemplate.id}"
+                th:text="${documentTemplate.name}"/>
+    </select>
+    <br>
+    <input type="submit" value="Import"/>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -139,5 +139,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canManageDocumentProducer}">
+    <h2>Document Producer</h2>
+
+    <p>
+        <a href="/admin/document-producer">Manage Document Templates and Variables</a>
+    </p>
+</th:block>
+
 </body>
 </html>


### PR DESCRIPTION
- Rename the document producer admin controller
- Bring the admin template over (this was missed in the original "bring it all over" PR) 
- Hook everything up with the new admin URLs (`/admin/document-producer`)