### PR TITLE
Fix intermittent test failures

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleStoreTest.kt
@@ -520,14 +520,14 @@ class ModuleStoreTest : DatabaseTest(), RunsAsUser {
           fetchAllResult
               .find { it.id == moduleId }!!
               .eventSessions
-              .mapValues { it.value.map { event -> event.id } }
+              .mapValues { it.value.map { event -> event.id }.toSet() }
 
       assertEquals(
           mapOf(
-              EventType.Workshop to listOf(workshop1, workshop2, workshop3),
-              EventType.LiveSession to listOf(liveSession1, liveSession2, liveSession3),
+              EventType.Workshop to setOf(workshop1, workshop2, workshop3),
+              EventType.LiveSession to setOf(liveSession1, liveSession2, liveSession3),
               EventType.OneOnOneSession to
-                  listOf(oneOnOneSession1, oneOnOneSession2, oneOnOneSession3),
+                  setOf(oneOnOneSession1, oneOnOneSession2, oneOnOneSession3),
           ),
           eventIds)
     }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -949,7 +949,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
         },
         {
           assertEquals(
-              listOf(
+              setOf(
                   WithdrawalsRow(
                       id = firstWithdrawal.id,
                       facilityId = facilityId,
@@ -971,7 +971,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       modifiedTime = secondWithdrawalTime,
                       destinationFacilityId = destinationFacilityId),
               ),
-              nurseryWithdrawalsDao.findAll(),
+              nurseryWithdrawalsDao.findAll().toSet(),
               "Should have inserted withdrawals rows")
         })
   }


### PR DESCRIPTION
`BatchStoreWithdrawTest` and `ModuleStoreTest` were assuming that unordered 
database queries would return results in a certain order, which was usually the
case but not 100% of the time. Change them to ignore the order.