### PR TITLE
SW-5795 Use dynamic IDs in nursery tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1415,17 +1415,16 @@ abstract class DatabaseBackedTest {
       addedDate: LocalDate = row.addedDate ?: LocalDate.EPOCH,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
-      facilityId: Any = row.facilityId ?: inserted.facilityId,
+      facilityId: FacilityId = row.facilityId ?: inserted.facilityId,
       germinatingQuantity: Int = row.germinatingQuantity ?: 0,
-      id: Any? = row.id,
       notReadyQuantity: Int = row.notReadyQuantity ?: 0,
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
-      projectId: Any? = row.projectId,
+      projectId: ProjectId? = row.projectId,
       readyQuantity: Int = row.readyQuantity ?: 0,
       readyByDate: LocalDate? = row.readyByDate,
-      speciesId: Any = row.speciesId ?: inserted.speciesId,
+      speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
       version: Int = row.version ?: 1,
-      batchNumber: String = row.batchNumber ?: id?.toString() ?: "${nextBatchNumber++}",
+      batchNumber: String = row.batchNumber ?: "${nextBatchNumber++}",
       germinationRate: Int? = row.germinationRate,
       totalGerminated: Int? = row.totalGerminated,
       totalGerminationCandidates: Int? = row.totalGerminationCandidates,
@@ -1457,12 +1456,11 @@ abstract class DatabaseBackedTest {
             batchNumber = batchNumber,
             createdBy = createdBy,
             createdTime = createdTime,
-            facilityId = facilityId.toIdWrapper { FacilityId(it) },
+            facilityId = facilityId,
             germinatingQuantity = germinatingQuantity,
             germinationRate = effectiveGerminationRate,
             totalGerminated = totalGerminated,
             totalGerminationCandidates = totalGerminationCandidates,
-            id = id?.toIdWrapper { BatchId(it) },
             latestObservedGerminatingQuantity = germinatingQuantity,
             latestObservedNotReadyQuantity = notReadyQuantity,
             latestObservedReadyQuantity = readyQuantity,
@@ -1474,10 +1472,10 @@ abstract class DatabaseBackedTest {
             modifiedTime = createdTime,
             notReadyQuantity = notReadyQuantity,
             organizationId = organizationId,
-            projectId = projectId?.toIdWrapper { ProjectId(it) },
+            projectId = projectId,
             readyQuantity = readyQuantity,
             readyByDate = readyByDate,
-            speciesId = speciesId.toIdWrapper { SpeciesId(it) },
+            speciesId = speciesId,
             version = version,
         )
 
@@ -1487,20 +1485,18 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertBatchSubLocation(
-      batchId: Any = inserted.batchId,
-      subLocationId: Any = inserted.subLocationId,
-      facilityId: Any? = null,
+      batchId: BatchId = inserted.batchId,
+      subLocationId: SubLocationId = inserted.subLocationId,
+      facilityId: FacilityId? = null,
   ) {
-    val subLocationIdWrapper = subLocationId.toIdWrapper { SubLocationId(it) }
     val effectiveFacilityId =
-        facilityId?.toIdWrapper { FacilityId(it) }
-            ?: subLocationsDao.fetchOneById(subLocationIdWrapper)!!.facilityId!!
+        facilityId ?: subLocationsDao.fetchOneById(subLocationId)!!.facilityId!!
 
     val row =
         BatchSubLocationsRow(
-            batchId = batchId.toIdWrapper { BatchId(it) },
+            batchId = batchId,
             facilityId = effectiveFacilityId,
-            subLocationId = subLocationIdWrapper,
+            subLocationId = subLocationId,
         )
 
     batchSubLocationsDao.insert(row)
@@ -1510,26 +1506,24 @@ abstract class DatabaseBackedTest {
       row: WithdrawalsRow = WithdrawalsRow(),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
-      destinationFacilityId: Any? = row.destinationFacilityId,
-      facilityId: Any = row.facilityId ?: inserted.facilityId,
-      id: Any? = row.id,
+      destinationFacilityId: FacilityId? = row.destinationFacilityId,
+      facilityId: FacilityId = row.facilityId ?: inserted.facilityId,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       purpose: WithdrawalPurpose = WithdrawalPurpose.Other,
-      undoesWithdrawalId: Any? = row.undoesWithdrawalId,
+      undoesWithdrawalId: WithdrawalId? = row.undoesWithdrawalId,
       withdrawnDate: LocalDate = row.withdrawnDate ?: LocalDate.EPOCH,
   ): WithdrawalId {
     val rowWithDefaults =
         row.copy(
             createdBy = createdBy,
             createdTime = createdTime,
-            destinationFacilityId = destinationFacilityId?.toIdWrapper { FacilityId(it) },
-            facilityId = facilityId.toIdWrapper { FacilityId(it) },
-            id = id?.toIdWrapper { WithdrawalId(it) },
+            destinationFacilityId = destinationFacilityId,
+            facilityId = facilityId,
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             purposeId = purpose,
-            undoesWithdrawalId = undoesWithdrawalId?.toIdWrapper { WithdrawalId(it) },
+            undoesWithdrawalId = undoesWithdrawalId,
             withdrawnDate = withdrawnDate,
         )
 
@@ -1540,21 +1534,21 @@ abstract class DatabaseBackedTest {
 
   fun insertBatchWithdrawal(
       row: BatchWithdrawalsRow = BatchWithdrawalsRow(),
-      batchId: Any = row.batchId ?: inserted.batchId,
-      destinationBatchId: Any? = row.destinationBatchId,
+      batchId: BatchId = row.batchId ?: inserted.batchId,
+      destinationBatchId: BatchId? = row.destinationBatchId,
       germinatingQuantityWithdrawn: Int = row.germinatingQuantityWithdrawn ?: 0,
       notReadyQuantityWithdrawn: Int = row.notReadyQuantityWithdrawn ?: 0,
       readyQuantityWithdrawn: Int = row.readyQuantityWithdrawn ?: 0,
-      withdrawalId: Any = row.withdrawalId ?: inserted.withdrawalId
+      withdrawalId: WithdrawalId = row.withdrawalId ?: inserted.withdrawalId
   ) {
     val rowWithDefaults =
         row.copy(
-            batchId = batchId.toIdWrapper { BatchId(it) },
-            destinationBatchId = destinationBatchId?.toIdWrapper { BatchId(it) },
+            batchId = batchId,
+            destinationBatchId = destinationBatchId,
             germinatingQuantityWithdrawn = germinatingQuantityWithdrawn,
             notReadyQuantityWithdrawn = notReadyQuantityWithdrawn,
             readyQuantityWithdrawn = readyQuantityWithdrawn,
-            withdrawalId = withdrawalId.toIdWrapper { WithdrawalId(it) },
+            withdrawalId = withdrawalId,
         )
 
     batchWithdrawalsDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/BatchServiceTest.kt
@@ -57,8 +57,8 @@ internal class BatchServiceTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var facilityId: FacilityId
   private val plantingSiteId by lazy { insertPlantingSite() }
-  private val speciesId1 by lazy { insertSpecies(1) }
-  private val speciesId2 by lazy { insertSpecies(2) }
+  private val speciesId1 by lazy { insertSpecies() }
+  private val speciesId2 by lazy { insertSpecies() }
 
   @BeforeEach
   fun setUp() {

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.nursery.BatchId
-import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
@@ -14,17 +13,18 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
-  private val batchId = BatchId(1)
   private val updateTime = Instant.ofEpochSecond(1000)
+
+  private lateinit var batchId: BatchId
 
   @BeforeEach
   fun setUpTestBatch() {
-    insertBatch(
-        id = batchId,
-        germinatingQuantity = 10,
-        notReadyQuantity = 20,
-        readyQuantity = 30,
-        speciesId = speciesId)
+    batchId =
+        insertBatch(
+            germinatingQuantity = 10,
+            notReadyQuantity = 20,
+            readyQuantity = 30,
+            speciesId = speciesId)
 
     clock.instant = updateTime
   }
@@ -52,7 +52,6 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
     assertEquals(
         listOf(
             BatchQuantityHistoryRow(
-                id = BatchQuantityHistoryId(1),
                 batchId = batchId,
                 historyTypeId = BatchQuantityHistoryType.StatusChanged,
                 createdBy = user.userId,
@@ -62,7 +61,7 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
                 readyQuantity = 37,
                 version = 2,
             )),
-        batchQuantityHistoryDao.findAll())
+        batchQuantityHistoryDao.findAll().map { it.copy(id = null) })
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreTest.kt
@@ -10,9 +10,6 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.nursery.tables.references.BATCHES
-import com.terraformation.backend.db.nursery.tables.references.BATCH_DETAILS_HISTORY
-import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.db.BatchStore
 import com.terraformation.backend.nursery.model.NewBatchModel
@@ -22,9 +19,6 @@ import org.junit.jupiter.api.BeforeEach
 
 internal abstract class BatchStoreTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
-
-  override val tablesToResetSequences =
-      listOf(BATCHES, BATCH_DETAILS_HISTORY, BATCH_QUANTITY_HISTORY)
 
   protected val clock = TestClock()
   protected val eventPublisher = TestEventPublisher()

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUndoWithdrawalTest.kt
@@ -24,29 +24,29 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
 internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
-  private val batch1Id = BatchId(11)
-  private val batch2Id = BatchId(12)
+  private lateinit var batch1Id: BatchId
+  private lateinit var batch2Id: BatchId
 
   @BeforeEach
   fun insertInitialBatches() {
-    insertBatch(
-        id = batch1Id,
-        speciesId = speciesId,
-        batchNumber = "21-2-1-011",
-        germinatingQuantity = 10,
-        notReadyQuantity = 20,
-        readyQuantity = 30,
-        totalLost = 0,
-        totalLossCandidates = 20 + 30)
-    insertBatch(
-        id = batch2Id,
-        speciesId = speciesId,
-        batchNumber = "21-2-1-012",
-        germinatingQuantity = 40,
-        notReadyQuantity = 50,
-        readyQuantity = 60,
-        totalLost = 0,
-        totalLossCandidates = 50 + 60)
+    batch1Id =
+        insertBatch(
+            speciesId = speciesId,
+            batchNumber = "21-2-1-011",
+            germinatingQuantity = 10,
+            notReadyQuantity = 20,
+            readyQuantity = 30,
+            totalLost = 0,
+            totalLossCandidates = 20 + 30)
+    batch2Id =
+        insertBatch(
+            speciesId = speciesId,
+            batchNumber = "21-2-1-012",
+            germinatingQuantity = 40,
+            notReadyQuantity = 50,
+            readyQuantity = 60,
+            totalLost = 0,
+            totalLossCandidates = 50 + 60)
 
     every { user.canReadWithdrawal(any()) } returns true
   }
@@ -175,7 +175,7 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
                   germinatingQuantityWithdrawn = 1,
                   notReadyQuantityWithdrawn = 2,
                   readyQuantityWithdrawn = 3)),
-      destinationFacilityId: Any? = null,
+      destinationFacilityId: FacilityId? = null,
       purpose: WithdrawalPurpose = WithdrawalPurpose.Other,
       withdrawnDate: LocalDate = LocalDate.EPOCH,
   ): WithdrawalId {
@@ -183,7 +183,7 @@ internal class BatchStoreUndoWithdrawalTest : BatchStoreTest() {
         .withdraw(
             NewWithdrawalModel(
                 batchWithdrawals = batchWithdrawals,
-                destinationFacilityId = destinationFacilityId?.toIdWrapper { FacilityId(it) },
+                destinationFacilityId = destinationFacilityId,
                 facilityId = facilityId,
                 id = null,
                 purpose = purpose,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
 import com.terraformation.backend.db.nursery.BatchId
-import com.terraformation.backend.db.nursery.BatchQuantityHistoryId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.nursery.db.BatchStaleException
@@ -12,12 +11,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
-  private val batchId = BatchId(1)
   private val updateTime = Instant.ofEpochSecond(1000)
+
+  private lateinit var batchId: BatchId
 
   @BeforeEach
   fun setUpTestBatch() {
-    insertBatch(id = batchId, readyQuantity = 1, speciesId = speciesId)
+    batchId = insertBatch(readyQuantity = 1, speciesId = speciesId)
 
     clock.instant = updateTime
   }
@@ -91,7 +91,6 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
     assertEquals(
         listOf(
             BatchQuantityHistoryRow(
-                id = BatchQuantityHistoryId(1),
                 batchId = batchId,
                 historyTypeId = BatchQuantityHistoryType.Computed,
                 createdBy = user.userId,
@@ -102,7 +101,7 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
                 version = 2,
             ),
         ),
-        batchQuantityHistoryDao.findAll())
+        batchQuantityHistoryDao.findAll().map { it.copy(id = null) })
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -29,40 +29,40 @@ import org.springframework.security.access.AccessDeniedException
 
 internal class BatchStoreWithdrawTest : BatchStoreTest() {
   private lateinit var speciesId2: SpeciesId
-  private val species1Batch1Id = BatchId(11)
-  private val species1Batch2Id = BatchId(12)
-  private val species2Batch1Id = BatchId(21)
+  private lateinit var species1Batch1Id: BatchId
+  private lateinit var species1Batch2Id: BatchId
+  private lateinit var species2Batch1Id: BatchId
 
   @BeforeEach
   fun insertInitialBatches() {
     speciesId2 = insertSpecies()
-    insertBatch(
-        id = species1Batch1Id,
-        speciesId = speciesId,
-        batchNumber = "21-2-1-011",
-        germinatingQuantity = 10,
-        notReadyQuantity = 20,
-        readyQuantity = 30,
-        totalLost = 0,
-        totalLossCandidates = 20 + 30)
-    insertBatch(
-        id = species1Batch2Id,
-        speciesId = speciesId,
-        batchNumber = "21-2-1-012",
-        germinatingQuantity = 40,
-        notReadyQuantity = 50,
-        readyQuantity = 60,
-        totalLost = 0,
-        totalLossCandidates = 50 + 60)
-    insertBatch(
-        id = species2Batch1Id,
-        speciesId = speciesId2,
-        batchNumber = "21-2-1-021",
-        germinatingQuantity = 70,
-        notReadyQuantity = 80,
-        readyQuantity = 90,
-        totalLost = 0,
-        totalLossCandidates = 80 + 90)
+    species1Batch1Id =
+        insertBatch(
+            speciesId = speciesId,
+            batchNumber = "21-2-1-011",
+            germinatingQuantity = 10,
+            notReadyQuantity = 20,
+            readyQuantity = 30,
+            totalLost = 0,
+            totalLossCandidates = 20 + 30)
+    species1Batch2Id =
+        insertBatch(
+            speciesId = speciesId,
+            batchNumber = "21-2-1-012",
+            germinatingQuantity = 40,
+            notReadyQuantity = 50,
+            readyQuantity = 60,
+            totalLost = 0,
+            totalLossCandidates = 50 + 60)
+    species2Batch1Id =
+        insertBatch(
+            speciesId = speciesId2,
+            batchNumber = "21-2-1-021",
+            germinatingQuantity = 70,
+            notReadyQuantity = 80,
+            readyQuantity = 90,
+            totalLost = 0,
+            totalLossCandidates = 80 + 90)
   }
 
   @Test
@@ -466,7 +466,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   fun `throws exception if any batches are not from requested facility ID`() {
     insertFacility(type = FacilityType.Nursery)
 
-    val otherFacilityBatchId = insertBatch(id = 100, speciesId = speciesId, germinatingQuantity = 1)
+    val otherFacilityBatchId = insertBatch(speciesId = speciesId, germinatingQuantity = 1)
 
     assertThrows<IllegalArgumentException> {
       store.withdraw(


### PR DESCRIPTION
Update the nursery-related tests to stop using hardwired IDs, and remove the
ability to pass numeric ID literals to the nursery-related insert functions.