### PR TITLE
SW-5900 Stop requiring map area to match land use totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -54,13 +54,6 @@ class Messages {
   fun applicationPreScreenFailureIneligibleCountry(country: String) =
       getMessage("applicationPreScreen.failure.ineligibleCountry", country)
 
-  fun applicationPreScreenFailureLandUseTotalTooLow(
-      projectHectares: Int,
-      totalLandUseHectares: Int
-  ) =
-      getMessage(
-          "applicationPreScreen.failure.landUseTotalTooLow", projectHectares, totalLandUseHectares)
-
   fun applicationPreScreenFailureMonocultureTooHigh(maximum: Int) =
       getMessage("applicationPreScreen.failure.monocultureTooHigh", maximum)
 


### PR DESCRIPTION
The original requirement for pre-screening was to check that the area of the map
boundary was approximately equal to the total of the hectare counts for different
land usage model types, but that turned out to be too finicky. Instead, make sure
both the boundary area and the total of the land usage model type hectares fall
within the minimum and maximum for the site's country.