### PR TITLE
Add AllowBlankStrings annotation to conditionally allow for blank strings in JSON payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -184,6 +184,9 @@ annotation class ApiResponse200Photo
                                 "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
 annotation class RequestBodyPhotoFile
 
+/**
+ * Allows payload fields to have blank strings during deserialization
+ */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FIELD)
 annotation class AllowBlankString

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -62,10 +62,7 @@ annotation class InternalEndpoint
         [
             Content(
                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = SimpleErrorResponsePayload::class),
-            ),
-        ],
-)
+                schema = Schema(implementation = SimpleErrorResponsePayload::class))])
 annotation class ApiResponseSimpleError(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "responseCode")
     val responseCode: String
@@ -143,10 +140,7 @@ annotation class ApiResponse415(
         [
             Content(
                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = SimpleSuccessResponsePayload::class),
-            ),
-        ],
-)
+                schema = Schema(implementation = SimpleSuccessResponsePayload::class))])
 annotation class ApiResponseSimpleSuccess(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
     val description: String = "The requested operation succeeded."
@@ -170,14 +164,10 @@ annotation class RequireGlobalRole(val roles: Array<GlobalRole>)
         [
             Content(
                 schema = Schema(type = "string", format = "binary"),
-                mediaType = MediaType.IMAGE_JPEG_VALUE,
-            ),
+                mediaType = MediaType.IMAGE_JPEG_VALUE),
             Content(
                 schema = Schema(type = "string", format = "binary"),
-                mediaType = MediaType.IMAGE_PNG_VALUE,
-            ),
-        ],
-)
+                mediaType = MediaType.IMAGE_PNG_VALUE)])
 annotation class ApiResponse200Photo
 
 @Retention(AnnotationRetention.RUNTIME)
@@ -191,12 +181,7 @@ annotation class ApiResponse200Photo
                         Encoding(
                             name = "file",
                             contentType =
-                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}",
-                        ),
-                    ],
-            ),
-        ],
-)
+                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
 annotation class RequestBodyPhotoFile
 
 @Retention(AnnotationRetention.RUNTIME) annotation class AllowBlankString()

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -184,9 +184,7 @@ annotation class ApiResponse200Photo
                                 "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
 annotation class RequestBodyPhotoFile
 
-/**
- * Allows payload fields to have blank strings during deserialization
- */
+/** Allows payload fields to have blank strings during deserialization */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FIELD)
 annotation class AllowBlankString

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -62,7 +62,10 @@ annotation class InternalEndpoint
         [
             Content(
                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = SimpleErrorResponsePayload::class))])
+                schema = Schema(implementation = SimpleErrorResponsePayload::class),
+            ),
+        ],
+)
 annotation class ApiResponseSimpleError(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "responseCode")
     val responseCode: String
@@ -140,7 +143,10 @@ annotation class ApiResponse415(
         [
             Content(
                 mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = Schema(implementation = SimpleSuccessResponsePayload::class))])
+                schema = Schema(implementation = SimpleSuccessResponsePayload::class),
+            ),
+        ],
+)
 annotation class ApiResponseSimpleSuccess(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
     val description: String = "The requested operation succeeded."
@@ -164,10 +170,14 @@ annotation class RequireGlobalRole(val roles: Array<GlobalRole>)
         [
             Content(
                 schema = Schema(type = "string", format = "binary"),
-                mediaType = MediaType.IMAGE_JPEG_VALUE),
+                mediaType = MediaType.IMAGE_JPEG_VALUE,
+            ),
             Content(
                 schema = Schema(type = "string", format = "binary"),
-                mediaType = MediaType.IMAGE_PNG_VALUE)])
+                mediaType = MediaType.IMAGE_PNG_VALUE,
+            ),
+        ],
+)
 annotation class ApiResponse200Photo
 
 @Retention(AnnotationRetention.RUNTIME)
@@ -181,5 +191,12 @@ annotation class ApiResponse200Photo
                         Encoding(
                             name = "file",
                             contentType =
-                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
+                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}",
+                        ),
+                    ],
+            ),
+        ],
+)
 annotation class RequestBodyPhotoFile
+
+@Retention(AnnotationRetention.RUNTIME) annotation class AllowBlankString()

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -184,4 +184,6 @@ annotation class ApiResponse200Photo
                                 "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}")])])
 annotation class RequestBodyPhotoFile
 
-@Retention(AnnotationRetention.RUNTIME) annotation class AllowBlankString()
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD)
+annotation class AllowBlankString

