### PR TITLE
SW-5780 Remove sequence reset from NotificationStoreTest

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
@@ -105,9 +105,12 @@ class NotificationStore(
    *   notifications, the organization id in the notification model will be null, hence this
    *   additional organization id parameter to capture context.
    */
-  fun create(notification: CreateNotificationModel, targetOrganizationId: OrganizationId) {
+  fun create(
+      notification: CreateNotificationModel,
+      targetOrganizationId: OrganizationId
+  ): NotificationId {
     requirePermissions { createNotification(notification.userId, targetOrganizationId) }
-    with(NOTIFICATIONS) {
+    return with(NOTIFICATIONS) {
       with(notification) {
         dslContext
             .insertInto(NOTIFICATIONS)
@@ -118,7 +121,8 @@ class NotificationStore(
             .set(BODY, body)
             .set(LOCAL_URL, localUrl)
             .set(CREATED_TIME, clock.instant())
-            .execute()
+            .returning(ID)
+            .fetchOne(ID)!!
       }
     }
   }


### PR DESCRIPTION
As a step toward supporting parallel test execution, remove the sequence resetting
and the reliance on specific hardwired IDs from NotificationStoreTest. This
requires changing NotificationStore.create to return the ID of the newly-inserted
notification.