### PR TITLE
SW-5780 Use dynamic IDs in search tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -7,9 +7,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.PlantingType
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.polygon
@@ -29,7 +26,6 @@ import org.locationtech.jts.geom.Geometry
 
 class TrackingSearchTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
-  override val tablesToResetSequences = listOf(PLANTING_SITES, PLANTING_ZONES, PLANTING_SUBZONES)
 
   private val clock = TestClock()
   private val searchService: SearchService by lazy { SearchService(dslContext) }
@@ -59,29 +55,31 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         insertPlantingSite(
             boundary = plantingSiteGeometry, exclusion = exclusionGeometry, projectId = projectId)
 
-    insertPlantingSeason(
-        id = 1,
-        startDate = LocalDate.of(1970, 1, 1),
-        endDate = LocalDate.of(1970, 2, 15),
-        isActive = true)
-    insertPlantingSeason(
-        id = 2, startDate = LocalDate.of(1970, 3, 1), endDate = LocalDate.of(1970, 6, 5))
+    val plantingSeasonId1 =
+        insertPlantingSeason(
+            startDate = LocalDate.of(1970, 1, 1),
+            endDate = LocalDate.of(1970, 2, 15),
+            isActive = true)
+    val plantingSeasonId2 =
+        insertPlantingSeason(
+            startDate = LocalDate.of(1970, 3, 1), endDate = LocalDate.of(1970, 6, 5))
 
-    insertPlantingZone(boundary = plantingZoneGeometry, id = 2)
+    val plantingZoneId2 = insertPlantingZone(boundary = plantingZoneGeometry, name = "Z2")
 
-    insertPlantingSubzone(boundary = plantingSubzoneGeometry3, id = 3)
-    insertMonitoringPlot(boundary = monitoringPlotGeometry5, id = 5)
-    insertMonitoringPlot(boundary = monitoringPlotGeometry6, id = 6)
+    val plantingSubzoneId3 = insertPlantingSubzone(boundary = plantingSubzoneGeometry3, name = "3")
+    val monitoringPlotId5 = insertMonitoringPlot(boundary = monitoringPlotGeometry5)
+    val monitoringPlotId6 = insertMonitoringPlot(boundary = monitoringPlotGeometry6)
 
-    insertPlantingSubzone(
-        boundary = plantingSubzoneGeometry4,
-        plantingCompletedTime = Instant.ofEpochSecond(1),
-        id = 4)
-    insertMonitoringPlot(boundary = monitoringPlotGeometry7, id = 7)
-    insertMonitoringPlot(boundary = monitoringPlotGeometry8, id = 8)
+    val plantingSubzoneId4 =
+        insertPlantingSubzone(
+            boundary = plantingSubzoneGeometry4,
+            plantingCompletedTime = Instant.ofEpochSecond(1),
+            name = "4")
+    val monitoringPlotId7 = insertMonitoringPlot(boundary = monitoringPlotGeometry7)
+    val monitoringPlotId8 = insertMonitoringPlot(boundary = monitoringPlotGeometry8)
 
-    val speciesId1 = insertSpecies(1)
-    val speciesId2 = insertSpecies(2)
+    val speciesId1 = insertSpecies()
+    val speciesId2 = insertSpecies()
 
     insertFacility(type = FacilityType.Nursery)
 
@@ -89,33 +87,39 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val deliveryId1 = insertDelivery(plantingSiteId = plantingSiteId)
     insertWithdrawal()
 
-    val plantingId1 = insertPlanting(numPlants = 1, plantingSubzoneId = 3, speciesId = speciesId1)
+    val plantingId1 =
+        insertPlanting(
+            numPlants = 1, plantingSubzoneId = plantingSubzoneId3, speciesId = speciesId1)
 
     val plantingId3 =
         insertPlanting(
             numPlants = -2,
             plantingTypeId = PlantingType.ReassignmentFrom,
-            plantingSubzoneId = 3,
+            plantingSubzoneId = plantingSubzoneId3,
             speciesId = speciesId1)
     val plantingId4 =
         insertPlanting(
             numPlants = 2,
             plantingTypeId = PlantingType.ReassignmentTo,
-            plantingSubzoneId = 4,
+            plantingSubzoneId = plantingSubzoneId4,
             speciesId = speciesId1)
-    val plantingId5 = insertPlanting(numPlants = 8, plantingSubzoneId = 4, speciesId = speciesId2)
+    val plantingId5 =
+        insertPlanting(
+            numPlants = 8, plantingSubzoneId = plantingSubzoneId4, speciesId = speciesId2)
     val deliveryId2 = insertDelivery(plantingSiteId = plantingSiteId)
-    val plantingId2 = insertPlanting(numPlants = 4, plantingSubzoneId = 3, speciesId = speciesId1)
+    val plantingId2 =
+        insertPlanting(
+            numPlants = 4, plantingSubzoneId = plantingSubzoneId3, speciesId = speciesId1)
 
     // These population numbers are arbitrary; we just need them to be unique to test that the
     // searches are querying the right columns from the right tables.
     insertPlantingSitePopulation(plantingSiteId, speciesId1, 2, 1)
     insertPlantingSitePopulation(plantingSiteId, speciesId2, 4, 3)
