### PR TITLE
Updated tika file type detection to only occur if mark/reset are supported

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/support/api/SupportController.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/api/SupportController.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.media.Encoding
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.ws.rs.InternalServerErrorException
 import jakarta.ws.rs.NotSupportedException
+import java.io.BufferedInputStream
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -76,7 +77,9 @@ class SupportController(private val service: SupportService) {
 
     val sizedInputStream =
         SizedInputStream(
-            file.inputStream, file.size, file.contentType?.let { MediaType.parseMediaType(it) })
+            BufferedInputStream(file.inputStream), // BufferedInputStream supports mark/reset
+            file.size,
+            file.contentType?.let { MediaType.parseMediaType(it) })
     val temporaryAttachments =
         try {
           service.attachTemporaryFile(file.getFilename(), sizedInputStream)

--- a/src/main/kotlin/com/terraformation/backend/support/api/SupportController.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/api/SupportController.kt
@@ -84,7 +84,6 @@ class SupportController(private val service: SupportService) {
         try {
           service.attachTemporaryFile(file.getFilename(), sizedInputStream)
         } catch (e: NotSupportedException) {
-          log.error("Unsupported file type ${file.contentType}", e)
           throw e
         } catch (e: Exception) {
           log.error("Unable to upload ${file.getFilename()}", e)


### PR DESCRIPTION
Currently, attachment uploads are failing because `Tika().detect()` reads bytes off the input stream, and results in "IO Error: Too few bytes" when streaming the file to Jira. 

Two changes to fix this:
1) Only perform Tika detection if the input stream can be marked and reset
2) Cast file stream to be a `BufferedInputStream`, so that it supports marking and resetting. 