### PR TITLE
SW-5761 Filter permanent clusters by requested subzones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -98,7 +98,9 @@ class ObservationService(
         plantingSite.plantingZones.forEach { plantingZone ->
           log.withMDC("plantingZoneId" to plantingZone.id) {
             if (plantingZone.plantingSubzones.any { it.id in plantedSubzoneIds }) {
-              val permanentPlotIds = plantingZone.choosePermanentPlots(plantedSubzoneIds)
+              val permanentPlotIds =
+                  plantingZone.choosePermanentPlots(
+                      plantedSubzoneIds, observation.requestedSubzoneIds)
               val temporaryPlotIds =
                   plantingZone
                       .chooseTemporaryPlots(


### PR DESCRIPTION
When an observation was requested for specific subzones, we were filtering out the
temporary plots from unrequested ones, but not the permanent plots.