### PR TITLE
SW-5632 Detect which countries a geometry is in

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
   implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
   implementation("org.freemarker:freemarker:2.3.33")
   implementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
+  implementation("org.geotools:gt-geojson:$geoToolsVersion")
   implementation("org.geotools:gt-shapefile:$geoToolsVersion")
   implementation("org.jobrunr:jobrunr-spring-boot-3-starter:7.2.2")
   implementation("org.jooq:jooq:$jooqVersion")

--- a/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.gis
+
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import org.geotools.geojson.feature.FeatureJSON
+import org.locationtech.jts.geom.Geometry
+
+/**
+ * Detects which countries contain a given geometry.
+ *
+ * Country borders are loaded from a file that is maintained as part of the
+ * [Natural Earth](https://www.naturalearthdata.com/) project, which makes its data available in the
+ * public domain. The specific file we use is the
+ * [GeoJSON 10-meter administrative countries file](https://github.com/nvkelso/natural-earth-vector/blob/master/geojson/ne_10m_admin_0_countries.geojson).
+ */
+@Named
+class CountryDetector {
+  private val log = perClassLogger()
+
+  val countryBorders: Map<String, Geometry> by lazy {
+    log.debug("Loading borders")
+
+    val result = mutableMapOf<String, Geometry>()
+
+    javaClass.getResourceAsStream("/gis/countries.geojson").use { stream ->
+      FeatureJSON().readFeatureCollection(stream).features().use { iterator ->
+        while (iterator.hasNext()) {
+          val feature = iterator.next()
+          val countryCode = feature.getProperty("ISO_A2_EH")?.value?.toString()
+          val border = feature.defaultGeometryProperty.value
+
+          if (countryCode != null && border is Geometry) {
+            // A country code can appear more than once if it has administrative regions such as
+            // territories or dependencies; in that case we want to treat them as part of the
+            // same country.
+            result.merge(countryCode, border) { a, b -> a.union(b) }
+          } else if (border !is Geometry) {
+            log.error("Unexpected geometry type ${border?.javaClass?.name} for $countryCode")
+          } else {
+            log.error("Found feature with no country code property")
+            log.debug("$feature")
+          }
+        }
+      }
+    }
+
+    log.debug("Done loading borders")
+
+    result
+  }
+
+  /**
+   * Returns the 2-letter country codes for the countries that contain a geometry. If the geometry
+   * falls outside any country, returns an empty set.
+   */
+  fun getCountries(geometry: Geometry): Set<String> {
+    return countryBorders.filterValues { border -> geometry.intersects(border) }.keys
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/CountryDetector.kt
@@ -11,7 +11,7 @@ import org.locationtech.jts.geom.Geometry
  * Country borders are loaded from a file that is maintained as part of the
  * [Natural Earth](https://www.naturalearthdata.com/) project, which makes its data available in the
  * public domain. The specific file we use is the
- * [GeoJSON 10-meter administrative countries file](https://github.com/nvkelso/natural-earth-vector/blob/master/geojson/ne_10m_admin_0_countries.geojson).
+ * [GeoJSON 1:10m administrative countries file](https://github.com/nvkelso/natural-earth-vector/blob/master/geojson/ne_10m_admin_0_countries.geojson).
  */
 @Named
 class CountryDetector {

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -38,6 +38,9 @@ logging:
     # bunch of informational messages at start time; suppress them to reduce log clutter in dev
     # environments.
     org.springframework.boot.devtools.restart.ChangeableUrls: WARN
+    # The data set we're using for country borders has a mix of Polygon and MultiPolygon geometries
+    # that causes GeoTools to spew warnings about mixed feature types.
+    org.geotools.feature.DefaultFeatureCollection: ERROR
   pattern:
     # This is the default Spring Boot console log format, but with the MDC values (%X) in between
     # the log message and the exception stacktrace.

--- a/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
@@ -1,0 +1,31 @@
+package com.terraformation.backend.gis
+
+import com.terraformation.backend.point
+import com.terraformation.backend.util.Turtle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CountryDetectorTest {
+  private val detector = CountryDetector()
+
+  @Test
+  fun `detects a geometry that is in one country`() {
+    val geometry = Turtle(point(0, 51)).makePolygon { rectangle(100, 100) }
+
+    assertEquals(setOf("GB"), detector.getCountries(geometry))
+  }
+
+  @Test
+  fun `detects a geometry that includes multiple countries`() {
+    val geometry = Turtle(point(3.5, 50)).makePolygon { rectangle(150000, 100000) }
+
+    assertEquals(setOf("BE", "FR"), detector.getCountries(geometry))
+  }
+
+  @Test
+  fun `detects a geometry that is completely outside any country`() {
+    val geometry = Turtle(point(0, 0)).makePolygon { rectangle(10, 10) }
+
+    assertEquals(emptySet<String>(), detector.getCountries(geometry))
+  }
+}


### PR DESCRIPTION
Add a utility class that loads a public-domain dataset with country borders and
determines which country or countries contain a particular geometry. We will use
this to do country auto-detection in accelerator applications.