### PR TITLE
SW-5699 Implement application history fetching

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationStatus
+import com.terraformation.backend.db.accelerator.tables.records.ApplicationHistoriesRecord
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -70,7 +71,9 @@ class ApplicationsController(
   fun getApplicationHistory(
       @PathVariable applicationId: ApplicationId
   ): GetApplicationHistoryResponsePayload {
-    TODO()
+    val history = applicationStore.fetchHistoryByApplicationId(applicationId)
+
+    return GetApplicationHistoryResponsePayload(history.map { ApplicationHistoryPayload(it) })
   }
 
   @GetMapping
@@ -230,7 +233,15 @@ data class ApplicationHistoryPayload(
     val internalComment: String?,
     val modifiedTime: Instant,
     val status: ApiApplicationStatus,
-)
+) {
+  constructor(
+      record: ApplicationHistoriesRecord
+  ) : this(
+      record.feedback,
+      record.internalComment,
+      record.modifiedTime!!,
+      ApiApplicationStatus.of(record.applicationStatusId!!))
+}
 
 data class ApplicationPayload(
     val boundary: Geometry?,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.ApplicationModuleStatus
 import com.terraformation.backend.db.accelerator.ApplicationStatus
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ModuleId
+import com.terraformation.backend.db.accelerator.tables.records.ApplicationHistoriesRecord
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_HISTORIES
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_MODULES
@@ -93,6 +94,18 @@ class ApplicationStore(
     requirePermissions { readAllAcceleratorDetails() }
 
     return fetchByCondition(DSL.trueCondition())
+  }
+
+  fun fetchHistoryByApplicationId(applicationId: ApplicationId): List<ApplicationHistoriesRecord> {
+    requirePermissions { readApplication(applicationId) }
+
+    return with(APPLICATION_HISTORIES) {
+      dslContext
+          .selectFrom(APPLICATION_HISTORIES)
+          .where(APPLICATION_ID.eq(applicationId))
+          .orderBy(MODIFIED_TIME.desc())
+          .fetch()
+    }
   }
 
   fun create(projectId: ProjectId): ExistingApplicationModel {


### PR DESCRIPTION
To support the web app showing how many times an application has been resubmitted,
implement the API endpoint to fetch the history of an application. This does not
return the history of boundary changes since they can be large and aren't currently
needed.