-    insertPlantingZonePopulation(2, speciesId1, 6, 5)
-    insertPlantingZonePopulation(2, speciesId2, 8, 7)
-    insertPlantingSubzonePopulation(3, speciesId1, 10, 9)
-    insertPlantingSubzonePopulation(4, speciesId1, 12, 11)
-    insertPlantingSubzonePopulation(4, speciesId2, 14, 13)
+    insertPlantingZonePopulation(plantingZoneId2, speciesId1, 6, 5)
+    insertPlantingZonePopulation(plantingZoneId2, speciesId2, 8, 7)
+    insertPlantingSubzonePopulation(plantingSubzoneId3, speciesId1, 10, 9)
+    insertPlantingSubzonePopulation(plantingSubzoneId4, speciesId1, 12, 11)
+    insertPlantingSubzonePopulation(plantingSubzoneId4, speciesId2, 14, 13)
 
     val expected =
         SearchResults(
@@ -181,7 +185,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                             ),
                         ),
                     "exclusion" to postgisRenderGeoJson(exclusionGeometry),
-                    "id" to "1",
+                    "id" to "$plantingSiteId",
                     "modifiedTime" to "1970-01-01T00:00:00Z",
                     "name" to "Site 1",
                     "numPlantingZones" to "1",
@@ -190,13 +194,13 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                         listOf(
                             mapOf(
                                 "endDate" to "1970-02-15",
-                                "id" to "1",
+                                "id" to "$plantingSeasonId1",
                                 "isActive" to "true",
                                 "startDate" to "1970-01-01",
                             ),
                             mapOf(
                                 "endDate" to "1970-06-05",
-                                "id" to "2",
+                                "id" to "$plantingSeasonId2",
                                 "isActive" to "false",
                                 "startDate" to "1970-03-01",
                             ),
@@ -206,7 +210,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                             mapOf(
                                 "boundary" to postgisRenderGeoJson(plantingZoneGeometry),
                                 "createdTime" to "1970-01-01T00:00:00Z",
-                                "id" to "2",
+                                "id" to "$plantingZoneId2",
                                 "modifiedTime" to "1970-01-01T00:00:00Z",
                                 "name" to "Z2",
                                 "plantingSubzones" to
@@ -216,7 +220,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                 postgisRenderGeoJson(plantingSubzoneGeometry3),
                                             "createdTime" to "1970-01-01T00:00:00Z",
                                             "fullName" to "Z1-3",
-                                            "id" to "3",
+                                            "id" to "$plantingSubzoneId3",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "3",
                                             "totalPlants" to "10",
@@ -224,17 +228,19 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                 listOf(
                                                     mapOf(
                                                         "plantsSinceLastObservation" to "9",
-                                                        "species_id" to "1",
+                                                        "species_id" to "$speciesId1",
                                                         "totalPlants" to "10",
                                                     )),
                                             "monitoringPlots" to
-                                                listOf(mapOf("id" to "5"), mapOf("id" to "6"))),
+                                                listOf(
+                                                    mapOf("id" to "$monitoringPlotId5"),
+                                                    mapOf("id" to "$monitoringPlotId6"))),
                                         mapOf(
                                             "boundary" to
                                                 postgisRenderGeoJson(plantingSubzoneGeometry4),
                                             "createdTime" to "1970-01-01T00:00:00Z",
                                             "fullName" to "Z1-4",
-                                            "id" to "4",
+                                            "id" to "$plantingSubzoneId4",
                                             "modifiedTime" to "1970-01-01T00:00:00Z",
                                             "name" to "4",
                                             "plantingCompletedTime" to "1970-01-01T00:00:01Z",
@@ -243,38 +249,40 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                 listOf(
                                                     mapOf(
                                                         "plantsSinceLastObservation" to "11",
-                                                        "species_id" to "1",
+                                                        "species_id" to "$speciesId1",
                                                         "totalPlants" to "12",
                                                     ),
                                                     mapOf(
                                                         "plantsSinceLastObservation" to "13",
-                                                        "species_id" to "2",
+                                                        "species_id" to "$speciesId2",
                                                         "totalPlants" to "14",
                                                     )),
                                             "monitoringPlots" to
-                                                listOf(mapOf("id" to "7"), mapOf("id" to "8")))),
+                                                listOf(
+                                                    mapOf("id" to "$monitoringPlotId7"),
+                                                    mapOf("id" to "$monitoringPlotId8")))),
                                 "populations" to
                                     listOf(
                                         mapOf(
                                             "plantsSinceLastObservation" to "5",
-                                            "species_id" to "1",
+                                            "species_id" to "$speciesId1",
                                             "totalPlants" to "6",
                                         ),
                                         mapOf(
                                             "plantsSinceLastObservation" to "7",
-                                            "species_id" to "2",
+                                            "species_id" to "$speciesId2",
                                             "totalPlants" to "8",
                                         )))),
                     "populations" to
                         listOf(
                             mapOf(
                                 "plantsSinceLastObservation" to "1",
-                                "species_id" to "1",
+                                "species_id" to "$speciesId1",
                                 "totalPlants" to "2",
                             ),
                             mapOf(
                                 "plantsSinceLastObservation" to "3",
-                                "species_id" to "2",
+                                "species_id" to "$speciesId2",
                                 "totalPlants" to "4",
                             )),
                     "project" to


### PR DESCRIPTION
Replace hardwired IDs in the nursery and tracking search tests with dynamic ones.