### PR TITLE
SW-5780 Use dynamic IDs in seedbank search tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -79,6 +79,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionSnapshot
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.UserDeliverableCategoriesRow
 import com.terraformation.backend.db.default_schema.AutomationId
+import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.EcosystemType
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
@@ -98,6 +99,7 @@ import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.db.default_schema.SubLocationId
@@ -984,7 +986,7 @@ abstract class DatabaseBackedTest {
           if (speciesId != null) "Species $speciesId" else "Species ${nextSpeciesNumber++}",
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      modifiedTime: Instant = Instant.EPOCH,
+      modifiedTime: Instant = createdTime,
       organizationId: Any = this.organizationId,
       deletedTime: Instant? = null,
       checkedTime: Instant? = null,
@@ -994,6 +996,9 @@ abstract class DatabaseBackedTest {
       growthForms: Set<GrowthForm> = emptySet(),
       plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod> = emptySet(),
       successionalGroups: Set<SuccessionalGroup> = emptySet(),
+      rare: Boolean? = null,
+      conservationCategory: ConservationCategory? = null,
+      seedStorageBehavior: SeedStorageBehavior? = null,
   ): SpeciesId {
     val speciesIdWrapper = speciesId?.toIdWrapper { SpeciesId(it) }
     val organizationIdWrapper = organizationId.toIdWrapper { OrganizationId(it) }
@@ -1004,6 +1009,7 @@ abstract class DatabaseBackedTest {
               .insertInto(SPECIES)
               .set(CHECKED_TIME, checkedTime)
               .set(COMMON_NAME, commonName)
+              .set(CONSERVATION_CATEGORY_ID, conservationCategory)
               .set(CREATED_BY, createdBy)
               .set(CREATED_TIME, createdTime)
               .set(DELETED_BY, if (deletedTime != null) createdBy else null)
@@ -1013,7 +1019,9 @@ abstract class DatabaseBackedTest {
               .set(MODIFIED_BY, createdBy)
               .set(MODIFIED_TIME, modifiedTime)
               .set(ORGANIZATION_ID, organizationIdWrapper)
+              .set(RARE, rare)
               .set(SCIENTIFIC_NAME, scientificName)
+              .set(SEED_STORAGE_BEHAVIOR_ID, seedStorageBehavior)
               .returning(ID)
               .fetchOne(ID)!!
         }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.mockUser
@@ -69,18 +68,16 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `returns exact-match statistics for exact-or-fuzzy searches if there are exact matches`() {
-    val speciesId1 = insertSpecies(1)
-    val speciesId2 = insertSpecies(2)
+    val speciesId1 = insertSpecies()
+    val speciesId2 = insertSpecies()
     insertAccession(
         AccessionsRow(
-            id = AccessionId(1),
             number = "22-1-001",
             remainingQuantity = BigDecimal.TEN,
             remainingUnitsId = SeedQuantityUnits.Seeds,
             speciesId = speciesId1))
     insertAccession(
         AccessionsRow(
-            id = AccessionId(2),
             number = "22-1-002",
             remainingQuantity = BigDecimal.ONE,
             remainingUnitsId = SeedQuantityUnits.Kilograms,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
@@ -20,16 +20,21 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `can search for exact ages`() {
-    listOf(1100L, 1101L, 1102L).forEach { id ->
-      insertAccession(id = id, stateId = AccessionState.Drying)
-    }
+    val accessionIds =
+        listOf(
+            accessionId1,
+            accessionId2,
+            insertAccession(stateId = AccessionState.Drying),
+            insertAccession(stateId = AccessionState.Drying),
+            insertAccession(stateId = AccessionState.Drying),
+        )
 
     setCollectedDates(
-        1000 to "2018-01-01", // 29 months old
-        1001 to "2019-01-01", // 17 months old
-        1100 to "2020-01-01", // 5 months old
-        1101 to "2020-06-01", // 0 months old
-        1102 to null,
+        accessionIds[0] to "2018-01-01", // 29 months old
+        accessionIds[1] to "2019-01-01", // 17 months old
+        accessionIds[2] to "2020-01-01", // 5 months old
+        accessionIds[3] to "2020-06-01", // 0 months old
+        accessionIds[4] to null,
     )
 
     val searchNode = FieldNode(ageMonthsField, listOf("0", "17", null))
@@ -39,18 +44,18 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1101",
+                    "id" to "${accessionIds[3]}",
                     "ageMonths" to "0",
                     "ageYears" to "0",
                     "collectedDate" to "2020-06-01",
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "${accessionIds[1]}",
                     "ageMonths" to "17",
                     "ageYears" to "1",
                     "collectedDate" to "2019-01-01",
                 ),
-                mapOf("id" to "1102"),
+                mapOf("id" to "${accessionIds[4]}"),
             ))
     val actual =
         searchService.search(
@@ -64,7 +69,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `sorting by age in months uses underlying date values`() {
-    setCollectedDates(1000 to "2020-06-01", 1001 to "2020-06-02")
+    setCollectedDates(accessionId2 to "2020-06-01", accessionId1 to "2020-06-02")
 
     val searchNode = FieldNode(ageMonthsField, listOf("0"))
     val sortField = SearchSortField(ageMonthsField, SearchDirection.Descending)
@@ -73,8 +78,8 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 // Oldest first, meaning ascending date order
-                mapOf("id" to "1000", "ageMonths" to "0", "collectedDate" to "2020-06-01"),
-                mapOf("id" to "1001", "ageMonths" to "0", "collectedDate" to "2020-06-02"),
+                mapOf("id" to "$accessionId2", "ageMonths" to "0", "collectedDate" to "2020-06-01"),
+                mapOf("id" to "$accessionId1", "ageMonths" to "0", "collectedDate" to "2020-06-02"),
             ))
 
     val actual =
@@ -89,7 +94,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `sorting by age in years uses underlying date values`() {
-    setCollectedDates(1000 to "2020-06-01", 1001 to "2020-06-02")
+    setCollectedDates(accessionId2 to "2020-06-01", accessionId1 to "2020-06-02")
 
     val searchNode = FieldNode(ageYearsField, listOf("0"))
     val sortField = SearchSortField(ageYearsField)
@@ -98,8 +103,8 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 // Youngest first, meaning reverse date order
-                mapOf("id" to "1001", "ageYears" to "0", "collectedDate" to "2020-06-02"),
-                mapOf("id" to "1000", "ageYears" to "0", "collectedDate" to "2020-06-01"),
+                mapOf("id" to "$accessionId1", "ageYears" to "0", "collectedDate" to "2020-06-02"),
+                mapOf("id" to "$accessionId2", "ageYears" to "0", "collectedDate" to "2020-06-01"),
             ))
 
     val actual =
@@ -114,11 +119,11 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `searching for null age returns accessions without collected dates`() {
-    setCollectedDates(1000 to null, 1001 to "2020-05-31")
+    setCollectedDates(accessionId1 to null, accessionId2 to "2020-05-31")
 
     val searchNode = FieldNode(ageMonthsField, listOf(null))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")))
+    val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -126,11 +131,11 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `searching for 0 months returns accessions from current month`() {
-    setCollectedDates(1000 to "2020-06-01", 1001 to "2020-05-31")
+    setCollectedDates(accessionId1 to "2020-06-01", accessionId2 to "2020-05-31")
 
     val searchNode = FieldNode(ageMonthsField, listOf("0"))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")))
+    val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -138,14 +143,18 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `range search by age in years returns results from entire year`() {
-    insertAccession(id = 1100)
+    val otherAccessionId = insertAccession()
 
-    setCollectedDates(1000 to "2018-01-01", 1001 to "2019-12-31", 1100 to "2020-01-01")
+    setCollectedDates(
+        accessionId1 to "2018-01-01",
+        accessionId2 to "2019-12-31",
+        otherAccessionId to "2020-01-01")
 
     val searchNode = FieldNode(ageYearsField, listOf("1", "2"), SearchFilterType.Range)
     val sortField = SearchSortField(ageYearsField)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001"), mapOf("id" to "1000")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionId2"), mapOf("id" to "$accessionId1")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode, listOf(sortField))
 
     assertEquals(expected, actual)
@@ -153,12 +162,12 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `range search with unbounded minimum age returns new matches`() {
-    setCollectedDates(1000 to "2020-01-01", 1001 to "2020-05-01")
+    setCollectedDates(accessionId1 to "2020-01-01", accessionId2 to "2020-05-01")
 
     // "Up to 2 months old"
     val searchNode = FieldNode(ageMonthsField, listOf(null, "2"), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001")))
+    val expected = SearchResults(listOf(mapOf("id" to "$accessionId2")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -166,12 +175,12 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
   @Test
   fun `range search with unbounded maximum age returns old matches`() {
-    setCollectedDates(1000 to "2020-01-01", 1001 to "2020-05-01")
+    setCollectedDates(accessionId1 to "2020-01-01", accessionId2 to "2020-05-01")
 
     // "At least 3 months old"
     val searchNode = FieldNode(ageMonthsField, listOf("3", null), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1000")))
+    val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
     val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
 
     assertEquals(expected, actual)
@@ -186,9 +195,9 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     }
   }
 
-  private fun setCollectedDates(vararg dates: Pair<Int, String?>) {
+  private fun setCollectedDates(vararg dates: Pair<AccessionId, String?>) {
     dates.forEach { (id, dateStr) ->
-      val accession = accessionsDao.fetchOneById(AccessionId(id.toLong()))!!
+      val accession = accessionsDao.fetchOneById(id)!!
       val collectedDate = dateStr?.let { LocalDate.parse(it) }
       accessionsDao.update(accession.copy(collectedDate = collectedDate))
     }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAliasedFieldTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
@@ -17,8 +16,8 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
     val fields = listOf(bagNumberField, bagNumberFlattenedField)
     val sortOrder = fields.map { SearchSortField(it) }
 
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "A"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "B"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "A"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "B"))
 
     val result =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
@@ -27,19 +26,19 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bagNumber" to "A",
                     "bags_number" to "A",
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bagNumber" to "B",
                     "bags_number" to "B",
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                 ),
             ))
@@ -53,12 +52,12 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFromAlias" to "2",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "plantsCollectedFromAlias" to "1",
                 ),
@@ -78,12 +77,12 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "alias(raw)" to "2",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "alias(raw)" to "1",
                 ),
@@ -97,7 +96,8 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
   fun `can use aliased field in search criteria`() {
     val criteria = FieldNode(plantsCollectedFromAlias, listOf("2"))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG")))
 
     val actual = searchAccessions(facilityId, emptyList(), criteria = criteria)
     assertEquals(expected, actual)
@@ -110,8 +110,8 @@ internal class SearchServiceAliasedFieldTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
             ))
 
     val actual =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
 import com.terraformation.backend.i18n.Locales
@@ -29,8 +28,8 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
     val fields = listOf(bagNumberField)
     val sortOrder = fields.map { SearchSortField(it) }
 
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "A"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "B"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "A"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "B"))
 
     val result =
         searchAccessions(
@@ -43,12 +42,12 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bagNumber" to "A",
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bagNumber" to "B",
                     "accessionNumber" to "XYZ",
                 ),
