### PR TITLE
SW-5795 Unique cohort and participant names in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -16,6 +16,7 @@ import io.mockk.every
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
+import java.util.UUID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -75,11 +76,12 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       val now = Instant.ofEpochSecond(30)
       clock.instant = now
 
-      val cohortId1 = insertCohort(id = 1)
-      val cohortId2 = insertCohort(id = 2)
-      val participantId1 = insertParticipant(id = 1, cohortId = cohortId1)
-      val participantId2 = insertParticipant(id = 2, cohortId = cohortId1)
-      val participantId3 = insertParticipant(id = 3, cohortId = cohortId2)
+      val suffix = "${UUID.randomUUID()}"
+      val cohortId1 = insertCohort()
+      val cohortId2 = insertCohort()
+      val participantId1 = insertParticipant(cohortId = cohortId1, name = "Participant 1 $suffix")
+      val participantId2 = insertParticipant(cohortId = cohortId1, name = "Participant 2 $suffix")
+      val participantId3 = insertParticipant(cohortId = cohortId2, name = "Participant 3 $suffix")
 
       val organizationId1 = insertOrganization()
       val organizationId2 = insertOrganization()
@@ -137,7 +139,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
       fun DeliverableSubmissionModel.forProject2() =
           copy(
               participantId = participantId2,
-              participantName = "Participant 2",
+              participantName = "Participant 2 $suffix",
               projectId = projectId2,
               projectName = "Project 2",
           )
@@ -147,7 +149,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
               organizationId = organizationId2,
               organizationName = "Organization 2",
               participantId = participantId1,
-              participantName = "Participant 1",
+              participantName = "Participant 1 $suffix",
               projectId = projectId3,
               projectName = "Project 3",
           )
@@ -159,7 +161,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
               organizationId = organizationId2,
               organizationName = "Organization 2",
               participantId = participantId3,
-              participantName = "Participant 3",
+              participantName = "Participant 3 $suffix",
               projectId = projectId4,
               projectName = "Project 4",
           )
@@ -209,7 +211,7 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
               organizationId = organizationId1,
               organizationName = "Organization 1",
               participantId = participantId1,
-              participantName = "Participant 1",
+              participantName = "Participant 1 $suffix",
               projectId = projectId1,
               projectName = "Project 1",
               status = SubmissionStatus.InReview,
@@ -400,11 +402,11 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `returns due dates according to cohort or project overrides`() {
-      val cohortWithDueDate = insertCohort(id = 1)
-      val cohortWithoutDueDate = insertCohort(id = 2)
+      val cohortWithDueDate = insertCohort()
+      val cohortWithoutDueDate = insertCohort()
 
-      val participantWithDueDate = insertParticipant(id = 1, cohortId = cohortWithDueDate)
-      val participantWithoutDueDate = insertParticipant(id = 3, cohortId = cohortWithoutDueDate)
+      val participantWithDueDate = insertParticipant(cohortId = cohortWithDueDate)
+      val participantWithoutDueDate = insertParticipant(cohortId = cohortWithoutDueDate)
 
       val moduleId = insertModule(id = 1)
       val deliverableId = insertDeliverable(id = 1, moduleId = 1)

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -92,6 +92,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.util.Locale
+import java.util.UUID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
@@ -807,7 +808,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store species added to project notification`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
-    val participantId = insertParticipant()
+    val participantName = "Participant ${UUID.randomUUID()}"
+    val participantId = insertParticipant(name = participantName)
     val projectId = insertProject(participantId = participantId)
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
@@ -815,7 +817,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val deliverableId = insertDeliverable()
 
     every {
-      messages.participantProjectSpeciesAddedToProject("Participant 1", "Project 1", "Species 1")
+      messages.participantProjectSpeciesAddedToProject(participantName, "Project 1", "Species 1")
     } returns NotificationMessage("species added title", "species added body")
 
     service.on(
@@ -834,7 +836,8 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `should store species approved species edited notification`() {
     insertUserGlobalRole(user.userId, GlobalRole.TFExpert)
-    val participantId = insertParticipant()
+    val participantName = "Participant ${UUID.randomUUID()}"
+    val participantId = insertParticipant(name = participantName)
     val projectId = insertProject(participantId = participantId)
     val speciesId = insertSpecies()
     insertParticipantProjectSpecies(projectId = projectId, speciesId = speciesId)
@@ -842,7 +845,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     val deliverableId = insertDeliverable()
 
     every {
-      messages.participantProjectSpeciesApprovedSpeciesEdited("Participant 1", "Species 1")
+      messages.participantProjectSpeciesApprovedSpeciesEdited(participantName, "Species 1")
     } returns NotificationMessage("species edited title", "species edited body")
 
     service.on(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2344,22 +2344,18 @@ abstract class DatabaseBackedTest {
     applicationModulesDao.insert(row)
   }
 
-  private var nextParticipantNumber = 1
-
   fun insertParticipant(
-      id: Any? = null,
-      name: String = "Participant ${nextParticipantNumber++}",
-      createdBy: Any = currentUser().userId,
+      name: String = "Participant ${UUID.randomUUID()}",
+      createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      cohortId: Any? = null,
+      cohortId: CohortId? = null,
   ): ParticipantId {
     val row =
         ParticipantsRow(
-            cohortId = cohortId?.toIdWrapper { CohortId(it) },
-            createdBy = createdBy.toIdWrapper { UserId(it) },
+            cohortId = cohortId,
+            createdBy = createdBy,
             createdTime = createdTime,
-            id = id?.toIdWrapper { ParticipantId(it) },
-            modifiedBy = createdBy.toIdWrapper { UserId(it) },
+            modifiedBy = createdBy,
             modifiedTime = createdTime,
             name = name,
         )
@@ -2403,21 +2399,17 @@ abstract class DatabaseBackedTest {
     return row.id!!.also { inserted.participantProjectSpeciesIds.add(it) }
   }
 
-  private var nextCohortNumber = 1
-
   fun insertCohort(
-      id: Any? = null,
-      name: String = "Cohort ${nextCohortNumber++}",
+      name: String = "Cohort ${UUID.randomUUID()}",
       phase: CohortPhase = CohortPhase.Phase0DueDiligence,
-      createdBy: Any = currentUser().userId,
+      createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
   ): CohortId {
     val row =
         CohortsRow(
-            createdBy = createdBy.toIdWrapper { UserId(it) },
+            createdBy = createdBy,
             createdTime = createdTime,
-            id = id?.toIdWrapper { CohortId(it) },
-            modifiedBy = createdBy.toIdWrapper { UserId(it) },
+            modifiedBy = createdBy,
             modifiedTime = createdTime,
             name = name,
             phaseId = phase,


### PR DESCRIPTION
Cohort and participant IDs and names are required to be globally unique, which
causes problems if two tests run concurrently and both try to insert using the
existing "start with a suffix of 1" naming strategy.

For IDs, switch to dynamically-allocated ones and remove the ability to insert
hardwired IDs.

For names, use random UUID suffixes instead of simple numbers; these should be
sufficiently unique such that the chances of a collision in a single test run
are effectively zero.