### PR TITLE
SW-5795 Use dynamic IDs in report tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2018,14 +2018,13 @@ abstract class DatabaseBackedTest {
   fun insertReport(
       row: ReportsRow = ReportsRow(),
       body: String = row.body?.data() ?: """{"version":"1","organizationName":"org"}""",
-      id: Any? = row.id,
-      lockedBy: Any? = row.lockedBy,
+      lockedBy: UserId? = row.lockedBy,
       lockedTime: Instant? = row.lockedTime ?: lockedBy?.let { Instant.EPOCH },
       organizationId: OrganizationId = row.organizationId ?: inserted.organizationId,
-      projectId: Any? = row.projectId,
+      projectId: ProjectId? = row.projectId,
       projectName: String? = row.projectName,
       quarter: Int = row.quarter ?: 1,
-      submittedBy: Any? = row.submittedBy,
+      submittedBy: UserId? = row.submittedBy,
       submittedTime: Instant? = row.submittedTime ?: submittedBy?.let { Instant.EPOCH },
       status: ReportStatus =
           row.statusId
@@ -2036,22 +2035,20 @@ abstract class DatabaseBackedTest {
               },
       year: Int = row.year ?: 1970,
   ): ReportId {
-    val projectIdWrapper = projectId?.toIdWrapper { ProjectId(it) }
     val projectNameWithDefault =
-        projectName ?: projectIdWrapper?.let { projectsDao.fetchOneById(it)?.name }
+        projectName ?: projectId?.let { projectsDao.fetchOneById(it)?.name }
 
     val rowWithDefaults =
         row.copy(
             body = JSONB.jsonb(body),
-            id = id?.toIdWrapper { ReportId(it) },
-            lockedBy = lockedBy?.toIdWrapper { UserId(it) },
+            lockedBy = lockedBy,
             lockedTime = lockedTime,
             organizationId = organizationId,
-            projectId = projectIdWrapper,
+            projectId = projectId,
             projectName = projectNameWithDefault,
             quarter = quarter,
             statusId = status,
-            submittedBy = submittedBy?.toIdWrapper { UserId(it) },
+            submittedBy = submittedBy,
             submittedTime = submittedTime,
             year = year,
         )
@@ -2075,13 +2072,13 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertProjectReportSettings(
-      projectId: Any = inserted.projectId,
+      projectId: ProjectId = inserted.projectId,
       isEnabled: Boolean = true,
   ) {
     val row =
         ProjectReportSettingsRow(
             isEnabled = isEnabled,
-            projectId = projectId.toIdWrapper { ProjectId(it) },
+            projectId = projectId,
         )
 
     projectReportSettingsDao.insert(row)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -26,11 +26,9 @@ import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.db.default_schema.tables.references.REPORTS
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
@@ -67,7 +65,6 @@ import org.junit.jupiter.api.assertThrows
 
 class ReportServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
-  override val tablesToResetSequences = listOf(REPORTS)
 
   private val clock = TestClock()
   private val googleDriveWriter: GoogleDriveWriter = mockk()
@@ -213,6 +210,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
       insertSampleWithdrawals(speciesId, nurseryId, plantingSiteId)
 
+      val created = service.create(organizationId)
+
       val expected =
           ReportModel(
               ReportBodyModelV1(
@@ -266,15 +265,13 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                   totalSeedBanks = 1,
               ),
               ReportMetadata(
-                  ReportId(1),
+                  created.id,
                   organizationId = organizationId,
                   quarter = 4,
                   status = ReportStatus.New,
                   year = 1969,
               ),
           )
-
-      val created = service.create(organizationId)
 
       val actual = reportStore.fetchOneById(created.id)
 
@@ -362,6 +359,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
       // it has no batches for the project in question.
       insertSampleWithdrawals(speciesId, nonProjectNurseryId, projectPlantingSiteId)
 
+      val created = service.create(organizationId, projectId)
+
       val expected =
           ReportModel(
               ReportBodyModelV1(
@@ -427,7 +426,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                   totalSeedBanks = 2,
               ),
               ReportMetadata(
-                  ReportId(1),
+                  created.id,
                   organizationId = organizationId,
                   projectId = projectId,
                   projectName = "Test Project",
@@ -436,8 +435,6 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
                   year = 1969,
               ),
           )
-
-      val created = service.create(organizationId, projectId)
 
       val actual = reportStore.fetchOneById(created.id)
 


### PR DESCRIPTION
Stop using hardwired IDs in the report-related tests and remove the ability to
pass numeric literal IDs to the related insert functions.