@@ -62,8 +61,8 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
     val fields = listOf(bagNumberFlattenedField)
     val sortOrder = fields.map { SearchSortField(it) }
 
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "A"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "B"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "A"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "B"))
 
     val result =
         searchAccessions(facilityId, fields, criteria = NoConditionNode(), sortOrder = sortOrder)
@@ -72,17 +71,17 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bags_number" to "A",
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bags_number" to "B",
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                 ),
             ))
@@ -104,14 +103,14 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "speciesName" to "Other Dogwood",
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "2",
                     "active" to "Active",
                 ),
                 mapOf(
                     "speciesName" to "Kousa Dogwood",
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "plantsCollectedFrom" to "1",
                     "active" to "Active",
@@ -163,7 +162,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `can filter on computed fields whose raw values are being queried`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.UsedUp))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(stateId = AccessionState.UsedUp))
 
     val fields = listOf(accessionNumberField, stateField)
     val searchNode = FieldNode(activeField, listOf("Inactive"))
@@ -172,7 +171,8 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Used Up")))
+            listOf(
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ", "state" to "Used Up")))
 
     assertEquals(expected, result)
   }
@@ -180,9 +180,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   @Test
   fun `exact search on text fields is case- and accent-insensitive`() {
     accessionsDao.update(
-        accessionsDao
-            .fetchOneById(AccessionId(1001))!!
-            .copy(processingNotes = "Sómé Mätching Nótes"))
+        accessionsDao.fetchOneById(accessionId2)!!.copy(processingNotes = "Sómé Mätching Nótes"))
 
     val fields = listOf(accessionNumberField)
     val searchNode =
