### PR TITLE
SW-5761 Restrict plot selection to requested subzones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -101,7 +101,11 @@ class ObservationService(
               val permanentPlotIds = plantingZone.choosePermanentPlots(plantedSubzoneIds)
               val temporaryPlotIds =
                   plantingZone
-                      .chooseTemporaryPlots(plantedSubzoneIds, gridOrigin, plantingSite.exclusion)
+                      .chooseTemporaryPlots(
+                          plantedSubzoneIds,
+                          gridOrigin,
+                          plantingSite.exclusion,
+                          observation.requestedSubzoneIds)
                       .map { plotBoundary ->
                         plantingSiteStore.createTemporaryPlot(
                             plantingSite.id, plantingZone.id, plotBoundary)


### PR DESCRIPTION
If an observation has a list of requested subzones, only pick monitoring plots in
those subzones when starting the observation.

This also updates how temporary plots are allocated to different subzones.
Previously, priority was given to planted subzones, but now it's given to subzones
that are both planted and requested (if the observation has requested subzones at
all).