### PR TITLE
SW-5795 Use dynamic organization IDs in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DealStage
 import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.default_schema.LandUseModelType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.i18n.Locales
 import com.terraformation.backend.i18n.toGibberish
@@ -30,9 +31,11 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
   private val searchService: SearchService by lazy { SearchService(dslContext) }
   private val searchTables = SearchTables(clock)
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertParticipant()
     insertProject(countryCode = "KE", participantId = inserted.participantId)
@@ -137,10 +140,10 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     insertOrganizationUser()
 
-    val otherAcceleratorOrgId = insertOrganization(2)
+    val otherAcceleratorOrgId = insertOrganization()
     insertOrganizationInternalTag(otherAcceleratorOrgId, InternalTagIds.Accelerator)
 
-    insertOrganization(3)
+    insertOrganization()
 
     val prefix = SearchFieldPrefix(searchTables.organizations)
     val fields = listOf(prefix.resolve("name"))
@@ -162,7 +165,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     insertOrganizationUser()
 
-    val otherAcceleratorOrgId = insertOrganization(2)
+    val otherAcceleratorOrgId = insertOrganization()
     insertOrganizationInternalTag(otherAcceleratorOrgId, InternalTagIds.Accelerator)
 
     val prefix = SearchFieldPrefix(searchTables.organizations)
@@ -179,7 +182,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     insertOrganizationUser()
 
-    val nonAcceleratorOrgId = insertOrganization(2)
+    val nonAcceleratorOrgId = insertOrganization()
     insertProject(organizationId = nonAcceleratorOrgId)
 
     val prefix = SearchFieldPrefix(searchTables.projects)
@@ -197,7 +200,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     insertOrganizationUser()
 
-    val otherAcceleratorOrgId = insertOrganization(2)
+    val otherAcceleratorOrgId = insertOrganization()
     insertOrganizationInternalTag(otherAcceleratorOrgId, InternalTagIds.Accelerator)
     insertProject(organizationId = otherAcceleratorOrgId)
 
@@ -211,7 +214,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `can filter organizations by internal tag to only retrieve accelerator data`() {
-    val nonAcceleratorOrgId = insertOrganization(2)
+    val nonAcceleratorOrgId = insertOrganization()
 
     insertOrganizationUser(organizationId = organizationId, role = Role.TerraformationContact)
     insertOrganizationUser(organizationId = nonAcceleratorOrgId, role = Role.Admin)
@@ -359,7 +362,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
             organizationId = inserted.organizationId, participantId = inserted.participantId)
 
     val otherUser = insertUser()
