### PR TITLE
Fix document upgrade for section variable injections

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
@@ -214,7 +214,7 @@ class DocumentUpgradeCalculator(
               is SectionValueText -> sectionValue.value
               is SectionValueVariable -> {
                 val existingUsedVariableId = sectionValue.value.usedVariableId
-                // This needs to come from all variables, since variables now
+                // This needs to come from all variables, since variables can
                 // exist outside the context of a manifest
                 val newUsedVariableId =
                     if (existingUsedVariableId in allVariables) {


### PR DESCRIPTION
- When upgrading a document, variable fragments for `SectionVariable` s where not being carried forward correctly because it was looking for the existing variable ID within the context of the variable manifest, but non Section variables are not intrinsically tied to variable manifests anymore.
- Load all variables during the document upgrade `init` so we can determine if a section fragment for a variable injection needs to be carried forward.