@@ -190,7 +188,8 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -265,7 +264,7 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "species_checkedTime" to checkedTimeString)))
 
@@ -288,8 +287,8 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
 
     val actual =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
@@ -24,8 +24,8 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "10000", "rare" to "false".toGibberish()),
-                mapOf("id" to "10001", "rare" to "true".toGibberish())))
+                mapOf("id" to "$speciesId1", "rare" to "false".toGibberish()),
+                mapOf("id" to "$speciesId2", "rare" to "true".toGibberish())))
 
     assertEquals(expected, result)
   }
@@ -38,7 +38,7 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
 
     val result = Locales.GIBBERISH.use { searchService.search(prefix, fields, criteria) }
 
-    val expected = SearchResults(listOf(mapOf("id" to "10001")))
+    val expected = SearchResults(listOf(mapOf("id" to "$speciesId2")))
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCompoundSearchTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.AndNode
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NotNode
@@ -12,9 +13,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class SearchServiceCompoundSearchTest : SearchServiceTest() {
+  private lateinit var accessionIds: List<AccessionId>
+
   @BeforeEach
   fun insertTreesCollectedFromExamples() {
-    (10..20).forEach { value -> insertAccession(number = "$value", treesCollectedFrom = value) }
+    accessionIds =
+        (10..20).map { value -> insertAccession(number = "$value", treesCollectedFrom = value) }
   }
 
   @Test
@@ -84,9 +88,7 @@ internal class SearchServiceCompoundSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(
             expectedValues.map { value ->
-              // We create accession numbers 10 through 20 and the ID sequence starts at 1
-              val id = value - 9
-              mapOf("id" to "$id", "accessionNumber" to "$value")
+              mapOf("id" to "${accessionIds[value - 10]}", "accessionNumber" to "$value")
             })
     val actual = searchAccessions(facilityId, listOf(accessionNumberField), searchNode)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCursorTest.kt
@@ -18,7 +18,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
         listOf(
             mapOf(
                 "speciesName" to "Kousa Dogwood",
-                "id" to "1000",
+                "id" to "$accessionId1",
                 "accessionNumber" to "XYZ",
                 "plantsCollectedFrom" to "1",
                 "active" to "Active",
@@ -37,7 +37,7 @@ internal class SearchServiceCursorTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "speciesName" to "Other Dogwood",
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "2",
                     "active" to "Active",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceDateFieldSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceDateFieldSearchTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
+import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
@@ -11,11 +12,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
+  private lateinit var accessionIdJan1: AccessionId
+  private lateinit var accessionIdJan2: AccessionId
+  private lateinit var accessionIdJan8: AccessionId
+
   @BeforeEach
   fun insertReceivedDateExamples() {
-    listOf(1, 2, 8).forEach { day ->
-      insertAccession(number = "JAN$day", receivedDate = LocalDate.of(2021, 1, day))
-    }
+    accessionIdJan1 = insertAccession(number = "JAN1", receivedDate = LocalDate.of(2021, 1, 1))
+    accessionIdJan2 = insertAccession(number = "JAN2", receivedDate = LocalDate.of(2021, 1, 2))
+    accessionIdJan8 = insertAccession(number = "JAN8", receivedDate = LocalDate.of(2021, 1, 8))
   }
 
   @Test
@@ -23,7 +28,8 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(receivedDateField, listOf("2021-01-02"), SearchFilterType.Exact)
 
-    val expected = SearchResults(listOf(mapOf("id" to "2", "accessionNumber" to "JAN2")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionIdJan2", "accessionNumber" to "JAN2")))
     val actual = searchAccessions(facilityId, fields, searchNode)
 
     assertEquals(expected, actual)
@@ -38,9 +44,9 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-                mapOf("id" to "2", "accessionNumber" to "JAN2"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionIdJan2", "accessionNumber" to "JAN2"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
     val actual = searchAccessions(facilityId, fields, searchNode)
 
@@ -57,8 +63,8 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "2", "accessionNumber" to "JAN2"),
-                mapOf("id" to "3", "accessionNumber" to "JAN8")))
+                mapOf("id" to "$accessionIdJan2", "accessionNumber" to "JAN2"),
+                mapOf("id" to "$accessionIdJan8", "accessionNumber" to "JAN8")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)
@@ -71,7 +77,8 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val searchNode =
         FieldNode(receivedDateField, listOf("2021-01-07", null), SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "3", "accessionNumber" to "JAN8")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionIdJan8", "accessionNumber" to "JAN8")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)
@@ -87,8 +94,8 @@ internal class SearchServiceDateFieldSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1", "accessionNumber" to "JAN1"),
-                mapOf("id" to "2", "accessionNumber" to "JAN2")))
+                mapOf("id" to "$accessionIdJan1", "accessionNumber" to "JAN1"),
+                mapOf("id" to "$accessionIdJan2", "accessionNumber" to "JAN2")))
     val actual = searchAccessions(facilityId, fields, searchNode, sortOrder)
 
     assertEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceEnumTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
