### PR TITLE
SW-5801 Import project setup data from PDH

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ApplicationStore.kt
@@ -97,6 +97,16 @@ class ApplicationStore(
         ?: throw ApplicationNotFoundException(applicationId)
   }
 
+  fun fetchOneByInternalName(internalName: String): ExistingApplicationModel? {
+    val application = fetchByCondition(APPLICATIONS.INTERNAL_NAME.eq(internalName)).singleOrNull()
+
+    if (application != null) {
+      requirePermissions { readApplication(application.id) }
+    }
+
+    return application
+  }
+
   fun fetchByProjectId(projectId: ProjectId): List<ExistingApplicationModel> {
     requirePermissions { readProject(projectId) }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortStore.kt
@@ -46,6 +46,21 @@ class CohortStore(
         ?: throw CohortNotFoundException(cohortId)
   }
 
+  fun fetchOneByName(
+      name: String,
+      cohortDepth: CohortDepth = CohortDepth.Cohort,
+      cohortModuleDepth: CohortModuleDepth = CohortModuleDepth.Cohort,
+  ): ExistingCohortModel? {
+    val cohort =
+        fetch(COHORTS.NAME.eq(name), cohortDepth, cohortModuleDepth).firstOrNull() ?: return null
+
+    if (cohortDepth == CohortDepth.Participant) {
+      requirePermissions { readCohortParticipants(cohort.id) }
+    }
+
+    return cohort
+  }
+
   fun findAll(
       cohortDepth: CohortDepth = CohortDepth.Cohort,
       cohortModuleDepth: CohortModuleDepth = CohortModuleDepth.Cohort,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
@@ -1,0 +1,310 @@
+package com.terraformation.backend.accelerator.migration
+
+import com.terraformation.backend.accelerator.db.ApplicationStore
+import com.terraformation.backend.accelerator.db.CohortStore
+import com.terraformation.backend.accelerator.db.ParticipantStore
+import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
+import com.terraformation.backend.accelerator.model.ExistingApplicationModel
+import com.terraformation.backend.accelerator.model.ExistingCohortModel
+import com.terraformation.backend.accelerator.model.NewParticipantModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.db.ProjectStore
+import com.terraformation.backend.customer.model.ExistingProjectModel
+import com.terraformation.backend.customer.model.NewProjectModel
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.ApplicationStatus
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.ScoreCategory
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_SCORES
+import com.terraformation.backend.db.default_schema.LandUseModelType
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
+import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.importer.processCsvFile
+import jakarta.inject.Named
+import java.io.InputStream
+import java.math.BigDecimal
+import java.net.URI
+import java.time.InstantSource
+import org.jooq.DSLContext
+
+@Named
+class ProjectSetUpImporter(
+    private val applicationStore: ApplicationStore,
+    private val clock: InstantSource,
+    private val cohortStore: CohortStore,
+    private val countriesDao: CountriesDao,
+    private val dslContext: DSLContext,
+    private val organizationStore: OrganizationStore,
+    private val participantStore: ParticipantStore,
+    private val projectAcceleratorDetailsStore: ProjectAcceleratorDetailsStore,
+    private val projectStore: ProjectStore,
+    private val systemUser: SystemUser,
+) {
+
+  fun importCsv(inputStream: InputStream) {
+    requirePermissions { createEntityWithOwner(systemUser.userId) }
+
+    val userId = currentUser().userId
+
+    systemUser.run {
+      dslContext.transaction { _ ->
+        lateinit var columnNames: Map<Int, String>
+
+        processCsvFile(inputStream, skipHeaderRow = false) { values, rowNumber, addError ->
+          try {
+            if (rowNumber == 1) {
+              columnNames =
+                  values
+                      .mapIndexed { index, name -> name?.let { index to it } }
+                      .filterNotNull()
+                      .toMap()
+            }
+
+            // Rows 2 and 3 are additional headers, so only process data starting at row 4.
+            if (rowNumber < 4) {
+              return@processCsvFile
+            }
+
+            val valuesByName =
+                values
+                    .mapIndexed { index, value -> value?.let { columnNames[index]!! to it } }
+                    .filterNotNull()
+                    .toMap()
+
+            val dealName = getMandatory(valuesByName, "Project Name")
+            val countryCode = fetchCountryCode(dealName)
+
+            // We'll use the non-country part of the deal name as the name for the org, project,
+            // etc.
+            val projectName = dealName.substring(4)
+
+            val application: ExistingApplicationModel
+            val project: ExistingProjectModel
+
+            // If we already have an application with the deal name, use it to get the existing
+            // organization and project IDs even if the spreadsheet doesn't have them listed.
+            val existingApplication = applicationStore.fetchOneByInternalName(dealName)
+
+            if (existingApplication != null) {
+              application = existingApplication
+              project = projectStore.fetchOneById(existingApplication.projectId)
+            } else {
+              val organizationIdFromCsv =
+                  valuesByName["Organization ID"]?.let { OrganizationId(it) }
+              val organization =
+                  if (organizationIdFromCsv != null) {
+                    organizationStore.fetchOneById(organizationIdFromCsv)
+                  } else {
+                    organizationStore.createWithAdmin(
+                        OrganizationsRow(countryCode = countryCode, name = projectName),
+                        ownerUserId = userId)
+                  }
+
+              val projectIdFromCsv = valuesByName["Project ID"]?.let { ProjectId(it) }
+              project =
+                  if (projectIdFromCsv != null) {
+                    projectStore.fetchOneById(projectIdFromCsv)
+                  } else {
+                    val projectId =
+                        projectStore.create(
+                            NewProjectModel(
+                                id = null, name = projectName, organizationId = organization.id))
+                    projectStore.fetchOneById(projectId)
+                  }
+
+              application = applicationStore.create(project.id)
+
+              // The default internal name has no country code.
+              with(APPLICATIONS) {
+                dslContext
+                    .update(APPLICATIONS)
+                    .set(INTERNAL_NAME, dealName)
+                    .where(ID.eq(application.id))
+                    .execute()
+              }
+            }
+
+            updateApplicationStatus(valuesByName, application)
+            updateParticipantId(valuesByName, project)
+            updateProjectAcceleratorDetails(valuesByName, project, countryCode)
+            updateScores(valuesByName, project)
+          } catch (e: Exception) {
+            addError(e.message ?: e.toString())
+          }
+        }
+      }
+    }
+  }
+
+  private fun updateScores(valuesByName: Map<String, String>, project: ExistingProjectModel) {
+    val columnNamePrefixes =
+        listOf(
+            "Phase 0: " to CohortPhase.Phase0DueDiligence,
+            "Phase 1: " to CohortPhase.Phase1FeasibilityStudy,
+        )
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    columnNamePrefixes.forEach { (phasePrefix, phase) ->
+      ScoreCategory.entries.forEach { category ->
+        val prefix = "$phasePrefix${category.name}"
+        val score = getInt(valuesByName, "$prefix Score")
+
+        // Qualitative column names sometimes include the word "Score" and sometimes not.
+        val qualitative =
+            valuesByName["$prefix Qualitative"] ?: valuesByName["$prefix Score Qualitative"]
+
+        if (score != null || qualitative != null) {
+          // Set directly rather than using ProjectScoreStore because some of the data would fail
+          // validation.
+          with(PROJECT_SCORES) {
+            dslContext
+                .insertInto(PROJECT_SCORES)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .set(PHASE_ID, phase)
+                .set(PROJECT_ID, project.id)
+                .set(QUALITATIVE, qualitative)
+                .set(SCORE, score)
+                .set(SCORE_CATEGORY_ID, category)
+                .onConflict()
+                .doUpdate()
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .set(QUALITATIVE, qualitative)
+                .set(SCORE, score)
+                .execute()
+          }
+        }
+      }
+    }
+  }
+
+  private fun updateProjectAcceleratorDetails(
+      valuesByName: Map<String, String>,
+      project: ExistingProjectModel,
+      countryCode: String
+  ) {
+    val landUseModelTypes =
+        valuesByName["Land Use Model Type"]
+            ?.let { typesString ->
+              typesString.split(";").map { LandUseModelType.forJsonValue(it.trim()) }
+            }
+            ?.toSet()
+
+    projectAcceleratorDetailsStore.update(project.id) { model ->
+      model.copy(
+          annualCarbon = getBigDecimal(valuesByName, "Annual Carbon (t)"),
+          applicationReforestableLand =
+              getBigDecimal(valuesByName, "Application Reforestable Land (ha)"),
+          carbonCapacity = getBigDecimal(valuesByName, "Carbon Capacity (tCO2/ha)"),
+          confirmedReforestableLand = getBigDecimal(valuesByName, "TF Reforestable Land (ha)"),
+          countryCode = countryCode,
+          dealDescription = valuesByName["Deal Description"],
+          dropboxFolderPath = valuesByName["Dropbox Path"],
+          failureRisk = valuesByName["Failure Risk"],
+          fileNaming = getMandatory(valuesByName, "Project Name"),
+          googleFolderUrl = valuesByName["GDrive URL"]?.let { URI(it) },
+          hubSpotUrl = valuesByName["HubSpot Link"]?.let { URI(it) },
+          investmentThesis = valuesByName["Investment Thesis"],
+          landUseModelTypes = landUseModelTypes ?: emptySet(),
+          maxCarbonAccumulation =
+              getBigDecimal(valuesByName, "Max Carbon Accumulation (CO2/ha/yr)"),
+          minCarbonAccumulation =
+              getBigDecimal(valuesByName, "Min Carbon Accumulation (CO2/ha/yr)"),
+          numNativeSpecies = getInt(valuesByName, "Number of native species"),
+          perHectareBudget = getBigDecimal(valuesByName, "Per Hectare Estimated Budget (USD)"),
+          totalCarbon = getBigDecimal(valuesByName, "Total Carbon (t)"),
+          totalExpansionPotential = getBigDecimal(valuesByName, "Total Expansion Potential (ha)"),
+          whatNeedsToBeTrue = valuesByName["What Needs To Be True"],
+      )
+    }
+  }
+
+  private fun updateParticipantId(
+      valuesByName: Map<String, String>,
+      project: ExistingProjectModel,
+  ) {
+    val cohortName = valuesByName["Cohort"]
+    if (cohortName != null && project.participantId == null) {
+      val cohort: ExistingCohortModel =
+          cohortStore.fetchOneByName(cohortName)
+              ?: throw ImportError("Cohort $cohortName does not exist")
+
+      val participantIdFromCsv = valuesByName["Participant ID"]?.let { ParticipantId(it) }
+      val participant =
+          participantIdFromCsv?.let { participantStore.fetchOneById(it) }
+              ?: participantStore.create(NewParticipantModel.create(project.name, cohort.id))
+
+      with(PROJECTS) {
+        dslContext
+            .update(PROJECTS)
+            .set(PARTICIPANT_ID, participant.id)
+            .where(ID.eq(project.id))
+            .execute()
+      }
+    }
+  }
+
+  private fun updateApplicationStatus(
+      valuesByName: Map<String, String>,
+      application: ExistingApplicationModel
+  ) {
+    val applicationStatus =
+        ApplicationStatus.forJsonValue(getMandatory(valuesByName, "Application Status"))
+
+    if (application.status != applicationStatus) {
+      // Update directly rather than using ApplicationStore; we don't want to send notifications
+      // about status changes.
+      dslContext
+          .update(APPLICATIONS)
+          .set(APPLICATIONS.APPLICATION_STATUS_ID, applicationStatus)
+          .where(APPLICATIONS.ID.eq(application.id))
+          .execute()
+    }
+  }
+
+  private fun fetchCountryCode(dealName: String): String {
+    val countryCodeAlpha3 = dealName.substring(0, 3)
+    val countriesRow =
+        countriesDao.fetchOneByCodeAlpha3(countryCodeAlpha3)
+            ?: throw ImportError("Invalid country code prefix on deal name")
+    val countryCode = countriesRow.code!!
+    return countryCode
+  }
+
+  private fun getMandatory(valuesByName: Map<String, String>, key: String) =
+      valuesByName[key] ?: throw ImportError("Missing required value in column $key")
+
+  private fun getBigDecimal(valuesByName: Map<String, String>, key: String): BigDecimal? {
+    return valuesByName[key]?.let { str ->
+      try {
+        BigDecimal(str)
+      } catch (e: Exception) {
+        throw ImportError("Value in column $key is not a number")
+      }
+    }
+  }
+
+  private fun getInt(valuesByName: Map<String, String>, key: String): Int? {
+    return valuesByName[key]?.let { str ->
+      try {
+        str.toInt()
+      } catch (e: Exception) {
+        throw ImportError("Value in column $key is not an integer")
+      }
+    }
+  }
+
+  private class ImportError(message: String) : Exception(message)
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPdhController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPdhController.kt
@@ -1,0 +1,52 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.accelerator.migration.ProjectSetUpImporter
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.importer.CsvImportFailedException
+import com.terraformation.backend.log.perClassLogger
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminPdhController(
+    private val projectSetUpImporter: ProjectSetUpImporter,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/pdh")
+  fun pdhHome(): String {
+    return "/admin/pdh"
+  }
+
+  @PostMapping("/uploadProjectSetUp")
+  fun uploadProjectSetUp(
+      @RequestPart file: MultipartFile,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      file.inputStream.use { inputStream -> projectSetUpImporter.importCsv(inputStream) }
+
+      redirectAttributes.successMessage = "Projects imported successfully."
+    } catch (e: CsvImportFailedException) {
+      redirectAttributes.failureMessage = e.message
+      redirectAttributes.failureDetails = e.errors.map { "Row ${it.rowNumber}: ${it.message}" }
+    } catch (e: Exception) {
+      log.warn("Import failed", e)
+      redirectAttributes.failureMessage = "Import failed: ${e.message}"
+    }
+
+    return redirectToPdhHome()
+  }
+
+  private fun redirectToPdhHome() = "redirect:/admin/pdh"
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -122,11 +122,14 @@ class OrganizationStore(
         }
   }
 
-  /** Creates a new organization and makes the current user an owner. */
+  /** Creates a new organization and adds a user as owner. */
   fun createWithAdmin(
       row: OrganizationsRow,
-      managedLocationTypes: Set<ManagedLocationType> = emptySet()
+      managedLocationTypes: Set<ManagedLocationType> = emptySet(),
+      ownerUserId: UserId = currentUser().userId,
   ): OrganizationModel {
+    requirePermissions { createEntityWithOwner(ownerUserId) }
+
     validateCountryCode(row.countryCode, row.countrySubdivisionCode)
     validateOrganizationType(row.organizationTypeId, row.organizationTypeDetails)
 
@@ -158,7 +161,7 @@ class OrganizationStore(
             .set(MODIFIED_TIME, clock.instant())
             .set(ORGANIZATION_ID, fullRow.id)
             .set(ROLE_ID, Role.Owner)
-            .set(USER_ID, currentUser().userId)
+            .set(USER_ID, ownerUserId)
             .execute()
       }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -208,6 +208,10 @@ data class IndividualUser(
   override fun canCreateDraftPlantingSite(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
 
+  override fun canCreateEntityWithOwner(userId: UserId): Boolean {
+    return userId == this.userId || isSuperAdmin()
+  }
+
   override fun canCreateFacility(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
   override fun canCreateNotification(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -245,6 +245,13 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun createEntityWithOwner(userId: UserId) {
+    if (!user.canCreateEntityWithOwner(userId)) {
+      readUser(userId)
+      throw AccessDeniedException("No permission to create entity with owner $userId")
+    }
+  }
+
   fun createFacility(organizationId: OrganizationId) {
     if (!user.canCreateFacility(organizationId)) {
       readOrganization(organizationId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -160,6 +160,8 @@ interface TerrawareUser : Principal {
 
   fun canCreateDraftPlantingSite(organizationId: OrganizationId): Boolean = defaultPermission
 
+  fun canCreateEntityWithOwner(userId: UserId): Boolean = defaultPermission
+
   fun canCreateFacility(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean =

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -155,5 +155,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canImportGlobalSpeciesData}">
+    <h2>PDH Migration</h2>
+
+    <p>
+        <a href="/admin/pdh">Import PDH data into Terraware</a>
+    </p>
+</th:block>
+
 </body>
 </html>

--- a/src/main/resources/templates/admin/pdh.html
+++ b/src/main/resources/templates/admin/pdh.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>PDH Migration</h2>
+
+<form method="POST" action="/admin/uploadProjectSetUp" enctype="multipart/form-data">
+    <label>
+        Project Set Up CSV
+        <input type="file" name="file" required/>
+    </label>
+    <input type="submit"/>
+</form>
+
+</body>
+</html>

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -96,6 +96,7 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     insertOrganizationInternalTag(organizationId, InternalTagIds.Reporter)
     facilityId = insertFacility()
 
+    every { user.canCreateEntityWithOwner(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
     every { user.canUpdateOrganization(any()) } returns true
     every { user.canAddOrganizationUser(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -364,6 +364,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
+  fun createEntityWithOwner() =
+      allow { createEntityWithOwner(otherUserId) } ifUser { canCreateEntityWithOwner(otherUserId) }
+
+  @Test
   fun createFacility() =
       allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1509,6 +1509,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
+        createEntityWithOwner = true,
         readUser = true,
         readUserDeliverableCategories = true,
         updateUserDeliverableCategories = true,
@@ -1684,6 +1685,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
+        createEntityWithOwner = true,
         readUser = true,
         readUserDeliverableCategories = true,
         updateUserDeliverableCategories = true,
@@ -2249,6 +2251,11 @@ internal class PermissionTest : DatabaseTest() {
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
+  }
+
+  @Test
+  fun `user can create organization as themselves`() {
+    assertTrue(user.canCreateEntityWithOwner(userId), "Can create organization as self")
   }
 
   @Test
@@ -3279,11 +3286,16 @@ internal class PermissionTest : DatabaseTest() {
 
     fun expect(
         vararg userIds: UserId,
+        createEntityWithOwner: Boolean = false,
         readUser: Boolean = false,
         readUserDeliverableCategories: Boolean = false,
         updateUserDeliverableCategories: Boolean = false,
     ) {
       userIds.forEach { userId ->
+        assertEquals(
+            createEntityWithOwner,
+            user.canCreateEntityWithOwner(userId),
+            "Can create entity with owner $userId")
         assertEquals(readUser, user.canReadUser(userId), "Can read user $userId")
         assertEquals(
             readUserDeliverableCategories,


### PR DESCRIPTION
Add an upload form to the admin UI that accepts the "Project Set Up" tab from
the PDH migration spreadsheet.

The import process can create organizations, projects, and participants if needed.
It creates applications, accelerator details, and scores for projects, or updates
existing ones if any.

Once the migration is finished, the importer can be removed from the code base.
