### PR TITLE
Simplify inserting deliverable variables in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -241,10 +241,8 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates deliverable status if all variables without dependencies have values`() {
-      val variableId1 =
-          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 1))
-      val variableId2 =
-          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 2))
+      val variableId1 = insertTextVariable(deliverableId = deliverableId)
+      val variableId2 = insertTextVariable(deliverableId = deliverableId)
 
       insertTextVariable(
           insertVariable(
@@ -266,9 +264,8 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not update deliverable status if variables without dependencies lack values`() {
-      val variableId1 =
-          insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 1))
-      insertTextVariable(insertVariable(deliverableId = deliverableId, deliverablePosition = 2))
+      val variableId1 = insertTextVariable(deliverableId = deliverableId)
+      insertTextVariable(deliverableId = deliverableId)
 
       insertValue(variableId = variableId1, textValue = "A")
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
@@ -130,13 +129,7 @@ class SubmissionNotifierTest : DatabaseTest(), RunsAsUser {
       insertVariableManifest()
       insertDocument()
 
-      insertVariableManifestEntry(
-          insertTextVariable(
-              id =
-                  insertVariable(
-                      deliverableId = inserted.deliverableId,
-                      deliverablePosition = 0,
-                      type = VariableType.Text)))
+      insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
     }
 
     @Test