@@ -22,9 +21,9 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   @Test
   fun `sorts enum fields by display name rather than ID`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(stateId = AccessionState.Drying))
+        accessionsDao.fetchOneById(accessionId2)!!.copy(stateId = AccessionState.Drying))
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.Processing))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(stateId = AccessionState.Processing))
 
     val fields = listOf(stateField)
     val sortOrder = listOf(SearchSortField(stateField, SearchDirection.Descending))
@@ -35,8 +34,8 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "Processing"),
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "state" to "Drying"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ", "state" to "Processing"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG", "state" to "Drying"),
             ))
 
     assertEquals(expected, result)
@@ -51,7 +50,9 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "state" to "In Storage")))
+            listOf(
+                mapOf(
+                    "id" to "$accessionId1", "accessionNumber" to "XYZ", "state" to "In Storage")))
 
     assertEquals(expected, result)
   }
@@ -59,9 +60,9 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
   @Test
   fun `can search on enum in child table`() {
     viabilityTestsDao.insert(
-        ViabilityTestsRow(accessionId = AccessionId(1000), testType = ViabilityTestType.Lab),
-        ViabilityTestsRow(accessionId = AccessionId(1000), testType = ViabilityTestType.Nursery),
-        ViabilityTestsRow(accessionId = AccessionId(1001), testType = ViabilityTestType.Lab),
+        ViabilityTestsRow(accessionId = accessionId1, testType = ViabilityTestType.Lab),
+        ViabilityTestsRow(accessionId = accessionId1, testType = ViabilityTestType.Nursery),
+        ViabilityTestsRow(accessionId = accessionId2, testType = ViabilityTestType.Lab),
     )
 
     val fields = listOf(viabilityTestsTypeField)
@@ -72,10 +73,17 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001", "accessionNumber" to "ABCDEFG", "viabilityTests_type" to "Lab"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ", "viabilityTests_type" to "Lab"),
+                    "id" to "$accessionId2",
+                    "accessionNumber" to "ABCDEFG",
+                    "viabilityTests_type" to "Lab"),
                 mapOf(
-                    "id" to "1000", "accessionNumber" to "XYZ", "viabilityTests_type" to "Nursery"),
+                    "id" to "$accessionId1",
+                    "accessionNumber" to "XYZ",
+                    "viabilityTests_type" to "Lab"),
+                mapOf(
+                    "id" to "$accessionId1",
+                    "accessionNumber" to "XYZ",
+                    "viabilityTests_type" to "Nursery"),
             ))
 
     val actual =
@@ -90,10 +98,10 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
     val gibberishAwaitingProcessing = "UHJvY2Vzc2luZw QXdhaXRpbmc"
 
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(stateId = AccessionState.Drying))
+        accessionsDao.fetchOneById(accessionId2)!!.copy(stateId = AccessionState.Drying))
     accessionsDao.update(
         accessionsDao
-            .fetchOneById(AccessionId(1000))!!
+            .fetchOneById(accessionId1)!!
             .copy(stateId = AccessionState.AwaitingProcessing))
 
     val fields = listOf(stateField)
