### PR TITLE
SW-5690 Populate total expansion potential

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationService.kt
@@ -71,6 +71,7 @@ class ApplicationService(
             landUseModelTypes = landUseModelTypes,
             numNativeSpecies = variableValues.numSpeciesToBePlanted,
             projectLead = projectLead,
+            totalExpansionPotential = variableValues.totalExpansionPotential,
         )
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/PreScreenVariableValuesFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/PreScreenVariableValuesFetcher.kt
@@ -26,6 +26,7 @@ class PreScreenVariableValuesFetcher(
   companion object {
     const val STABLE_ID_NUM_SPECIES = "22"
     const val STABLE_ID_PROJECT_TYPE = "3"
+    const val STABLE_ID_TOTAL_EXPANSION_POTENTIAL = "24"
 
     val stableIdsByLandUseModelType =
         mapOf(
@@ -82,7 +83,15 @@ class PreScreenVariableValuesFetcher(
           }
         }
 
-    return PreScreenVariableValues(landUseHectares, numSpeciesToBePlanted, projectType)
+    val totalExpansionPotential =
+        getNumberValue(valuesByStableId, STABLE_ID_TOTAL_EXPANSION_POTENTIAL)
+
+    return PreScreenVariableValues(
+        landUseModelHectares = landUseHectares,
+        numSpeciesToBePlanted = numSpeciesToBePlanted,
+        projectType = projectType,
+        totalExpansionPotential = totalExpansionPotential,
+    )
   }
 
   private fun getNumberValue(values: Map<String, ExistingValue>, stableId: String): BigDecimal? {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/PreScreenVariableValues.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/PreScreenVariableValues.kt
@@ -10,11 +10,12 @@ enum class PreScreenProjectType {
 }
 
 /**
- * Values of variables that are relevant to the pre-screen qualification check. This does not
- * include values that are part of [ExistingApplicationModel].
+ * Values of variables that are relevant to the pre-screen logic. This does not include values that
+ * are part of [ExistingApplicationModel].
  */
 data class PreScreenVariableValues(
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>,
     val numSpeciesToBePlanted: Int?,
     val projectType: PreScreenProjectType?,
+    val totalExpansionPotential: BigDecimal?,
 )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -71,9 +71,10 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
     fun `fetches variable values for pre-screen submissions`() {
       val preScreenVariableValues =
           PreScreenVariableValues(
-              mapOf(LandUseModelType.Mangroves to BigDecimal(10)),
-              123,
-              PreScreenProjectType.Terrestrial)
+              landUseModelHectares = mapOf(LandUseModelType.Mangroves to BigDecimal(10)),
+              numSpeciesToBePlanted = 123,
+              projectType = PreScreenProjectType.Terrestrial,
+              totalExpansionPotential = BigDecimal(1000))
       val applicationModel =
           ExistingApplicationModel(
               createdTime = Instant.EPOCH,
@@ -116,19 +117,22 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
     fun `populates project accelerator details on pre-screen success`() {
       val projectLead = "Johnny Appleseed"
       val internalName = "KEN_Project 1"
+      val totalExpansionPotential = BigDecimal(1000)
 
       val projectId = insertProject()
       insertDefaultProjectLead(Region.SubSaharanAfrica, projectLead)
 
       val preScreenVariableValues =
           PreScreenVariableValues(
-              mapOf(
-                  LandUseModelType.Agroforestry to BigDecimal.ZERO,
-                  LandUseModelType.Mangroves to BigDecimal(1),
-                  LandUseModelType.NativeForest to BigDecimal(100),
-              ),
+              landUseModelHectares =
+                  mapOf(
+                      LandUseModelType.Agroforestry to BigDecimal.ZERO,
+                      LandUseModelType.Mangroves to BigDecimal(1),
+                      LandUseModelType.NativeForest to BigDecimal(100),
+                  ),
               numSpeciesToBePlanted = 50,
               projectType = PreScreenProjectType.Mixed,
+              totalExpansionPotential = totalExpansionPotential,
           )
       val applicationModel =
           ExistingApplicationModel(
@@ -164,6 +168,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
               projectId = projectId,
               region = Region.SubSaharanAfrica,
               projectLead = projectLead,
+              totalExpansionPotential = totalExpansionPotential,
           ),
           projectAcceleratorDetailsStore.fetchOneById(projectId),
           "Project accelerator details after submission")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -516,12 +516,14 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
           store.submit(
               applicationId,
               PreScreenVariableValues(
-                  mapOf(
-                      LandUseModelType.Monoculture to BigDecimal.ZERO,
-                      LandUseModelType.NativeForest to landUseTotal,
-                  ),
+                  landUseModelHectares =
+                      mapOf(
+                          LandUseModelType.Monoculture to BigDecimal.ZERO,
+                          LandUseModelType.NativeForest to landUseTotal,
+                      ),
                   numSpeciesToBePlanted = 500,
-                  projectType = PreScreenProjectType.Mixed))
+                  projectType = PreScreenProjectType.Mixed,
+                  totalExpansionPotential = BigDecimal(5000)))
 
       assertEquals(
           listOf(
@@ -542,12 +544,14 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
           store.submit(
               applicationId,
               PreScreenVariableValues(
-                  mapOf(
-                      LandUseModelType.Monoculture to halfArea,
-                      LandUseModelType.NativeForest to halfArea,
-                  ),
+                  landUseModelHectares =
+                      mapOf(
+                          LandUseModelType.Monoculture to halfArea,
+                          LandUseModelType.NativeForest to halfArea,
+                      ),
                   numSpeciesToBePlanted = 500,
-                  projectType = PreScreenProjectType.Mixed))
+                  projectType = PreScreenProjectType.Mixed,
+                  totalExpansionPotential = BigDecimal(1000)))
 
       assertEquals(
           listOf(messages.applicationPreScreenFailureMonocultureTooHigh(10)), result.problems)
@@ -625,11 +629,14 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
     private fun validVariables(boundary: Geometry): PreScreenVariableValues {
       val projectHectares = boundary.calculateAreaHectares()
       return PreScreenVariableValues(
-          mapOf(
-              LandUseModelType.NativeForest to projectHectares,
-              LandUseModelType.Monoculture to BigDecimal.ZERO),
-          500,
-          PreScreenProjectType.Terrestrial)
+          landUseModelHectares =
+              mapOf(
+                  LandUseModelType.NativeForest to projectHectares,
+                  LandUseModelType.Monoculture to BigDecimal.ZERO),
+          numSpeciesToBePlanted = 500,
+          projectType = PreScreenProjectType.Terrestrial,
+          totalExpansionPotential = BigDecimal(1500),
+      )
     }
   }
 


### PR DESCRIPTION
It's not used for the pre-screen qualification checks, but we need to populate the
"total expansion potential" field in the project accelerator details from the
pre-screen questionnaire.