### PR TITLE
SW-5673 Don't update all project countries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -105,6 +105,7 @@ class ProjectAcceleratorDetailsStore(
             .set(COUNTRY_CODE, updated.countryCode)
             .set(MODIFIED_BY, currentUser().userId)
             .set(MODIFIED_TIME, clock.instant())
+            .where(ID.eq(projectId))
             .execute()
       }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -160,6 +160,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `updates details for project with existing details`() {
       val projectId = insertProject(countryCode = "KE")
+      val otherProjectId = insertProject(countryCode = "GB")
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 
@@ -210,10 +211,18 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               whatNeedsToBeTrue = "new needs",
           )
 
+      val otherDetails = store.fetchOneById(otherProjectId)
+
       store.update(projectId) { updatedDetails }
 
       assertEquals(
-          updatedDetails.copy(region = Region.EastAsiaPacific), store.fetchOneById(projectId))
+          updatedDetails.copy(region = Region.EastAsiaPacific),
+          store.fetchOneById(projectId),
+          "Should have updated project details")
+      assertEquals(
+          otherDetails,
+          store.fetchOneById(otherProjectId),
+          "Should not have updated details of other project")
     }
 
     @Test


### PR DESCRIPTION
Fix a bug in project accelerator details editing that caused the country codes of
_all_ projects to be updated.