@@ -102,9 +110,12 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "state" to gibberishDrying, "accessionNumber" to "ABCDEFG"),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId2",
+                    "state" to gibberishDrying,
+                    "accessionNumber" to "ABCDEFG"),
+                mapOf(
+                    "id" to "$accessionId1",
                     "state" to gibberishAwaitingProcessing,
                     "accessionNumber" to "XYZ"),
             ))
@@ -134,7 +145,7 @@ internal class SearchServiceEnumTest : SearchServiceTest() {
                 mapOf(
                     "accessionNumber" to "XYZ",
                     "active" to gibberishActive,
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "state" to gibberishInStorage,
                 )))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -1,8 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.search.FieldNode
@@ -21,7 +19,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
   @Test
   fun `renders null values as null, not as a string`() {
-    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(speciesId = null))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(speciesId = null))
     val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
     assertEquals(listOf("Other Dogwood", null), values)
   }
@@ -48,14 +46,13 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
   @Test
   fun `exact-or-fuzzy search of accession number with value that is an exact substring match`() {
-    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(number = "ABCD"))
-    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1001))!!.copy(number = "ABCEF"))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(number = "ABCD"))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(number = "ABCEF"))
     insertAccession(
         AccessionsRow(
-            id = AccessionId(1002),
             number = "ZABCDY",
             stateId = AccessionState.Processing,
-            speciesId = SpeciesId(10001),
+            speciesId = speciesId2,
             treesCollectedFrom = 2))
     val values =
         searchService.fetchValues(
@@ -68,15 +65,14 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   @Test
   fun `exact-or-fuzzy search of collection site name with value that is an exact substring match`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(collectionSiteName = "Location 10"))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(collectionSiteName = "Location 10"))
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(collectionSiteName = "Location 11"))
+        accessionsDao.fetchOneById(accessionId2)!!.copy(collectionSiteName = "Location 11"))
     insertAccession(
         AccessionsRow(
-            id = AccessionId(1002),
             number = "IJK",
             stateId = AccessionState.Processing,
-            speciesId = SpeciesId(10001),
+            speciesId = speciesId2,
             treesCollectedFrom = 2,
             collectionSiteName = "Location 2"))
     val values =
@@ -135,7 +131,7 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   @Test
   fun `can filter on computed column value`() {
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(stateId = AccessionState.UsedUp))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(stateId = AccessionState.UsedUp))
     val values =
         searchService.fetchValues(
             rootPrefix, activeField, FieldNode(activeField, listOf("Inactive")))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceInitializationTest.kt
@@ -55,14 +55,14 @@ internal class SearchServiceInitializationTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "speciesName" to "Kousa Dogwood",
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "plantsCollectedFrom" to "1",
                     "active" to "Active",
                 ),
                 mapOf(
                     "speciesName" to "Other Dogwood",
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "2",
                     "active" to "Active",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -1,8 +1,6 @@
 package com.terraformation.backend.seedbank.search
 
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.terraformation.backend.db.seedbank.AccessionId
+import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
@@ -40,14 +38,14 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
   @BeforeEach
   fun insertNestedData() {
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "1"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1000), bagNumber = "5"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1001), bagNumber = "2"))
-    bagsDao.insert(BagsRow(accessionId = AccessionId(1001), bagNumber = "6"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "1"))
+    bagsDao.insert(BagsRow(accessionId = accessionId1, bagNumber = "5"))
+    bagsDao.insert(BagsRow(accessionId = accessionId2, bagNumber = "2"))
+    bagsDao.insert(BagsRow(accessionId = accessionId2, bagNumber = "6"))
 
     val viabilityTestResultsRow =
         ViabilityTestsRow(
-            accessionId = AccessionId(1000),
+            accessionId = accessionId1,
             seedsSown = 15,
             testType = ViabilityTestType.Lab,
             totalPercentGerminated = 100,
@@ -160,10 +158,10 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                             // 4 entries here because we're bringing a flattened sublist into the
                             // picture, even though it's only on a sort field. Unclear if this is
                             // the desirable result or not, but it's at least a predictable one.
-                            mapOf("id" to "1000"),
-                            mapOf("id" to "1001"),
-                            mapOf("id" to "1000"),
-                            mapOf("id" to "1001"),
+                            mapOf("id" to "$accessionId1"),
+                            mapOf("id" to "$accessionId2"),
+                            mapOf("id" to "$accessionId1"),
+                            mapOf("id" to "$accessionId2"),
                         ))))
 
     assertEquals(expected, result)
@@ -251,7 +249,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
                     "accessionNumber" to "XYZ",
                 )))
@@ -274,12 +272,12 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
                     "accessionNumber" to "XYZ",
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6")),
                     "accessionNumber" to "ABCDEFG",
                 ),
@@ -303,7 +301,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -330,8 +328,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG")))
 
     assertEquals(expected, result)
   }
