### PR TITLE
Add permissions for internal workflow details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -311,6 +311,8 @@ data class DeviceManagerUser(
 
   override fun canReadInternalTags(): Boolean = false
 
+  override fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = false
+
   override fun canReadModule(moduleId: ModuleId): Boolean = false
 
   override fun canReadModuleDetails(moduleId: ModuleId): Boolean = false
@@ -353,8 +355,6 @@ data class DeviceManagerUser(
   override fun canReadProjectModules(projectId: ProjectId): Boolean = false
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = false
-
-  override fun canReadProjectVariableOwners(projectId: ProjectId): Boolean = false
 
   override fun canReadProjectVotes(projectId: ProjectId): Boolean = false
 
@@ -422,6 +422,8 @@ data class DeviceManagerUser(
 
   override fun canUpdateGlobalRoles(): Boolean = false
 
+  override fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = false
+
   override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = false
 
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = false
@@ -451,8 +453,6 @@ data class DeviceManagerUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = false
-
-  override fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -385,6 +385,8 @@ data class IndividualUser(
 
   override fun canReadGlobalRoles() = isAcceleratorAdmin()
 
+  override fun canReadInternalVariableWorkflowDetails(projectId: ProjectId) = isReadOnlyOrHigher()
+
   override fun canReadModule(moduleId: ModuleId): Boolean {
     return parentStore.exists(moduleId, userId) || isReadOnlyOrHigher()
   }
@@ -460,8 +462,6 @@ data class IndividualUser(
   }
 
   override fun canReadProjectScores(projectId: ProjectId) = isReadOnlyOrHigher()
-
-  override fun canReadProjectVariableOwners(projectId: ProjectId) = isReadOnlyOrHigher()
 
   override fun canReadProjectVotes(projectId: ProjectId) = isReadOnlyOrHigher()
 
@@ -577,6 +577,8 @@ data class IndividualUser(
         }
       }
 
+  override fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId) = isTFExpertOrHigher()
+
   override fun canUpdateNotification(notificationId: NotificationId) =
       canReadNotification(notificationId)
 
@@ -615,8 +617,6 @@ data class IndividualUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId) = isAcceleratorAdmin()
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = isTFExpertOrHigher()
-
-  override fun canUpdateProjectVariableOwners(projectId: ProjectId) = isTFExpertOrHigher()
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = isTFExpertOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -798,10 +798,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun readProjectVariableOwners(projectId: ProjectId) {
-    if (!user.canReadProjectVariableOwners(projectId)) {
+  fun readInternalVariableWorkflowDetails(projectId: ProjectId) {
+    if (!user.canReadInternalVariableWorkflowDetails(projectId)) {
       readProject(projectId)
-      throw AccessDeniedException("No permission to read variable owners for project $projectId")
+      throw AccessDeniedException(
+          "No permission to read variable workflow details for project $projectId")
     }
   }
 
@@ -1148,10 +1149,11 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun updateProjectVariableOwners(projectId: ProjectId) {
-    if (!user.canUpdateProjectVariableOwners(projectId)) {
+  fun updateInternalVariableWorkflowDetails(projectId: ProjectId) {
+    if (!user.canUpdateInternalVariableWorkflowDetails(projectId)) {
       readProject(projectId)
-      throw AccessDeniedException("No permission to update variable owners for project $projectId")
+      throw AccessDeniedException(
+          "No permission to update variable workflow details for project $projectId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -309,6 +309,8 @@ class SystemUser(
 
   override fun canReadInternalTags(): Boolean = true
 
+  override fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = true
+
   override fun canReadModule(moduleId: ModuleId): Boolean = true
 
   override fun canReadModuleDetails(moduleId: ModuleId): Boolean = true
@@ -353,8 +355,6 @@ class SystemUser(
   override fun canReadProjectModules(projectId: ProjectId): Boolean = true
 
   override fun canReadProjectScores(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectVariableOwners(projectId: ProjectId): Boolean = true
 
   override fun canReadProjectVotes(projectId: ProjectId): Boolean = true
 
@@ -432,6 +432,8 @@ class SystemUser(
 
   override fun canUpdateGlobalRoles(): Boolean = true
 
+  override fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = true
+
   override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = true
 
   override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
@@ -461,8 +463,6 @@ class SystemUser(
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
 
   override fun canUpdateProjectScores(projectId: ProjectId): Boolean = true
-
-  override fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean = true
 
   override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = true
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -263,6 +263,8 @@ interface TerrawareUser : Principal {
 
   fun canReadInternalTags(): Boolean
 
+  fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean
+
   fun canReadModule(moduleId: ModuleId): Boolean
 
   fun canReadModuleDetails(moduleId: ModuleId): Boolean
@@ -306,8 +308,6 @@ interface TerrawareUser : Principal {
   fun canReadProjectModules(projectId: ProjectId): Boolean
 
   fun canReadProjectScores(projectId: ProjectId): Boolean
-
-  fun canReadProjectVariableOwners(projectId: ProjectId): Boolean
 
   fun canReadProjectVotes(projectId: ProjectId): Boolean
 
@@ -383,6 +383,8 @@ interface TerrawareUser : Principal {
 
   fun canUpdateGlobalRoles(): Boolean
 
+  fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean
+
   fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean
 
   fun canUpdateNotification(notificationId: NotificationId): Boolean
@@ -412,8 +414,6 @@ interface TerrawareUser : Principal {
   fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean
 
   fun canUpdateProjectScores(projectId: ProjectId): Boolean
-
-  fun canUpdateProjectVariableOwners(projectId: ProjectId): Boolean
 
   fun canUpdateProjectVotes(projectId: ProjectId): Boolean
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableOwnerStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableOwnerStore.kt
@@ -19,7 +19,7 @@ class VariableOwnerStore(
     private val dslContext: DSLContext,
 ) {
   fun listOwners(projectId: ProjectId): Map<VariableId, UserId> {
-    requirePermissions { readProjectVariableOwners(projectId) }
+    requirePermissions { readInternalVariableWorkflowDetails(projectId) }
 
     return with(VARIABLE_OWNERS) {
       dslContext
@@ -31,7 +31,7 @@ class VariableOwnerStore(
   }
 
   fun updateOwner(projectId: ProjectId, variableId: VariableId, ownedBy: UserId?) {
-    requirePermissions { updateProjectVariableOwners(projectId) }
+    requirePermissions { updateInternalVariableWorkflowDetails(projectId) }
 
     if (!dslContext.fetchExists(PROJECTS, PROJECTS.ID.eq(projectId))) {
       throw ProjectNotFoundException(projectId)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -594,6 +594,21 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun readInternalTags() = allow { readInternalTags() } ifUser { canReadInternalTags() }
 
+  @Test
+  fun readInternalVariableWorkflowDetails() {
+    assertThrows<ProjectNotFoundException> {
+      requirements.readInternalVariableWorkflowDetails(projectId)
+    }
+
+    grant { user.canReadProject(projectId) }
+    assertThrows<AccessDeniedException> {
+      requirements.readInternalVariableWorkflowDetails(projectId)
+    }
+
+    grant { user.canReadInternalVariableWorkflowDetails(projectId) }
+    requirements.readInternalVariableWorkflowDetails(projectId)
+  }
+
   @Test fun readModule() = testRead { readModule(moduleId) }
 
   @Test
@@ -703,17 +718,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
     grant { user.canReadProjectScores(projectId) }
     requirements.readProjectScores(projectId)
-  }
-
-  @Test
-  fun readProjectVariableOwners() {
-    assertThrows<ProjectNotFoundException> { requirements.readProjectVariableOwners(projectId) }
-
-    grant { user.canReadProject(projectId) }
-    assertThrows<AccessDeniedException> { requirements.readProjectVariableOwners(projectId) }
-
-    grant { user.canReadProjectVariableOwners(projectId) }
-    requirements.readProjectVariableOwners(projectId)
   }
 
   @Test fun readReport() = testRead { readReport(reportId) }
@@ -844,6 +848,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun updateGlobalRoles() = allow { updateGlobalRoles() } ifUser { canUpdateGlobalRoles() }
 
   @Test
+  fun updateInternalVariableWorkflowDetails() =
+      allow { updateInternalVariableWorkflowDetails(projectId) } ifUser
+          {
+            canUpdateInternalVariableWorkflowDetails(projectId)
+          }
+
+  @Test
   fun updateNotification() =
       allow { updateNotification(notificationId) } ifUser { canUpdateNotification(notificationId) }
 
@@ -908,13 +919,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateProjectScores() =
       allow { updateProjectScores(projectId) } ifUser { canUpdateProjectScores(projectId) }
-
-  @Test
-  fun updateProjectVariableOwners() =
-      allow { updateProjectVariableOwners(projectId) } ifUser
-          {
-            canUpdateProjectVariableOwners(projectId)
-          }
 
   @Test
   fun updateProjectVotes() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1444,18 +1444,18 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
     )
 
@@ -1555,19 +1555,19 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1588,18 +1588,18 @@ internal class PermissionTest : DatabaseTest() {
         createParticipantProjectSpecies = true,
         createSubmission = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
         updateDefaultVoters = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1737,18 +1737,18 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1771,15 +1771,15 @@ internal class PermissionTest : DatabaseTest() {
         createParticipantProjectSpecies = true,
         createSubmission = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1915,17 +1915,17 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -1941,16 +1941,16 @@ internal class PermissionTest : DatabaseTest() {
         ProjectId(4000),
         createParticipantProjectSpecies = true,
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
+        updateInternalVariableWorkflowDetails = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
-        updateProjectVariableOwners = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
     )
@@ -2090,12 +2090,12 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *projectIds.forOrg1(),
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
     )
 
@@ -2103,12 +2103,12 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(4000),
         readDefaultVoters = true,
+        readInternalVariableWorkflowDetails = true,
         readProject = true,
         readProjectAcceleratorDetails = true,
         readProjectDeliverables = true,
         readProjectModules = true,
         readProjectScores = true,
-        readProjectVariableOwners = true,
         readProjectVotes = true,
     )
 
@@ -2934,19 +2934,19 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission: Boolean = false,
         deleteProject: Boolean = false,
         readDefaultVoters: Boolean = false,
+        readInternalVariableWorkflowDetails: Boolean = false,
         readProject: Boolean = false,
         readProjectAcceleratorDetails: Boolean = false,
         readProjectDeliverables: Boolean = false,
         readProjectModules: Boolean = false,
         readProjectScores: Boolean = false,
-        readProjectVariableOwners: Boolean = false,
         readProjectVotes: Boolean = false,
         updateDefaultVoters: Boolean = false,
+        updateInternalVariableWorkflowDetails: Boolean = false,
         updateProject: Boolean = false,
         updateProjectAcceleratorDetails: Boolean = false,
         updateProjectDocumentSettings: Boolean = false,
         updateProjectScores: Boolean = false,
-        updateProjectVariableOwners: Boolean = false,
         updateProjectVotes: Boolean = false,
         updateSubmissionStatus: Boolean = false,
     ) {
@@ -2963,6 +2963,10 @@ internal class PermissionTest : DatabaseTest() {
             deleteProject, user.canDeleteProject(projectId), "Can delete project $projectId")
         assertEquals(readDefaultVoters, user.canReadDefaultVoters(), "Can read default voters")
         assertEquals(
+            readInternalVariableWorkflowDetails,
+            user.canReadInternalVariableWorkflowDetails(projectId),
+            "Can read variable owners for project $projectId")
+        assertEquals(
             readProjectModules, user.canReadProjectModules(projectId), "Can read project modules")
         assertEquals(readProject, user.canReadProject(projectId), "Can read project $projectId")
         assertEquals(
@@ -2978,15 +2982,15 @@ internal class PermissionTest : DatabaseTest() {
             user.canReadProjectScores(projectId),
             "Can read scores for project $projectId")
         assertEquals(
-            readProjectVariableOwners,
-            user.canReadProjectVariableOwners(projectId),
-            "Can read variable owners for project $projectId")
-        assertEquals(
             readProjectVotes,
             user.canReadProjectVotes(projectId),
             "Can read votes for project $projectId")
         assertEquals(
             updateDefaultVoters, user.canUpdateDefaultVoters(), "Can update default voters")
+        assertEquals(
+            updateInternalVariableWorkflowDetails,
+            user.canUpdateInternalVariableWorkflowDetails(projectId),
+            "Can update variable owners for project $projectId")
         assertEquals(
             updateProject, user.canUpdateProject(projectId), "Can update project $projectId")
         assertEquals(
@@ -3001,10 +3005,6 @@ internal class PermissionTest : DatabaseTest() {
             updateProjectScores,
             user.canUpdateProjectScores(projectId),
             "Can update scores for project $projectId")
-        assertEquals(
-            updateProjectVariableOwners,
-            user.canUpdateProjectVariableOwners(projectId),
-            "Can update variable owners for project $projectId")
         assertEquals(
             updateProjectVotes,
             user.canUpdateProjectVotes(projectId),


### PR DESCRIPTION
Variable owners are just one of the internal-use-only workflow-related details
of a variable in a project. Replace the read and update permission on project
variable owners with a broader permission for internal-only project variable
details.

No difference in behavior here; upcoming changes will use the new permissions
in other contexts.