### PR TITLE
Exclude springdoc-openapi from Renovate group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,6 +33,8 @@
         {
             "description": "Group Spring dependencies",
             "matchPackagePatterns": ["spring"],
+            // Until https://github.com/springdoc/springdoc-openapi/issues/2639 is fixed
+            "excludePackagePatterns": ["springdoc-openapi"],
             "groupName": "Spring dependencies"
         },
         {


### PR DESCRIPTION
We can't upgrade springdoc-openapi until a particular bug is fixed. Renovate
is supposed to not suggest upgrading dependencies to versions it has previously
suggested, but that only works for dependencies that aren't grouped together.

Add an exclusion rule to stop springdoc-openapi from being grouped with the
other Spring dependencies so it won't continue to be included when other
dependencies in the group have new versions.