### PR TITLE
Fix default value population for subsequent documents

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -346,7 +346,8 @@ class VariableValueStore(
                 .from(VARIABLE_VALUES)
                 .join(VARIABLE_MANIFEST_ENTRIES)
                 .on(VARIABLE_MANIFEST_ENTRIES.VARIABLE_ID.eq(VARIABLE_VALUES.VARIABLE_ID))
-                .where(VARIABLE_VALUES.PROJECT_ID.eq(projectId)))
+                .where(VARIABLE_VALUES.PROJECT_ID.eq(projectId))
+                .and(VARIABLE_MANIFEST_ENTRIES.VARIABLE_MANIFEST_ID.eq(manifestId)))
     if (hasValues) {
       throw IllegalStateException("Can only populate initial values of a new document")
     }


### PR DESCRIPTION
- Populate default values for documents that are created, even if there are other documents in the system
- The condition wasn't checking the manifest ID, so it was failing for all documents after at least one exists in the system for the project