@@ -353,7 +351,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -381,12 +379,12 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "bags" to listOf(mapOf("number" to "6"), mapOf("number" to "2")),
                     "accessionNumber" to "ABCDEFG",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "bags" to listOf(mapOf("number" to "5"), mapOf("number" to "1")),
                     "accessionNumber" to "XYZ",
                 ),
@@ -401,7 +399,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     viabilityTestsDao.insert(
         ViabilityTestsRow(
-            accessionId = AccessionId(1000), testType = ViabilityTestType.Nursery, seedsSown = 1))
+            accessionId = accessionId1, testType = ViabilityTestType.Nursery, seedsSown = 1))
 
     val result =
         searchAccessions(
@@ -414,7 +412,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -423,7 +421,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                         ),
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                 ),
             ))
@@ -441,11 +439,11 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6"))),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
                     "viabilityTests" to
@@ -477,7 +475,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -488,7 +486,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                                         mapOf("seedsGerminated" to "10")))),
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                 ),
             ))
@@ -509,7 +507,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -518,7 +516,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                         ),
                 ),
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                 ),
             ))
@@ -542,8 +540,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
 
     assertEquals(expected, result)
@@ -555,11 +553,11 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     // can detect if the ORDER BY clause is using the wrong field.
     accessionsDao.update(
         accessionsDao
-            .fetchOneById(AccessionId(1000))!!
+            .fetchOneById(accessionId1)!!
             .copy(number = "B", receivedDate = LocalDate.of(2020, 1, 2)))
     accessionsDao.update(
         accessionsDao
-            .fetchOneById(AccessionId(1001))!!
+            .fetchOneById(accessionId2)!!
             .copy(number = "A", receivedDate = LocalDate.of(2020, 1, 1)))
 
     val selectFields = listOf(accessionNumberField, bagsNumberField, receivedDateField)
@@ -608,13 +606,13 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 // Bag 6
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
                 // Bag 5
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
                 // Bag 2
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
                 // Bag 1
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
 
     assertEquals(expected, result)
@@ -632,7 +630,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -644,7 +642,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "viabilityTests_viabilityTestResults_seedsGerminated" to "5",
                 ),
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -672,7 +670,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "facility" to mapOf("name" to "Facility 1"))))
 
@@ -693,7 +691,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -729,7 +727,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "accessionNumber" to "XYZ",
                     "viabilityTests" to
                         listOf(
@@ -809,15 +807,14 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val userTimeZone = "America/Santiago"
 
     organizationsDao.update(
-        organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = ZoneId.of("$orgTimeZone")))
+        organizationsDao.fetchOneById(organizationId)!!.copy(timeZone = ZoneId.of(orgTimeZone)))
     facilitiesDao.update(
-        facilitiesDao.fetchOneById(facilityId)!!.copy(timeZone = ZoneId.of("$facilityTimeZone")))
-    usersDao.update(
-        usersDao.fetchOneById(user.userId)!!.copy(timeZone = ZoneId.of("$userTimeZone")))
+        facilitiesDao.fetchOneById(facilityId)!!.copy(timeZone = ZoneId.of(facilityTimeZone)))
+    usersDao.update(usersDao.fetchOneById(user.userId)!!.copy(timeZone = ZoneId.of(userTimeZone)))
 
     val cutTestRow =
         ViabilityTestsRow(
-            accessionId = AccessionId(1000),
+            accessionId = accessionId1,
             seedsCompromised = 1,
             seedsEmpty = 2,
             seedsFilled = 3,
@@ -833,7 +830,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                     "accessionNumber" to "ABCDEFG",
                     "active" to "Active",
                     "bags" to listOf(mapOf("number" to "2"), mapOf("number" to "6")),
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "plantsCollectedFrom" to "2",
                     "source" to "Web",
                     "speciesName" to "Other Dogwood",
@@ -859,7 +856,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                             mapOf("name" to "collector 3", "position" to "2"),
                         ),
                     "bags" to listOf(mapOf("number" to "1"), mapOf("number" to "5")),
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "plantId" to "plantId",
                     "plantsCollectedFrom" to "1",
                     "source" to "Seed Collector App",
@@ -912,14 +909,14 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             mapOf(
                 "checkedTime" to checkedTimeString,
                 "commonName" to "Common 1",
-                "id" to "10000",
+                "id" to "$speciesId1",
                 "rare" to "false",
                 "scientificName" to "Kousa Dogwood",
             ),
             mapOf(
                 "commonName" to "Common 2",
                 "conservationCategory" to "EN",
-                "id" to "10001",
+                "id" to "$speciesId2",
                 "rare" to "true",
                 "scientificName" to "Other Dogwood",
                 "seedStorageBehavior" to "Orthodox",
@@ -979,17 +976,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val result = searchService.search(prefix, fields, NoConditionNode())
 
     assertNull(result.cursor)
-
-    if (expected != result.results) {
-      // Pretty-print both values so they are easy to diff.
-      val objectMapper =
-          jacksonObjectMapper()
-              .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-              .enable(SerializationFeature.INDENT_OUTPUT)
-      assertEquals(
-          objectMapper.writeValueAsString(expected),
-          objectMapper.writeValueAsString(result.results))
-    }
+    assertJsonEquals(expected, result.results)
   }
 
   @Test
