### PR TITLE
Make shapefile feature names case-insensitive

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ShapefileFeature.kt
@@ -57,7 +57,7 @@ data class ShapefileFeature(
                 property.type.binding == String::class.java ||
                     Number::class.java.isAssignableFrom(property.type.binding)
               }
-              .associate { "${it.name}" to "${it.value}" }
+              .associate { "${it.name}".lowercase() to "${it.value}" }
 
       return ShapefileFeature(geometry, properties, crs)
     }


### PR DESCRIPTION
When importing shapefiles, we look for properties with specific names to identify
zones and subzones. This fails if the property names are capitalized.

Change the shapefile parsing code to fold all property names to lower case.