### PR TITLE
SW-5852 Don't list table columns as top-level variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -118,6 +118,10 @@ class VariableStore(
             .select(DSL.max(ID))
             .from(VARIABLES)
             .where(DELIVERABLE_ID.eq(deliverableId))
+            .andNotExists(
+                DSL.selectOne()
+                    .from(VARIABLE_TABLE_COLUMNS)
+                    .where(ID.eq(VARIABLE_TABLE_COLUMNS.VARIABLE_ID)))
             .groupBy(STABLE_ID)
             .fetch()
             .map { fetchVariable(it[DSL.max(ID)]!!) }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -2,10 +2,15 @@ package com.terraformation.backend.documentproducer.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.docprod.VariableTableStyle
+import com.terraformation.backend.db.docprod.VariableTextType
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.documentproducer.model.BaseVariableProperties
 import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SectionVariable
+import com.terraformation.backend.documentproducer.model.TableColumn
+import com.terraformation.backend.documentproducer.model.TableVariable
+import com.terraformation.backend.documentproducer.model.TextVariable
 import com.terraformation.backend.documentproducer.model.Variable
 import com.terraformation.backend.mockUser
 import java.math.BigDecimal
@@ -275,6 +280,63 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                   maxValue = null))
 
       val actual = store.fetchDeliverableVariables(deliverableId1)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `fetches tables`() {
+      insertModule()
+      val deliverableId = insertDeliverable()
+      val tableId =
+          insertTableVariable(
+              insertVariable(
+                  deliverableId = deliverableId,
+                  deliverablePosition = 1,
+                  isList = true,
+                  name = "Table",
+                  type = VariableType.Table))
+      val columnId =
+          insertTextVariable(
+              insertVariable(
+                  deliverableId = deliverableId, deliverablePosition = 2, type = VariableType.Text))
+      insertTableColumn(tableId, columnId)
+
+      val expected =
+          listOf(
+              TableVariable(
+                  base =
+                      BaseVariableProperties(
+                          deliverableId = deliverableId,
+                          deliverablePosition = 1,
+                          id = tableId,
+                          isList = true,
+                          manifestId = null,
+                          name = "Table",
+                          position = 0,
+                          stableId = "1",
+                      ),
+                  tableStyle = VariableTableStyle.Horizontal,
+                  columns =
+                      listOf(
+                          TableColumn(
+                              isHeader = false,
+                              variable =
+                                  TextVariable(
+                                      base =
+                                          BaseVariableProperties(
+                                              deliverableId = deliverableId,
+                                              deliverablePosition = 2,
+                                              id = columnId,
+                                              isList = false,
+                                              manifestId = null,
+                                              name = "Variable 2",
+                                              position = 0,
+                                              stableId = "2",
+                                          ),
+                                      textType = VariableTextType.SingleLine)))))
+
+      val actual = store.fetchDeliverableVariables(deliverableId)
 
       assertEquals(expected, actual)
     }


### PR DESCRIPTION
If a table column variable had a deliverable ID configured, the "fetch variables
for deliverable" endpoint was including it both as a child of the table variable
and as an entry in the top-level variable list. This caused table columns to show
up twice in the web app.