### PR TITLE
[WIP] SW-5626 Add applications to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/field/RestrictedField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/RestrictedField.kt
@@ -1,0 +1,30 @@
+package com.terraformation.backend.search.field
+
+import org.jooq.Field
+import org.jooq.impl.DSL
+
+/**
+ * Search field that is only available to some users. Wraps an underlying search field. If the user
+ * fails the permission check, values of this field are always null.
+ */
+class RestrictedField(
+    private val underlyingField: SearchField,
+    private val permissionCheck: () -> Boolean,
+) : SearchField by underlyingField {
+  private val nullSelectFields = underlyingField.selectFields.map { DSL.castNull(it) }
+
+  override val orderByField: Field<*>
+    get() = DSL.castNull(underlyingField.orderByField)
+
+  override val selectFields: List<Field<*>>
+    get() {
+      return if (permissionCheck()) {
+        underlyingField.selectFields
+      } else {
+        nullSelectFields
+      }
+    }
+}
+
+fun SearchField.withRestriction(permissionCheck: () -> Boolean): RestrictedField =
+    RestrictedField(this, permissionCheck)

--- a/src/main/kotlin/com/terraformation/backend/search/table/ApplicationHistoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ApplicationHistoriesTable.kt
@@ -1,0 +1,50 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.accelerator.ApplicationHistoryId
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_HISTORIES
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.search.field.withRestriction
+import org.jooq.Record
+import org.jooq.SelectJoinStep
+import org.jooq.TableField
+
+class ApplicationHistoriesTable(tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = APPLICATION_HISTORIES.ID
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          applications.asSingleValueSublist(
+              "application", APPLICATION_HISTORIES.APPLICATION_ID.eq(APPLICATIONS.ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      listOf(
+          geometryField("boundary", APPLICATION_HISTORIES.BOUNDARY),
+          textField("feedback", APPLICATION_HISTORIES.FEEDBACK),
+          idWrapperField("id", APPLICATION_HISTORIES.ID) { ApplicationHistoryId(it) },
+          textField("internalComment", APPLICATION_HISTORIES.INTERNAL_COMMENT).internalOnly(),
+          idWrapperField("modifiedBy", APPLICATION_HISTORIES.MODIFIED_BY) { UserId(it) }
+              .internalOnly(),
+          timestampField("modifiedTime", APPLICATION_HISTORIES.MODIFIED_TIME),
+          enumField("status", APPLICATION_HISTORIES.STATUS_ID),
+      )
+
+  override val inheritsVisibilityFrom: SearchTable = tables.applications
+
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
+    return query.join(APPLICATIONS).on(APPLICATION_HISTORIES.APPLICATION_ID.eq(APPLICATIONS.ID))
+  }
+
+  private fun SearchField.internalOnly() = withRestriction {
+    currentUser().canReadAllAcceleratorDetails()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/ApplicationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ApplicationsTable.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.accelerator.ApplicationId
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_HISTORIES
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.search.SearchTable
+import com.terraformation.backend.search.SublistField
+import com.terraformation.backend.search.field.SearchField
+import com.terraformation.backend.search.field.withRestriction
+import org.jooq.Record
+import org.jooq.SelectJoinStep
+import org.jooq.TableField
+
+class ApplicationsTable(tables: SearchTables) : SearchTable() {
+  override val primaryKey: TableField<out Record, out Any?>
+    get() = APPLICATIONS.ID
+
+  override val sublists: List<SublistField> by lazy {
+    with(tables) {
+      listOf(
+          applicationHistories.asMultiValueSublist(
+              "history", APPLICATIONS.ID.eq(APPLICATION_HISTORIES.APPLICATION_ID)),
+          projects.asSingleValueSublist("project", APPLICATIONS.PROJECT_ID.eq(PROJECTS.ID)),
+      )
+    }
+  }
+
+  override val fields: List<SearchField> =
+      listOf(
+          geometryField("boundary", APPLICATIONS.BOUNDARY),
+          idWrapperField("createdBy", APPLICATIONS.CREATED_BY) { UserId(it) }.internalOnly(),
+          timestampField("createdTime", APPLICATIONS.CREATED_TIME),
+          textField("feedback", APPLICATIONS.FEEDBACK),
+          idWrapperField("id", APPLICATIONS.ID) { ApplicationId(it) },
+          textField("internalComment", APPLICATIONS.INTERNAL_COMMENT).internalOnly(),
+          textField("internalName", APPLICATIONS.INTERNAL_NAME).internalOnly(),
+          idWrapperField("modifiedBy", APPLICATIONS.MODIFIED_BY) { UserId(it) }.internalOnly(),
+          timestampField("modifiedTime", APPLICATIONS.MODIFIED_TIME),
+          enumField("status", APPLICATIONS.STATUS_ID),
+      )
+
+  override val inheritsVisibilityFrom: SearchTable = tables.projects
+
+  override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
+    return query.join(PROJECTS).on(APPLICATIONS.PROJECT_ID.eq(PROJECTS.ID))
+  }
+
+  private fun SearchField.internalOnly() = withRestriction {
+    currentUser().canReadAllAcceleratorDetails()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.EVENTS
 import com.terraformation.backend.db.accelerator.tables.references.EVENT_PROJECTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
@@ -35,6 +36,11 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           accessions.asMultiValueSublist("accessions", PROJECTS.ID.eq(ACCESSIONS.PROJECT_ID)),
+          applications.asSingleValueSublist(
+              "application",
+              PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID),
+              isRequired = false,
+              isTraversedForGetAllFields = true),
           batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCH_SUMMARIES.PROJECT_ID)),
           countries.asSingleValueSublist("country", PROJECTS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
           draftPlantingSites.asMultiValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SearchTables.kt
@@ -24,6 +24,8 @@ import java.time.Clock
 class SearchTables(clock: Clock) {
   val accessionCollectors = AccessionCollectorsTable(this)
   val accessions = AccessionsTable(this, clock)
+  val applicationHistories = ApplicationHistoriesTable(this)
+  val applications = ApplicationsTable(this)
   val bags = BagsTable(this)
   val batches = BatchesTable(this)
   val batchSubLocations = BatchSubLocationsTable(this)


### PR DESCRIPTION
Add search tables for applications and application histories. This introduces a
new field type that supports wrapping an underlying field with a permission check
so as to make the internal comments field available via search API for admin users
but not for regular users.