@@ -1007,8 +994,8 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 mapOf(
                     "collectors.name" to "collector 1\r\ncollector 2\r\ncollector 3",
                     "collectors.position" to "0\r\n1\r\n2",
-                    "id" to "1000"),
-                mapOf("id" to "1001"),
+                    "id" to "$accessionId1"),
+                mapOf("id" to "$accessionId2"),
             ))
 
     val result =
@@ -1078,7 +1065,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val otherFacilityId = insertFacility()
 
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(facilityId = otherFacilityId))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(facilityId = otherFacilityId))
 
     val expected = SearchResults(listOf(mapOf("number" to "2"), mapOf("number" to "6")))
 
@@ -1100,11 +1087,11 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val otherFacilityId = insertFacility()
 
     accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(facilityId = otherFacilityId))
+        accessionsDao.fetchOneById(accessionId1)!!.copy(facilityId = otherFacilityId))
 
     val viabilityTestResultsRow =
         ViabilityTestsRow(
-            accessionId = AccessionId(1001), testType = ViabilityTestType.Lab, seedsSown = 50)
+            accessionId = accessionId2, testType = ViabilityTestType.Lab, seedsSown = 50)
 
     viabilityTestsDao.insert(viabilityTestResultsRow)
     viabilityTestResultsDao.insert(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNullValueTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.NoConditionNode
 import com.terraformation.backend.search.SearchFilterType
@@ -11,8 +10,7 @@ import org.junit.jupiter.api.Test
 internal class SearchServiceNullValueTest : SearchServiceTest() {
   @Test
   fun `search leaves out null values`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(processingNotes = "Notes"))
 
     val fields = listOf(processingNotesField)
 
@@ -21,8 +19,11 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf(
+                    "id" to "$accessionId2",
+                    "accessionNumber" to "ABCDEFG",
+                    "processingNotes" to "Notes"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
 
     assertEquals(expected, result)
@@ -30,11 +31,9 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
 
   @Test
   fun `can do exact search for null values`() {
-    insertAccession(number = "MISSING")
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(processingNotes = "Other"))
+    val missingAccessionId = insertAccession(number = "MISSING")
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(processingNotes = "Notes"))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(processingNotes = "Other"))
 
     val fields = listOf(processingNotesField)
     val searchNode = FieldNode(processingNotesField, listOf("Notes", null))
@@ -44,8 +43,11 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
-                mapOf("id" to "1", "accessionNumber" to "MISSING"),
+                mapOf(
+                    "id" to "$accessionId2",
+                    "accessionNumber" to "ABCDEFG",
+                    "processingNotes" to "Notes"),
+                mapOf("id" to "$missingAccessionId", "accessionNumber" to "MISSING"),
             ))
 
     assertEquals(expected, result)
@@ -53,8 +55,7 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
 
   @Test
   fun `fuzzy search treats null values as no-ops`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(processingNotes = "Notes"))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(processingNotes = "Notes"))
 
     val fields = listOf(processingNotesField)
     val searchNode =
@@ -63,8 +64,11 @@ internal class SearchServiceNullValueTest : SearchServiceTest() {
     assertEquals(
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG", "processingNotes" to "Notes"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf(
+                    "id" to "$accessionId2",
+                    "accessionNumber" to "ABCDEFG",
+                    "processingNotes" to "Notes"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             )),
         searchAccessions(facilityId, fields, searchNode))
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
@@ -23,8 +23,8 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
     val expected =
         SearchResults(
             listOf(
-                mapOf("id" to "1001", "accessionNumber" to "ABCDEFG"),
-                mapOf("id" to "1000", "accessionNumber" to "XYZ"),
+                mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG"),
+                mapOf("id" to "$accessionId1", "accessionNumber" to "XYZ"),
             ))
 
     val actual =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRangeSearchTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
 import com.terraformation.backend.search.SearchResults
@@ -11,8 +10,7 @@ import org.junit.jupiter.api.assertThrows
 internal class SearchServiceRangeSearchTest : SearchServiceTest() {
   @Test
   fun `can do range search on integer field`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(treesCollectedFrom = 500))
     val fields = listOf(plantsCollectedFromField)
     val searchNode =
         FieldNode(plantsCollectedFromField, listOf("2", "3000"), SearchFilterType.Range)
@@ -23,7 +21,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "500")))
 
@@ -32,8 +30,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
   @Test
   fun `can do range search on integer field with no minimum`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(treesCollectedFrom = 500))
     val fields = listOf(plantsCollectedFromField)
     val searchNode = FieldNode(plantsCollectedFromField, listOf(null, "3"), SearchFilterType.Range)
 
@@ -41,15 +38,18 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
 
     val expected =
         SearchResults(
-            listOf(mapOf("id" to "1000", "accessionNumber" to "XYZ", "plantsCollectedFrom" to "1")))
+            listOf(
+                mapOf(
+                    "id" to "$accessionId1",
+                    "accessionNumber" to "XYZ",
+                    "plantsCollectedFrom" to "1")))
 
     assertEquals(expected, result)
   }
 
   @Test
   fun `can do range search on integer field with no maximum`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1001))!!.copy(treesCollectedFrom = 500))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId2)!!.copy(treesCollectedFrom = 500))
     val fields = listOf(plantsCollectedFromField)
     val searchNode = FieldNode(plantsCollectedFromField, listOf("2", null), SearchFilterType.Range)
 
