### PR TITLE
SW-5628 Revert change to default Student's t value

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -402,15 +402,15 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
 
   companion object {
     // Default values of the three parameters that determine how many monitoring plots should be
-    // required in each observation. The "Student's t" value is a constant based on an 80%
+    // required in each observation. The "Student's t" value is a constant based on a 90%
     // confidence level and should rarely need to change, but the other two will be adjusted by
     // admins based on the conditions at the planting site. These defaults mean that planting zones
-    // will have 7 permanent clusters and 9 temporary plots.
+    // will have 11 permanent clusters and 14 temporary plots.
     val DEFAULT_ERROR_MARGIN = BigDecimal(100)
-    val DEFAULT_STUDENTS_T = BigDecimal("1.282")
+    val DEFAULT_STUDENTS_T = BigDecimal("1.645")
     val DEFAULT_VARIANCE = BigDecimal(40000)
-    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 7
-    const val DEFAULT_NUM_TEMPORARY_PLOTS = 9
+    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 11
+    const val DEFAULT_NUM_TEMPORARY_PLOTS = 14
 
     /** Target planting density to use if not included in zone properties. */
     val DEFAULT_TARGET_PLANTING_DENSITY = BigDecimal(1500)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -435,8 +435,8 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
               newSite(width = 600),
               newSite(width = 600) {
                 zone {
-                  extraPermanentClusters = 1
-                  numPermanentClusters = 8
+                  extraPermanentClusters = 2
+                  numPermanentClusters = 13
                 }
               })
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -137,7 +137,7 @@ class PlantingSiteEditCalculatorTest {
                         existingModel = existing.plantingZones[0],
                         monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
-                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
+                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 700,
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Update(


### PR DESCRIPTION
Set the default value for the "Student's t" input to the calculation of the number
of monitoring plots per zone back to its old value of 1.645 to get a 90%
confidence interval. This causes the default number of clusters and plots to
increase, which also increases the number of plots and clusters that are added to
new areas when a zone's size is increased.