### PR TITLE
Fix the default value population for new documents

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -344,7 +344,7 @@ class VariableValueStore(
             dslContext
                 .select()
                 .from(VARIABLE_VALUES)
-                .rightJoin(VARIABLE_MANIFEST_ENTRIES)
+                .join(VARIABLE_MANIFEST_ENTRIES)
                 .on(VARIABLE_MANIFEST_ENTRIES.VARIABLE_ID.eq(VARIABLE_VALUES.VARIABLE_ID))
                 .where(VARIABLE_VALUES.PROJECT_ID.eq(projectId)))
     if (hasValues) {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.docprod.tables.references.DOCUMENTS
 import com.terraformation.backend.db.docprod.tables.references.VARIABLES
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_IMAGE_VALUES
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_LINK_VALUES
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_MANIFEST_ENTRIES
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_SECTION_DEFAULT_VALUES
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_SECTION_VALUES
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_SELECT_OPTION_VALUES
@@ -339,7 +340,13 @@ class VariableValueStore(
   /** Populates a new document with the values of variables that are configured with defaults. */
   fun populateDefaultValues(projectId: ProjectId, manifestId: VariableManifestId) {
     val hasValues =
-        dslContext.fetchExists(VARIABLE_VALUES, VARIABLE_VALUES.PROJECT_ID.eq(projectId))
+        dslContext.fetchExists(
+            dslContext
+                .select()
+                .from(VARIABLE_VALUES)
+                .rightJoin(VARIABLE_MANIFEST_ENTRIES)
+                .on(VARIABLE_MANIFEST_ENTRIES.VARIABLE_ID.eq(VARIABLE_VALUES.VARIABLE_ID))
+                .where(VARIABLE_VALUES.PROJECT_ID.eq(projectId)))
     if (hasValues) {
       throw IllegalStateException("Can only populate initial values of a new document")
     }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -90,6 +90,13 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
     @Test
     fun `populates sections with default values`() {
+      // Other values may exist for a project before a new document is created
+      insertModule()
+      val deliverableId = insertDeliverable()
+      val variableId = insertVariable(deliverableId = deliverableId, deliverablePosition = 0)
+      insertTextVariable(variableId)
+      insertValue(variableId = variableId, projectId = inserted.projectId, textValue = "Text")
+
       val textVariableId = insertVariableManifestEntry(insertTextVariable())
       val sectionId = insertVariableManifestEntry(insertSectionVariable(renderHeading = false))
       insertDefaultSectionValue(sectionId, listPosition = 0, textValue = "Some text")


### PR DESCRIPTION
- The `hasValues` query from before seemed to ignore the passed in manifest ID (due to a recent change moving document ID -> project ID), so it would produce false positives if a value has ever been saved to another document or a deliverable
- Now that values are saved against a project, and used in documents or deliverables, we need to also check against the manifest ID to determine if we can populate the values