### PR TITLE
SW-5582 Project-based variable value endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ImagesController.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.getFilename
 import com.terraformation.backend.api.getPlainContentType
 import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableValueId
@@ -29,14 +30,106 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 
 @InternalEndpoint
-@RequestMapping("/api/v1/document-producer/documents/{documentId}/images")
+@RequestMapping("/api/v1/document-producer")
 @RestController
 class ImagesController(
     private val documentStore: DocumentStore,
     private val variableFileService: VariableFileService,
 ) {
   @GetMapping(
-      "/{valueId}",
+      "/projects/{projectId}/images/{valueId}",
+      produces =
+          [MediaType.APPLICATION_JSON_VALUE, MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE])
+  @Operation(
+      summary = "Gets the contents of an image variable value.",
+      description =
+          "Optional maxWidth and maxHeight parameters may be included to control the dimensions " +
+              "of the image; the server will scale the original down as needed. If neither " +
+              "parameter is specified, the original full-size image will be returned. The aspect " +
+              "ratio of the original image is maintained, so the returned image may be smaller " +
+              "than the requested width and height. If only maxWidth or only maxHeight is " +
+              "supplied, the other dimension will be computed based on the original image's " +
+              "aspect ratio.")
+  fun getProjectImageValue(
+      @PathVariable projectId: ProjectId,
+      @PathVariable valueId: VariableValueId,
+      @RequestParam
+      @Schema(
+          description =
+              "Maximum desired width in pixels. If neither this nor maxHeight is specified, the " +
+                  "full-sized original image will be returned. If this is specified, an image no " +
+                  "wider than this will be returned. The image may be narrower than this value " +
+                  "if needed to preserve the aspect ratio of the original.")
+      maxWidth: Int? = null,
+      @RequestParam
+      @Schema(
+          description =
+              "Maximum desired height in pixels. If neither this nor maxWidth is specified, the " +
+                  "full-sized original image will be returned. If this is specified, an image no " +
+                  "taller than this will be returned. The image may be shorter than this value " +
+                  "if needed to preserve the aspect ratio of the original.")
+      maxHeight: Int? = null,
+  ): ResponseEntity<InputStreamResource> {
+    return variableFileService
+        .readImageValue(projectId, valueId, maxWidth, maxHeight)
+        .toResponseEntity()
+  }
+
+  @Operation(summary = "Save an image to a new variable value.")
+  @PostMapping("/projects/{projectId}/images")
+  fun uploadProjectImageValue(
+      @PathVariable projectId: ProjectId,
+      @RequestPart file: MultipartFile,
+      @RequestPart(required = false) caption: String?,
+      @RequestPart(required = false) citation: String?,
+      @RequestPart @Schema(format = "int64", type = "integer") variableId: String,
+      @RequestPart(required = false)
+      @Schema(
+          description =
+              "If the variable is a list, which list position to use for the value. If not " +
+                  "specified, the server will use the next available list position if the " +
+                  "variable is a list, or will replace any existing image if the variable is " +
+                  "not a list.",
+          format = "int32",
+          type = "integer")
+      listPosition: String? = null,
+      @RequestPart(required = false)
+      @Schema(
+          description =
+              "If the variable is a table column, value ID of the row the value should belong to.",
+          format = "int64",
+          type = "integer")
+      rowValueId: String? = null,
+  ): UploadImageFileResponsePayload {
+    val newMetadata =
+        FileMetadata.of(
+            contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES),
+            filename = file.getFilename("file"),
+            size = file.size,
+        )
+
+    val isAppend = listPosition == null
+
+    val base =
+        BaseVariableValueProperties(
+            citation = citation,
+            id = null,
+            // If list position isn't specified, the value here will be ignored because isAppend
+            // will be true.
+            listPosition = listPosition?.toIntOrNull() ?: 0,
+            projectId = projectId,
+            rowValueId = rowValueId?.ifEmpty { null }?.let { VariableValueId(it.toLong()) },
+            variableId = VariableId(variableId.toLong()),
+        )
+
+    val valueId =
+        variableFileService.storeImageValue(file.inputStream, newMetadata, base, caption, isAppend)
+
+    return UploadImageFileResponsePayload(valueId)
+  }
+
+  @GetMapping(
+      "/documents/{documentId}/images/{valueId}",
       produces =
           [MediaType.APPLICATION_JSON_VALUE, MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE])
   @Operation(
@@ -73,13 +166,11 @@ class ImagesController(
         documentStore.fetchDocumentById(documentId).projectId
             ?: throw DocumentNotFoundException(documentId)
 
-    return variableFileService
-        .readImageValue(projectId, valueId, maxWidth, maxHeight)
-        .toResponseEntity()
+    return getProjectImageValue(projectId, valueId, maxWidth, maxHeight)
   }
 
   @Operation(summary = "Save an image to a new variable value.")
-  @PostMapping
+  @PostMapping("/documents/{documentId}/images")
   fun uploadImageValue(
       @PathVariable documentId: DocumentId,
       @RequestPart file: MultipartFile,
@@ -104,32 +195,10 @@ class ImagesController(
           type = "integer")
       rowValueId: String? = null,
   ): UploadImageFileResponsePayload {
-    val newMetadata =
-        FileMetadata.of(
-            contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES),
-            filename = file.getFilename("file"),
-            size = file.size,
-        )
-
     val projectId = documentStore.fetchProjectId(documentId)
-    val isAppend = listPosition == null
 
-    val base =
-        BaseVariableValueProperties(
-            citation = citation,
-            id = null,
-            // If list position isn't specified, the value here will be ignored because isAppend
-            // will be true.
-            listPosition = listPosition?.toIntOrNull() ?: 0,
-            projectId = projectId,
-            rowValueId = rowValueId?.ifEmpty { null }?.let { VariableValueId(it.toLong()) },
-            variableId = VariableId(variableId.toLong()),
-        )
-
-    val valueId =
-        variableFileService.storeImageValue(file.inputStream, newMetadata, base, caption, isAppend)
-
-    return UploadImageFileResponsePayload(valueId)
+    return uploadProjectImageValue(
+        projectId, file, caption, citation, variableId, listPosition, rowValueId)
   }
 }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
 import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableValueId
