### PR TITLE
SW-5680 Mark deliverables and modules as completed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableCompleter.kt
@@ -1,0 +1,82 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.ApplicationStore
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.accelerator.db.ModuleStore
+import com.terraformation.backend.accelerator.db.SubmissionStore
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
+import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.event.QuestionsDeliverableSubmittedEvent
+import jakarta.inject.Named
+import org.springframework.context.event.EventListener
+
+/** Marks deliverables as complete when the user has supplied their information. */
+@Named
+class DeliverableCompleter(
+    private val applicationStore: ApplicationStore,
+    private val deliverableStore: DeliverableStore,
+    private val moduleStore: ModuleStore,
+    private val submissionStore: SubmissionStore,
+    private val variableStore: VariableStore,
+    private val variableValueStore: VariableValueStore,
+) {
+  @EventListener
+  fun on(event: DeliverableDocumentUploadedEvent) {
+    completeApplicationDeliverable(event.deliverableId, event.projectId)
+  }
+
+  @EventListener
+  fun on(event: ParticipantProjectSpeciesAddedEvent) {
+    completeApplicationDeliverable(event.deliverableId, event.participantProjectSpecies.projectId)
+  }
+
+  @EventListener
+  fun on(event: QuestionsDeliverableSubmittedEvent) {
+    completeApplicationDeliverable(event.deliverableId, event.projectId) {
+      val variables = variableStore.fetchDeliverableVariables(event.deliverableId)
+      val valuesByVariableId =
+          variableValueStore.listValues(event.projectId, event.deliverableId).associateBy {
+            it.variableId
+          }
+
+      // Mark deliverable as complete if all variables that don't depend on other variables have
+      // values.
+      variables
+          .filter { it.dependencyVariableStableId == null }
+          .none { it.id !in valuesByVariableId }
+    }
+  }
+
+  /**
+   * Marks a deliverable as completed if it is in a module in one of the application phases. If all
+   * the deliverables in the module are completed, marks the module as completed too.
+   *
+   * @param predicate Only mark the deliverable as completed if this returns true. The predicate is
+   *   only called if the deliverable's module is in an application phase.
+   */
+  private fun completeApplicationDeliverable(
+      deliverableId: DeliverableId,
+      projectId: ProjectId,
+      predicate: (() -> Boolean)? = null
+  ) {
+    val moduleId = deliverableStore.fetchDeliverableModuleId(deliverableId)
+    val phase = moduleStore.fetchCohortPhase(moduleId)
+
+    if (phase == CohortPhase.PreScreen || phase == CohortPhase.Application) {
+      if (predicate == null || predicate()) {
+        submissionStore.createSubmission(deliverableId, projectId, SubmissionStatus.Completed)
+
+        if (submissionStore.moduleDeliverablesAllCompleted(deliverableId, projectId)) {
+          applicationStore.updateModuleStatus(projectId, moduleId, ApplicationModuleStatus.Complete)
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverableStore.kt
@@ -46,6 +46,14 @@ class DeliverableStore(
         ?: throw DeliverableNotFoundException(deliverableId)
   }
 
+  fun fetchDeliverableModuleId(deliverableId: DeliverableId): ModuleId {
+    return dslContext
+        .select(DELIVERABLES.MODULE_ID)
+        .from(DELIVERABLES)
+        .where(DELIVERABLES.ID.eq(deliverableId))
+        .fetchOne(DELIVERABLES.MODULE_ID) ?: throw DeliverableNotFoundException(deliverableId)
+  }
+
   fun fetchDeliverableSubmissions(
       organizationId: OrganizationId? = null,
       participantId: ParticipantId? = null,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -43,8 +43,14 @@ class ParticipantProjectSpeciesProjectNotFoundException(id: ProjectId) :
 class ProjectApplicationExistsException(projectId: ProjectId) :
     MismatchedStateException("Project $projectId already has an application")
 
+class ProjectApplicationNotFoundException(projectId: ProjectId) :
+    MismatchedStateException("Project $projectId has no application")
+
 class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
     MismatchedStateException("Project $id document upload settings have not been configured")
+
+class ProjectModuleNotFoundException(projectId: ProjectId, moduleId: ModuleId) :
+    MismatchedStateException("Project $projectId is not associated with module $moduleId")
 
 class ProjectNotInCohortException(id: ProjectId) :
     MismatchedStateException("Project $id is not assigned to any cohorts")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModuleStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.accelerator.model.EventModel
 import com.terraformation.backend.accelerator.model.ModuleDeliverableModel
 import com.terraformation.backend.accelerator.model.ModuleModel
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
@@ -51,6 +52,14 @@ class ModuleStore(
   fun fetchAllModules(): List<ModuleModel> {
     requirePermissions { manageModules() }
     return fetch()
+  }
+
+  fun fetchCohortPhase(moduleId: ModuleId): CohortPhase {
+    return dslContext
+        .select(MODULES.PHASE_ID)
+        .from(MODULES)
+        .where(MODULES.ID.eq(moduleId))
+        .fetchOne(MODULES.PHASE_ID) ?: throw ModuleNotFoundException(moduleId)
   }
 
   private fun cohortsMultiset(): Field<List<CohortModuleModel>> {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -1,0 +1,260 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.ApplicationStore
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.accelerator.db.ModuleStore
+import com.terraformation.backend.accelerator.db.SubmissionStore
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
+import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.ApplicationId
+import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.ModuleId
+import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.docprod.DependencyCondition
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.event.QuestionsDeliverableSubmittedEvent
+import com.terraformation.backend.gis.CountryDetector
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+
+  private val completer: DeliverableCompleter by lazy {
+    DeliverableCompleter(
+        ApplicationStore(
+            clock, countriesDao, CountryDetector(), dslContext, Messages(), organizationsDao),
+        DeliverableStore(dslContext),
+        ModuleStore(dslContext),
+        SubmissionStore(clock, dslContext, eventPublisher),
+        VariableStore(
+            dslContext,
+            variableNumbersDao,
+            variablesDao,
+            variableSectionDefaultValuesDao,
+            variableSectionRecommendationsDao,
+            variableSectionsDao,
+            variableSelectsDao,
+            variableSelectOptionsDao,
+            variableTablesDao,
+            variableTableColumnsDao,
+            variableTextsDao),
+        VariableValueStore(
+            clock,
+            documentsDao,
+            dslContext,
+            eventPublisher,
+            variableImageValuesDao,
+            variableLinkValuesDao,
+            variablesDao,
+            variableSectionValuesDao,
+            variableSelectOptionValuesDao,
+            variableValuesDao,
+            variableValueTableRowsDao))
+  }
+
+  private lateinit var applicationId: ApplicationId
+  private lateinit var applicationModuleId: ModuleId
+  private lateinit var preScreenModuleId: ModuleId
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertOrganizationUser(role = Role.Admin)
+
+    projectId = insertProject()
+    applicationId = insertApplication()
+
+    applicationModuleId = insertModule(phase = CohortPhase.Application)
+    preScreenModuleId = insertModule(phase = CohortPhase.PreScreen)
+
+    every { user.adminOrganizations() } returns setOf(organizationId)
+    every { user.canCreateSubmission(projectId) } returns true
+    every { user.canReadApplication(applicationId) } returns true
+    every { user.canReadProject(projectId) } returns true
+    every { user.canReadProjectDeliverables(projectId) } returns true
+    every { user.canUpdateApplicationSubmissionStatus(applicationId) } returns true
+  }
+
+  @Nested
+  inner class OnDeliverableDocumentUploadedEvent {
+    private lateinit var deliverableId: DeliverableId
+
+    @BeforeEach
+    fun setUp() {
+      deliverableId =
+          insertDeliverable(
+              deliverableTypeId = DeliverableType.Document, moduleId = applicationModuleId)
+      insertApplicationModule(applicationId, applicationModuleId)
+    }
+
+    @Test
+    fun `updates deliverable status`() {
+      val otherDeliverableId = insertDeliverable(moduleId = applicationModuleId)
+      insertSubmission()
+
+      completer.on(
+          DeliverableDocumentUploadedEvent(deliverableId, SubmissionDocumentId(1), projectId))
+
+      assertEquals(
+          mapOf(
+              deliverableId to SubmissionStatus.Completed,
+              otherDeliverableId to SubmissionStatus.NotSubmitted),
+          submissionsDao.fetchByProjectId(projectId).associate {
+            it.deliverableId to it.submissionStatusId
+          })
+    }
+
+    @Test
+    fun `updates module status if all deliverables completed`() {
+      insertDeliverable(
+          deliverableTypeId = DeliverableType.Document, moduleId = applicationModuleId)
+      insertSubmission(submissionStatus = SubmissionStatus.Completed, projectId = projectId)
+
+      completer.on(
+          DeliverableDocumentUploadedEvent(deliverableId, SubmissionDocumentId(1), projectId))
+
+      assertEquals(
+          ApplicationModuleStatus.Complete,
+          applicationModulesDao
+              .fetchByModuleId(applicationModuleId)
+              .single()
+              .applicationModuleStatusId)
+    }
+
+    @Test
+    fun `does not update module status if some deliverables not completed`() {
+      insertDeliverable(
+          deliverableTypeId = DeliverableType.Document, moduleId = applicationModuleId)
+
+      completer.on(
+          DeliverableDocumentUploadedEvent(deliverableId, SubmissionDocumentId(1), projectId))
+
+      assertEquals(
+          ApplicationModuleStatus.Incomplete,
+          applicationModulesDao
+              .fetchByModuleId(applicationModuleId)
+              .single()
+              .applicationModuleStatusId)
+    }
+
+    @Test
+    fun `does not update deliverable status for non-application phase`() {
+      insertModule(phase = CohortPhase.Phase0DueDiligence)
+      val otherModuleDeliverableId = insertDeliverable()
+
+      completer.on(
+          DeliverableDocumentUploadedEvent(
+              otherModuleDeliverableId, SubmissionDocumentId(1), projectId))
+
+      assertEquals(
+          emptyList<SubmissionsRow>(),
+          submissionsDao.fetchByDeliverableId(otherModuleDeliverableId))
+    }
+  }
+
+  @Nested
+  inner class OnParticipantProjectSpeciesAddedEvent {
+    private lateinit var deliverableId: DeliverableId
+
+    @BeforeEach
+    fun setUp() {
+      deliverableId =
+          insertDeliverable(
+              deliverableTypeId = DeliverableType.Species, moduleId = applicationModuleId)
+      insertApplicationModule(applicationId, applicationModuleId)
+    }
+
+    @Test
+    fun `updates deliverable status`() {
+      completer.on(
+          ParticipantProjectSpeciesAddedEvent(
+              deliverableId,
+              ExistingParticipantProjectSpeciesModel(
+                  id = ParticipantProjectSpeciesId(1),
+                  projectId = projectId,
+                  speciesId = SpeciesId(1),
+              )))
+
+      assertEquals(
+          SubmissionStatus.Completed,
+          submissionsDao.fetchByProjectId(projectId).single().submissionStatusId)
+    }
+  }
+
+  @Nested
+  inner class OnQuestionsDeliverableSubmittedEvent {
+    private lateinit var deliverableId: DeliverableId
+
+    @BeforeEach
+    fun setUp() {
+      deliverableId =
+          insertDeliverable(
+              deliverableTypeId = DeliverableType.Questions, moduleId = preScreenModuleId)
+      insertApplicationModule(applicationId, preScreenModuleId)
+    }
+
+    @Test
+    fun `updates deliverable status if all variables without dependencies have values`() {
+      val variableId1 =
+          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 1))
+      val variableId2 =
+          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 2))
+
+      insertTextVariable(
+          insertVariable(
+              deliverableId = deliverableId,
+              deliverablePosition = 3,
+              dependencyCondition = DependencyCondition.Eq,
+              dependencyValue = "X",
+              dependencyVariableStableId = "1"))
+
+      insertValue(variableId = variableId1, textValue = "A")
+      insertValue(variableId = variableId2, textValue = "B")
+
+      completer.on(QuestionsDeliverableSubmittedEvent(deliverableId, projectId, emptyMap()))
+
+      assertEquals(
+          SubmissionStatus.Completed,
+          submissionsDao.fetchByProjectId(projectId).single().submissionStatusId)
+    }
+
+    @Test
+    fun `does not update deliverable status if variables without dependencies lack values`() {
+      val variableId1 =
+          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 1))
+      insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 2))
+
+      insertValue(variableId = variableId1, textValue = "A")
+
+      completer.on(QuestionsDeliverableSubmittedEvent(deliverableId, projectId, emptyMap()))
+
+      assertEquals(emptyList<SubmissionsRow>(), submissionsDao.fetchByProjectId(projectId))
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -163,6 +163,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_SU
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentSavedVersionId
 import com.terraformation.backend.db.docprod.DocumentStatus
@@ -2266,7 +2267,7 @@ abstract class DatabaseBackedTest {
   fun insertApplicationModule(
       applicationId: Any,
       moduleId: Any,
-      status: ApplicationModuleStatus,
+      status: ApplicationModuleStatus = ApplicationModuleStatus.Incomplete,
   ) {
     val row =
         ApplicationModulesRow(
@@ -2956,6 +2957,9 @@ abstract class DatabaseBackedTest {
   protected fun insertVariable(
       deliverableId: Any? = null,
       deliverablePosition: Int? = null,
+      dependencyCondition: DependencyCondition? = null,
+      dependencyValue: String? = null,
+      dependencyVariableStableId: String? = null,
       description: String? = null,
       id: Any? = null,
       isList: Boolean = false,
@@ -2970,6 +2974,9 @@ abstract class DatabaseBackedTest {
         VariablesRow(
             deliverableId = deliverableId?.toIdWrapper { DeliverableId(it) },
             deliverablePosition = deliverablePosition,
+            dependencyConditionId = dependencyCondition,
+            dependencyValue = dependencyValue,
+            dependencyVariableStableId = dependencyVariableStableId,
             description = description,
             id = id?.toIdWrapper { VariableId(it) },
             isList = isList,


### PR DESCRIPTION
Automatically update the status of a deliverable to Completed if it is in a
module in the Pre-Screen or Application phases and it meets the completion
criteria for its type:

- Document: First document uploaded
- Questionnaire: All variables that don't depend on other variables have values
- Species: First species added to project

If all the deliverables in a module in the Pre-Screen or Application phases are
marked as Completed, the module status is also set to Completed.