### PR TITLE
SW-5795 Use dynamic IDs in notification tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -48,10 +48,8 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.Role
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.NotificationsRow
-import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.device.db.DeviceStore
@@ -325,18 +323,13 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganizationUser()
 
     val nurseryName = "my nursery"
-    val speciesId = SpeciesId(100)
-    val batchId = BatchId(100)
     val batchNumber = "22-2-001"
 
     val facilityId = insertFacility(type = FacilityType.Nursery, name = nurseryName)
-    insertSpecies(speciesId)
-    insertBatch(
-        BatchesRow(
-            id = batchId,
-            batchNumber = batchNumber,
-            speciesId = speciesId,
-            facilityId = facilityId))
+    val speciesId = insertSpecies()
+    val batchId =
+        insertBatch(
+            BatchesRow(batchNumber = batchNumber, speciesId = speciesId, facilityId = facilityId))
 
     service.on(NurserySeedlingBatchReadyEvent(batchId, batchNumber, speciesId, nurseryName))
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -652,17 +652,18 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `withNotificationsDue rolls back and continues to next facility on exception`() {
+    lateinit var notificationId: NotificationId
     val rolledBackFacilityId = inserted.facilityId
-    val otherFacilityId = insertFacility()
+    insertFacility()
 
     store.withNotificationsDue { facility ->
-      insertNotification(NotificationId(facility.id.value))
+      notificationId = insertNotification()
       if (facility.id == rolledBackFacilityId) {
         throw Exception("I have failed")
       }
     }
 
-    val expectedNotifications = listOf(NotificationId(otherFacilityId.value))
+    val expectedNotifications = listOf(notificationId)
     val actualNotifications = notificationsDao.findAll().map { it.id }
 
     assertEquals(expectedNotifications, actualNotifications)

--- a/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
@@ -76,9 +76,10 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `advancing test clock causes newly-due jobs to be run`() {
+    lateinit var notificationId: NotificationId
     val increment = Duration.ofDays(7)
 
-    notifiers.add(FacilityNotifier { _, _ -> insertNotification(NotificationId(1)) })
+    notifiers.add(FacilityNotifier { _, _ -> notificationId = insertNotification() })
 
     facilitiesDao.update(
         facilitiesDao
@@ -95,7 +96,7 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
 
     scanner.on(ClockAdvancedEvent(Duration.ofDays(1)))
 
-    assertEquals(listOf(NotificationId(1)), notificationsDao.findAll().map { it.id })
+    assertEquals(listOf(notificationId), notificationsDao.findAll().map { it.id })
     assertIsEventListener<ClockAdvancedEvent>(scanner)
   }
 
@@ -129,7 +130,7 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `rolls back changes from all notifiers if one notifier throws an exception`() {
-    notifiers.add(FacilityNotifier { _, _ -> insertNotification(NotificationId(1)) })
+    notifiers.add(FacilityNotifier { _, _ -> insertNotification() })
     notifiers.add(FacilityNotifier { _, _ -> throw Exception("boom") })
 
     scanner.sendNotifications()


### PR DESCRIPTION
Stop using hardwired IDs in the notification-related tests and remove the ability
to pass numeric literal IDs to the relevant insert functions.