### PR TITLE
Fix classpath conflict

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,9 @@ dependencies {
   implementation("com.opencsv:opencsv:5.9")
   implementation("com.squarespace.cldr-engine:cldr-engine:1.8.0")
   implementation("commons-validator:commons-validator:1.9.0")
-  implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.2.1")
+  implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.2.1") {
+    exclude("org.apache.tomcat")
+  }
   implementation("io.ktor:ktor-client-auth:$ktorVersion")
   implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
   implementation("io.ktor:ktor-client-java:$ktorVersion")


### PR DESCRIPTION
The access log library we're using depends on an older version of some of the
classes for the Tomcat embedded web server, which can cause the server to fail to
start up in dev environments if Gradle decides to put that library before Spring
Boot in the classpath.

The failure is due to https://github.com/gradle/gradle/issues/20286 and can happen
intermittently.