### PR TITLE
SW-5203 Remove "nullable" from search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchTable.kt
@@ -224,82 +224,60 @@ abstract class SearchTable {
       databaseField: TableField<*, LocalDate?>,
       granularity: AgeField.AgeGranularity,
       clock: Clock,
-      nullable: Boolean = true,
-  ) = AgeField(fieldName, databaseField, this, nullable, true, true, granularity, clock)
+  ) = AgeField(fieldName, databaseField, this, true, true, granularity, clock)
 
-  fun bigDecimalField(
-      fieldName: String,
-      databaseField: Field<BigDecimal?>,
-  ) = BigDecimalField(fieldName, databaseField, this)
+  fun bigDecimalField(fieldName: String, databaseField: Field<BigDecimal?>) =
+      BigDecimalField(fieldName, databaseField, this)
 
-  fun booleanField(fieldName: String, databaseField: Field<Boolean?>, nullable: Boolean = true) =
-      BooleanField(fieldName, databaseField, this, nullable)
+  fun booleanField(fieldName: String, databaseField: Field<Boolean?>) =
+      BooleanField(fieldName, databaseField, this)
 
-  fun dateField(
-      fieldName: String,
-      databaseField: TableField<*, LocalDate?>,
-      nullable: Boolean = false
-  ) = DateField(fieldName, databaseField, this, nullable)
+  fun dateField(fieldName: String, databaseField: TableField<*, LocalDate?>) =
+      DateField(fieldName, databaseField, this)
 
-  fun doubleField(fieldName: String, databaseField: Field<Double?>, nullable: Boolean = false) =
-      DoubleField(fieldName, databaseField, this, nullable)
+  fun doubleField(fieldName: String, databaseField: Field<Double?>) =
+      DoubleField(fieldName, databaseField, this)
 
   inline fun <E : Enum<E>, reified T : LocalizableEnum<E>> enumField(
       fieldName: String,
       databaseField: TableField<*, T?>,
-      nullable: Boolean = true,
       localize: Boolean = true,
-  ) = EnumField(fieldName, databaseField, this, T::class.java, nullable, localize)
+  ) = EnumField(fieldName, databaseField, this, T::class.java, localize)
 
-  fun geometryField(
-      fieldName: String,
-      databaseField: TableField<*, Geometry?>,
-      nullable: Boolean = true
-  ) = GeometryField(fieldName, databaseField, this, nullable)
+  fun geometryField(fieldName: String, databaseField: TableField<*, Geometry?>) =
+      GeometryField(fieldName, databaseField, this)
 
   fun <T : Any> idWrapperField(fieldName: String, databaseField: Field<T?>, fromLong: (Long) -> T) =
       IdWrapperField(fieldName, databaseField, this, fromLong)
 
-  fun integerField(
-      fieldName: String,
-      databaseField: Field<Int?>,
-      nullable: Boolean = true,
-      localize: Boolean = true,
-  ) = IntegerField(fieldName, databaseField, this, nullable, localize)
+  fun integerField(fieldName: String, databaseField: Field<Int?>, localize: Boolean = true) =
+      IntegerField(fieldName, databaseField, this, localize)
 
   fun localizedTextField(
       fieldName: String,
       databaseField: TableField<*, String?>,
-      resourceBundleName: String,
-      nullable: Boolean = true
-  ) = LocalizedTextField(fieldName, databaseField, resourceBundleName, this, nullable)
+      resourceBundleName: String
+  ) = LocalizedTextField(fieldName, databaseField, resourceBundleName, this)
 
   fun longField(fieldName: String, databaseField: Field<Long?>, nullable: Boolean = true) =
-      LongField(fieldName, databaseField, this, nullable)
+      LongField(fieldName, databaseField, this)
 
   inline fun <E : Enum<E>, reified T : EnumFromReferenceTable<*, E>> nonLocalizableEnumField(
       fieldName: String,
-      databaseField: TableField<*, T?>,
-      nullable: Boolean = true
-  ) = NonLocalizableEnumField(fieldName, databaseField, this, T::class.java, nullable)
+      databaseField: TableField<*, T?>
+  ) = NonLocalizableEnumField(fieldName, databaseField, this, T::class.java)
 
-  fun textField(fieldName: String, databaseField: Field<String?>, nullable: Boolean = true) =
-      TextField(fieldName, databaseField, this, nullable)
+  fun textField(fieldName: String, databaseField: Field<String?>) =
+      TextField(fieldName, databaseField, this)
 
-  fun timestampField(
-      fieldName: String,
-      databaseField: TableField<*, Instant?>,
-      nullable: Boolean = true
-  ) = TimestampField(fieldName, databaseField, this, nullable)
+  fun timestampField(fieldName: String, databaseField: TableField<*, Instant?>) =
+      TimestampField(fieldName, databaseField, this)
 
-  fun upperCaseTextField(
-      fieldName: String,
-      databaseField: Field<String?>,
-      nullable: Boolean = true
-  ) = UpperCaseTextField(fieldName, databaseField, this, nullable)
+  fun upperCaseTextField(fieldName: String, databaseField: Field<String?>) =
+      UpperCaseTextField(fieldName, databaseField, this)
 
