### PR TITLE
Remove whitespace from properties generated by i18n tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/EnumsTest.kt
@@ -56,7 +56,7 @@ class EnumsTest : DatabaseTest() {
     // Render the missing keys one per line with leading and trailing newlines suitable for
     // copy-pasting into Enums_en.properties.
     val missingProperties =
-        missingKeys.sorted().joinToString("\n", "\n", "\n") { "$it = ${enums[it] ?: ""}" }
+        missingKeys.sorted().joinToString("\n", "\n", "\n") { "$it=${enums[it] ?: ""}" }
     assertEquals("\n\n", missingProperties, "Bundle $bundleName is missing values")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
@@ -23,7 +23,7 @@ class SearchFieldMetadataTest {
                 messages.searchFieldDisplayName(table.name, field.fieldName)
                 null
               } catch (e: Exception) {
-                "search.${table.name}.${field.fieldName} = "
+                "search.${table.name}.${field.fieldName}="
               }
             }
             .sorted()


### PR DESCRIPTION
Commit 066597e25 updated the assertion failure messages of the tests that check
for missing strings to account for Phrase changing their properties file exporter
to start putting whitespace around equals signs.

Phrase has now removed the extra whitespace. Update the tests accordingly.