### PR TITLE
SW-5605 Stop using hardwired facility IDs in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -103,6 +103,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Autowired private lateinit var config: TerrawareServerConfig
 
+  private lateinit var facilityId: FacilityId
   private lateinit var otherUserId: UserId
 
   private val clock = TestClock()
@@ -131,6 +132,9 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     val objectMapper = jacksonObjectMapper()
     val publisher = TestEventPublisher()
+
+    insertOrganization()
+    facilityId = insertFacility()
 
     parentStore = ParentStore(dslContext)
 
@@ -257,7 +261,6 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     every { user.locale } returns Locale.ENGLISH
     every { user.organizationRoles } returns mapOf(organizationId to Role.Admin)
 
-    insertSiteData()
     otherUserId = insertUser()
   }
 
@@ -317,13 +320,12 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store nursery seedling batch ready notification`() {
     insertOrganizationUser()
 
-    val facilityId = FacilityId(1000)
     val nurseryName = "my nursery"
     val speciesId = SpeciesId(100)
     val batchId = BatchId(100)
     val batchNumber = "22-2-001"
 
-    insertFacility(id = facilityId, type = FacilityType.Nursery, name = nurseryName)
+    val facilityId = insertFacility(type = FacilityType.Nursery, name = nurseryName)
     insertSpecies(speciesId)
     insertBatch(
         BatchesRow(
@@ -361,7 +363,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val automationId = AutomationId(1)
     val deviceId = DeviceId(1)
     val timeseriesName = "test timeseries"
-    val facilityName = "Facility $facilityId"
+    val facilityName = "Facility 1"
     val badValue = 5.678
 
     insertOrganizationUser()
@@ -387,7 +389,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val automationId = AutomationId(1)
     val automationName = "automation name"
     val automationType = "unknown"
-    val facilityName = "Facility $facilityId"
+    val facilityName = "Facility 1"
     val message = "message"
 
     insertOrganizationUser()

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.i18n.Messages
@@ -94,9 +93,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
     insertBatch(facilityId = nurseryFacilityId, speciesId = speciesId)
   }
   private val projectId by lazy { insertProject() }
-  private val nurseryFacilityId by lazy {
-    insertFacility(FacilityId(2), type = FacilityType.Nursery)
-  }
+  private val nurseryFacilityId by lazy { insertFacility(type = FacilityType.Nursery) }
   private val plantingSiteId1 by lazy { insertPlantingSite() }
   private val plantingSiteId2 by lazy { insertPlantingSite() }
   private val speciesId by lazy { insertSpecies() }
@@ -112,10 +109,10 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
         speciesId = otherOrgSpeciesId)
   }
   private val otherOrgNurseryFacilityId by lazy {
-    insertFacility(FacilityId(3), type = FacilityType.Nursery, organizationId = otherOrganizationId)
+    insertFacility(type = FacilityType.Nursery, organizationId = otherOrganizationId)
   }
   private val otherOrgSeedBankFacilityId by lazy {
-    insertFacility(FacilityId(4), organizationId = otherOrganizationId)
+    insertFacility(organizationId = otherOrganizationId)
   }
   private val otherOrgPlantingSiteId by lazy {
     insertPlantingSite(organizationId = otherOrganizationId)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -18,6 +18,8 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var permissionStore: PermissionStore
 
+  private lateinit var org1FacilityId: FacilityId
+  private lateinit var org2FacilityId: FacilityId
   private lateinit var org2Owner: UserId
   private lateinit var org1Contributor2Manager: UserId
 
@@ -30,15 +32,14 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchFacilityRoles includes all facilities in organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(FacilityId(1000) to Role.Contributor, FacilityId(2000) to Role.Manager),
+        mapOf(org1FacilityId to Role.Contributor, org2FacilityId to Role.Manager),
         permissionStore.fetchFacilityRoles(org1Contributor2Manager))
   }
 
   @Test
   fun `fetchFacilityRoles only includes facilities in organizations the user is in`() {
     insertTestData()
-    assertEquals(
-        mapOf(FacilityId(2000) to Role.Owner), permissionStore.fetchFacilityRoles(org2Owner))
+    assertEquals(mapOf(org2FacilityId to Role.Owner), permissionStore.fetchFacilityRoles(org2Owner))
   }
 
   @Test
@@ -81,9 +82,9 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
    * Inserts some test data to exercise the fetch methods. The data set:
    * ```
    * - Organization 1
-   *   - Facility 1000
+   *   - Facility org1FacilityId
    * - Organization 2
-   *   - Facility 2000
+   *   - Facility org2FacilityId
    *
    * - User
    *   - Org 1 role: manager