-  fun uriField(fieldName: String, databaseField: Field<URI?>, nullable: Boolean = true) =
-      UriField(fieldName, databaseField, this, nullable)
+  fun uriField(fieldName: String, databaseField: Field<URI?>) =
+      UriField(fieldName, databaseField, this)
 
   /**
    * Returns an array of [SearchField]s for a seed quantity: one for each supported weight unit, one
@@ -359,9 +337,6 @@ abstract class SearchTable {
         enumField("${fieldNamePrefix}Units".uncapitalize(), unitsField))
   }
 
-  fun zoneIdField(
-      fieldName: String,
-      databaseField: TableField<*, ZoneId?>,
-      nullable: Boolean = true
-  ) = ZoneIdField(fieldName, databaseField, this, nullable)
+  fun zoneIdField(fieldName: String, databaseField: TableField<*, ZoneId?>) =
+      ZoneIdField(fieldName, databaseField, this)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AgeField.kt
@@ -30,7 +30,6 @@ class AgeField(
     override val fieldName: String,
     override val databaseField: TableField<*, LocalDate?>,
     override val table: SearchTable,
-    override val nullable: Boolean,
     override val localize: Boolean = true,
     override val exportable: Boolean = true,
     private val granularity: AgeGranularity,
@@ -90,7 +89,7 @@ class AgeField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      AgeField(rawFieldName(), databaseField, table, nullable, false, false, granularity, clock)
+      AgeField(rawFieldName(), databaseField, table, false, false, granularity, clock)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/AliasField.kt
@@ -37,13 +37,6 @@ private constructor(
     }
   }
 
-  /**
-   * True if the target field or any of the sublists it belongs to are nullable. We can't use the
-   * nullability of the target field itself here, because the alias may be an optional reference to
-   * a table where the field is a required value.
-   */
-  override val nullable: Boolean = original.nullable || targetPath.sublists.any { !it.isRequired }
-
   override fun raw(): SearchField? {
     return if (localize) {
       val rawOriginal = original.raw() ?: return null

--- a/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/BooleanField.kt
@@ -18,7 +18,6 @@ class BooleanField(
     override val fieldName: String,
     override val databaseField: Field<Boolean?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
     override val localize: Boolean = true,
     override val exportable: Boolean = true,
 ) : SingleColumnSearchField<Boolean>() {
@@ -64,7 +63,7 @@ class BooleanField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      BooleanField(rawFieldName(), databaseField, table, nullable, false, false)
+      BooleanField(rawFieldName(), databaseField, table, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DateField.kt
@@ -15,7 +15,6 @@ class DateField(
     override val fieldName: String,
     override val databaseField: TableField<*, LocalDate?>,
     override val table: SearchTable,
-    override val nullable: Boolean
 ) : SingleColumnSearchField<LocalDate>() {
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = EnumSet.of(SearchFilterType.Exact, SearchFilterType.Range)

--- a/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/DoubleField.kt
@@ -10,10 +10,9 @@ class DoubleField(
     fieldName: String,
     databaseField: Field<Double?>,
     table: SearchTable,
-    nullable: Boolean = true,
     localize: Boolean = true,
     exportable: Boolean = true,
-) : NumericSearchField<Double>(fieldName, databaseField, table, nullable, localize, exportable) {
+) : NumericSearchField<Double>(fieldName, databaseField, table, localize, exportable) {
   override fun fromString(value: String) = numberFormat.parse(value).toDouble()
 
   override fun makeNumberFormat(): NumberFormat {
@@ -24,7 +23,7 @@ class DoubleField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      DoubleField(rawFieldName(), databaseField, table, nullable, false, false)
+      DoubleField(rawFieldName(), databaseField, table, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/EnumField.kt
@@ -25,7 +25,6 @@ class EnumField<E : Enum<E>, T : LocalizableEnum<E>>(
     override val databaseField: TableField<*, T?>,
     override val table: SearchTable,
     private val enumClass: Class<T>,
-    override val nullable: Boolean = true,
     override val localize: Boolean = true,
     override val exportable: Boolean = true,
 ) : SingleColumnSearchField<T>() {
@@ -86,7 +85,7 @@ class EnumField<E : Enum<E>, T : LocalizableEnum<E>>(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      EnumField(rawFieldName(), databaseField, table, enumClass, nullable, false, false)
+      EnumField(rawFieldName(), databaseField, table, enumClass, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/GeometryField.kt
@@ -18,7 +18,6 @@ class GeometryField(
     override val fieldName: String,
     geometryField: TableField<*, Geometry?>,
     override val table: SearchTable,
-    override val nullable: Boolean,
 ) : SingleColumnSearchField<String>() {
   override val supportedFilterTypes: Set<SearchFilterType>
     get() = emptySet()

--- a/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IdWrapperField.kt
@@ -14,9 +14,6 @@ class IdWrapperField<T : Any>(
     override val table: SearchTable,
     private val fromLong: (Long) -> T,
 ) : SingleColumnSearchField<T>() {
-  override val nullable: Boolean
-    get() = false
-
   override fun getCondition(fieldNode: FieldNode): Condition {
     val allValues = fieldNode.values.filterNotNull().map { fromLong(it.toLong()) }
     return when (fieldNode.type) {

--- a/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/IntegerField.kt
@@ -10,10 +10,9 @@ class IntegerField(
     fieldName: String,
     databaseField: Field<Int?>,
     table: SearchTable,
-    nullable: Boolean = true,
     localize: Boolean = true,
     exportable: Boolean = true,
-) : NumericSearchField<Int>(fieldName, databaseField, table, nullable, localize, exportable) {
+) : NumericSearchField<Int>(fieldName, databaseField, table, localize, exportable) {
   override fun fromString(value: String) =
       if (localize) numberFormat.parse(value).toInt() else value.toInt()
 
@@ -21,7 +20,7 @@ class IntegerField(
 
   override fun raw(): SearchField? {
     return if (localize) {
-      IntegerField(rawFieldName(), databaseField, table, nullable, false, false)
+      IntegerField(rawFieldName(), databaseField, table, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LocalizedTextField.kt
@@ -24,7 +24,6 @@ class LocalizedTextField(
     override val databaseField: Field<String?>,
     private val resourceBundleName: String,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
     override val localize: Boolean = true,
     override val exportable: Boolean = true,
 ) : SingleColumnSearchField<String>() {

--- a/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/LongField.kt
@@ -10,17 +10,16 @@ class LongField(
     fieldName: String,
     databaseField: Field<Long?>,
     table: SearchTable,
-    nullable: Boolean = true,
     localize: Boolean = true,
     exportable: Boolean = true,
-) : NumericSearchField<Long>(fieldName, databaseField, table, nullable, localize, exportable) {
+) : NumericSearchField<Long>(fieldName, databaseField, table, localize, exportable) {
   override fun fromString(value: String) = numberFormat.parse(value).toLong()
 
   override fun makeNumberFormat(): NumberFormat = NumberFormat.getIntegerInstance(currentLocale())
 
   override fun raw(): SearchField? {
     return if (localize) {
-      LongField(rawFieldName(), databaseField, table, nullable, false, false)
+      LongField(rawFieldName(), databaseField, table, false, false)
     } else {
       null
     }

--- a/src/main/kotlin/com/terraformation/backend/search/field/NonLocalizableEnumField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NonLocalizableEnumField.kt
@@ -24,7 +24,6 @@ class NonLocalizableEnumField<E : Enum<E>, T : EnumFromReferenceTable<*, E>>(
     override val databaseField: TableField<*, T?>,
     override val table: SearchTable,
     private val enumClass: Class<T>,
-    override val nullable: Boolean = true,
     override val exportable: Boolean = true,
 ) : SingleColumnSearchField<T>() {
   private val byName = enumClass.enumConstants!!.associateBy { it.jsonValue }

--- a/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/NumericSearchField.kt
@@ -21,7 +21,6 @@ abstract class NumericSearchField<T : Number>(
     override val fieldName: String,
     override val databaseField: Field<T?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
     override val localize: Boolean,
     override val exportable: Boolean,
 ) : SingleColumnSearchField<T>() {

--- a/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/SearchField.kt
@@ -54,10 +54,6 @@ interface SearchField {
   val possibleValues: List<String>?
     get() = null
 
-  /** If true, the field is allowed to not have a value. */
-  val nullable: Boolean
-    get() = true
-
   /** If true, values should be localized to the current locale. */
   val localize: Boolean
     get() = true

--- a/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TextField.kt
@@ -21,7 +21,6 @@ class TextField(
     override val fieldName: String,
     override val databaseField: Field<String?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
 ) : SingleColumnSearchField<String>() {
   override val localize: Boolean
     get() = false

--- a/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/TimestampField.kt
@@ -15,7 +15,6 @@ class TimestampField(
     override val fieldName: String,
     override val databaseField: TableField<*, Instant?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true
 ) : SingleColumnSearchField<Instant>() {
   override val localize: Boolean
     get() = false

--- a/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UpperCaseTextField.kt
@@ -16,7 +16,6 @@ class UpperCaseTextField(
     override val fieldName: String,
     override val databaseField: Field<String?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
 ) : SingleColumnSearchField<String>() {
   override val localize: Boolean
     get() = false

--- a/src/main/kotlin/com/terraformation/backend/search/field/UriField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/UriField.kt
@@ -14,7 +14,6 @@ class UriField(
     override val fieldName: String,
     override val databaseField: Field<URI?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true,
 ) : SingleColumnSearchField<URI>() {
   override val localize: Boolean
     get() = false

--- a/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/field/ZoneIdField.kt
@@ -15,7 +15,6 @@ class ZoneIdField(
     override val fieldName: String,
     override val databaseField: TableField<*, ZoneId?>,
     override val table: SearchTable,
-    override val nullable: Boolean = true
 ) : SingleColumnSearchField<ZoneId>() {
   private val validZoneNames = ZoneId.getAvailableZoneIds()
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/AccessionsTable.kt
@@ -67,7 +67,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
   // This needs to be lazy-initialized because aliasField() references the list of sublists
   override val fields: List<SearchField> by lazy {
     listOf(
-        upperCaseTextField("accessionNumber", ACCESSIONS.NUMBER, nullable = false),
+        upperCaseTextField("accessionNumber", ACCESSIONS.NUMBER),
         ActiveField("active"),
         ageField("ageMonths", ACCESSIONS.COLLECTED_DATE, AgeField.MonthGranularity, clock),
         ageField("ageYears", ACCESSIONS.COLLECTED_DATE, AgeField.YearGranularity, clock),
@@ -100,7 +100,7 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
             ACCESSIONS.REMAINING_GRAMS),
         enumField("source", ACCESSIONS.DATA_SOURCE_ID),
         aliasField("speciesName", "species_scientificName"),
-        enumField("state", ACCESSIONS.STATE_ID, nullable = false),
+        enumField("state", ACCESSIONS.STATE_ID),
         integerField("totalViabilityPercent", ACCESSIONS.TOTAL_VIABILITY_PERCENT),
         integerField("totalWithdrawnCount", ACCESSIONS.TOTAL_WITHDRAWN_COUNT),
         *weightFields(
@@ -141,8 +141,6 @@ class AccessionsTable(private val tables: SearchTables, private val clock: Clock
       get() = listOf(ACCESSIONS.STATE_ID)
 
     override val possibleValues = AccessionActive::class.java.enumConstants!!.map { "$it" }
-    override val nullable
-      get() = false
 
     override fun getConditions(fieldNode: FieldNode): List<Condition> {
       val values =

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -42,25 +42,25 @@ class BatchesTable(private val tables: SearchTables) : SearchTable() {
   // This needs to be lazy-initialized because aliasField() references the list of sublists
   override val fields: List<SearchField> by lazy {
     listOf(
-        dateField("addedDate", BATCH_SUMMARIES.ADDED_DATE, nullable = false),
-        upperCaseTextField("batchNumber", BATCH_SUMMARIES.BATCH_NUMBER, nullable = false),
-        integerField("germinatingQuantity", BATCH_SUMMARIES.GERMINATING_QUANTITY, nullable = false),
+        dateField("addedDate", BATCH_SUMMARIES.ADDED_DATE),
+        upperCaseTextField("batchNumber", BATCH_SUMMARIES.BATCH_NUMBER),
+        integerField("germinatingQuantity", BATCH_SUMMARIES.GERMINATING_QUANTITY),
         integerField("germinationRate", BATCH_SUMMARIES.GERMINATION_RATE),
         idWrapperField("id", BATCH_SUMMARIES.ID, ::BatchId),
         idWrapperField("initialBatchId", BATCH_SUMMARIES.INITIAL_BATCH_ID, ::BatchId),
         integerField("lossRate", BATCH_SUMMARIES.LOSS_RATE),
         textField("notes", BATCH_SUMMARIES.NOTES),
-        integerField("notReadyQuantity", BATCH_SUMMARIES.NOT_READY_QUANTITY, nullable = false),
+        integerField("notReadyQuantity", BATCH_SUMMARIES.NOT_READY_QUANTITY),
         dateField("readyByDate", BATCH_SUMMARIES.READY_BY_DATE),
-        integerField("readyQuantity", BATCH_SUMMARIES.READY_QUANTITY, nullable = false),
+        integerField("readyQuantity", BATCH_SUMMARIES.READY_QUANTITY),
         enumField("substrate", BATCH_SUMMARIES.SUBSTRATE_ID),
         textField("substrateNotes", BATCH_SUMMARIES.SUBSTRATE_NOTES),
-        integerField("totalQuantity", BATCH_SUMMARIES.TOTAL_QUANTITY, nullable = false),
+        integerField("totalQuantity", BATCH_SUMMARIES.TOTAL_QUANTITY),
         enumField("treatment", BATCH_SUMMARIES.TREATMENT_ID),
         textField("treatmentNotes", BATCH_SUMMARIES.TREATMENT_NOTES),
         longField(
             "totalQuantityWithdrawn", BATCH_SUMMARIES.TOTAL_QUANTITY_WITHDRAWN, nullable = false),
-        integerField("version", BATCH_SUMMARIES.VERSION, nullable = false, localize = false),
+        integerField("version", BATCH_SUMMARIES.VERSION, localize = false),
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/CohortModulesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CohortModulesTable.kt
@@ -25,9 +25,9 @@ class CohortModulesTable(tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> =
       listOf(
-          textField("title", COHORT_MODULES.TITLE, nullable = false),
-          dateField("startDate", COHORT_MODULES.START_DATE, nullable = false),
-          dateField("endDate", COHORT_MODULES.END_DATE, nullable = false),
+          textField("title", COHORT_MODULES.TITLE),
+          dateField("startDate", COHORT_MODULES.START_DATE),
+          dateField("endDate", COHORT_MODULES.END_DATE),
       )
 
   override val inheritsVisibilityFrom: SearchTable = tables.cohorts

--- a/src/main/kotlin/com/terraformation/backend/search/table/CohortsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CohortsTable.kt
@@ -31,14 +31,13 @@ class CohortsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", COHORTS.ID) { CohortId(it) },
-          textField("name", COHORTS.NAME, nullable = false),
+          textField("name", COHORTS.NAME),
           integerField(
               "numParticipants",
               DSL.field(
                   DSL.selectCount()
                       .from(PARTICIPANTS)
-                      .where(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))),
-              nullable = false),
+                      .where(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID)))),
           enumField("phase", COHORTS.PHASE_ID),
       )
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/DeliveriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DeliveriesTable.kt
@@ -30,7 +30,7 @@ class DeliveriesTable(private val tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> by lazy {
     listOf(
-        timestampField("createdTime", DELIVERIES.CREATED_TIME, nullable = false),
+        timestampField("createdTime", DELIVERIES.CREATED_TIME),
         idWrapperField("id", DELIVERIES.ID) { DeliveryId(it) },
         timestampField("reassignedTime", DELIVERIES.REASSIGNED_TIME),
     )

--- a/src/main/kotlin/com/terraformation/backend/search/table/DocumentTemplatesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DocumentTemplatesTable.kt
@@ -17,5 +17,5 @@ class DocumentTemplatesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", DOCUMENT_TEMPLATES.ID) { DocumentTemplateId(it) },
-          textField("name", DOCUMENT_TEMPLATES.NAME, nullable = false))
+          textField("name", DOCUMENT_TEMPLATES.NAME))
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/DocumentsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DocumentsTable.kt
@@ -32,7 +32,7 @@ class DocumentsTable(tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> =
       listOf(
-          timestampField("createdTime", DOCUMENTS.CREATED_TIME, nullable = false),
+          timestampField("createdTime", DOCUMENTS.CREATED_TIME),
           idWrapperField("id", DOCUMENTS.ID) { DocumentId(it) },
           idWrapperField(
               "lastSavedVersionId",
@@ -46,10 +46,10 @@ class DocumentsTable(tables: SearchTables) : SearchTable() {
               }) {
                 DocumentSavedVersionId(it)
               },
-          timestampField("modifiedTime", DOCUMENTS.MODIFIED_TIME, nullable = false),
-          textField("name", DOCUMENTS.NAME, nullable = false),
+          timestampField("modifiedTime", DOCUMENTS.MODIFIED_TIME),
+          textField("name", DOCUMENTS.NAME),
           idWrapperField("projectId", DOCUMENTS.PROJECT_ID) { ProjectId(it) },
-          enumField("status", DOCUMENTS.STATUS_ID, nullable = false))
+          enumField("status", DOCUMENTS.STATUS_ID))
 
   override fun conditionForVisibility(): Condition =
       if (currentUser().canManageDocumentProducer()) {

--- a/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/DraftPlantingSitesTable.kt
@@ -34,11 +34,11 @@ class DraftPlantingSitesTable(tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> =
       listOf(
-          timestampField("createdTime", DRAFT_PLANTING_SITES.CREATED_TIME, nullable = false),
+          timestampField("createdTime", DRAFT_PLANTING_SITES.CREATED_TIME),
           textField("description", DRAFT_PLANTING_SITES.DESCRIPTION),
           idWrapperField("id", DRAFT_PLANTING_SITES.ID) { DraftPlantingSiteId(it) },
-          timestampField("modifiedTime", DRAFT_PLANTING_SITES.MODIFIED_TIME, nullable = false),
-          textField("name", DRAFT_PLANTING_SITES.NAME, nullable = false),
+          timestampField("modifiedTime", DRAFT_PLANTING_SITES.MODIFIED_TIME),
+          textField("name", DRAFT_PLANTING_SITES.NAME),
           integerField("numPlantingZones", DRAFT_PLANTING_SITES.NUM_PLANTING_ZONES),
           integerField("numPlantingSubzones", DRAFT_PLANTING_SITES.NUM_PLANTING_SUBZONES),
           zoneIdField("timeZone", DRAFT_PLANTING_SITES.TIME_ZONE),

--- a/src/main/kotlin/com/terraformation/backend/search/table/EventsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/EventsTable.kt
@@ -31,10 +31,10 @@ class EventsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", EVENTS.ID) { EventId(it) },
-          enumField("status", EVENTS.EVENT_STATUS_ID, nullable = false),
-          enumField("type", EVENTS.EVENT_TYPE_ID, nullable = false),
-          timestampField("startTime", EVENTS.START_TIME, nullable = false),
-          timestampField("endTime", EVENTS.END_TIME, nullable = false),
+          enumField("status", EVENTS.EVENT_STATUS_ID),
+          enumField("type", EVENTS.EVENT_TYPE_ID),
+          timestampField("startTime", EVENTS.START_TIME),
+          timestampField("endTime", EVENTS.END_TIME),
           uriField("meetingUrl", EVENTS.MEETING_URL),
           uriField("recordingUrl", EVENTS.RECORDING_URL),
           uriField("slidesUrl", EVENTS.SLIDES_URL),

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -42,15 +42,15 @@ class FacilitiesTable(tables: SearchTables) : SearchTable() {
           dateField("buildCompletedDate", FACILITIES.BUILD_COMPLETED_DATE),
           dateField("buildStartedDate", FACILITIES.BUILD_STARTED_DATE),
           integerField("capacity", FACILITIES.CAPACITY),
-          enumField("connectionState", FACILITIES.CONNECTION_STATE_ID, nullable = false),
-          timestampField("createdTime", FACILITIES.CREATED_TIME, nullable = false),
+          enumField("connectionState", FACILITIES.CONNECTION_STATE_ID),
+          timestampField("createdTime", FACILITIES.CREATED_TIME),
           textField("description", FACILITIES.DESCRIPTION),
-          integerField("facilityNumber", FACILITIES.FACILITY_NUMBER, nullable = false),
+          integerField("facilityNumber", FACILITIES.FACILITY_NUMBER),
           idWrapperField("id", FACILITIES.ID) { FacilityId(it) },
-          textField("name", FACILITIES.NAME, nullable = false),
+          textField("name", FACILITIES.NAME),
           dateField("operationStartedDate", FACILITIES.OPERATION_STARTED_DATE),
           zoneIdField("timeZone", FACILITIES.TIME_ZONE),
-          enumField("type", FACILITIES.TYPE_ID, nullable = false),
+          enumField("type", FACILITIES.TYPE_ID),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/GeolocationsTable.kt
@@ -48,7 +48,6 @@ class GeolocationsTable(private val tables: SearchTables) : SearchTable() {
       override val fieldName: String,
       private val latitudeField: TableField<*, BigDecimal?>,
       private val longitudeField: TableField<*, BigDecimal?>,
-      override val nullable: Boolean = true
   ) : SearchField {
     override val localize: Boolean
       get() = false

--- a/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
@@ -35,10 +35,10 @@ class ModulesTable(tables: SearchTables) : SearchTable() {
           textField("additionalResources", MODULES.ADDITIONAL_RESOURCES),
           idWrapperField("id", MODULES.ID) { ModuleId(it) },
           textField("liveSessionDescription", MODULES.LIVE_SESSION_DESCRIPTION),
-          textField("name", MODULES.NAME, nullable = false),
+          textField("name", MODULES.NAME),
           textField("oneOnOneSessionDescription", MODULES.ONE_ON_ONE_SESSION_DESCRIPTION),
           textField("overview", MODULES.OVERVIEW),
-          enumField("phase", MODULES.PHASE_ID, nullable = false),
+          enumField("phase", MODULES.PHASE_ID),
           textField("preparationMaterials", MODULES.PREPARATION_MATERIALS),
           textField("workshopDescription", MODULES.WORKSHOP_DESCRIPTION),
       )

--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -26,11 +26,11 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           geometryField("boundary", MONITORING_PLOTS.BOUNDARY),
-          timestampField("createdTime", MONITORING_PLOTS.CREATED_TIME, nullable = false),
-          textField("fullName", MONITORING_PLOTS.FULL_NAME, nullable = false),
+          timestampField("createdTime", MONITORING_PLOTS.CREATED_TIME),
+          textField("fullName", MONITORING_PLOTS.FULL_NAME),
           idWrapperField("id", MONITORING_PLOTS.ID) { MonitoringPlotId(it) },
-          timestampField("modifiedTime", MONITORING_PLOTS.MODIFIED_TIME, nullable = false),
-          textField("name", MONITORING_PLOTS.NAME, nullable = false),
+          timestampField("modifiedTime", MONITORING_PLOTS.MODIFIED_TIME),
+          textField("name", MONITORING_PLOTS.NAME),
       )
 
   override val inheritsVisibilityFrom: SearchTable = tables.plantingSubzones

--- a/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/NurseryWithdrawalsTable.kt
@@ -37,7 +37,7 @@ class NurseryWithdrawalsTable(private val tables: SearchTables) : SearchTable() 
 
   override val fields: List<SearchField> =
       listOf(
-          timestampField("createdTime", WITHDRAWAL_SUMMARIES.CREATED_TIME, nullable = false),
+          timestampField("createdTime", WITHDRAWAL_SUMMARIES.CREATED_TIME),
           // This is exposed as an ID value rather than a sublist because the search code currently
           // doesn't support joining with the same child table twice from the same parent, and
           // there's already a "facility" sublist for the originating facility.
@@ -45,14 +45,13 @@ class NurseryWithdrawalsTable(private val tables: SearchTables) : SearchTable() 
             FacilityId(it)
           },
           textField("destinationName", WITHDRAWAL_SUMMARIES.DESTINATION_NAME),
-          booleanField(
-              "hasReassignments", WITHDRAWAL_SUMMARIES.HAS_REASSIGNMENTS, nullable = false),
+          booleanField("hasReassignments", WITHDRAWAL_SUMMARIES.HAS_REASSIGNMENTS),
           idWrapperField("id", WITHDRAWAL_SUMMARIES.ID) { WithdrawalId(it) },
           textField("notes", WITHDRAWAL_SUMMARIES.NOTES),
           textField("plantingSubzoneNames", WITHDRAWAL_SUMMARIES.PLANTING_SUBZONE_NAMES),
-          enumField("purpose", WITHDRAWAL_SUMMARIES.PURPOSE_ID, nullable = false),
+          enumField("purpose", WITHDRAWAL_SUMMARIES.PURPOSE_ID),
           longField("totalWithdrawn", WITHDRAWAL_SUMMARIES.TOTAL_WITHDRAWN),
-          dateField("withdrawnDate", WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE, nullable = false),
+          dateField("withdrawnDate", WITHDRAWAL_SUMMARIES.WITHDRAWN_DATE),
           dateField("undoesWithdrawalDate", WITHDRAWAL_SUMMARIES.UNDOES_WITHDRAWAL_DATE),
           idWrapperField("undoesWithdrawalId", WITHDRAWAL_SUMMARIES.UNDOES_WITHDRAWAL_ID) {
             WithdrawalId(it)

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationUsersTable.kt
@@ -27,7 +27,7 @@ class OrganizationUsersTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           timestampField("createdTime", ORGANIZATION_USERS.CREATED_TIME),
-          enumField("roleName", ORGANIZATION_USERS.ROLE_ID, nullable = false))
+          enumField("roleName", ORGANIZATION_USERS.ROLE_ID))
 
   override val primaryKey: TableField<out Record, out Any?>
     get() = ORGANIZATION_USERS.ORGANIZATION_USER_ID

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -65,9 +65,9 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
       listOf(
           textField("countryCode", ORGANIZATIONS.COUNTRY_CODE),
           textField("countrySubdivisionCode", ORGANIZATIONS.COUNTRY_SUBDIVISION_CODE),
-          timestampField("createdTime", ORGANIZATIONS.CREATED_TIME, nullable = false),
+          timestampField("createdTime", ORGANIZATIONS.CREATED_TIME),
           idWrapperField("id", ORGANIZATIONS.ID) { OrganizationId(it) },
-          textField("name", ORGANIZATIONS.NAME, nullable = false),
+          textField("name", ORGANIZATIONS.NAME),
           zoneIdField("timeZone", ORGANIZATIONS.TIME_ZONE),
       )
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/ParticipantProjectSpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ParticipantProjectSpeciesTable.kt
@@ -34,10 +34,7 @@ class ParticipantProjectSpeciesTable(private val tables: SearchTables) : SearchT
           idWrapperField("id", PARTICIPANT_PROJECT_SPECIES.ID) { ParticipantProjectSpeciesId(it) },
           textField("feedback", PARTICIPANT_PROJECT_SPECIES.FEEDBACK),
           textField("rationale", PARTICIPANT_PROJECT_SPECIES.RATIONALE),
-          enumField(
-              "submissionStatus",
-              PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID,
-              nullable = false),
+          enumField("submissionStatus", PARTICIPANT_PROJECT_SPECIES.SUBMISSION_STATUS_ID),
       )
 
   override val inheritsVisibilityFrom: SearchTable?

--- a/src/main/kotlin/com/terraformation/backend/search/table/ParticipantsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ParticipantsTable.kt
@@ -30,7 +30,7 @@ class ParticipantsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", PARTICIPANTS.ID) { ParticipantId(it) },
-          textField("name", PARTICIPANTS.NAME, nullable = false),
+          textField("name", PARTICIPANTS.NAME),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitePopulationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitePopulationsTable.kt
@@ -32,7 +32,7 @@ class PlantingSitePopulationsTable(private val tables: SearchTables) : SearchTab
           integerField(
               "plantsSinceLastObservation",
               PLANTING_SITE_POPULATIONS.PLANTS_SINCE_LAST_OBSERVATION),
-          integerField("totalPlants", PLANTING_SITE_POPULATIONS.TOTAL_PLANTS, nullable = false),
+          integerField("totalPlants", PLANTING_SITE_POPULATIONS.TOTAL_PLANTS),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -45,12 +45,12 @@ class PlantingSitesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           geometryField("boundary", PLANTING_SITE_SUMMARIES.BOUNDARY),
-          timestampField("createdTime", PLANTING_SITE_SUMMARIES.CREATED_TIME, nullable = false),
+          timestampField("createdTime", PLANTING_SITE_SUMMARIES.CREATED_TIME),
           textField("description", PLANTING_SITE_SUMMARIES.DESCRIPTION),
           geometryField("exclusion", PLANTING_SITE_SUMMARIES.EXCLUSION),
           idWrapperField("id", PLANTING_SITE_SUMMARIES.ID) { PlantingSiteId(it) },
-          timestampField("modifiedTime", PLANTING_SITE_SUMMARIES.MODIFIED_TIME, nullable = false),
-          textField("name", PLANTING_SITE_SUMMARIES.NAME, nullable = false),
+          timestampField("modifiedTime", PLANTING_SITE_SUMMARIES.MODIFIED_TIME),
+          textField("name", PLANTING_SITE_SUMMARIES.NAME),
           longField("numPlantingZones", PLANTING_SITE_SUMMARIES.NUM_PLANTING_ZONES),
           longField("numPlantingSubzones", PLANTING_SITE_SUMMARIES.NUM_PLANTING_SUBZONES),
           zoneIdField("timeZone", PLANTING_SITE_SUMMARIES.TIME_ZONE),

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonePopulationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonePopulationsTable.kt
@@ -33,7 +33,7 @@ class PlantingSubzonePopulationsTable(private val tables: SearchTables) : Search
           integerField(
               "plantsSinceLastObservation",
               PLANTING_SUBZONE_POPULATIONS.PLANTS_SINCE_LAST_OBSERVATION),
-          integerField("totalPlants", PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS, nullable = false),
+          integerField("totalPlants", PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSubzonesTable.kt
@@ -40,13 +40,12 @@ class PlantingSubzonesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           geometryField("boundary", PLANTING_SUBZONES.BOUNDARY),
-          timestampField("createdTime", PLANTING_SUBZONES.CREATED_TIME, nullable = false),
-          textField("fullName", PLANTING_SUBZONES.FULL_NAME, nullable = false),
+          timestampField("createdTime", PLANTING_SUBZONES.CREATED_TIME),
+          textField("fullName", PLANTING_SUBZONES.FULL_NAME),
           idWrapperField("id", PLANTING_SUBZONES.ID) { PlantingSubzoneId(it) },
-          timestampField("modifiedTime", PLANTING_SUBZONES.MODIFIED_TIME, nullable = false),
-          textField("name", PLANTING_SUBZONES.NAME, nullable = false),
-          timestampField(
-              "plantingCompletedTime", PLANTING_SUBZONES.PLANTING_COMPLETED_TIME, nullable = false),
+          timestampField("modifiedTime", PLANTING_SUBZONES.MODIFIED_TIME),
+          textField("name", PLANTING_SUBZONES.NAME),
+          timestampField("plantingCompletedTime", PLANTING_SUBZONES.PLANTING_COMPLETED_TIME),
           bigDecimalField(
               "totalPlants",
               DSL.field(

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonePopulationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonePopulationsTable.kt
@@ -32,7 +32,7 @@ class PlantingZonePopulationsTable(private val tables: SearchTables) : SearchTab
           integerField(
               "plantsSinceLastObservation",
               PLANTING_ZONE_POPULATIONS.PLANTS_SINCE_LAST_OBSERVATION),
-          integerField("totalPlants", PLANTING_ZONE_POPULATIONS.TOTAL_PLANTS, nullable = false),
+          integerField("totalPlants", PLANTING_ZONE_POPULATIONS.TOTAL_PLANTS),
       )
 
   override val inheritsVisibilityFrom: SearchTable

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
@@ -32,10 +32,10 @@ class PlantingZonesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           geometryField("boundary", PLANTING_ZONES.BOUNDARY),
-          timestampField("createdTime", PLANTING_ZONES.CREATED_TIME, nullable = false),
+          timestampField("createdTime", PLANTING_ZONES.CREATED_TIME),
           idWrapperField("id", PLANTING_ZONES.ID) { PlantingZoneId(it) },
-          timestampField("modifiedTime", PLANTING_ZONES.MODIFIED_TIME, nullable = false),
-          textField("name", PLANTING_ZONES.NAME, nullable = false),
+          timestampField("modifiedTime", PLANTING_ZONES.MODIFIED_TIME),
+          textField("name", PLANTING_ZONES.NAME),
       )
 
   override val inheritsVisibilityFrom: SearchTable = tables.plantingSites

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingsTable.kt
@@ -32,11 +32,11 @@ class PlantingsTable(private val tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> by lazy {
     listOf(
-        timestampField("createdTime", PLANTINGS.CREATED_TIME, nullable = false),
+        timestampField("createdTime", PLANTINGS.CREATED_TIME),
         idWrapperField("id", PLANTINGS.ID) { PlantingId(it) },
         textField("notes", PLANTINGS.NOTES),
-        integerField("numPlants", PLANTINGS.NUM_PLANTS, nullable = false),
-        enumField("type", PLANTINGS.PLANTING_TYPE_ID, nullable = false),
+        integerField("numPlants", PLANTINGS.NUM_PLANTS),
+        enumField("type", PLANTINGS.PLANTING_TYPE_ID),
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectDeliverablesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectDeliverablesTable.kt
@@ -30,17 +30,17 @@ class ProjectDeliverablesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", PROJECT_DELIVERABLES.DELIVERABLE_ID) { DeliverableId(it) },
-          enumField("category", PROJECT_DELIVERABLES.DELIVERABLE_CATEGORY_ID, nullable = false),
+          enumField("category", PROJECT_DELIVERABLES.DELIVERABLE_CATEGORY_ID),
           textField("description", PROJECT_DELIVERABLES.DESCRIPTION_HTML),
-          dateField("dueDate", PROJECT_DELIVERABLES.DUE_DATE, nullable = false),
+          dateField("dueDate", PROJECT_DELIVERABLES.DUE_DATE),
           textField("feedback", PROJECT_DELIVERABLES.SUBMISSION_FEEDBACK),
-          textField("name", PROJECT_DELIVERABLES.NAME, nullable = false),
-          integerField("position", PROJECT_DELIVERABLES.POSITION, nullable = false),
-          booleanField("required", PROJECT_DELIVERABLES.IS_REQUIRED, nullable = false),
-          booleanField("sensitive", PROJECT_DELIVERABLES.IS_SENSITIVE, nullable = false),
+          textField("name", PROJECT_DELIVERABLES.NAME),
+          integerField("position", PROJECT_DELIVERABLES.POSITION),
+          booleanField("required", PROJECT_DELIVERABLES.IS_REQUIRED),
+          booleanField("sensitive", PROJECT_DELIVERABLES.IS_SENSITIVE),
           enumField("status", PROJECT_DELIVERABLES.SUBMISSION_STATUS_ID),
           idWrapperField("submissionId", PROJECT_DELIVERABLES.SUBMISSION_ID) { SubmissionId(it) },
-          enumField("type", PROJECT_DELIVERABLES.DELIVERABLE_TYPE_ID, nullable = false),
+          enumField("type", PROJECT_DELIVERABLES.DELIVERABLE_TYPE_ID),
       )
 
   override val defaultOrderFields =

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -64,11 +64,11 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
 
   override val fields: List<SearchField> =
       listOf(
-          timestampField("createdTime", PROJECTS.CREATED_TIME, nullable = false),
+          timestampField("createdTime", PROJECTS.CREATED_TIME),
           textField("description", PROJECTS.DESCRIPTION),
           idWrapperField("id", PROJECTS.ID) { ProjectId(it) },
-          timestampField("modifiedTime", PROJECTS.MODIFIED_TIME, nullable = false),
-          textField("name", PROJECTS.NAME, nullable = false),
+          timestampField("modifiedTime", PROJECTS.MODIFIED_TIME),
+          textField("name", PROJECTS.NAME),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/ReportsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ReportsTable.kt
@@ -33,9 +33,9 @@ class ReportsTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           idWrapperField("id", REPORTS.ID) { ReportId(it) },
-          integerField("quarter", REPORTS.QUARTER, nullable = false),
-          enumField("status", REPORTS.STATUS_ID, nullable = false),
-          integerField("year", REPORTS.YEAR, nullable = false),
+          integerField("quarter", REPORTS.QUARTER),
+          enumField("status", REPORTS.STATUS_ID),
+          integerField("year", REPORTS.YEAR),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -57,10 +57,10 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
           timestampField("checkedTime", SPECIES.CHECKED_TIME),
           textField("commonName", SPECIES.COMMON_NAME),
           enumField("conservationCategory", SPECIES.CONSERVATION_CATEGORY_ID, localize = false),
-          textField("familyName", SPECIES.FAMILY_NAME, nullable = false),
+          textField("familyName", SPECIES.FAMILY_NAME),
           idWrapperField("id", SPECIES.ID) { SpeciesId(it) },
           booleanField("rare", SPECIES.RARE),
-          textField("scientificName", SPECIES.SCIENTIFIC_NAME, nullable = false),
+          textField("scientificName", SPECIES.SCIENTIFIC_NAME),
           enumField("seedStorageBehavior", SPECIES.SEED_STORAGE_BEHAVIOR_ID),
       )
 


### PR DESCRIPTION
Early versions of the search API paid attention to whether or not fields were
marked as nullable, but that changed some time ago and now the "nullable" property
isn't referenced anywhere. Remove it to reduce clutter in the search table
definitions.