### PR TITLE
Fix missing foreign keys in migration

### DIFF
--- a/src/main/resources/db/migration/0300/V302__DeliverableInternalInterestMapping.sql
+++ b/src/main/resources/db/migration/0300/V302__DeliverableInternalInterestMapping.sql
@@ -1,6 +1,20 @@
 ALTER TABLE accelerator.deliverable_categories
     ADD COLUMN internal_interest_id INTEGER REFERENCES accelerator.internal_interests ON DELETE RESTRICT;
 
+-- These are also in R__TypeCodes.sql, but need to be here so the referenced interest IDs exist
+-- when we update deliverable_categories.
+INSERT INTO accelerator.internal_interests (id, name)
+VALUES (1, 'Compliance'),
+       (2, 'Financial Viability'),
+       (3, 'GIS'),
+       (4, 'Carbon Eligibility'),
+       (5, 'Stakeholders and Community Impact'),
+       (6, 'Proposed Restoration Activities'),
+       (7, 'Verra Non-Permanence Risk Tool (NPRT)'),
+       (8, 'Supplemental Files'),
+       (101, 'Sourcing')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 UPDATE accelerator.deliverable_categories
 SET internal_interest_id = id;
 


### PR DESCRIPTION
The V302 migration succeeded on an empty database (such as the one that's
used to run tests) but failed if the `deliverable_categories` table was
already populated from a previous server run because it was trying to
refer to interest IDs that hadn't been inserted yet.

This is an edit to an existing migration, but shouldn't require any Flyway
migration history surgery because it's either running on a clean database
(in which case the previous version won't have been run anyway) or it will
be running on a database where the previous version failed.