### PR TITLE
SW-5695 Add default project leads table, admin UI

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -90,7 +90,11 @@ val ENUM_TABLES =
                     isLocalizable = false),
                 EnumTable("organization_types", isLocalizable = false),
                 EnumTable("plant_material_sourcing_methods"),
-                EnumTable("regions", listOf("countries\\.region_id")),
+                EnumTable(
+                    "regions",
+                    listOf(
+                        "accelerator\\.default_project_leads\\.region_id",
+                        "countries\\.region_id")),
                 EnumTable("report_statuses", listOf("reports\\.status_id")),
                 EnumTable("roles"),
                 EnumTable("seed_storage_behaviors"),

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -45,6 +45,7 @@ class AdminController(
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
     model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())
+    model.addAttribute("canManageDefaultProjectLeads", currentUser().canManageDefaultProjectLeads())
     model.addAttribute("canManageDocumentProducer", currentUser().canManageDocumentProducer())
     model.addAttribute(
         "canManageModules",

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDefaultProjectLeadsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDefaultProjectLeadsController.kt
@@ -1,0 +1,85 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.tables.references.DEFAULT_PROJECT_LEADS
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.log.perClassLogger
+import jakarta.servlet.http.HttpServletRequest
+import org.jooq.DSLContext
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+@Validated
+class AdminDefaultProjectLeadsController(
+    private val dslContext: DSLContext,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/defaultProjectLeads")
+  fun getDefaultProjectLeads(
+      model: Model,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    requirePermissions { manageDefaultProjectLeads() }
+
+    val defaultLeadsByRegionName: Map<String, String?> =
+        with(DEFAULT_PROJECT_LEADS) {
+          dslContext.selectFrom(DEFAULT_PROJECT_LEADS).fetch().associate {
+            it[REGION_ID]!!.name to it[PROJECT_LEAD]
+          }
+        }
+
+    model.addAttribute("regions", Region.entries.sortedBy { it.jsonValue })
+    model.addAttribute("defaultLeads", defaultLeadsByRegionName)
+
+    return "/admin/defaultProjectLeads"
+  }
+
+  @PostMapping("/defaultProjectLeads")
+  fun updateDefaultProjectLeads(
+      request: HttpServletRequest,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    requirePermissions { manageDefaultProjectLeads() }
+
+    try {
+      Region.entries.forEach { region ->
+        val lead = request.getParameter(region.name)?.ifBlank { null }
+
+        with(DEFAULT_PROJECT_LEADS) {
+          if (lead != null) {
+            dslContext
+                .insertInto(DEFAULT_PROJECT_LEADS)
+                .set(REGION_ID, region)
+                .set(PROJECT_LEAD, lead)
+                .onConflict()
+                .doUpdate()
+                .set(PROJECT_LEAD, lead)
+                .execute()
+          } else {
+            dslContext.deleteFrom(DEFAULT_PROJECT_LEADS).where(REGION_ID.eq(region)).execute()
+          }
+        }
+      }
+
+      redirectAttributes.successMessage = "Saved default project leads."
+    } catch (e: Exception) {
+      log.error("Unable to save default project leads", e)
+      redirectAttributes.failureMessage = "Unable to save default project leads: ${e.message}"
+    }
+
+    return redirectToDefaultProjectLeads()
+  }
+
+  private fun redirectToDefaultProjectLeads() = "redirect:/admin/defaultProjectLeads"
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -326,6 +326,8 @@ data class IndividualUser(
 
   override fun canListReports(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
+  override fun canManageDefaultProjectLeads() = isAcceleratorAdmin()
+
   override fun canManageDeliverables() = isAcceleratorAdmin()
 
   override fun canManageDocumentProducer() = isTFExpertOrHigher()

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -519,6 +519,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun manageDefaultProjectLeads() {
+    if (!user.canManageDefaultProjectLeads()) {
+      throw AccessDeniedException("No permission to manage default project leads")
+    }
+  }
+
   fun manageDeliverables() {
     if (!user.canManageDeliverables()) {
       throw AccessDeniedException("No permission to manage deliverables")

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -246,6 +246,8 @@ interface TerrawareUser : Principal {
 
   fun canListReports(organizationId: OrganizationId): Boolean = defaultPermission
 
+  fun canManageDefaultProjectLeads(): Boolean = defaultPermission
+
   fun canManageDeliverables(): Boolean = defaultPermission
 
   fun canManageDocumentProducer(): Boolean = defaultPermission

--- a/src/main/resources/db/migration/0250/V289__DefaultProjectLeads.sql
+++ b/src/main/resources/db/migration/0250/V289__DefaultProjectLeads.sql
@@ -1,0 +1,4 @@
+CREATE TABLE accelerator.default_project_leads (
+    region_id INTEGER PRIMARY KEY REFERENCES regions,
+    project_lead TEXT
+);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -489,6 +489,8 @@ COMMENT ON TABLE accelerator.cohort_phases IS '(Enum) Available cohort phases';
 
 COMMENT ON TABLE accelerator.deal_stages IS '(Enum) Stages in the deal workflow that a project progresses through.';
 
+COMMENT ON TABLE accelerator.default_project_leads IS 'Default project leads to use at application submission time based on project region.';
+
 COMMENT ON TABLE accelerator.default_voters IS 'Users to automatically be assigned as voters on accelerator projects.';
 
 COMMENT ON TABLE accelerator.deliverable_categories IS '(Enum) High-level groups for organizing deliverables.';

--- a/src/main/resources/templates/admin/defaultProjectLeads.html
+++ b/src/main/resources/templates/admin/defaultProjectLeads.html
@@ -1,0 +1,46 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<p>
+    <a href="/admin/">Home</a>
+</p>
+
+<h2>Default Project Leads</h2>
+
+<p>
+    When an application for a project in a particular region passes pre-screening, its project
+    lead is set to the value for that region listed here.
+</p>
+<p>
+    <b>Changing the values here will not update the project leads of any existing applications!</b>
+    These names are only used as the defaults for new applications.
+</p>
+
+<form method="POST" action="/admin/defaultProjectLeads">
+    <table>
+        <tr>
+            <th>Region</th>
+            <th>Lead</th>
+        </tr>
+
+        <tr th:each="region : ${regions}" class="striped">
+            <td th:text="${region.jsonValue}">East Narnia</td>
+            <td>
+                <input type="text" th:name="${region.name}" th:value="${defaultLeads[region.name]}" />
+            </td>
+        </tr>
+
+        <tr class="striped">
+            <td colspan="2">
+                <input type="submit" value="Update"/>
+            </td>
+        </tr>
+    </table>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -147,5 +147,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canManageDefaultProjectLeads}">
+    <h2>Default Project Leads</h2>
+
+    <p>
+        <a href="/admin/defaultProjectLeads">Manage default project leads for regions</a>
+    </p>
+</th:block>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -522,6 +522,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun listReports() =
       allow { listReports(organizationId) } ifUser { canListReports(organizationId) }
 
+  @Test
+  fun manageDefaultProjectLeads() =
+      allow { manageDefaultProjectLeads() } ifUser { canManageDefaultProjectLeads() }
+
   @Test fun manageDeliverables() = allow { manageDeliverables() } ifUser { canManageDeliverables() }
 
   @Test fun manageModuleEvents() = allow { manageModuleEvents() } ifUser { canManageModuleEvents() }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1367,6 +1367,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipant = true,
         deleteParticipantProject = true,
         deleteSupportIssue = true,
+        manageDefaultProjectLeads = true,
         manageModuleEventStatuses = true,
         manageNotifications = true,
         readAllAcceleratorDetails = true,
@@ -1703,6 +1704,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         deleteUsers = true,
         importGlobalSpeciesData = true,
+        manageDefaultProjectLeads = true,
         manageDeliverables = true,
         manageInternalTags = true,
         manageModuleEvents = true,
@@ -1900,6 +1902,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteParticipantProject = true,
         deleteSelf = true,
         importGlobalSpeciesData = false,
+        manageDefaultProjectLeads = true,
         manageDeliverables = true,
         manageInternalTags = false,
         manageModuleEvents = true,
@@ -2683,6 +2686,7 @@ internal class PermissionTest : DatabaseTest() {
         manageModuleEventStatuses: Boolean = false,
         manageModules: Boolean = false,
         manageNotifications: Boolean = false,
+        manageDefaultProjectLeads: Boolean = false,
         readAllAcceleratorDetails: Boolean = false,
         readAllDeliverables: Boolean = false,
         readCohort: Boolean = false,
@@ -2733,6 +2737,10 @@ internal class PermissionTest : DatabaseTest() {
           importGlobalSpeciesData,
           user.canImportGlobalSpeciesData(),
           "Can import global species data")
+      assertEquals(
+          manageDefaultProjectLeads,
+          user.canManageDefaultProjectLeads(),
+          "Can manage default project leads")
       assertEquals(manageDeliverables, user.canManageDeliverables(), "Can manage deliverables")
       assertEquals(manageInternalTags, user.canManageInternalTags(), "Can manage internal tags")
       assertEquals(manageModuleEvents, user.canManageModuleEvents(), "Can manage module events")

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -136,6 +136,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "cohort_modules" to setOf(ALL, ACCELERATOR),
                   "cohort_phases" to setOf(ALL, ACCELERATOR),
                   "deal_stages" to setOf(ALL, ACCELERATOR),
+                  "default_project_leads" to setOf(ALL, ACCELERATOR),
                   "default_voters" to setOf(ALL, ACCELERATOR),
                   "deliverable_categories" to setOf(ALL, ACCELERATOR),
                   "deliverable_cohort_due_dates" to setOf(ALL, ACCELERATOR),


### PR DESCRIPTION
When an application passes pre-screening, we need to set its project lead based on
which region it's in. Add a table to hold the project lead value for each region
and add a form to the admin UI to allow the values to be edited.