### PR TITLE
SW-5926 Create Google Drive folders on demand

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -87,6 +87,9 @@ class TerrawareServerConfig(
     /** Configures how the server works with GBIF species data. */
     @NotNull val gbif: GbifConfig = GbifConfig(),
 
+    /** Configures options related to accelerator features. */
+    val accelerator: AcceleratorConfig = AcceleratorConfig(),
+
     /** Configures how the server interacts with Atlassian. */
     val atlassian: AtlassianConfig = AtlassianConfig(),
 
@@ -109,6 +112,11 @@ class TerrawareServerConfig(
     /** Terraware support email config */
     val support: SupportConfig = SupportConfig(),
 ) {
+  class AcceleratorConfig(
+      /** File ID of parent folder to use when creating new folders for application documents. */
+      val applicationGoogleFolderId: String? = null,
+  )
+
   class AtlassianConfig(
       /** Atlassian account name */
       val account: String? = null,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.accelerator.db.ProjectDocumentSettingsNotConfi
 import com.terraformation.backend.accelerator.db.ProjectDocumentStorageFailedException
 import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent
 import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent.FailureReason
+import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DeliverableId
@@ -18,8 +19,10 @@ import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.ws.rs.core.MediaType
-import org.junit.jupiter.api.Assertions.*
+import java.net.URI
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -30,12 +33,13 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock = TestClock()
+  private val config: TerrawareServerConfig = mockk()
   private val dropboxWriter: DropboxWriter = mockk()
   private val eventPublisher = TestEventPublisher()
   private val googleDriveWriter: GoogleDriveWriter = mockk()
 
   private val service: SubmissionService by lazy {
-    SubmissionService(clock, dropboxWriter, dslContext, eventPublisher, googleDriveWriter)
+    SubmissionService(clock, config, dropboxWriter, dslContext, eventPublisher, googleDriveWriter)
   }
 
   private val contentType = MediaType.APPLICATION_OCTET_STREAM
@@ -74,7 +78,10 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `publishes event and throws exception if Google URL not configured`() {
+    fun `publishes event and throws exception if Google folder ID not configured`() {
+      every { config.accelerator } returns
+          TerrawareServerConfig.AcceleratorConfig(applicationGoogleFolderId = null)
+
       insertProjectAcceleratorDetails(fileNaming = "xyz")
 
       assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
@@ -88,6 +95,41 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEventAndException<ProjectDocumentSettingsNotConfiguredException>(
           FailureReason.FolderNotConfigured, DocumentStore.Dropbox)
+    }
+
+    @Test
+    fun `creates new Google Drive folder if none exists and deliverable is not sensitive`() {
+      val parentFolderId = "parent"
+      val driveId = "drive"
+      val fileNaming = "xyz"
+      val newFolderId = "xyzzy"
+      val newFolderUrl = URI("https://drive.google.com/drive/$newFolderId")
+
+      insertProjectAcceleratorDetails(fileNaming = fileNaming)
+
+      every { config.accelerator } returns
+          TerrawareServerConfig.AcceleratorConfig(applicationGoogleFolderId = parentFolderId)
+      every { googleDriveWriter.findOrCreateFolders(driveId, parentFolderId, any()) } returns
+          newFolderId
+      every { googleDriveWriter.getDriveIdForFile(any()) } returns driveId
+      every { googleDriveWriter.getFileIdForFolderUrl(newFolderUrl) } returns newFolderId
+      every { googleDriveWriter.shareFile(newFolderId) } returns newFolderUrl
+      every {
+        googleDriveWriter.uploadFile(
+            newFolderId, any(), any(), any(), driveId, any(), any(), any(), any())
+      } returns "file"
+
+      receiveDocument()
+
+      verify(exactly = 1) {
+        googleDriveWriter.findOrCreateFolders(
+            driveId, parentFolderId, listOf("$fileNaming [Internal]"))
+      }
+
+      assertEquals(
+          newFolderUrl,
+          projectAcceleratorDetailsDao.fetchOneByProjectId(projectId)?.googleFolderUrl,
+          "Google folder URL")
     }
 
     @Test


### PR DESCRIPTION
Currently we require an admin to configure the Google Drive folder to use for
uploaded documents for projects, but that doesn't work well for applications since
they won't have been reviewed yet at the time they need to start uploading
documents.

Add a config option that specifies a Google Drive folder in which new project
folders will be created on demand for projects that don't currently have folders.