### PR TITLE
SW-5557 Update endpoint to list project documents

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.documentproducer.model.ExistingSavedVersionMod
 import com.terraformation.backend.documentproducer.model.NewDocumentModel
 import com.terraformation.backend.documentproducer.model.NewSavedVersionModel
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @InternalEndpoint
@@ -43,8 +45,17 @@ class DocumentsController(
 ) {
   @GetMapping
   @Operation(summary = "Gets a list of all the documents.")
-  fun listDocuments(): ListDocumentsResponsePayload {
-    val models = documentStore.findAll()
+  fun listDocuments(
+      @Parameter(description = "If present, only list documents for this project.")
+      @RequestParam
+      projectId: ProjectId?
+  ): ListDocumentsResponsePayload {
+    val models =
+        if (projectId != null) {
+          documentStore.fetchByProjectId(projectId)
+        } else {
+          documentStore.findAll()
+        }
 
     return ListDocumentsResponsePayload(models.map { DocumentPayload(it) })
   }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/DocumentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/DocumentStore.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.documentproducer.db
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentSavedVersionId
 import com.terraformation.backend.db.docprod.DocumentStatus
@@ -97,6 +98,13 @@ class DocumentStore(
 
   fun findAll(): List<ExistingDocumentModel> {
     return documentsDao.findAll().map { ExistingDocumentModel(it) }
+  }
+
+  fun fetchByProjectId(projectId: ProjectId): List<ExistingDocumentModel> {
+    return documentsDao
+        .fetchByProjectId(projectId)
+        .map { ExistingDocumentModel(it) }
+        .filter { currentUser().canReadDocument(it.id) }
   }
 
   fun fetchDocumentById(documentId: DocumentId): DocumentsRow {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.tables.pojos.VariableValuesRow
 import com.terraformation.backend.db.docprod.tables.references.DOCUMENTS
-import io.ktor.client.utils.EmptyContent.status
 import java.math.BigDecimal
 import java.time.Duration
 import java.time.Instant
@@ -146,6 +145,36 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
                       "projectId": $otherProjectId,
                       "status": "Locked",
                       "variableManifestId": $otherVariableManifestId
+                    }
+                  ]
+                }"""
+                  .trimIndent())
+    }
+
+    @Test
+    fun `can limit results to a single project`() {
+      val projectId = inserted.projectId
+      val documentId = insertDocument()
+      insertProject(name = "Other Project")
+      insertDocument()
+
+      mockMvc
+          .get("$path?projectId=$projectId")
+          .andExpectJson(
+              """
+                {
+                  "documents": [
+                    {
+                      "createdBy": ${inserted.userId},
+                      "createdTime": "${Instant.EPOCH}",
+                      "id": $documentId,
+                      "documentTemplateId": ${inserted.documentTemplateId},
+                      "modifiedBy": ${inserted.userId},
+                      "modifiedTime": "${Instant.EPOCH}",
+                      "ownedBy": ${inserted.userId},
+                      "projectId": $projectId,
+                      "status": "Draft",
+                      "variableManifestId": ${inserted.variableManifestId}
                     }
                   ]
                 }"""


### PR DESCRIPTION
To support allowing the user to select a project in the documents list UI, add an
optional query parameter to the "list documents" endpoint to restrict results to
a single project's documents.