### PR TITLE
SW-5672 Delete old species list snapshots when creating new ones

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -186,6 +186,7 @@ val ID_WRAPPERS =
                     "ParticipantProjectSpeciesId", listOf("participant_project_species\\.id")),
                 IdWrapper("SubmissionDocumentId", listOf("submission_documents\\.id")),
                 IdWrapper("SubmissionId", listOf("submissions\\.id", ".*\\.submission_id")),
+                IdWrapper("SubmissionSnapshotId", listOf("submission_snapshots\\.id")),
             ),
         "docprod" to
             listOf(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.daos.DeliverablesDao
 import com.terraformation.backend.db.accelerator.tables.daos.SubmissionSnapshotsDao
@@ -24,6 +25,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import jakarta.inject.Named
 import java.io.ByteArrayInputStream
@@ -120,8 +122,10 @@ class ParticipantProjectSpeciesService(
   }
 
   /**
-   * When a species deliverable status is updated to "approved", we save a snapshot of the species
-   * list and reference it in the deliverable submission
+   * When a species deliverable status is updated to "Approved", we save a snapshot of the species
+   * list and reference it in the deliverable submission. Since a deliverable can be "reset", and
+   * therefor can move to the "Approved" status more than once, if a submission snapshot already
+   * exists for the submission, it will be deleted and a new one will be created.
    */
   @EventListener
   fun on(event: DeliverableStatusUpdatedEvent) {
@@ -168,19 +172,15 @@ class ParticipantProjectSpeciesService(
         }
 
     val inputStream = ByteArrayInputStream(stream.toByteArray())
+    val submissionId = event.submissionId
     val timestamp = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").format(ZonedDateTime.now(clock))
-    val filename = "species-list-snapshot-${event.submissionId}-$timestamp.csv"
+    val filename = "species-list-snapshot-$submissionId-$timestamp.csv"
     val metadata =
         FileMetadata.of(MediaType.valueOf("text/csv").toString(), filename, stream.size().toLong())
 
-    fileService.storeFile("species-list-deliverable", inputStream, metadata, null) { fileId ->
-      with(SUBMISSION_SNAPSHOTS) {
-        dslContext
-            .insertInto(this)
-            .set(SUBMISSION_ID, event.submissionId)
-            .set(FILE_ID, fileId)
-            .execute()
-      }
+    dslContext.transaction { _ ->
+      deleteSubmissionSnapshotFile(submissionId)
+      createSubmissionSnapshotFile(inputStream, metadata, submissionId)
     }
   }
 
@@ -205,6 +205,38 @@ class ParticipantProjectSpeciesService(
 
     return fileService.readFile(snapshotRow.fileId!!)
   }
+
+  private fun createSubmissionSnapshotFile(
+      inputStream: ByteArrayInputStream,
+      metadata: NewFileMetadata,
+      submissionId: SubmissionId
+  ) =
+      fileService.storeFile("species-list-deliverable", inputStream, metadata, null) { fileId ->
+        with(SUBMISSION_SNAPSHOTS) {
+          dslContext
+              .insertInto(SUBMISSION_SNAPSHOTS)
+              .set(SUBMISSION_ID, submissionId)
+              .set(FILE_ID, fileId)
+              .execute()
+        }
+      }
+
+  /** Delete a submission snapshot file, if it exists */
+  private fun deleteSubmissionSnapshotFile(submissionId: SubmissionId) =
+      with(SUBMISSION_SNAPSHOTS) {
+        val fileId =
+            dslContext
+                .select(FILE_ID)
+                .from(SUBMISSION_SNAPSHOTS)
+                .where(SUBMISSION_ID.eq(submissionId))
+                .fetchOne(FILE_ID)
+
+        if (fileId != null) {
+          fileService.deleteFile(fileId) {
+            dslContext.deleteFrom(SUBMISSION_SNAPSHOTS).where(FILE_ID.eq(fileId)).execute()
+          }
+        }
+      }
 
   /**
    * If a Participant Project Species is created, and there is either an active or recent

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -124,7 +124,7 @@ class ParticipantProjectSpeciesService(
   /**
    * When a species deliverable status is updated to "Approved", we save a snapshot of the species
    * list and reference it in the deliverable submission. Since a deliverable can be "reset", and
-   * therefor can move to the "Approved" status more than once, if a submission snapshot already
+   * therefore can move to the "Approved" status more than once, if a submission snapshot already
    * exists for the submission, it will be deleted and a new one will be created.
    */
   @EventListener

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.accelerator.ScoreCategory
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
+import com.terraformation.backend.db.accelerator.SubmissionSnapshotId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationHistoriesDao
@@ -74,6 +75,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ProjectScoresRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVoteDecisionsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVotesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionDocumentsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionSnapshotsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.UserDeliverableCategoriesRow
 import com.terraformation.backend.db.default_schema.AutomationId
@@ -1118,6 +1120,25 @@ abstract class DatabaseBackedTest {
     submissionDocumentsDao.insert(row)
 
     return row.id!!.also { inserted.submissionDocumentIds.add(it) }
+  }
+
+  fun insertSubmissionSnapshot(
+      id: Any? = null,
+      fileId: Any? = inserted.fileId,
+      submissionId: Any? = inserted.submissionId,
+  ): SubmissionSnapshotId {
+    nextSubmissionNumber++
+
+    val row =
+        SubmissionSnapshotsRow(
+            id = id?.toIdWrapper { SubmissionSnapshotId(it) },
+            fileId = fileId?.toIdWrapper { FileId(it) },
+            submissionId = submissionId?.toIdWrapper { SubmissionId(it) },
+        )
+
+    submissionSnapshotsDao.insert(row)
+
+    return row.id!!.also { inserted.submissionSnapshotIds.add(it) }
   }
 
   /** Creates a user that can be referenced by various tests. */
@@ -3143,8 +3164,9 @@ abstract class DatabaseBackedTest {
     val reportIds = mutableListOf<ReportId>()
     val speciesIds = mutableListOf<SpeciesId>()
     val subLocationIds = mutableListOf<SubLocationId>()
-    val submissionIds = mutableListOf<SubmissionId>()
     val submissionDocumentIds = mutableListOf<SubmissionDocumentId>()
+    val submissionIds = mutableListOf<SubmissionId>()
+    val submissionSnapshotIds = mutableListOf<SubmissionSnapshotId>()
     val uploadIds = mutableListOf<UploadId>()
     val userIds = mutableListOf<UserId>()
     val variableIds = mutableListOf<VariableId>()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1127,8 +1127,6 @@ abstract class DatabaseBackedTest {
       fileId: Any? = inserted.fileId,
       submissionId: Any? = inserted.submissionId,
   ): SubmissionSnapshotId {
-    nextSubmissionNumber++
-
     val row =
         SubmissionSnapshotsRow(
             id = id?.toIdWrapper { SubmissionSnapshotId(it) },


### PR DESCRIPTION
If there is already a submission snapshot for a species list deliverable submission when it is being approved (this can happen is a submission was ever "reset"), delete the old snapshot before creating the new one.