### PR TITLE
Fix variable fetch for "replaced" variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -101,6 +101,8 @@ class VariableStore(
             .select(ID)
             .from(VARIABLES)
             .where(STABLE_ID.eq(stableId))
+            .orderBy(ID.desc())
+            .limit(1)
             .fetchOne(VARIABLES.ID)
             ?.let { fetchVariable(it) }
       }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
@@ -229,12 +229,8 @@ class ManifestImporter(
                   val variableRow =
                       if (variableStableId.isNotEmpty()) {
                         val referencedVariable =
-                            if (defaultTextVariableByStableId.containsKey(variableStableId)) {
-                              defaultTextVariableByStableId[variableStableId]
-                            } else {
-                              defaultTextVariableByStableId.computeIfAbsent(variableStableId) {
-                                variableStore.fetchByStableId(variableStableId)
-                              }
+                            defaultTextVariableByStableId.computeIfAbsent(variableStableId) {
+                              variableStore.fetchByStableId(variableStableId)
                             }
 
                         if (referencedVariable != null) {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -41,6 +41,52 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
+  inner class FetchByStableId {
+    @Test
+    fun `fetches the correct variable for a given stable ID`() {
+      val variableName = "Variable 1"
+      val stableId = "1"
+
+      val variableId1 =
+          insertNumberVariable(
+              insertVariable(name = variableName, stableId = stableId, type = VariableType.Number))
+      val variableId2 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName,
+                  stableId = stableId,
+                  type = VariableType.Number,
+                  replacesVariableId = variableId1))
+      val variableId3 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName,
+                  stableId = stableId,
+                  type = VariableType.Number,
+                  replacesVariableId = variableId2))
+
+      val expected =
+          NumberVariable(
+              base =
+                  BaseVariableProperties(
+                      id = variableId3,
+                      manifestId = null,
+                      name = variableName,
+                      position = 0,
+                      replacesVariableId = variableId2,
+                      stableId = stableId,
+                  ),
+              decimalPlaces = 0,
+              minValue = null,
+              maxValue = null)
+
+      val actual = store.fetchByStableId(stableId)
+
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Nested
   inner class FetchVariable {
     @Test
     fun `fetches nested sections`() {


### PR DESCRIPTION
When a variable is imported, and it has been "replaced" before (new variable due to change in all variables import csv), importing sections that reference those variables in their default text were failing to import. 

- This fixes that by ensuring we are only grabbing the most recent version of a variable when fetching it by stable ID.
- Remove redundant code in the manifest importer where the variable is loaded by stable ID.