### PR TITLE
SW-5566 Add variable owners

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -423,4 +423,9 @@ val EMBEDDABLES =
         EmbeddableDefinitionType()
             .withName("variable_manifest_entry_id")
             .withTables("variable_manifest_entries")
-            .withColumns("variable_id", "variable_manifest_id"))
+            .withColumns("variable_id", "variable_manifest_id"),
+        EmbeddableDefinitionType()
+            .withName("variable_owner_id")
+            .withTables("variable_owners")
+            .withColumns("variable_id", "project_id"),
+    )

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -354,6 +354,8 @@ data class DeviceManagerUser(
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = false
 
+  override fun canReadProjectVariableOwners(projectId: ProjectId): Boolean = false
+
   override fun canReadProjectVotes(projectId: ProjectId): Boolean = false
 
   override fun canReadReport(reportId: ReportId): Boolean = false
@@ -449,6 +451,8 @@ data class DeviceManagerUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = false
+
+  override fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -461,6 +461,8 @@ data class IndividualUser(
 
   override fun canReadProjectScores(projectId: ProjectId) = isReadOnlyOrHigher()
 
+  override fun canReadProjectVariableOwners(projectId: ProjectId) = isReadOnlyOrHigher()
+
   override fun canReadProjectVotes(projectId: ProjectId) = isReadOnlyOrHigher()
 
   override fun canReadReport(reportId: ReportId) =
@@ -613,6 +615,8 @@ data class IndividualUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId) = isAcceleratorAdmin()
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = isTFExpertOrHigher()
+
+  override fun canUpdateProjectVariableOwners(projectId: ProjectId) = isTFExpertOrHigher()
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = isTFExpertOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -794,14 +794,21 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun readProjectScores(projectId: ProjectId) {
     if (!user.canReadProjectScores(projectId)) {
       readProject(projectId)
-      throw throw AccessDeniedException("No permission to view scores for project $projectId")
+      throw AccessDeniedException("No permission to view scores for project $projectId")
+    }
+  }
+
+  fun readProjectVariableOwners(projectId: ProjectId) {
+    if (!user.canReadProjectVariableOwners(projectId)) {
+      readProject(projectId)
+      throw AccessDeniedException("No permission to read variable owners for project $projectId")
     }
   }
 
   fun readProjectVotes(projectId: ProjectId) {
     if (!user.canReadProjectVotes(projectId)) {
       readProject(projectId)
-      throw throw AccessDeniedException("No permission to view votes for project $projectId")
+      throw AccessDeniedException("No permission to view votes for project $projectId")
     }
   }
 
@@ -1137,14 +1144,21 @@ class PermissionRequirements(private val user: TerrawareUser) {
   fun updateProjectScores(projectId: ProjectId) {
     if (!user.canUpdateProjectScores(projectId)) {
       readProject(projectId)
-      throw throw AccessDeniedException("No permission to update scores for project $projectId")
+      throw AccessDeniedException("No permission to update scores for project $projectId")
+    }
+  }
+
+  fun updateProjectVariableOwners(projectId: ProjectId) {
+    if (!user.canUpdateProjectVariableOwners(projectId)) {
+      readProject(projectId)
+      throw AccessDeniedException("No permission to update variable owners for project $projectId")
     }
   }
 
   fun updateProjectVotes(projectId: ProjectId) {
     if (!user.canUpdateProjectVotes(projectId)) {
       readProject(projectId)
-      throw throw AccessDeniedException("No permission to update votes for project $projectId")
+      throw AccessDeniedException("No permission to update votes for project $projectId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -354,6 +354,8 @@ class SystemUser(
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = true
 
+  override fun canReadProjectVariableOwners(projectId: ProjectId): Boolean = true
+
   override fun canReadProjectVotes(projectId: ProjectId): Boolean = true
 
   override fun canReadReport(reportId: ReportId): Boolean = true
@@ -459,6 +461,8 @@ class SystemUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = true
+
+  override fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean = true
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -307,6 +307,8 @@ interface TerrawareUser : Principal {
 
   fun canReadProjectScores(projectId: ProjectId): Boolean
 
+  fun canReadProjectVariableOwners(projectId: ProjectId): Boolean
+
   fun canReadProjectVotes(projectId: ProjectId): Boolean
 
   fun canReadReport(reportId: ReportId): Boolean
@@ -410,6 +412,8 @@ interface TerrawareUser : Principal {
   fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean
 
   fun canUpdateProjectScores(projectId: ProjectId): Boolean
+
+  fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean
 
   fun canUpdateProjectVotes(projectId: ProjectId): Boolean
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersController.kt
@@ -1,0 +1,61 @@
+package com.terraformation.backend.documentproducer.api
+
+import com.terraformation.backend.api.InternalEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.documentproducer.db.VariableOwnerStore
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@InternalEndpoint
+@RequestMapping("/api/v1/document-producer/projects/{projectId}/owners")
+@RestController
+class VariableOwnersController(
+    private val variableOwnerStore: VariableOwnerStore,
+) {
+  @GetMapping
+  @Operation(
+      summary = "List the owners of a project's variables.",
+      description = "Only variables that actually have owners are returned.")
+  fun listVariableOwners(@PathVariable projectId: ProjectId): ListVariableOwnersResponsePayload {
+    val owners = variableOwnerStore.listOwners(projectId)
+
+    return ListVariableOwnersResponsePayload(
+        owners.entries.map { VariableOwnersResponseElement(it.value, it.key) })
+  }
+
+  @PutMapping("/{variableId}")
+  @Operation(summary = "Update or remove the owner of a variable in a project.")
+  fun updateVariableOwner(
+      @PathVariable projectId: ProjectId,
+      @PathVariable variableId: VariableId,
+      @RequestBody payload: UpdateVariableOwnerRequestPayload
+  ): SimpleSuccessResponsePayload {
+    variableOwnerStore.updateOwner(projectId, variableId, payload.ownedBy)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class VariableOwnersResponseElement(
+    val ownedBy: UserId,
+    val variableId: VariableId,
+)
+
+data class ListVariableOwnersResponsePayload(val variables: List<VariableOwnersResponseElement>) :
+    SuccessResponsePayload
+
+data class UpdateVariableOwnerRequestPayload(
+    @Schema(
+        description = "New owner of the variable, or null if the variable should have no owner.")
+    val ownedBy: UserId?
+)

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableOwnerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableOwnerStore.kt
@@ -1,0 +1,68 @@
+package com.terraformation.backend.documentproducer.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.UserNotFoundException
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.tables.references.VARIABLES
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_OWNERS
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class VariableOwnerStore(
+    private val dslContext: DSLContext,
+) {
+  fun listOwners(projectId: ProjectId): Map<VariableId, UserId> {
+    requirePermissions { readProjectVariableOwners(projectId) }
+
+    return with(VARIABLE_OWNERS) {
+      dslContext
+          .select(VARIABLE_ID, OWNED_BY)
+          .from(VARIABLE_OWNERS)
+          .where(PROJECT_ID.eq(projectId))
+          .fetchMap(VARIABLE_ID.asNonNullable(), OWNED_BY.asNonNullable())
+    }
+  }
+
+  fun updateOwner(projectId: ProjectId, variableId: VariableId, ownedBy: UserId?) {
+    requirePermissions { updateProjectVariableOwners(projectId) }
+
+    if (!dslContext.fetchExists(PROJECTS, PROJECTS.ID.eq(projectId))) {
+      throw ProjectNotFoundException(projectId)
+    }
+
+    if (!dslContext.fetchExists(VARIABLES, VARIABLES.ID.eq(variableId))) {
+      throw VariableNotFoundException(variableId)
+    }
+
+    if (ownedBy != null && !dslContext.fetchExists(USERS, USERS.ID.eq(ownedBy))) {
+      throw UserNotFoundException(ownedBy)
+    }
+
+    with(VARIABLE_OWNERS) {
+      if (ownedBy != null) {
+        dslContext
+            .insertInto(VARIABLE_OWNERS)
+            .set(PROJECT_ID, projectId)
+            .set(VARIABLE_ID, variableId)
+            .set(OWNED_BY, ownedBy)
+            .onConflict()
+            .doUpdate()
+            .set(OWNED_BY, ownedBy)
+            .execute()
+      } else {
+        dslContext
+            .deleteFrom(VARIABLE_OWNERS)
+            .where(PROJECT_ID.eq(projectId))
+            .and(VARIABLE_ID.eq(variableId))
+            .execute()
+      }
+    }
+  }
+}

--- a/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
+++ b/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
@@ -318,6 +318,17 @@ CREATE TABLE docprod.variable_value_table_rows (
 
 CREATE INDEX ON docprod.variable_value_table_rows (table_row_value_id);
 
+CREATE TABLE docprod.variable_owners (
+    project_id BIGINT NOT NULL REFERENCES projects ON DELETE CASCADE,
+    variable_id BIGINT NOT NULL REFERENCES docprod.variables,
+    owned_by BIGINT NOT NULL REFERENCES users ON DELETE CASCADE,
+
+    PRIMARY KEY (project_id, variable_id)
+);
+
+CREATE INDEX ON docprod.variable_owners (variable_id);
+CREATE INDEX ON docprod.variable_owners (owned_by);
+
 CREATE FUNCTION docprod.reject_delete() RETURNS TRIGGER AS $$
 BEGIN
     RAISE 'This table does not allow deletes.';

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -562,6 +562,8 @@ COMMENT ON TABLE docprod.variable_manifests IS 'A collection of the definitions 
 
 COMMENT ON TABLE docprod.variable_numbers IS 'Information about number variables that is not relevant for other variable types.';
 
+COMMENT ON TABLE docprod.variable_owners IS 'Which internal users are responsible for reviewing the values of which variables for which projects.';
+
 COMMENT ON TABLE docprod.variable_section_recommendations IS 'Which sections recommend using which other variables. Can vary between manifests.';
 
 COMMENT ON TABLE docprod.variable_section_values IS 'Fragments of the contents of document sections. Each fragment is either a block of text or a usage of a variable; they are assembled in order to render the contents of the section.';

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -705,6 +705,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.readProjectScores(projectId)
   }
 
+  @Test
+  fun readProjectVariableOwners() {
+    assertThrows<ProjectNotFoundException> { requirements.readProjectVariableOwners(projectId) }
+
+    grant { user.canReadProject(projectId) }
+    assertThrows<AccessDeniedException> { requirements.readProjectVariableOwners(projectId) }
+
+    grant { user.canReadProjectVariableOwners(projectId) }
+    requirements.readProjectVariableOwners(projectId)
+  }
+
   @Test fun readReport() = testRead { readReport(reportId) }
 
   @Test fun readSpecies() = testRead { readSpecies(speciesId) }
@@ -897,6 +908,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateProjectScores() =
       allow { updateProjectScores(projectId) } ifUser { canUpdateProjectScores(projectId) }
+
+  @Test
+  fun updateProjectVariableOwners() =
+      allow { updateProjectVariableOwners(projectId) } ifUser
+          {
+            canUpdateProjectVariableOwners(projectId)
+          }
 
   @Test
   fun updateProjectVotes() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1449,11 +1449,13 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
     )
 
@@ -1558,12 +1560,14 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1589,11 +1593,13 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1736,11 +1742,13 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1766,10 +1774,12 @@ internal class PermissionTest : DatabaseTest() {
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1910,10 +1920,12 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1934,9 +1946,11 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
+        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -2081,6 +2095,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
     )
 
@@ -2093,6 +2108,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
+        readProjectVariableOwners = true,
         readProjectVotes = true,
     )
 
@@ -2923,12 +2939,14 @@ internal class PermissionTest : DatabaseTest() {
         readProjectDeliverables: Boolean = false,
         readProjectModules: Boolean = false,
         readProjectScores: Boolean = false,
+        readProjectVariableOwners: Boolean = false,
         readProjectVotes: Boolean = false,
         updateDefaultVoters: Boolean = false,
         updateProject: Boolean = false,
         updateProjectAcceleratorDetails: Boolean = false,
         updateProjectDocumentSettings: Boolean = false,
         updateProjectScores: Boolean = false,
+        updateProjectVariableOwners: Boolean = false,
         updateProjectVotes: Boolean = false,
         updateSubmissionStatus: Boolean = false,
     ) {
@@ -2960,6 +2978,10 @@ internal class PermissionTest : DatabaseTest() {
             user.canReadProjectScores(projectId),
             "Can read scores for project $projectId")
         assertEquals(
+            readProjectVariableOwners,
+            user.canReadProjectVariableOwners(projectId),
+            "Can read variable owners for project $projectId")
+        assertEquals(
             readProjectVotes,
             user.canReadProjectVotes(projectId),
             "Can read votes for project $projectId")
@@ -2979,7 +3001,10 @@ internal class PermissionTest : DatabaseTest() {
             updateProjectScores,
             user.canUpdateProjectScores(projectId),
             "Can update scores for project $projectId")
-
+        assertEquals(
+            updateProjectVariableOwners,
+            user.canUpdateProjectVariableOwners(projectId),
+            "Can update variable owners for project $projectId")
         assertEquals(
             updateProjectVotes,
             user.canUpdateProjectVotes(projectId),

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -172,6 +172,7 @@ import com.terraformation.backend.db.docprod.tables.daos.VariableLinkValuesDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableManifestEntriesDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableManifestsDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableNumbersDao
+import com.terraformation.backend.db.docprod.tables.daos.VariableOwnersDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableSectionRecommendationsDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableSectionValuesDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableSectionsDao
@@ -192,6 +193,7 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariableLinkValuesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableManifestEntriesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableManifestsRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableNumbersRow
+import com.terraformation.backend.db.docprod.tables.pojos.VariableOwnersRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSectionRecommendationsRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSectionValuesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSectionsRow
@@ -551,6 +553,7 @@ abstract class DatabaseBackedTest {
   protected val variableManifestEntriesDao: VariableManifestEntriesDao by lazyDao()
   protected val variableManifestsDao: VariableManifestsDao by lazyDao()
   protected val variableNumbersDao: VariableNumbersDao by lazyDao()
+  protected val variableOwnersDao: VariableOwnersDao by lazyDao()
   protected val variableSelectsDao: VariableSelectsDao by lazyDao()
   protected val variableSelectOptionValuesDao: VariableSelectOptionValuesDao by lazyDao()
   protected val variableSelectOptionsDao: VariableSelectOptionsDao by lazyDao()
@@ -2890,6 +2893,21 @@ abstract class DatabaseBackedTest {
     variableManifestEntriesDao.insert(row)
 
     return variableIdWrapper
+  }
+
+  protected fun insertVariableOwner(
+      variableId: Any,
+      ownedBy: Any,
+      projectId: Any = inserted.projectId,
+  ) {
+    val row =
+        VariableOwnersRow(
+            ownedBy = ownedBy.toIdWrapper { UserId(it) },
+            projectId = projectId.toIdWrapper { ProjectId(it) },
+            variableId = variableId.toIdWrapper { VariableId(it) },
+        )
+
+    variableOwnersDao.insert(row)
   }
 
   class Inserted {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
@@ -1,0 +1,176 @@
+package com.terraformation.backend.documentproducer.api
+
+import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.tables.pojos.VariableOwnersRow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.put
+
+class VariableOwnersControllerTest : ControllerIntegrationTest() {
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    projectId = insertProject()
+  }
+
+  @Nested
+  inner class ListVariableOwners {
+    private fun path(project: ProjectId = projectId) =
+        "/api/v1/document-producer/projects/$project/owners"
+
+    @Nested
+    inner class WithPermission {
+      @BeforeEach
+      fun setUp() {
+        insertUserGlobalRole(role = GlobalRole.TFExpert)
+      }
+
+      @Test
+      fun `returns owner user IDs for variables with owners`() {
+        val ownerId1 = insertUser(100)
+        val ownerId2 = insertUser(101)
+
+        val sectionId1 = insertSectionVariable()
+        val sectionId2 = insertSectionVariable()
+        val sectionId3 = insertSectionVariable()
+
+        insertVariableOwner(sectionId1, ownerId1)
+        insertVariableOwner(sectionId2, ownerId2)
+
+        // Owners from other projects shouldn't be returned.
+        insertProject()
+        insertVariableOwner(sectionId3, ownerId1)
+
+        mockMvc
+            .get(path())
+            .andExpectJson(
+                """
+                  {
+                    "variables": [
+                      {
+                        "ownedBy": $ownerId1,
+                        "variableId": $sectionId1
+                      },
+                      {
+                        "ownedBy": $ownerId2,
+                        "variableId": $sectionId2
+                      }
+                    ],
+                    "status": "ok"
+                  }
+              """
+                    .trimIndent(),
+                strict = true)
+      }
+    }
+
+    @Test
+    fun `returns error if user has no permission to list owners`() {
+      insertOrganizationUser()
+      mockMvc.get(path()).andExpect { status { isForbidden() } }
+    }
+  }
+
+  @Nested
+  inner class UpdateVariableOwner {
+    private lateinit var sectionId: VariableId
+    private lateinit var otherSectionId: VariableId
+
+    private fun path(
+        projectId: ProjectId = inserted.projectId,
+        variableId: VariableId = sectionId
+    ) = "/api/v1/document-producer/projects/$projectId/owners/$variableId"
+
+    @BeforeEach
+    fun setUp() {
+      sectionId = insertSectionVariable()
+
+      // Should only update the owner of the specified variable, even if other variables exist.
+      otherSectionId = insertSectionVariable()
+    }
+
+    @Nested
+    inner class WithPermission {
+      @BeforeEach
+      fun setUp() {
+        insertUserGlobalRole(role = GlobalRole.TFExpert)
+      }
+
+      @Test
+      fun `sets initial owner`() {
+        mockMvc
+            .put(path()) { content = """{"ownedBy": ${user.userId}}""" }
+            .andExpect { status { isOk() } }
+
+        assertEquals(
+            listOf(VariableOwnersRow(inserted.projectId, sectionId, user.userId)),
+            variableOwnersDao.findAll(),
+            "New owner should have been stored in database")
+      }
+
+      @Test
+      fun `updates owner if one already exists`() {
+        val newOwnerId = insertUser(100)
+        insertVariableOwner(sectionId, user.userId)
+        insertVariableOwner(otherSectionId, user.userId)
+
+        mockMvc
+            .put(path()) { content = """{"ownedBy": $newOwnerId}""" }
+            .andExpect { status { isOk() } }
+
+        assertEquals(
+            setOf(
+                VariableOwnersRow(inserted.projectId, sectionId, newOwnerId),
+                VariableOwnersRow(inserted.projectId, otherSectionId, user.userId),
+            ),
+            variableOwnersDao.findAll().toSet(),
+            "New owner should have been stored in database")
+      }
+
+      @Test
+      fun `removes existing owner`() {
+        insertVariableOwner(sectionId, user.userId)
+        insertVariableOwner(otherSectionId, user.userId)
+
+        mockMvc.put(path()) { content = """{"ownedBy": null}""" }.andExpect { status { isOk() } }
+
+        assertEquals(
+            listOf(VariableOwnersRow(inserted.projectId, otherSectionId, user.userId)),
+            variableOwnersDao.findAll(),
+            "Should have deleted existing owner")
+      }
+
+      @Test
+      fun `returns error if project does not exist`() {
+        mockMvc
+            .put(path(projectId = ProjectId(0))) { content = """{"ownedBy": ${user.userId}}""" }
+            .andExpect { status { isNotFound() } }
+      }
+
+      @Test
+      fun `returns error if variable does not exist`() {
+        mockMvc
+            .put(path(variableId = VariableId(0))) { content = """{"ownedBy": ${user.userId}}""" }
+            .andExpect { status { isNotFound() } }
+      }
+    }
+
+    @Test
+    fun `returns error if user has no permission to update owner`() {
+      insertOrganizationUser()
+
+      mockMvc
+          .put(path(variableId = VariableId(0))) { content = """{"ownedBy": ${user.userId}}""" }
+          .andExpect { status { isForbidden() } }
+    }
+  }
+}


### PR DESCRIPTION
Allow variables to be assigned to owners on a per-project basis.

Initially, this will be used to assign numbered sections to owners during the
feasibility study authoring process, but this implementation is more general
and allows any variable to have an owner.

Variable ownership is not considered part of the variable's value; it's a
separate piece of metadata that can exist even for variables that don't yet
have values in a project.

In anticipation of changing the variables API to stop requiring documents
(which will be necessary to support questionnaire deliverables), the new
endpoints added here use project IDs rather than document IDs.