### PR TITLE
Return all non-section variables when no deliverable or manifest ID is provided

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -55,7 +55,7 @@ class VariablesController(
         } else if (manifestId != null) {
           variableStore.fetchManifestVariables(manifestId)
         } else {
-          throw BadRequestException("Deliverable ID or Manifest ID must be provided.")
+          variableStore.fetchAllNonSectionVariables()
         }
 
     return ListVariablesResponsePayload(variables.map { VariablePayload.of(it) })

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -39,7 +39,8 @@ import org.springframework.web.bind.annotation.RestController
 class VariablesController(
     private val variableStore: VariableStore,
 ) {
-  @Operation(summary = "List the variables within a given manifest or deliverable.")
+  @Operation(
+      summary = "List the variables, optionally filtered by a given manifest or deliverable.")
   @GetMapping
   fun listVariables(
       @RequestParam deliverableId: DeliverableId?,


### PR DESCRIPTION
- Since variables in the document editor are "system wide" (values are still per project), we need a way of listing all non-section variables so a user can embed them in the editor