@@ -23,24 +24,21 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     insertUserGlobalRole(userId = userId, GlobalRole.TFExpert)
     insertOrganization()
     insertProject()
-    insertDocumentTemplate()
-    insertVariableManifest()
-    insertDocument()
   }
 
-  private fun path(documentId: DocumentId = inserted.documentId) =
-      "/api/v1/document-producer/documents/$documentId/values"
+  private fun path(projectId: ProjectId = inserted.projectId) =
+      "/api/v1/document-producer/projects/$projectId/values"
 
   @Nested
-  inner class ListVariableValues {
+  inner class ListProjectVariableValues {
     @Test
     fun `returns appropriate data structures for all value types`() {
-      val dateVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Date))
-      val imageVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Image))
-      val numberVariableId = insertVariableManifestEntry(insertNumberVariable())
-      val textVariableId = insertVariableManifestEntry(insertTextVariable())
-      val linkVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Link))
-      val sectionVariableId = insertVariableManifestEntry(insertSectionVariable())
+      val dateVariableId = insertVariable(type = VariableType.Date)
+      val imageVariableId = insertVariable(type = VariableType.Image)
+      val numberVariableId = insertNumberVariable()
+      val textVariableId = insertTextVariable()
+      val linkVariableId = insertVariable(type = VariableType.Link)
+      val sectionVariableId = insertSectionVariable()
       val selectVariableId = insertSelectVariable()
       val selectOptionId1 = insertSelectOption(selectVariableId, "Option 1")
       val selectOptionId2 = insertSelectOption(selectVariableId, "Option 2")
