### PR TITLE
Use system user ID when automatically updating variable status

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdater.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.accelerator.event.VariableValueUpdatedEvent
-import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
@@ -16,11 +15,9 @@ class VariableValueStatusUpdater(
   /** Update variable status to "in review" when value is updated */
   @EventListener
   fun on(event: VariableValueUpdatedEvent) {
-    val createdBy = currentUser().userId
-
     systemUser.run {
       variableWorkflowStore.update(
-          event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null, createdBy)
+          event.projectId, event.variableId, VariableWorkflowStatus.InReview, null, null)
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
@@ -69,7 +68,6 @@ class VariableWorkflowStore(
       status: VariableWorkflowStatus,
       feedback: String?,
       internalComment: String?,
-      createdBy: UserId = currentUser().userId,
   ): ExistingVariableWorkflowHistoryModel {
     requirePermissions { updateInternalVariableWorkflowDetails(projectId) }
 
@@ -93,7 +91,7 @@ class VariableWorkflowStore(
       val newModel =
           dslContext
               .insertInto(VARIABLE_WORKFLOW_HISTORY)
-              .set(CREATED_BY, createdBy)
+              .set(CREATED_BY, currentUser().userId)
               .set(CREATED_TIME, clock.instant())
               .set(FEEDBACK, feedback)
               .set(INTERNAL_COMMENT, internalComment)


### PR DESCRIPTION
- Product has decided that they would rather have the system user ID in place of the original user ID, this PR implements that change.