### PR TITLE
SW-5553 Return HTTP 507 on failed document uploads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.db.DeliverableNotFoundException
 import com.terraformation.backend.accelerator.db.ProjectDocumentSettingsNotConfiguredException
+import com.terraformation.backend.accelerator.db.ProjectDocumentStorageFailedException
 import com.terraformation.backend.accelerator.db.SubmissionDocumentNotFoundException
 import com.terraformation.backend.accelerator.document.DropboxReceiver
 import com.terraformation.backend.accelerator.document.GoogleDriveReceiver
@@ -322,6 +323,10 @@ class SubmissionService(
             documentStoreFolder,
             exception))
 
-    throw exception ?: ProjectDocumentSettingsNotConfiguredException(projectId)
+    if (exception != null) {
+      throw ProjectDocumentStorageFailedException(projectId, cause = exception)
+    } else {
+      throw ProjectDocumentSettingsNotConfiguredException(projectId)
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -49,8 +49,15 @@ class ProjectApplicationNotFoundException(projectId: ProjectId) :
 class ProjectDeliverableNotFoundException(deliverableId: DeliverableId, projectId: ProjectId) :
     EntityNotFoundException("Deliverable $deliverableId not found for project $projectId")
 
+open class ProjectDocumentStorageFailedException(
+    projectId: ProjectId,
+    message: String = "Project $projectId document storage failed",
+    cause: Throwable? = null
+) : Exception(message, cause)
+
 class ProjectDocumentSettingsNotConfiguredException(id: ProjectId) :
-    MismatchedStateException("Project $id document upload settings have not been configured")
+    ProjectDocumentStorageFailedException(
+        id, "Project $id document upload settings have not been configured")
 
 class ProjectModuleNotFoundException(projectId: ProjectId, moduleId: ModuleId) :
     MismatchedStateException("Project $projectId is not associated with module $moduleId")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
@@ -19,7 +19,7 @@ data class DeliverableDocumentUploadFailedEvent(
     /** Which folder on the document store would have been used, or null if none is configured. */
     val documentStoreFolder: String? = null,
     /** Exception that caused the failure, if any. */
-    val exception: Exception? = null,
+    val exception: Throwable? = null,
 ) {
   /**
    * Why the upload failed. The descriptions here are included in the support ticket that gets filed


### PR DESCRIPTION
The client needs to be able to indicate to end users that the system has already
notified customer support about a failed document upload. Make the server return
HTTP 507 (which is named "insufficient storage" but is actually a catch-all WebDAV
code for the server being unable to store a file) in cases where it has attempted
to generate a support ticket.