### PR TITLE
SW-5754 API to manage organization internal tags

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/InternalTagsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/InternalTagsController.kt
@@ -1,0 +1,78 @@
+package com.terraformation.backend.customer.api
+
+import com.terraformation.backend.api.InternalEndpoint
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.db.InternalTagStore
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.InternalTagId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.pojos.InternalTagsRow
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@InternalEndpoint
+@RequestMapping("/api/v1")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@RestController
+class InternalTagsController(
+    private val internalTagStore: InternalTagStore,
+) {
+  @GetMapping("/internalTags")
+  @Operation(summary = "List all the available internal tags")
+  fun listAllInternalTags(): ListAllInternalTagsResponsePayload {
+    val rows = internalTagStore.findAllTags()
+
+    return ListAllInternalTagsResponsePayload(rows.map { InternalTagPayload(it) })
+  }
+
+  @GetMapping("/organizations/{organizationId}/internalTags")
+  @Operation(summary = "List the internal tags assigned to an organization")
+  fun listOrganizationInternalTags(
+      @PathVariable organizationId: OrganizationId
+  ): ListOrganizationInternalTagsResponsePayload {
+    val tagIds = internalTagStore.fetchTagsByOrganization(organizationId)
+
+    return ListOrganizationInternalTagsResponsePayload(tagIds)
+  }
+
+  @PutMapping("/organizations/{organizationId}/internalTags")
+  @Operation(summary = "Replace the list of internal tags assigned to an organization")
+  fun updateOrganizationInternalTags(
+      @PathVariable organizationId: OrganizationId,
+      @RequestBody payload: UpdateOrganizationInternalTagsRequestPayload
+  ): SimpleSuccessResponsePayload {
+    internalTagStore.updateOrganizationTags(organizationId, payload.tagIds)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class InternalTagPayload(
+    val id: InternalTagId,
+    @Schema(
+        description =
+            "If true, this internal tag is system-defined and may affect the behavior of the " +
+                "application. If falso, the tag is admin-defined and is only used for reporting.")
+    val isSystem: Boolean,
+    val name: String,
+) {
+  constructor(
+      row: InternalTagsRow
+  ) : this(id = row.id!!, name = row.name!!, isSystem = row.isSystem!!)
+}
+
+data class ListAllInternalTagsResponsePayload(val tags: List<InternalTagPayload>) :
+    SuccessResponsePayload
+
+data class ListOrganizationInternalTagsResponsePayload(val tagIds: Set<InternalTagId>) :
+    SuccessResponsePayload
+
+data class UpdateOrganizationInternalTagsRequestPayload(val tagIds: Set<InternalTagId>)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
@@ -96,6 +96,7 @@ class InternalTagStore(
         .join(ORGANIZATIONS)
         .on(ORGANIZATION_INTERNAL_TAGS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
         .where(ORGANIZATION_INTERNAL_TAGS.INTERNAL_TAG_ID.eq(tagId))
+        .orderBy(ORGANIZATIONS.ID)
         .fetchInto(OrganizationsRow::class.java)
   }
 
@@ -120,6 +121,7 @@ class InternalTagStore(
           .select(INTERNAL_TAG_ID)
           .from(ORGANIZATION_INTERNAL_TAGS)
           .where(ORGANIZATION_ID.eq(organizationId))
+          .orderBy(INTERNAL_TAG_ID)
           .fetchSet(INTERNAL_TAG_ID.asNonNullable())
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
@@ -1,0 +1,150 @@
+package com.terraformation.backend.customer.api
+
+import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.default_schema.GlobalRole
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.put
+
+class InternalTagsControllerTest : ControllerIntegrationTest() {
+  @Nested
+  inner class ListAllInternalTags {
+    @Test
+    fun `returns all internal tags`() {
+      insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+      val newTagId = insertInternalTag("Random Tag")
+
+      mockMvc
+          .get("/api/v1/internalTags")
+          .andExpectJson(
+              """
+                {
+                  "tags": [
+                    {
+                      "id": ${InternalTagIds.Reporter},
+                      "isSystem": true,
+                      "name": "Reporter"
+                    },
+                    {
+                      "id": ${InternalTagIds.Internal},
+                      "isSystem": true,
+                      "name": "Internal"
+                    },
+                    {
+                      "id": ${InternalTagIds.Testing},
+                      "isSystem": true,
+                      "name": "Testing"
+                    },
+                    {
+                      "id": ${InternalTagIds.Accelerator},
+                      "isSystem": true,
+                      "name": "Accelerator"
+                    },
+                    {
+                      "id": $newTagId,
+                      "isSystem": false,
+                      "name": "Random Tag"
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                  .trimIndent())
+    }
+
+    @Test
+    fun `returns error if user is not a super-admin`() {
+      mockMvc.get("/api/v1/internalTags").andExpect { status { isForbidden() } }
+    }
+  }
+
+  @Nested
+  inner class ListOrganizationInternalTags {
+    @Test
+    fun `returns internal tag IDs for requested organization`() {
+      insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+      val organizationId = insertOrganization()
+      insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
+      val newTagId = insertInternalTag()
+      insertOrganizationInternalTag()
+
+      insertOrganization()
+      insertOrganizationInternalTag(tagId = InternalTagIds.Reporter)
+
+      mockMvc
+          .get("/api/v1/organizations/$organizationId/internalTags")
+          .andExpectJson(
+              """
+                {
+                  "tagIds": [
+                    ${InternalTagIds.Accelerator},
+                    $newTagId
+                  ],
+                  "status": "ok"
+                }
+              """
+                  .trimIndent())
+    }
+
+    @Test
+    fun `returns error if user is not a super-admin`() {
+      val organizationId = insertOrganization()
+      mockMvc.get("/api/v1/organizations/$organizationId/internalTags").andExpect {
+        status { isForbidden() }
+      }
+    }
+  }
+
+  @Nested
+  inner class UpdateOrganizationInternalTags {
+    @Test
+    fun `updates organization internal tags`() {
+      insertUserGlobalRole(role = GlobalRole.SuperAdmin)
+      val organizationId = insertOrganization()
+      insertOrganizationInternalTag(tagId = InternalTagIds.Internal)
+      val otherOrganizationId = insertOrganization()
+      insertOrganizationInternalTag(tagId = InternalTagIds.Testing)
+      val newTagId = insertInternalTag()
+
+      val payload =
+          """
+            {
+              "tagIds": [
+                ${InternalTagIds.Reporter},
+                $newTagId
+              ]
+            }
+          """
+              .trimIndent()
+
+      mockMvc
+          .put("/api/v1/organizations/$organizationId/internalTags") { content = payload }
+          .andExpect { status { isOk() } }
+
+      assertEquals(
+          setOf(
+              organizationId to InternalTagIds.Reporter,
+              organizationId to newTagId,
+              otherOrganizationId to InternalTagIds.Testing,
+          ),
+          organizationInternalTagsDao
+              .findAll()
+              .map { it.organizationId to it.internalTagId }
+              .toSet(),
+          "Organization internal tags after update")
+    }
+
+    @Test
+    fun `returns error if user is not a super-admin`() {
+      val organizationId = insertOrganization()
+      mockMvc
+          .put("/api/v1/organizations/$organizationId/internalTags") {
+            content = """{ "tagIds": [] }"""
+          }
+          .andExpect { status { isForbidden() } }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -151,6 +151,7 @@ import com.terraformation.backend.db.default_schema.tables.daos.UsersDao
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceManagersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
+import com.terraformation.backend.db.default_schema.tables.pojos.InternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationInternalTagsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationReportSettingsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectLandUseModelTypesRow
@@ -2149,9 +2150,35 @@ abstract class DatabaseBackedTest {
     return rowWithDefaults.id!!
   }
 
+  private var nextInternalTagNumber = 1
+
+  protected fun insertInternalTag(
+      name: String = "Tag ${nextInternalTagNumber++}",
+      description: String? = null,
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+  ): InternalTagId {
+    val row =
+        InternalTagsRow(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            description = description,
+            isSystem = false,
+            modifiedBy = createdBy,
+            modifiedTime = createdTime,
+            name = name,
+        )
+
+    internalTagsDao.insert(row)
+
+    return row.id!!.also { inserted.internalTagIds.add(it) }
+  }
+
   protected fun insertOrganizationInternalTag(
       organizationId: OrganizationId = inserted.organizationId,
-      tagId: InternalTagId = InternalTagIds.Reporter,
+      tagId: InternalTagId =
+          if (inserted.internalTagIds.isEmpty()) InternalTagIds.Reporter
+          else inserted.internalTagId,
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
   ) {
@@ -2998,6 +3025,7 @@ abstract class DatabaseBackedTest {
     val eventIds = mutableListOf<EventId>()
     val facilityIds = mutableListOf<FacilityId>()
     val fileIds = mutableListOf<FileId>()
+    val internalTagIds = mutableListOf<InternalTagId>()
     val moduleIds = mutableListOf<ModuleId>()
     val monitoringPlotIds = mutableListOf<MonitoringPlotId>()
     val notificationIds = mutableListOf<NotificationId>()
@@ -3070,6 +3098,9 @@ abstract class DatabaseBackedTest {
 
     val fileId
       get() = fileIds.last()
+
+    val internalTagId
+      get() = internalTagIds.last()
 
     val moduleId
       get() = moduleIds.last()


### PR DESCRIPTION
Currently, internal tags can be assigned to organizations via the admin UI, but
not via the REST API. Add endpoints to list the available internal tags, to
list the internal tags for an organization, and to update an organization's
internal tags.

Creation and deletion of custom admin-defined tags continues to be an admin UI
feature, though the new API endpoints can be used to add custom tags to
organizations once they've been created.