### PR TITLE
SW-5662 Implement non-variable pre-screen checks

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -309,12 +309,12 @@ class ApplicationStore(
     if (application.boundary != null) {
       val countries = countryDetector.getCountries(application.boundary)
       when (countries.size) {
-        0 -> problems.add(messages.applicationPreCheckFailureNoCountry())
+        0 -> problems.add(messages.applicationPreScreenFailureNoCountry())
         1 -> countryCode = countries.first()
-        else -> problems.add(messages.applicationPreCheckFailureMultipleCountries())
+        else -> problems.add(messages.applicationPreScreenFailureMultipleCountries())
       }
     } else {
-      problems.add(messages.applicationPreCheckFailureNoBoundary())
+      problems.add(messages.applicationPreScreenFailureNoBoundary())
     }
 
     val countriesRow = countryCode?.let { countriesDao.fetchOneByCode(it) }
@@ -322,14 +322,14 @@ class ApplicationStore(
     if (countriesRow != null) {
       if (countriesRow.eligible != true) {
         // TODO: Look up localized country name
-        problems.add(messages.applicationPreCheckFailureIneligibleCountry(countriesRow.name!!))
+        problems.add(messages.applicationPreScreenFailureIneligibleCountry(countriesRow.name!!))
       } else {
         val minimumHectares = perCountryMinimumHectares[countryCode] ?: defaultMinimumHectares
         val siteArea = application.boundary!!.calculateAreaHectares().toInt()
 
         if (siteArea < minimumHectares || siteArea > defaultMaximumHectares) {
           problems.add(
-              messages.applicationPreCheckFailureBadSize(
+              messages.applicationPreScreenFailureBadSize(
                   countriesRow.name!!, minimumHectares, defaultMaximumHectares))
         }
       }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.db
 
+import com.terraformation.backend.accelerator.model.ApplicationSubmissionResult
 import com.terraformation.backend.accelerator.model.ExistingApplicationModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
@@ -13,7 +14,9 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.OrganizationsDao
 import com.terraformation.backend.gis.CountryDetector
+import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.util.calculateAreaHectares
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
@@ -27,8 +30,19 @@ class ApplicationStore(
     private val countriesDao: CountriesDao,
     private val countryDetector: CountryDetector,
     private val dslContext: DSLContext,
+    private val messages: Messages,
     private val organizationsDao: OrganizationsDao,
 ) {
+  private val defaultMinimumHectares = 15000
+  private val defaultMaximumHectares = 100000
+  private val perCountryMinimumHectares =
+      mapOf(
+          "CO" to 3000,
+          "GH" to 3000,
+          "KE" to 3000,
+          "TZ" to 3000,
+      )
+
   private val log = perClassLogger()
 
   fun fetchOneById(applicationId: ApplicationId): ExistingApplicationModel {
@@ -117,16 +131,29 @@ class ApplicationStore(
     }
   }
 
-  fun submit(applicationId: ApplicationId) {
+  /**
+   * Submits an application. If it is being submitted for pre-screening, does the pre-screening
+   * qualification checks.
+   */
+  fun submit(applicationId: ApplicationId): ApplicationSubmissionResult {
     requirePermissions { updateApplicationSubmissionStatus(applicationId) }
 
     val existing = fetchOneById(applicationId)
 
-    if (existing.status == ApplicationStatus.NotSubmitted) {
-      updateStatus(applicationId, ApplicationStatus.Submitted)
+    return if (existing.status == ApplicationStatus.NotSubmitted) {
+      val problems = checkPreScreenCriteria(existing)
+
+      if (problems.isNotEmpty()) {
+        updateStatus(applicationId, ApplicationStatus.FailedPreScreen)
+      } else {
+        updateStatus(applicationId, ApplicationStatus.PassedPreScreen)
+      }
+
+      ApplicationSubmissionResult(fetchOneById(applicationId), problems)
     } else {
       log.info(
           "Application $applicationId has status ${existing.status}; ignoring submission request")
+      ApplicationSubmissionResult(existing, emptyList())
     }
   }
 
@@ -272,5 +299,46 @@ class ApplicationStore(
         .where(conditionWithPermission)
         .orderBy(APPLICATIONS.ID)
         .fetch { ExistingApplicationModel.of(it) }
+  }
+
+  private fun checkPreScreenCriteria(application: ExistingApplicationModel): List<String> {
+    val problems = mutableListOf<String>()
+
+    var countryCode: String? = null
+
+    if (application.boundary != null) {
+      val countries = countryDetector.getCountries(application.boundary)
+      when (countries.size) {
+        0 -> problems.add(messages.applicationPreCheckFailureNoCountry())
+        1 -> countryCode = countries.first()
+        else -> problems.add(messages.applicationPreCheckFailureMultipleCountries())
+      }
+    } else {
+      problems.add(messages.applicationPreCheckFailureNoBoundary())
+    }
+
+    val countriesRow = countryCode?.let { countriesDao.fetchOneByCode(it) }
+
+    if (countriesRow != null) {
+      if (countriesRow.eligible != true) {
+        // TODO: Look up localized country name
+        problems.add(messages.applicationPreCheckFailureIneligibleCountry(countriesRow.name!!))
+      } else {
+        val minimumHectares = perCountryMinimumHectares[countryCode] ?: defaultMinimumHectares
+        val siteArea = application.boundary!!.calculateAreaHectares().toInt()
+
+        if (siteArea < minimumHectares || siteArea > defaultMaximumHectares) {
+          problems.add(
+              messages.applicationPreCheckFailureBadSize(
+                  countriesRow.name!!, minimumHectares, defaultMaximumHectares))
+        }
+      }
+    }
+
+    // TODO: Check land use type percentages
+
+    // TODO: Check number of species based on project type
+
+    return problems
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationSubmissionResult.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationSubmissionResult.kt
@@ -1,0 +1,13 @@
+package com.terraformation.backend.accelerator.model
+
+data class ApplicationSubmissionResult(
+    /**
+     * The application after the submission. Its status will reflect the outcome of the submission.
+     */
+    val application: ExistingApplicationModel,
+    /**
+     * If the submission was for pre-screening and the application failed, a list of the failure
+     * reasons.
+     */
+    val problems: List<String> = emptyList(),
+)

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -47,6 +47,25 @@ class Messages {
     return messageSource.getMessage(code, args, currentLocale())
   }
 
+  fun applicationPreCheckFailureBadSize(country: String, minimum: Int, maximum: Int) =
+      getMessage("applicationPreCheck.failure.badSize", country, minimum, maximum)
+
+  fun applicationPreCheckFailureIneligibleCountry(country: String) =
+      getMessage("applicationPreCheck.failure.ineligibleCountry", country)
+
+  fun applicationPreCheckFailureMonocultureTooHigh(maximum: Int) =
+      getMessage("applicationPreCheck.failure.monocultureTooHigh", maximum)
+
+  fun applicationPreCheckFailureMultipleCountries() =
+      getMessage("applicationPreCheck.failure.multipleCountries")
+
+  fun applicationPreCheckFailureNoBoundary() = getMessage("applicationPreCheck.failure.noBoundary")
+
+  fun applicationPreCheckFailureNoCountry() = getMessage("applicationPreCheck.failure.noCountry")
+
+  fun applicationPreCheckFailureTooFewSpecies(minimum: Int) =
+      getMessage("applicationPreCheck.failure.tooFewSpecies", minimum)
+
   fun csvBadHeader() = getMessage("csvBadHeader")
 
   fun csvRequiredFieldMissing() = getMessage("csvRequiredFieldMissing")

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -47,24 +47,24 @@ class Messages {
     return messageSource.getMessage(code, args, currentLocale())
   }
 
-  fun applicationPreCheckFailureBadSize(country: String, minimum: Int, maximum: Int) =
-      getMessage("applicationPreCheck.failure.badSize", country, minimum, maximum)
+  fun applicationPreScreenFailureBadSize(country: String, minimum: Int, maximum: Int) =
+      getMessage("applicationPreScreen.failure.badSize", country, minimum, maximum)
 
-  fun applicationPreCheckFailureIneligibleCountry(country: String) =
-      getMessage("applicationPreCheck.failure.ineligibleCountry", country)
+  fun applicationPreScreenFailureIneligibleCountry(country: String) =
+      getMessage("applicationPreScreen.failure.ineligibleCountry", country)
 
-  fun applicationPreCheckFailureMonocultureTooHigh(maximum: Int) =
-      getMessage("applicationPreCheck.failure.monocultureTooHigh", maximum)
+  fun applicationPreScreenFailureMonocultureTooHigh(maximum: Int) =
+      getMessage("applicationPreScreen.failure.monocultureTooHigh", maximum)
 
-  fun applicationPreCheckFailureMultipleCountries() =
-      getMessage("applicationPreCheck.failure.multipleCountries")
+  fun applicationPreScreenFailureMultipleCountries() =
+      getMessage("applicationPreScreen.failure.multipleCountries")
 
-  fun applicationPreCheckFailureNoBoundary() = getMessage("applicationPreCheck.failure.noBoundary")
+  fun applicationPreScreenFailureNoBoundary() = getMessage("applicationPreScreen.failure.noBoundary")
 
-  fun applicationPreCheckFailureNoCountry() = getMessage("applicationPreCheck.failure.noCountry")
+  fun applicationPreScreenFailureNoCountry() = getMessage("applicationPreScreen.failure.noCountry")
 
-  fun applicationPreCheckFailureTooFewSpecies(minimum: Int) =
-      getMessage("applicationPreCheck.failure.tooFewSpecies", minimum)
+  fun applicationPreScreenFailureTooFewSpecies(minimum: Int) =
+      getMessage("applicationPreScreen.failure.tooFewSpecies", minimum)
 
   fun csvBadHeader() = getMessage("csvBadHeader")
 

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -59,7 +59,8 @@ class Messages {
   fun applicationPreScreenFailureMultipleCountries() =
       getMessage("applicationPreScreen.failure.multipleCountries")
 
-  fun applicationPreScreenFailureNoBoundary() = getMessage("applicationPreScreen.failure.noBoundary")
+  fun applicationPreScreenFailureNoBoundary() =
+      getMessage("applicationPreScreen.failure.noBoundary")
 
   fun applicationPreScreenFailureNoCountry() = getMessage("applicationPreScreen.failure.noCountry")
 

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -33,6 +33,16 @@ accessionCsvStatusInvalid=Status must be one of\: {0}
 accessionState.Active=Active
 # Accession active/inactive states (active = seeds are still available, inactive = used up)
 accessionState.Inactive=Inactive
+# {0} is a country name; {1} and {2} are numbers
+applicationPreCheck.failure.badSize=Projects in {0} must be between {1} and {2} hectares.
+# {0} is a country name
+applicationPreCheck.failure.ineligibleCountry=Projects in {0} are not eligible for the accelerator.
+applicationPreCheck.failure.monocultureTooHigh=The project must not use more than {0}% of land for monoculture.
+applicationPreCheck.failure.multipleCountries=The project is located in more than one country.
+applicationPreCheck.failure.noBoundary=The project does not have boundaries.
+applicationPreCheck.failure.noCountry=The project is not located in a country.
+# {0} is a number greater than 1
+applicationPreCheck.failure.tooFewSpecies=The project must plant at least {0} species.
 batchCsvColumnName.0=Species (Scientific Name)
 batchCsvColumnName.1=Species (Common Name)
 batchCsvColumnName.2=Germinating Quantity

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -34,15 +34,15 @@ accessionState.Active=Active
 # Accession active/inactive states (active = seeds are still available, inactive = used up)
 accessionState.Inactive=Inactive
 # {0} is a country name; {1} and {2} are numbers
-applicationPreCheck.failure.badSize=Projects in {0} must be between {1} and {2} hectares.
+applicationPreScreen.failure.badSize=Projects in {0} must be between {1} and {2} hectares.
 # {0} is a country name
-applicationPreCheck.failure.ineligibleCountry=Projects in {0} are not eligible for the accelerator.
-applicationPreCheck.failure.monocultureTooHigh=The project must not use more than {0}% of land for monoculture.
-applicationPreCheck.failure.multipleCountries=The project is located in more than one country.
-applicationPreCheck.failure.noBoundary=The project does not have boundaries.
-applicationPreCheck.failure.noCountry=The project is not located in a country.
+applicationPreScreen.failure.ineligibleCountry=Projects in {0} are not eligible for the accelerator.
+applicationPreScreen.failure.monocultureTooHigh=The project must not use more than {0}% of land for monoculture.
+applicationPreScreen.failure.multipleCountries=The project is located in more than one country.
+applicationPreScreen.failure.noBoundary=The project does not have boundaries.
+applicationPreScreen.failure.noCountry=The project is not located in a country.
 # {0} is a number greater than 1
-applicationPreCheck.failure.tooFewSpecies=The project must plant at least {0} species.
+applicationPreScreen.failure.tooFewSpecies=The project must plant at least {0} species.
 batchCsvColumnName.0=Species (Scientific Name)
 batchCsvColumnName.1=Species (Common Name)
 batchCsvColumnName.2=Germinating Quantity

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -420,7 +420,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       val result = store.submit(applicationId)
 
-      assertEquals(listOf(messages.applicationPreCheckFailureNoBoundary()), result.problems)
+      assertEquals(listOf(messages.applicationPreScreenFailureNoBoundary()), result.problems)
       assertEquals(ApplicationStatus.FailedPreScreen, result.application.status)
     }
 
@@ -430,7 +430,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       val result = store.submit(applicationId)
 
-      assertEquals(listOf(messages.applicationPreCheckFailureNoCountry()), result.problems)
+      assertEquals(listOf(messages.applicationPreScreenFailureNoCountry()), result.problems)
       assertEquals(ApplicationStatus.FailedPreScreen, result.application.status)
     }
 
@@ -442,7 +442,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       val result = store.submit(applicationId)
 
-      assertEquals(listOf(messages.applicationPreCheckFailureMultipleCountries()), result.problems)
+      assertEquals(listOf(messages.applicationPreScreenFailureMultipleCountries()), result.problems)
       assertEquals(ApplicationStatus.FailedPreScreen, result.application.status)
     }
 
@@ -468,7 +468,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
         val result = store.submit(applicationId)
 
         assertEquals(
-            listOf(messages.applicationPreCheckFailureBadSize(country, minHectares, 100000)),
+            listOf(messages.applicationPreScreenFailureBadSize(country, minHectares, 100000)),
             result.problems,
             country)
         assertEquals(ApplicationStatus.FailedPreScreen, result.application.status, country)
@@ -484,7 +484,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result = store.submit(applicationId)
 
       assertEquals(
-          listOf(messages.applicationPreCheckFailureBadSize("United States", 15000, 100000)),
+          listOf(messages.applicationPreScreenFailureBadSize("United States", 15000, 100000)),
           result.problems)
       assertEquals(ApplicationStatus.FailedPreScreen, result.application.status)
     }
@@ -498,7 +498,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result = store.submit(applicationId)
 
       assertEquals(
-          listOf(messages.applicationPreCheckFailureIneligibleCountry("Canada")), result.problems)
+          listOf(messages.applicationPreScreenFailureIneligibleCountry("Canada")), result.problems)
       assertEquals(ApplicationStatus.FailedPreScreen, result.application.status)
     }
 


### PR DESCRIPTION
Change the response of the "submit application" API endpoint to return a list of
problems and an updated copy of the application data, including its updated
status.

Implement the check logic for all the pre-screen requirements that don't involve
fetching values from variables; the variable-based ones will require the
variables to be defined which isn't done yet. But these initial checks should be
enough to support testing the submission logic in the frontend.