### PR TITLE
Set correct phase when re-importing modules

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
@@ -96,7 +96,7 @@ class ModulesImporter(
                 .set(LIVE_SESSION_DESCRIPTION, liveSessionInfo)
                 .set(ONE_ON_ONE_SESSION_DESCRIPTION, oneOnOneInfo)
                 .set(WORKSHOP_DESCRIPTION, workshopInfo)
-                .set(PHASE_ID, CohortPhase.Phase1FeasibilityStudy)
+                .set(PHASE_ID, phase)
                 .set(MODIFIED_BY, userId)
                 .set(MODIFIED_TIME, now)
                 .execute()


### PR DESCRIPTION
The phase number from the modules spreadsheet was getting overwritten with a
hardcoded value when importing a module that already existed in the database.