### PR TITLE
SW-5597 Save native category on project species create

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesController.kt
@@ -72,6 +72,7 @@ class ParticipantProjectSpeciesController(
                 projectId = payload.projectId,
                 rationale = payload.rationale,
                 speciesId = payload.speciesId,
+                speciesNativeCategory = payload.speciesNativeCategory,
             ))
 
     return GetParticipantProjectSpeciesResponsePayload(ParticipantProjectSpeciesPayload(model))


### PR DESCRIPTION
When a species is initially added to a participant project, the request payload
includes a "native category" field, but the value wasn't being saved.