@@ -174,13 +167,7 @@ class SubmissionNotifierTest : DatabaseTest(), RunsAsUser {
       insertVariableManifest()
       insertDocument()
 
-      insertVariableManifestEntry(
-          insertTextVariable(
-              id =
-                  insertVariable(
-                      deliverableId = inserted.deliverableId,
-                      deliverablePosition = 0,
-                      type = VariableType.Text)))
+      insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
 
       insertValue(variableId = inserted.variableId)
     }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2549,14 +2549,17 @@ abstract class DatabaseBackedTest {
   }
 
   protected fun insertNumberVariable(
-      id: VariableId = insertVariable(type = VariableType.Number),
+      id: VariableId? = null,
       decimalPlaces: Int = 0,
+      deliverableId: DeliverableId? = null,
       minValue: BigDecimal? = null,
       maxValue: BigDecimal? = null,
   ): VariableId {
+    val actualId = id ?: insertVariable(type = VariableType.Number, deliverableId = deliverableId)
+
     val row =
         VariableNumbersRow(
-            variableId = id,
+            variableId = actualId,
             variableTypeId = VariableType.Number,
             decimalPlaces = decimalPlaces,
             maxValue = maxValue,
@@ -2565,7 +2568,7 @@ abstract class DatabaseBackedTest {
 
     variableNumbersDao.insert(row)
 
-    return id
+    return actualId
   }
 
   protected fun insertSavedVersion(
@@ -2745,19 +2748,22 @@ abstract class DatabaseBackedTest {
   }
 
   protected fun insertSelectVariable(
-      id: VariableId = insertVariable(type = VariableType.Select),
+      id: VariableId? = null,
+      deliverableId: DeliverableId? = null,
       isMultiple: Boolean = false,
   ): VariableId {
+    val actualId = id ?: insertVariable(type = VariableType.Select, deliverableId = deliverableId)
+
     val row =
         VariableSelectsRow(
-            variableId = id,
+            variableId = actualId,
             variableTypeId = VariableType.Select,
             isMultiple = isMultiple,
         )
 
     variableSelectsDao.insert(row)
 
-    return id
+    return actualId
   }
 
   private var lastTableColumnTableId: VariableId? = null
@@ -2794,35 +2800,41 @@ abstract class DatabaseBackedTest {
   }
 
   protected fun insertTableVariable(
-      id: VariableId = insertVariable(type = VariableType.Table),
+      id: VariableId? = null,
+      deliverableId: DeliverableId? = null,
       style: VariableTableStyle = VariableTableStyle.Horizontal,
   ): VariableId {
+    val actualId = id ?: insertVariable(type = VariableType.Table, deliverableId = deliverableId)
+
     val row =
         VariableTablesRow(
-            variableId = id,
+            variableId = actualId,
             variableTypeId = VariableType.Table,
             tableStyleId = style,
         )
 
     variableTablesDao.insert(row)
 
-    return id
+    return actualId
   }
 
   protected fun insertTextVariable(
-      id: VariableId = insertVariable(type = VariableType.Text),
+      id: VariableId? = null,
+      deliverableId: DeliverableId? = null,
       textType: VariableTextType = VariableTextType.SingleLine,
   ): VariableId {
+    val actualId = id ?: insertVariable(type = VariableType.Text, deliverableId = deliverableId)
+
     val row =
         VariableTextsRow(
-            variableId = id,
+            variableId = actualId,
             variableTypeId = VariableType.Text,
             variableTextTypeId = textType,
         )
 
     variableTextsDao.insert(row)
 
-    return id
+    return actualId
   }
 
   protected fun insertThumbnail(
@@ -2898,11 +2910,12 @@ abstract class DatabaseBackedTest {
     variableValueTableRowsDao.insert(row)
   }
 
+  private var nextDeliverablePosition = 1
   private var nextVariableNumber = 1
 
   protected fun insertVariable(
       deliverableId: DeliverableId? = null,
-      deliverablePosition: Int? = null,
+      deliverablePosition: Int? = if (deliverableId != null) nextDeliverablePosition++ else null,
       deliverableQuestion: String? = null,
       dependencyCondition: DependencyCondition? = null,
       dependencyValue: String? = null,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -91,7 +91,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
       // Other values may exist for a project before a new document is created
       insertModule()
       val deliverableId = insertDeliverable()
-      val variableId = insertVariable(deliverableId = deliverableId, deliverablePosition = 0)
+      val variableId = insertVariable(deliverableId = deliverableId)
       insertTextVariable(variableId)
       insertValue(variableId = variableId, projectId = inserted.projectId, textValue = "Text")
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -126,31 +126,15 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
       val deliverableId1 = insertDeliverable()
       val deliverableId2 = insertDeliverable()
 
-      val variableId1 =
-          insertTextVariable(
-              id =
-                  insertVariable(
-                      type = VariableType.Text,
-                      deliverableId = deliverableId1,
-                      deliverablePosition = 0))
+      val variableId1 = insertTextVariable(deliverableId = deliverableId1)
       val valueId1 =
           insertValue(projectId = projectId, textValue = "value1", variableId = variableId1)
-      val variableId2 =
-          insertTextVariable(
-              id =
-                  insertVariable(
-                      type = VariableType.Text,
-                      deliverableId = deliverableId1,
-                      deliverablePosition = 1))
+      val variableId2 = insertTextVariable(deliverableId = deliverableId1)
+
       val valueId2 =
           insertValue(projectId = projectId, textValue = "value2", variableId = variableId2)
-      val variableId3 =
-          insertTextVariable(
-              id =
-                  insertVariable(
-                      type = VariableType.Text,
-                      deliverableId = deliverableId2,
-                      deliverablePosition = 0))
+      val variableId3 = insertTextVariable(deliverableId = deliverableId2)
+
       insertValue(textValue = "value3", variableId = variableId3)
 
       val expected =
@@ -370,13 +354,7 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
       @Test
       fun `publishes event for a non-list variable if a deliverable is associated`() {
         val variableId =
-            insertVariableManifestEntry(
-                insertTextVariable(
-                    id =
-                        insertVariable(
-                            deliverableId = inserted.deliverableId,
-                            deliverablePosition = 0,
-                            type = VariableType.Text)))
+            insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
 
         val updatedValues =
             store.updateValues(
@@ -397,7 +375,6 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
                     id =
                         insertVariable(
                             deliverableId = inserted.deliverableId,
-                            deliverablePosition = 0,
                             isList = true,
                             type = VariableType.Text)))
 
@@ -426,7 +403,6 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
                     id =
                         insertVariable(
                             deliverableId = inserted.deliverableId,
-                            deliverablePosition = 0,
                             isList = true,
                             type = VariableType.Text)))
 
@@ -463,7 +439,6 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
                     id =
                         insertVariable(
                             deliverableId = inserted.deliverableId,
-                            deliverablePosition = 0,
                             isList = true,
                             type = VariableType.Text)))
 
@@ -492,10 +467,7 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
 
       @Test
       fun `does not publish event if a deliverable is not associated`() {
-        val variableId =
-            insertVariableManifestEntry(
-                insertTextVariable(
-                    id = insertVariable(deliverableId = null, type = VariableType.Text)))
+        val variableId = insertVariableManifestEntry(insertTextVariable(deliverableId = null))
         store.updateValues(
             listOf(AppendValueOperation(NewTextValue(newValueProps(variableId), "new"))))
 
@@ -505,13 +477,7 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
       @Test
       fun `publishes event if a variable value is updated`() {
         val variableId =
-            insertVariableManifestEntry(
-                insertTextVariable(
-                    id =
-                        insertVariable(
-                            deliverableId = inserted.deliverableId,
-                            deliverablePosition = 0,
-                            type = VariableType.Text)))
+            insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
 
         val updatedValues =
             store.updateValues(

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
@@ -37,13 +37,8 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
     insertDocument()
     insertModule()
     insertDeliverable()
-    insertVariableManifestEntry(
-        insertTextVariable(
-            id =
-                insertVariable(
-                    deliverableId = inserted.deliverableId,
-                    deliverablePosition = 0,
-                    type = VariableType.Text)))
+    insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
+
     insertValue(variableId = inserted.variableId)
 
     every { user.canReadProject(any()) } returns true
@@ -81,13 +76,8 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
       )
 
       val otherVariableId =
-          insertVariableManifestEntry(
-              insertTextVariable(
-                  id =
-                      insertVariable(
-                          deliverableId = inserted.deliverableId,
-                          deliverablePosition = 0,
-                          type = VariableType.Text)))
+          insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
+
       insertValue(variableId = otherVariableId)
       val otherWorkflowId =
           insertVariableWorkflowHistory(


### PR DESCRIPTION
Inserting a variable with a deliverable ID is a common enough pattern to deserve a
more concise syntax. Add deliverable ID parameters to the variable-type-specific
insert methods and auto-allocate deliverable positions as needed.