### PR TITLE
SW-5795 Use dynamic IDs in remaining seedbank tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.IDENTIFIER_SEQUENCES
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
 import com.terraformation.backend.db.seedbank.AccessionState
@@ -114,12 +113,10 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
   @Test
   fun `create with isManualState uses caller-supplied species ID`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
     val oldSpeciesName = "Old species"
     val newSpeciesName = "New species"
-    insertSpecies(oldSpeciesId, oldSpeciesName)
-    insertSpecies(newSpeciesId, newSpeciesName)
+    insertSpecies(scientificName = oldSpeciesName)
+    val newSpeciesId = insertSpecies(scientificName = newSpeciesName)
 
     val initial = store.create(accessionModel(species = oldSpeciesName, speciesId = newSpeciesId))
 
@@ -161,9 +158,9 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
 
   @Test
   fun `create writes all API payload fields to database`() {
+    val speciesId = insertSpecies()
     insertProject()
-    insertSpecies(1)
-    insertSubLocation(1, facilityId, "Location 1")
+    insertSubLocation(facilityId = facilityId, name = "Location 1")
 
     val today = LocalDate.now(clock)
     val accession =
@@ -191,7 +188,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
             projectId = inserted.projectId,
             receivedDate = today,
             source = DataSource.FileImport,
-            speciesId = SpeciesId(1),
+            speciesId = speciesId,
             state = AccessionStateV2.AwaitingProcessing,
             subLocation = "Location 1",
         )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.AccessionSpeciesHasDeliveriesException
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.FacilityType
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.seedbank.CollectionSource
 import com.terraformation.backend.db.seedbank.DataSource
@@ -75,6 +74,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `update writes all API payload fields to database`() {
+    val speciesId = insertSpecies()
     val projectId = insertProject()
     val subLocationName = "Test Location"
     val today = LocalDate.now(clock)
@@ -105,7 +105,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             receivedDate = today,
             remainingQuantity = kilograms(15),
             remainingQuantityNotes = "more seeds",
-            speciesId = SpeciesId(1),
+            speciesId = speciesId,
             state = AccessionStateV2.Drying,
             subLocation = subLocationName,
             subsetCount = 5,
@@ -138,8 +138,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
       }
     }
 
-    insertSpecies(1)
-    insertSubLocation(1, name = subLocationName)
+    insertSubLocation(name = subLocationName)
 
     val initial = store.create(accessionModel(source = DataSource.SeedCollectorApp))
     val stored = store.updateAndFetch(update.applyToModel(initial))
@@ -207,6 +206,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `delete removes data from child tables`() {
+    val speciesId = insertSpecies()
     val subLocationName = "Test Location"
     val today = LocalDate.now(clock)
     val update =
@@ -223,7 +223,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             facilityId = facilityId,
             receivedDate = today,
             remainingQuantity = seeds(100),
-            speciesId = SpeciesId(1),
+            speciesId = speciesId,
             state = AccessionStateV2.InStorage,
             subLocation = subLocationName,
         )
@@ -238,8 +238,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
             notes = "notes",
             withdrawnQuantity = seeds(41))
 
-    insertSpecies(1)
-    insertSubLocation(1, name = subLocationName)
+    insertSubLocation(name = subLocationName)
 
     val initial = store.create(accessionModel())
     val accessionId = initial.id!!
@@ -272,11 +271,10 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
   @Test
   fun `fetchOneById uses species names from species table`() {
-    val speciesId = SpeciesId(1)
     val oldScientificName = "Test Scientific Name"
     val newScientificName = "New Scientific Name"
     val commonName = "Test Common Name"
-    insertSpecies(speciesId, scientificName = oldScientificName, commonName = commonName)
+    val speciesId = insertSpecies(scientificName = oldScientificName, commonName = commonName)
 
     val initial = store.create(accessionModel(speciesId = speciesId))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreManualStateTest.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.seedbank.AccessionState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -26,10 +25,8 @@ internal class AccessionStoreManualStateTest : AccessionStoreTest() {
 
   @Test
   fun `update with isManualState uses caller-supplied species ID`() {
-    val oldSpeciesId = SpeciesId(1)
-    val newSpeciesId = SpeciesId(2)
-    insertSpecies(oldSpeciesId, "Old species")
-    insertSpecies(newSpeciesId, "New species")
+    val oldSpeciesId = insertSpecies(scientificName = "Old species")
+    val newSpeciesId = insertSpecies(scientificName = "New species")
 
     val initial = store.create(accessionModel(speciesId = oldSpeciesId))
     val updated =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -1,7 +1,5 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
@@ -434,14 +432,10 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
     val otherOrganizationId = insertOrganization()
     val otherOrgFacilityId = insertFacility()
 
-    val speciesId = SpeciesId(1)
-    val sameOrgSpeciesId = SpeciesId(2)
-    val inactiveAccessionSpeciesId = SpeciesId(3)
-    val otherOrgSpeciesId = SpeciesId(4)
-    insertSpecies(speciesId)
-    insertSpecies(sameOrgSpeciesId)
-    insertSpecies(inactiveAccessionSpeciesId)
-    insertSpecies(otherOrgSpeciesId, organizationId = otherOrganizationId)
+    val speciesId = insertSpecies()
+    val sameOrgSpeciesId = insertSpecies()
+    val otherOrgSpeciesId = insertSpecies(organizationId = otherOrganizationId)
+    insertSpecies()
 
     listOf(
             // No species ID
@@ -493,18 +487,14 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `getSummaryStatistics does not count deleted species`() {
     val facilityId = inserted.facilityId
     val sameOrgFacilityId = insertFacility()
+
+    val speciesId = insertSpecies()
+    val sameOrgSpeciesId = insertSpecies()
+    insertSpecies()
+
     val otherOrganizationId = insertOrganization()
     val otherOrgFacilityId = insertFacility()
-
-    val speciesId = SpeciesId(1)
-    val sameOrgSpeciesId = SpeciesId(2)
-    val inactiveAccessionSpeciesId = SpeciesId(3)
-    val otherOrgSpeciesId = SpeciesId(4)
-
-    insertSpecies(speciesId)
-    insertSpecies(sameOrgSpeciesId)
-    insertSpecies(inactiveAccessionSpeciesId)
-    insertSpecies(otherOrgSpeciesId, organizationId = otherOrganizationId)
+    val otherOrgSpeciesId = insertSpecies(organizationId = otherOrganizationId)
 
     listOf(
             // No species ID
@@ -572,11 +562,8 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
   fun `countActiveInSubLocation only counts active accessions in location`() {
     every { user.canReadSubLocation(any()) } returns true
 
-    val subLocationId = SubLocationId(1)
-    val otherSubLocationId = SubLocationId(2)
-
-    insertSubLocation(subLocationId)
-    insertSubLocation(otherSubLocationId)
+    val subLocationId = insertSubLocation()
+    val otherSubLocationId = insertSubLocation()
 
     insertAccession(
         AccessionsRow(stateId = AccessionState.InStorage, subLocationId = subLocationId))


### PR DESCRIPTION
Get rid of the last of the hardwired IDs in the seedbank tests.