### PR TITLE
SW-5605 Stop using hardwired user IDs in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/MockUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/MockUser.kt
@@ -2,20 +2,18 @@ package com.terraformation.backend
 
 import com.terraformation.backend.auth.CurrentUserHolder
 import com.terraformation.backend.customer.model.IndividualUser
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
 import java.time.ZoneId
 
-fun mockUser(userId: UserId = UserId(2)): IndividualUser {
+fun mockUser(): IndividualUser {
   val timeZone = ZoneId.of("Pacific/Honolulu")
   val user: IndividualUser = mockk(relaxed = true)
 
-  every { user.userId } returns userId
-  every { user.email } returns "$userId@terraformation.com"
-  every { user.authId } returns "$userId"
+  every { user.email } answers { "${user.userId}@terraformation.com" }
+  every { user.authId } answers { "${user.userId}" }
   every { user.firstName } returns "First"
   every { user.lastName } returns "Last"
   every { user.fullName } returns "First Last"

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -21,7 +21,6 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -32,7 +32,6 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertParticipant()
@@ -359,7 +358,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
         insertProject(
             organizationId = inserted.organizationId, participantId = inserted.participantId)
 
-    val otherUser = insertUser(100)
+    val otherUser = insertUser()
     val otherOrganization = insertOrganization(id = 100, createdBy = otherUser)
     insertOrganizationUser(
         userId = otherUser, organizationId = otherOrganization, role = Role.Admin)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -33,7 +33,6 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(
         userId = inserted.userId, organizationId = inserted.organizationId, role = Role.Admin)
@@ -276,7 +275,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
         insertProject(
             organizationId = inserted.organizationId, participantId = inserted.participantId)
 
-    val otherUser = insertUser(100)
+    val otherUser = insertUser()
     val otherOrganization = insertOrganization(id = 100, createdBy = otherUser)
     insertOrganizationUser(
         userId = otherUser, organizationId = otherOrganization, role = Role.Admin)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventServiceTest.kt
@@ -53,7 +53,6 @@ class ModuleEventServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertModule()
     insertCohort()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -29,7 +29,6 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(
         userId = inserted.userId, organizationId = inserted.organizationId, role = Role.Admin)
@@ -198,7 +197,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
     val userParticipant = insertParticipant(cohortId = userCohort)
     insertProject(participantId = userParticipant, organizationId = inserted.organizationId)
 
-    val otherUser = insertUser(100)
+    val otherUser = insertUser()
     val otherCohort = insertCohort()
     val otherParticipant = insertParticipant(cohortId = otherCohort)
     val otherOrganization = insertOrganization(100)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -68,7 +68,6 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canCreateParticipantProjectSpecies(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantServiceTest.kt
@@ -36,7 +36,6 @@ class ParticipantServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canAddParticipantProject(any(), any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -35,7 +35,6 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(
         userId = inserted.userId, organizationId = inserted.organizationId, role = Role.Admin)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
@@ -50,7 +50,6 @@ class SpeciesNotifierTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertModule()
     insertCohort()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
@@ -37,7 +37,6 @@ class SubmissionNotifierTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertModule()
     insertCohort()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -38,15 +38,14 @@ class VoteServiceTest : DatabaseTest(), RunsAsUser {
         VoteStore(clock, dslContext, PhaseChecker(dslContext)))
   }
 
-  private val voter1 = UserId(101)
-  private val voter2 = UserId(102)
+  private lateinit var voter1: UserId
+  private lateinit var voter2: UserId
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
-    insertUser(voter1)
-    insertUser(voter2)
+    voter1 = insertUser()
+    voter2 = insertUser()
     insertDefaultVoter(voter1)
     insertDefaultVoter(voter2)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
@@ -24,8 +24,6 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadInternalTags() } returns true
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortStoreTest.kt
@@ -36,8 +36,6 @@ class CohortStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadCohort(any()) } returns true
     every { user.canReadCohortParticipants(any()) } returns true
   }
@@ -279,7 +277,7 @@ class CohortStoreTest : DatabaseTest(), RunsAsUser {
   inner class Update {
     @Test
     fun `updates editable fields`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
       val cohortId =
           insertCohort(
               name = "Old Name", createdBy = otherUserId, phase = CohortPhase.Phase0DueDiligence)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DefaultVoterStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DefaultVoterStoreTest.kt
@@ -21,8 +21,6 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadDefaultVoters() } returns true
     every { user.canUpdateDefaultVoters() } returns true
   }
