### PR TITLE
Fixed unrecognized Jira request types problem

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClient.kt
@@ -95,9 +95,12 @@ class AtlassianHttpClient(private val config: TerrawareServerConfig) {
   }
 
   private fun getJiraServiceRequestTypes(): Map<SupportRequestType, Int> =
-      makeRequest(ListServiceRequestTypesHttpRequest(serviceDesk.id)).values.associate {
-        SupportRequestType.forJsonValue(it.name) to it.id
-      }
+      makeRequest(ListServiceRequestTypesHttpRequest(serviceDesk.id))
+          .values
+          .mapNotNull { model ->
+            SupportRequestType.forJsonValue(model.name)?.let { it to model.id }
+          }
+          .associate { it }
 
   private fun findServiceDesk(): ServiceDeskProjectModel =
       makeRequest(ListServiceDesksHttpRequest()).values.firstOrNull {

--- a/src/main/kotlin/com/terraformation/backend/support/atlassian/model/SupportRequestType.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/atlassian/model/SupportRequestType.kt
@@ -15,9 +15,8 @@ enum class SupportRequestType(@get:JsonValue val jsonValue: String) {
 
     @JsonCreator
     @JvmStatic
-    fun forJsonValue(jsonValue: String): SupportRequestType {
+    fun forJsonValue(jsonValue: String): SupportRequestType? {
       return byJsonValue[jsonValue]
-          ?: throw IllegalArgumentException("Unrecognized value: $jsonValue")
     }
   }
 }


### PR DESCRIPTION
Fixed an issue where if a Jira request type is unrecognized, the whole API call will crash out.

Instead, this PR implements a way to gracefully handle an unrecognized value by filtering `null` types. 