### PR TITLE
SW-5499 Return workflow details with variable values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.docprod.VariableInjectionDisplayStyle
 import com.terraformation.backend.db.docprod.VariableSelectOptionId
 import com.terraformation.backend.db.docprod.VariableUsageType
 import com.terraformation.backend.db.docprod.VariableValueId
+import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.model.DateValue
 import com.terraformation.backend.documentproducer.model.DeletedValue
 import com.terraformation.backend.documentproducer.model.ExistingDateValue
@@ -275,6 +276,16 @@ data class ExistingVariableValuesPayload(
     val variableId: VariableId,
     @Schema(description = "If this is the value of a table cell, the ID of the row it's part of.")
     val rowValueId: VariableValueId? = null,
+    @Schema(
+        description = "User-visible feedback from reviewer. Not populated for table cell values.")
+    val feedback: String?,
+    @Schema(
+        description =
+            "Internal comment from reviewer. Only populated if the current user has permission " +
+                "to read internal comments. Not populated for table cell values.")
+    val internalComment: String?,
+    @Schema(description = "Current status of this variable. Not populated for table cell values.")
+    val status: VariableWorkflowStatus?,
     @Schema(
         description =
             "Values of this variable or this table cell. When getting the full set of values for " +

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.documentproducer.VariableValueService
 import com.terraformation.backend.documentproducer.db.DocumentStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
-import com.terraformation.backend.log.perClassLogger
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -126,22 +125,17 @@ class ValuesController(
       @PathVariable projectId: ProjectId,
       @RequestBody payload: UpdateVariableValuesRequestPayload
   ): SimpleSuccessResponsePayload {
-    try {
-      val existingValueIds = payload.operations.mapNotNull { it.getExistingValueId() }
-      val existingBases = variableValueStore.fetchBaseProperties(existingValueIds)
-      val operations =
-          payload.operations.map { operationPayload ->
-            val base = operationPayload.getExistingValueId()?.let { existingBases[it] }
-            operationPayload.toOperationModel(projectId, base)
-          }
+    val existingValueIds = payload.operations.mapNotNull { it.getExistingValueId() }
+    val existingBases = variableValueStore.fetchBaseProperties(existingValueIds)
+    val operations =
+        payload.operations.map { operationPayload ->
+          val base = operationPayload.getExistingValueId()?.let { existingBases[it] }
+          operationPayload.toOperationModel(projectId, base)
+        }
 
-      variableValueService.validate(operations)
+    variableValueService.validate(operations)
 
-      variableValueStore.updateValues(operations)
-    } catch (e: Exception) {
-      perClassLogger().error("Failed", e)
-      throw e
-    }
+    variableValueStore.updateValues(operations)
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
@@ -1,0 +1,62 @@
+package com.terraformation.backend.documentproducer.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_WORKFLOW_HISTORY
+import com.terraformation.backend.documentproducer.model.ExistingVariableWorkflowHistoryModel
+import jakarta.inject.Named
+import org.jooq.Condition
+import org.jooq.DSLContext
+
+@Named
+class VariableWorkflowStore(
+    private val dslContext: DSLContext,
+) {
+  /**
+   * Returns the current workflow information for the variables in a project. Internal comment is
+   * only populated if the current user has permission to read it.
+   */
+  fun fetchCurrentForProject(
+      projectId: ProjectId
+  ): Map<VariableId, ExistingVariableWorkflowHistoryModel> {
+    requirePermissions { readProject(projectId) }
+
+    return fetchCurrentByCondition(VARIABLE_WORKFLOW_HISTORY.PROJECT_ID.eq(projectId)).associateBy {
+      it.variableId
+    }
+  }
+
+  private fun fetchCurrentByCondition(
+      condition: Condition
+  ): List<ExistingVariableWorkflowHistoryModel> {
+    return with(VARIABLE_WORKFLOW_HISTORY) {
+      dslContext
+          .select(
+              CREATED_BY,
+              CREATED_TIME,
+              FEEDBACK,
+              ID,
+              INTERNAL_COMMENT,
+              MAX_VARIABLE_VALUE_ID,
+              PROJECT_ID,
+              VARIABLE_ID,
+              VARIABLE_WORKFLOW_STATUS_ID,
+          )
+          .distinctOn(PROJECT_ID, VARIABLE_ID)
+          .from(VARIABLE_WORKFLOW_HISTORY)
+          .where(condition)
+          .orderBy(PROJECT_ID, VARIABLE_ID, ID.desc())
+          .fetch { record ->
+            val model = ExistingVariableWorkflowHistoryModel(record)
+
+            if (currentUser().canReadInternalVariableWorkflowDetails(model.projectId)) {
+              model
+            } else {
+              model.copy(internalComment = null)
+            }
+          }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingVariableWorkflowHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingVariableWorkflowHistoryModel.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.documentproducer.model
+
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.VariableValueId
+import com.terraformation.backend.db.docprod.VariableWorkflowHistoryId
+import com.terraformation.backend.db.docprod.VariableWorkflowStatus
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_WORKFLOW_HISTORY
+import java.time.Instant
+import org.jooq.Record
+
+data class ExistingVariableWorkflowHistoryModel(
+    val createdBy: UserId,
+    val createdTime: Instant,
+    val feedback: String?,
+    val id: VariableWorkflowHistoryId,
+    val internalComment: String?,
+    val maxVariableValueId: VariableValueId,
+    val projectId: ProjectId,
+    val status: VariableWorkflowStatus,
+    val variableId: VariableId,
+) {
+  constructor(
+      record: Record
+  ) : this(
+      createdBy = record[VARIABLE_WORKFLOW_HISTORY.CREATED_BY]!!,
+      createdTime = record[VARIABLE_WORKFLOW_HISTORY.CREATED_TIME]!!,
+      feedback = record[VARIABLE_WORKFLOW_HISTORY.FEEDBACK],
+      id = record[VARIABLE_WORKFLOW_HISTORY.ID]!!,
+      internalComment = record[VARIABLE_WORKFLOW_HISTORY.INTERNAL_COMMENT],
+      maxVariableValueId = record[VARIABLE_WORKFLOW_HISTORY.MAX_VARIABLE_VALUE_ID]!!,
+      projectId = record[VARIABLE_WORKFLOW_HISTORY.PROJECT_ID]!!,
+      status = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_WORKFLOW_STATUS_ID]!!,
+      variableId = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_ID]!!,
+  )
+}


### PR DESCRIPTION
Return the current workflow details for variables as part of the "list values"
response. Internal comments are only returned if the user has permission to see
them (that is, if they have an appropriate global role).

In addition to the new payload fields, there is a behavior change here: the list
of values for a variable can be empty if the variable has workflow details in the
project but doesn't have any values yet. Previously, the values list for a
variable was guaranteed to be non-empty.