### PR TITLE
SW-5553 File support ticket when document upload fails

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
@@ -1,0 +1,35 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DocumentStore
+import com.terraformation.backend.db.default_schema.ProjectId
+
+/**
+ * Published when the user attempts to upload a document for a document deliverable but the upload
+ * fails due to an error on our side.
+ */
+data class DeliverableDocumentUploadFailedEvent(
+    val deliverableId: DeliverableId,
+    val projectId: ProjectId,
+    val reason: FailureReason,
+    /** Which document store the file would have been saved to, or null if none is configured. */
+    val documentStore: DocumentStore,
+    /** The user-supplied name of the uploaded file, if any. */
+    val originalName: String?,
+    /** Which folder on the document store would have been used, or null if none is configured. */
+    val documentStoreFolder: String? = null,
+    /** Exception that caused the failure, if any. */
+    val exception: Exception? = null,
+) {
+  /**
+   * Why the upload failed. The descriptions here are included in the support ticket that gets filed
+   * about the failure.
+   */
+  enum class FailureReason(val description: String) {
+    ProjectNotConfigured("Project document settings are not configured"),
+    FileNamingNotConfigured("File naming is not configured for project"),
+    FolderNotConfigured("Upload folder is not configured for project"),
+    CouldNotUpload("Could not upload to the configured folder"),
+    CouldNotRename("Could not rename uploaded document"),
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
@@ -1,0 +1,62 @@
+package com.terraformation.backend.support
+
+import com.terraformation.backend.accelerator.db.ParticipantStore
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.db.ProjectStore
+import com.terraformation.backend.db.accelerator.tables.daos.DeliverablesDao
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.support.atlassian.model.SupportRequestType
+import jakarta.inject.Named
+import org.springframework.context.event.EventListener
+
+@Named
+class FailureReportingService(
+    private val config: TerrawareServerConfig,
+    private val deliverablesDao: DeliverablesDao,
+    private val organizationStore: OrganizationStore,
+    private val participantStore: ParticipantStore,
+    private val projectStore: ProjectStore,
+    private val supportService: SupportService,
+) {
+  private val log = perClassLogger()
+
+  @EventListener
+  fun on(event: DeliverableDocumentUploadFailedEvent) {
+    try {
+      val deliverablesRow = deliverablesDao.fetchOneById(event.deliverableId)
+      val project = projectStore.fetchOneById(event.projectId)
+      val organization = organizationStore.fetchOneById(project.organizationId)
+      val participant = project.participantId?.let { participantStore.fetchOneById(it) }
+
+      val description =
+          """
+            An error occurred when a user tried to upload a document for a deliverable. This is a system-generated support ticket.
+            
+            Reason: ${event.reason.description}
+            
+            Organization: ${organization.name}
+            Participant: ${participant?.name ?: "N/A"}
+            Project: ${project.name}
+            
+            Deliverable: ${deliverablesRow?.name ?: "N/A"} (ID ${event.deliverableId})
+            
+            Service: ${event.documentStore}
+            Folder: ${event.documentStoreFolder ?: "Not configured"}
+            
+            System error: ${event.exception}
+          """
+              .trimIndent()
+
+      if (config.atlassian.enabled) {
+        supportService.submitServiceRequest(
+            SupportRequestType.BugReport, "Document upload failed", description)
+      } else {
+        log.info("Atlassian integration disabled; would file support ticket:\n$description")
+      }
+    } catch (e: Exception) {
+      log.error("Failed to file support ticket for upload failure", e)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
@@ -1,0 +1,133 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.ProjectDocumentSettingsNotConfiguredException
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent
+import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent.FailureReason
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.DocumentStore
+import com.terraformation.backend.db.accelerator.SubmissionDocumentId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.file.DropboxWriter
+import com.terraformation.backend.file.GoogleDriveWriter
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.core.MediaType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val dropboxWriter: DropboxWriter = mockk()
+  private val eventPublisher = TestEventPublisher()
+  private val googleDriveWriter: GoogleDriveWriter = mockk()
+
+  private val service: SubmissionService by lazy {
+    SubmissionService(clock, dropboxWriter, dslContext, eventPublisher, googleDriveWriter)
+  }
+
+  private val contentType = MediaType.APPLICATION_OCTET_STREAM
+  private val description = "description"
+  private val googleDriveFolder = "https://drive.google.com/drive/folders/abc"
+  private val inputStream = byteArrayOf(1, 2, 3).inputStream()
+  private val originalName = "file.doc"
+
+  private lateinit var deliverableId: DeliverableId
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    projectId = insertProject()
+    insertModule()
+    deliverableId = insertDeliverable()
+
+    every { user.canCreateSubmission(any()) } returns true
+  }
+
+  @Nested
+  inner class ReceiveDocument {
+    @Test
+    fun `publishes event and throws exception if project accelerator details not configured`() {
+      assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
+          FailureReason.ProjectNotConfigured)
+    }
+
+    @Test
+    fun `publishes event and throws exception if file naming not configured`() {
+      insertProjectAcceleratorDetails()
+
+      assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
+          FailureReason.FileNamingNotConfigured)
+    }
+
+    @Test
+    fun `publishes event and throws exception if Google URL not configured`() {
+      insertProjectAcceleratorDetails(fileNaming = "xyz")
+
+      assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
+          FailureReason.FolderNotConfigured)
+    }
+
+    @Test
+    fun `publishes event and throws exception if Dropbox URL not configured`() {
+      insertProjectAcceleratorDetails(fileNaming = "xyz")
+      deliverableId = insertDeliverable(isSensitive = true)
+
+      assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
+          FailureReason.FolderNotConfigured, DocumentStore.Dropbox)
+    }
+
+    @Test
+    fun `publishes event and throws exception if upload to document store fails`() {
+      insertProjectAcceleratorDetails(fileNaming = "xyz", googleFolderUrl = googleDriveFolder)
+
+      val exception = IllegalStateException("Failure")
+
+      every { googleDriveWriter.getFileIdForFolderUrl(any()) } returns "abc"
+      every { googleDriveWriter.getDriveIdForFile(any()) } returns "def"
+      every {
+        googleDriveWriter.uploadFile(any(), any(), any(), any(), any(), any(), any(), any(), any())
+      } throws exception
+
+      assertEventAndException(
+          FailureReason.CouldNotUpload, DocumentStore.Google, googleDriveFolder, exception)
+    }
+
+    @Test
+    fun `throws exception if no permission to create submission`() {
+      every { user.canCreateSubmission(any()) } returns false
+      every { user.canReadProject(any()) } returns true
+
+      assertThrows<AccessDeniedException> { receiveDocument() }
+    }
+
+    private inline fun <reified E : Exception> assertEventAndException(
+        reason: FailureReason,
+        documentStore: DocumentStore = DocumentStore.Google,
+        folder: String? = null,
+        exception: E? = null,
+    ) {
+      assertThrows<E> { receiveDocument() }
+
+      eventPublisher.assertEventPublished(
+          DeliverableDocumentUploadFailedEvent(
+              deliverableId, projectId, reason, documentStore, originalName, folder, exception))
+    }
+
+    private fun receiveDocument(): SubmissionDocumentId =
+        service.receiveDocument(
+            inputStream, originalName, projectId, deliverableId, description, contentType)
+  }
+}


### PR DESCRIPTION
If the Google or Dropbox folders for a project are misconfigured, either in our
database or on the Google/Dropbox side, uploading a document for a document
deliverable will fail, but the accelerator admins will never find out about it
since they don't monitor server errors.

With this change, failed deliverable document uploads will cause support tickets
to be created in Jira; the tickets can then be routed to whichever person is
responsible for configuring the project's folders.