### PR TITLE
SW-5795 Use dynamic IDs in species tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -997,9 +997,7 @@ abstract class DatabaseBackedTest {
   private var nextSpeciesNumber = 1
 
   fun insertSpecies(
-      speciesId: Any? = null,
-      scientificName: String =
-          if (speciesId != null) "Species $speciesId" else "Species ${nextSpeciesNumber++}",
+      scientificName: String = "Species ${nextSpeciesNumber++}",
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       modifiedTime: Instant = createdTime,
@@ -1016,8 +1014,6 @@ abstract class DatabaseBackedTest {
       conservationCategory: ConservationCategory? = null,
       seedStorageBehavior: SeedStorageBehavior? = null,
   ): SpeciesId {
-    val speciesIdWrapper = speciesId?.toIdWrapper { SpeciesId(it) }
-
     val actualSpeciesId =
         with(SPECIES) {
           dslContext
@@ -1029,7 +1025,6 @@ abstract class DatabaseBackedTest {
               .set(CREATED_TIME, createdTime)
               .set(DELETED_BY, if (deletedTime != null) createdBy else null)
               .set(DELETED_TIME, deletedTime)
-              .apply { speciesIdWrapper?.let { set(ID, it) } }
               .set(INITIAL_SCIENTIFIC_NAME, initialScientificName)
               .set(MODIFIED_BY, createdBy)
               .set(MODIFIED_TIME, modifiedTime)

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.SpeciesInUseException
 import com.terraformation.backend.db.SpeciesNotFoundException
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
@@ -71,9 +70,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `updateSpecies checks for problems with species data`() {
-    val speciesId = SpeciesId(1)
-
-    insertSpecies(speciesId, "Old name")
+    val speciesId = insertSpecies("Old name")
     val originalModel = speciesStore.fetchSpeciesById(speciesId)
 
     val updatedModel = service.updateSpecies(originalModel.copy(scientificName = "New name"))
@@ -108,9 +105,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteSpecies throws exception if species is in use`() {
-    val speciesId = SpeciesId(1)
-
-    insertSpecies(speciesId, "species name")
+    val speciesId = insertSpecies("species name")
     insertFacility()
     insertBatch(speciesId = speciesId)
 
@@ -119,9 +114,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `deleteSpecies deletes species when not in use`() {
-    val speciesId = SpeciesId(1)
-
-    insertSpecies(speciesId, "species name")
+    val speciesId = insertSpecies("species name")
     assertNotNull(speciesStore.fetchSpeciesById(speciesId))
 
     service.deleteSpecies(speciesId)

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -227,7 +227,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
             organizationId = organizationId,
             status = UploadStatus.AwaitingProcessing,
             storageUrl = storageUrl)
-    insertSpecies(2, "Corrected name", initialScientificName = "Initial name")
+    insertSpecies("Corrected name", initialScientificName = "Initial name")
 
     importer.validateCsv(uploadId)
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -484,11 +484,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchAllUncheckedSpeciesIds only returns unchecked species`() {
-    val checkedSpeciesId = SpeciesId(1)
-    val uncheckedSpeciesId = SpeciesId(2)
-
-    insertSpecies(checkedSpeciesId, checkedTime = Instant.EPOCH)
-    insertSpecies(uncheckedSpeciesId)
+    val uncheckedSpeciesId = insertSpecies()
+    insertSpecies(checkedTime = Instant.EPOCH)
 
     assertEquals(listOf(uncheckedSpeciesId), store.fetchUncheckedSpeciesIds(organizationId))
   }


### PR DESCRIPTION
Stop using hardwired IDs in the species-related tests, including the GBIF tests
(which use IDs that come from an external source but must still be unique).