@@ -95,15 +96,10 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
    * ```
    */
   private fun insertTestData() {
-    val structure =
-        mapOf(
-            OrganizationId(1) to listOf(FacilityId(1000)),
-            OrganizationId(2) to listOf(FacilityId(2000)))
-
-    structure.forEach { (organizationId, facilities) ->
-      insertOrganization(organizationId)
-      facilities.forEach { facilityId -> insertFacility(facilityId, organizationId) }
-    }
+    insertOrganization(1)
+    org1FacilityId = insertFacility()
+    insertOrganization(2)
+    org2FacilityId = insertFacility()
 
     configureUser(mapOf(1 to Role.Manager))
     org2Owner = configureUser(mapOf(2 to Role.Owner))

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -410,7 +410,6 @@ abstract class DatabaseBackedTest {
   // ID values inserted by insertSiteData(). These are used in most database-backed tests. They are
   // marked as final so they can be referenced in constructor-initialized properties in subclasses.
   protected val organizationId: OrganizationId = OrganizationId(1)
-  protected val facilityId: FacilityId = FacilityId(100)
 
   /** IDs of entities that have been inserted using the `insert` helper methods during this test. */
   val inserted = Inserted()
@@ -642,10 +641,10 @@ abstract class DatabaseBackedTest {
   private var nextFacilityNumber = 1
 
   fun insertFacility(
-      id: Any = this.facilityId,
-      organizationId: Any = this.organizationId,
-      name: String = "Facility $id",
-      description: String? = "Description $id",
+      id: Any? = null,
+      organizationId: Any = inserted.organizationId,
+      name: String = "Facility $nextFacilityNumber",
+      description: String? = "Description $nextFacilityNumber",
       createdBy: UserId = currentUser().userId,
       type: FacilityType = FacilityType.SeedBank,
       maxIdleMinutes: Int = 30,
@@ -659,11 +658,11 @@ abstract class DatabaseBackedTest {
       buildCompletedDate: LocalDate? = null,
       operationStartedDate: LocalDate? = null,
       capacity: Int? = null,
-      facilityNumber: Int = nextFacilityNumber++,
+      facilityNumber: Int = nextFacilityNumber,
   ): FacilityId {
-    return with(FACILITIES) {
-      val insertedId = id.toIdWrapper { FacilityId(it) }
+    nextFacilityNumber++
 
+    return with(FACILITIES) {
       dslContext
           .insertInto(FACILITIES)
           .set(BUILD_COMPLETED_DATE, buildCompletedDate)
@@ -674,7 +673,7 @@ abstract class DatabaseBackedTest {
           .set(CREATED_TIME, Instant.EPOCH)
           .set(DESCRIPTION, description)
           .set(FACILITY_NUMBER, facilityNumber)
-          .set(ID, insertedId)
+          .apply { id?.toIdWrapper { FacilityId(it) }?.let { set(ID, it) } }
           .set(IDLE_AFTER_TIME, idleAfterTime)
           .set(IDLE_SINCE_TIME, idleSinceTime)
           .set(LAST_NOTIFICATION_DATE, lastNotificationDate)
@@ -915,7 +914,7 @@ abstract class DatabaseBackedTest {
 
   protected fun insertDevice(
       id: Any,
-      facilityId: Any = this.facilityId,
+      facilityId: Any = inserted.facilityId,
       name: String = "device $id",
       createdBy: UserId = currentUser().userId,
       type: String = "type"
@@ -943,7 +942,7 @@ abstract class DatabaseBackedTest {
 
   protected fun insertAutomation(
       id: Any,
-      facilityId: Any = this.facilityId,
+      facilityId: Any = inserted.facilityId,
       name: String = "automation $id",
       type: String = AutomationModel.SENSOR_BOUNDS_TYPE,
       deviceId: Any? = "$id".toLong(),
@@ -1206,7 +1205,7 @@ abstract class DatabaseBackedTest {
   /** Adds a sub-location to a facility. */
   fun insertSubLocation(
       id: Any? = null,
-      facilityId: Any = this.facilityId,
+      facilityId: Any = inserted.facilityId,
       name: String = id?.let { "Location $it" } ?: "Location ${nextSubLocationNumber++}",
       createdBy: UserId = currentUser().userId,
   ): SubLocationId {
@@ -1338,7 +1337,7 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       dataSourceId: DataSource = row.dataSourceId ?: DataSource.Web,
-      facilityId: Any = row.facilityId ?: this.facilityId,
+      facilityId: Any = row.facilityId ?: inserted.facilityId,
       id: Any? = row.id,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
@@ -1374,7 +1373,7 @@ abstract class DatabaseBackedTest {
       addedDate: LocalDate = row.addedDate ?: LocalDate.EPOCH,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
-      facilityId: Any = row.facilityId ?: this.facilityId,
+      facilityId: Any = row.facilityId ?: inserted.facilityId,
       germinatingQuantity: Int = row.germinatingQuantity ?: 0,
       id: Any? = row.id,
       notReadyQuantity: Int = row.notReadyQuantity ?: 0,
@@ -1470,7 +1469,7 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       destinationFacilityId: Any? = row.destinationFacilityId,
-      facilityId: Any = row.facilityId ?: this.facilityId,
+      facilityId: Any = row.facilityId ?: inserted.facilityId,
       id: Any? = row.id,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -62,23 +62,27 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
     )
   }
 
-  private val bmuRow =
-      DevicesRow(
-          facilityId = facilityId,
-          name = "PV",
-          deviceType = "BMU",
-          make = "Blue Ion",
-          model = "LV",
-      )
+  private lateinit var facilityId: FacilityId
 
-  private val omniSenseRow =
-      DevicesRow(
-          facilityId = facilityId,
-          deviceType = "sensor",
-          name = "0123ABCD",
-          make = "OmniSense",
-          model = "S-11",
-      )
+  private val bmuRow: DevicesRow by lazy {
+    DevicesRow(
+        facilityId = facilityId,
+        name = "PV",
+        deviceType = "BMU",
+        make = "Blue Ion",
+        model = "LV",
+    )
+  }
+
+  private val omniSenseRow: DevicesRow by lazy {
+    DevicesRow(
+        facilityId = facilityId,
+        deviceType = "sensor",
+        name = "0123ABCD",
+        make = "OmniSense",
+        model = "S-11",
+    )
+  }
 
   /** Expected temperature and humidity ranges for temperature sensors. */
   data class OmniSense(
@@ -135,7 +139,8 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadFacility(any()) } returns true
     every { user.canUpdateDevice(any()) } returns true
 
-    insertSiteData()
+    insertOrganization()
+    facilityId = insertFacility()
   }
 
   @Test
@@ -283,8 +288,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createDefaultDevices does nothing if facility has no default template category`() {
-    val desalFacilityId = FacilityId(2)
-    insertFacility(desalFacilityId, type = FacilityType.Desalination)
+    val desalFacilityId = insertFacility(type = FacilityType.Desalination)
     deviceTemplatesDao.insert(
         DeviceTemplatesRow(
             categoryId = DeviceTemplateCategory.SeedBankDefault,

--- a/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
@@ -109,7 +109,8 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
             overallProgress = 30,
         )
 
-    val existingRow = insertDeviceManager(456, balenaId = device.id, facilityId = 100)
+    val existingRow =
+        insertDeviceManager(456, balenaId = device.id, facilityId = inserted.facilityId)
 
     clock.instant = Instant.ofEpochSecond(200)
     every { balenaClient.listModifiedDevices(any()) } returns listOf(device)

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -110,9 +110,11 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `insert throws exception if facility ID specified and user cannot update facility`() {
-    every { user.canUpdateFacility(facilityId) } returns false
+    every { user.canUpdateFacility(inserted.facilityId) } returns false
 
-    assertThrows<AccessDeniedException> { store.insert(newRow(id = null, facilityId = facilityId)) }
+    assertThrows<AccessDeniedException> {
+      store.insert(newRow(id = null, facilityId = inserted.facilityId))
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.PlantingType
@@ -54,6 +55,7 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
         dslContext)
   }
 
+  private lateinit var facilityId: FacilityId
   private val plantingSiteId by lazy { insertPlantingSite() }
   private val speciesId1 by lazy { insertSpecies(1) }
   private val speciesId2 by lazy { insertSpecies(2) }
@@ -68,7 +70,7 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateDelivery(any()) } returns true
 
     insertOrganization()
-    insertFacility(type = FacilityType.Nursery)
+    facilityId = insertFacility(type = FacilityType.Nursery)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
@@ -111,6 +112,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
   }
 
   private val uploadId = UploadId(1)
