### PR TITLE
SW-5813 Include requested subzones in observation API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -370,6 +370,12 @@ data class ObservationPayload(
     val numUnclaimedPlots: Int,
     val plantingSiteId: PlantingSiteId,
     val plantingSiteName: String,
+    @ArraySchema(
+        arraySchema =
+            Schema(
+                description =
+                    "If specific subzones were requested for this observation, their IDs."))
+    val requestedSubzoneIds: Set<PlantingSubzoneId>?,
     @Schema(description = "Date this observation started.") //
     val startDate: LocalDate,
     val state: ObservationState,
@@ -386,6 +392,7 @@ data class ObservationPayload(
       numUnclaimedPlots = counts?.totalUnclaimed ?: 0,
       plantingSiteId = model.plantingSiteId,
       plantingSiteName = plantingSiteName,
+      requestedSubzoneIds = model.requestedSubzoneIds.ifEmpty { null },
       startDate = model.startDate,
       state = model.state,
   )


### PR DESCRIPTION
Add a `requestedSubzoneIds` field to the observation response payloads so clients
can see which observations were requested for which subzones.