### PR TITLE
SW-5763 Include project name with list document responses, delete unused function in DocumentStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -75,8 +75,7 @@ class DocumentsController(
   @Operation(summary = "Gets a document.")
   @GetMapping("/{id}")
   fun getDocument(@PathVariable("id") id: DocumentId): GetDocumentResponsePayload {
-    return GetDocumentResponsePayload(
-        DocumentPayload(ExistingDocumentModel(documentStore.fetchDocumentById(id))))
+    return GetDocumentResponsePayload(DocumentPayload(documentStore.fetchOneById(id)))
   }
 
   @Operation(summary = "Updates a document.")

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -172,7 +172,7 @@ data class DocumentPayload(
     val name: String,
     val ownedBy: UserId,
     val projectId: ProjectId,
-    val projectName: String?,
+    val projectName: String,
     val status: DocumentStatus,
     val variableManifestId: VariableManifestId,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -173,6 +173,7 @@ data class DocumentPayload(
     val name: String,
     val ownedBy: UserId,
     val projectId: ProjectId,
+    val projectName: String?,
     val status: DocumentStatus,
     val variableManifestId: VariableManifestId,
 ) {
@@ -188,6 +189,7 @@ data class DocumentPayload(
       name = model.name,
       ownedBy = model.ownedBy,
       projectId = model.projectId,
+      projectName = model.projectName,
       status = model.status,
       variableManifestId = model.variableManifestId,
   )

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/DocumentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/DocumentStore.kt
@@ -67,7 +67,7 @@ class DocumentStore(
 
     documentsDao.insert(row)
 
-    return ExistingDocumentModel(row)
+    return fetchOneById(row.id!!)
   }
 
   fun createSavedVersion(model: NewSavedVersionModel): ExistingSavedVersionModel {
@@ -105,6 +105,10 @@ class DocumentStore(
 
   fun fetchByProjectId(projectId: ProjectId): List<ExistingDocumentModel> =
       fetchByCondition(DOCUMENTS.PROJECT_ID.eq(projectId))
+
+  fun fetchOneById(documentId: DocumentId): ExistingDocumentModel =
+      fetchByCondition(DOCUMENTS.ID.eq(documentId)).firstOrNull()
+          ?: throw DocumentNotFoundException(documentId)
 
   fun fetchDocumentById(documentId: DocumentId): DocumentsRow {
     requirePermissions { readDocument(documentId) }
@@ -238,5 +242,5 @@ class DocumentStore(
           .where(condition)
           .fetch()
           .filter { currentUser().canReadDocument(it[DOCUMENTS.ID]!!) }
-          .map { ExistingDocumentModel.of(it) }
+          .map { ExistingDocumentModel.of(it, it[PROJECTS.NAME]!!) }
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
@@ -38,7 +38,6 @@ data class ExistingDocumentModel(
       name = row.name!!,
       ownedBy = row.ownedBy!!,
       projectId = row.projectId!!,
-      projectName = null,
       status = row.statusId!!,
       variableManifestId = row.variableManifestId!!,
   )

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
@@ -2,12 +2,15 @@ package com.terraformation.backend.documentproducer.model
 
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentStatus
 import com.terraformation.backend.db.docprod.DocumentTemplateId
 import com.terraformation.backend.db.docprod.VariableManifestId
 import com.terraformation.backend.db.docprod.tables.pojos.DocumentsRow
+import com.terraformation.backend.db.docprod.tables.references.DOCUMENTS
 import java.time.Instant
+import org.jooq.Record
 
 data class ExistingDocumentModel(
     val createdBy: UserId,
@@ -19,6 +22,7 @@ data class ExistingDocumentModel(
     val name: String,
     val ownedBy: UserId,
     val projectId: ProjectId,
+    val projectName: String? = null,
     val status: DocumentStatus,
     val variableManifestId: VariableManifestId,
 ) {
@@ -34,7 +38,27 @@ data class ExistingDocumentModel(
       name = row.name!!,
       ownedBy = row.ownedBy!!,
       projectId = row.projectId!!,
+      projectName = null,
       status = row.statusId!!,
       variableManifestId = row.variableManifestId!!,
   )
+
+  companion object {
+    fun of(record: Record): ExistingDocumentModel {
+      return ExistingDocumentModel(
+          createdBy = record[DOCUMENTS.CREATED_BY]!!,
+          createdTime = record[DOCUMENTS.CREATED_TIME]!!,
+          documentTemplateId = record[DOCUMENTS.DOCUMENT_TEMPLATE_ID]!!,
+          id = record[DOCUMENTS.ID]!!,
+          modifiedBy = record[DOCUMENTS.MODIFIED_BY]!!,
+          modifiedTime = record[DOCUMENTS.MODIFIED_TIME]!!,
+          name = record[DOCUMENTS.NAME]!!,
+          ownedBy = record[DOCUMENTS.OWNED_BY]!!,
+          projectId = record[DOCUMENTS.PROJECT_ID]!!,
+          projectName = record[PROJECTS.NAME]!!,
+          status = record[DOCUMENTS.STATUS_ID]!!,
+          variableManifestId = record[DOCUMENTS.VARIABLE_MANIFEST_ID]!!,
+      )
+    }
+  }
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingDocumentModel.kt
@@ -2,12 +2,10 @@ package com.terraformation.backend.documentproducer.model
 
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
-import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.DocumentStatus
 import com.terraformation.backend.db.docprod.DocumentTemplateId
 import com.terraformation.backend.db.docprod.VariableManifestId
-import com.terraformation.backend.db.docprod.tables.pojos.DocumentsRow
 import com.terraformation.backend.db.docprod.tables.references.DOCUMENTS
 import java.time.Instant
 import org.jooq.Record
@@ -22,28 +20,12 @@ data class ExistingDocumentModel(
     val name: String,
     val ownedBy: UserId,
     val projectId: ProjectId,
-    val projectName: String? = null,
+    val projectName: String,
     val status: DocumentStatus,
     val variableManifestId: VariableManifestId,
 ) {
-  constructor(
-      row: DocumentsRow,
-  ) : this(
-      createdBy = row.createdBy!!,
-      createdTime = row.createdTime!!,
-      documentTemplateId = row.documentTemplateId!!,
-      id = row.id!!,
-      modifiedBy = row.modifiedBy!!,
-      modifiedTime = row.modifiedTime!!,
-      name = row.name!!,
-      ownedBy = row.ownedBy!!,
-      projectId = row.projectId!!,
-      status = row.statusId!!,
-      variableManifestId = row.variableManifestId!!,
-  )
-
   companion object {
-    fun of(record: Record): ExistingDocumentModel {
+    fun of(record: Record, projectName: String): ExistingDocumentModel {
       return ExistingDocumentModel(
           createdBy = record[DOCUMENTS.CREATED_BY]!!,
           createdTime = record[DOCUMENTS.CREATED_TIME]!!,
@@ -54,7 +36,7 @@ data class ExistingDocumentModel(
           name = record[DOCUMENTS.NAME]!!,
           ownedBy = record[DOCUMENTS.OWNED_BY]!!,
           projectId = record[DOCUMENTS.PROJECT_ID]!!,
-          projectName = record[PROJECTS.NAME]!!,
+          projectName = projectName,
           status = record[DOCUMENTS.STATUS_ID]!!,
           variableManifestId = record[DOCUMENTS.VARIABLE_MANIFEST_ID]!!,
       )


### PR DESCRIPTION
- Add nullable `projectName` field to `ExistingDocumentModel` and change the two fetch methods in the `DocumentStore` that are used in the "list documents" API call to use the DSL Context instead of DAO, and plumb in the Project Name field
- Removes an unused function in the `DocumentStore` - `fetchProjectId` (only usage removed [here](https://github.com/terraware/terraware-server/commit/aed4f6dff473c5df8797456a5b0a48f990661f13#diff-4635e395b44f0b9a82689f3909db748d1e303e6af7388c5a870b3158e72c2597L114))