### PR TITLE
SW-5754 List all organizations and internal tags

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
@@ -75,7 +75,7 @@ class InternalTagsControllerTest : ControllerIntegrationTest() {
       insertOrganizationInternalTag(tagId = InternalTagIds.Reporter)
 
       mockMvc
-          .get("/api/v1/organizations/$organizationId/internalTags")
+          .get("/api/v1/internalTags/organizations/$organizationId")
           .andExpectJson(
               """
                 {
@@ -92,7 +92,7 @@ class InternalTagsControllerTest : ControllerIntegrationTest() {
     @Test
     fun `returns error if user is not a super-admin`() {
       val organizationId = insertOrganization()
-      mockMvc.get("/api/v1/organizations/$organizationId/internalTags").andExpect {
+      mockMvc.get("/api/v1/internalTags/organizations/$organizationId").andExpect {
         status { isForbidden() }
       }
     }
@@ -121,7 +121,7 @@ class InternalTagsControllerTest : ControllerIntegrationTest() {
               .trimIndent()
 
       mockMvc
-          .put("/api/v1/organizations/$organizationId/internalTags") { content = payload }
+          .put("/api/v1/internalTags/organizations/$organizationId") { content = payload }
           .andExpect { status { isOk() } }
 
       assertEquals(
@@ -141,7 +141,7 @@ class InternalTagsControllerTest : ControllerIntegrationTest() {
     fun `returns error if user is not a super-admin`() {
       val organizationId = insertOrganization()
       mockMvc
-          .put("/api/v1/organizations/$organizationId/internalTags") {
+          .put("/api/v1/internalTags/organizations/$organizationId") {
             content = """{ "tagIds": [] }"""
           }
           .andExpect { status { isForbidden() } }


### PR DESCRIPTION
To support editing internal tags for organizations in the web app, the frontend
needs to be able to show a menu of available organizations and which tags they
have. Add an endpoint to return the full list of organizations and each one's
tags, only accessible by super-admin users.

For consistency, this also changes the URL paths of the endpoints introduced in
commit c97c8296 so they all fall under `/api/v1/internalTags`.