### PR TITLE
SW-5928 Image variable as a part of questionnaire deliverable never marked as submitted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -433,12 +433,15 @@ class VariableValueStore(
       throw VariableTypeMismatchException(newValue.variableId, newValue.type)
     }
 
+    val result =
+        dslContext.transactionResult { _ ->
+          insertValue(newValue.projectId, newValue.listPosition, newValue.rowValueId, newValue)
+        }
+
     // notify variable value was updated
     eventPublisher.publishEvent(VariableValueUpdatedEvent(newValue.projectId, newValue.variableId))
 
-    return dslContext.transactionResult { _ ->
-      insertValue(newValue.projectId, newValue.listPosition, newValue.rowValueId, newValue)
-    }
+    return result
   }
 
   private fun appendValue(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -433,6 +433,9 @@ class VariableValueStore(
       throw VariableTypeMismatchException(newValue.variableId, newValue.type)
     }
 
+    // notify variable value was updated
+    eventPublisher.publishEvent(VariableValueUpdatedEvent(newValue.projectId, newValue.variableId))
+
     return dslContext.transactionResult { _ ->
       insertValue(newValue.projectId, newValue.listPosition, newValue.rowValueId, newValue)
     }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -17,6 +17,8 @@ import com.terraformation.backend.documentproducer.model.ExistingDeletedValue
 import com.terraformation.backend.documentproducer.model.ExistingTableValue
 import com.terraformation.backend.documentproducer.model.ExistingTextValue
 import com.terraformation.backend.documentproducer.model.ExistingValue
+import com.terraformation.backend.documentproducer.model.ImageValueDetails
+import com.terraformation.backend.documentproducer.model.NewImageValue
 import com.terraformation.backend.documentproducer.model.NewTableValue
 import com.terraformation.backend.documentproducer.model.NewTextValue
 import com.terraformation.backend.documentproducer.model.ReplaceValuesOperation
@@ -487,6 +489,15 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
           eventPublisher.assertEventPublished(
               VariableValueUpdatedEvent(inserted.projectId, value.variableId))
         }
+      }
+
+      @Test
+      fun `publishes event if a variable value is written`() {
+        val variableId = insertVariable(type = VariableType.Image)
+        val fileId = insertFile()
+        store.writeValue(NewImageValue(newValueProps(variableId), ImageValueDetails("", fileId)))
+        eventPublisher.assertEventPublished(
+            VariableValueUpdatedEvent(inserted.projectId, variableId))
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -502,6 +502,7 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
         }
       }
 
+      @Test
       fun `does not publish event if a variable value is updated and triggerWorkflows is false`() {
         val variableId =
             insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))


### PR DESCRIPTION
I think this is happening because it is never marked as in review