+  private lateinit var facilityId: FacilityId
   private lateinit var subLocationId: SubLocationId
 
   @BeforeEach
@@ -127,7 +129,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
     every { userStore.fetchOneById(userId) } returns user
 
     insertOrganization()
-    insertFacility(type = FacilityType.Nursery)
+    facilityId = insertFacility(type = FacilityType.Nursery)
     subLocationId = insertSubLocation(name = "Location 1")
   }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -6,10 +6,8 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchPhotoId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchPhotosRow
@@ -220,15 +218,12 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `handler for OrganizationDeletionStartedEvent deletes photos for all batches in organization`() {
-    val facilityId2 = FacilityId(2)
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(3)
-    insertOrganization(otherOrganizationId)
-    insertFacility(facilityId2, type = FacilityType.Nursery)
-    insertFacility(otherOrgFacilityId, otherOrganizationId, type = FacilityType.Nursery)
-    val facility2BatchId = insertBatch(facilityId = facilityId2)
-    val otherOrgBatchId =
-        insertBatch(facilityId = otherOrgFacilityId, organizationId = otherOrganizationId)
+    insertFacility(type = FacilityType.Nursery)
+    val facility2BatchId = insertBatch()
+
+    val otherOrganizationId = insertOrganization(2)
+    insertFacility(type = FacilityType.Nursery)
+    val otherOrgBatchId = insertBatch(organizationId = otherOrganizationId)
 
     storePhoto()
     storePhoto()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -5,10 +5,8 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
 import com.terraformation.backend.file.FileService
@@ -130,17 +128,15 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `handler for OrganizationDeletionStartedEvent deletes photos for all withdrawals in organization`() {
-    val facilityId2 = FacilityId(2)
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(3)
-    insertOrganization(otherOrganizationId)
-    insertFacility(facilityId2, type = FacilityType.Nursery)
-    insertFacility(otherOrgFacilityId, otherOrganizationId, type = FacilityType.Nursery)
-    val facility2WithdrawalId = insertWithdrawal(facilityId = facilityId2)
-    val otherOrgWithdrawalId = insertWithdrawal(facilityId = otherOrgFacilityId)
+    storePhoto()
+    storePhoto()
 
-    storePhoto()
-    storePhoto()
+    val facilityId2 = insertFacility(type = FacilityType.Nursery)
+    val facility2WithdrawalId = insertWithdrawal(facilityId = facilityId2)
+    insertOrganization(2)
+    insertFacility(type = FacilityType.Nursery)
+    val otherOrgWithdrawalId = insertWithdrawal()
+
     storePhoto(facility2WithdrawalId)
     val otherOrgfileId = storePhoto(otherOrgWithdrawalId)
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAccessionSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreAccessionSpeciesTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.assertIsEventListener
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.seedbank.event.AccessionSpeciesChangedEvent
@@ -11,8 +10,7 @@ import org.junit.jupiter.api.Test
 internal class BatchStoreAccessionSpeciesTest : BatchStoreTest() {
   @Test
   fun `updates affected batches`() {
-    val seedBankFacilityId = FacilityId(2)
-    insertFacility(id = seedBankFacilityId, type = FacilityType.SeedBank)
+    val seedBankFacilityId = insertFacility(type = FacilityType.SeedBank)
     val accessionId = insertAccession(facilityId = seedBankFacilityId)
     val otherAccessionId = insertAccession(facilityId = seedBankFacilityId)
     val otherSpeciesId = insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCalculationsTest.kt
@@ -17,11 +17,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class BatchStoreCalculationsTest : BatchStoreTest() {
-  private val destinationFacilityId = FacilityId(3)
+  private lateinit var destinationFacilityId: FacilityId
 
   @BeforeEach
   fun insertOtherNursery() {
-    insertFacility(destinationFacilityId, type = FacilityType.Nursery)
+    destinationFacilityId = insertFacility(type = FacilityType.Nursery)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.SubLocationAtWrongFacilityException
 import com.terraformation.backend.db.SubLocationNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SeedTreatment
@@ -146,7 +145,7 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
 
   @Test
   fun `includes facility number in batch number`() {
-    val secondFacilityId = insertFacility(2, type = FacilityType.Nursery, facilityNumber = 2)
+    val secondFacilityId = insertFacility(type = FacilityType.Nursery, facilityNumber = 2)
 
     val inputModel =
         CreateBatchRequestPayload(
@@ -166,8 +165,7 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if facility is not a nursery`() {
-    val seedBankFacilityId = FacilityId(2)
-    insertFacility(seedBankFacilityId, type = FacilityType.SeedBank)
+    val seedBankFacilityId = insertFacility(type = FacilityType.SeedBank)
 
     assertThrows<FacilityTypeMismatchException> {
       store.create(makeNewBatchModel().copy(facilityId = seedBankFacilityId))
@@ -194,8 +192,8 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if sub-location is not at same facility`() {
-    val otherFacilityId = insertFacility(2, type = FacilityType.Nursery)
-    val otherSubLocationId = insertSubLocation(facilityId = otherFacilityId)
+    insertFacility(type = FacilityType.Nursery)
+    val otherSubLocationId = insertSubLocation()
 
     assertThrows<SubLocationAtWrongFacilityException> {
       store.create(makeNewBatchModel().copy(subLocationIds = setOf(otherSubLocationId)))

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchEstimatedReadyTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchEstimatedReadyTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.nursery.db.batchStore
 
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.nursery.event.NurserySeedlingBatchReadyEvent
 import java.time.LocalDate
@@ -10,16 +9,10 @@ import org.junit.jupiter.api.Test
 internal class BatchStoreFetchEstimatedReadyTest : BatchStoreTest() {
   @Test
   fun `returns rows within specified ready by date range`() {
-    val facilityId = FacilityId(1000)
-    insertFacility(id = facilityId, type = FacilityType.Nursery, name = "baby plant nursery")
-    val batchId1 =
-        insertBatch(
-            speciesId = speciesId, facilityId = facilityId, readyByDate = LocalDate.of(2022, 11, 3))
-    val batchId2 =
-        insertBatch(
-            speciesId = speciesId, facilityId = facilityId, readyByDate = LocalDate.of(2022, 11, 4))
-    insertBatch(
-        speciesId = speciesId, facilityId = facilityId, readyByDate = LocalDate.of(2022, 11, 10))
+    val facilityId = insertFacility(type = FacilityType.Nursery, name = "baby plant nursery")
+    val batchId1 = insertBatch(speciesId = speciesId, readyByDate = LocalDate.of(2022, 11, 3))
+    val batchId2 = insertBatch(speciesId = speciesId, readyByDate = LocalDate.of(2022, 11, 4))
+    insertBatch(speciesId = speciesId, readyByDate = LocalDate.of(2022, 11, 10))
 
     val expected =
         batchesDao.fetchById(batchId1, batchId2).map {
@@ -34,12 +27,9 @@ internal class BatchStoreFetchEstimatedReadyTest : BatchStoreTest() {
 
   @Test
   fun `filters results by facility ID`() {
-    val facilityId = FacilityId(1000)
-    val otherFacilityId = FacilityId(1001)
-    insertFacility(id = facilityId, type = FacilityType.Nursery)
-    insertFacility(id = otherFacilityId, type = FacilityType.Nursery)
-    insertBatch(
-        speciesId = speciesId, facilityId = facilityId, readyByDate = LocalDate.of(2022, 11, 3))
+    insertFacility(type = FacilityType.Nursery)
+    insertBatch(speciesId = speciesId, readyByDate = LocalDate.of(2022, 11, 3))
+    val otherFacilityId = insertFacility(type = FacilityType.Nursery)
 
     val expected = emptyList<NurserySeedlingBatchReadyEvent>()
     val actual =

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetNurseryStatsTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.assertJsonEquals
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.nursery.model.NurseryStats
@@ -13,8 +12,7 @@ internal class BatchStoreGetNurseryStatsTest : BatchStoreTest() {
   fun `rolls up multiple species and withdrawals only for specified facility`() {
     every { user.canReadFacility(any()) } returns true
 
-    val otherNurseryId = FacilityId(20)
-    insertFacility(otherNurseryId, type = FacilityType.Nursery)
+    val otherNurseryId = insertFacility(type = FacilityType.Nursery)
     val speciesId2 = insertSpecies(scientificName = "Second species")
 
     val batchId1 =

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.nursery.db.batchStore
 
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -34,8 +33,7 @@ internal class BatchStoreSpeciesSummaryTest : BatchStoreTest() {
 
   @Test
   fun `includes nurseries that have fully-withdrawn batches`() {
-    val facilityId2 = FacilityId(2)
-    insertFacility(facilityId2, name = "Other Nursery", type = FacilityType.Nursery)
+    val facilityId2 = insertFacility(name = "Other Nursery", type = FacilityType.Nursery)
     insertBatch(speciesId = speciesId, facilityId = facilityId)
     insertBatch(speciesId = speciesId, facilityId = facilityId, readyQuantity = 1)
     insertBatch(speciesId = speciesId, facilityId = facilityId2)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
@@ -45,12 +46,13 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
     )
   }
 
+  protected lateinit var facilityId: FacilityId
   protected lateinit var speciesId: SpeciesId
 
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    insertFacility(name = "Nursery", type = FacilityType.Nursery)
+    facilityId = insertFacility(name = "Nursery", type = FacilityType.Nursery)
     speciesId = insertSpecies()
 
     every { user.canCreateBatch(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
@@ -133,7 +133,7 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if undoing nursery transfer`() {
-    val otherFacilityId = insertFacility(id = 3, type = FacilityType.Nursery)
+    val otherFacilityId = insertFacility(type = FacilityType.Nursery)
 
     val withdrawalId =
         makeInitialWithdrawal(

--- a/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/db/ReportStoreTest.kt
@@ -386,7 +386,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
                           buildCompletedDateEditable = true,
                           buildStartedDate = null,
                           buildStartedDateEditable = true,
-                          id = FacilityId(1),
+                          id = inserted.facilityId,
                           name = "bank",
                           notes = "notes",
                           operationStartedDate = null,
@@ -485,9 +485,9 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `saves seed bank and nursery information`() {
-      insertFacility(1)
-      insertFacility(2)
-      insertFacility(3, type = FacilityType.Nursery)
+      val facilityId1 = insertFacility()
+      val facilityId2 = insertFacility()
+      val facilityId3 = insertFacility(type = FacilityType.Nursery)
       val body =
           ReportBodyModelV1(
               organizationName = "org",
@@ -495,7 +495,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
               seedBanks =
                   listOf(
                       ReportBodyModelV1.SeedBank(
-                          id = FacilityId(1),
+                          id = facilityId1,
                           name = "bank",
                           buildStartedDate = LocalDate.EPOCH,
                           buildCompletedDate = LocalDate.EPOCH,
@@ -503,7 +503,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
                           workers = ReportBodyModelV1.Workers(1, 1, 1),
                       ),
                       ReportBodyModelV1.SeedBank(
-                          id = FacilityId(2),
+                          id = facilityId2,
                           selected = false,
                           name = "bank",
                           buildStartedDate = LocalDate.EPOCH,
@@ -515,7 +515,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
               nurseries =
                   listOf(
                       ReportBodyModelV1.Nursery(
-                          id = FacilityId(3),
+                          id = facilityId3,
                           name = "nursery",
                           buildStartedDate = LocalDate.EPOCH,
                           buildCompletedDate = LocalDate.EPOCH,
@@ -532,17 +532,17 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
       store.submit(reportId)
 
-      val seedBankResult = getFacilityById(FacilityId(1))
+      val seedBankResult = getFacilityById(facilityId1)
       assertEquals(seedBankResult.buildStartedDate, LocalDate.EPOCH)
       assertEquals(seedBankResult.buildCompletedDate, LocalDate.EPOCH)
       assertEquals(seedBankResult.operationStartedDate, LocalDate.EPOCH)
 
-      val unselectedSeedBankResult = getFacilityById(FacilityId(2))
+      val unselectedSeedBankResult = getFacilityById(facilityId2)
       assertNull(unselectedSeedBankResult.buildStartedDate)
       assertNull(unselectedSeedBankResult.buildCompletedDate)
       assertNull(unselectedSeedBankResult.operationStartedDate)
 
-      val nurseryResult = getFacilityById(FacilityId(3))
+      val nurseryResult = getFacilityById(facilityId3)
       assertEquals(nurseryResult.buildStartedDate, LocalDate.EPOCH)
       assertEquals(nurseryResult.buildCompletedDate, LocalDate.EPOCH)
       assertEquals(nurseryResult.operationStartedDate, LocalDate.EPOCH)
@@ -551,7 +551,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if report is incomplete`() {
-      insertFacility(1)
+      insertFacility()
       val body =
           ReportBodyModelV1(
               organizationName = "org",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.UploadNotAwaitingActionException
+import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadProblemId
@@ -143,6 +144,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   }
   private val userStore: UserStore = mockk()
 
+  private lateinit var facilityId: FacilityId
   private val uploadId = UploadId(1)
 
   @BeforeEach
@@ -160,7 +162,8 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateUpload(any()) } returns true
     every { userStore.fetchOneById(userId) } returns user
 
-    insertSiteData()
+    insertOrganization()
+    facilityId = insertFacility()
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.customer.event.OrganizationDeletionStartedEven
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -276,15 +275,13 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `OrganizationDeletionStartedEvent listener deletes photos from all facilities in organization`() {
-    val sameOrgFacilityId = FacilityId(2)
     val sameOrgAccessionId = AccessionId(2)
     val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(3)
     val otherOrgAccessionId = AccessionId(3)
 
+    val sameOrgFacilityId = insertFacility()
     insertOrganization(otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
+    val otherOrgFacilityId = insertFacility()
     insertAccession(id = sameOrgAccessionId, facilityId = sameOrgFacilityId)
     insertAccession(id = otherOrgAccessionId, facilityId = otherOrgFacilityId)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -74,7 +74,7 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
           .set(CREATED_BY, user.userId)
           .set(CREATED_TIME, clock.instant())
           .set(DATA_SOURCE_ID, DataSource.FileImport)
-          .set(FACILITY_ID, facilityId)
+          .set(FACILITY_ID, inserted.facilityId)
           .set(MODIFIED_BY, user.userId)
           .set(MODIFIED_TIME, clock.instant())
           .set(STATE_ID, AccessionState.InStorage)
@@ -203,8 +203,8 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `creates new nursery transfers`() {
     insertSpecies()
-    val nurseryFacilityId = insertFacility(2, type = FacilityType.Nursery)
-    val batchId = insertBatch(facilityId = nurseryFacilityId)
+    insertFacility(type = FacilityType.Nursery)
+    val batchId = insertBatch()
 
     val newWithdrawal =
         WithdrawalModel(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -134,9 +133,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
   @Test
   fun `create does not allow creating an accession at a nursery facility`() {
-    val nurseryFacilityId = FacilityId(2)
-
-    insertFacility(nurseryFacilityId, type = FacilityType.Nursery)
+    val nurseryFacilityId = insertFacility(type = FacilityType.Nursery)
 
     assertThrows<FacilityTypeMismatchException> {
       store.create(accessionModel(facilityId = nurseryFacilityId))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
@@ -18,12 +17,11 @@ import org.junit.jupiter.api.Test
 internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   @Test
   fun countByState() {
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
     val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
     insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
+    val otherOrgFacilityId = insertFacility()
 
     val toCreate =
         mapOf(
@@ -77,12 +75,11 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics counts seeds remaining`() {
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
     val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
     insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
+    val otherOrgFacilityId = insertFacility()
 
     listOf(
             AccessionsRow(
@@ -154,12 +151,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics estimates seeds remaining by weight`() {
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
-    insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
+    insertOrganization(2)
+    val otherOrgFacilityId = insertFacility()
 
     listOf(
             AccessionsRow(
@@ -261,12 +256,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics counts total withdrawn quantity`() {
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
-    insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
+    insertOrganization(2)
+    val otherOrgFacilityId = insertFacility()
 
     listOf(
             AccessionsRow(
@@ -348,12 +341,11 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics counts unknown-quantity accessions`() {
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
     val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
     insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
+    val otherOrgFacilityId = insertFacility()
 
     listOf(
             // No subset weight, no subset count
@@ -440,17 +432,16 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics counts species`() {
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
+
+    val otherOrganizationId = insertOrganization(2)
+    val otherOrgFacilityId = insertFacility()
+
     val speciesId = SpeciesId(1)
     val sameOrgSpeciesId = SpeciesId(2)
     val inactiveAccessionSpeciesId = SpeciesId(3)
     val otherOrgSpeciesId = SpeciesId(4)
-
-    insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
     insertSpecies(speciesId)
     insertSpecies(sameOrgSpeciesId)
     insertSpecies(inactiveAccessionSpeciesId)
@@ -504,17 +495,16 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `getSummaryStatistics does not count deleted species`() {
-    val otherOrganizationId = OrganizationId(2)
-    val otherOrgFacilityId = FacilityId(4)
-    val sameOrgFacilityId = FacilityId(5)
+    val facilityId = inserted.facilityId
+    val sameOrgFacilityId = insertFacility()
+    val otherOrganizationId = insertOrganization(2)
+    val otherOrgFacilityId = insertFacility()
+
     val speciesId = SpeciesId(1)
     val sameOrgSpeciesId = SpeciesId(2)
     val inactiveAccessionSpeciesId = SpeciesId(3)
     val otherOrgSpeciesId = SpeciesId(4)
 
-    insertOrganization(otherOrganizationId)
-    insertFacility(otherOrgFacilityId, otherOrganizationId)
-    insertFacility(sameOrgFacilityId)
     insertSpecies(speciesId)
     insertSpecies(sameOrgSpeciesId)
     insertSpecies(inactiveAccessionSpeciesId)
@@ -605,17 +595,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `countActiveBySubLocation only counts active accessions in facility`() {
-    val otherFacilityId = FacilityId(20)
-    val subLocationId = SubLocationId(1)
-    val otherSubLocationId = SubLocationId(2)
-    val emptySubLocationId = SubLocationId(3)
-    val otherFacilitySubLocationId = SubLocationId(4)
-
-    insertFacility(otherFacilityId)
-    insertSubLocation(subLocationId)
-    insertSubLocation(otherSubLocationId)
-    insertSubLocation(emptySubLocationId)
-    insertSubLocation(otherFacilitySubLocationId, otherFacilityId)
+    val facilityId = inserted.facilityId
+    val subLocationId = insertSubLocation(facilityId = facilityId)
+    val otherSubLocationId = insertSubLocation(facilityId = facilityId)
+    insertSubLocation(facilityId = facilityId)
 
     insertAccession(
         AccessionsRow(stateId = AccessionState.InStorage, subLocationId = subLocationId))
@@ -624,6 +607,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
     insertAccession(AccessionsRow(stateId = AccessionState.UsedUp, subLocationId = subLocationId))
     insertAccession(
         AccessionsRow(stateId = AccessionState.InStorage, subLocationId = otherSubLocationId))
+
+    val otherFacilityId = insertFacility()
+    val otherFacilitySubLocationId = insertSubLocation(facilityId = otherFacilityId)
+
     insertAccession(
         AccessionsRow(
             facilityId = otherFacilityId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -63,6 +63,8 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   protected lateinit var parentStore: ParentStore
   protected lateinit var speciesStore: SpeciesStore
 
+  protected lateinit var facilityId: FacilityId
+
   @BeforeEach
   protected fun init() {
     parentStore = ParentStore(dslContext)
@@ -107,7 +109,8 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             speciesGrowthFormsDao,
             speciesProblemsDao)
 
-    insertSiteData()
+    insertOrganization()
+    facilityId = insertFacility()
   }
 
   protected fun createAccessionWithViabilityTest(): AccessionModel {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -64,7 +64,7 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
     insertSiteData()
     insertOrganizationUser()
 
-    every { user.facilityRoles } returns mapOf(facilityId to Role.Contributor)
+    every { user.facilityRoles } returns mapOf(inserted.facilityId to Role.Contributor)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
@@ -275,11 +274,13 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
   @Test
   fun `search only includes results from requested facility`() {
-    every { user.facilityRoles } returns
-        mapOf(facilityId to Role.Manager, FacilityId(1100) to Role.Contributor)
+    val facilityId = inserted.facilityId
 
-    insertFacility(1100)
-    insertAccession(facilityId = 1100)
+    val otherFacilityId = insertFacility()
+    insertAccession(facilityId = otherFacilityId)
+
+    every { user.facilityRoles } returns
+        mapOf(facilityId to Role.Manager, otherFacilityId to Role.Contributor)
 
     val fields = listOf(accessionNumberField)
     val sortOrder = fields.map { SearchSortField(it) }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -145,9 +144,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
   @Test
   fun `only includes values from accessions the user has permission to view`() {
-    insertFacility(1100)
+    val otherFacilityId = insertFacility()
 
-    insertAccession(facilityId = 1100, treesCollectedFrom = 3)
+    insertAccession(facilityId = otherFacilityId, treesCollectedFrom = 3)
 
     val expected = listOf("1", "2")
 
@@ -158,12 +157,12 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
   @Test
   fun `includes values from accessions at multiple facilities`() {
+    val otherFacilityId = insertFacility()
+
     every { user.facilityRoles } returns
-        mapOf(facilityId to Role.Manager, FacilityId(1100) to Role.Contributor)
+        mapOf(facilityId to Role.Manager, otherFacilityId to Role.Contributor)
 
-    insertFacility(1100)
-
-    insertAccession(facilityId = 1100, treesCollectedFrom = 3)
+    insertAccession(facilityId = otherFacilityId, treesCollectedFrom = 3)
 
     val expected = listOf("1", "2", "3")
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.seedbank.search
 
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestType
@@ -675,7 +674,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 mapOf(
                     "id" to "1000",
                     "accessionNumber" to "XYZ",
-                    "facility" to mapOf("name" to "Facility $facilityId"))))
+                    "facility" to mapOf("name" to "Facility 1"))))
 
     assertEquals(expected, result)
   }
@@ -933,10 +932,10 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 "accessions" to expectedAccessions,
                 "connectionState" to "Not Connected",
                 "createdTime" to "1970-01-01T00:00:00Z",
-                "description" to "Description 100",
+                "description" to "Description 1",
                 "facilityNumber" to "1",
-                "id" to "100",
-                "name" to "Facility 100",
+                "id" to "$facilityId",
+                "name" to "Facility 1",
                 "timeZone" to facilityTimeZone,
                 "type" to "Seed Bank",
             ))
@@ -1075,9 +1074,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val order = listOf(SearchSortField(bagNumberField))
 
     // A facility in an org the user isn't in
-    val otherFacilityId = FacilityId(2000)
     insertOrganization(2)
-    insertFacility(otherFacilityId)
+    val otherFacilityId = insertFacility()
 
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1000))!!.copy(facilityId = otherFacilityId))
@@ -1098,9 +1096,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val order = listOf(SearchSortField(seedsGerminatedField))
 
     // A facility in an org the user isn't in
-    val otherFacilityId = FacilityId(2000)
     insertOrganization(2)
-    insertFacility(otherFacilityId)
+    val otherFacilityId = insertFacility()
 
     accessionsDao.update(
         accessionsDao.fetchOneById(AccessionId(1000))!!.copy(facilityId = otherFacilityId))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
@@ -10,10 +10,12 @@ import org.junit.jupiter.api.Test
 internal class SearchServicePermissionTest : SearchServiceTest() {
   @Test
   fun `search only includes accessions at facilities the user has permission to view`() {
+    val memberFacilityId = inserted.facilityId
+
     // A facility in an org the user isn't in
     insertOrganization(2)
-    insertFacility(2000)
-    insertAccession(facilityId = 2000)
+    val otherFacilityId = insertFacility()
+    insertAccession(facilityId = otherFacilityId)
 
     val fields = listOf(accessionNumberField)
     val sortOrder = fields.map { SearchSortField(it) }
@@ -26,7 +28,8 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
             ))
 
     val actual =
-        searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
+        searchAccessions(
+            memberFacilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -73,15 +73,18 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected val viabilityTestSeedsTestedField = rootPrefix.resolve("viabilityTests_seedsTested")
   protected val viabilityTestsTypeField = rootPrefix.resolve("viabilityTests_type")
 
+  protected lateinit var facilityId: FacilityId
+
   @BeforeEach
   protected fun init() {
     searchService = SearchService(dslContext)
 
+    insertOrganization()
+    facilityId = insertFacility()
+
     clock.instant = Instant.parse("2020-06-15T00:00:00.00Z")
     every { user.organizationRoles } returns mapOf(organizationId to Role.Manager)
     every { user.facilityRoles } returns mapOf(facilityId to Role.Manager)
-
-    insertSiteData()
 
     insertOrganizationUser(role = Role.Manager)
 

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -7,7 +7,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.SpeciesInUseException
 import com.terraformation.backend.db.SpeciesNotFoundException
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
@@ -109,7 +108,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     val speciesId = SpeciesId(1)
 
     insertSpecies(speciesId, "species name")
-    insertFacility(id = FacilityId(200))
+    insertFacility()
     insertBatch(speciesId = speciesId)
 
     assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.ScientificNameExistsException
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.EcosystemType
-import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.PlantMaterialSourcingMethod
@@ -645,7 +644,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
 
     // create a batch with 'other' species
-    insertFacility(id = FacilityId(200))
+    insertFacility()
     insertBatch(speciesId = created)
 
     // create another org batch
@@ -653,7 +652,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val other =
         store.createSpecies(
             NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
-    insertFacility(id = FacilityId(300))
+    insertFacility()
     insertBatch(speciesId = other)
 
     val expected = listOf(store.fetchSpeciesById(created))
@@ -671,7 +670,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
 
     // create an accession with 'other' species
-    insertFacility(id = FacilityId(200))
+    insertFacility()
     insertAccession(row = AccessionsRow(speciesId = created))
 
     // create another org accession
@@ -679,7 +678,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val other =
         store.createSpecies(
             NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
-    insertFacility(id = FacilityId(300))
+    insertFacility()
     insertAccession(row = AccessionsRow(speciesId = other))
 
     val expected = listOf(store.fetchSpeciesById(created))
@@ -697,7 +696,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
 
     // create plantings with 'other' species
-    insertFacility(id = FacilityId(200))
+    insertFacility()
     insertPlantingSite()
     insertPlantingZone()
     insertPlantingSubzone()
@@ -710,7 +709,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val other =
         store.createSpecies(
             NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
-    insertFacility(id = FacilityId(300))
+    insertFacility()
     insertPlantingSite()
     insertPlantingZone()
     insertPlantingSubzone()


### PR DESCRIPTION
As a step toward being able to run tests in parallel, eliminate nearly all uses of
hardwired facility IDs in tests, instead letting the database allocate IDs
dynamically.

The "insert" methods in `DatabaseBackedTest` whose facility ID arguments used to
default to the hardwired ID now use the last inserted ID instead; this eliminates
the need to pass in facility IDs explicitly in a number of tests.

The exception is `PermissionTest` where the numeric values of the IDs affect the
test logic; that one will require more extensive reworking.