### PR TITLE
Remove Spring Boot R2DBC workaround

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/Application.kt
+++ b/src/main/kotlin/com/terraformation/backend/Application.kt
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -40,10 +39,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
     description = "Session cookie")
 @EnableConfigurationProperties(TerrawareServerConfig::class)
 @EnableScheduling
-@SpringBootApplication(
-    // https://github.com/spring-projects/spring-boot/issues/26439
-    exclude = [R2dbcAutoConfiguration::class],
-    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator::class)
+@SpringBootApplication(nameGenerator = FullyQualifiedAnnotationBeanNameGenerator::class)
 class Application
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
At one point there was a problem with Spring Boot's jOOQ autoconfiguration where
it would try to set up a database library we don't use; as a workaround we added
configuration to explicitly disable that library. The problem has since been
fixed in Spring Boot, so the workaround isn't needed any more.