### PR TITLE
SW-5559 Add user deliverable categories to API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/GlobalRolesController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.api
 
+import com.terraformation.backend.accelerator.db.UserDeliverableCategoriesStore
 import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
@@ -7,6 +8,7 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.UserId
 import io.swagger.v3.oas.annotations.Operation
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 @RestController
 class GlobalRolesController(
+    private val userDeliverableCategoriesStore: UserDeliverableCategoriesStore,
     private val userStore: UserStore,
 ) {
   @ApiResponse200
@@ -30,7 +33,10 @@ class GlobalRolesController(
   @Operation(summary = "Gets the list of users that have global roles.")
   fun listGlobalRoles(): GlobalRoleUsersListResponsePayload =
       GlobalRoleUsersListResponsePayload(
-          userStore.fetchWithGlobalRoles().map { UserWithGlobalRolesPayload(it) })
+          userStore.fetchWithGlobalRoles().map { user ->
+            UserWithGlobalRolesPayload(
+                user, userDeliverableCategoriesStore.fetchForUser(user.userId))
+          })
 
   @ApiResponse200
   @ApiResponse404
@@ -60,6 +66,7 @@ class GlobalRolesController(
 
 data class UserWithGlobalRolesPayload(
     val createdTime: Instant,
+    val deliverableCategories: Set<DeliverableCategory>,
     val id: UserId,
     val email: String,
     val firstName: String?,
@@ -67,9 +74,11 @@ data class UserWithGlobalRolesPayload(
     val lastName: String?,
 ) {
   constructor(
-      user: IndividualUser
+      user: IndividualUser,
+      deliverableCategories: Set<DeliverableCategory>,
   ) : this(
       createdTime = user.createdTime,
+      deliverableCategories = deliverableCategories,
       id = user.userId,
       email = user.email,
       firstName = user.firstName,

--- a/src/main/kotlin/com/terraformation/backend/customer/api/UserDeliverableCategoriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UserDeliverableCategoriesController.kt
@@ -1,0 +1,62 @@
+package com.terraformation.backend.customer.api
+
+import com.terraformation.backend.accelerator.db.UserDeliverableCategoriesStore
+import com.terraformation.backend.api.AcceleratorEndpoint
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.default_schema.UserId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@AcceleratorEndpoint
+@RequestMapping("/api/v1/users/{userId}/deliverableCategories")
+@RestController
+class UserDeliverableCategoriesController(
+    private val userDeliverableCategoriesStore: UserDeliverableCategoriesStore,
+) {
+  @ApiResponse200
+  @GetMapping
+  @Operation(summary = "Get the list of deliverable categories assigned to a user.")
+  fun getUserDeliverableCategories(
+      @PathVariable userId: UserId
+  ): GetUserDeliverableCategoriesResponsePayload {
+    val categories = userDeliverableCategoriesStore.fetchForUser(userId)
+
+    return GetUserDeliverableCategoriesResponsePayload(categories)
+  }
+
+  @ApiResponse200
+  @Operation(summary = "Update which deliverable categories are assigned to a user.")
+  @PutMapping
+  fun updateUserDeliverableCategories(
+      @PathVariable userId: UserId,
+      @RequestBody payload: UpdateUserDeliverableCategoriesRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    userDeliverableCategoriesStore.updateForUser(userId, payload.deliverableCategories)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class GetUserDeliverableCategoriesResponsePayload(
+    val deliverableCategories: Set<DeliverableCategory>,
+) : SuccessResponsePayload
+
+data class UpdateUserDeliverableCategoriesRequestPayload(
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "New set of category assignments. Existing assignments that aren't included " +
+                        "here will be removed from the user."))
+    val deliverableCategories: Set<DeliverableCategory>,
+)


### PR DESCRIPTION
Add new endpoints to retrieve and update the list of deliverable categories that
are assigned to a user.

In addition, since deliverable categories will be shown in the same admin UIs that
show users' global roles, include them in the response payloads for user global
role data.