### PR TITLE
Add example pre-push hook to check formatting

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -15,6 +15,8 @@ All Kotlin code must be formatted with [ktfmt](https://github.com/facebookincuba
 
 There isn't currently a way to make IntelliJ's real-time formatting adhere strictly to ktfmt's formatting rules, but the supplied `.editorconfig` file is an approximation. IntelliJ should detect it and use it automatically.
 
+To prevent yourself from accidentally pushing a PR that fails the formatting check, you can add a git pre-push hook. There's an example in this directory: [pre-push](pre-push).
+
 ### Wildcard imports
 
 By default, IntelliJ uses wildcard imports for the `java.util` and `javax` packages, and overriding that default in `.editorconfig` doesn't work reliably. You'll want to remove those packages manually from the Kotlin code style preferences ("Auto-Import" tab) in IntelliJ's settings.

--- a/docs/pre-push
+++ b/docs/pre-push
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Hook script to verify that the code is correctly formatted. Copy this to
+# .git/hooks/pre-push and you'll be prevented from pushing code (including
+# PRs) that fail the format check. Make sure it has execute permission:
+#
+#    cp docs/pre-push .git/hooks
+#    chmod 755 .git/hooks/pre-push
+#
+# See .git/hooks/pre-push.example for more on how pre-push scripts are called.
+#
+# If you need to skip this check for some reason, you can either move the
+# script out of the way or use "git push --no-verify".
+
+if ./gradlew spotlessCheck; then
+    # If you want to do other pre-push checks, add them here.
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
We often accidentally forget to fix code formatting before pushing PR branches to
GitHub. Document how to add a pre-push hook to protect against that.