### PR TITLE
Add whitespace to properties generated by i18n tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
@@ -53,8 +53,10 @@ class EnumsTest : DatabaseTest() {
     val expectedKeys = enums.keys.toSet()
     val missingKeys = expectedKeys - keysInBundle
 
-    // Render the missing keys one per line suitable for copy-pasting into Enums_en.properties.
-    val missingProperties = missingKeys.sorted().joinToString("\n") { "$it=${enums[it] ?: ""}" }
-    assertEquals("", missingProperties, "Bundle $bundleName is missing values")
+    // Render the missing keys one per line with leading and trailing newlines suitable for
+    // copy-pasting into Enums_en.properties.
+    val missingProperties =
+        missingKeys.sorted().joinToString("\n", "\n", "\n") { "$it = ${enums[it] ?: ""}" }
+    assertEquals("\n\n", missingProperties, "Bundle $bundleName is missing values")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
@@ -13,6 +13,8 @@ class SearchFieldMetadataTest {
 
   @Test
   fun `all search fields have English descriptions`() {
+    // Generate a string with one line per missing field, suitable for copy-pasting into
+    // Messages_en.properties.
     val missingFields =
         mapAllSearchFields { table, field ->
               try {
@@ -21,13 +23,13 @@ class SearchFieldMetadataTest {
                 messages.searchFieldDisplayName(table.name, field.fieldName)
                 null
               } catch (e: Exception) {
-                "search.${table.name}.${field.fieldName}="
+                "search.${table.name}.${field.fieldName} = "
               }
             }
             .sorted()
-            .joinToString("\n")
+            .joinToString("\n", "\n", "\n")
 
-    assertEquals("", missingFields, "Missing search field descriptions")
+    assertEquals("\n\n", missingFields, "Missing search field descriptions")
   }
 
   @Test


### PR DESCRIPTION
The JUnit tests that verify there are strings in the English properties files for
various things (enums, search fields, etc.) generate assertion failure messages
that include entries suitable for copy-pasting into the properties files.

Phrase recently changed their properties file exporter to put whitespace around
the equals signs. Update the tests to follow the same format.

Also surround the generated entries with newlines so that they're not on the same
lines as other parts of the assertion failure message, making them easier to
copy-paste.