### PR TITLE
SW-5498 Add function to VariableStore for fetching variable IDs for a given deliverable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.db
 
+import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableManifestId
@@ -76,6 +77,13 @@ class VariableStore(
    * list.
    */
   private val replacements = ConcurrentHashMap<VariableId, List<VariableId>>()
+
+  fun fetchDeliverableVariableIds(deliverableId: DeliverableId): List<VariableId> =
+      dslContext
+          .select(VARIABLES.ID)
+          .from(VARIABLES)
+          .where(VARIABLES.DELIVERABLE_ID.eq(deliverableId))
+          .fetch(VARIABLES.ID.asNonNullable())
 
   /**
    * Returns information about a variable. Eagerly fetches other variables that are related to the

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -41,7 +41,7 @@
 
 <h2>Import All Variable CSV</h2>
 
-<form method="POST" action="/admin/document-producer/uploadVariables" enctype="multipart/form-data">
+<form method="POST" action="/admin/document-producer/uploadAllVariables" enctype="multipart/form-data">
     <label for="uploadManifestCsv">CSV</label>
     <input type="file" id="uploadAllVariableCsv" name="file" minlength="1"/>
     <br>

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2833,6 +2833,8 @@ abstract class DatabaseBackedTest {
   private var nextVariableNumber = 1
 
   protected fun insertVariable(
+      deliverableId: Any? = null,
+      deliverablePosition: Int? = null,
       description: String? = null,
       id: Any? = null,
       isList: Boolean = false,
@@ -2845,6 +2847,8 @@ abstract class DatabaseBackedTest {
 
     val row =
         VariablesRow(
+            deliverableId = deliverableId?.toIdWrapper { DeliverableId(it) },
+            deliverablePosition = deliverablePosition,
             description = description,
             id = id?.toIdWrapper { VariableId(it) },
             isList = isList,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -134,4 +134,33 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
       }
     }
   }
+
+  @Nested
+  inner class FetchDeliverableVariableIds {
+    @Test
+    fun `fetches the variable IDs associated to a particular deliverable`() {
+      insertModule()
+      val deliverableId1 = insertDeliverable()
+      val deliverableId2 = insertDeliverable()
+
+      val variableId1 =
+          insertNumberVariable(
+              insertVariable(
+                  type = VariableType.Number,
+                  deliverableId = deliverableId1,
+                  deliverablePosition = 0))
+      val variableId2 =
+          insertNumberVariable(
+              insertVariable(
+                  type = VariableType.Number,
+                  deliverableId = deliverableId1,
+                  deliverablePosition = 1))
+      insertNumberVariable(
+          insertVariable(
+              type = VariableType.Number, deliverableId = deliverableId2, deliverablePosition = 0))
+
+      assertEquals(
+          listOf(variableId1, variableId2), store.fetchDeliverableVariableIds(deliverableId1))
+    }
+  }
 }


### PR DESCRIPTION
We already have APIs available for fetching values. Instead of rewriting that to accept deliverable ID, and couple those two areas more than needed, we will simply fetch the variable IDs for a deliverable and (in a later PR) use those variable IDs to explicitly fetch the values for a given project.