### PR TITLE
Fix ordering assumption in NotificationStoreTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -122,7 +122,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         expected,
-        store.fetchByOrganization(orgId),
+        store.fetchByOrganization(orgId).sortedBy { it.id.value },
         "Listed organizations do not match what was created")
   }
 


### PR DESCRIPTION
The test was assuming that an unordered database fetch would return rows in the
same order they were inserted, but that's not guaranteed; this was causing the
test to fail intermittently.