@@ -59,7 +59,7 @@ internal class SearchServiceRangeSearchTest : SearchServiceTest() {
         SearchResults(
             listOf(
                 mapOf(
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "accessionNumber" to "ABCDEFG",
                     "plantsCollectedFrom" to "500")))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.i18n.Locales
 import com.terraformation.backend.i18n.use
@@ -13,11 +12,11 @@ import org.junit.jupiter.api.Test
 internal class SearchServiceRawTest : SearchServiceTest() {
   @Test
   fun `can search for raw and localized fields at the same time`() {
-    accessionsDao.update(accessionsDao.fetchOneById(AccessionId(1000))!!.copy(estSeedCount = 12000))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(estSeedCount = 12000))
 
     val fields =
         listOf(rootPrefix.resolve("estimatedCount"), rootPrefix.resolve("estimatedCount(raw)"))
-    val criteria = FieldNode(accessionIdField, listOf("1000"))
+    val criteria = FieldNode(accessionIdField, listOf("$accessionId1"))
 
     val result = searchService.search(rootPrefix, fields, criteria)
 
@@ -29,8 +28,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
 
   @Test
   fun `accepts raw values as search criteria`() {
-    accessionsDao.update(
-        accessionsDao.fetchOneById(AccessionId(1000))!!.copy(treesCollectedFrom = 8000))
+    accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(treesCollectedFrom = 8000))
 
     val rawActiveField = rootPrefix.resolve("active(raw)")
     val rawPlantsField = rootPrefix.resolve("plantsCollectedFrom(raw)")
@@ -65,7 +63,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "active(raw)" to "Active",
-                    "id" to "1000",
+                    "id" to "$accessionId1",
                     "plantsCollectedFrom(raw)" to "8000",
                     "species_rare(raw)" to "false",
                     "state(raw)" to "In Storage",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceWeightTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceWeightTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.search
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.search.FieldNode
 import com.terraformation.backend.search.SearchFilterType
@@ -14,18 +13,18 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
 
 internal class SearchServiceWeightTest : SearchServiceTest() {
-  // Sets accession 1001 to 1kg and accession 1000 to another value.
+  /** Sets accession 1's weight to the specified value and accession 2's to 1kg. */
   private fun setAccessionWeights(otherWeight: SeedQuantityModel = grams(800)) {
     accessionsDao.update(
         accessionsDao
-            .fetchOneById(AccessionId(1000))!!
+            .fetchOneById(accessionId1)!!
             .copy(
                 remainingGrams = otherWeight.grams,
                 remainingQuantity = otherWeight.quantity,
                 remainingUnitsId = otherWeight.units))
     accessionsDao.update(
         accessionsDao
-            .fetchOneById(AccessionId(1001))!!
+            .fetchOneById(accessionId2)!!
             .copy(
                 remainingGrams = BigDecimal(1000),
                 remainingQuantity = BigDecimal(1),
@@ -43,7 +42,8 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
             listOf("900000 Milligrams", "650,000.000001 Pounds"),
             SearchFilterType.Range)
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG")))
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -57,7 +57,8 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
     val fields = listOf(accessionNumberField)
     val searchNode = FieldNode(remainingGramsField, listOf("1000"))
 
-    val expected = SearchResults(listOf(mapOf("id" to "1001", "accessionNumber" to "ABCDEFG")))
+    val expected =
+        SearchResults(listOf(mapOf("id" to "$accessionId2", "accessionNumber" to "ABCDEFG")))
 
     val result = searchAccessions(facilityId, fields, searchNode)
 
@@ -94,7 +95,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
             listOf(
                 mapOf(
                     "accessionNumber" to "ABCDEFG",
-                    "id" to "1001",
+                    "id" to "$accessionId2",
                     "remainingKilograms" to "1",
                     "remainingMilligrams" to "1,000,000",
                     "remainingOunces" to "35.274",
@@ -116,7 +117,7 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
           val searchNode = FieldNode(remainingPoundsField, listOf("2.205"), SearchFilterType.Fuzzy)
 
           val expected =
-              SearchResults(listOf(mapOf("accessionNumber" to "ABCDEFG", "id" to "1001")))
+              SearchResults(listOf(mapOf("accessionNumber" to "ABCDEFG", "id" to "$accessionId2")))
 
           val result = searchAccessions(facilityId, emptyList(), searchNode)
 
@@ -128,8 +129,8 @@ internal class SearchServiceWeightTest : SearchServiceTest() {
           val expected =
               SearchResults(
                   listOf(
-                      mapOf("accessionNumber" to "ABCDEFG", "id" to "1001"),
-                      mapOf("accessionNumber" to "XYZ", "id" to "1000")))
+                      mapOf("accessionNumber" to "ABCDEFG", "id" to "$accessionId2"),
+                      mapOf("accessionNumber" to "XYZ", "id" to "$accessionId1")))
 
           val result = searchAccessions(facilityId, emptyList(), searchNode)
 


### PR DESCRIPTION
In preparation for supporting parallel test runs, update the seedbank search
tests to stop using hardwired IDs and to stop resetting the accession ID
database sequence.