--- a/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
@@ -15,21 +15,6 @@ import com.fasterxml.jackson.databind.deser.std.StringDeserializer
  */
 class BlankStringDeserializer : JsonDeserializer<String?>() {
   override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): String? {
-    val clazz = handledType()
-    val allowBlankString =
-        if (clazz != null) {
-          val annotated = ctxt.config.introspectClassAnnotations(clazz).classInfo
-          val annotations = annotated.getAnnotations()
-          annotations.has(AllowBlankString::class.java)
-        } else {
-          false
-        }
-
-    val deserialized = StringDeserializer.instance.deserialize(parser, ctxt)
-    return if (allowBlankString) {
-      deserialized
-    } else {
-      deserialized?.ifBlank { null }
-    }
+    return StringDeserializer.instance.deserialize(parser, ctxt)?.ifBlank { null }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
@@ -1,8 +1,10 @@
 package com.terraformation.backend.api
 
 import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.BeanProperty
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer
 import com.fasterxml.jackson.databind.deser.std.StringDeserializer
 
 /**
@@ -12,8 +14,21 @@ import com.fasterxml.jackson.databind.deser.std.StringDeserializer
  *
  * Does not affect the values of [ArbitraryJsonObject] payload fields; those are treated as opaque
  * and can contain empty strings.
+ *
+ * Does not affect fields annotated with [AllowBlankString].
  */
-class BlankStringDeserializer : JsonDeserializer<String?>() {
+class BlankStringDeserializer : JsonDeserializer<String?>(), ContextualDeserializer {
+  override fun createContextual(
+      ctxt: DeserializationContext,
+      property: BeanProperty?
+  ): JsonDeserializer<*> {
+    return if (property?.getAnnotation(AllowBlankString::class.java) != null) {
+      StringDeserializer.instance
+    } else {
+      this
+    }
+  }
+
   override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): String? {
     return StringDeserializer.instance.deserialize(parser, ctxt)?.ifBlank { null }
   }

--- a/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/BlankStringDeserializer.kt
@@ -15,6 +15,21 @@ import com.fasterxml.jackson.databind.deser.std.StringDeserializer
  */
 class BlankStringDeserializer : JsonDeserializer<String?>() {
   override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): String? {
-    return StringDeserializer.instance.deserialize(parser, ctxt)?.ifBlank { null }
+    val clazz = handledType()
+    val allowBlankString =
+        if (clazz != null) {
+          val annotated = ctxt.config.introspectClassAnnotations(clazz).classInfo
+          val annotations = annotated.getAnnotations()
+          annotations.has(AllowBlankString::class.java)
+        } else {
+          false
+        }
+
+    val deserialized = StringDeserializer.instance.deserialize(parser, ctxt)
+    return if (allowBlankString) {
+      deserialized
+    } else {
+      deserialized?.ifBlank { null }
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyName
 import com.fasterxml.jackson.databind.introspect.Annotated
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleModule
@@ -8,12 +9,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 class CustomAnnotationIntrospector : JacksonAnnotationIntrospector() {
-  override fun findKeyDeserializer(a: Annotated?): Any? {
+  override fun findDeserializer(a: Annotated?): Any {
     val customAnnotation = a?.getAnnotation(AllowBlankString::class.java)
     return if (customAnnotation != null) {
-      null
+      return super.findDeserializer(a)
     } else {
-      super.findKeyDeserializer(a)
+      return super.findDeserializer(a)
     }
   }
 }
@@ -21,13 +22,13 @@ class CustomAnnotationIntrospector : JacksonAnnotationIntrospector() {
 @Configuration
 class SerializerConfiguration {
   @Bean
-  fun blankStringDeserializerModule(): ObjectMapper {
+  fun blankStringDeserializerModule(): SimpleModule {
     val mapper = ObjectMapper()
     val module = SimpleModule("BlankStringDeserializer")
     module.addDeserializer(String::class.java, BlankStringDeserializer())
     mapper.registerModule(module)
     mapper.setAnnotationIntrospector(CustomAnnotationIntrospector())
-    return mapper
+    return module
   }
 
   @Bean

--- a/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
@@ -1,33 +1,15 @@
 package com.terraformation.backend.api
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.introspect.Annotated
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-
-class CustomAnnotationIntrospector : JacksonAnnotationIntrospector() {
-  override fun findDeserializer(a: Annotated?): Any {
-    val customAnnotation = a?.getAnnotation(AllowBlankString::class.java)
-    return if (customAnnotation != null) {
-      return super.findDeserializer(a)
-    } else {
-      return super.findDeserializer(a)
-    }
-  }
-}
 
 @Configuration
 class SerializerConfiguration {
   @Bean
   fun blankStringDeserializerModule(): SimpleModule {
-    val mapper = ObjectMapper()
-    val module = SimpleModule("BlankStringDeserializer")
-    module.addDeserializer(String::class.java, BlankStringDeserializer())
-    mapper.registerModule(module)
-    mapper.setAnnotationIntrospector(CustomAnnotationIntrospector())
-    return module
+    return SimpleModule("BlankStringDeserializer")
+        .addDeserializer(String::class.java, BlankStringDeserializer())
   }
 
   @Bean

--- a/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.PropertyName
 import com.fasterxml.jackson.databind.introspect.Annotated
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleModule

--- a/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/SerializerConfiguration.kt
@@ -1,15 +1,33 @@
 package com.terraformation.backend.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.introspect.Annotated
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+class CustomAnnotationIntrospector : JacksonAnnotationIntrospector() {
+  override fun findKeyDeserializer(a: Annotated?): Any? {
+    val customAnnotation = a?.getAnnotation(AllowBlankString::class.java)
+    return if (customAnnotation != null) {
+      null
+    } else {
+      super.findKeyDeserializer(a)
+    }
+  }
+}
+
 @Configuration
 class SerializerConfiguration {
   @Bean
-  fun blankStringDeserializerModule(): SimpleModule {
-    return SimpleModule("BlankStringDeserializer")
-        .addDeserializer(String::class.java, BlankStringDeserializer())
+  fun blankStringDeserializerModule(): ObjectMapper {
+    val mapper = ObjectMapper()
+    val module = SimpleModule("BlankStringDeserializer")
+    module.addDeserializer(String::class.java, BlankStringDeserializer())
+    mapper.registerModule(module)
+    mapper.setAnnotationIntrospector(CustomAnnotationIntrospector())
+    return mapper
   }
 
   @Bean

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
@@ -139,8 +139,7 @@ data class NewSectionTextValuePayload(
                 "different positions, you can split it into multiple text values and put a " +
                 "citation on each of them.")
     override val citation: String?,
-    @AllowBlankString
-    val textValue: String,
+    @AllowBlankString val textValue: String,
 ) : NewValuePayload {
   override val type: VariableValuePayloadType
     get() = VariableValuePayloadType.SectionText

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.documentproducer.api
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.terraformation.backend.api.AllowBlankString
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableInjectionDisplayStyle
@@ -138,6 +139,7 @@ data class NewSectionTextValuePayload(
                 "different positions, you can split it into multiple text values and put a " +
                 "citation on each of them.")
     override val citation: String?,
+    @AllowBlankString
     val textValue: String,
 ) : NewValuePayload {
   override val type: VariableValuePayloadType

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableValue.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableValue.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.model
 
+import com.terraformation.backend.api.AllowBlankString
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId
@@ -95,7 +96,7 @@ data class NumberValue<ID : VariableValueId?>(
 
 sealed interface SectionValueFragment
 
-data class SectionValueText(val textValue: String) : SectionValueFragment
+data class SectionValueText(@AllowBlankString val textValue: String) : SectionValueFragment
 
 data class SectionValueVariable(
     val usedVariableId: VariableId,

--- a/src/test/kotlin/com/terraformation/backend/api/BlankStringDeserializerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/BlankStringDeserializerTest.kt
@@ -1,0 +1,25 @@
+package com.terraformation.backend.api
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class BlankStringDeserializerTest {
+  private val objectMapper =
+      jacksonObjectMapper()
+          .registerModule(SerializerConfiguration().blankStringDeserializerModule())
+
+  @Test
+  fun `allows blank strings on fields annotated with AllowBlankString`() {
+    val json = """{"allowBlank": "", "nullIfBlank": ""}"""
+    val payload = objectMapper.readValue<TestPayload>(json)
+
+    assertEquals(TestPayload(allowBlank = "", nullIfBlank = null), payload)
+  }
+
+  data class TestPayload(
+      @AllowBlankString val allowBlank: String?,
+      val nullIfBlank: String?,
+  )
+}


### PR DESCRIPTION
- This is needed because section text that contains two variables separated by a space were failing since the `textValue` belonging to one of the chunks is `" "` which is a blank string, but necessary in this use case.