### PR TITLE
Fix IntelliJ warning in UserStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -724,6 +724,7 @@ class UserStore(
   }
 
   /** Relevant parts of the payload of a valid response to an OpenID Connect token request. */
+  @Suppress("PropertyName") // Snake-case property name is defined by OIDC standard
   @JsonIgnoreProperties(ignoreUnknown = true)
   data class OpenIdConnectTokenResponsePayload(val refresh_token: String)
 


### PR DESCRIPTION
IntelliJ warns about property names not following Kotlin's naming convention, but
in this case the name is from an externally-controlled payload definition.