### PR TITLE
Roll back upgrade to springdoc-openapi

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlinVersion=2.0.0
 ktfmtVersion=0.50
 ktorVersion=2.3.12
 postgresJdbcVersion=42.7.3
-springDocVersion=2.6.0
+springDocVersion=2.5.0
 
 # For code generation, we run database migrations against an ephemeral database in a Docker
 # container using this image. If you change this, make sure you also change DatabaseTest.kt.


### PR DESCRIPTION
Commit c4dc30b3 upgraded springdoc-openapi to version 2.6.0 but that version
introduces https://github.com/springdoc/springdoc-openapi/issues/2639 which
breaks code generation in terraware-web.

The new version didn't have any changes we need, so revert it. When the bug is
fixed, we can upgrade again.