### PR TITLE
Keep track of table column order

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -311,7 +311,7 @@ class VariableStore(
               .on(VARIABLE_TABLE_COLUMNS.VARIABLE_ID.eq(VARIABLE_MANIFEST_ENTRIES.VARIABLE_ID))
               .where(VARIABLE_TABLE_COLUMNS.TABLE_VARIABLE_ID.eq(base.id))
               .and(VARIABLE_MANIFEST_ENTRIES.VARIABLE_MANIFEST_ID.eq(manifestId))
-              .orderBy(VARIABLE_MANIFEST_ENTRIES.POSITION)
+              .orderBy(VARIABLE_TABLE_COLUMNS.POSITION)
               .fetch { record ->
                 TableColumn(
                     record[VARIABLE_TABLE_COLUMNS.IS_HEADER.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
@@ -328,12 +328,19 @@ class ManifestImporter(
           csvVariableByPath[csvVariable.parentPath]?.variableId
               ?: throw IllegalStateException(
                   "Parent variable has not been imported - ${csvVariable.parent}")
+      val zeroIndexedPosition =
+          csvVariablesByParentPath[csvVariable.parentPath]?.indexOfFirst {
+            it.variableId == csvVariable.variableId
+          }
+              ?: throw IllegalStateException(
+                  "Variable ${csvVariable.variableId} not found in parent ${csvVariable.parentPath}")
 
       variableStore.importTableColumnVariable(
           VariableTableColumnsRow(
               variableId = csvVariable.variableId,
               tableVariableId = tableVariableId,
               tableVariableTypeId = VariableType.Table,
+              position = zeroIndexedPosition + 1,
               isHeader = csvVariable.isHeader))
     }
 

--- a/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
+++ b/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
@@ -148,9 +148,12 @@ CREATE TABLE docprod.variable_table_columns (
     variable_id BIGINT PRIMARY KEY REFERENCES docprod.variables,
     table_variable_id BIGINT NOT NULL REFERENCES docprod.variables,
     table_variable_type_id INTEGER NOT NULL REFERENCES docprod.variable_types,
+    position INTEGER NOT NULL,
     is_header BOOLEAN NOT NULL,
 
     CHECK (table_variable_type_id = 6),
+
+    UNIQUE (table_variable_id, position),
 
     FOREIGN KEY (table_variable_id, table_variable_type_id)
         REFERENCES docprod.variable_tables (variable_id, variable_type_id)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2678,15 +2678,31 @@ abstract class DatabaseBackedTest {
     return variableId
   }
 
+  private var lastTableColumnTableId: VariableId? = null
+  private var lastTableColumnPosition = 0
+
   protected fun insertTableColumn(
       tableId: Any,
       columnId: Any,
       isHeader: Boolean = false,
+      position: Int? = null,
   ): VariableId {
+    val tableIdWrapper = tableId.toIdWrapper { VariableId(it) }
+    val effectivePosition =
+        when {
+          position != null -> position
+          lastTableColumnTableId == tableIdWrapper -> lastTableColumnPosition + 1
+          else -> 1
+        }
+
+    lastTableColumnTableId = tableIdWrapper
+    lastTableColumnPosition = effectivePosition
+
     val row =
         VariableTableColumnsRow(
             isHeader = isHeader,
-            tableVariableId = tableId.toIdWrapper { VariableId(it) },
+            position = effectivePosition,
+            tableVariableId = tableIdWrapper,
             tableVariableTypeId = VariableType.Table,
             variableId = columnId.toIdWrapper { VariableId(it) },
         )

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -161,16 +161,19 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
                   variableId = tableColumnVariableRow1.id!!,
                   tableVariableId = actualTableVariable.id!!,
                   tableVariableTypeId = VariableType.Table,
+                  position = 1,
                   isHeader = false),
               VariableTableColumnsRow(
                   variableId = tableColumnVariableRow2.id!!,
                   tableVariableId = actualTableVariable.id!!,
                   tableVariableTypeId = VariableType.Table,
+                  position = 2,
                   isHeader = false),
               VariableTableColumnsRow(
                   variableId = tableColumnVariableRow3.id!!,
                   tableVariableId = actualTableVariable.id!!,
                   tableVariableTypeId = VariableType.Table,
+                  position = 3,
                   isHeader = false))
 
       assertEquals(emptyList<String>(), importResult.errors, "no errors")
@@ -207,11 +210,13 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
                   variableId = tableColumnVariableRow1.id!!,
                   tableVariableId = actualTableVariable.id!!,
                   tableVariableTypeId = VariableType.Table,
+                  position = 1,
                   isHeader = true),
               VariableTableColumnsRow(
                   variableId = tableColumnVariableRow2.id!!,
                   tableVariableId = actualTableVariable.id!!,
                   tableVariableTypeId = VariableType.Table,
+                  position = 2,
                   isHeader = false))
 
       val actualNumberRow = variableNumbersDao.fetchOneByVariableId(tableColumnVariableRow2.id!!)


### PR DESCRIPTION
In the original PDD schema, we used the manifest entry's position to determine
the order of table columns. In the absence of a manifest entry, we need to track
column order explicitly. Add a position field for that.