### PR TITLE
SW-5761 Store requested subzone IDs for observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
@@ -3,9 +3,11 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import java.time.Instant
 import java.time.LocalDate
+import org.jooq.Field
 import org.jooq.Record
 
 data class ObservationModel<ID : ObservationId?>(
@@ -13,6 +15,7 @@ data class ObservationModel<ID : ObservationId?>(
     val endDate: LocalDate,
     val id: ID,
     val plantingSiteId: PlantingSiteId,
+    val requestedSubzoneIds: Set<PlantingSubzoneId> = emptySet(),
     val startDate: LocalDate,
     val state: ObservationState,
     val upcomingNotificationSentTime: Instant? = null,
@@ -32,12 +35,16 @@ data class ObservationModel<ID : ObservationId?>(
             ObservationState.Overdue to ObservationState.Completed,
         )
 
-    fun of(record: Record): ExistingObservationModel {
+    fun of(
+        record: Record,
+        requestedSubzoneIdsField: Field<Set<PlantingSubzoneId>>
+    ): ExistingObservationModel {
       return ObservationModel(
           completedTime = record[OBSERVATIONS.COMPLETED_TIME],
           endDate = record[OBSERVATIONS.END_DATE]!!,
           id = record[OBSERVATIONS.ID]!!,
           plantingSiteId = record[OBSERVATIONS.PLANTING_SITE_ID]!!,
+          requestedSubzoneIds = record[requestedSubzoneIdsField],
           startDate = record[OBSERVATIONS.START_DATE]!!,
           state = record[OBSERVATIONS.STATE_ID]!!,
           upcomingNotificationSentTime = record[OBSERVATIONS.UPCOMING_NOTIFICATION_SENT_TIME],

--- a/src/main/resources/db/migration/0250/V296__ObservationRequestedSubzones.sql
+++ b/src/main/resources/db/migration/0250/V296__ObservationRequestedSubzones.sql
@@ -1,0 +1,8 @@
+CREATE TABLE tracking.observation_requested_subzones (
+    observation_id BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
+    planting_subzone_id BIGINT NOT NULL REFERENCES tracking.planting_subzones ON DELETE CASCADE,
+
+    PRIMARY KEY (observation_id, planting_subzone_id)
+);
+
+CREATE INDEX ON tracking.observation_requested_subzones (planting_subzone_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -365,6 +365,8 @@ COMMENT ON COLUMN tracking.observation_plots.completed_time IS 'Server-generated
 COMMENT ON COLUMN tracking.observation_plots.is_permanent IS 'If true, this plot was selected for observation as part of a permanent monitoring plot cluster. If false, this plot was selected as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.observation_plots.observed_time IS 'Client-supplied observation date and time. This is the time the observation was performed in the field, not the time it was submitted to the server.';
 
+COMMENT ON TABLE tracking.observation_requested_subzones IS 'If an observation should only cover a specific set of subzones, the subzone IDs are stored here. If an observation is of the entire site (the default), there will be no rows for that observation in this table.';
+
 COMMENT ON TABLE tracking.observation_states IS '(Enum) Where in the observation lifecycle a particular observation is.';
 
 COMMENT ON TABLE tracking.observations IS 'Scheduled observations of planting sites. This table may contain rows describing future observations as well as current and past ones.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -281,6 +281,7 @@ import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPhotosDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotConditionsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
+import com.terraformation.backend.db.tracking.tables.daos.ObservationRequestedSubzonesDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservedPlotCoordinatesDao
 import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
@@ -301,6 +302,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.DraftPlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationPhotosRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationPlotsRow
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationRequestedSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedPlotCoordinatesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
@@ -528,6 +530,7 @@ abstract class DatabaseBackedTest {
   protected val observationPhotosDao: ObservationPhotosDao by lazyDao()
   protected val observationPlotConditionsDao: ObservationPlotConditionsDao by lazyDao()
   protected val observationPlotsDao: ObservationPlotsDao by lazyDao()
+  protected val observationRequestedSubzonesDao: ObservationRequestedSubzonesDao by lazyDao()
   protected val observationsDao: ObservationsDao by lazyDao()
   protected val observedPlotCoordinatesDao: ObservedPlotCoordinatesDao by lazyDao()
   protected val organizationInternalTagsDao: OrganizationInternalTagsDao by lazyDao()
@@ -2189,6 +2192,14 @@ abstract class DatabaseBackedTest {
         )
 
     observationPlotsDao.insert(rowWithDefaults)
+  }
+
+  fun insertObservationRequestedSubzone(
+      observationId: ObservationId = inserted.observationId,
+      plantingSubzoneId: PlantingSubzoneId = inserted.plantingSubzoneId
+  ) {
+    observationRequestedSubzonesDao.insert(
+        ObservationRequestedSubzonesRow(observationId, plantingSubzoneId))
   }
 
   fun insertObservedCoordinates(

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -292,6 +292,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "observation_plot_conditions" to setOf(ALL, TRACKING),
                   "observation_plot_positions" to setOf(ALL, TRACKING),
                   "observation_plots" to setOf(ALL, TRACKING),
+                  "observation_requested_subzones" to setOf(ALL, TRACKING),
                   "observation_states" to setOf(ALL, TRACKING),
                   "observations" to setOf(ALL, TRACKING),
                   "observed_plot_coordinates" to setOf(ALL, TRACKING),

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -113,6 +113,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
+        observationRequestedSubzonesDao,
         recordedPlantsDao)
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -35,6 +35,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
+        observationRequestedSubzonesDao,
         recordedPlantsDao)
   }
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -61,6 +61,7 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
+        observationRequestedSubzonesDao,
         recordedPlantsDao)
   }
   private val resultsStore by lazy { ObservationResultsStore(dslContext) }


### PR DESCRIPTION
Add a concept of "requested subzones" that can be specified when an observation is
initially created.

This just updates the data model and changes the store class to read and write
the list of requested subzone IDs; subsequent changes will make use of the
information and expose it in the API.