### PR TITLE
SW-5727 Calculate weighted project score totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectScoresController.kt
@@ -45,7 +45,7 @@ class ProjectScoresController(
           PhaseScores(
               phase,
               scoreModels.map { Score(it.category, it.modifiedTime, it.qualitative, it.score) },
-              ProjectScoreModel.totalScore(scoreModels))
+              ProjectScoreModel.totalScore(phase, scoreModels))
         }
 
     return GetProjectScoresResponsePayload(phaseScores)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
@@ -1,7 +1,9 @@
 package com.terraformation.backend.accelerator.model
 
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
+import com.terraformation.backend.log.perClassLogger
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
@@ -14,6 +16,8 @@ data class ProjectScoreModel<INSTANT : Instant?>(
     val score: Int?,
 ) {
   companion object {
+    private val log = perClassLogger()
+
     fun of(record: Record) =
         ExistingProjectScoreModel(
             category = record[PROJECT_SCORES.SCORE_CATEGORY_ID]!!,
@@ -26,10 +30,95 @@ data class ProjectScoreModel<INSTANT : Instant?>(
      * Returns the total (average) score for a set of per-category scores, rounded to 2 decimal
      * places.
      */
-    fun totalScore(scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
-      val validScoreValues = scores.mapNotNull { it.score }
-      return if (validScoreValues.isNotEmpty()) {
-        validScoreValues.average().toBigDecimal().setScale(2, RoundingMode.HALF_UP)
+    fun totalScore(phase: CohortPhase, scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
+      return when (phase) {
+        CohortPhase.Phase0DueDiligence -> phase0Total(scores)
+        CohortPhase.Phase1FeasibilityStudy -> phase1Total(scores)
+        else -> {
+          log.error("BUG! Should not be trying to calculate score for phase $phase")
+          null
+        }
+      }
+    }
+
+    private val projectLeadCategories =
+        setOf(
+            ScoreCategory.ExpansionPotential,
+            ScoreCategory.ExperienceAndUnderstanding,
+            ScoreCategory.ValuesAlignment,
+            ScoreCategory.ResponsivenessAndAttentionToDetail,
+        )
+
+    /**
+     * The total score of phase 0 is a weighted average based on category. The project lead scores
+     * are given a combined weight of 1; since phase 0 requires that all scores be present, we can
+     * get the same effect by giving each of the four of them a weight of 0.25.
+     */
+    private val phase0Weights =
+        mapOf(
+            ScoreCategory.Community to 1.0,
+            ScoreCategory.ExpansionPotential to 0.25,
+            ScoreCategory.ExperienceAndUnderstanding to 0.25,
+            ScoreCategory.Finance to 2.0,
+            ScoreCategory.Forestry to 1.0,
+            ScoreCategory.GIS to 1.0,
+            ScoreCategory.Legal to 1.0,
+            ScoreCategory.OperationalCapacity to 1.0,
+            ScoreCategory.ResponsivenessAndAttentionToDetail to 0.25,
+            ScoreCategory.ValuesAlignment to 0.25,
+        )
+
+    /**
+     * Total of the weights of the phase 0 categories. The sum of the weighted scores is divided by
+     * this to get the weighted average.
+     */
+    private val phase0TotalWeight = phase0Weights.values.sum()
+
+    /**
+     * Returns the "total" score (really a weighted average) for phase 0. The phase 0 score is only
+     * calculated if there are score values for _all_ of the categories that are required for phase
+     * 0, which excludes a couple of categories that are only in phase 1.
+     */
+    private fun phase0Total(scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
+      val weightedScores =
+          scores.mapNotNull { scoreModel ->
+            phase0Weights[scoreModel.category]?.let { weight -> scoreModel.score?.times(weight) }
+          }
+
+      // For phase 0, the total is only calculated when all categories have values.
+      if (weightedScores.size != phase0Weights.size) {
+        return null
+      }
+
+      return (weightedScores.sum() / phase0TotalWeight)
+          .toBigDecimal()
+          .setScale(2, RoundingMode.HALF_UP)
+    }
+
+    /**
+     * Returns the "total" score (really the average) for phase 1. The phase 1 score is calculated
+     * if there are score values for _any_ of the categories.
+     */
+    private fun phase1Total(scores: Collection<ProjectScoreModel<*>>): BigDecimal? {
+      // The project lead category scores have to be averaged and treated as a single score when
+      // calculating the overall average.
+      val projectLeadScores =
+          scores.filter { it.category in projectLeadCategories }.mapNotNull { it.score }
+
+      val nonLeadScores =
+          scores
+              .filterNot { it.category in projectLeadCategories }
+              .mapNotNull { it.score?.toDouble() }
+
+      val relevantScores =
+          if (projectLeadScores.isNotEmpty()) {
+            nonLeadScores + projectLeadScores.average()
+          } else {
+            nonLeadScores
+          }
+
+      return if (relevantScores.isNotEmpty()) {
+        relevantScores.average().toBigDecimal().setScale(2, RoundingMode.HALF_UP)
       } else {
         null
       }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
@@ -1,0 +1,135 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.ScoreCategory
+import java.math.BigDecimal
+import java.math.RoundingMode
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ProjectScoreModelTest {
+  @Nested
+  inner class Phase0 {
+    @Test
+    fun `treats project lead scores as a single score in the average`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, 1),
+              newModel(ScoreCategory.Finance, 1),
+              newModel(ScoreCategory.Forestry, 1),
+              newModel(ScoreCategory.GIS, 1),
+              newModel(ScoreCategory.Legal, 1),
+              newModel(ScoreCategory.OperationalCapacity, 1),
+              // Project lead categories have scores of 2
+              newModel(ScoreCategory.ExpansionPotential, 2),
+              newModel(ScoreCategory.ExperienceAndUnderstanding, 2),
+              newModel(ScoreCategory.ResponsivenessAndAttentionToDetail, 2),
+              newModel(ScoreCategory.ValuesAlignment, 2),
+          )
+
+      // Average of 7 values of 1.0 (finance counted twice) and 1 value of 2.0
+      assertEquals(
+          BigDecimal(9.0 / 8.0).setScale(2, RoundingMode.HALF_UP),
+          ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores))
+    }
+
+    @Test
+    fun `gives double weight to finance score`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, 1),
+              newModel(ScoreCategory.Finance, 2),
+              newModel(ScoreCategory.Forestry, 1),
+              newModel(ScoreCategory.GIS, 1),
+              newModel(ScoreCategory.Legal, 1),
+              newModel(ScoreCategory.OperationalCapacity, 1),
+              newModel(ScoreCategory.ExpansionPotential, 1),
+              newModel(ScoreCategory.ExperienceAndUnderstanding, 1),
+              newModel(ScoreCategory.ResponsivenessAndAttentionToDetail, 1),
+              newModel(ScoreCategory.ValuesAlignment, 1),
+          )
+
+      // Average of 6 values of 1.0 (including the project lead average) and 2 values of 2.0
+      // (finance counted twice)
+      assertEquals(
+          BigDecimal(10.0 / 8.0).setScale(2, RoundingMode.HALF_UP),
+          ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores))
+    }
+
+    @Test
+    fun `returns null if required score is missing`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, 1),
+              newModel(ScoreCategory.ExpansionPotential, 1),
+              newModel(ScoreCategory.ExperienceAndUnderstanding, 1),
+              newModel(ScoreCategory.Finance, 1),
+              newModel(ScoreCategory.Forestry, 1),
+              newModel(ScoreCategory.GIS, 1),
+              newModel(ScoreCategory.Legal, 1),
+              newModel(ScoreCategory.OperationalCapacity, 1),
+              newModel(ScoreCategory.ResponsivenessAndAttentionToDetail, 1),
+              // Missing ValuesAlignment
+          )
+
+      assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase0DueDiligence, scores))
+    }
+  }
+
+  @Nested
+  inner class Phase1 {
+    @Test
+    fun `treats project lead scores as a single score in the average`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, 1),
+              // Project lead categories have scores of 2
+              newModel(ScoreCategory.ExpansionPotential, 2),
+              newModel(ScoreCategory.ValuesAlignment, 3),
+          )
+
+      // Average of 1 value of 1.0 and 1 value of 2.5 (average of the two project lead scores)
+      assertEquals(
+          BigDecimal(3.5 / 2.0).setScale(2, RoundingMode.HALF_UP),
+          ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores))
+    }
+
+    @Test
+    fun `calculates average of whichever scores have values`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, 1),
+              newModel(ScoreCategory.GIS, null),
+              newModel(ScoreCategory.ExpansionPotential, 2),
+          )
+
+      assertEquals(
+          BigDecimal(3.0 / 2.0).setScale(2, RoundingMode.HALF_UP),
+          ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores))
+    }
+
+    @Test
+    fun `returns null if no scores are available`() {
+      val scores =
+          listOf(
+              newModel(ScoreCategory.Community, null),
+              newModel(ScoreCategory.ExpansionPotential, null),
+          )
+
+      assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores))
+    }
+  }
+
+  @Test
+  fun `returns null for non-scored cohort phases`() {
+    val scores = listOf(NewProjectScoreModel(ScoreCategory.GIS, null, null, 1))
+
+    assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase2PlanAndScale, scores), "Phase 2")
+    assertNull(
+        ProjectScoreModel.totalScore(CohortPhase.Phase3ImplementAndMonitor, scores), "Phase 3")
+  }
+
+  private fun newModel(category: ScoreCategory, score: Int?) =
+      NewProjectScoreModel(category, null, null, score)
+}


### PR DESCRIPTION
Treat all the "project lead" score categories as a single combined value when
calculating totalproject scores, rather than treating each of them as a
separate input into the overall average.

For phase 0, update the project score calculation so that it uses a weighted
average of a subset of the categories, and so that it only calculates the
value once all categories have been scored.