### PR TITLE
SW-5703 Add recorded sessions to modules

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
@@ -27,7 +27,8 @@ class ModulesImporter(
     private const val COLUMN_LIVE_SESSION_INFO = COLUMN_ADDITIONAL_RESOURCES + 1
     private const val COLUMN_ONE_ON_ONE_INFO = COLUMN_LIVE_SESSION_INFO + 1
     private const val COLUMN_WORKSHOP_INFO = COLUMN_ONE_ON_ONE_INFO + 1
-    private const val NUM_COLUMNS = COLUMN_WORKSHOP_INFO + 1
+    private const val COLUMN_RECORDED_SESSION_INFO = COLUMN_WORKSHOP_INFO + 1
+    private const val NUM_COLUMNS = COLUMN_RECORDED_SESSION_INFO + 1
 
     /** Lookup table for phases with both lower-case names and numeric IDs. */
     private val phases: Map<String, CohortPhase> =
@@ -57,6 +58,7 @@ class ModulesImporter(
         val liveSessionInfo = values[COLUMN_LIVE_SESSION_INFO]
         val oneOnOneInfo = values[COLUMN_ONE_ON_ONE_INFO]
         val workshopInfo = values[COLUMN_WORKSHOP_INFO]
+        val recordedSessionInfo = values[COLUMN_RECORDED_SESSION_INFO]
 
         if (moduleId == null) {
           addError("Missing or invalid module ID")
@@ -81,6 +83,7 @@ class ModulesImporter(
                 .set(LIVE_SESSION_DESCRIPTION, liveSessionInfo)
                 .set(ONE_ON_ONE_SESSION_DESCRIPTION, oneOnOneInfo)
                 .set(WORKSHOP_DESCRIPTION, workshopInfo)
+                .set(RECORDED_SESSION_DESCRIPTION, recordedSessionInfo)
                 .set(PHASE_ID, CohortPhase.Phase1FeasibilityStudy)
                 .set(POSITION, rowNumber)
                 .set(CREATED_BY, userId)
@@ -97,6 +100,7 @@ class ModulesImporter(
                 .set(LIVE_SESSION_DESCRIPTION, liveSessionInfo)
                 .set(ONE_ON_ONE_SESSION_DESCRIPTION, oneOnOneInfo)
                 .set(WORKSHOP_DESCRIPTION, workshopInfo)
+                .set(RECORDED_SESSION_DESCRIPTION, recordedSessionInfo)
                 .set(PHASE_ID, phase)
                 .set(POSITION, rowNumber)
                 .set(MODIFIED_BY, userId)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ModuleModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ModuleModel.kt
@@ -76,6 +76,9 @@ data class ModuleModel(
                       record[MODULES.ONE_ON_ONE_SESSION_DESCRIPTION]?.let {
                         EventType.OneOnOneSession to it
                       },
+                      record[MODULES.RECORDED_SESSION_DESCRIPTION]?.let {
+                        EventType.RecordedSession to it
+                      },
                       record[MODULES.WORKSHOP_DESCRIPTION]?.let { EventType.Workshop to it },
                   )
                   .toMap(),

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.customer.model.CreateNotificationModel
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationType
@@ -428,10 +429,14 @@ class AppNotificationService(
       val moduleEvent = moduleEventStore.fetchOneById(event.eventId)
       val module = moduleStore.fetchOneById(moduleEvent.moduleId)
       val renderMessage = {
-        messages.moduleEventStartingNotification(
-            moduleEvent.eventType,
-            module.name,
-        )
+        if (moduleEvent.eventType == EventType.RecordedSession) {
+          messages.moduleRecordedSessionNotification(module.name)
+        } else {
+          messages.moduleEventStartingNotification(
+              moduleEvent.eventType,
+              module.name,
+          )
+        }
       }
       moduleEvent.projects!!.forEach {
         val organizationId = parentStore.getOrganizationId(it)!!

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -191,6 +191,11 @@ class Messages {
                   eventType.getDisplayName(currentLocale()),
                   moduleName))
 
+  fun moduleRecordedSessionNotification(moduleName: String): NotificationMessage =
+      NotificationMessage(
+          title = getMessage("notification.module.recordedSession.title"),
+          body = getMessage("notification.module.recordedSession.body", moduleName))
+
   fun nurserySeedlingBatchReadyNotification(
       batchNumber: String,
       facilityName: String

--- a/src/main/resources/db/migration/0250/V294__ModuleRecordedSession.sql
+++ b/src/main/resources/db/migration/0250/V294__ModuleRecordedSession.sql
@@ -1,0 +1,6 @@
+ALTER TABLE accelerator.modules ADD COLUMN recorded_session_description TEXT;
+
+-- For recorded sessions, start and end time will be the same.
+ALTER TABLE accelerator.events DROP CONSTRAINT times_start_before_end;
+ALTER TABLE accelerator.events ADD CONSTRAINT times_start_before_end
+    CHECK (start_time <= end_time);

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -191,7 +191,8 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 INSERT INTO accelerator.event_types (id, name)
 VALUES (1, 'One-on-One Session'),
        (2, 'Workshop'),
-       (3, 'Live Session')
+       (3, 'Live Session'),
+       (4, 'Recorded Session')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO facility_connection_states (id, name)

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -46,6 +46,7 @@ accelerator.EventStatus.NotStarted=Not Started
 accelerator.EventStatus.StartingSoon=Starting Soon
 accelerator.EventType.LiveSession=Live Session
 accelerator.EventType.OneOnOneSession=1\:1 Session
+accelerator.EventType.RecordedSession=Recorded Session
 accelerator.EventType.Workshop=Workshop
 accelerator.SubmissionStatus.Approved=Approved
 accelerator.SubmissionStatus.Completed=Completed

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -147,6 +147,9 @@ notification.email.text.footer=Manage your notification settings\: {0}\n\nTerraf
 notification.module.eventStarting.body=Click the join {0} button to join the video call for {1}
 # {0} is the type of the event. {1} is the notification lead time configured.
 notification.module.eventStarting.title=Your {0} will start in {1} minutes
+# {0} is the title of an instructional session.
+notification.module.recordedSession.body=Click the View button to view the recorded session for {0}
+notification.module.recordedSession.title=Your Recorded Session is ready to view
 # {0} is the name of an organization
 notification.observation.monitoringPlotReplaced.email.body.1=Organization {0} has requested an observation plot change
 notification.observation.monitoringPlotReplaced.email.body.2=There is currently no assigned Terraformation primary project contact for this organization. Please assign one and let them know of this requested change.

--- a/src/main/resources/templates/admin/moduleView.html
+++ b/src/main/resources/templates/admin/moduleView.html
@@ -85,14 +85,15 @@
         <div th:utext="${module.eventDescriptions.get(event)}"> Event Description </div>
 
         <h4> Sessions </h4>
+
         <table>
             <thead>
             <tr>
                 <th>ID</th>
                 <th>Status</th>
                 <th>Start Time</th>
-                <th>End Time</th>
-                <th>Meeting Link</th>
+                <th th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">End Time</th>
+                <th th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">Meeting Link</th>
                 <th>Recording Link</th>
                 <th>Slides Link</th>
                 <th>Remove projects</th>
@@ -113,14 +114,14 @@
                            th:form="|update-${eventSession.id}|"
                            th:value="${#temporals.format(eventSession.startTime.atZone('UTC'), dateFormat)}" />
                 </td>
-                <td>
+                <td th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">
                     <input type="datetime-local"
                            name="endTime"
                            required
                            th:form="|update-${eventSession.id}|"
                            th:value="${#temporals.format(eventSession.endTime.atZone('UTC'), dateFormat)}" />
                 </td>
-                <td>
+                <td th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">
                     <input type="url"
                            name="meetingUrl"
                            th:form="|update-${eventSession.id}|"
@@ -194,13 +195,13 @@
                            required
                            th:form="|add-${event.getId()}|" />
                 </td>
-                <td>
+                <td th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">
                     <input type="datetime-local"
                            name="endTime"
                            required
                            th:form="|add-${event.getId()}|" />
                 </td>
-                <td>
+                <td th:if="${event != T(com.terraformation.backend.db.accelerator.EventType).RecordedSession}">
                     <input type="url"
                            name="meetingUrl"
                            th:form="|add-${event.getId()}|" />


### PR DESCRIPTION
Add a fourth module event type, "Recorded Session," which is for sessions where
the content is a prerecorded video rather than a live video call.

The description of the recorded session is imported from an additional column in
the modules spreadsheet.

Since the session is a recording, it doesn't take place during a specific time
period. But we still want to send out notifications when the recording is ready
to view. For consistency with the way the other event types work, the notification
is sent based on the event's start time, but unlike other event types, the end
time is always set to the same value as the start time such that the "event"
is finished as soon as its time arrives.

The notification text is also customized since the wording for other event types
isn't appropriate for recorded sessions.