### PR TITLE
Add deliverable_position to variables and calculate on import

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -228,6 +228,7 @@ class VariableStore(
 
         val base =
             BaseVariableProperties(
+                deliverablePosition = variablesRow.deliverablePosition,
                 description = variablesRow.description,
                 id = variableId,
                 isList = variablesRow.isList!!,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
@@ -56,20 +56,24 @@ data class AllVariableCsvVariable(
     /** Column 19/S - Internal Only */
     val internalOnly: Boolean,
 
-    /** Position in the sheet, recorded against the variable manifest entry */
-    val position: Int,
-    /** The path to the variable within the hierarchy */
-    var variablePath: String,
+    /** These are calculated during the import */
+    /** The position of this variable within the associated deliverable, if applicable * */
+    var deliverablePosition: Int?,
     /** The path to the parent variable within the hierarchy */
     var parentPath: String?,
-    /** The base variable ID */
-    var variableId: VariableId? = null,
+    /** Position in the sheet, recorded against the variable manifest entry */
+    val position: Int,
     /** If this variable replaces one from an earlier manifest, that variable's ID. */
     var replacesVariableId: VariableId? = null,
+    /** The base variable ID */
+    var variableId: VariableId? = null,
+    /** The path to the variable within the hierarchy */
+    var variablePath: String,
 ) {
   fun mapToVariablesRow() =
       VariablesRow(
           deliverableId = deliverableId,
+          deliverablePosition = deliverablePosition,
           deliverableQuestion = deliverableQuestion,
           dependencyVariableStableId = dependencyVariableStableId,
           dependencyConditionId = dependencyCondition,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
@@ -10,6 +10,7 @@ import java.io.InputStreamReader
 import java.math.BigDecimal
 
 class CsvVariableNormalizer {
+  private val deliverablePositions: MutableMap<DeliverableId?, Int> = mutableMapOf()
   private val variablePaths: MutableList<String> = mutableListOf()
 
   fun normalizeFromCsv(inputBytes: ByteArray): List<AllVariableCsvVariable> {
@@ -25,6 +26,8 @@ class CsvVariableNormalizer {
       // Sections are always lists.
       val isList = normalizeBoolean(values[VARIABLE_CSV_COLUMN_INDEX_IS_LIST])
 
+      val deliverableId =
+          values[VARIABLE_CSV_COLUMN_INDEX_DELIVERABLE_ID]?.let { DeliverableId(it) }
       val name = rawValues[VARIABLE_CSV_COLUMN_INDEX_NAME].trim()
       val parent = values[VARIABLE_CSV_COLUMN_INDEX_PARENT]?.trim()
 
@@ -50,8 +53,13 @@ class CsvVariableNormalizer {
               else VariableTableStyle.Horizontal,
           isHeader = normalizeBoolean(values[VARIABLE_CSV_COLUMN_INDEX_IS_HEADER]),
           notes = values[VARIABLE_CSV_COLUMN_INDEX_NOTES],
-          deliverableId =
-              values[VARIABLE_CSV_COLUMN_INDEX_DELIVERABLE_ID]?.let { DeliverableId(it) },
+          deliverableId = deliverableId,
+          deliverablePosition =
+              deliverableId?.let {
+                deliverablePositions.getOrDefault(it, 0).also { deliverablePosition ->
+                  deliverablePositions[it] = deliverablePosition + 1
+                }
+              },
           deliverableQuestion = values[VARIABLE_CSV_COLUMN_INDEX_DELIVERABLE_QUESTION],
           dependencyVariableStableId =
               values[VARIABLE_CSV_COLUMN_INDEX_DEPENDENCY_VARIABLE_STABLE_ID],

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
@@ -10,7 +10,7 @@ import java.io.InputStreamReader
 import java.math.BigDecimal
 
 class CsvVariableNormalizer {
-  private val deliverablePositions: MutableMap<DeliverableId?, Int> = mutableMapOf()
+  private val deliverablePositions: MutableMap<DeliverableId, Int> = mutableMapOf()
   private val variablePaths: MutableList<String> = mutableListOf()
 
   fun normalizeFromCsv(inputBytes: ByteArray): List<AllVariableCsvVariable> {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
@@ -402,6 +402,7 @@ class VariableImporter(
         variable: Variable
     ): Boolean {
       return csvVariable.description == variable.description &&
+          csvVariable.deliverablePosition == variable.deliverablePosition &&
           csvVariable.isList == variable.isList &&
           csvVariable.name == variable.name &&
           csvVariable.stableId == variable.stableId &&

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
@@ -26,6 +26,9 @@ import java.time.format.DateTimeParseException
  * implementations can delegate to [BaseVariableProperties] to cut down on needless repetition.
  */
 interface BaseVariable {
+  /** The position of this variable within its associated deliverable, if applicable * */
+  val deliverablePosition: Int?
+
   /** Optional description if the variable's name isn't sufficient. Can vary between manifests. */
   val description: String?
 
@@ -64,6 +67,7 @@ interface BaseVariable {
  * classes that implement [Variable].
  */
 data class BaseVariableProperties(
+    override val deliverablePosition: Int? = null,
     override val description: String? = null,
     override val id: VariableId,
     override val isList: Boolean = false,

--- a/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
+++ b/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
@@ -43,8 +43,8 @@ CREATE TABLE docprod.variables (
     -- Compound unique key so child tables can constrain themselves to variables of the correct type.
     UNIQUE (id, variable_type_id),
 
-    -- Make sure that if a deliverable_id is supplied, a position is also supplied
-    CHECK (deliverable_id is null OR (deliverable_id is not null AND deliverable_position is not null))
+    -- Make sure that both deliverable_id and deliverable_position exist or don't exist
+    CHECK ((deliverable_id IS NULL) = (deliverable_position IS NULL))
 );
 
 CREATE TABLE docprod.variable_manifests (

--- a/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
+++ b/src/main/resources/db/migration/0250/V282__DocumentProducerTables.sql
@@ -31,6 +31,7 @@ CREATE TABLE docprod.variables (
     description TEXT,
     deliverable_id BIGINT REFERENCES accelerator.deliverables ON DELETE SET NULL,
     deliverable_question TEXT,
+    deliverable_position INTEGER,
     dependency_variable_stable_id TEXT,
     dependency_condition_id INTEGER REFERENCES docprod.dependency_conditions,
     dependency_value TEXT,
@@ -40,7 +41,10 @@ CREATE TABLE docprod.variables (
         UNIQUE (replaces_variable_id),
 
     -- Compound unique key so child tables can constrain themselves to variables of the correct type.
-    UNIQUE (id, variable_type_id)
+    UNIQUE (id, variable_type_id),
+
+    -- Make sure that if a deliverable_id is supplied, a position is also supplied
+    CHECK (deliverable_id is null OR (deliverable_id is not null AND deliverable_position is not null))
 );
 
 CREATE TABLE docprod.variable_manifests (


### PR DESCRIPTION
- Add `deliverable_position` column to `variables` table to determine position of a question within a deliverable
- Adds a check to ensure position is supplied when the deliverable ID is supplied
- Calculates the position during import