### PR TITLE
SW-5672 Reset species list deliverable submission when new species are added

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdater.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.SubmissionStore
+import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
+
+@Named
+class SpeciesSubmissionUpdater(
+    private val dslContext: DSLContext,
+    private val submissionStore: SubmissionStore,
+) {
+  /**
+   * When a species is added to a deliverable with a submission that is "Approved", it must be reset
+   * back to "Not Submitted".
+   */
+  @EventListener
+  fun on(event: ParticipantProjectSpeciesAddedEvent) {
+    val deliverableId = event.deliverableId
+    val projectId = event.participantProjectSpecies.projectId
+
+    val (feedback, internalComment, submissionStatus) =
+        with(SUBMISSIONS) {
+          dslContext
+              .select(FEEDBACK, INTERNAL_COMMENT, SUBMISSION_STATUS_ID)
+              .from(SUBMISSIONS)
+              .where(PROJECT_ID.eq(projectId))
+              .and(DELIVERABLE_ID.eq(deliverableId))
+              .fetchOne()
+              ?.map { Triple(it[FEEDBACK], it[INTERNAL_COMMENT], it[SUBMISSION_STATUS_ID]!!) }
+              /** If there is no submission, there is nothing to do */
+              ?: return
+        }
+
+    if (submissionStatus != SubmissionStatus.Approved) {
+      return
+    }
+
+    submissionStore.updateSubmissionStatus(
+        deliverableId, projectId, SubmissionStatus.NotSubmitted, feedback, internalComment)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdater.kt
@@ -30,16 +30,13 @@ class SpeciesSubmissionUpdater(
               .where(PROJECT_ID.eq(projectId))
               .and(DELIVERABLE_ID.eq(deliverableId))
               .fetchOne()
-              ?.map { Triple(it[FEEDBACK], it[INTERNAL_COMMENT], it[SUBMISSION_STATUS_ID]!!) }
               /** If there is no submission, there is nothing to do */
               ?: return
         }
 
-    if (submissionStatus != SubmissionStatus.Approved) {
-      return
+    if (submissionStatus == SubmissionStatus.Approved) {
+      submissionStore.updateSubmissionStatus(
+          deliverableId, projectId, SubmissionStatus.NotSubmitted, feedback, internalComment)
     }
-
-    submissionStore.updateSubmissionStatus(
-        deliverableId, projectId, SubmissionStatus.NotSubmitted, feedback, internalComment)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
@@ -1,0 +1,149 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.SubmissionStore
+import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
+import com.terraformation.backend.accelerator.model.ExistingParticipantProjectSpeciesModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+
+  private val submissionStore: SubmissionStore by lazy {
+    SubmissionStore(clock, dslContext, eventPublisher)
+  }
+
+  private val updater: SpeciesSubmissionUpdater by lazy {
+    SpeciesSubmissionUpdater(dslContext, submissionStore)
+  }
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+
+    every { user.canReadProject(any()) } returns true
+    every { user.canReadSubmission(any()) } returns true
+    every { user.canUpdateSubmissionStatus(any(), any()) } returns true
+  }
+
+  @Nested
+  inner class NotifyIfNoNewerAddedSpecies {
+    @Test
+    fun `resets the submission status if it exists and is currently 'Approved'`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+      val speciesId = insertSpecies()
+      val moduleId = insertModule()
+      val deliverableId =
+          insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+      val submissionId =
+          insertSubmission(
+              deliverableId = deliverableId,
+              feedback = "So far so good",
+              internalComment = "Internal comment",
+              projectId = projectId,
+              submissionStatus = SubmissionStatus.Approved)
+
+      val participantProjectSpeciesId =
+          insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
+
+      updater.on(
+          ParticipantProjectSpeciesAddedEvent(
+              deliverableId = deliverableId,
+              participantProjectSpecies =
+                  ExistingParticipantProjectSpeciesModel(
+                      id = participantProjectSpeciesId,
+                      projectId = projectId,
+                      speciesId = speciesId,
+                      submissionStatus = SubmissionStatus.NotSubmitted,
+                  )))
+
+      val userId = currentUser().userId
+      val now = clock.instant
+
+      val actual = submissionsDao.fetchOneById(submissionId)
+      val expected =
+          SubmissionsRow(
+              createdBy = userId,
+              createdTime = now,
+              deliverableId = deliverableId,
+              feedback = "So far so good",
+              id = submissionId,
+              internalComment = "Internal comment",
+              modifiedBy = userId,
+              modifiedTime = now,
+              projectId = projectId,
+              submissionStatusId = SubmissionStatus.NotSubmitted)
+
+      assertEquals(expected, actual, "The submission's status was not updated to 'Not Submitted'")
+    }
+
+    @Test
+    fun `does nothing if the submission status is not 'Approved'`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId = insertProject(participantId = participantId)
+      val speciesId = insertSpecies()
+      val moduleId = insertModule()
+      val deliverableId =
+          insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
+      val submissionId =
+          insertSubmission(
+              deliverableId = deliverableId,
+              feedback = "So far so good",
+              internalComment = "Internal comment",
+              projectId = projectId,
+              submissionStatus = SubmissionStatus.InReview)
+
+      val participantProjectSpeciesId =
+          insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
+
+      updater.on(
+          ParticipantProjectSpeciesAddedEvent(
+              deliverableId = deliverableId,
+              participantProjectSpecies =
+                  ExistingParticipantProjectSpeciesModel(
+                      id = participantProjectSpeciesId,
+                      projectId = projectId,
+                      speciesId = speciesId,
+                      submissionStatus = SubmissionStatus.NotSubmitted,
+                  )))
+
+      val userId = currentUser().userId
+      val now = clock.instant
+
+      val actual = submissionsDao.fetchOneById(submissionId)
+      val expected =
+          SubmissionsRow(
+              createdBy = userId,
+              createdTime = now,
+              deliverableId = deliverableId,
+              feedback = "So far so good",
+              id = submissionId,
+              internalComment = "Internal comment",
+              modifiedBy = userId,
+              modifiedTime = now,
+              projectId = projectId,
+              submissionStatusId = SubmissionStatus.InReview)
+
+      assertEquals(expected, actual, "The submission's status was not updated to 'Not Submitted'")
+    }
+  }
+}


### PR DESCRIPTION
If a species is added to a participant project, and there is an associated deliverable ID (active or recent), and there is a submission that is "Approved" for the deliverable / project, "reset" the submission to the "Not Submitted" status.