### PR TITLE
SW-5795 Use dynamic IDs in ApplicationServiceTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -54,15 +54,16 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
     )
   }
 
+  // This is only returned by the mock ApplicationStore, not inserted into the database.
   private val applicationId = ApplicationId(1)
-  private val projectId = ProjectId(3)
 
   private lateinit var organizationId: OrganizationId
+  private lateinit var projectId: ProjectId
 
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    insertProject()
+    projectId = insertProject()
 
     every { user.canReadProject(any()) } returns true
     every { user.canUpdateApplicationSubmissionStatus(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -697,13 +697,12 @@ abstract class DatabaseBackedTest {
   private var nextProjectNumber = 1
 
   protected fun insertProject(
-      id: Any? = null,
       organizationId: OrganizationId = inserted.organizationId,
-      name: String = if (id != null) "Project $id" else "Project ${nextProjectNumber++}",
+      name: String = "Project ${nextProjectNumber++}",
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       description: String? = null,
-      participantId: Any? = null,
+      participantId: ParticipantId? = null,
       countryCode: String? = null,
   ): ProjectId {
     val row =
@@ -712,12 +711,11 @@ abstract class DatabaseBackedTest {
             createdBy = createdBy,
             createdTime = createdTime,
             description = description,
-            id = id?.toIdWrapper { ProjectId(it) },
             modifiedBy = createdBy,
             modifiedTime = createdTime,
             name = name,
             organizationId = organizationId,
-            participantId = participantId?.toIdWrapper { ParticipantId(it) },
+            participantId = participantId,
         )
 
     projectsDao.insert(row)


### PR DESCRIPTION
Stop using a hardwired project ID in ApplicationServiceTest, and remove the
ability to insert projects with fixed IDs.