### PR TITLE
SW-5841 Run variable workflow update as system user

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.event.VariableValueUpdatedEvent
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
 import jakarta.inject.Named
@@ -8,13 +9,15 @@ import org.springframework.context.event.EventListener
 
 @Named
 class VariableValueStatusUpdater(
+    private val systemUser: SystemUser,
     private val variableWorkflowStore: VariableWorkflowStore,
 ) {
-
   /** Update variable status to "in review" when value is updated */
   @EventListener
   fun on(event: VariableValueUpdatedEvent) {
-    variableWorkflowStore.update(
-        event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null)
+    systemUser.run {
+      variableWorkflowStore.update(
+          event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.event.VariableValueUpdatedEvent
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
@@ -15,9 +16,11 @@ class VariableValueStatusUpdater(
   /** Update variable status to "in review" when value is updated */
   @EventListener
   fun on(event: VariableValueUpdatedEvent) {
+    val createdBy = currentUser().userId
+
     systemUser.run {
       variableWorkflowStore.update(
-          event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null)
+          event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null, createdBy)
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
@@ -68,6 +69,7 @@ class VariableWorkflowStore(
       status: VariableWorkflowStatus,
       feedback: String?,
       internalComment: String?,
+      createdBy: UserId = currentUser().userId,
   ): ExistingVariableWorkflowHistoryModel {
     requirePermissions { updateInternalVariableWorkflowDetails(projectId) }
 
@@ -91,7 +93,7 @@ class VariableWorkflowStore(
       val newModel =
           dslContext
               .insertInto(VARIABLE_WORKFLOW_HISTORY)
-              .set(CREATED_BY, currentUser().userId)
+              .set(CREATED_BY, createdBy)
               .set(CREATED_TIME, clock.instant())
               .set(FEEDBACK, feedback)
               .set(INTERNAL_COMMENT, internalComment)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdaterTest.kt
@@ -1,0 +1,117 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.VariableValueUpdatedEvent
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.VariableType
+import com.terraformation.backend.db.docprod.VariableWorkflowStatus
+import com.terraformation.backend.db.docprod.tables.pojos.VariableWorkflowHistoryRow
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_WORKFLOW_HISTORY
+import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class VariableValueStatusUpdaterTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val systemUser = SystemUser(mockk())
+
+  private val variableWorkflowStore: VariableWorkflowStore by lazy {
+    VariableWorkflowStore(clock, dslContext, eventPublisher, variablesDao)
+  }
+
+  private val updater: VariableValueStatusUpdater by lazy {
+    VariableValueStatusUpdater(systemUser, variableWorkflowStore)
+  }
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+
+    every { systemUser.userId } answers { UserId(1) }
+  }
+
+  @Nested
+  inner class UpdateVariableStatus {
+    @Test
+    fun `updates the variable workflow details status with a new history entry`() {
+      val projectId = insertProject()
+      val variableId = insertNumberVariable(id = insertVariable(type = VariableType.Number))
+      val valueId = insertValue(variableId = variableId, numberValue = BigDecimal(10))
+
+      insertVariableWorkflowHistory(
+          feedback = null,
+          internalComment = null,
+          maxVariableValueId = valueId,
+          projectId = projectId,
+          status = VariableWorkflowStatus.NotSubmitted,
+          variableId = variableId,
+      )
+
+      insertVariableWorkflowHistory(
+          feedback = "Looks good",
+          internalComment = "This is very good",
+          maxVariableValueId = valueId,
+          projectId = projectId,
+          status = VariableWorkflowStatus.Approved,
+          variableId = variableId,
+      )
+
+      val userId = currentUser().userId
+
+      updater.on(VariableValueUpdatedEvent(projectId = projectId, variableId = variableId))
+
+      val now = clock.instant
+
+      val actual = fetchLatestWorkflowEntry(projectId, variableId)
+      val expected =
+          VariableWorkflowHistoryRow(
+              createdBy = userId,
+              createdTime = now,
+              feedback = null,
+              id = null,
+              internalComment = null,
+              projectId = projectId,
+              variableId = variableId,
+              variableWorkflowStatusId = VariableWorkflowStatus.InReview,
+              maxVariableValueId = valueId)
+
+      assertEquals(
+          expected,
+          actual,
+          "The variable's workflow details submission status was not updated to 'In Review'")
+    }
+  }
+
+  private fun fetchLatestWorkflowEntry(
+      projectId: ProjectId,
+      variableId: VariableId
+  ): VariableWorkflowHistoryRow =
+      with(VARIABLE_WORKFLOW_HISTORY) {
+        dslContext
+            .select(asterisk())
+            .from(VARIABLE_WORKFLOW_HISTORY)
+            .where(VARIABLE_ID.eq(variableId))
+            .and(PROJECT_ID.eq(projectId))
+            .orderBy(ID.desc())
+            .limit(1)
+            .fetchOneInto(VariableWorkflowHistoryRow::class.java)!!
+            .copy(id = null)
+      }
+}

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowControllerTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.put
 
 class VariableWorkflowControllerTest : ControllerIntegrationTest() {


### PR DESCRIPTION
Since a regular org user can update a variable value, which consequently updates the variable's workflow details (by setting it to "In Review"), run the update as a system user with elevated permissions.

In order to ensure we know who updated a variable's status, the user ID can optionally be passed in to the update function, otherwise it defaults to the current user.