### PR TITLE
Fix IntelliJ warnings in DatabaseBackedTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -40,8 +40,8 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
 
     insertDevice(otherDeviceId)
 
-    insertAutomation(1, deviceId = deviceId, objectMapper = objectMapper)
-    insertAutomation(2, deviceId = otherDeviceId, objectMapper = objectMapper)
+    insertAutomation(1, deviceId = deviceId)
+    insertAutomation(2, deviceId = otherDeviceId)
 
     val expectedRow = automationsDao.fetchOneById(AutomationId(1))!!
     val expected = listOf(AutomationModel(expectedRow, objectMapper))


### PR DESCRIPTION
IntelliJ flagged a number of minor problems with DatabaseBackedTest. Fix them:

* A reference to an unresolved class in a KDoc block
* Protected methods/properties that are intended to be usable by test classes but
  aren't currently used by any and thus showed up as "could be private"
* Unnecessary `final` modifiers
* `dslContext` is autowired but IntelliJ can't tell which Spring context it's from
* Unused method parameters
* Spelling / usage errors