### PR TITLE
SW-5625 Make internal name optional, unique

### DIFF
--- a/src/main/resources/db/migration/0250/V288__ApplicationsUniqueInternalName.sql
+++ b/src/main/resources/db/migration/0250/V288__ApplicationsUniqueInternalName.sql
@@ -1,0 +1,2 @@
+ALTER TABLE accelerator.applications ALTER COLUMN internal_name DROP NOT NULL;
+ALTER TABLE accelerator.applications ADD UNIQUE (internal_name);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2224,7 +2224,7 @@ abstract class DatabaseBackedTest {
       feedback: String? = null,
       id: Any? = null,
       internalComment: String? = null,
-      internalName: String = "USA_Organization",
+      internalName: String? = null,
       projectId: Any = inserted.projectId,
       modifiedBy: Any = createdBy,
       modifiedTime: Instant = createdTime,


### PR DESCRIPTION
We've decided to not set the internal name until the country can be determined
from the project boundaries, so change the database schema to make it nullable.
Internal names must also be globally unique; add a constraint to enforce that.