### PR TITLE
SW-5795 Use dynamic accession IDs in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1337,6 +1337,8 @@ abstract class DatabaseBackedTest {
     }
   }
 
+  private var nextAccessionNumber = 1
+
   /**
    * Inserts a new accession with reasonable defaults for required fields.
    *
@@ -1351,11 +1353,10 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       dataSourceId: DataSource = row.dataSourceId ?: DataSource.Web,
-      facilityId: Any = row.facilityId ?: inserted.facilityId,
-      id: Any? = row.id,
+      facilityId: FacilityId = row.facilityId ?: inserted.facilityId,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
-      number: String? = row.number ?: id?.let { "$it" },
+      number: String? = row.number ?: "${nextAccessionNumber++}",
       receivedDate: LocalDate? = row.receivedDate,
       stateId: AccessionState = row.stateId ?: AccessionState.Processing,
       treesCollectedFrom: Int? = row.treesCollectedFrom,
@@ -1365,8 +1366,7 @@ abstract class DatabaseBackedTest {
             createdBy = createdBy,
             createdTime = createdTime,
             dataSourceId = dataSourceId,
-            facilityId = facilityId.toIdWrapper { FacilityId(it) },
-            id = id?.toIdWrapper { AccessionId(it) },
+            facilityId = facilityId,
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             number = number,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -54,7 +54,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   override val user: TerrawareUser = mockUser()
 
-  private val accessionId = AccessionId(12345)
   private val accessionNumber = "ZYXWVUTSRQPO"
   private val contentType = MediaType.IMAGE_JPEG_VALUE
   private val filename = "test-photo.jpg"
@@ -66,6 +65,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     javaClass.getResourceAsStream("/file/sixPixels.png").use { it.readAllBytes() }
   }
 
+  private lateinit var accessionId: AccessionId
   private lateinit var organizationId: OrganizationId
   private lateinit var photoStorageUrl: URI
 
@@ -102,7 +102,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
     organizationId = insertOrganization()
     insertFacility()
-    insertAccession(id = accessionId, number = accessionNumber)
+    accessionId = insertAccession(number = accessionNumber)
   }
 
   @Test
@@ -277,14 +277,11 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `OrganizationDeletionStartedEvent listener deletes photos from all facilities in organization`() {
-    val sameOrgAccessionId = AccessionId(2)
-    val otherOrgAccessionId = AccessionId(3)
-
-    val sameOrgFacilityId = insertFacility()
+    insertFacility()
+    val sameOrgAccessionId = insertAccession()
     insertOrganization()
-    val otherOrgFacilityId = insertFacility()
-    insertAccession(id = sameOrgAccessionId, facilityId = sameOrgFacilityId)
-    insertAccession(id = otherOrgAccessionId, facilityId = otherOrgFacilityId)
+    insertFacility()
+    val otherOrgAccessionId = insertAccession()
 
     listOf(accessionId, sameOrgAccessionId, otherOrgAccessionId).forEach { photoAccessionId ->
       val filesRow =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
@@ -1,22 +1,18 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.BagId
-import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 internal class AccessionStoreBagTest : AccessionStoreTest() {
   @Test
   fun `bag numbers are not shared between accessions`() {
     val payload = accessionModel(bagNumbers = setOf("bag 1", "bag 2"))
-    store.create(payload)
-    store.create(payload)
+    val accessionId1 = store.create(payload).id!!
+    val accessionId2 = store.create(payload).id!!
 
-    val initialBags = bagsDao.fetchByAccessionId(AccessionId(1)).toSet()
-    val secondBags = bagsDao.fetchByAccessionId(AccessionId(2)).toSet()
+    val initialBags = bagsDao.fetchByAccessionId(accessionId1).toSet()
+    val secondBags = bagsDao.fetchByAccessionId(accessionId2).toSet()
 
     assertNotEquals(initialBags, secondBags)
   }
@@ -24,22 +20,26 @@ internal class AccessionStoreBagTest : AccessionStoreTest() {
   @Test
   fun `bags are inserted and deleted as needed`() {
     val initial = store.create(accessionModel(bagNumbers = setOf("bag 1", "bag 2")))
-    val initialBags = bagsDao.fetchByAccessionId(AccessionId(1))
+    val accessionId = initial.id!!
+    val initialBags = bagsDao.fetchByAccessionId(accessionId)
 
-    // Insertion order is not defined by the API, so don't assume bag ID 1 is "bag 1".
-
-    assertEquals(setOf(BagId(1), BagId(2)), initialBags.map { it.id }.toSet(), "Initial bag IDs")
     assertEquals(
         setOf("bag 1", "bag 2"), initialBags.map { it.bagNumber }.toSet(), "Initial bag numbers")
+
+    val bag1Id = initialBags.first { it.bagNumber == "bag 1" }.id!!
+    val bag2Id = initialBags.first { it.bagNumber == "bag 2" }.id!!
 
     val desired = initial.copy(bagNumbers = setOf("bag 2", "bag 3"))
 
     store.update(desired)
 
-    val updatedBags = bagsDao.fetchByAccessionId(AccessionId(1))
+    val updatedBags = bagsDao.fetchByAccessionId(accessionId)
+    val bag3Id = updatedBags.first { it.bagNumber == "bag 3" }.id!!
 
-    assertTrue(BagsRow(BagId(3), AccessionId(1), "bag 3") in updatedBags, "New bag inserted")
-    assertTrue(updatedBags.none { it.bagNumber == "bag 1" }, "Missing bag deleted")
+    assertNotEquals(bag1Id, bag3Id, "Should not have reused bag 1 ID")
+    assertNotEquals(bag2Id, bag3Id, "Should not have reused bag 2 ID")
+    assertEquals(
+        emptyList<Any>(), updatedBags.filter { it.bagNumber == "bag 1" }, "Missing bag not deleted")
     assertEquals(
         initialBags.filter { it.bagNumber == "bag 2" },
         updatedBags.filter { it.bagNumber == "bag 2" },

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
@@ -26,7 +25,7 @@ internal class AccessionStoreCheckInTest : AccessionStoreTest() {
     assertEquals(
         listOf(
             AccessionStateHistoryRow(
-                accessionId = AccessionId(1),
+                accessionId = initial.id,
                 newStateId = AccessionState.AwaitingProcessing,
                 oldStateId = AccessionState.AwaitingCheckIn,
                 reason = "Accession has been checked in",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -1,7 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.seedbank.AccessionId
-import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryId
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
@@ -40,10 +38,9 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
                 createdBy = user.userId,
                 createdTime = Instant.EPOCH,
                 historyTypeId = AccessionQuantityHistoryType.Observed,
-                id = AccessionQuantityHistoryId(1),
                 remainingQuantity = BigDecimal.TEN,
                 remainingUnitsId = SeedQuantityUnits.Seeds)),
-        accessionQuantityHistoryDao.findAll())
+        accessionQuantityHistoryDao.findAll().map { it.copy(id = null) })
   }
 
   @Test
@@ -275,7 +272,7 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     assertEquals(
         listOf(
             AccessionStateHistoryRow(
-                accessionId = AccessionId(1),
+                accessionId = initial.id,
                 newStateId = AccessionState.AwaitingCheckIn,
                 reason = "Accession created",
                 updatedBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePhotoTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePhotoTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
 import java.net.URI
 import java.time.Instant
@@ -26,8 +25,7 @@ internal class AccessionStorePhotoTest : AccessionStoreTest() {
         )
     filesDao.insert(filesRow)
 
-    accessionPhotosDao.insert(
-        AccessionPhotosRow(accessionId = AccessionId(1), fileId = filesRow.id))
+    accessionPhotosDao.insert(AccessionPhotosRow(accessionId = initial.id!!, fileId = filesRow.id))
 
     val fetched = store.fetchOneById(initial.id!!)
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreStateTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
@@ -47,7 +46,7 @@ internal class AccessionStoreStateTest : AccessionStoreTest() {
     assertEquals(
         listOf(
             AccessionStateHistoryRow(
-                accessionId = AccessionId(1),
+                accessionId = initial.id!!,
                 newStateId = AccessionState.InStorage,
                 oldStateId = AccessionState.Drying,
                 reason = "Accession has been edited",

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -11,16 +11,9 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
-import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
-import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
-import com.terraformation.backend.db.seedbank.tables.references.BAGS
-import com.terraformation.backend.db.seedbank.tables.references.GEOLOCATIONS
-import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
-import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.db.AccessionStore
@@ -39,23 +32,10 @@ import io.mockk.every
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
-import org.jooq.Record
-import org.jooq.Table
 import org.junit.jupiter.api.BeforeEach
 
 internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   override val user: IndividualUser = mockUser()
-
-  override val tablesToResetSequences: List<Table<out Record>>
-    get() =
-        listOf(
-            ACCESSION_QUANTITY_HISTORY,
-            ACCESSIONS,
-            BAGS,
-            GEOLOCATIONS,
-            VIABILITY_TESTS,
-            SPECIES,
-            WITHDRAWALS)
 
   protected val clock = TestClock()
   protected val publisher = TestEventPublisher()


### PR DESCRIPTION
Stop using hardwired IDs and resetting database sequences in the remaining tests
that insert accessions, and remove the ability to specify a hardwired ID when
inserting.