### PR TITLE
SW-5605 Run JUnit tests in parallel

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionSnapshotId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.accelerator.VoteOption
+import com.terraformation.backend.db.accelerator.keys.COHORTS_PKEY
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationHistoriesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationModulesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationsDao
@@ -111,6 +112,7 @@ import com.terraformation.backend.db.default_schema.UploadStatus
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.keys.USERS_PKEY
 import com.terraformation.backend.db.default_schema.tables.daos.AutomationsDao
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
 import com.terraformation.backend.db.default_schema.tables.daos.CountrySubdivisionsDao
@@ -188,6 +190,7 @@ import com.terraformation.backend.db.docprod.VariableUsageType
 import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.VariableWorkflowHistoryId
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
+import com.terraformation.backend.db.docprod.keys.VARIABLES_PKEY
 import com.terraformation.backend.db.docprod.tables.daos.DocumentSavedVersionsDao
 import com.terraformation.backend.db.docprod.tables.daos.DocumentTemplatesDao
 import com.terraformation.backend.db.docprod.tables.daos.DocumentsDao
@@ -237,6 +240,7 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.nursery.keys.BATCHES_PKEY
 import com.terraformation.backend.db.nursery.tables.daos.BatchDetailsHistoryDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchDetailsHistorySubLocationsDao
 import com.terraformation.backend.db.nursery.tables.daos.BatchPhotosDao
@@ -252,6 +256,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
+import com.terraformation.backend.db.seedbank.keys.ACCESSION_PKEY
 import com.terraformation.backend.db.seedbank.tables.daos.AccessionCollectorsDao
 import com.terraformation.backend.db.seedbank.tables.daos.AccessionPhotosDao
 import com.terraformation.backend.db.seedbank.tables.daos.AccessionQuantityHistoryDao
@@ -279,6 +284,7 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.keys.PLANTING_SITES_PKEY
 import com.terraformation.backend.db.tracking.tables.daos.DeliveriesDao
 import com.terraformation.backend.db.tracking.tables.daos.DraftPlantingSitesDao
 import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotsDao
@@ -357,7 +363,9 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.support.TestPropertySourceUtils
+import org.springframework.test.context.transaction.InheritedTransactionRemover
 import org.springframework.transaction.annotation.Transactional
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.PostgreSQLContainer
@@ -394,6 +402,9 @@ import org.testcontainers.utility.DockerImageName
 @EnableConfigurationProperties(TerrawareServerConfig::class)
 @Suppress("MemberVisibilityCanBePrivate") // Some DAOs are not used in tests yet
 @Testcontainers
+@TestExecutionListeners(
+    InheritedTransactionRemover::class,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @Transactional
 abstract class DatabaseBackedTest {
   @Autowired
@@ -3152,6 +3163,17 @@ abstract class DatabaseBackedTest {
   }
 
   companion object {
+    init {
+      // Work around non-thread-safe initialization of jOOQ constants by evaluating one symbol
+      // from the generated Keys.kt file for each schema.
+      ACCESSION_PKEY
+      BATCHES_PKEY
+      COHORTS_PKEY
+      PLANTING_SITES_PKEY
+      USERS_PKEY
+      VARIABLES_PKEY
+    }
+
     /**
      * Balena IDs are required to be unique but aren't generated by our database (we get them from
      * Balena's API). We need to generate test IDs that are unique across all threads in case the

--- a/src/test/kotlin/org/springframework/test/context/transaction/InheritedTransactionRemover.kt
+++ b/src/test/kotlin/org/springframework/test/context/transaction/InheritedTransactionRemover.kt
@@ -1,0 +1,59 @@
+package org.springframework.test.context.transaction
+
+import java.util.concurrent.ForkJoinPool
+import org.jooq.DSLContext
+import org.springframework.core.annotation.Order
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListener
+
+/**
+ * Removes database transactions from new threads before they run their first tests.
+ *
+ * This is a workaround for a bad interaction involving jOOQ, the jUnit parallel test runner, and
+ * the Spring test framework that would otherwise cause random test failures. Here's what happens
+ * without this class:
+ * 1. jUnit sets up a [ForkJoinPool] to run tests in parallel.
+ * 2. Spring's [TransactionContextHolder] creates a thread-local variable to track each test
+ *    thread's currently open transaction. This variable is an [InheritableThreadLocal] meaning that
+ *    if code on a test thread spawns a new thread of its own, e.g., to do some work in the
+ *    background, it inherits the transaction.
+ * 3. Before each database-backed test method is run, Spring's [TransactionalTestExecutionListener]
+ *    checks whether there's already a transaction associated with the current thread; it throws an
+ *    exception if so since transactions are supposed to have been cleared between tests.
+ * 4. Spring's [TransactionalTestExecutionListener] begins a new transaction and stores its
+ *    information in the thread-local variable in [TransactionContextHolder].
+ * 5. As the test runs, the application code calls [DSLContext.transaction]. (This is fine even
+ *    though there's already an open transaction.)
+ * 6. In order to handle cases where transactions are running in asynchronous code such that the
+ *    actual work is done in other threads, jOOQ runs the transactional code in a managed block
+ *    using [ForkJoinPool.managedBlock], whose purpose is to prevent deadlocks by ensuring that if
+ *    it's called from a pooled thread, the pool has spare capacity available.
+ * 8. [ForkJoinPool.managedBlock] detects that it's running in the pool created by jUnit in step 1.
+ * 9. If there are tests running in all the threads in the pool, which there will be once the test
+ *    run has warmed up, it spawns a new thread as a spare.
+ * 10. The new thread inherits the transaction context in [TransactionContextHolder] because the
+ *     variable there is an [InheritableThreadLocal].
+ * 11. The pool now has an additional thread available, and there's work queued up for the thread
+ *     pool because there are still lots of tests remaining to be run, so a new test starts running
+ *     on the newly-created thread.
+ * 12. The sanity check from step 3 detects that there's a transaction associated with the new
+ *     thread, and it throws an exception, marking the test as failed.
+ *
+ * The workaround is to explicitly clear the transaction context the first time a test runs on each
+ * thread, such that the sanity check in [TransactionalTestExecutionListener] doesn't see the
+ * inherited value. Subsequent tests on the same thread still get sanity-checked as normal.
+ *
+ * This class is under `org.springframework` rather than `com.terraformation` because
+ * [TransactionContextHolder] is a package-private class.
+ */
+@Order(3000) // TransactionalTestExecutionListener is order 4000
+class InheritedTransactionRemover : TestExecutionListener {
+  private val transactionRemoved = ThreadLocal.withInitial { false }
+
+  override fun beforeTestMethod(testContext: TestContext) {
+    if (!transactionRemoved.get()) {
+      TransactionContextHolder.removeCurrentTransactionContext()
+      transactionRemoved.set(true)
+    }
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,6 +1,10 @@
 spring:
   datasource:
     url: jdbc:tc:postgresql:15:///terraware
+    hikari:
+      # Set this higher than the expected number of concurrent tests so tests don't block
+      # waiting for connections from the pool.
+      maximum-pool-size: 30
   flyway:
     locations:
       - "classpath:db/migration/dev"

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+# Enable parallel test execution and allow all tests to run concurrently. jUnit will create as
+# many test-running threads as there are CPUs on the host (its default behavior).
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
Configure JUnit to run tests concurrently. The concurrency level depends on the
number of CPUs on the host.

This requires working around a bug in the Spring test scaffolding's transaction
management.