### PR TITLE
Ignore Kotlin compiler temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ openapi.yaml
 .DS_Store
 .run
 docker/volumes
+
+# Kotlin compiler temporary files
+.kotlin


### PR DESCRIPTION
The Kotlin compiler creates a `.kotlin` directory to store temporary files. Add it
to `.gitignore` so it doesn't get committed if you happen to create a commit in
the middle of a build.