### PR TITLE
SW-5546 Fix permission error on deliverable approval

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -394,17 +394,19 @@ class AppNotificationService(
   @EventListener
   fun on(event: DeliverableStatusUpdatedEvent) {
     if (event.isUserVisible()) {
-      val organizationId = parentStore.getOrganizationId(event.projectId)!!
-      val deliverableUrl = webAppUrls.deliverable(event.deliverableId, event.projectId)
-      val renderMessage = { messages.deliverableStatusUpdated() }
+      systemUser.run {
+        val organizationId = parentStore.getOrganizationId(event.projectId)!!
+        val deliverableUrl = webAppUrls.deliverable(event.deliverableId, event.projectId)
+        val renderMessage = { messages.deliverableStatusUpdated() }
 
-      log.info("Creating app notifications for deliverable ${event.deliverableId} status updated")
-      insertOrganizationNotifications(
-          organizationId,
-          NotificationType.DeliverableStatusUpdated,
-          renderMessage,
-          deliverableUrl,
-          setOf(Role.Owner, Role.Admin, Role.Manager))
+        log.info("Creating app notifications for deliverable ${event.deliverableId} status updated")
+        insertOrganizationNotifications(
+            organizationId,
+            NotificationType.DeliverableStatusUpdated,
+            renderMessage,
+            deliverableUrl,
+            setOf(Role.Owner, Role.Admin, Role.Manager))
+      }
     }
   }
 


### PR DESCRIPTION
When an accelerator admin approved or rejected a deliverable from an
organization they're not a member of, the system was failing to create the
in-app notifications due to a permission failure, leading to an error message
in the accelerator console. Run notification creation as the system user like
we do for other notifications.