### PR TITLE
Update weighted scores to use SocialImpact

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModel.kt
@@ -56,7 +56,6 @@ data class ProjectScoreModel<INSTANT : Instant?>(
      */
     private val phase0Weights =
         mapOf(
-            ScoreCategory.Community to 1.0,
             ScoreCategory.ExpansionPotential to 0.25,
             ScoreCategory.ExperienceAndUnderstanding to 0.25,
             ScoreCategory.Finance to 2.0,
@@ -65,6 +64,7 @@ data class ProjectScoreModel<INSTANT : Instant?>(
             ScoreCategory.Legal to 1.0,
             ScoreCategory.OperationalCapacity to 1.0,
             ScoreCategory.ResponsivenessAndAttentionToDetail to 0.25,
+            ScoreCategory.SocialImpact to 1.0,
             ScoreCategory.ValuesAlignment to 0.25,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectScoreModelTest.kt
@@ -15,12 +15,12 @@ class ProjectScoreModelTest {
     fun `treats project lead scores as a single score in the average`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, 1),
               newModel(ScoreCategory.Finance, 1),
               newModel(ScoreCategory.Forestry, 1),
               newModel(ScoreCategory.GIS, 1),
               newModel(ScoreCategory.Legal, 1),
               newModel(ScoreCategory.OperationalCapacity, 1),
+              newModel(ScoreCategory.SocialImpact, 1),
               // Project lead categories have scores of 2
               newModel(ScoreCategory.ExpansionPotential, 2),
               newModel(ScoreCategory.ExperienceAndUnderstanding, 2),
@@ -38,7 +38,6 @@ class ProjectScoreModelTest {
     fun `gives double weight to finance score`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, 1),
               newModel(ScoreCategory.Finance, 2),
               newModel(ScoreCategory.Forestry, 1),
               newModel(ScoreCategory.GIS, 1),
@@ -47,6 +46,7 @@ class ProjectScoreModelTest {
               newModel(ScoreCategory.ExpansionPotential, 1),
               newModel(ScoreCategory.ExperienceAndUnderstanding, 1),
               newModel(ScoreCategory.ResponsivenessAndAttentionToDetail, 1),
+              newModel(ScoreCategory.SocialImpact, 1),
               newModel(ScoreCategory.ValuesAlignment, 1),
           )
 
@@ -61,7 +61,6 @@ class ProjectScoreModelTest {
     fun `returns null if required score is missing`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, 1),
               newModel(ScoreCategory.ExpansionPotential, 1),
               newModel(ScoreCategory.ExperienceAndUnderstanding, 1),
               newModel(ScoreCategory.Finance, 1),
@@ -70,6 +69,7 @@ class ProjectScoreModelTest {
               newModel(ScoreCategory.Legal, 1),
               newModel(ScoreCategory.OperationalCapacity, 1),
               newModel(ScoreCategory.ResponsivenessAndAttentionToDetail, 1),
+              newModel(ScoreCategory.SocialImpact, 1),
               // Missing ValuesAlignment
           )
 
@@ -83,7 +83,7 @@ class ProjectScoreModelTest {
     fun `treats project lead scores as a single score in the average`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, 1),
+              newModel(ScoreCategory.SocialImpact, 1),
               // Project lead categories have scores of 2
               newModel(ScoreCategory.ExpansionPotential, 2),
               newModel(ScoreCategory.ValuesAlignment, 3),
@@ -99,9 +99,9 @@ class ProjectScoreModelTest {
     fun `calculates average of whichever scores have values`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, 1),
-              newModel(ScoreCategory.GIS, null),
               newModel(ScoreCategory.ExpansionPotential, 2),
+              newModel(ScoreCategory.GIS, null),
+              newModel(ScoreCategory.SocialImpact, 1),
           )
 
       assertEquals(
@@ -113,8 +113,8 @@ class ProjectScoreModelTest {
     fun `returns null if no scores are available`() {
       val scores =
           listOf(
-              newModel(ScoreCategory.Community, null),
               newModel(ScoreCategory.ExpansionPotential, null),
+              newModel(ScoreCategory.SocialImpact, null),
           )
 
       assertNull(ProjectScoreModel.totalScore(CohortPhase.Phase1FeasibilityStudy, scores))


### PR DESCRIPTION
We renamed the Community score to SocialImpact but the weighted-average code was
still referring to the old name.