### PR TITLE
Add user to "added to organization" email model

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -212,7 +212,7 @@ class EmailNotificationService(
 
     emailService.sendUserNotification(
         user,
-        UserAddedToOrganization(config, admin, organization, organizationHomeUrl),
+        UserAddedToOrganization(config, admin, organization, organizationHomeUrl, user),
         requireOptIn = false)
   }
 

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -153,6 +153,7 @@ class UserAddedToOrganization(
     val admin: IndividualUser,
     val organization: OrganizationModel,
     val organizationHomeUrl: String,
+    val user: IndividualUser,
 ) : EmailTemplateModel(config) {
   override val templateDir: String
     get() = "user/addedToOrganization"


### PR DESCRIPTION
Add a `user` object to the model that's accessible by the "user added to
organization" email templates. This allows the notificaiton email to greet the
user by name.