### PR TITLE
SW-5594 Reduce boilerplate when adding permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -2,43 +2,16 @@ package com.terraformation.backend.customer.model
 
 import com.terraformation.backend.auth.CurrentUserHolder
 import com.terraformation.backend.auth.currentUser
-import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.DeliverableId
-import com.terraformation.backend.db.accelerator.EventId
-import com.terraformation.backend.db.accelerator.ModuleId
-import com.terraformation.backend.db.accelerator.ParticipantId
-import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
-import com.terraformation.backend.db.accelerator.SubmissionDocumentId
-import com.terraformation.backend.db.accelerator.SubmissionId
-import com.terraformation.backend.db.default_schema.AutomationId
-import com.terraformation.backend.db.default_schema.DeviceId
-import com.terraformation.backend.db.default_schema.DeviceManagerId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.GlobalRole
-import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.SubLocationId
-import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
-import com.terraformation.backend.db.docprod.DocumentId
-import com.terraformation.backend.db.nursery.BatchId
-import com.terraformation.backend.db.nursery.WithdrawalId
-import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.ViabilityTestId
-import com.terraformation.backend.db.tracking.DeliveryId
-import com.terraformation.backend.db.tracking.DraftPlantingSiteId
-import com.terraformation.backend.db.tracking.MonitoringPlotId
-import com.terraformation.backend.db.tracking.ObservationId
-import com.terraformation.backend.db.tracking.PlantingId
-import com.terraformation.backend.db.tracking.PlantingSiteId
-import com.terraformation.backend.db.tracking.PlantingSubzoneId
-import com.terraformation.backend.db.tracking.PlantingZoneId
 import jakarta.inject.Named
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -115,6 +88,9 @@ class SystemUser(
   override val globalRoles: Set<GlobalRole>
     get() = emptySet()
 
+  override val defaultPermission: Boolean
+    get() = true
+
   override fun <T> run(func: () -> T): T {
     return CurrentUserHolder.runAs(this, func)
   }
@@ -124,138 +100,17 @@ class SystemUser(
   override fun getName(): String = USERNAME
 
   /*
-   * All permission checks always succeed except for operations that should only be performed
-   * manually by a system administrator.
+   * All permission checks always succeed (thanks to defaultPermission) except for operations that
+   * should only be performed manually by a system administrator.
    */
-
-  override fun canAddAnyOrganizationUser(): Boolean = true
-
-  override fun canAddCohortParticipant(cohortId: CohortId, participantId: ParticipantId): Boolean =
-      true
-
-  override fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = true
-
-  override fun canAddParticipantProject(
-      participantId: ParticipantId,
-      projectId: ProjectId
-  ): Boolean = true
-
-  override fun canAddTerraformationContact(organizationId: OrganizationId): Boolean = true
-
-  override fun canCountNotifications(): Boolean = true
-
-  override fun canCreateAccession(facilityId: FacilityId): Boolean = true
-
-  override fun canCreateApiKey(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateAutomation(facilityId: FacilityId): Boolean = true
-
-  override fun canCreateBatch(facilityId: FacilityId): Boolean = true
-
-  override fun canCreateCohort(): Boolean = true
-
-  override fun canCreateCohortModule(): Boolean = true
-
-  override fun canCreateDelivery(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canCreateDevice(facilityId: FacilityId): Boolean = true
-
-  override fun canCreateDeviceManager(): Boolean = true
-
-  override fun canCreateDocument(): Boolean = true
-
-  override fun canCreateDraftPlantingSite(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateFacility(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateNotification(
-      targetUserId: UserId,
-      organizationId: OrganizationId
-  ): Boolean = true
-
-  override fun canCreateObservation(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canCreateParticipant(): Boolean = true
-
-  override fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean = true
-
-  override fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateProject(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateReport(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateSavedVersion(documentId: DocumentId): Boolean = true
-
-  override fun canCreateSpecies(organizationId: OrganizationId): Boolean = true
-
-  override fun canCreateSubLocation(facilityId: FacilityId): Boolean = true
-
-  override fun canCreateSubmission(projectId: ProjectId): Boolean = true
-
-  override fun canCreateTimeseries(deviceId: DeviceId): Boolean = true
-
-  override fun canCreateVariableManifest(): Boolean = true
-
-  override fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = true
-
-  override fun canDeleteAccession(accessionId: AccessionId): Boolean = true
-
-  override fun canDeleteAutomation(automationId: AutomationId): Boolean = true
-
-  override fun canDeleteBatch(batchId: BatchId): Boolean = true
-
-  override fun canDeleteCohort(cohortId: CohortId): Boolean = true
-
-  override fun canDeleteCohortParticipant(
-      cohortId: CohortId,
-      participantId: ParticipantId
-  ): Boolean = true
-
-  override fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean = true
-
-  override fun canDeleteOrganization(organizationId: OrganizationId): Boolean = true
-
-  override fun canDeleteParticipant(participantId: ParticipantId): Boolean = true
-
-  override fun canDeleteParticipantProjectSpecies(
-      participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean = true
-
-  override fun canDeleteParticipantProject(
-      participantId: ParticipantId,
-      projectId: ProjectId
-  ): Boolean = true
-
-  override fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canDeleteProject(projectId: ProjectId): Boolean = true
 
   override fun canDeleteReport(reportId: ReportId): Boolean = false
 
   override fun canDeleteSelf(): Boolean = false
 
-  override fun canDeleteSpecies(speciesId: SpeciesId): Boolean = true
-
-  override fun canDeleteSubLocation(subLocationId: SubLocationId): Boolean = true
-
-  override fun canDeleteSupportIssue(): Boolean = true
-
-  override fun canDeleteUpload(uploadId: UploadId): Boolean = true
-
   override fun canDeleteUsers(): Boolean = false
 
   override fun canImportGlobalSpeciesData(): Boolean = false
-
-  override fun canListAutomations(facilityId: FacilityId): Boolean = true
-
-  override fun canListFacilities(organizationId: OrganizationId): Boolean = true
-
-  override fun canListNotifications(organizationId: OrganizationId?): Boolean = true
-
-  override fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = true
-
-  override fun canListReports(organizationId: OrganizationId): Boolean = true
 
   override fun canManageDeliverables(): Boolean = false
 
@@ -265,227 +120,14 @@ class SystemUser(
 
   override fun canManageModuleEvents(): Boolean = false
 
-  override fun canManageModuleEventStatuses() = true
-
   override fun canManageModules(): Boolean = false
-
-  override fun canManageNotifications(): Boolean = true
-
-  override fun canManageObservation(observationId: ObservationId): Boolean = true
-
-  override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canReadAccession(accessionId: AccessionId): Boolean = true
-
-  override fun canReadAllAcceleratorDetails(): Boolean = true
-
-  override fun canReadAllDeliverables(): Boolean = true
-
-  override fun canReadAutomation(automationId: AutomationId): Boolean = true
-
-  override fun canReadBatch(batchId: BatchId): Boolean = true
-
-  override fun canReadCohort(cohortId: CohortId): Boolean = true
-
-  override fun canReadCohortParticipants(cohortId: CohortId): Boolean = true
-
-  override fun canReadCohorts(): Boolean = true
-
-  override fun canReadDefaultVoters(): Boolean = true
-
-  override fun canReadDelivery(deliveryId: DeliveryId): Boolean = true
-
-  override fun canReadDevice(deviceId: DeviceId): Boolean = true
-
-  override fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
-
-  override fun canReadDocument(documentId: DocumentId): Boolean = true
-
-  override fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean = true
-
-  override fun canReadFacility(facilityId: FacilityId): Boolean = true
-
-  override fun canReadGlobalRoles(): Boolean = true
-
-  override fun canReadInternalTags(): Boolean = true
-
-  override fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = true
-
-  override fun canReadModule(moduleId: ModuleId): Boolean = true
-
-  override fun canReadModuleDetails(moduleId: ModuleId): Boolean = true
-
-  override fun canReadModuleEvent(eventId: EventId): Boolean = true
-
-  override fun canReadModuleEventParticipants(): Boolean = true
-
-  override fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean = true
-
-  override fun canReadNotification(notificationId: NotificationId): Boolean = true
-
-  override fun canReadObservation(observationId: ObservationId): Boolean = true
-
-  override fun canReadOrganization(organizationId: OrganizationId): Boolean = true
-
-  override fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean = true
-
-  override fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
-      true
-
-  override fun canReadParticipant(participantId: ParticipantId): Boolean = true
-
-  override fun canReadParticipantProjectSpecies(
-      participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean = true
-
-  override fun canReadPlanting(plantingId: PlantingId): Boolean = true
-
-  override fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = true
-
-  override fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
-
-  override fun canReadProject(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectAcceleratorDetails(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectDeliverables(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectModules(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectScores(projectId: ProjectId): Boolean = true
-
-  override fun canReadProjectVotes(projectId: ProjectId): Boolean = true
-
-  override fun canReadReport(reportId: ReportId): Boolean = true
-
-  override fun canReadSpecies(speciesId: SpeciesId): Boolean = true
-
-  override fun canReadSubLocation(subLocationId: SubLocationId): Boolean = true
-
-  override fun canReadSubmission(submissionId: SubmissionId): Boolean = true
-
-  override fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = true
-
-  override fun canReadTimeseries(deviceId: DeviceId): Boolean = true
-
-  override fun canReadUpload(uploadId: UploadId): Boolean = true
-
-  override fun canReadUser(userId: UserId): Boolean = true
-
-  override fun canReadUserDeliverableCategories(userId: UserId): Boolean = true
-
-  override fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = true
-
-  override fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = true
 
   override fun canRegenerateAllDeviceManagerTokens(): Boolean = false
 
-  override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
-      true
-
-  override fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = true
-
-  override fun canReplaceObservationPlot(observationId: ObservationId): Boolean = true
-
-  override fun canRescheduleObservation(observationId: ObservationId): Boolean = true
-
-  override fun canSendAlert(facilityId: FacilityId): Boolean = true
-
-  override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
-      true
-
-  override fun canSetTerraformationContact(organizationId: OrganizationId): Boolean = true
-
-  override fun canSetTestClock(): Boolean = true
-
-  override fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = true
-
-  override fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canTriggerAutomation(automationId: AutomationId): Boolean = true
-
-  override fun canUpdateAccession(accessionId: AccessionId): Boolean = true
-
-  override fun canUpdateAppVersions(): Boolean = true
-
-  override fun canUpdateAutomation(automationId: AutomationId): Boolean = true
-
-  override fun canUpdateBatch(batchId: BatchId): Boolean = true
-
-  override fun canUpdateCohort(cohortId: CohortId): Boolean = true
-
-  override fun canUpdateDefaultVoters(): Boolean = true
-
-  override fun canUpdateDelivery(deliveryId: DeliveryId): Boolean = true
-
-  override fun canUpdateDevice(deviceId: DeviceId): Boolean = true
-
-  override fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = true
-
-  override fun canUpdateDeviceTemplates(): Boolean = true
-
-  override fun canUpdateDocument(documentId: DocumentId): Boolean = true
-
-  override fun canUpdateDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean = true
-
-  override fun canUpdateFacility(facilityId: FacilityId): Boolean = true
-
-  override fun canUpdateGlobalRoles(): Boolean = true
-
-  override fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = true
-
-  override fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = true
-
-  override fun canUpdateNotification(notificationId: NotificationId): Boolean = true
-
-  override fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = true
-
-  override fun canUpdateObservation(observationId: ObservationId): Boolean = true
-
-  override fun canUpdateOrganization(organizationId: OrganizationId): Boolean = true
-
-  override fun canUpdateParticipant(participantId: ParticipantId): Boolean = true
-
-  override fun canUpdateParticipantProjectSpecies(
-      participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean = true
-
-  override fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = true
-
-  override fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = true
-
-  override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = true
-
-  override fun canUpdateProject(projectId: ProjectId): Boolean = true
-
-  override fun canUpdateProjectAcceleratorDetails(projectId: ProjectId): Boolean = true
-
   override fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = false
-
-  override fun canUpdateProjectScores(projectId: ProjectId): Boolean = true
-
-  override fun canUpdateProjectVotes(projectId: ProjectId): Boolean = true
-
-  override fun canUpdateReport(reportId: ReportId): Boolean = true
-
-  override fun canUpdateSpecies(speciesId: SpeciesId): Boolean = true
-
-  override fun canUpdateSubLocation(subLocationId: SubLocationId): Boolean = true
 
   override fun canUpdateSubmissionStatus(
       deliverableId: DeliverableId,
       projectId: ProjectId
   ): Boolean = false
-
-  override fun canUpdateTerraformationContact(organizationId: OrganizationId): Boolean = true
-
-  override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = true
-
-  override fun canUpdateUpload(uploadId: UploadId): Boolean = true
-
-  override fun canUpdateUserDeliverableCategories(userId: UserId): Boolean = true
-
-  override fun canUploadPhoto(accessionId: AccessionId): Boolean = true
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -91,351 +91,373 @@ interface TerrawareUser : Principal {
   /** Returns true if the user is an admin or owner of any organizations. */
   fun hasAnyAdminRole(): Boolean
 
+  /**
+   * Returns the default permission value for this user. This is to support the system and device
+   * manager user types, whose permissions are usually constant values with exceptions for specific
+   * operations.
+   */
+  val defaultPermission: Boolean
+    get() {
+      throw NotImplementedError("Permission logic not implemented")
+    }
+
   /*
    * Permission checks. Each of these returns true if the user has permission to perform the action.
    */
 
-  fun canAddAnyOrganizationUser(): Boolean
+  fun canAddAnyOrganizationUser(): Boolean = defaultPermission
 
-  fun canAddCohortParticipant(cohortId: CohortId, participantId: ParticipantId): Boolean
+  fun canAddCohortParticipant(cohortId: CohortId, participantId: ParticipantId): Boolean =
+      defaultPermission
 
-  fun canAddParticipantProject(participantId: ParticipantId, projectId: ProjectId): Boolean
+  fun canAddParticipantProject(participantId: ParticipantId, projectId: ProjectId): Boolean =
+      defaultPermission
 
-  fun canAddOrganizationUser(organizationId: OrganizationId): Boolean
+  fun canAddOrganizationUser(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canAddTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canAddTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCountNotifications(): Boolean
+  fun canCountNotifications(): Boolean = defaultPermission
 
-  fun canCreateAccession(facilityId: FacilityId): Boolean
+  fun canCreateAccession(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canCreateApiKey(organizationId: OrganizationId): Boolean
+  fun canCreateApiKey(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateAutomation(facilityId: FacilityId): Boolean
+  fun canCreateAutomation(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canCreateBatch(facilityId: FacilityId): Boolean
+  fun canCreateBatch(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canCreateCohort(): Boolean
+  fun canCreateCohort(): Boolean = defaultPermission
 
-  fun canCreateCohortModule(): Boolean
+  fun canCreateCohortModule(): Boolean = defaultPermission
 
-  fun canCreateDelivery(plantingSiteId: PlantingSiteId): Boolean
+  fun canCreateDelivery(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canCreateDevice(facilityId: FacilityId): Boolean
+  fun canCreateDevice(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canCreateDeviceManager(): Boolean
+  fun canCreateDeviceManager(): Boolean = defaultPermission
 
-  fun canCreateDocument(): Boolean
+  fun canCreateDocument(): Boolean = defaultPermission
 
-  fun canCreateDraftPlantingSite(organizationId: OrganizationId): Boolean
+  fun canCreateDraftPlantingSite(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateFacility(organizationId: OrganizationId): Boolean
+  fun canCreateFacility(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean
+  fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean =
+      defaultPermission
 
-  fun canCreateObservation(plantingSiteId: PlantingSiteId): Boolean
+  fun canCreateObservation(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canCreateParticipant(): Boolean
+  fun canCreateParticipant(): Boolean = defaultPermission
 
-  fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean
+  fun canCreateParticipantProjectSpecies(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canCreatePlantingSite(organizationId: OrganizationId): Boolean
+  fun canCreatePlantingSite(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateProject(organizationId: OrganizationId): Boolean
+  fun canCreateProject(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateReport(organizationId: OrganizationId): Boolean
+  fun canCreateReport(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateSavedVersion(documentId: DocumentId): Boolean
+  fun canCreateSavedVersion(documentId: DocumentId): Boolean = defaultPermission
 
-  fun canCreateSpecies(organizationId: OrganizationId): Boolean
+  fun canCreateSpecies(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateSubLocation(facilityId: FacilityId): Boolean
+  fun canCreateSubLocation(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canCreateSubmission(projectId: ProjectId): Boolean
+  fun canCreateSubmission(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canCreateTimeseries(deviceId: DeviceId): Boolean
+  fun canCreateTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 
-  fun canCreateVariableManifest(): Boolean
+  fun canCreateVariableManifest(): Boolean = defaultPermission
 
-  fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean
+  fun canCreateWithdrawalPhoto(withdrawalId: WithdrawalId): Boolean = defaultPermission
 
-  fun canDeleteAccession(accessionId: AccessionId): Boolean
+  fun canDeleteAccession(accessionId: AccessionId): Boolean = defaultPermission
 
-  fun canDeleteAutomation(automationId: AutomationId): Boolean
+  fun canDeleteAutomation(automationId: AutomationId): Boolean = defaultPermission
 
-  fun canDeleteBatch(batchId: BatchId): Boolean
+  fun canDeleteBatch(batchId: BatchId): Boolean = defaultPermission
 
-  fun canDeleteCohort(cohortId: CohortId): Boolean
+  fun canDeleteCohort(cohortId: CohortId): Boolean = defaultPermission
 
-  fun canDeleteCohortParticipant(cohortId: CohortId, participantId: ParticipantId): Boolean
+  fun canDeleteCohortParticipant(cohortId: CohortId, participantId: ParticipantId): Boolean =
+      defaultPermission
 
-  fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean
+  fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean =
+      defaultPermission
 
-  fun canDeleteOrganization(organizationId: OrganizationId): Boolean
+  fun canDeleteOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canDeleteParticipant(participantId: ParticipantId): Boolean
+  fun canDeleteParticipant(participantId: ParticipantId): Boolean = defaultPermission
 
-  fun canDeleteParticipantProject(participantId: ParticipantId, projectId: ProjectId): Boolean
+  fun canDeleteParticipantProject(participantId: ParticipantId, projectId: ProjectId): Boolean =
+      defaultPermission
 
   fun canDeleteParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean
+  ): Boolean = defaultPermission
 
-  fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canDeletePlantingSite(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canDeleteProject(projectId: ProjectId): Boolean
+  fun canDeleteProject(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canDeleteReport(reportId: ReportId): Boolean
+  fun canDeleteReport(reportId: ReportId): Boolean = defaultPermission
 
-  fun canDeleteSelf(): Boolean
+  fun canDeleteSelf(): Boolean = defaultPermission
 
-  fun canDeleteSpecies(speciesId: SpeciesId): Boolean
+  fun canDeleteSpecies(speciesId: SpeciesId): Boolean = defaultPermission
 
-  fun canDeleteSubLocation(subLocationId: SubLocationId): Boolean
+  fun canDeleteSubLocation(subLocationId: SubLocationId): Boolean = defaultPermission
 
-  fun canDeleteSupportIssue(): Boolean
+  fun canDeleteSupportIssue(): Boolean = defaultPermission
 
-  fun canDeleteUpload(uploadId: UploadId): Boolean
+  fun canDeleteUpload(uploadId: UploadId): Boolean = defaultPermission
 
-  fun canDeleteUsers(): Boolean
+  fun canDeleteUsers(): Boolean = defaultPermission
 
-  fun canImportGlobalSpeciesData(): Boolean
+  fun canImportGlobalSpeciesData(): Boolean = defaultPermission
 
-  fun canListAutomations(facilityId: FacilityId): Boolean
+  fun canListAutomations(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canListFacilities(organizationId: OrganizationId): Boolean
+  fun canListFacilities(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canListNotifications(organizationId: OrganizationId?): Boolean
+  fun canListNotifications(organizationId: OrganizationId?): Boolean = defaultPermission
 
-  fun canListOrganizationUsers(organizationId: OrganizationId): Boolean
+  fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canListReports(organizationId: OrganizationId): Boolean
+  fun canListReports(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canManageDeliverables(): Boolean
+  fun canManageDeliverables(): Boolean = defaultPermission
 
-  fun canManageDocumentProducer(): Boolean
+  fun canManageDocumentProducer(): Boolean = defaultPermission
 
-  fun canManageInternalTags(): Boolean
+  fun canManageInternalTags(): Boolean = defaultPermission
 
-  fun canManageModuleEvents(): Boolean
+  fun canManageModuleEvents(): Boolean = defaultPermission
 
-  fun canManageModuleEventStatuses(): Boolean
+  fun canManageModuleEventStatuses(): Boolean = defaultPermission
 
-  fun canManageModules(): Boolean
+  fun canManageModules(): Boolean = defaultPermission
 
-  fun canManageNotifications(): Boolean
+  fun canManageNotifications(): Boolean = defaultPermission
 
-  fun canManageObservation(observationId: ObservationId): Boolean
+  fun canManageObservation(observationId: ObservationId): Boolean = defaultPermission
 
-  fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean
+  fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canReadAccession(accessionId: AccessionId): Boolean
+  fun canReadAccession(accessionId: AccessionId): Boolean = defaultPermission
 
-  fun canReadAllAcceleratorDetails(): Boolean
+  fun canReadAllAcceleratorDetails(): Boolean = defaultPermission
 
-  fun canReadAllDeliverables(): Boolean
+  fun canReadAllDeliverables(): Boolean = defaultPermission
 
-  fun canReadAutomation(automationId: AutomationId): Boolean
+  fun canReadAutomation(automationId: AutomationId): Boolean = defaultPermission
 
-  fun canReadBatch(batchId: BatchId): Boolean
+  fun canReadBatch(batchId: BatchId): Boolean = defaultPermission
 
-  fun canReadCohort(cohortId: CohortId): Boolean
+  fun canReadCohort(cohortId: CohortId): Boolean = defaultPermission
 
-  fun canReadCohortParticipants(cohortId: CohortId): Boolean
+  fun canReadCohortParticipants(cohortId: CohortId): Boolean = defaultPermission
 
-  fun canReadCohorts(): Boolean
+  fun canReadCohorts(): Boolean = defaultPermission
 
-  fun canReadDefaultVoters(): Boolean
+  fun canReadDefaultVoters(): Boolean = defaultPermission
 
-  fun canReadDelivery(deliveryId: DeliveryId): Boolean
+  fun canReadDelivery(deliveryId: DeliveryId): Boolean = defaultPermission
 
-  fun canReadDevice(deviceId: DeviceId): Boolean
+  fun canReadDevice(deviceId: DeviceId): Boolean = defaultPermission
 
-  fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean
+  fun canReadDeviceManager(deviceManagerId: DeviceManagerId): Boolean = defaultPermission
 
-  fun canReadDocument(documentId: DocumentId): Boolean
+  fun canReadDocument(documentId: DocumentId): Boolean = defaultPermission
 
-  fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean
+  fun canReadDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean =
+      defaultPermission
 
-  fun canReadFacility(facilityId: FacilityId): Boolean
+  fun canReadFacility(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canReadGlobalRoles(): Boolean
+  fun canReadGlobalRoles(): Boolean = defaultPermission
 
-  fun canReadInternalTags(): Boolean
+  fun canReadInternalTags(): Boolean = defaultPermission
 
-  fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean
+  fun canReadInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadModule(moduleId: ModuleId): Boolean
+  fun canReadModule(moduleId: ModuleId): Boolean = defaultPermission
 
-  fun canReadModuleDetails(moduleId: ModuleId): Boolean
+  fun canReadModuleDetails(moduleId: ModuleId): Boolean = defaultPermission
 
-  fun canReadModuleEvent(eventId: EventId): Boolean
+  fun canReadModuleEvent(eventId: EventId): Boolean = defaultPermission
 
-  fun canReadModuleEventParticipants(): Boolean
+  fun canReadModuleEventParticipants(): Boolean = defaultPermission
 
-  fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean
+  fun canReadMonitoringPlot(monitoringPlotId: MonitoringPlotId): Boolean = defaultPermission
 
-  fun canReadNotification(notificationId: NotificationId): Boolean
+  fun canReadNotification(notificationId: NotificationId): Boolean = defaultPermission
 
-  fun canReadObservation(observationId: ObservationId): Boolean
+  fun canReadObservation(observationId: ObservationId): Boolean = defaultPermission
 
-  fun canReadOrganization(organizationId: OrganizationId): Boolean
+  fun canReadOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean
+  fun canReadOrganizationDeliverables(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
+  fun canReadOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      defaultPermission
 
-  fun canReadParticipant(participantId: ParticipantId): Boolean
+  fun canReadParticipant(participantId: ParticipantId): Boolean = defaultPermission
 
   fun canReadParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean
+  ): Boolean = defaultPermission
 
-  fun canReadPlanting(plantingId: PlantingId): Boolean
+  fun canReadPlanting(plantingId: PlantingId): Boolean = defaultPermission
 
-  fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean
+  fun canReadPlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = defaultPermission
 
-  fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean
+  fun canReadPlantingZone(plantingZoneId: PlantingZoneId): Boolean = defaultPermission
 
-  fun canReadProject(projectId: ProjectId): Boolean
+  fun canReadProject(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadProjectAcceleratorDetails(projectId: ProjectId): Boolean
+  fun canReadProjectAcceleratorDetails(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadProjectDeliverables(projectId: ProjectId): Boolean
+  fun canReadProjectDeliverables(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadProjectModules(projectId: ProjectId): Boolean
+  fun canReadProjectModules(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadProjectScores(projectId: ProjectId): Boolean
+  fun canReadProjectScores(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadProjectVotes(projectId: ProjectId): Boolean
+  fun canReadProjectVotes(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canReadReport(reportId: ReportId): Boolean
+  fun canReadReport(reportId: ReportId): Boolean = defaultPermission
 
-  fun canReadSpecies(speciesId: SpeciesId): Boolean
+  fun canReadSpecies(speciesId: SpeciesId): Boolean = defaultPermission
 
-  fun canReadSubLocation(subLocationId: SubLocationId): Boolean
+  fun canReadSubLocation(subLocationId: SubLocationId): Boolean = defaultPermission
 
-  fun canReadSubmission(submissionId: SubmissionId): Boolean
+  fun canReadSubmission(submissionId: SubmissionId): Boolean = defaultPermission
 
-  fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean
+  fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = defaultPermission
 
-  fun canReadTimeseries(deviceId: DeviceId): Boolean
+  fun canReadTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 
-  fun canReadUpload(uploadId: UploadId): Boolean
+  fun canReadUpload(uploadId: UploadId): Boolean = defaultPermission
 
-  fun canReadUser(userId: UserId): Boolean
+  fun canReadUser(userId: UserId): Boolean = defaultPermission
 
-  fun canReadUserDeliverableCategories(userId: UserId): Boolean
+  fun canReadUserDeliverableCategories(userId: UserId): Boolean = defaultPermission
 
-  fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean
+  fun canReadViabilityTest(viabilityTestId: ViabilityTestId): Boolean = defaultPermission
 
-  fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean
+  fun canReadWithdrawal(withdrawalId: WithdrawalId): Boolean = defaultPermission
 
-  fun canRegenerateAllDeviceManagerTokens(): Boolean
+  fun canRegenerateAllDeviceManagerTokens(): Boolean = defaultPermission
 
-  fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean
+  fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean =
+      defaultPermission
 
-  fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canRemoveTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canReplaceObservationPlot(observationId: ObservationId): Boolean
+  fun canReplaceObservationPlot(observationId: ObservationId): Boolean = defaultPermission
 
-  fun canRescheduleObservation(observationId: ObservationId): Boolean
+  fun canRescheduleObservation(observationId: ObservationId): Boolean = defaultPermission
 
-  fun canSendAlert(facilityId: FacilityId): Boolean
+  fun canSendAlert(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean
+  fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
+      defaultPermission
 
-  fun canSetTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canSetTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canSetTestClock(): Boolean
+  fun canSetTestClock(): Boolean = defaultPermission
 
-  fun canSetWithdrawalUser(accessionId: AccessionId): Boolean
+  fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = defaultPermission
 
-  fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean
+  fun canScheduleObservation(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canTriggerAutomation(automationId: AutomationId): Boolean
+  fun canTriggerAutomation(automationId: AutomationId): Boolean = defaultPermission
 
-  fun canUpdateAccession(accessionId: AccessionId): Boolean
+  fun canUpdateAccession(accessionId: AccessionId): Boolean = defaultPermission
 
-  fun canUpdateAppVersions(): Boolean
+  fun canUpdateAppVersions(): Boolean = defaultPermission
 
-  fun canUpdateAutomation(automationId: AutomationId): Boolean
+  fun canUpdateAutomation(automationId: AutomationId): Boolean = defaultPermission
 
-  fun canUpdateBatch(batchId: BatchId): Boolean
+  fun canUpdateBatch(batchId: BatchId): Boolean = defaultPermission
 
-  fun canUpdateCohort(cohortId: CohortId): Boolean
+  fun canUpdateCohort(cohortId: CohortId): Boolean = defaultPermission
 
-  fun canUpdateDefaultVoters(): Boolean
+  fun canUpdateDefaultVoters(): Boolean = defaultPermission
 
-  fun canUpdateDelivery(deliveryId: DeliveryId): Boolean
+  fun canUpdateDelivery(deliveryId: DeliveryId): Boolean = defaultPermission
 
-  fun canUpdateDevice(deviceId: DeviceId): Boolean
+  fun canUpdateDevice(deviceId: DeviceId): Boolean = defaultPermission
 
-  fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean
+  fun canUpdateDeviceManager(deviceManagerId: DeviceManagerId): Boolean = defaultPermission
 
-  fun canUpdateDeviceTemplates(): Boolean
+  fun canUpdateDeviceTemplates(): Boolean = defaultPermission
 
-  fun canUpdateDocument(documentId: DocumentId): Boolean
+  fun canUpdateDocument(documentId: DocumentId): Boolean = defaultPermission
 
-  fun canUpdateDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean
+  fun canUpdateDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean =
+      defaultPermission
 
-  fun canUpdateFacility(facilityId: FacilityId): Boolean
+  fun canUpdateFacility(facilityId: FacilityId): Boolean = defaultPermission
 
-  fun canUpdateGlobalRoles(): Boolean
+  fun canUpdateGlobalRoles(): Boolean = defaultPermission
 
-  fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean
+  fun canUpdateInternalVariableWorkflowDetails(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean
+  fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = defaultPermission
 
-  fun canUpdateNotification(notificationId: NotificationId): Boolean
+  fun canUpdateNotification(notificationId: NotificationId): Boolean = defaultPermission
 
-  fun canUpdateNotifications(organizationId: OrganizationId?): Boolean
+  fun canUpdateNotifications(organizationId: OrganizationId?): Boolean = defaultPermission
 
-  fun canUpdateObservation(observationId: ObservationId): Boolean
+  fun canUpdateObservation(observationId: ObservationId): Boolean = defaultPermission
 
-  fun canUpdateOrganization(organizationId: OrganizationId): Boolean
+  fun canUpdateOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canUpdateParticipant(participantId: ParticipantId): Boolean
+  fun canUpdateParticipant(participantId: ParticipantId): Boolean = defaultPermission
 
   fun canUpdateParticipantProjectSpecies(
       participantProjectSpeciesId: ParticipantProjectSpeciesId
-  ): Boolean
+  ): Boolean = defaultPermission
 
-  fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean
+  fun canUpdatePlantingSite(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean
+  fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = defaultPermission
 
-  fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean
+  fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = defaultPermission
 
-  fun canUpdateProject(projectId: ProjectId): Boolean
+  fun canUpdateProject(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateProjectAcceleratorDetails(projectId: ProjectId): Boolean
+  fun canUpdateProjectAcceleratorDetails(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean
+  fun canUpdateProjectDocumentSettings(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateProjectScores(projectId: ProjectId): Boolean
+  fun canUpdateProjectScores(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateProjectVotes(projectId: ProjectId): Boolean
+  fun canUpdateProjectVotes(projectId: ProjectId): Boolean = defaultPermission
 
-  fun canUpdateReport(reportId: ReportId): Boolean
+  fun canUpdateReport(reportId: ReportId): Boolean = defaultPermission
 
-  fun canUpdateSpecies(speciesId: SpeciesId): Boolean
+  fun canUpdateSpecies(speciesId: SpeciesId): Boolean = defaultPermission
 
-  fun canUpdateSubLocation(subLocationId: SubLocationId): Boolean
+  fun canUpdateSubLocation(subLocationId: SubLocationId): Boolean = defaultPermission
 
-  fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId): Boolean
+  fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId): Boolean =
+      defaultPermission
 
-  fun canUpdateTerraformationContact(organizationId: OrganizationId): Boolean
+  fun canUpdateTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canUpdateTimeseries(deviceId: DeviceId): Boolean
+  fun canUpdateTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 
-  fun canUpdateUpload(uploadId: UploadId): Boolean
+  fun canUpdateUpload(uploadId: UploadId): Boolean = defaultPermission
 
-  fun canUpdateUserDeliverableCategories(userId: UserId): Boolean
+  fun canUpdateUserDeliverableCategories(userId: UserId): Boolean = defaultPermission
 
-  fun canUploadPhoto(accessionId: AccessionId): Boolean
+  fun canUploadPhoto(accessionId: AccessionId): Boolean = defaultPermission
 
   // When adding new permissions, put them in alphabetical order in the above block.
 }


### PR DESCRIPTION
Currently, when you add a new permission, you have to add implementations to the
system and device manager user classes, but these nearly always return true and
false respectively.

Add the concept of a "default permission" and make the permission checking methods
return it by default.

This should make it a bit less of a chore to add new permissions, at the cost of
the compiler no longer being able to detect if you add a permission method to
`TerrawareUser` and forget to implement it in `IndividualUser`. In that case,
an exception will be thrown which will cause any code that checks the new
permission to fail, so the risk should be acceptably low.