@@ -36,11 +34,11 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all with users added`() {
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      insertDefaultVoter(user100)
-      insertDefaultVoter(user200)
-      assertEquals(listOf(user100, user200), store.findAll())
+      val user1 = insertUser()
+      val user2 = insertUser()
+      insertDefaultVoter(user1)
+      insertDefaultVoter(user2)
+      assertEquals(listOf(user1, user2), store.findAll())
     }
 
     @Test
@@ -54,23 +52,23 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
   inner class Exists {
     @Test
     fun `exists when empty`() {
-      val user100 = insertUser(100)
-      assertFalse(store.exists(user100))
+      val userId = insertUser()
+      assertFalse(store.exists(userId))
     }
 
     @Test
     fun `exists when user is not in table`() {
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      insertDefaultVoter(user100)
-      assertFalse(store.exists(user200))
+      val user1 = insertUser()
+      val user2 = insertUser()
+      insertDefaultVoter(user1)
+      assertFalse(store.exists(user2))
     }
 
     @Test
     fun `exists when user is in table`() {
-      val user100 = insertUser(100)
-      insertDefaultVoter(user100)
-      assertTrue(store.exists(user100))
+      val userId = insertUser()
+      insertDefaultVoter(userId)
+      assertTrue(store.exists(userId))
     }
   }
 
@@ -79,7 +77,7 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `inserts new entry to empty`() {
-      val userId = insertUser(100)
+      val userId = insertUser()
       store.insert(userId)
 
       assertEquals(listOf(DefaultVotersRow(userId)), defaultVotersDao.findAll())
@@ -87,28 +85,28 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `inserts new entry to non-empty`() {
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      insertDefaultVoter(user100)
-      store.insert(user200)
+      val user1 = insertUser()
+      val user2 = insertUser()
+      insertDefaultVoter(user1)
+      store.insert(user2)
 
       assertEquals(
-          listOf(DefaultVotersRow(user100), DefaultVotersRow(user200)), defaultVotersDao.findAll())
+          listOf(DefaultVotersRow(user1), DefaultVotersRow(user2)), defaultVotersDao.findAll())
     }
 
     @Test
     fun `inserts duplicated results in no-op`() {
-      val user100 = insertUser(100)
-      insertDefaultVoter(user100)
-      store.insert(user100)
-      assertEquals(listOf(DefaultVotersRow(user100)), defaultVotersDao.findAll())
+      val userId = insertUser()
+      insertDefaultVoter(userId)
+      store.insert(userId)
+      assertEquals(listOf(DefaultVotersRow(userId)), defaultVotersDao.findAll())
     }
 
     @Test
     fun `inserts without permission throws exception`() {
-      val user100 = insertUser(100)
+      val userId = insertUser()
       every { user.canUpdateDefaultVoters() } returns false
-      assertThrows<AccessDeniedException> { store.insert(user100) }
+      assertThrows<AccessDeniedException> { store.insert(userId) }
     }
   }
 
@@ -117,7 +115,7 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `deletes only one`() {
-      val userId = insertUser(100)
+      val userId = insertUser()
 
       insertDefaultVoter(userId)
       store.delete(userId)
@@ -127,31 +125,31 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `deletes one from many`() {
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      insertDefaultVoter(user100)
-      insertDefaultVoter(user200)
-      store.delete(user200)
+      val user1 = insertUser()
+      val user2 = insertUser()
+      insertDefaultVoter(user1)
+      insertDefaultVoter(user2)
+      store.delete(user2)
 
-      assertEquals(listOf(DefaultVotersRow(user100)), defaultVotersDao.findAll())
+      assertEquals(listOf(DefaultVotersRow(user1)), defaultVotersDao.findAll())
     }
 
     @Test
     fun `deletes no matching record results in no-op`() {
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      insertDefaultVoter(user100)
-      store.delete(user200)
+      val user1 = insertUser()
+      val user2 = insertUser()
+      insertDefaultVoter(user1)
+      store.delete(user2)
 
-      assertEquals(listOf(DefaultVotersRow(user100)), defaultVotersDao.findAll())
+      assertEquals(listOf(DefaultVotersRow(user1)), defaultVotersDao.findAll())
     }
 
     @Test
     fun `deletes without permission throws exception`() {
-      val user100 = insertUser(100)
-      insertDefaultVoter(user100)
+      val user1 = insertUser()
+      insertDefaultVoter(user1)
       every { user.canUpdateDefaultVoters() } returns false
-      assertThrows<AccessDeniedException> { store.delete(user100) }
+      assertThrows<AccessDeniedException> { store.delete(user1) }
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
@@ -22,7 +22,6 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canReadAllDeliverables() } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -29,8 +29,6 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadAllDeliverables() } returns true
     every { user.canReadOrganization(any()) } returns true
     every { user.canReadOrganizationDeliverables(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
@@ -42,7 +42,6 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     cohortId = insertCohort()
     insertParticipant(cohortId = cohortId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
@@ -37,7 +37,6 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     cohortId = insertCohort()
     insertParticipant(cohortId = inserted.cohortId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -42,7 +42,6 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canCreateParticipantProjectSpecies(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantStoreTest.kt
@@ -30,8 +30,6 @@ class ParticipantStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadParticipant(any()) } returns true
   }
 
@@ -185,7 +183,7 @@ class ParticipantStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `updates editable fields`() {
       val cohortId = insertCohort()
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
       val participantId = insertParticipant(name = "Old Name", createdBy = otherUserId)
 
       every { user.canUpdateParticipant(participantId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -27,7 +27,6 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canReadProject(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -28,7 +28,6 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertCohort(phase = CohortPhase.Phase0DueDiligence)
     insertParticipant(cohortId = inserted.cohortId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -29,7 +29,6 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canReadProject(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/UserDeliverableCategoriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/UserDeliverableCategoriesStoreTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,11 +22,6 @@ class UserDeliverableCategoriesStoreTest : DatabaseTest(), RunsAsUser {
     UserDeliverableCategoriesStore(clock, dslContext)
   }
 
-  @BeforeEach
-  fun setUp() {
-    insertUser()
-  }
-
   @Nested
   inner class FetchForUser {
     @Test
@@ -39,7 +33,7 @@ class UserDeliverableCategoriesStoreTest : DatabaseTest(), RunsAsUser {
 
       val expected = setOf(DeliverableCategory.Compliance, DeliverableCategory.GIS)
 
-      val targetUserId = insertUser(10)
+      val targetUserId = insertUser()
       expected.forEach { insertUserDeliverableCategory(it) }
 
       assertEquals(
@@ -48,7 +42,7 @@ class UserDeliverableCategoriesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       assertThrows<UserNotFoundException> { store.fetchForUser(otherUserId) }
     }
@@ -61,11 +55,11 @@ class UserDeliverableCategoriesStoreTest : DatabaseTest(), RunsAsUser {
       every { user.canReadUserDeliverableCategories(any()) } returns true
       every { user.canUpdateUserDeliverableCategories(any()) } returns true
 
-      val targetUserId = insertUser(10)
+      val targetUserId = insertUser()
       insertUserDeliverableCategory(DeliverableCategory.Compliance)
       insertUserDeliverableCategory(DeliverableCategory.FinancialViability)
 
-      val otherUserId = insertUser(11)
+      val otherUserId = insertUser()
       insertUserDeliverableCategory(DeliverableCategory.CarbonEligibility)
 
       store.updateForUser(
@@ -84,7 +78,7 @@ class UserDeliverableCategoriesStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       assertThrows<UserNotFoundException> { store.updateForUser(otherUserId, emptySet()) }
     }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -31,7 +31,6 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     val cohortId = insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
     insertParticipant(cohortId = cohortId)
@@ -57,61 +56,58 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val email100 = "batman@terraformation.com"
-      val firstName100 = "Bruce"
-      val lastName100 = "Wayne"
+      val email1 = "batman@terraformation.com"
+      val firstName1 = "Bruce"
+      val lastName1 = "Wayne"
 
-      val email200 = "superman@terraformation.com"
-      val firstName200 = "Clark"
-      val lastName200 = "Kent"
+      val email2 = "superman@terraformation.com"
+      val firstName2 = "Clark"
+      val lastName2 = "Kent"
 
-      val email300 = "harley.quinn@terraformation.com"
-      val firstName300 = "Harley"
-      val lastName300 = "Quinn"
+      val email3 = "harley.quinn@terraformation.com"
+      val firstName3 = "Harley"
+      val lastName3 = "Quinn"
 
-      val user100 =
-          insertUser(100, email = email100, firstName = firstName100, lastName = lastName100)
-      val user200 =
-          insertUser(200, email = email200, firstName = firstName200, lastName = lastName200)
-      val user300 =
-          insertUser(300, email = email300, firstName = firstName300, lastName = lastName300)
-      val vote100 = VoteOption.No
-      val vote200 = VoteOption.Yes
-      val vote300 = VoteOption.Conditional
-      val condition300 = "I will not vote yes until this happens."
+      val user1 = insertUser(email = email1, firstName = firstName1, lastName = lastName1)
+      val user2 = insertUser(email = email2, firstName = firstName2, lastName = lastName2)
+      val user3 = insertUser(email = email3, firstName = firstName3, lastName = lastName3)
+      val vote1 = VoteOption.No
+      val vote2 = VoteOption.Yes
+      val vote3 = VoteOption.Conditional
+      val condition3 = "I will not vote yes until this happens."
 
-      insertVote(projectId, phase, user100, vote100)
-      insertVote(projectId, phase, user200, vote200)
-      insertVote(projectId, phase, user300, vote300, condition300)
+      insertVote(projectId, phase, user1, vote1)
+      insertVote(projectId, phase, user2, vote2)
+      insertVote(projectId, phase, user3, vote3, condition3)
 
       assertEquals(
           listOf(
               VoteModel(
                   conditionalInfo = null,
-                  email = email100,
-                  firstName = firstName100,
-                  lastName = lastName100,
+                  email = email1,
+                  firstName = firstName1,
+                  lastName = lastName1,
                   phase = phase,
-                  userId = user100,
-                  voteOption = vote100,
+                  userId = user1,
+                  voteOption = vote1,
               ),
               VoteModel(
                   conditionalInfo = null,
-                  email = email200,
-                  firstName = firstName200,
-                  lastName = lastName200,
+                  email = email2,
+                  firstName = firstName2,
+                  lastName = lastName2,
                   phase = phase,
-                  userId = user200,
-                  voteOption = vote200,
+                  userId = user2,
+                  voteOption = vote2,
               ),
               VoteModel(
-                  conditionalInfo = condition300,
-                  email = email300,
-                  firstName = firstName300,
-                  lastName = lastName300,
+                  conditionalInfo = condition3,
+                  email = email3,
+                  firstName = firstName3,
+                  lastName = lastName3,
                   phase = phase,
-                  userId = user300,
-                  voteOption = vote300,
+                  userId = user3,
+                  voteOption = vote3,
               )),
           store.fetchAllVotes(projectId))
     }
@@ -123,52 +119,50 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val email100 = "batman@terraformation.com"
-      val firstName100 = "Bruce"
-      val lastName100 = "Wayne"
+      val email1 = "batman@terraformation.com"
+      val firstName1 = "Bruce"
+      val lastName1 = "Wayne"
 
-      val email200 = "superman@terraformation.com"
-      val firstName200 = "Clark"
-      val lastName200 = "Kent"
+      val email2 = "superman@terraformation.com"
+      val firstName2 = "Clark"
+      val lastName2 = "Kent"
 
-      val user100 =
-          insertUser(100, email = email100, firstName = firstName100, lastName = lastName100)
-      val user200 =
-          insertUser(200, email = email200, firstName = firstName200, lastName = lastName200)
+      val user1 = insertUser(email = email1, firstName = firstName1, lastName = lastName1)
+      val user2 = insertUser(email = email2, firstName = firstName2, lastName = lastName2)
 
       val votes: MutableMap<VoteKey, VoteOption> = mutableMapOf()
 
-      votes[VoteKey(user100, projectId, phase0)] = VoteOption.No
-      votes[VoteKey(user200, projectId, phase0)] = VoteOption.No
+      votes[VoteKey(user1, projectId, phase0)] = VoteOption.No
+      votes[VoteKey(user2, projectId, phase0)] = VoteOption.No
 
-      votes[VoteKey(user100, projectId, phase1)] = VoteOption.Yes
-      votes[VoteKey(user200, projectId, phase1)] = VoteOption.Yes
+      votes[VoteKey(user1, projectId, phase1)] = VoteOption.Yes
+      votes[VoteKey(user2, projectId, phase1)] = VoteOption.Yes
 
-      insertVote(projectId, phase0, user100, votes[VoteKey(user100, projectId, phase0)])
-      insertVote(projectId, phase0, user200, votes[VoteKey(user200, projectId, phase0)])
+      insertVote(projectId, phase0, user1, votes[VoteKey(user1, projectId, phase0)])
+      insertVote(projectId, phase0, user2, votes[VoteKey(user2, projectId, phase0)])
 
-      insertVote(projectId, phase1, user100, votes[VoteKey(user100, projectId, phase1)])
-      insertVote(projectId, phase1, user200, votes[VoteKey(user200, projectId, phase1)])
+      insertVote(projectId, phase1, user1, votes[VoteKey(user1, projectId, phase1)])
+      insertVote(projectId, phase1, user2, votes[VoteKey(user2, projectId, phase1)])
 
       assertEquals(
           listOf(
               VoteModel(
                   conditionalInfo = null,
-                  email = email100,
-                  firstName = firstName100,
-                  lastName = lastName100,
+                  email = email1,
+                  firstName = firstName1,
+                  lastName = lastName1,
                   phase = phase0,
-                  userId = user100,
-                  voteOption = votes[VoteKey(user100, projectId, phase0)],
+                  userId = user1,
+                  voteOption = votes[VoteKey(user1, projectId, phase0)],
               ),
               VoteModel(
                   conditionalInfo = null,
-                  email = email200,
-                  firstName = firstName200,
-                  lastName = lastName200,
+                  email = email2,
+                  firstName = firstName2,
+                  lastName = lastName2,
                   phase = phase0,
-                  userId = user200,
-                  voteOption = votes[VoteKey(user200, projectId, phase0)],
+                  userId = user2,
+                  voteOption = votes[VoteKey(user2, projectId, phase0)],
               )),
           store.fetchAllVotes(projectId, phase0))
     }
@@ -231,7 +225,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
 
       insertVote(projectId, phase, newUser, vote)
@@ -247,27 +241,27 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      val user300 = insertUser(300)
-      val vote100 = VoteOption.No
-      val vote200 = VoteOption.Yes
-      val vote300 = VoteOption.Conditional
-      val condition300 = "I will not vote yes until this happens."
+      val user1 = insertUser()
+      val user2 = insertUser()
+      val user3 = insertUser()
+      val vote1 = VoteOption.No
+      val vote2 = VoteOption.Yes
+      val vote3 = VoteOption.Conditional
+      val condition3 = "I will not vote yes until this happens."
 
-      insertVote(projectId, phase, user100, vote100, createdTime = clock.instant)
-      insertVote(projectId, phase, user200, vote200, createdTime = clock.instant)
-      insertVote(projectId, phase, user300, vote300, condition300, createdTime = clock.instant)
+      insertVote(projectId, phase, user1, vote1, createdTime = clock.instant)
+      insertVote(projectId, phase, user2, vote2, createdTime = clock.instant)
+      insertVote(projectId, phase, user3, vote3, condition3, createdTime = clock.instant)
 
-      store.delete(projectId, phase, user200)
+      store.delete(projectId, phase, user2)
 
       assertEquals(
           listOf(
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase,
-                  userId = user100,
-                  voteOptionId = vote100,
+                  userId = user1,
+                  voteOptionId = vote1,
                   conditionalInfo = null,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -277,9 +271,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase,
-                  userId = user300,
-                  voteOptionId = vote300,
-                  conditionalInfo = condition300,
+                  userId = user3,
+                  voteOptionId = vote3,
+                  conditionalInfo = condition3,
                   createdBy = user.userId,
                   createdTime = clock.instant,
                   modifiedBy = user.userId,
@@ -295,40 +289,40 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
+      val user1 = insertUser()
+      val user2 = insertUser()
 
       val votes: MutableMap<VoteKey, VoteOption> = mutableMapOf()
 
-      votes[VoteKey(user100, projectId, phase0)] = VoteOption.No
-      votes[VoteKey(user200, projectId, phase0)] = VoteOption.No
+      votes[VoteKey(user1, projectId, phase0)] = VoteOption.No
+      votes[VoteKey(user2, projectId, phase0)] = VoteOption.No
 
-      votes[VoteKey(user100, projectId, phase1)] = VoteOption.No
-      votes[VoteKey(user200, projectId, phase1)] = VoteOption.No
+      votes[VoteKey(user1, projectId, phase1)] = VoteOption.No
+      votes[VoteKey(user2, projectId, phase1)] = VoteOption.No
 
       insertVote(
           projectId,
           phase0,
-          user100,
-          votes[VoteKey(user100, projectId, phase0)],
+          user1,
+          votes[VoteKey(user1, projectId, phase0)],
           createdTime = clock.instant)
       insertVote(
           projectId,
           phase0,
-          user200,
-          votes[VoteKey(user200, projectId, phase0)],
+          user2,
+          votes[VoteKey(user2, projectId, phase0)],
           createdTime = clock.instant)
       insertVote(
           projectId,
           phase1,
-          user100,
-          votes[VoteKey(user100, projectId, phase1)],
+          user1,
+          votes[VoteKey(user1, projectId, phase1)],
           createdTime = clock.instant)
       insertVote(
           projectId,
           phase1,
-          user200,
-          votes[VoteKey(user200, projectId, phase1)],
+          user2,
+          votes[VoteKey(user2, projectId, phase1)],
           createdTime = clock.instant)
 
       store.delete(projectId, phase1)
@@ -338,8 +332,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase0,
-                  userId = user100,
-                  voteOptionId = votes[VoteKey(user100, projectId, phase0)],
+                  userId = user1,
+                  voteOptionId = votes[VoteKey(user1, projectId, phase0)],
                   conditionalInfo = null,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -349,8 +343,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase0,
-                  userId = user200,
-                  voteOptionId = votes[VoteKey(user200, projectId, phase0)],
+                  userId = user2,
+                  voteOptionId = votes[VoteKey(user2, projectId, phase0)],
                   conditionalInfo = null,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -364,7 +358,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on delete if no permission to update votes `() {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -377,7 +371,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on delete if project not in cohort `() {
       val projectId = insertProject()
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -388,7 +382,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on delete for wrong phase `() {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -400,20 +394,20 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      val vote100 = VoteOption.No
-      val vote200 = VoteOption.Yes
+      val user1 = insertUser()
+      val user2 = insertUser()
+      val vote1 = VoteOption.No
+      val vote2 = VoteOption.Yes
 
-      insertVote(projectId, phase, user100, vote100)
-      insertVote(projectId, phase, user200, vote200)
+      insertVote(projectId, phase, user1, vote1)
+      insertVote(projectId, phase, user2, vote2)
       insertVoteDecision(projectId, phase, null, Instant.EPOCH)
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      store.delete(projectId, phase, user200)
+      store.delete(projectId, phase, user2)
       assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, vote100, clock.instant)),
