### PR TITLE
SW-5605 Make in-memory test doubles thread-safe

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/TestClock.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestClock.kt
@@ -11,9 +11,21 @@ import java.time.ZoneOffset
 @Named
 @Priority(2)
 class TestClock(
-    var instant: Instant = Instant.EPOCH,
+    private val initialInstant: Instant = Instant.EPOCH,
     private val zone: ZoneId = ZoneOffset.UTC,
 ) : Clock(), BeanTestDouble {
+  /**
+   * The clock's current value is tracked per thread since two tests running in parallel could share
+   * the same Spring-managed instance of this class, and they shouldn't interact with each other.
+   */
+  private val threadInstant = ThreadLocal.withInitial { initialInstant }
+
+  var instant: Instant
+    get() = threadInstant.get()
+    set(value) {
+      threadInstant.set(value)
+    }
+
   override fun instant(): Instant = instant
 
   override fun withZone(zone: ZoneId): Clock = TestClock(instant, zone)
@@ -21,6 +33,6 @@ class TestClock(
   override fun getZone(): ZoneId = zone
 
   override fun resetState() {
-    instant = Instant.EPOCH
+    threadInstant.remove()
   }
 }


### PR DESCRIPTION
In tests such as controller tests that use Spring-managed dependencies, there is a
single instance of each class that's shared between test threads. This works fine
for stateless classes (which our application code tends to be) but less well for
a couple of in-memory test doubles that allow tests to modify their state.

Update the classes to keep their state in thread-local variables so concurrent
tests won't interfere with each other.