### PR TITLE
Remove geolocation search field

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -88,7 +88,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.EST_WEIGHT_QUANTITY,
             ACCESSIONS.EST_WEIGHT_UNITS_ID,
             ACCESSIONS.EST_WEIGHT_GRAMS),
-        aliasField("geolocation", "geolocations_coordinates"),
         idWrapperField("id", ACCESSIONS.ID) { AccessionId(it) },
         textField("plantId", ACCESSIONS.FOUNDER_ID),
         integerField("plantsCollectedFrom", ACCESSIONS.TREES_COLLECTED_FROM),


### PR DESCRIPTION
We have `geolocation` as an alias for `geolocations_coordinates` on the accessions
search table. The alias isn't being used in the web app, and it doesn't play
nicely with accessions that have multiple sets of coordinates; remove it.