### PR TITLE
SW-5559 Permissions for user deliverable categories

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -372,6 +372,8 @@ data class DeviceManagerUser(
 
   override fun canReadUpload(uploadId: UploadId): Boolean = false
 
+  override fun canReadUserDeliverableCategories(userId: UserId): Boolean = false
+
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = false
 
   override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = false
@@ -470,6 +472,8 @@ data class DeviceManagerUser(
   override fun canUpdateTerraformationContact(organizationId: OrganizationId): Boolean = false
 
   override fun canUpdateUpload(uploadId: UploadId): Boolean = false
+
+  override fun canUpdateUserDeliverableCategories(userId: UserId): Boolean = false
 
   override fun canUploadPhoto(accessionId: AccessionId): Boolean = false
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -487,6 +487,8 @@ data class IndividualUser(
 
   override fun canReadUser(userId: UserId) = isAcceleratorAdmin()
 
+  override fun canReadUserDeliverableCategories(userId: UserId) = isAcceleratorAdmin()
+
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId) =
       isMember(parentStore.getFacilityId(viabilityTestId))
 
@@ -638,6 +640,8 @@ data class IndividualUser(
       isAdminOrHigher(parentStore.getFacilityId(deviceId))
 
   override fun canUpdateUpload(uploadId: UploadId) = canReadUpload(uploadId)
+
+  override fun canUpdateUserDeliverableCategories(userId: UserId) = isAcceleratorAdmin()
 
   override fun canUploadPhoto(accessionId: AccessionId) = canReadAccession(accessionId)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -861,6 +861,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readUserDeliverableCategories(userId: UserId) {
+    if (!user.canReadUserDeliverableCategories(userId)) {
+      readUser(userId)
+      throw AccessDeniedException("No permission to read deliverable categories for user $userId")
+    }
+  }
+
   fun readViabilityTest(viabilityTestId: ViabilityTestId) {
     if (!user.canReadViabilityTest(viabilityTestId)) {
       throw ViabilityTestNotFoundException(viabilityTestId)
@@ -1216,6 +1223,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateUpload(uploadId)) {
       readUpload(uploadId)
       throw AccessDeniedException("No permission to update upload")
+    }
+  }
+
+  fun updateUserDeliverableCategories(userId: UserId) {
+    if (!user.canUpdateUserDeliverableCategories(userId)) {
+      readUser(userId)
+      throw AccessDeniedException("No permission to update deliverable categories for user $userId")
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -374,6 +374,8 @@ class SystemUser(
 
   override fun canReadUser(userId: UserId): Boolean = true
 
+  override fun canReadUserDeliverableCategories(userId: UserId): Boolean = true
+
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = true
 
   override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = true
@@ -482,6 +484,8 @@ class SystemUser(
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true
 
   override fun canUpdateUpload(uploadId: UploadId): Boolean = true
+
+  override fun canUpdateUserDeliverableCategories(userId: UserId): Boolean = true
 
   override fun canUploadPhoto(accessionId: AccessionId): Boolean = true
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -327,6 +327,8 @@ interface TerrawareUser : Principal {
 
   fun canReadUser(userId: UserId): Boolean
 
+  fun canReadUserDeliverableCategories(userId: UserId): Boolean
+
   fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean
 
   fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean
@@ -430,6 +432,8 @@ interface TerrawareUser : Principal {
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean
 
   fun canUpdateUpload(uploadId: UploadId): Boolean
+
+  fun canUpdateUserDeliverableCategories(userId: UserId): Boolean
 
   fun canUploadPhoto(accessionId: AccessionId): Boolean
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -730,6 +730,17 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun readUser() = testRead { readUser(otherUserId) }
 
+  @Test
+  fun readUserDeliverableCategories() {
+    assertThrows<UserNotFoundException> { requirements.readUserDeliverableCategories(otherUserId) }
+
+    grant { user.canReadUser(otherUserId) }
+    assertThrows<AccessDeniedException> { requirements.readUserDeliverableCategories(otherUserId) }
+
+    grant { user.canReadUserDeliverableCategories(otherUserId) }
+    requirements.readUserDeliverableCategories(otherUserId)
+  }
+
   @Test fun readUpload() = testRead { readUpload(uploadId) }
 
   @Test fun readViabilityTest() = testRead { readViabilityTest(viabilityTestId) }
@@ -956,6 +967,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
+
+  @Test
+  fun updateUserDeliverableCategories() =
+      allow { updateUserDeliverableCategories(otherUserId) } ifUser
+          {
+            canUpdateUserDeliverableCategories(otherUserId)
+          }
 
   @Test
   fun uploadAccessionPhoto() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1472,6 +1472,8 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
         readUser = true,
+        readUserDeliverableCategories = true,
+        updateUserDeliverableCategories = true,
     )
 
     permissions.andNothingElse()
@@ -1629,6 +1631,8 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
         readUser = true,
+        readUserDeliverableCategories = true,
+        updateUserDeliverableCategories = true,
     )
 
     permissions.expect(
@@ -1809,6 +1813,8 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
         readUser = true,
+        readUserDeliverableCategories = true,
+        updateUserDeliverableCategories = true,
     )
 
     permissions.expect(
@@ -3104,9 +3110,19 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg userIds: UserId,
         readUser: Boolean = false,
+        readUserDeliverableCategories: Boolean = false,
+        updateUserDeliverableCategories: Boolean = false,
     ) {
       userIds.forEach { userId ->
         assertEquals(readUser, user.canReadUser(userId), "Can read user $userId")
+        assertEquals(
+            readUserDeliverableCategories,
+            user.canReadUserDeliverableCategories(userId),
+            "Can read deliverable categories for user $userId")
+        assertEquals(
+            updateUserDeliverableCategories,
+            user.canUpdateUserDeliverableCategories(userId),
+            "Can update deliverable categories for user $userId")
 
         uncheckedUsers.remove(userId)
       }


### PR DESCRIPTION
In preparation for allowing deliverable categories to be assigned to accelerator
admins, add permissions for read and update operations on the categories.

Currently only accelerator admins and super admins can access them.