+          listOf(ProjectVoteDecisionsRow(projectId, phase, vote1, clock.instant)),
           projectVoteDecisionDao.findAll())
     }
 
@@ -422,7 +416,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
 
       insertVote(projectId, phase, newUser, vote)
@@ -466,7 +460,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `creates blank vote for other user`() {
       val projectId = insertProject(participantId = inserted.participantId)
-      val otherUser = insertUser(100)
+      val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
@@ -491,7 +485,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `creates conditional vote for other user`() {
       val projectId = insertProject(participantId = inserted.participantId)
-      val otherUser = insertUser(100)
+      val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
@@ -520,7 +514,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       val newVote = VoteOption.Conditional
       val newCondition = "I will not vote yes until this happens."
@@ -555,32 +549,32 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
 
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
-      val user300 = insertUser(300)
-      val vote100 = VoteOption.No
-      val vote200 = VoteOption.Yes
-      val vote300 = VoteOption.Conditional
-      val condition300 = "I will not vote yes until this happens."
+      val user1 = insertUser()
+      val user2 = insertUser()
+      val user3 = insertUser()
+      val vote1 = VoteOption.No
+      val vote2 = VoteOption.Yes
+      val vote3 = VoteOption.Conditional
+      val condition3 = "I will not vote yes until this happens."
 
-      insertVote(projectId, phase, user100, vote100, createdTime = createdTime)
-      insertVote(projectId, phase, user200, vote200, createdTime = createdTime)
-      insertVote(projectId, phase, user300, vote300, condition300, createdTime = createdTime)
+      insertVote(projectId, phase, user1, vote1, createdTime = createdTime)
+      insertVote(projectId, phase, user2, vote2, createdTime = createdTime)
+      insertVote(projectId, phase, user3, vote3, condition3, createdTime = createdTime)
 
       val newVote = VoteOption.Yes
       val newCondition = null
 
       // Time elapse before update
       clock.instant = Instant.EPOCH.plusSeconds(1000)
-      store.upsert(projectId, phase, user300, newVote, newCondition)
+      store.upsert(projectId, phase, user3, newVote, newCondition)
 
       assertEquals(
           listOf(
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase,
-                  userId = user100,
-                  voteOptionId = vote100,
+                  userId = user1,
+                  voteOptionId = vote1,
                   conditionalInfo = null,
                   createdBy = user.userId,
                   createdTime = createdTime,
@@ -590,8 +584,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase,
-                  userId = user200,
-                  voteOptionId = vote200,
+                  userId = user2,
+                  voteOptionId = vote2,
                   conditionalInfo = null,
                   createdBy = user.userId,
                   createdTime = createdTime,
@@ -601,7 +595,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
               ProjectVotesRow(
                   projectId = projectId,
                   phaseId = phase,
-                  userId = user300,
+                  userId = user3,
                   voteOptionId = newVote,
                   conditionalInfo = newCondition,
                   createdBy = user.userId,
@@ -712,7 +706,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on upsert if no permission to update votes`() {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -725,7 +719,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on upsert if project not in cohort`() {
       val projectId = insertProject()
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -738,7 +732,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
     fun `throws exception on upsert if project in wrong phase`() {
       val projectId = insertProject(participantId = inserted.participantId)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.No
       insertVote(projectId, phase, newUser, vote)
 
@@ -753,7 +747,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.Yes
 
       store.upsert(projectId, phase, newUser, vote, null)
@@ -769,7 +763,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
 
       store.upsert(projectId, phase, newUser, null, null)
 
@@ -784,7 +778,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val newUser = insertUser(100)
+      val newUser = insertUser()
       val vote = VoteOption.Yes
       val newVote = VoteOption.No
 
@@ -804,16 +798,16 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val user100 = insertUser(100)
-      val vote100 = VoteOption.Yes
+      val user1 = insertUser()
+      val vote1 = VoteOption.Yes
 
-      val user200 = insertUser(200)
-      val vote200 = VoteOption.No
+      val user2 = insertUser()
+      val vote2 = VoteOption.No
 
-      insertVote(projectId, phase, user100, vote100)
-      insertVoteDecision(projectId, phase, vote100, Instant.EPOCH)
+      insertVote(projectId, phase, user1, vote1)
+      insertVoteDecision(projectId, phase, vote1, Instant.EPOCH)
 
-      store.upsert(projectId, phase, user200, vote200, null)
+      store.upsert(projectId, phase, user2, vote2, null)
 
       assertEquals(
           listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),
@@ -826,15 +820,15 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
-      val user100 = insertUser(100)
-      val user200 = insertUser(200)
+      val user1 = insertUser()
+      val user2 = insertUser()
       val vote = VoteOption.Yes
 
-      insertVote(projectId, phase, user100, vote)
-      insertVote(projectId, phase, user200, vote)
+      insertVote(projectId, phase, user1, vote)
+      insertVote(projectId, phase, user2, vote)
       insertVoteDecision(projectId, phase, vote, Instant.EPOCH)
 
-      store.upsert(projectId, phase, user200, null, null)
+      store.upsert(projectId, phase, user2, null, null)
 
       assertEquals(
           listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),

--- a/src/test/kotlin/com/terraformation/backend/api/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/ControllerIntegrationTest.kt
@@ -4,7 +4,10 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.DatabaseBackedTest
 import com.terraformation.backend.mockUser
+import io.mockk.every
 import jakarta.ws.rs.core.MediaType
+import java.util.UUID
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
@@ -36,6 +39,14 @@ abstract class ControllerIntegrationTest : DatabaseBackedTest(), RunsAsUser {
                   .apply { with(oidcLogin().idToken { it.subject(currentUser().authId) }) })
           .apply<DefaultMockMvcBuilder>(SecurityMockMvcConfigurers.springSecurity())
           .build()
+
+  @BeforeEach
+  fun insertMockUser() {
+    val authId = "${UUID.randomUUID()}"
+    val userId = insertUser(authId = authId)
+    every { user.userId } returns userId
+    every { user.authId } returns authId
+  }
 
   /**
    * Asserts that a controller returns an HTTP 200 response with a JSON body that includes the

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -24,7 +24,6 @@ import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.UserNotFoundForEmailException
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationUsersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationUsersRecord
@@ -54,7 +53,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.security.access.AccessDeniedException
 
 internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
-  override val user: TerrawareUser = mockUser(UserId(200))
+  override val user: TerrawareUser = mockUser()
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(ORGANIZATIONS)
 
@@ -104,9 +103,8 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization throws exception if organization has users other than the current one`() {
-    val otherUserId = insertUser(100)
+    val otherUserId = insertUser()
 
-    insertUser(user.userId)
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
     insertOrganizationUser(otherUserId)
@@ -124,7 +122,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization removes current user from organization`() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
 
@@ -137,8 +134,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization removes Terraformation Contact user from organization`() {
-    val tfContactUserId = insertUser(5, email = "tfcontact@terraformation.com")
-    insertUser()
+    val tfContactUserId = insertUser(email = "tfcontact@terraformation.com")
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
     insertOrganizationUser(userId = tfContactUserId, role = Role.TerraformationContact)
@@ -152,7 +148,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteOrganization publishes event on success`() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(role = Role.Owner)
 
@@ -168,8 +163,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     val sharedOrganizationId = OrganizationId(3)
     val unrelatedOrganizationId = OrganizationId(4)
 
-    insertUser(user.userId)
-    val otherUserId = insertUser(100)
+    val otherUserId = insertUser()
 
     insertOrganization(soloOrganizationId1)
     insertOrganization(soloOrganizationId2)
@@ -255,8 +249,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
   fun `UserAddedToOrganization event is published when existing user is added to an organization`() {
     val organizationId = OrganizationId(1)
 
-    insertUser(user.userId)
-    val otherUserId = insertUser(100, email = "existingUser@email.com")
+    val otherUserId = insertUser(email = "existingUser@email.com")
 
     insertOrganization(organizationId)
 
@@ -276,7 +269,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     val newUserEmail = "newuser@email.com"
     val organizationId = OrganizationId(1)
 
-    insertUser(user.userId)
     insertOrganization(organizationId)
 
     every { user.canAddOrganizationUser(organizationId) } returns true
@@ -311,8 +303,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `assigning a Terraformation Contact throws exception for non-terraformation emails`() {
-    insertUser(user.userId)
-    insertUser(userId = UserId(5), email = "tfcontact@nonterraformation.com")
+    insertUser(email = "tfcontact@nonterraformation.com")
     insertOrganization(organizationId)
 
     every { user.canAddTerraformationContact(organizationId) } returns true
@@ -324,8 +315,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `assigns a brand new Terraformation Contact`() {
-    insertUser(user.userId)
-    insertUser(userId = UserId(5), email = "tfcontact@terraformation.com")
+    insertUser(email = "tfcontact@terraformation.com")
     insertOrganization(organizationId)
 
     assertNull(
@@ -344,9 +334,8 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `removes existing Terraformation Contact and assigns a new one`() {
-    insertUser(user.userId)
-    insertUser(userId = UserId(5), email = "tfcontact@terraformation.com")
-    insertUser(userId = UserId(6), email = "tfcontactnew@terraformation.com")
+    insertUser(email = "tfcontact@terraformation.com")
+    insertUser(email = "tfcontactnew@terraformation.com")
     insertOrganization(organizationId)
 
     every { user.canAddTerraformationContact(organizationId) } returns true
@@ -369,8 +358,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `removes existing Terraformation Contact and sets the role for reassigned Terraformation Contact if user already exists`() {
-    insertUser(user.userId)
-    insertUser(userId = UserId(5), email = "tfcontact@terraformation.com")
+    insertUser(email = "tfcontact@terraformation.com")
     insertOrganization(organizationId)
 
     every { user.canAddTerraformationContact(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -189,7 +189,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateSubLocation updates correct values`() {
-    val otherUserId = insertUser(10)
+    val otherUserId = insertUser()
     insertSubLocation(subLocationId, createdBy = otherUserId)
 
     val newTime = Instant.EPOCH.plusSeconds(30)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
@@ -29,8 +29,6 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canManageInternalTags() } returns true
     every { user.canReadInternalTags() } returns true
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -225,7 +225,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should throw an error when reading notifications belonging to another user`() {
-    val otherUserId = insertUser(3)
+    val otherUserId = insertUser()
     assertThrows<NotificationNotFoundException> {
       val notification = notificationModel(userId = otherUserId)
       store.create(notification, organizationId)
@@ -235,7 +235,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should delete user notifications when user is deleted`() {
-    val otherUserId = insertUser(3)
+    val otherUserId = insertUser()
 
     store.create(notificationModel(userId = otherUserId), organizationId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -123,7 +123,7 @@ internal class PermissionTest : DatabaseTest() {
 
   private val clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)!!
 
-  private val userId = UserId(1234)
+  private lateinit var userId: UserId
   private val user: TerrawareUser by lazy { fetchUser() }
 
   /*
@@ -165,13 +165,8 @@ internal class PermissionTest : DatabaseTest() {
   private val deviceManagerIds = listOf(1000L, 1001L, 2000L).map { DeviceManagerId(it) }
   private val nonConnectedDeviceManagerIds = deviceManagerIds.filterToArray { it.value >= 2000 }
 
-  private val sameOrgUserId = UserId(8765)
-  private val otherUserIds =
-      mapOf(
-          OrganizationId(1) to sameOrgUserId,
-          OrganizationId(2) to UserId(8766),
-          OrganizationId(3) to UserId(9876),
-          OrganizationId(4) to UserId(6543))
+  private lateinit var sameOrgUserId: UserId
+  private lateinit var otherUserIds: Map<OrganizationId, UserId>
 
   private val uploadId = UploadId(1)
 
@@ -214,7 +209,8 @@ internal class PermissionTest : DatabaseTest() {
             usersDao,
         )
 
-    insertUser(userId)
+    userId = insertUser()
+    sameOrgUserId = insertUser()
 
     organizationIds.forEach { organizationId ->
       insertOrganization(organizationId, createdBy = userId)
@@ -223,8 +219,14 @@ internal class PermissionTest : DatabaseTest() {
 
     insertOrganizationInternalTag(OrganizationId(4), InternalTagIds.Accelerator, createdBy = userId)
 
+    otherUserIds =
+        mapOf(
+            OrganizationId(1) to sameOrgUserId,
+            OrganizationId(2) to insertUser(),
+            OrganizationId(3) to insertUser(),
+            OrganizationId(4) to insertUser())
+
     otherUserIds.forEach { (organizationId, otherUserId) ->
-      insertUser(otherUserId)
       insertOrganizationUser(otherUserId, organizationId, createdBy = userId)
     }
 

--- a/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
@@ -67,7 +67,6 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     every { config.dailyTasks } returns TerrawareServerConfig.DailyTasksConfig()
 
-    insertUser()
     insertOrganization()
     insertFacility(lastNotificationDate = LocalDate.EPOCH, nextNotificationTime = Instant.EPOCH)
   }

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -54,7 +54,6 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization(timeZone = timeZone)
 
     clock.instant = initialInstant

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -311,6 +311,7 @@ import java.time.LocalDate
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.Locale
+import java.util.UUID
 import kotlin.math.roundToInt
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
@@ -586,7 +587,6 @@ abstract class DatabaseBackedTest {
    * tests.
    */
   fun insertSiteData() {
-    insertUser()
     insertOrganization()
     insertFacility()
   }
@@ -1087,9 +1087,8 @@ abstract class DatabaseBackedTest {
 
   /** Creates a user that can be referenced by various tests. */
   fun insertUser(
-      userId: Any? = currentUser().userId,
-      authId: String? = "$userId",
-      email: String = "$userId@terraformation.com",
+      authId: String? = "${UUID.randomUUID()}",
+      email: String = "$authId@terraformation.com",
       firstName: String? = "First",
       lastName: String? = "Last",
       type: UserType = UserType.Individual,
@@ -1099,8 +1098,6 @@ abstract class DatabaseBackedTest {
       cookiesConsented: Boolean? = null,
       cookiesConsentedTime: Instant? = if (cookiesConsented != null) Instant.EPOCH else null,
   ): UserId {
-    val userIdWrapper = userId?.toIdWrapper { UserId(it) }
-
     val insertedId =
         with(USERS) {
           dslContext
@@ -1111,7 +1108,6 @@ abstract class DatabaseBackedTest {
               .set(CREATED_TIME, Instant.EPOCH)
               .set(EMAIL, email)
               .set(EMAIL_NOTIFICATIONS_ENABLED, emailNotificationsEnabled)
-              .apply { userIdWrapper?.let { set(ID, it) } }
               .set(FIRST_NAME, firstName)
               .set(LAST_NAME, lastName)
               .set(LOCALE, locale)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseTest.kt
@@ -1,6 +1,18 @@
 package com.terraformation.backend.db
 
+import com.terraformation.backend.RunsAsUser
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.boot.test.autoconfigure.jooq.JooqTest
 
 /** Superclass for tests that require database access but not the entire set of Spring beans. */
-@JooqTest abstract class DatabaseTest : DatabaseBackedTest()
+@JooqTest
+abstract class DatabaseTest : DatabaseBackedTest() {
+  @BeforeEach
+  fun insertMockUser() {
+    if (this is RunsAsUser) {
+      val userId = insertUser()
+      every { user.userId } returns userId
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
@@ -19,7 +19,6 @@ internal class IdentifierGeneratorTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.TimeseriesNotFoundException
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.TimeseriesId
 import com.terraformation.backend.db.default_schema.TimeseriesType
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.TimeseriesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.TimeseriesValuesRow
 import com.terraformation.backend.db.default_schema.tables.records.TimeseriesValuesRecord
@@ -103,8 +102,9 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createOrUpdate updates existing timeseries with same name and device ID`() {
-    val otherUser = mockUser(UserId(3))
-    insertUser(otherUser.userId)
+    val otherUser = mockUser()
+    val otherUserId = insertUser()
+    every { otherUser.userId } returns otherUserId
     every { otherUser.canCreateTimeseries(any()) } returns true
 
     timeseriesDao.insert(timeseriesRow)

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
@@ -68,7 +68,6 @@ class DocumentUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertProject()
     insertDocumentTemplate()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentTemplatesControllerTest.kt
@@ -1,18 +1,12 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.get
 
 class DocumentTemplatesControllerTest : ControllerIntegrationTest() {
   private val path = "/api/v1/document-producer/templates"
-
-  @BeforeEach
-  fun setUp() {
-    insertUser()
-  }
 
   @Nested
   inner class ListDocumentTemplates {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -30,8 +30,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
   @BeforeEach
   fun setUp() {
-    val userId = insertUser()
-    insertUserGlobalRole(userId = userId, GlobalRole.TFExpert)
+    insertUserGlobalRole(userId = user.userId, GlobalRole.TFExpert)
     insertOrganization()
     insertProject()
     insertDocumentTemplate()
@@ -99,7 +98,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       val otherDocumentTemplateId = insertDocumentTemplate()
       val otherVariableManifestId =
           insertVariableManifest(documentTemplateId = otherDocumentTemplateId)
-      val otherUserId = insertUser(101)
+      val otherUserId = insertUser()
       val otherCreatedTime = Instant.EPOCH.plusSeconds(100)
       val otherModifiedTime = otherCreatedTime.plusSeconds(1)
       val documentId1 = insertDocument(projectId = projectId)
@@ -234,7 +233,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       val otherDocumentTemplateId = insertDocumentTemplate()
       val otherVariableManifestId =
           insertVariableManifest(documentTemplateId = otherDocumentTemplateId)
-      val otherUserId = insertUser(101)
+      val otherUserId = insertUser()
       val otherCreatedTime = Instant.EPOCH.plusSeconds(100)
       val otherModifiedTime = otherCreatedTime.plusSeconds(1)
       val documentId =
@@ -431,8 +430,8 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       var timestamp = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
       lateinit var lastValueId: VariableValueId
 
-      val userId1 = insertUser(101)
-      val userId2 = insertUser(102)
+      val userId1 = insertUser()
+      val userId2 = insertUser()
       val documentId = insertDocument(createdBy = userId1)
       val variableManifestId1 = insertVariableManifest()
       val variableId = insertVariableManifestEntry(insertTextVariable())

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
@@ -26,7 +26,6 @@ class ImagesControllerTest : ControllerIntegrationTest() {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertUserGlobalRole(role = GlobalRole.TFExpert)
     insertOrganization()
     insertProject()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -22,8 +23,7 @@ import org.springframework.test.web.servlet.post
 class ValuesControllerTest : ControllerIntegrationTest() {
   @BeforeEach
   fun setUp() {
-    val userId = insertUser()
-    insertUserGlobalRole(userId = userId, GlobalRole.TFExpert)
+    insertUserGlobalRole(userId = currentUser().userId, GlobalRole.TFExpert)
     insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertProject()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
@@ -17,7 +17,6 @@ class VariableOwnersControllerTest : ControllerIntegrationTest() {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     projectId = insertProject()
   }
@@ -36,8 +35,8 @@ class VariableOwnersControllerTest : ControllerIntegrationTest() {
 
       @Test
       fun `returns owner user IDs for variables with owners`() {
-        val ownerId1 = insertUser(100)
-        val ownerId2 = insertUser(101)
+        val ownerId1 = insertUser()
+        val ownerId2 = insertUser()
 
         val sectionId1 = insertSectionVariable()
         val sectionId2 = insertSectionVariable()
@@ -119,7 +118,7 @@ class VariableOwnersControllerTest : ControllerIntegrationTest() {
 
       @Test
       fun `updates owner if one already exists`() {
-        val newOwnerId = insertUser(100)
+        val newOwnerId = insertUser()
         insertVariableOwner(sectionId, user.userId)
         insertVariableOwner(otherSectionId, user.userId)
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowControllerTest.kt
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.put
 class VariableWorkflowControllerTest : ControllerIntegrationTest() {
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
@@ -13,7 +13,6 @@ import org.springframework.test.web.servlet.get
 class VariablesControllerTest : ControllerIntegrationTest() {
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertProject()
     insertDocumentTemplate()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -65,7 +65,6 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertDocumentTemplate()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -46,11 +46,6 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
     VariableImporter(deliverableStore, dslContext, messages, variableStore)
   }
 
-  @BeforeEach
-  fun setUp() {
-    insertUser()
-  }
-
   @Nested
   inner class UploadManifest {
     private var oldAuthentication: Authentication? = null

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -32,7 +32,6 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertProject()
     insertDocumentTemplate()

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -45,7 +45,6 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertProject()
     insertDocumentTemplate()

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -80,8 +80,6 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
     photoStorageUrl = URI("file:///${relativePath.invariantSeparatorsPathString}")
 
     fileService = FileService(dslContext, clock, config, filesDao, fileStore, thumbnailStore)
-
-    insertUser()
   }
 
   @AfterEach

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -61,7 +61,6 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     store = ThumbnailStore(clock, dslContext, fileStore, filesDao, thumbnailsDao, imageUtils)
 
-    insertUser()
     filesDao.insert(
         FilesRow(
             id = fileId,

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -55,8 +55,6 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadUpload(any()) } returns true
     every { user.canUpdateUpload(any()) } returns true
     every { user.canDeleteUpload(any()) } returns true
-
-    insertUser()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -67,7 +67,6 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateBatch(any()) } returns true
     every { user.canUpdateDelivery(any()) } returns true
 
-    insertUser()
     insertOrganization()
     insertFacility(type = FacilityType.Nursery)
   }

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -43,7 +43,6 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization(organizationId)
     insertOrganizationUser(user.userId, organizationId, Role.Manager)
     insertFacility(facilityId, name = "Nursery", type = FacilityType.Nursery)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -126,7 +126,6 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateUpload(any()) } returns true
     every { userStore.fetchOneById(userId) } returns user
 
-    insertUser()
     insertOrganization()
     insertFacility(type = FacilityType.Nursery)
     subLocationId = insertSubLocation(name = "Location 1")

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -65,7 +65,6 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertSpecies()
     insertFacility(type = FacilityType.Nursery)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -58,7 +58,6 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertFacility(type = FacilityType.Nursery)
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -49,7 +49,6 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertFacility(name = "Nursery", type = FacilityType.Nursery)
     speciesId = insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
@@ -72,7 +72,6 @@ class ReportFileServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     reportId = insertReport()
 

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -172,7 +172,6 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateReport(any()) } returns true
     every { user.organizationRoles } returns mapOf(organizationId to Role.Admin)
 
-    insertUser()
     insertOrganization()
     insertOrganizationUser(user.userId, organizationId, Role.Admin)
   }
@@ -938,7 +937,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by another user`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
       val reportId = insertReport(lockedBy = otherUserId)
 
       assertThrows<ReportLockedException> { service.update(reportId) { it } }

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -261,7 +261,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `overwrites existing lock if force is true`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(lockedBy = otherUserId, lockedTime = Instant.EPOCH)
 
@@ -287,7 +287,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already locked and force is not true`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -296,7 +296,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already submitted`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -343,7 +343,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by someone else`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -352,7 +352,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report already submitted`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -418,7 +418,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is already submitted`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(status = ReportStatus.Submitted, submittedBy = otherUserId)
 
@@ -438,7 +438,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by someone else`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
 
       val reportId = insertReport(lockedBy = otherUserId)
 
@@ -571,7 +571,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is locked by another user`() {
-      val otherUserId = insertUser(10)
+      val otherUserId = insertUser()
       val reportId = insertReport(lockedBy = otherUserId)
 
       assertThrows<ReportLockedException> { store.submit(reportId) }

--- a/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
@@ -22,7 +22,6 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser(currentUser().userId, inserted.organizationId)
     every { user.canReadOrganization(inserted.organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -84,7 +84,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetches existing withdrawals`() {
-    val otherUserId = insertUser(10, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(firstName = "Other", lastName = "User")
 
     // Insert batches that are linked to the withdrawals
     for (batchId in setOf(batchId1, batchId2)) {
@@ -242,7 +242,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `allows new withdrawals to be attributed to other organization users`() {
-    val otherUserId = insertUser(20, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(firstName = "Other", lastName = "User")
     insertOrganizationUser(otherUserId, organizationId)
 
     val newWithdrawal =
@@ -282,7 +282,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `throws exception if user sets withdrawn by to another user and has no permission to read user`() {
-    val otherUserId = insertUser(20)
+    val otherUserId = insertUser()
 
     every { user.canReadOrganizationUser(organizationId, otherUserId) } returns false
 
@@ -304,7 +304,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `ignores withdrawnByUserId on new withdrawal if user has no permission to set withdrawal users`() {
-    val otherUserId = insertUser(20)
+    val otherUserId = insertUser()
 
     every { user.canSetWithdrawalUser(any()) } returns false
 
@@ -479,7 +479,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update ignores withdrawnByUserId if user has no permission to set withdrawal users`() {
-    val otherUserId = insertUser(20, firstName = "Other", lastName = "User")
+    val otherUserId = insertUser(firstName = "Other", lastName = "User")
 
     val initial =
         WithdrawalModel(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -115,11 +115,11 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     val secondWithdrawalTime = firstWithdrawalTime.plus(1, ChronoUnit.DAYS)
     val backdatedWithdrawalTime = secondWithdrawalTime.plus(1, ChronoUnit.DAYS)
 
-    val createUserId = insertUser(20, firstName = "First", lastName = "Last")
-    val checkInUserId = insertUser(30, firstName = null, lastName = null)
-    val processUserId = insertUser(40, firstName = "Bono", lastName = null)
-    val firstWithdrawerUserId = insertUser(50, firstName = "First", lastName = "Withdrawer")
-    val viabilityTesterUserId = insertUser(60, firstName = "Viability", lastName = "Tester")
+    val createUserId = insertUser(firstName = "First", lastName = "Last")
+    val checkInUserId = insertUser(firstName = null, lastName = null)
+    val processUserId = insertUser(firstName = "Bono", lastName = null)
+    val firstWithdrawerUserId = insertUser(firstName = "First", lastName = "Withdrawer")
+    val viabilityTesterUserId = insertUser(firstName = "Viability", lastName = "Tester")
 
     clock.instant = createTime
     every { user.userId } returns createUserId

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -826,6 +826,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             testType = ViabilityTestType.Cut)
     viabilityTestsDao.insert(cutTestRow)
 
+    val email = usersDao.fetchOneById(user.userId)!!.email!!
+
     val expectedAccessions =
         listOf(
                 mapOf(
@@ -942,9 +944,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val expectedUser =
         mapOf(
             "createdTime" to "1970-01-01T00:00:00Z",
-            "email" to "2@terraformation.com",
+            "email" to email,
             "firstName" to "First",
-            "id" to "2",
+            "id" to "${user.userId}",
             "lastName" to "Last",
             "organizationMemberships" to
                 listOf(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -21,15 +21,15 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
   private val usersPrefix = SearchFieldPrefix(tables.users)
 
   private val otherOrganizationId = OrganizationId(2)
-  private val bothOrgsUserId = UserId(4)
-  private val otherOrgUserId = UserId(5)
-  private val deviceManagerUserId = UserId(6)
+  private lateinit var bothOrgsUserId: UserId
+  private lateinit var otherOrgUserId: UserId
+  private lateinit var deviceManagerUserId: UserId
 
   @BeforeEach
   fun insertOtherUsers() {
-    insertUser(deviceManagerUserId, type = UserType.DeviceManager)
-    insertUser(bothOrgsUserId)
-    insertUser(otherOrgUserId)
+    deviceManagerUserId = insertUser(type = UserType.DeviceManager)
+    bothOrgsUserId = insertUser()
+    otherOrgUserId = insertUser()
 
     insertOrganization(otherOrganizationId)
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -101,7 +101,6 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     userId = user.userId
-    insertUser()
     insertOrganization()
 
     every { speciesChecker.checkAllUncheckedSpecies(organizationId) } just Runs

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -147,7 +147,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     plantingSiteId = insertPlantingSite(x = 0, width = 11, gridOrigin = point(1))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -46,8 +46,6 @@ class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
-
     every { user.canReadOrganization(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -69,7 +69,6 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertFacility(type = FacilityType.Nursery)
     insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -38,7 +38,6 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     insertOrganizationUser()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -56,7 +56,6 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadPlantingSite(any()) } returns true
     every { user.canUpdateDelivery(any()) } returns true
 
-    insertUser()
     insertOrganization()
     insertFacility(type = FacilityType.Nursery)
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DraftPlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DraftPlantingSiteStoreTest.kt
@@ -32,7 +32,6 @@ class DraftPlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
 
     every { user.canCreateDraftPlantingSite(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -67,7 +67,6 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     plantingSiteId = insertPlantingSite(areaHa = BigDecimal(2500))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -79,7 +79,6 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     plantingSiteId = insertPlantingSite()
 
@@ -151,8 +150,8 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchObservationPlotDetails {
     @Test
     fun `calculates correct values from related tables`() {
-      val userId1 = insertUser(101, firstName = "First", lastName = "Person")
-      val userId2 = insertUser(102, firstName = "Second", lastName = "Human")
+      val userId1 = insertUser(firstName = "First", lastName = "Person")
+      val userId2 = insertUser(firstName = "Second", lastName = "Human")
 
       insertPlantingZone(name = "Z1")
       val plantingSubzoneId1 = insertPlantingSubzone(fullName = "Z1-S1", name = "S1")
@@ -838,7 +837,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if plot is claimed by someone else`() {
-      val otherUserId = insertUser(100)
+      val otherUserId = insertUser()
 
       insertObservationPlot(claimedBy = otherUserId, claimedTime = Instant.EPOCH)
 
@@ -894,7 +893,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if plot is claimed by someone else`() {
-      val otherUserId = insertUser(100)
+      val otherUserId = insertUser()
 
       insertObservationPlot(claimedBy = otherUserId, claimedTime = Instant.EPOCH)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -50,7 +50,6 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canCreatePlantingSite(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
 
-    insertUser()
     insertOrganization()
     insertOrganizationUser()
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTest.kt
@@ -33,7 +33,6 @@ internal abstract class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertUser()
     insertOrganization()
     timeZone = ZoneId.of("Pacific/Honolulu")
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
@@ -17,7 +17,7 @@ internal class PlantingSiteStoreUpdateZoneTest : PlantingSiteStoreTest() {
     @Test
     fun `updates editable values`() {
       val createdTime = Instant.ofEpochSecond(1000)
-      val createdBy = insertUser(100)
+      val createdBy = insertUser()
       val plantingSiteId = insertPlantingSite()
 
       val initialRow =


### PR DESCRIPTION
As a step toward being able to run our JUnit tests in parallel, stop inserting
hardwired user IDs in tests and instead let the database allocate IDs. This will
avoid deadlocks when multiple tests try to insert the same user ID in different
transactions.

The default auth ID and email addresses were based on the hardwired user IDs;
replace those with random UUIDs which should help avoid unique-key collisions
on those as well.

Many of the references to hardwired user IDs were in the form of fetching the
user ID from the object returned by `mockUser()`. Add setup methods to
automatically insert a user into the database and make the mock return its ID;
tests can continue to reference `user.userId` as before but now it will return
a dynamically-assigned value instead of a fixed one. As a side benefit, tests
no longer need to call `insertUser()` explicitly to insert the mock user into
the database.

Some tests still use hardwired non-unique email addresses; those can be fixed
in a later change.