### PR TITLE
SW-5761 Add requested subzones to admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -80,6 +80,11 @@ class AdminPlantingSitesController(
     val plantCounts = plantingSiteStore.countReportedPlantsInSubzones(plantingSiteId)
     val organization = organizationStore.fetchOneById(plantingSite.organizationId)
     val reportedPlants = plantingSiteStore.countReportedPlants(plantingSiteId)
+    val subzonesById =
+        plantingSite.plantingZones
+            .flatMap { it.plantingSubzones }
+            .sortedBy { it.fullName }
+            .associateBy { it.id }
 
     val allOrganizations =
         if (currentUser().canMovePlantingSiteToAnyOrg(plantingSiteId)) {
@@ -148,6 +153,7 @@ class AdminPlantingSitesController(
     model.addAttribute("plotCounts", plotCounts)
     model.addAttribute("reportedPlants", reportedPlants)
     model.addAttribute("site", plantingSite)
+    model.addAttribute("subzonesById", subzonesById)
 
     return "/admin/plantingSite"
   }
@@ -634,6 +640,7 @@ class AdminPlantingSitesController(
       @RequestParam plantingSiteId: PlantingSiteId,
       @RequestParam startDate: String,
       @RequestParam endDate: String,
+      @RequestParam requestedSubzoneIds: Set<PlantingSubzoneId>? = null,
       redirectAttributes: RedirectAttributes,
   ): String {
     try {
@@ -643,6 +650,7 @@ class AdminPlantingSitesController(
                   endDate = LocalDate.parse(endDate),
                   id = null,
                   plantingSiteId = plantingSiteId,
+                  requestedSubzoneIds = requestedSubzoneIds ?: emptySet(),
                   startDate = LocalDate.parse(startDate),
                   state = ObservationState.Upcoming))
 

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -367,11 +367,18 @@
 
     <h3>Observations</h3>
 
-    <table>
+    <table border="1">
         <tr>
             <th>ID</th>
             <th>Start</th>
             <th>End</th>
+            <th>
+                Requested Subzones
+                <br/>
+                <small>
+                    If none, use whole site
+                </small>
+            </th>
             <th>State</th>
             <th></th>
         </tr>
@@ -380,6 +387,12 @@
             <td th:text="${observation.id}">1</td>
             <td th:text="${observation.startDate}">2023-01-01</td>
             <td th:text="${observation.endDate}">2023-01-31</td>
+            <td>
+                    <div th:each="subzoneId : ${observation.requestedSubzoneIds}"
+                        th:text="|${subzonesById.get(subzoneId).fullName} (${subzoneId})|">
+                        abc-123 (456)
+                    </div>
+            </td>
             <td th:text="${observation.state}">Upcoming</td>
             <td>
                 <th:block th:text="${observationMessages[observation.id]}"></th:block>
@@ -400,6 +413,15 @@
             </td>
             <td>
                 <input type="date" form="createObservation" name="endDate" th:value="${nextObservationEnd}"/>
+            </td>
+            <td>
+                <select multiple form="createObservation" name="requestedSubzoneIds">
+                    <option th:each="subzone : ${subzonesById.values()}"
+                            th:text="|${subzone.fullName} (${subzone.id})|"
+                            th:value="${subzone.id}">
+                        abc-123 (456)
+                    </option>
+                </select>
             </td>
             <td></td>
             <td>


### PR DESCRIPTION
Show the list of requested subzones for each observation on the planting site
page in the admin UI, and allow subzones to be selected when creating
observations.