### PR TITLE
Remove deprecated locale service provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -311,7 +311,7 @@ openApi {
     // Use application-apidoc.yaml for application configuration.
     jvmArgs.add("-Dspring.profiles.active=apidoc")
 
-    jvmArgs.add("-Djava.locale.providers=SPI,CLDR,COMPAT")
+    jvmArgs.add("-Djava.locale.providers=SPI,CLDR")
     jvmArgs.add("-Dserver.port=$listenPort")
 
     // Spring Boot Devtools aren't useful for a one-shot server run, and they add log output.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,4 @@ COPY --chown=$USER_ID application/ ./
 EXPOSE 8080
 
 USER $USER_ID
-CMD ["java", "-Djava.locale.providers=SPI,CLDR,COMPAT", "org.springframework.boot.loader.launch.JarLauncher"]
+CMD ["java", "-Djava.locale.providers=SPI,CLDR", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/src/main/kotlin/com/terraformation/backend/Application.kt
+++ b/src/main/kotlin/com/terraformation/backend/Application.kt
@@ -48,7 +48,7 @@ fun main(args: Array<String>) {
 
   // Make sure the system property to allow registering custom locale providers is set. Annoyingly,
   // it is not possible to change this programmatically; it has to be a command-line argument.
-  val expectedProviders = "SPI,CLDR,COMPAT"
+  val expectedProviders = "SPI,CLDR"
   if (System.getProperty("java.locale.providers") != expectedProviders) {
     throw RuntimeException(
         "Please add -Djava.locale.providers=$expectedProviders to the JVM's command-line arguments.")


### PR DESCRIPTION
The "COMPAT" locale service provider is deprecated in recent Java versions and
including it in the providers list causes the server to spit out a warning message
when it starts up. The CLDR provider has everything we need anyway, so remove the
COMPAT provider from the providers list.