-    val otherOrganization = insertOrganization(id = 100, createdBy = otherUser)
+    val otherOrganization = insertOrganization(createdBy = otherUser)
     insertOrganizationUser(
         userId = otherUser, organizationId = otherOrganization, role = Role.Admin)
     val otherParticipant = insertParticipant(cohortId = inserted.cohortId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.ApplicationStatus
 import com.terraformation.backend.db.default_schema.LandUseModelType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.gis.CountryDetector
@@ -56,9 +57,11 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
   private val applicationId = ApplicationId(1)
   private val projectId = ProjectId(3)
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertProject()
 
     every { user.canReadProject(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.accelerator.ParticipantProjectSpeciesId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionsRow
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -85,12 +86,13 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var applicationId: ApplicationId
   private lateinit var applicationModuleId: ModuleId
+  private lateinit var organizationId: OrganizationId
   private lateinit var preScreenModuleId: ModuleId
   private lateinit var projectId: ProjectId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertOrganizationUser(role = Role.Admin)
 
     projectId = insertProject()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -276,7 +276,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
             organizationId = inserted.organizationId, participantId = inserted.participantId)
 
     val otherUser = insertUser()
-    val otherOrganization = insertOrganization(id = 100, createdBy = otherUser)
+    val otherOrganization = insertOrganization(createdBy = otherUser)
     insertOrganizationUser(
         userId = otherUser, organizationId = otherOrganization, role = Role.Admin)
     val otherParticipant = insertParticipant(cohortId = inserted.cohortId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -200,7 +200,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
     val otherUser = insertUser()
     val otherCohort = insertCohort()
     val otherParticipant = insertParticipant(cohortId = otherCohort)
-    val otherOrganization = insertOrganization(100)
+    val otherOrganization = insertOrganization()
     insertOrganizationUser(otherUser, otherOrganization)
     insertProject(participantId = otherParticipant, organizationId = otherOrganization)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -291,7 +291,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
     val otherCohort = insertCohort()
     insertCohortModule(cohortId = otherCohort, moduleId = inserted.moduleId)
 
-    val otherOrganization = insertOrganization(100)
+    val otherOrganization = insertOrganization()
     val otherParticipant = insertParticipant(cohortId = otherCohort)
     val otherProject =
         insertProject(participantId = otherParticipant, organizationId = otherOrganization)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/AcceleratorOrganizationStoreTest.kt
@@ -31,10 +31,10 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchWithUnassignedProjects {
     @Test
     fun `only returns unassigned projects in Accelerator tagged organizations`() {
-      val acceleratorOrgId1 = insertOrganization(1)
-      val acceleratorOrgId2 = insertOrganization(2)
-      val nonAcceleratorOrgId = insertOrganization(3)
-      val untaggedOrgId = insertOrganization(4)
+      val acceleratorOrgId1 = insertOrganization()
+      val acceleratorOrgId2 = insertOrganization()
+      val nonAcceleratorOrgId = insertOrganization()
+      val untaggedOrgId = insertOrganization()
       val participantId = insertParticipant()
       val currentUserId = user.userId
 
@@ -44,10 +44,10 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsUser {
 
       insertProject(organizationId = nonAcceleratorOrgId)
       insertProject(organizationId = untaggedOrgId)
-      insertProject(organizationId = 1, participantId = participantId)
-      val unassignedProjectId1 = insertProject(organizationId = 1, name = "A")
-      val unassignedProjectId2 = insertProject(organizationId = 2, name = "C")
-      val unassignedProjectId3 = insertProject(organizationId = 2, name = "B")
+      insertProject(organizationId = acceleratorOrgId1, participantId = participantId)
+      val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
+      val unassignedProjectId2 = insertProject(organizationId = acceleratorOrgId2, name = "C")
+      val unassignedProjectId3 = insertProject(organizationId = acceleratorOrgId2, name = "B")
 
       assertEquals(
           mapOf(
@@ -110,11 +110,11 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsUser {
   inner class FindAll {
     @Test
     fun `returns both assigned and unassigned projects in Accelerator tagged organizations`() {
-      val acceleratorOrgId1 = insertOrganization(1)
-      val acceleratorOrgId2 = insertOrganization(2)
-      val acceleratorOrgIdWithoutProjects = insertOrganization(3)
-      val nonAcceleratorOrgId = insertOrganization(4)
-      val untaggedOrgId = insertOrganization(5)
+      val acceleratorOrgId1 = insertOrganization()
+      val acceleratorOrgId2 = insertOrganization()
+      val acceleratorOrgIdWithoutProjects = insertOrganization()
+      val nonAcceleratorOrgId = insertOrganization()
+      val untaggedOrgId = insertOrganization()
       val participantId = insertParticipant()
       val currentUserId = user.userId
 
@@ -126,9 +126,10 @@ class AcceleratorOrganizationStoreTest : DatabaseTest(), RunsAsUser {
       insertProject(organizationId = nonAcceleratorOrgId)
       insertProject(organizationId = untaggedOrgId)
       val assignedProjectId =
-          insertProject(organizationId = 1, name = "D", participantId = participantId)
-      val unassignedProjectId1 = insertProject(organizationId = 1, name = "A")
-      val unassignedProjectId2 = insertProject(organizationId = 2, name = "C")
+          insertProject(
+              organizationId = acceleratorOrgId1, name = "D", participantId = participantId)
+      val unassignedProjectId1 = insertProject(organizationId = acceleratorOrgId1, name = "A")
+      val unassignedProjectId2 = insertProject(organizationId = acceleratorOrgId2, name = "C")
 
       assertEquals(
           mapOf(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -67,9 +67,11 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
         organizationsDao)
   }
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization(countryCode = "US", name = "Organization 1")
+    organizationId = insertOrganization(countryCode = "US", name = "Organization 1")
     insertProject(name = "Project A")
 
     every { user.adminOrganizations() } returns setOf(organizationId)
@@ -182,7 +184,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
               status = ApplicationStatus.PLReview,
           )
 
-      organizationId2 = insertOrganization(2, name = "Organization 2")
+      organizationId2 = insertOrganization(name = "Organization 2")
       org2ProjectId1 = insertProject(organizationId = organizationId2, name = "Project C")
       org2Project1ApplicationId =
           insertApplication(projectId = org2ProjectId1, internalName = "internalName3")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -81,8 +81,8 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       val participantId2 = insertParticipant(id = 2, cohortId = cohortId1)
       val participantId3 = insertParticipant(id = 3, cohortId = cohortId2)
 
-      val organizationId1 = insertOrganization(id = 1)
-      val organizationId2 = insertOrganization(id = 2)
+      val organizationId1 = insertOrganization()
+      val organizationId2 = insertOrganization()
       val projectId1 =
           insertProject(id = 1, organizationId = organizationId1, participantId = participantId1)
       val projectId2 =
@@ -476,7 +476,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       every { user.canReadProjectDeliverables(any()) } returns false
       every { user.canReadModule(any()) } returns false
 
-      insertOrganization()
+      val organizationId = insertOrganization()
       val participantId = insertParticipant()
       val projectId = insertProject()
       val moduleId = insertModule()

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -106,6 +106,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Autowired private lateinit var config: TerrawareServerConfig
 
   private lateinit var facilityId: FacilityId
+  private lateinit var organizationId: OrganizationId
   private lateinit var otherUserId: UserId
 
   private val clock = TestClock()
@@ -135,7 +136,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val objectMapper = jacksonObjectMapper()
     val publisher = TestEventPublisher()
 
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility()
 
     parentStore = ParentStore(dslContext)
@@ -898,7 +899,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
     // Other project in different org
     val thirdUserId = insertUser()
-    val otherOrgId = insertOrganization(300)
+    val otherOrgId = insertOrganization()
     insertOrganizationUser(thirdUserId, otherOrgId)
     val otherProjectId = insertProject(organizationId = otherOrgId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
@@ -98,7 +97,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
   private val plantingSiteId2 by lazy { insertPlantingSite() }
   private val speciesId by lazy { insertSpecies() }
 
-  private val otherOrganizationId by lazy { insertOrganization(OrganizationId(2)) }
+  private val otherOrganizationId by lazy { insertOrganization() }
   private val otherOrgAccessionId by lazy {
     insertAccession(facilityId = otherOrgSeedBankFacilityId)
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -59,6 +59,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
   private lateinit var store: FacilityStore
 
   private lateinit var facilityId: FacilityId
+  private lateinit var organizationId: OrganizationId
   private val subLocationId = SubLocationId(1000)
   private lateinit var timeZone: ZoneId
 
@@ -86,7 +87,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateTimeseries(any()) } returns true
 
     timeZone = ZoneId.of("Pacific/Honolulu")
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility()
   }
 
@@ -495,10 +496,9 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update updates all editable fields`() {
-    val otherOrganizationId = OrganizationId(10)
     val otherTimeZone = ZoneId.of("Europe/Paris")
 
-    insertOrganization(otherOrganizationId)
+    val otherOrganizationId = insertOrganization()
     insertOrganizationUser(organizationId = otherOrganizationId, role = Role.Admin)
 
     val initial =

--- a/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.InternalTagIsSystemDefinedException
 import com.terraformation.backend.db.default_schema.InternalTagId
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.InternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
 import com.terraformation.backend.mockUser
@@ -110,10 +109,9 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchOrganizationsByTagId returns tagged organizations`() {
+    val organizationId = insertOrganization()
     val otherTagId = insertInternalTag()
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(organizationId)
-    insertOrganization(otherOrganizationId)
+    val otherOrganizationId = insertOrganization()
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     insertOrganizationInternalTag(otherOrganizationId, otherTagId)
 
@@ -124,9 +122,8 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchAllOrganizationTagIds handles organizations with multiple tags`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(organizationId)
-    insertOrganization(otherOrganizationId)
+    val organizationId = insertOrganization()
+    val otherOrganizationId = insertOrganization()
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
     insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Testing)
@@ -141,9 +138,8 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchTagsByOrganization returns correct tag IDs`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(organizationId)
-    insertOrganization(otherOrganizationId)
+    val organizationId = insertOrganization()
+    val otherOrganizationId = insertOrganization()
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
     insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Internal)
@@ -162,9 +158,8 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateOrganizationTags inserts and deletes values`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(organizationId)
-    insertOrganization(otherOrganizationId)
+    val organizationId = insertOrganization()
+    val otherOrganizationId = insertOrganization()
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     insertOrganizationInternalTag(organizationId, InternalTagIds.Internal)
     insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Reporter)
@@ -201,7 +196,7 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `write methods throw AccessDeniedException if no permission to manage internal tags`() {
-    insertOrganization()
+    val organizationId = insertOrganization()
     val tagId = insertInternalTag()
 
     every { user.canManageInternalTags() } returns false
@@ -221,7 +216,7 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `read methods throw AccessDeniedException if no permission to read internal tags`() {
-    insertOrganization()
+    val organizationId = insertOrganization()
     val tagId = insertInternalTag()
 
     every { user.canManageInternalTags() } returns false

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
-import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.net.URI
@@ -34,11 +33,13 @@ import org.junit.jupiter.params.provider.ValueSource
 internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
   override val tablesToResetSequences: List<Table<out Record>>
-    get() = listOf(NOTIFICATIONS, ORGANIZATIONS)
+    get() = listOf(NOTIFICATIONS)
 
   private val clock = TestClock()
   private lateinit var permissionStore: PermissionStore
   private lateinit var store: NotificationStore
+
+  private lateinit var organizationId: OrganizationId
 
   private fun notificationModel(
       globalNotification: Boolean = false,
@@ -70,6 +71,8 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
+    organizationId = insertOrganization()
+
     permissionStore = PermissionStore(dslContext)
     store = NotificationStore(dslContext, clock)
 
@@ -82,8 +85,6 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canCountNotifications() } returns true
 
     every { user.organizationRoles } returns mapOf(organizationId to Role.Owner)
-
-    insertSiteData()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -18,6 +18,8 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var permissionStore: PermissionStore
 
+  private lateinit var organizationId1: OrganizationId
+  private lateinit var organizationId2: OrganizationId
   private lateinit var org1FacilityId: FacilityId
   private lateinit var org2FacilityId: FacilityId
   private lateinit var org2Owner: UserId
@@ -46,14 +48,14 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchOrganizationRoles only includes organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(OrganizationId(2) to Role.Owner), permissionStore.fetchOrganizationRoles(org2Owner))
+        mapOf(organizationId2 to Role.Owner), permissionStore.fetchOrganizationRoles(org2Owner))
   }
 
   @Test
   fun `fetchOrganizationRoles includes all organizations the user is in`() {
     insertTestData()
     assertEquals(
-        mapOf(OrganizationId(1) to Role.Contributor, OrganizationId(2) to Role.Manager),
+        mapOf(organizationId1 to Role.Contributor, organizationId2 to Role.Manager),
         permissionStore.fetchOrganizationRoles(org1Contributor2Manager))
   }
 
@@ -96,17 +98,18 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
    * ```
    */
   private fun insertTestData() {
-    insertOrganization(1)
+    organizationId1 = insertOrganization()
     org1FacilityId = insertFacility()
-    insertOrganization(2)
+    organizationId2 = insertOrganization()
     org2FacilityId = insertFacility()
 
-    configureUser(mapOf(1 to Role.Manager))
-    org2Owner = configureUser(mapOf(2 to Role.Owner))
-    org1Contributor2Manager = configureUser(mapOf(1 to Role.Contributor, 2 to Role.Manager))
+    configureUser(mapOf(organizationId1 to Role.Manager))
+    org2Owner = configureUser(mapOf(organizationId2 to Role.Owner))
+    org1Contributor2Manager =
+        configureUser(mapOf(organizationId1 to Role.Contributor, organizationId2 to Role.Manager))
   }
 
-  private fun configureUser(roles: Map<Int, Role>): UserId {
+  private fun configureUser(roles: Map<OrganizationId, Role>): UserId {
     val userId = insertUser()
     roles.forEach { (orgId, role) -> insertOrganizationUser(userId, orgId, role) }
     return userId

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -233,7 +233,8 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     facilityIds.forEach { facilityId ->
-      val organizationId = facilityId.value / 1000
+      val organizationId = OrganizationId(facilityId.value / 1000)
+      val speciesId = SpeciesId(organizationId.value)
 
       insertFacility(facilityId, organizationId, createdBy = userId)
       insertDevice(facilityId.value, facilityId, createdBy = userId)
@@ -251,7 +252,7 @@ internal class PermissionTest : DatabaseTest() {
           id = facilityId.value,
           facilityId = facilityId,
           organizationId = organizationId,
-          speciesId = organizationId,
+          speciesId = speciesId,
       )
       insertWithdrawal(
           createdBy = userId,
@@ -327,7 +328,7 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     draftPlantingSiteIds.forEach { draftPlantingSiteId ->
-      val organizationId = draftPlantingSiteId.value / 1000
+      val organizationId = OrganizationId(draftPlantingSiteId.value / 1000)
       insertDraftPlantingSite(
           createdBy = userId,
           id = draftPlantingSiteId,

--- a/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/IdentifierGeneratorTest.kt
@@ -17,17 +17,18 @@ internal class IdentifierGeneratorTest : DatabaseTest(), RunsAsUser {
 
   private val generator: IdentifierGenerator by lazy { IdentifierGenerator(clock, dslContext) }
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
   }
 
   @Test
   fun `identifiers are allocated per organization and per type`() {
     clock.instant = Instant.parse("2022-01-01T00:00:00Z")
 
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
+    val otherOrganizationId = insertOrganization()
 
     val org1AccessionIdentifier1 =
         generator.generateIdentifier(organizationId, IdentifierType.ACCESSION, 1)

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadStatus
 import com.terraformation.backend.db.default_schema.UploadType
@@ -66,7 +65,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
     every { fileStore.newUrl(any(), any(), any()) } returns storageUrl
     every { fileStore.write(storageUrl, any()) } just Runs
-    insertOrganization()
+    val organizationId = insertOrganization()
 
     val expected =
         listOf(
@@ -198,7 +197,6 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `OrganizationDeletionStartedEvent listener deletes all uploads in organization`() {
-    val otherOrganizationId = OrganizationId(2)
     val uploadId1 = UploadId(1)
     val uploadId2 = UploadId(2)
     val otherOrgUploadId = UploadId(3)
@@ -209,8 +207,8 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
     every { fileStore.delete(any()) } just Runs
     every { user.canReadOrganization(any()) } returns true
 
-    insertOrganization(organizationId)
-    insertOrganization(otherOrganizationId)
+    val organizationId = insertOrganization()
+    val otherOrganizationId = insertOrganization()
     insertUpload(uploadId1, organizationId = organizationId, storageUrl = storageUrl1)
     insertUpload(uploadId2, organizationId = organizationId, storageUrl = storageUrl2)
     insertUpload(

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -42,17 +42,18 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
   private val numberFormat = NumberFormat.getIntegerInstance()
 
   private lateinit var facilityId: FacilityId
+  private lateinit var organizationId: OrganizationId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization(organizationId)
+    organizationId = insertOrganization()
     insertOrganizationUser(user.userId, organizationId, Role.Manager)
     facilityId = insertFacility(name = "Nursery", type = FacilityType.Nursery)
   }
 
   @Nested
   inner class SummaryTables {
-    private val organizationId2 = OrganizationId(2)
+    private lateinit var organizationId2: OrganizationId
     private val speciesId1 = SpeciesId(1)
     private val speciesId2 = SpeciesId(2)
     private val org2SpeciesId = SpeciesId(3)
@@ -62,20 +63,17 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
 
     @BeforeEach
     fun insertBatches() {
-      insertOrganization(organizationId2)
-      insertOrganizationUser(user.userId, organizationId2, Role.Contributor)
-
-      insertSubLocation(subLocationId)
-      facilityId2 = insertFacility(name = "Other Nursery", type = FacilityType.Nursery)
-      org2FacilityId =
-          insertFacility(
-              name = "Other Org Nursery",
-              organizationId = organizationId2,
-              type = FacilityType.Nursery)
-
       insertSpecies(speciesId1)
       insertSpecies(speciesId2)
-      insertSpecies(org2SpeciesId, organizationId = organizationId2)
+      insertSubLocation(subLocationId)
+
+      facilityId2 = insertFacility(name = "Other Nursery", type = FacilityType.Nursery)
+
+      organizationId2 = insertOrganization()
+      insertOrganizationUser(user.userId, role = Role.Contributor)
+      org2FacilityId = insertFacility(name = "Other Org Nursery", type = FacilityType.Nursery)
+
+      insertSpecies(org2SpeciesId)
 
       every { user.facilityRoles } returns
           mapOf(
@@ -87,6 +85,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
 
       insertBatch(
           addedDate = LocalDate.of(2021, 3, 4),
+          organizationId = organizationId,
           facilityId = facilityId,
           germinatingQuantity = 1,
           notReadyQuantity = 2,
@@ -96,6 +95,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
       insertBatchSubLocation()
       insertBatch(
           addedDate = LocalDate.of(2022, 9, 2),
+          organizationId = organizationId,
           facilityId = facilityId,
           germinatingQuantity = 8,
           notReadyQuantity = 16,
@@ -106,6 +106,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
       insertBatch(
           BatchesRow(readyByDate = LocalDate.of(2022, 10, 2)),
           addedDate = LocalDate.of(2022, 9, 3),
+          organizationId = organizationId,
           facilityId = facilityId2,
           germinatingQuantity = 64,
           notReadyQuantity = 128,
@@ -114,6 +115,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
       )
       insertBatch(
           addedDate = LocalDate.of(2022, 9, 4),
+          organizationId = organizationId,
           facilityId = facilityId,
           germinatingQuantity = 512,
           notReadyQuantity = 1024,
@@ -507,7 +509,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           numPlants = 3, plantingTypeId = PlantingType.ReassignmentTo, speciesId = speciesId2)
 
       // Withdrawal for another organization shouldn't be visible.
-      insertOrganization(3)
+      insertOrganization()
       insertFacility()
       insertWithdrawal()
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UploadId
@@ -113,6 +114,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
 
   private val uploadId = UploadId(1)
   private lateinit var facilityId: FacilityId
+  private lateinit var organizationId: OrganizationId
   private lateinit var subLocationId: SubLocationId
 
   @BeforeEach
@@ -128,7 +130,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateUpload(any()) } returns true
     every { userStore.fetchOneById(userId) } returns user
 
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility(type = FacilityType.Nursery)
     subLocationId = insertSubLocation(name = "Location 1")
   }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchPhotoId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchPhotosRow
@@ -59,13 +60,16 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   private val metadata = FileMetadata.of(MediaType.IMAGE_JPEG_VALUE, "filename", 123L)
-  private val batchId: BatchId by lazy { insertBatch() }
+
+  private lateinit var batchId: BatchId
+  private lateinit var organizationId: OrganizationId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertSpecies()
     insertFacility(type = FacilityType.Nursery)
+    batchId = insertBatch()
 
     every { thumbnailStore.deleteThumbnails(any()) } just Runs
     every { user.canReadBatch(any()) } returns true
@@ -221,9 +225,9 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
     insertFacility(type = FacilityType.Nursery)
     val facility2BatchId = insertBatch()
 
-    val otherOrganizationId = insertOrganization(2)
+    insertOrganization()
     insertFacility(type = FacilityType.Nursery)
-    val otherOrgBatchId = insertBatch(organizationId = otherOrganizationId)
+    val otherOrgBatchId = insertBatch()
 
     storePhoto()
     storePhoto()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
 import com.terraformation.backend.file.FileService
@@ -54,9 +55,11 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
   private val metadata = FileMetadata.of(MediaType.IMAGE_JPEG_VALUE, "filename", 123L)
   private val withdrawalId: WithdrawalId by lazy { insertWithdrawal() }
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertFacility(type = FacilityType.Nursery)
 
     every { thumbnailStore.deleteThumbnails(any()) } just Runs
@@ -133,7 +136,7 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
 
     val facilityId2 = insertFacility(type = FacilityType.Nursery)
     val facility2WithdrawalId = insertWithdrawal(facilityId = facilityId2)
-    insertOrganization(2)
+    insertOrganization()
     insertFacility(type = FacilityType.Nursery)
     val otherOrgWithdrawalId = insertWithdrawal()
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreCreateBatchTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.SubLocationAtWrongFacilityException
 import com.terraformation.backend.db.SubLocationNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.nursery.BatchDetailsHistoryId
@@ -174,9 +173,8 @@ internal class BatchStoreCreateBatchTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if project is not from same organization as nursery`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
-    val projectId = insertProject(organizationId = otherOrganizationId)
+    insertOrganization()
+    val projectId = insertProject()
 
     assertThrows<ProjectInDifferentOrganizationException> {
       store.create(makeNewBatchModel().copy(projectId = projectId))

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_DETAILS_HISTORY
@@ -47,11 +48,12 @@ internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   protected lateinit var facilityId: FacilityId
+  protected lateinit var organizationId: OrganizationId
   protected lateinit var speciesId: SpeciesId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility(name = "Nursery", type = FacilityType.Nursery)
     speciesId = insertSpecies()
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedTreatment
 import com.terraformation.backend.db.default_schema.SubLocationId
@@ -156,9 +155,8 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if project is not in same organization as nursery`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
-    val otherOrgProjectId = insertProject(organizationId = otherOrganizationId)
+    insertOrganization()
+    val otherOrgProjectId = insertProject()
 
     assertThrows<ProjectInDifferentOrganizationException> {
       store.updateDetails(batchId = batchId, version = 1) { it.copy(projectId = otherOrgProjectId) }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
@@ -979,8 +978,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
 
   @Test
   fun `throws exception if destination facility is in a different organization`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility(type = FacilityType.Nursery)
 
     assertThrows<CrossOrganizationNurseryTransferNotAllowedException> {

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -159,8 +159,12 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
     )
   }
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
+    organizationId = insertOrganization()
+
     every { user.canCreateReport(any()) } returns true
     every { user.canDeleteReport(any()) } returns true
     every { user.canListReports(any()) } returns true
@@ -172,7 +176,6 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateReport(any()) } returns true
     every { user.organizationRoles } returns mapOf(organizationId to Role.Admin)
 
-    insertOrganization()
     insertOrganizationUser(user.userId, organizationId, Role.Admin)
   }
 
@@ -480,11 +483,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates reports for organizations that need them`() {
-      val nonReportingOrganization = OrganizationId(2)
-      val alreadyInProgressOrganization = OrganizationId(3)
+      insertOrganization()
+      val alreadyInProgressOrganization = insertOrganization()
 
-      insertOrganization(nonReportingOrganization)
-      insertOrganization(alreadyInProgressOrganization)
       insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
       insertOrganizationInternalTag(alreadyInProgressOrganization, InternalTagIds.Reporter)
       insertReport(organizationId = alreadyInProgressOrganization, quarter = 4, year = 1969)
@@ -590,11 +591,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
   inner class DeleteOrganization {
     @Test
     fun `deletes all reports for organization when organization deletion starts`() {
-      val otherOrganizationId = OrganizationId(2)
-
-      insertOrganization(otherOrganizationId)
       insertReport(year = 2000)
       insertReport(year = 2001)
+      val otherOrganizationId = insertOrganization()
       val otherOrgReportId = insertReport(organizationId = otherOrganizationId)
 
       service.on(OrganizationDeletionStartedEvent(organizationId))

--- a/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
@@ -22,7 +22,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    val organizationId = insertOrganization()
     insertOrganizationUser(currentUser().userId, inserted.organizationId)
     every { user.canReadOrganization(inserted.organizationId) } returns true
     every { user.organizationRoles } returns mapOf(organizationId to Role.Contributor)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/AccessionServiceTest.kt
@@ -225,6 +225,7 @@ internal class AccessionServiceTest : DatabaseTest(), RunsAsUser {
     private val batchId = BatchId(1)
     private val seedBankFacilityId = FacilityId(1)
     private val nurseryFacilityId = FacilityId(2)
+    private val organizationId = OrganizationId(1)
 
     private val accession =
         AccessionModel(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.UploadNotAwaitingActionException
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadProblemType
@@ -132,6 +133,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
   private val userStore: UserStore = mockk()
 
   private lateinit var facilityId: FacilityId
+  private lateinit var organizationId: OrganizationId
   private val uploadId = UploadId(1)
 
   @BeforeEach
@@ -149,7 +151,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateUpload(any()) } returns true
     every { userStore.fetchOneById(userId) } returns user
 
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -54,8 +54,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   override val user: TerrawareUser = mockUser()
 
-  private lateinit var photoStorageUrl: URI
-
   private val accessionId = AccessionId(12345)
   private val accessionNumber = "ZYXWVUTSRQPO"
   private val contentType = MediaType.IMAGE_JPEG_VALUE
@@ -67,6 +65,9 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   private val sixPixelPng: ByteArray by lazy {
     javaClass.getResourceAsStream("/file/sixPixels.png").use { it.readAllBytes() }
   }
+
+  private lateinit var organizationId: OrganizationId
+  private lateinit var photoStorageUrl: URI
 
   @BeforeEach
   fun setUp() {
@@ -99,7 +100,8 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     fileService = FileService(dslContext, clock, mockk(), filesDao, fileStore, thumbnailStore)
     repository = PhotoRepository(accessionPhotosDao, dslContext, fileService, ImageUtils(fileStore))
 
-    insertSiteData()
+    organizationId = insertOrganization()
+    insertFacility()
     insertAccession(id = accessionId, number = accessionNumber)
   }
 
@@ -276,11 +278,10 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `OrganizationDeletionStartedEvent listener deletes photos from all facilities in organization`() {
     val sameOrgAccessionId = AccessionId(2)
-    val otherOrganizationId = OrganizationId(2)
     val otherOrgAccessionId = AccessionId(3)
 
     val sameOrgFacilityId = insertFacility()
-    insertOrganization(otherOrganizationId)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
     insertAccession(id = sameOrgAccessionId, facilityId = sameOrgFacilityId)
     insertAccession(id = otherOrgAccessionId, facilityId = otherOrgFacilityId)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/WithdrawalStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.UserNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
@@ -52,10 +53,14 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
   override val tablesToResetSequences: List<Table<out Record>>
     get() = listOf(WITHDRAWALS)
 
+  private lateinit var organizationId: OrganizationId
   private val speciesId by lazy { insertSpecies(42) }
 
   @BeforeEach
   fun setup() {
+    organizationId = insertOrganization()
+    insertFacility()
+
     store = WithdrawalStore(dslContext, clock, Messages(), ParentStore(dslContext))
 
     clock.instant = Instant.ofEpochSecond(1000)
@@ -63,8 +68,6 @@ internal class WithdrawalStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadOrganization(organizationId) } returns true
     every { user.canReadOrganizationUser(organizationId, any()) } returns true
     every { user.canSetWithdrawalUser(any()) } returns true
-
-    insertSiteData()
 
     // Insert a minimal accession in a state that allows withdrawals.
     with(ACCESSIONS) {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.db.FacilityTypeMismatchException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.IDENTIFIER_SEQUENCES
@@ -247,9 +246,8 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
   @Test
   fun `throws exception if project is in different organization than facility`() {
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
-    val projectId = insertProject(organizationId = otherOrganizationId)
+    insertOrganization()
+    val projectId = insertProject()
 
     assertThrows<ProjectInDifferentOrganizationException> {
       store.create(accessionModel(projectId = projectId))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.AccessionSpeciesHasDeliveriesException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.CollectionSource
@@ -196,9 +195,8 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   @Test
   fun `update throws exception if project is in a different organization`() {
     val projectId = insertProject()
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
-    val otherOrgProjectId = insertProject(organizationId = otherOrganizationId)
+    insertOrganization()
+    val otherOrgProjectId = insertProject()
 
     val initial = store.create(accessionModel(projectId = projectId))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
-import com.terraformation.backend.db.default_schema.OrganizationId
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -52,8 +51,7 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
   @Test
   fun `update does not write to database if facility id to update does not belong to same organization as previous facility`() {
     val initialFacilityId = inserted.facilityId
-    val anotherOrgId = OrganizationId(5)
-    insertOrganization(anotherOrgId, "dev-2")
+    insertOrganization()
     val facilityIdInAnotherOrg = insertFacility()
 
     every { user.canUpdateAccession(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.seedbank.AccessionState
@@ -19,8 +18,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun countByState() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     val toCreate =
@@ -77,8 +75,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics counts seeds remaining`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     listOf(
@@ -153,7 +150,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics estimates seeds remaining by weight`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    insertOrganization(2)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     listOf(
@@ -258,7 +255,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics counts total withdrawn quantity`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    insertOrganization(2)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     listOf(
@@ -343,8 +340,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics counts unknown-quantity accessions`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    val otherOrganizationId = OrganizationId(2)
-    insertOrganization(otherOrganizationId)
+    insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     listOf(
@@ -435,7 +431,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
 
-    val otherOrganizationId = insertOrganization(2)
+    val otherOrganizationId = insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     val speciesId = SpeciesId(1)
@@ -497,7 +493,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics does not count deleted species`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
-    val otherOrganizationId = insertOrganization(2)
+    val otherOrganizationId = insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
     val speciesId = SpeciesId(1)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.customer.model.IndividualUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
@@ -64,9 +65,13 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   protected lateinit var speciesStore: SpeciesStore
 
   protected lateinit var facilityId: FacilityId
+  protected lateinit var organizationId: OrganizationId
 
   @BeforeEach
   protected fun init() {
+    organizationId = insertOrganization()
+    facilityId = insertFacility()
+
     parentStore = ParentStore(dslContext)
 
     every { user.canCreateAccession(any()) } returns true
@@ -108,9 +113,6 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
             speciesEcosystemTypesDao,
             speciesGrowthFormsDao,
             speciesProblemsDao)
-
-    insertOrganization()
-    facilityId = insertFacility()
   }
 
   protected fun createAccessionWithViabilityTest(): AccessionModel {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -173,7 +173,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val rootSeedsGerminatedField = viabilityTestResultsPrefix.resolve("seedsGerminated")
     val orgNameField =
         viabilityTestResultsPrefix.resolve("viabilityTest.accession.facility.organization.name")
-    val orgName = "Organization $organizationId"
+    val orgName = "Organization 1"
 
     val result =
         searchService.search(
@@ -199,7 +199,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val rootSeedsGerminatedField = viabilityTestResultsPrefix.resolve("seedsGerminated")
     val flattenedFieldName = "viabilityTest_accession_facility_organization_name"
     val orgNameField = viabilityTestResultsPrefix.resolve(flattenedFieldName)
-    val orgName = "Organization $organizationId"
+    val orgName = "Organization 1"
 
     val result =
         searchService.search(
@@ -966,7 +966,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             mapOf(
                 "createdTime" to "1970-01-01T00:00:00Z",
                 "facilities" to expectedFacilities,
-                "id" to "1",
+                "id" to "$organizationId",
                 "name" to "Organization 1",
                 "members" to expectedOrganizationUsers,
                 "species" to expectedSpecies,
@@ -1008,7 +1008,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
   fun `all fields are valid sort keys`() {
     val prefix = SearchFieldPrefix(tables.organizations)
 
-    val expected = listOf(mapOf("id" to "1"))
+    val expected = listOf(mapOf("id" to "$organizationId"))
     val searchFields = listOf(prefix.resolve("id"))
 
     prefix.searchTable.getAllFieldNames().forEach { fieldName ->
@@ -1061,7 +1061,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val order = listOf(SearchSortField(bagNumberField))
 
     // A facility in an org the user isn't in
-    insertOrganization(2)
+    insertOrganization()
     val otherFacilityId = insertFacility()
 
     accessionsDao.update(
@@ -1083,7 +1083,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val order = listOf(SearchSortField(seedsGerminatedField))
 
     // A facility in an org the user isn't in
-    insertOrganization(2)
+    insertOrganization()
     val otherFacilityId = insertFacility()
 
     accessionsDao.update(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServicePermissionTest.kt
@@ -13,7 +13,7 @@ internal class SearchServicePermissionTest : SearchServiceTest() {
     val memberFacilityId = inserted.facilityId
 
     // A facility in an org the user isn't in
-    insertOrganization(2)
+    insertOrganization()
     val otherFacilityId = insertFacility()
     insertAccession(facilityId = otherFacilityId)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -70,6 +71,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected lateinit var accessionId1: AccessionId
   protected lateinit var accessionId2: AccessionId
   protected lateinit var facilityId: FacilityId
+  protected lateinit var organizationId: OrganizationId
   protected lateinit var speciesId1: SpeciesId
   protected lateinit var speciesId2: SpeciesId
 
@@ -77,7 +79,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
   protected fun init() {
     searchService = SearchService(dslContext)
 
-    insertOrganization()
+    organizationId = insertOrganization()
     facilityId = insertFacility()
 
     clock.instant = Instant.parse("2020-06-15T00:00:00.00Z")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -20,7 +20,7 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
   private val organizationsPrefix = SearchFieldPrefix(tables.organizations)
   private val usersPrefix = SearchFieldPrefix(tables.users)
 
-  private val otherOrganizationId = OrganizationId(2)
+  private lateinit var otherOrganizationId: OrganizationId
   private lateinit var bothOrgsUserId: UserId
   private lateinit var otherOrgUserId: UserId
   private lateinit var deviceManagerUserId: UserId
@@ -31,10 +31,10 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
     bothOrgsUserId = insertUser()
     otherOrgUserId = insertUser()
 
-    insertOrganization(otherOrganizationId)
+    otherOrganizationId = insertOrganization()
 
-    insertOrganizationUser(deviceManagerUserId)
-    insertOrganizationUser(bothOrgsUserId, role = Role.Admin)
+    insertOrganizationUser(deviceManagerUserId, organizationId)
+    insertOrganizationUser(bothOrgsUserId, organizationId, Role.Admin)
     insertOrganizationUser(bothOrgsUserId, otherOrganizationId, Role.Admin)
     insertOrganizationUser(otherOrgUserId, otherOrganizationId)
   }

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.SpeciesInUseException
 import com.terraformation.backend.db.SpeciesNotFoundException
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
@@ -43,8 +44,12 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     SpeciesService(dslContext, eventPublisher, speciesChecker, speciesStore)
   }
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
+    organizationId = insertOrganization()
+
     every { speciesChecker.checkSpecies(any()) } just Runs
     every { speciesChecker.recheckSpecies(any(), any()) } just Runs
     every { user.canCreateSpecies(organizationId) } returns true
@@ -52,8 +57,6 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canReadSpecies(any()) } returns true
     every { user.canUpdateSpecies(any()) } returns true
     every { user.canDeleteSpecies(any()) } returns true
-
-    insertSiteData()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.UploadNotAwaitingActionException
 import com.terraformation.backend.db.default_schema.ConservationCategory
 import com.terraformation.backend.db.default_schema.EcosystemType
 import com.terraformation.backend.db.default_schema.GrowthForm
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SeedStorageBehavior
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UploadId
@@ -96,12 +97,14 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
 
   private val storageUrl = URI.create("file:///test")
   private val uploadId = UploadId(10)
+
+  private lateinit var organizationId: OrganizationId
   private lateinit var userId: UserId
 
   @BeforeEach
   fun setUp() {
     userId = user.userId
-    insertOrganization()
+    organizationId = insertOrganization()
 
     every { speciesChecker.checkAllUncheckedSpecies(organizationId) } just Runs
     every { user.canCreateSpecies(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -101,7 +101,7 @@ class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
       val oldTimeZone = ZoneId.of("America/New_York")
       val newTimeZone = ZoneId.of("America/Buenos_Aires")
 
-      insertOrganization(timeZone = oldTimeZone)
+      val organizationId = insertOrganization(timeZone = oldTimeZone)
       insertPlantingSite(timeZone = oldTimeZone)
       val plantingSiteWithoutTimeZone1 =
           plantingSiteStore.fetchSiteById(insertPlantingSite(), PlantingSiteDepth.Site)

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.ObservationStore
@@ -68,9 +69,11 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
 
   private val gen = ShapefileGenerator(defaultPermanentClusters = 1, defaultTemporaryPlots = 2)
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     insertFacility(type = FacilityType.Nursery)
     insertSpecies()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.PlantingType
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
@@ -38,7 +37,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    val organizationId = insertOrganization()
     insertOrganizationUser()
 
     every { user.organizationRoles } returns mapOf(organizationId to Role.Contributor)
@@ -352,10 +351,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `search for plots excludes planting sites in other organizations`() {
-    val otherOrganizationId = OrganizationId(2)
-
-    insertOrganization(otherOrganizationId)
-    insertPlantingSite(organizationId = otherOrganizationId)
+    insertOrganization()
+    insertPlantingSite()
     insertPlantingZone()
     insertPlantingSubzone()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.PlantingId
@@ -162,8 +161,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `requires that planting site be owned by same organization as withdrawal`() {
-      val otherOrgId = OrganizationId(2)
-      insertOrganization(otherOrgId)
+      val otherOrgId = insertOrganization()
       plantingSitesDao.update(
           plantingSitesDao.fetchOneById(plantingSiteId)!!.copy(organizationId = otherOrgId))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
@@ -37,11 +38,6 @@ import org.junit.jupiter.api.assertThrows
 class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
-  private lateinit var plantingSiteId: PlantingSiteId
-  private lateinit var plotIds: Map<String, MonitoringPlotId>
-  private lateinit var subzoneIds: Map<String, PlantingSubzoneId>
-  private lateinit var zoneIds: Map<String, PlantingZoneId>
-
   private val allSpeciesNames = mutableSetOf<String>()
   private val permanentPlotNames = mutableSetOf<String>()
   private val speciesIds = mutableMapOf<String, SpeciesId>()
@@ -66,9 +62,15 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
   }
   private val resultsStore by lazy { ObservationResultsStore(dslContext) }
 
+  private lateinit var organizationId: OrganizationId
+  private lateinit var plantingSiteId: PlantingSiteId
+  private lateinit var plotIds: Map<String, MonitoringPlotId>
+  private lateinit var subzoneIds: Map<String, PlantingSubzoneId>
+  private lateinit var zoneIds: Map<String, PlantingZoneId>
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     plantingSiteId = insertPlantingSite(areaHa = BigDecimal(2500))
 
     every { user.canReadObservation(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -76,11 +76,12 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
     ObservationTestHelper(this, store, user.userId)
   }
 
+  private lateinit var organizationId: OrganizationId
   private lateinit var plantingSiteId: PlantingSiteId
 
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     plantingSiteId = insertPlantingSite()
 
     every { user.canCreateObservation(any()) } returns true
@@ -1831,8 +1832,8 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
         insertObservationPlot(monitoringPlotId = insertMonitoringPlot())
 
         // Make sure we're actually filtering by planting site
-        val otherOrganizationId = insertOrganization(OrganizationId(2))
-        insertPlantingSite(organizationId = otherOrganizationId)
+        insertOrganization()
+        insertPlantingSite()
         insertPlantingZone()
         insertPlantingSubzone()
         insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
@@ -45,12 +46,14 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
 
   private val resourcesDir = "src/test/resources/tracking"
 
+  private lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
     every { user.canCreatePlantingSite(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
 
-    insertOrganization()
+    organizationId = insertOrganization()
     insertOrganizationUser()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -471,7 +471,7 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
 
     @Test
     fun `throws exception if no permission to update site`() {
-      val existing = store.createPlantingSite(newSite())
+      val existing = store.createPlantingSite(newSite().copy(organizationId = organizationId))
 
       every { user.canUpdatePlantingSite(any()) } returns false
 
@@ -507,7 +507,8 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
 
       // createPlantingSite doesn't create monitoring plots since they are expected to be created
       // on demand later on, so we need to create them ourselves.
-      val existingWithoutPlots = store.createPlantingSite(initial)
+      val existingWithoutPlots =
+          store.createPlantingSite(initial.copy(organizationId = organizationId))
 
       initial.plantingZones.forEach { initialZone ->
         val existingZone = existingWithoutPlots.plantingZones.single { it.name == initialZone.name }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
@@ -462,9 +461,8 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
 
     @Test
     fun `throws exception if project is in a different organization`() {
-      val otherOrganizationId = OrganizationId(2)
-      insertOrganization(otherOrganizationId)
-      val projectId = insertProject(organizationId = otherOrganizationId)
+      insertOrganization()
+      val projectId = insertProject()
 
       assertThrows<ProjectInDifferentOrganizationException> {
         store.createPlantingSite(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreMoveTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreMoveTest.kt
@@ -13,7 +13,7 @@ internal class PlantingSiteStoreMoveTest : PlantingSiteStoreTest() {
   inner class MovePlantingSite {
     @Test
     fun `updates organization ID`() {
-      val otherOrganizationId = insertOrganization(2)
+      val otherOrganizationId = insertOrganization()
       val plantingSiteId = insertPlantingSite()
       val before = plantingSitesDao.fetchOneById(plantingSiteId)!!
       val newTime = Instant.ofEpochSecond(1000)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import io.mockk.every
@@ -31,9 +32,11 @@ internal abstract class PlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
   protected lateinit var timeZone: ZoneId
 
+  protected lateinit var organizationId: OrganizationId
+
   @BeforeEach
   fun setUp() {
-    insertOrganization()
+    organizationId = insertOrganization()
     timeZone = ZoneId.of("Pacific/Honolulu")
 
     every { user.canCreatePlantingSite(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
-import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.multiPolygon
@@ -139,9 +138,8 @@ internal class PlantingSiteStoreUpdateSiteTest : PlantingSiteStoreTest() {
     @Test
     fun `throws exception if project is in a different organization`() {
       val plantingSiteId = insertPlantingSite()
-      val otherOrganizationId = OrganizationId(2)
-      insertOrganization(otherOrganizationId)
-      val otherOrgProjectId = insertProject(organizationId = otherOrganizationId)
+      insertOrganization()
+      val otherOrgProjectId = insertProject()
 
       assertThrows<ProjectInDifferentOrganizationException> {
         store.updatePlantingSite(plantingSiteId, emptyList()) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -107,7 +107,7 @@ private constructor(
   var exclusion: MultiPolygon? = null
   var gridOrigin: Point = geometryFactory.createPoint(boundary.envelope.coordinates[0])
   var name: String = "Site"
-  var organizationId: OrganizationId = OrganizationId(1)
+  var organizationId: OrganizationId = OrganizationId(-1)
 
   private var currentSubzoneId: Long = 0
   private var currentZoneId: Long = 0


### PR DESCRIPTION
As a step toward being able to run tests in parallel, eliminate all the
hardwired organization IDs from tests, with the exception of `PermissionTest`
which will be updated separately.

This is a somewhat large change because a lot of tests used to use the default
organization ID from `DatabaseBackedTest`, which no longer exists. All the
insert methods that take organization ID arguments now default to using the
most recently inserted organization ID instead; in some places this means we
can get rid of explicit organization ID arguments at call sites.

The organization ID arguments of the various insert methods are now required
to be of type `OrganizationId` since there's no longer a valid reason to use
numeric literals.