### PR TITLE
Fixed admin UI by using new deliverableStore method

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
@@ -74,7 +74,9 @@ class AdminCohortsController(
     val cohortModules = cohortModuleStore.fetch(cohortId)
 
     val modules = moduleStore.fetchAllModules()
-    val moduleDeliverables = deliverableStore.fetchDeliverables().associateBy { it.moduleId }
+    val allDeliverables = deliverableStore.fetchDeliverables().groupBy { it.moduleId }
+    val moduleDeliverables = modules.associate { it.id to (allDeliverables[it.id] ?: emptyList()) }
+
     val moduleNames = modules.associate { it.id to "(${it.id}) ${it.name}" }
 
     val unassignedModules = modules.filter { module -> cohortModules.all { module.id != it.id } }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminModulesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminModulesController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.accelerator.db.CohortStore
+import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.db.DeliverablesImporter
 import com.terraformation.backend.accelerator.db.ModuleEventStore
 import com.terraformation.backend.accelerator.db.ModuleNotFoundException
@@ -44,6 +45,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 class AdminModulesController(
     private val cohortStore: CohortStore,
     private val deliverablesImporter: DeliverablesImporter,
+    private val deliverableStore: DeliverableStore,
     private val dslContext: DSLContext,
     private val eventStore: ModuleEventStore,
     private val participantStore: ParticipantStore,
@@ -86,7 +88,6 @@ class AdminModulesController(
         }
 
     val cohorts = cohortStore.findByModule(moduleId, CohortDepth.Participant)
-
     val cohortProjects =
         cohorts.associate {
           it.id to
@@ -97,8 +98,8 @@ class AdminModulesController(
                   .map { projectId -> projectStore.fetchOneById(projectId) }
         }
 
+    val deliverables = deliverableStore.fetchDeliverables(moduleId = module.id)
     val moduleProjects = cohortProjects.values.flatten()
-
     val projects = moduleProjects.associateBy { it.id }
 
     // cohort name - project name
@@ -116,6 +117,7 @@ class AdminModulesController(
     model.addAttribute("canManageModules", currentUser().canManageModules())
     model.addAttribute("cohortProjectNames", cohortProjectNames)
     model.addAttribute("dateFormat", dateFormat)
+    model.addAttribute("deliverables", deliverables)
     model.addAttribute("eventSessions", eventSessions)
     model.addAttribute("module", module)
     model.addAttribute("moduleProjects", moduleProjects)

--- a/src/main/resources/templates/admin/cohortView.html
+++ b/src/main/resources/templates/admin/cohortView.html
@@ -78,7 +78,7 @@
         </td>
         <td>
             <select name="deliverableId" th:form="|deliverables-${module.id}|">
-                <option th:each="deliverable : ${moduleDeliverables.get(module.moduleId)}"
+                <option th:each="deliverable : ${moduleDeliverables.get(module.id)}"
                         th:text="|(${deliverable.id}) ${deliverable.name}|"
                         th:value="${deliverable.id}">
                     (Deliverable ID) Deliverable Name

--- a/src/main/resources/templates/admin/moduleView.html
+++ b/src/main/resources/templates/admin/moduleView.html
@@ -45,7 +45,7 @@
         </thead>
 
         <tbody>
-        <tr th:each="deliverable : ${module.deliverables}" class="striped">
+        <tr th:each="deliverable : ${deliverables}" class="striped">
             <td th:text="${deliverable.position}">Deliverable Position</td>
             <td th:text="${deliverable.id}">Deliverable ID</td>
             <td th:text="${deliverable.category.getDisplayName(#locale.default)}">Deliverable Category</td>


### PR DESCRIPTION
The admin UIs for single cohort view, and single module view were both referencing `module.deliverables` which was removed from the `ModuleModel`. This fetches the deliverables by moduleId directly to mitigate the issue. 