### PR TITLE
SW-5795 Use dynamic device and automation IDs in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -40,8 +40,6 @@ import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
-import com.terraformation.backend.db.default_schema.AutomationId
-import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -363,15 +361,13 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store sensor bounds alert notification`() {
-    val automationId = AutomationId(1)
-    val deviceId = DeviceId(1)
     val timeseriesName = "test timeseries"
     val facilityName = "Facility 1"
     val badValue = 5.678
 
     insertOrganizationUser()
-    insertDevice(deviceId)
-    insertAutomation(automationId, deviceId = deviceId, timeseriesName = timeseriesName)
+    val deviceId = insertDevice()
+    val automationId = insertAutomation(timeseriesName = timeseriesName)
 
     every {
       messages.sensorBoundsAlert(
@@ -389,14 +385,14 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store unknown automation triggered notification`() {
-    val automationId = AutomationId(1)
     val automationName = "automation name"
     val automationType = "unknown"
     val facilityName = "Facility 1"
     val message = "message"
 
     insertOrganizationUser()
-    insertAutomation(automationId, name = automationName, type = automationType, deviceId = null)
+    val automationId =
+        insertAutomation(name = automationName, type = automationType, deviceId = null)
 
     val title = "Automation $automationId triggered at $facilityName"
     every { messages.unknownAutomationTriggered(automationName, facilityName, message) } returns
@@ -413,11 +409,10 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `should store device unresponsive notification`() {
-    val deviceId = DeviceId(1)
     val deviceName = "test device"
+    val deviceId = insertDevice(name = deviceName, type = "sensor")
 
     insertOrganizationUser()
-    insertDevice(deviceId, name = deviceName, type = "sensor")
 
     every { messages.deviceUnresponsive(deviceName) } returns
         NotificationMessage("unresponsive title", "unresponsive body")

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -6,8 +6,6 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.default_schema.AutomationId
-import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.*
@@ -23,27 +21,22 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
     AutomationStore(automationsDao, clock, dslContext, objectMapper, ParentStore(dslContext))
   }
 
-  private val deviceId = DeviceId(1000)
-
   @BeforeEach
   fun setUp() {
     every { user.canListAutomations(any()) } returns true
     every { user.canReadDevice(any()) } returns true
 
     insertSiteData()
-    insertDevice(deviceId)
   }
 
   @Test
   fun `fetchByDeviceId filters by device ID`() {
-    val otherDeviceId = DeviceId(1001)
+    val deviceId = insertDevice()
+    val automationId = insertAutomation()
+    insertDevice()
+    insertAutomation()
 
-    insertDevice(otherDeviceId)
-
-    insertAutomation(1, deviceId = deviceId)
-    insertAutomation(2, deviceId = otherDeviceId)
-
-    val expectedRow = automationsDao.fetchOneById(AutomationId(1))!!
+    val expectedRow = automationsDao.fetchOneById(automationId)!!
     val expected = listOf(AutomationModel(expectedRow, objectMapper))
     val actual = store.fetchByDeviceId(deviceId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.SubLocationInUseException
 import com.terraformation.backend.db.SubLocationNameExistsException
-import com.terraformation.backend.db.default_schema.DeviceId
 import com.terraformation.backend.db.default_schema.FacilityConnectionState
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -238,8 +237,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateLastTimeseriesTimes resets idle timestamps`() {
-    val deviceId = DeviceId(1)
-    insertDevice(deviceId)
+    val deviceId = insertDevice()
 
     val initial = facilitiesDao.fetchOneById(facilityId)!!
     facilitiesDao.update(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -917,10 +917,11 @@ abstract class DatabaseBackedTest {
     deliverableProjectDueDatesDao.insert(row)
   }
 
+  private var nextDeviceNumber = 1
+
   protected fun insertDevice(
-      id: Any? = null,
       facilityId: FacilityId = inserted.facilityId,
-      name: String = "device $id",
+      name: String = "device ${nextDeviceNumber++}",
       createdBy: UserId = currentUser().userId,
       type: String = "type"
   ): DeviceId {
@@ -930,8 +931,7 @@ abstract class DatabaseBackedTest {
           .set(ADDRESS, "address")
           .set(CREATED_BY, createdBy)
           .set(DEVICE_TYPE, type)
-          .set(FACILITY_ID, facilityId.toIdWrapper { FacilityId(it) })
-          .apply { id?.toIdWrapper { DeviceId(it) }?.let { set(ID, it) } }
+          .set(FACILITY_ID, facilityId)
           .set(MAKE, "make")
           .set(MODEL, "model")
           .set(MODIFIED_BY, createdBy)
@@ -943,10 +943,11 @@ abstract class DatabaseBackedTest {
     }
   }
 
+  var nextAutomationNumber = 1
+
   protected fun insertAutomation(
-      id: Any? = null,
       facilityId: FacilityId = inserted.facilityId,
-      name: String = "automation $id",
+      name: String = "automation ${nextAutomationNumber++}",
       type: String = AutomationModel.SENSOR_BOUNDS_TYPE,
       deviceId: Any? = inserted.deviceId,
       timeseriesName: String? = "timeseries",
@@ -961,7 +962,6 @@ abstract class DatabaseBackedTest {
           .set(CREATED_TIME, Instant.EPOCH)
           .set(DEVICE_ID, deviceId?.toIdWrapper { DeviceId(it) })
           .set(FACILITY_ID, facilityId.toIdWrapper { FacilityId(it) })
-          .apply { id?.toIdWrapper { AutomationId(it) }?.let { set(ID, it) } }
           .set(LOWER_THRESHOLD, lowerThreshold)
           .set(MODIFIED_BY, createdBy)
           .set(MODIFIED_TIME, Instant.EPOCH)

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -32,8 +32,7 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
   private lateinit var store: TimeseriesStore
 
-  private val deviceId = DeviceId(1)
-
+  private lateinit var deviceId: DeviceId
   private lateinit var timeseriesRow: TimeseriesRow
 
   @BeforeEach
@@ -41,7 +40,7 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
     store = TimeseriesStore(clock, dslContext)
 
     insertSiteData()
-    insertDevice(deviceId)
+    deviceId = insertDevice()
 
     every { user.canCreateTimeseries(any()) } returns true
     every { user.canReadDevice(any()) } returns true


### PR DESCRIPTION
Remove the ability to insert devices and automations with fixed IDs in tests
using the insert helper methods.