### PR TITLE
Remove unused dependency from VariableValueStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableManifestId
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableValueId
-import com.terraformation.backend.db.docprod.tables.daos.DocumentsDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableImageValuesDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableLinkValuesDao
 import com.terraformation.backend.db.docprod.tables.daos.VariableSectionValuesDao
@@ -80,7 +79,6 @@ import org.springframework.context.ApplicationEventPublisher
 @Named
 class VariableValueStore(
     private val clock: InstantSource,
-    private val documentsDao: DocumentsDao,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val variableImageValuesDao: VariableImageValuesDao,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -74,7 +74,6 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
             variableTextsDao),
         VariableValueStore(
             clock,
-            documentsDao,
             dslContext,
             eventPublisher,
             variableImageValuesDao,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenVariableValuesFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/PreScreenVariableValuesFetcherTest.kt
@@ -43,7 +43,6 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
             variableTextsDao),
         VariableValueStore(
             TestClock(),
-            documentsDao,
             dslContext,
             TestEventPublisher(),
             variableImageValuesDao,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionNotifierTest.kt
@@ -55,7 +55,6 @@ class SubmissionNotifierTest : DatabaseTest(), RunsAsUser {
             variableTextsDao),
         VariableValueStore(
             clock,
-            documentsDao,
             dslContext,
             eventPublisher,
             variableImageValuesDao,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
@@ -62,7 +62,6 @@ class DocumentUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
   private val variableValueStore: VariableValueStore by lazy {
     VariableValueStore(
         clock,
-        documentsDao,
         dslContext,
         eventPublisher,
         variableImageValuesDao,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -34,7 +34,6 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
   private val store by lazy {
     VariableValueStore(
         clock,
-        documentsDao,
         dslContext,
         eventPublisher,
         variableImageValuesDao,


### PR DESCRIPTION
`VariableValueStore` depended on `DocumentsDao` but wasn't using it.