### PR TITLE
Remove DatabaseBackedTest.insertSiteData()

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -128,7 +128,8 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateBatch(any()) } returns true
     every { user.canUpdatePlantingSite(any()) } returns true
 
-    insertSiteData()
+    insertOrganization()
+    insertFacility()
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/AutomationStoreTest.kt
@@ -26,7 +26,8 @@ internal class AutomationStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canListAutomations(any()) } returns true
     every { user.canReadDevice(any()) } returns true
 
-    insertSiteData()
+    insertOrganization()
+    insertFacility()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -606,15 +606,6 @@ abstract class DatabaseBackedTest {
   protected val withdrawalPhotosDao: WithdrawalPhotosDao by lazyDao()
   protected val withdrawalsDao: WithdrawalsDao by lazyDao()
 
-  /**
-   * Creates a user, organization, project, site, and facility that can be referenced by various
-   * tests.
-   */
-  fun insertSiteData() {
-    insertOrganization()
-    insertFacility()
-  }
-
   private var nextOrganizationNumber = 1
 
   protected fun insertOrganization(

--- a/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/BalenaPollerTest.kt
@@ -38,7 +38,8 @@ internal class BalenaPollerTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     every { balenaClient.listModifiedDevices(any()) } returns emptyList()
 
-    insertSiteData()
+    insertOrganization()
+    insertFacility()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/DeviceManagerStoreTest.kt
@@ -39,7 +39,7 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canUpdateDeviceManager(any()) } returns true
     every { user.canUpdateFacility(any()) } returns true
 
-    insertSiteData()
+    insertOrganization()
   }
 
   @Test
@@ -110,6 +110,8 @@ internal class DeviceManagerStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `insert throws exception if facility ID specified and user cannot update facility`() {
+    insertFacility()
+
     every { user.canUpdateFacility(inserted.facilityId) } returns false
 
     assertThrows<AccessDeniedException> {

--- a/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/db/TimeseriesStoreTest.kt
@@ -39,7 +39,8 @@ internal class TimeseriesStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     store = TimeseriesStore(clock, dslContext)
 
-    insertSiteData()
+    insertOrganization()
+    insertFacility()
     deviceId = insertDevice()
 
     every { user.canCreateTimeseries(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/AccessionServiceSearchSummaryTest.kt
@@ -60,8 +60,9 @@ internal class AccessionServiceSearchSummaryTest : DatabaseTest(), RunsAsUser {
 
   @BeforeEach
   fun setUp() {
-    insertSiteData()
+    insertOrganization()
     insertOrganizationUser()
+    insertFacility()
 
     every { user.facilityRoles } returns mapOf(inserted.facilityId to Role.Contributor)
   }


### PR DESCRIPTION
This function was convenient when the setup process for database-backed tests was
more complex and required inserting rows into several tables with fixed IDs, but
it's now so simple as to not be worth the reduction in clarity in the tests.