@@ -182,10 +180,9 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
     @Test
     fun `associates values with table rows`() {
-      val tableVariableId = insertVariableManifestEntry(insertTableVariable())
+      val tableVariableId = insertTableVariable()
       val textVariableId =
-          insertVariableManifestEntry(
-              insertTextVariable(insertVariable(isList = true, type = VariableType.Text)))
+          insertTextVariable(insertVariable(isList = true, type = VariableType.Text))
       insertTableColumn(tableVariableId, textVariableId)
 
       val rowValueId0 =
@@ -265,11 +262,11 @@ class ValuesControllerTest : ControllerIntegrationTest() {
   }
 
   @Nested
-  inner class AppendValues {
+  inner class AppendProjectValues {
     @Test
     fun `can append to column of existing row`() {
-      val tableVariableId = insertVariableManifestEntry(insertTableVariable())
-      val columnVariableId = insertVariableManifestEntry(insertTextVariable())
+      val tableVariableId = insertTableVariable()
+      val columnVariableId = insertTextVariable()
       insertTableColumn(tableVariableId, columnVariableId)
 
       val rowValueId = insertValue(variableId = tableVariableId)
@@ -307,7 +304,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
     @Test
     fun `validates new values against variable settings`() {
-      val variableId = insertVariableManifestEntry(insertNumberVariable(maxValue = BigDecimal.TWO))
+      val variableId = insertNumberVariable(maxValue = BigDecimal.TWO)
 
       val payload =
           """
@@ -336,13 +333,13 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
     @Test
     fun `can append values of all non-image variable types`() {
-      val sectionVariableId = insertVariableManifestEntry(insertSectionVariable())
-      val tableVariableId = insertVariableManifestEntry(insertTableVariable())
-      val textVariableId = insertVariableManifestEntry(insertTextVariable())
-      val numberVariableId = insertVariableManifestEntry(insertNumberVariable())
-      val linkVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Link))
-      val dateVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Date))
-      val selectVariableId = insertVariableManifestEntry(insertSelectVariable())
+      val sectionVariableId = insertSectionVariable()
+      val tableVariableId = insertTableVariable()
+      val textVariableId = insertTextVariable()
+      val numberVariableId = insertNumberVariable()
+      val linkVariableId = insertVariable(type = VariableType.Link)
+      val dateVariableId = insertVariable(type = VariableType.Date)
+      val selectVariableId = insertSelectVariable()
       val selectOptionId = insertSelectOption(selectVariableId, "Option")
 
       val payload =
@@ -432,10 +429,10 @@ class ValuesControllerTest : ControllerIntegrationTest() {
   }
 
   @Nested
-  inner class UpdateValues {
+  inner class UpdateProjectValues {
     @Test
     fun `can update caption and citation of existing image value`() {
-      val imageVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Image))
+      val imageVariableId = insertVariable(type = VariableType.Image)
       val fileId = insertFile()
       val existingValueId = insertImageValue(imageVariableId, fileId, caption = "Old caption")
 
@@ -490,10 +487,10 @@ class ValuesControllerTest : ControllerIntegrationTest() {
   }
 
   @Nested
-  inner class DeleteValues {
+  inner class DeleteProjectValues {
     @Test
     fun `renumbers remaining items if deleting from list`() {
-      val variableId = insertVariableManifestEntry(insertTextVariable())
+      val variableId = insertTextVariable()
       val valueId0 = insertValue(variableId = variableId, listPosition = 0, textValue = "First")
       val valueId1 = insertValue(variableId = variableId, listPosition = 1, textValue = "Second")
       insertValue(variableId = variableId, listPosition = 2, textValue = "Third")
@@ -551,8 +548,8 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
     @Test
     fun `associates values with correctly-numbered rows after deleting earlier row`() {
-      val tableVariableId = insertVariableManifestEntry(insertTableVariable())
-      val columnVariableId = insertVariableManifestEntry(insertTextVariable())
+      val tableVariableId = insertTableVariable()
+      val columnVariableId = insertTextVariable()
       insertTableColumn(tableVariableId, columnVariableId)
 
       val rowId0 = insertValue(variableId = tableVariableId, listPosition = 0)
@@ -642,6 +639,636 @@ class ValuesControllerTest : ControllerIntegrationTest() {
               """
                   .trimIndent(),
               strict = true)
+    }
+  }
+
+  @Nested
+  inner class DocumentBasedEndpoints {
+    @BeforeEach
+    fun setUp() {
+      insertDocumentTemplate()
+      insertVariableManifest()
+      insertDocument()
+    }
+
+    private fun path(documentId: DocumentId = inserted.documentId) =
+        "/api/v1/document-producer/documents/$documentId/values"
+
+    @Nested
+    inner class ListVariableValues {
+      @Test
+      fun `returns appropriate data structures for all value types`() {
+        val dateVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Date))
+        val imageVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Image))
+        val numberVariableId = insertVariableManifestEntry(insertNumberVariable())
+        val textVariableId = insertVariableManifestEntry(insertTextVariable())
+        val linkVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Link))
+        val sectionVariableId = insertVariableManifestEntry(insertSectionVariable())
+        val selectVariableId = insertSelectVariable()
+        val selectOptionId1 = insertSelectOption(selectVariableId, "Option 1")
+        val selectOptionId2 = insertSelectOption(selectVariableId, "Option 2")
+        val tableVariableId = insertTableVariable()
+
+        val dateValueId =
+            insertValue(variableId = dateVariableId, dateValue = LocalDate.of(2023, 9, 25))
+        val imageValueId =
+            insertImageValue(imageVariableId, insertFile(), caption = "Image caption")
+        val numberValueId =
+            insertValue(variableId = numberVariableId, numberValue = BigDecimal(12345))
+        val textValueId = insertValue(variableId = textVariableId, textValue = "Text value")
+        val linkValueId =
+            insertLinkValue(
+                variableId = linkVariableId, url = "https://dummy", title = "Link title")
+        val sectionTextValueId =
+            insertSectionValue(
+                variableId = sectionVariableId, listPosition = 0, textValue = "Section text")
+        val sectionVariableValueId =
+            insertSectionValue(
+                variableId = sectionVariableId, listPosition = 1, usedVariableId = dateVariableId)
+        val selectValueId =
+            insertSelectValue(
+                variableId = selectVariableId, optionIds = setOf(selectOptionId1, selectOptionId2))
+        val tableValueId = insertValue(citation = "Table citation", variableId = tableVariableId)
+
+        mockMvc
+            .get(path())
+            .andExpectJson(
+                """
+                {
+                  "nextValueId": ${tableValueId.value + 1},
+                  "values": [
+                    {
+                      "variableId": $dateVariableId,
+                      "values": [
+                        {
+                          "id": $dateValueId,
+                          "listPosition": 0,
+                          "type": "Date",
+                          "dateValue": "2023-09-25"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $imageVariableId,
+                      "values": [
+                        {
+                          "id": $imageValueId,
+                          "listPosition": 0,
+                          "type": "Image",
+                          "caption": "Image caption"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $numberVariableId,
+                      "values": [
+                        {
+                          "id": $numberValueId,
+                          "listPosition": 0,
+                          "type": "Number",
+                          "numberValue": 12345
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $textVariableId,
+                      "values": [
+                        {
+                          "id": $textValueId,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Text value"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $linkVariableId,
+                      "values": [
+                        {
+                          "id": $linkValueId,
+                          "listPosition": 0,
+                          "type": "Link",
+                          "url": "https://dummy",
+                          "title": "Link title"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $sectionVariableId,
+                      "values": [
+                        {
+                          "id": $sectionTextValueId,
+                          "listPosition": 0,
+                          "type": "SectionText",
+                          "textValue": "Section text"
+                        },
+                        {
+                          "id": $sectionVariableValueId,
+                          "listPosition": 1,
+                          "type": "SectionVariable",
+                          "variableId": $dateVariableId,
+                          "usageType": "Injection",
+                          "displayStyle": "Block"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $selectVariableId,
+                      "values": [
+                        {
+                          "id": $selectValueId,
+                          "listPosition": 0,
+                          "type": "Select",
+                          "optionValues": [
+                            $selectOptionId1,
+                            $selectOptionId2
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $tableVariableId,
+                      "values": [
+                        {
+                          "id": $tableValueId,
+                          "listPosition": 0,
+                          "type": "Table",
+                          "citation": "Table citation"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                    .trimIndent(),
+                strict = true)
+      }
+
+      @Test
+      fun `associates values with table rows`() {
+        val tableVariableId = insertVariableManifestEntry(insertTableVariable())
+        val textVariableId =
+            insertVariableManifestEntry(
+                insertTextVariable(insertVariable(isList = true, type = VariableType.Text)))
+        insertTableColumn(tableVariableId, textVariableId)
+
+        val rowValueId0 =
+            insertValue(variableId = tableVariableId, listPosition = 0, type = VariableType.Table)
+        val rowValueId1 =
+            insertValue(variableId = tableVariableId, listPosition = 1, type = VariableType.Table)
+
+        val textValueId00 =
+            insertValue(variableId = textVariableId, listPosition = 0, textValue = "Row 0 item 0")
+        insertValueTableRow(textValueId00, rowValueId0)
+        val textValueId01 =
+            insertValue(variableId = textVariableId, listPosition = 1, textValue = "Row 0 item 1")
+        insertValueTableRow(textValueId01, rowValueId0)
+        val textValueId10 =
+            insertValue(variableId = textVariableId, listPosition = 0, textValue = "Row 1 item 0")
+        insertValueTableRow(textValueId10, rowValueId1)
+
+        mockMvc
+            .get(path())
+            .andExpectJson(
+                """
+                {
+                  "nextValueId": ${textValueId10.value + 1},
+                  "values": [
+                    {
+                      "variableId": $tableVariableId,
+                      "values": [
+                        {
+                          "id": $rowValueId0,
+                          "listPosition": 0,
+                          "type": "Table"
+                        },
+                        {
+                          "id": $rowValueId1,
+                          "listPosition": 1,
+                          "type": "Table"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $textVariableId,
+                      "rowValueId": $rowValueId0,
+                      "values": [
+                        {
+                          "id": $textValueId00,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Row 0 item 0"
+                        },
+                        {
+                          "id": $textValueId01,
+                          "listPosition": 1,
+                          "type": "Text",
+                          "textValue": "Row 0 item 1"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $textVariableId,
+                      "rowValueId": $rowValueId1,
+                      "values": [
+                        {
+                          "id": $textValueId10,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Row 1 item 0"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                    .trimIndent(),
+                strict = true)
+      }
+    }
+
+    @Nested
+    inner class AppendValues {
+      @Test
+      fun `can append to column of existing row`() {
+        val tableVariableId = insertVariableManifestEntry(insertTableVariable())
+        val columnVariableId = insertVariableManifestEntry(insertTextVariable())
+        insertTableColumn(tableVariableId, columnVariableId)
+
+        val rowValueId = insertValue(variableId = tableVariableId)
+
+        val payload =
+            """
+            {
+              "operations": [
+                {
+                  "operation": "Append",
+                  "variableId": $columnVariableId,
+                  "rowValueId": $rowValueId,
+                  "value": {
+                    "type": "Text",
+                    "textValue": "Column value"
+                  }
+                }
+              ]
+            }
+          """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isOk() } }
+
+        // Operation will have inserted a new value with the next available ID
+        val newValueId = VariableValueId(rowValueId.value + 1)
+
+        val valueTableRow = variableValueTableRowsDao.fetchByTableRowValueId(rowValueId).single()
+
+        assertEquals(
+            newValueId,
+            valueTableRow.variableValueId,
+            "New value should have been associated with row")
+      }
+
+      @Test
+      fun `validates new values against variable settings`() {
+        val variableId =
+            insertVariableManifestEntry(insertNumberVariable(maxValue = BigDecimal.TWO))
+
+        val payload =
+            """
+          {
+            "operations": [
+              {
+                "operation": "Append",
+                "variableId": $variableId,
+                "value": {
+                  "type": "Number",
+                  "numberValue": 15
+                }
+              }
+            ]
+          }
+        """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isBadRequest() } }
+
+        assertEquals(
+            emptyList<VariableValuesRow>(),
+            variableValuesDao.findAll(),
+            "Should not have stored invalid value")
+      }
+
+      @Test
+      fun `can append values of all non-image variable types`() {
+        val sectionVariableId = insertVariableManifestEntry(insertSectionVariable())
+        val tableVariableId = insertVariableManifestEntry(insertTableVariable())
+        val textVariableId = insertVariableManifestEntry(insertTextVariable())
+        val numberVariableId = insertVariableManifestEntry(insertNumberVariable())
+        val linkVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Link))
+        val dateVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Date))
+        val selectVariableId = insertVariableManifestEntry(insertSelectVariable())
+        val selectOptionId = insertSelectOption(selectVariableId, "Option")
+
+        val payload =
+            """
+            {
+              "operations": [
+                {
+                  "operation": "Append",
+                  "variableId": $sectionVariableId,
+                  "value": {
+                    "type": "SectionText",
+                    "citation": "Citation",
+                    "textValue": "Section text value"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $sectionVariableId,
+                  "value": {
+                    "type": "SectionVariable",
+                    "citation": "Citation",
+                    "variableId": $textVariableId,
+                    "usageType": "Injection",
+                    "displayStyle": "Inline"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $tableVariableId,
+                  "value": {
+                    "type": "Table",
+                    "citation": "Citation"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $textVariableId,
+                  "value": {
+                    "type": "Text",
+                    "citation": "Citation",
+                    "textValue": "Text value"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $numberVariableId,
+                  "value": {
+                    "type": "Number",
+                    "citation": "Citation",
+                    "numberValue": 123
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $linkVariableId,
+                  "value": {
+                    "type": "Link",
+                    "citation": "Citation",
+                    "url": "https://google.com/"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $dateVariableId,
+                  "value": {
+                    "type": "Date",
+                    "citation": "Citation",
+                    "dateValue": "2023-01-01T11:22:33Z"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $selectVariableId,
+                  "value": {
+                    "type": "Select",
+                    "citation": "Citation",
+                    "optionIds": [$selectOptionId]
+                  }
+                }
+              ]
+            }
+          """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isOk() } }
+      }
+    }
+
+    @Nested
+    inner class UpdateValues {
+      @Test
+      fun `can update caption and citation of existing image value`() {
+        val imageVariableId = insertVariableManifestEntry(insertVariable(type = VariableType.Image))
+        val fileId = insertFile()
+        val existingValueId = insertImageValue(imageVariableId, fileId, caption = "Old caption")
+
+        val payload =
+            """
+            {
+              "operations": [
+                {
+                  "operation": "Update",
+                  "valueId": $existingValueId,
+                  "value": {
+                    "type": "Image",
+                    "caption": "New caption",
+                    "citation": "New citation"
+                  }
+                }
+              ]
+            }
+          """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isOk() } }
+
+        val newValueId = VariableValueId(existingValueId.value + 1)
+
+        val imageValuesRows = variableImageValuesDao.findAll().toSet()
+
+        assertEquals(
+            setOf(
+                VariableImageValuesRow(
+                    caption = "Old caption",
+                    fileId = fileId,
+                    variableId = imageVariableId,
+                    variableTypeId = VariableType.Image,
+                    variableValueId = existingValueId,
+                ),
+                VariableImageValuesRow(
+                    caption = "New caption",
+                    fileId = fileId,
+                    variableId = imageVariableId,
+                    variableTypeId = VariableType.Image,
+                    variableValueId = newValueId,
+                ),
+            ),
+            imageValuesRows,
+            "Caption should have been added to new value")
+
+        val valuesRow = variableValuesDao.fetchOneById(newValueId)!!
+
+        assertEquals("New citation", valuesRow.citation, "New value should have new citation")
+      }
+    }
+
+    @Nested
+    inner class DeleteValues {
+      @Test
+      fun `renumbers remaining items if deleting from list`() {
+        val variableId = insertVariableManifestEntry(insertTextVariable())
+        val valueId0 = insertValue(variableId = variableId, listPosition = 0, textValue = "First")
+        val valueId1 = insertValue(variableId = variableId, listPosition = 1, textValue = "Second")
+        insertValue(variableId = variableId, listPosition = 2, textValue = "Third")
+        insertValue(variableId = variableId, listPosition = 3, textValue = "Fourth")
+
+        val payload =
+            """
+            {
+              "operations": [
+                {
+                  "operation": "Delete",
+                  "valueId": $valueId1
+                }
+              ]
+            }
+          """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isOk() } }
+
+        mockMvc
+            .get(path())
+            .andExpectJson(
+                """
+                {
+                  "values": [
+                    {
+                      "variableId": $variableId,
+                      "values": [
+                        {
+                          "id": $valueId0,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "First"
+                        },
+                        {
+                          "listPosition": 1,
+                          "type": "Text",
+                          "textValue": "Third"
+                        },
+                        {
+                          "listPosition": 2,
+                          "type": "Text",
+                          "textValue": "Fourth"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                    .trimIndent(),
+            )
+      }
+
+      @Test
+      fun `associates values with correctly-numbered rows after deleting earlier row`() {
+        val tableVariableId = insertVariableManifestEntry(insertTableVariable())
+        val columnVariableId = insertVariableManifestEntry(insertTextVariable())
+        insertTableColumn(tableVariableId, columnVariableId)
+
+        val rowId0 = insertValue(variableId = tableVariableId, listPosition = 0)
+        val rowId1 = insertValue(variableId = tableVariableId, listPosition = 1)
+        val rowId2 =
+            insertValue(variableId = tableVariableId, listPosition = 2, citation = "Table citation")
+        val valueId0 = insertValue(variableId = columnVariableId, textValue = "First")
+        val valueId1 = insertValue(variableId = columnVariableId, textValue = "Second")
+        val valueId2 = insertValue(variableId = columnVariableId, textValue = "Third")
+        insertValueTableRow(valueId0, rowId0)
+        insertValueTableRow(valueId1, rowId1)
+        insertValueTableRow(valueId2, rowId2)
+
+        val payload =
+            """
+            {
+              "operations": [
+                {
+                  "operation": "Delete",
+                  "valueId": $rowId0
+                }
+              ]
+            }
+          """
+                .trimIndent()
+
+        mockMvc.post(path()) { content = payload }.andExpect { status { isOk() } }
+
+        // Each of the remaining two rows gets a new value ID to hold its updated list position.
+        val newIdForRow1 = valueId2.value + 1
+        val newIdForRow2 = newIdForRow1 + 1
+
+        // There'll be one new value for the deleted row, and one new value for the deleted cell
+        // value, so the next value will be one more than that.
+        val nextValueId = newIdForRow2 + 3
+
+        mockMvc
+            .get(path())
+            .andExpectJson(
+                """
+                {
+                  "nextValueId": $nextValueId,
+                  "values": [
+                    {
+                      "variableId": $tableVariableId,
+                      "values": [
+                        {
+                          "id": $newIdForRow1,
+                          "listPosition": 0,
+                          "type": "Table"
+                        },
+                        {
+                          "id": $newIdForRow2,
+                          "listPosition": 1,
+                          "type": "Table",
+                          "citation": "Table citation"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $columnVariableId,
+                      "rowValueId": $newIdForRow1,
+                      "values": [
+                        {
+                          "id": $valueId1,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Second"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $columnVariableId,
+                      "rowValueId": $newIdForRow2,
+                      "values": [
+                        {
+                          "id": $valueId2,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Third"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                    .trimIndent(),
+                strict = true)
+      }
     }
   }
 }


### PR DESCRIPTION
To support variable values that aren't associated with documents, add versions of
the variable value endpoints that take a project ID rather than a document ID in
the URL path. The existing document-based endpoints continue to work as before;
once the web app has been updated to move to the project-based ones, we can remove
the document-based versions.