### PR TITLE
SW-5697 Add endpoint to complete a submission

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -166,6 +166,19 @@ class DeliverablesController(
 
     return SimpleSuccessResponsePayload()
   }
+
+  @ApiResponseSimpleSuccess
+  @Operation(summary = "Marks a submission from a project as completed.")
+  @PostMapping("/{deliverableId}/submissions/{projectId}/complete")
+  fun completeSubmission(
+      @PathVariable deliverableId: DeliverableId,
+      @PathVariable projectId: ProjectId
+  ): SimpleSuccessResponsePayload {
+    // "Create" operation updates status of existing submission if there is one.
+    submissionStore.createSubmission(deliverableId, projectId, SubmissionStatus.Completed)
+
+    return SimpleSuccessResponsePayload()
+  }
 }
 
 data class ListDeliverablesElement(


### PR DESCRIPTION
To support the web app automatically marking an application questionnaire
deliverable as completed when all the required questions have been answered,
add an endpoint to mark a deliverable as completed for a project.