### PR TITLE
SW-5923 Allowed creating submissions in InReview status and added /submit endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -183,7 +183,7 @@ class DeliverablesController(
 
   @ApiResponseSimpleSuccess
   @Operation(summary = "Submits a submission from a project.")
-  @PutMapping("/{deliverableId}/submissions/{projectId}/submit")
+  @PostMapping("/{deliverableId}/submissions/{projectId}/submit")
   fun submitSubmission(
       @PathVariable deliverableId: DeliverableId,
       @PathVariable projectId: ProjectId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -182,6 +182,18 @@ class DeliverablesController(
   }
 
   @ApiResponseSimpleSuccess
+  @Operation(summary = "Submits a submission from a project.")
+  @PutMapping("/{deliverableId}/submissions/{projectId}/submit")
+  fun submitSubmission(
+      @PathVariable deliverableId: DeliverableId,
+      @PathVariable projectId: ProjectId,
+  ): SimpleSuccessResponsePayload {
+    submissionStore.createSubmission(deliverableId, projectId, SubmissionStatus.InReview)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponseSimpleSuccess
   @Operation(summary = "Marks a submission from a project as completed.")
   @PostMapping("/{deliverableId}/submissions/{projectId}/complete")
   fun completeSubmission(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -38,7 +38,9 @@ class SubmissionStore(
   ): SubmissionId {
     requirePermissions { createSubmission(projectId) }
 
-    if (status != SubmissionStatus.NotSubmitted && status != SubmissionStatus.Completed) {
+    if (status != SubmissionStatus.NotSubmitted &&
+        status != SubmissionStatus.Completed &&
+        status != SubmissionStatus.InReview) {
       throw IllegalArgumentException("Cannot create submissions in $status")
     }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -282,7 +282,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `throws exception if creating submission for status other than Not Submitted or Completed`() {
+    fun `throws exception if creating submission for internal only statuses`() {
       insertModule()
       val projectId = insertProject()
       val deliverableId = insertDeliverable()
@@ -291,7 +291,6 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
           setOf(
               SubmissionStatus.Approved,
               SubmissionStatus.Rejected,
-              SubmissionStatus.InReview,
               SubmissionStatus.NeedsTranslation,
               SubmissionStatus.NotNeeded,
           )


### PR DESCRIPTION
We will use the endpoint for submissions of questionnaire deliverables and species list deliverables. Previously we were incorrectly using the review endpoint which caused permission issues.