### PR TITLE
SW-5951 Upgrade calculator for all-variables list

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculator.kt
@@ -1,0 +1,150 @@
+package com.terraformation.backend.documentproducer
+
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.VariableValueId
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.db.variable.VariableImporter
+import com.terraformation.backend.documentproducer.model.AppendValueOperation
+import com.terraformation.backend.documentproducer.model.BaseVariableValueProperties
+import com.terraformation.backend.documentproducer.model.ExistingValue
+import com.terraformation.backend.documentproducer.model.NewTableValue
+import com.terraformation.backend.documentproducer.model.TableVariable
+import com.terraformation.backend.documentproducer.model.ValueOperation
+import com.terraformation.backend.documentproducer.model.Variable
+import com.terraformation.backend.log.perClassLogger
+
+/**
+ * Calculates the list of operations needed to upgrade variables from the all-variables list to the
+ * latest versions.
+ *
+ * This is not a service; create a new instance of it for each upgrade.
+ */
+class VariableUpgradeCalculator(
+    /**
+     * Which old variables were replaced by which new variables in the new version of the
+     * all-variables list. This typically comes from the return value of [VariableImporter.import].
+     */
+    private val replacements: Map<VariableId, VariableId>,
+    private val variableStore: VariableStore,
+    private val variableValueStore: VariableValueStore,
+) {
+  private val log = perClassLogger()
+
+  /** Map of new variable ID to the older ID it replaces. The inverse of [replacements]. */
+  private val oldVariableIds: Map<VariableId, VariableId> =
+      replacements.entries.associate { it.value to it.key }
+
+  private lateinit var valuesOfOldVariables: Map<VariableId, List<ExistingValue>>
+
+  fun calculateOperations(): List<ValueOperation> {
+    val newVariableIds = replacements.values
+    val newVariables = newVariableIds.map { variableStore.fetchVariable(it) }
+    val tableColumnVariableIds =
+        newVariables
+            .filterIsInstance<TableVariable>()
+            .flatMap { variable -> variable.columns.map { it.variable.id } }
+            .toSet()
+
+    val projectsWithValuesForNewVariables: Map<VariableId, Set<ProjectId>> =
+        variableValueStore.fetchProjectsWithValues(newVariableIds)
+
+    valuesOfOldVariables =
+        variableValueStore
+            .listValues(replacements.keys)
+            .filter { oldValue ->
+              // If the new variable already has a value for a project, don't overwrite it by
+              // upgrading the old values.
+              //
+              // There won't be values yet in the common case of upgrading as part of importing a
+              // new all-variables list since the new variables will have just been created, but
+              // there might be if this is a manually-triggered upgrade to backfill values for
+              // variables that were replaced before this class existed.
+
+              val projects = projectsWithValuesForNewVariables[replacements[oldValue.variableId]]
+              projects == null || oldValue.projectId !in projects
+            }
+            .groupBy { it.variableId }
+
+    return newVariables
+        .filterNot { variable ->
+          // Values of table columns are upgraded as part of the upgrade of the table.
+          variable.id in tableColumnVariableIds
+        }
+        .flatMap { variableOperations(it) }
+  }
+
+  private fun variableOperations(newVariable: Variable): List<ValueOperation> {
+    val valuesOfOldVariable =
+        oldVariableIds[newVariable.id]?.let { valuesOfOldVariables[it] } ?: return emptyList()
+
+    val oldVariable = variableStore.fetchVariable(valuesOfOldVariable.first().variableId)
+
+    return if (newVariable is TableVariable) {
+      if (oldVariable is TableVariable) {
+        tableOperations(oldVariable, valuesOfOldVariable, newVariable)
+      } else {
+        // Replacing a non-table with a table is allowed, but unusual enough to be worth
+        // flagging for someone to look at.
+        log.warn("Variable ${newVariable.name} used to be ${oldVariable.type} but is now a table")
+        emptyList()
+      }
+    } else {
+      valuesOfOldVariable
+          .mapNotNull { oldValue ->
+            newVariable.convertValue(oldVariable, oldValue, null, variableStore::fetchVariable)
+          }
+          .map { AppendValueOperation(it) }
+    }
+  }
+
+  private fun tableOperations(
+      oldTable: TableVariable,
+      oldRows: List<ExistingValue>,
+      newTable: TableVariable
+  ): List<ValueOperation> {
+    val oldColumnsByStableId = oldTable.columns.associate { it.variable.stableId to it.variable }
+
+    // old column ID -> old row value ID -> list of values in the old cell
+    val valuesOfOldCells: Map<VariableId, Map<VariableValueId, List<ExistingValue>>> =
+        oldTable.columns
+            .mapNotNull { oldColumn ->
+              valuesOfOldVariables[oldColumn.variable.id]?.let { oldColumnValues ->
+                val valuesByOldRowValueId =
+                    oldColumnValues
+                        .filter { it.rowValueId != null }
+                        .sortedBy { it.listPosition }
+                        .groupBy { it.rowValueId!! }
+
+                oldColumn.variable.id to valuesByOldRowValueId
+              }
+            }
+            .toMap()
+
+    return oldRows.flatMap { oldRow ->
+      val rowOperation =
+          AppendValueOperation(
+              NewTableValue(
+                  BaseVariableValueProperties(
+                      null, oldRow.projectId, 0, newTable.id, oldRow.citation)))
+
+      val columnOperations =
+          newTable.columns
+              .map { it.variable }
+              .flatMap { newColumn ->
+                val oldColumn = oldColumnsByStableId[newColumn.stableId]
+
+                oldColumn
+                    ?.let { valuesOfOldCells[oldColumn.id]?.get(oldRow.id) }
+                    ?.mapNotNull { oldValue ->
+                      newColumn.convertValue(
+                          oldColumn, oldValue, null, variableStore::fetchVariable)
+                    }
+                    ?.map { AppendValueOperation(it) } ?: emptyList()
+              }
+
+      listOf(rowOperation) + columnOperations
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2554,8 +2554,12 @@ abstract class DatabaseBackedTest {
       deliverableId: DeliverableId? = null,
       minValue: BigDecimal? = null,
       maxValue: BigDecimal? = null,
+      stableId: String = "$nextVariableNumber",
   ): VariableId {
-    val actualId = id ?: insertVariable(type = VariableType.Number, deliverableId = deliverableId)
+    val actualId =
+        id
+            ?: insertVariable(
+                type = VariableType.Number, deliverableId = deliverableId, stableId = stableId)
 
     val row =
         VariableNumbersRow(
@@ -2803,8 +2807,12 @@ abstract class DatabaseBackedTest {
       id: VariableId? = null,
       deliverableId: DeliverableId? = null,
       style: VariableTableStyle = VariableTableStyle.Horizontal,
+      stableId: String = "$nextVariableNumber",
   ): VariableId {
-    val actualId = id ?: insertVariable(type = VariableType.Table, deliverableId = deliverableId)
+    val actualId =
+        id
+            ?: insertVariable(
+                type = VariableType.Table, deliverableId = deliverableId, stableId = stableId)
 
     val row =
         VariableTablesRow(
@@ -2822,8 +2830,12 @@ abstract class DatabaseBackedTest {
       id: VariableId? = null,
       deliverableId: DeliverableId? = null,
       textType: VariableTextType = VariableTextType.SingleLine,
+      stableId: String = "$nextVariableNumber",
   ): VariableId {
-    val actualId = id ?: insertVariable(type = VariableType.Text, deliverableId = deliverableId)
+    val actualId =
+        id
+            ?: insertVariable(
+                type = VariableType.Text, deliverableId = deliverableId, stableId = stableId)
 
     val row =
         VariableTextsRow(

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculatorTest.kt
@@ -1,0 +1,322 @@
+package com.terraformation.backend.documentproducer
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.VariableType
+import com.terraformation.backend.db.docprod.VariableValueId
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.model.AppendValueOperation
+import com.terraformation.backend.documentproducer.model.BaseVariableValueProperties
+import com.terraformation.backend.documentproducer.model.NewNumberValue
+import com.terraformation.backend.documentproducer.model.NewTableValue
+import com.terraformation.backend.documentproducer.model.NewTextValue
+import com.terraformation.backend.documentproducer.model.ValueOperation
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import java.math.BigDecimal
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VariableUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+
+  private val variableStore: VariableStore by lazy {
+    VariableStore(
+        dslContext,
+        variableNumbersDao,
+        variablesDao,
+        variableSectionDefaultValuesDao,
+        variableSectionRecommendationsDao,
+        variableSectionsDao,
+        variableSelectsDao,
+        variableSelectOptionsDao,
+        variableTablesDao,
+        variableTableColumnsDao,
+        variableTextsDao)
+  }
+  private val variableValueStore: VariableValueStore by lazy {
+    VariableValueStore(
+        clock,
+        dslContext,
+        eventPublisher,
+        variableImageValuesDao,
+        variableLinkValuesDao,
+        variablesDao,
+        variableSectionValuesDao,
+        variableSelectOptionValuesDao,
+        variableValuesDao,
+        variableValueTableRowsDao)
+  }
+
+  private val stableId = "${UUID.randomUUID()}"
+
+  private lateinit var deliverableId: DeliverableId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertProject()
+    insertModule()
+    deliverableId = insertDeliverable()
+
+    every { user.canReadProjectDeliverables(any()) } returns true
+  }
+
+  @Test
+  fun `does not return operations for values that no longer validate`() {
+    val oldVariableId = insertNumberVariable(deliverableId = deliverableId, stableId = stableId)
+
+    insertValue(variableId = oldVariableId, numberValue = BigDecimal.ONE)
+    val newVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                replacesVariableId = oldVariableId,
+                deliverableId = deliverableId,
+                stableId = stableId),
+            minValue = BigDecimal.TEN)
+
+    assertEquals(
+        emptyList<ValueOperation>(), calculateOperations(mapOf(oldVariableId to newVariableId)))
+  }
+
+  // This just tests that values are converted as part of the upgrade calculations; the conversion
+  // logic is covered in VariableTest.
+  @Test
+  fun `converts value to new variable type`() {
+    val oldVariableId =
+        insertNumberVariable(decimalPlaces = 5, deliverableId = deliverableId, stableId = stableId)
+    insertValue(variableId = oldVariableId, numberValue = BigDecimal("1.23456"))
+
+    val newVariableId =
+        insertTextVariable(
+            insertVariable(
+                type = VariableType.Text,
+                replacesVariableId = oldVariableId,
+                deliverableId = deliverableId,
+                stableId = stableId))
+
+    assertEquals(
+        listOf(AppendValueOperation(NewTextValue(newValueProps(newVariableId), "1.23456"))),
+        calculateOperations(mapOf(oldVariableId to newVariableId)))
+  }
+
+  @Test
+  fun `appends valid list items in same order as original list`() {
+    val oldVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                isList = true,
+                deliverableId = deliverableId,
+                stableId = stableId))
+
+    insertValue(variableId = oldVariableId, listPosition = 0, numberValue = BigDecimal(0))
+    insertValue(variableId = oldVariableId, listPosition = 1, numberValue = BigDecimal(1))
+    insertValue(variableId = oldVariableId, listPosition = 2, numberValue = BigDecimal(100))
+    insertValue(variableId = oldVariableId, listPosition = 3, numberValue = BigDecimal(3))
+
+    val newVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                isList = true,
+                replacesVariableId = oldVariableId,
+                deliverableId = deliverableId,
+                stableId = stableId),
+            maxValue = BigDecimal.TEN)
+
+    assertEquals(
+        listOf(
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, listPosition = 0), BigDecimal(0))),
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, listPosition = 1), BigDecimal(1))),
+            // List position is preserved across value conversion, so we expect to skip position 2
+            // here; it is ignored by append operations so this won't result in a hole in the final
+            // result.
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, listPosition = 3), BigDecimal(3))),
+        ),
+        calculateOperations(mapOf(oldVariableId to newVariableId)))
+  }
+
+  @Test
+  fun `populates new table rows with values from old columns`() {
+    // Original table has one obsolete column that won't appear in the new table version, and one
+    // outdated column that will appear, but with different settings (a minimum value).
+    val oldTableVariableId =
+        insertTableVariable(deliverableId = deliverableId, stableId = "table-$stableId")
+    val oldTableObsoleteColumnId =
+        insertTextVariable(deliverableId = deliverableId, stableId = "col1-$stableId")
+    insertTableColumn(oldTableVariableId, oldTableObsoleteColumnId)
+    val oldTableOutdatedColumnId =
+        insertNumberVariable(deliverableId = deliverableId, stableId = "col2-$stableId")
+    insertTableColumn(oldTableVariableId, oldTableOutdatedColumnId)
+
+    val newTableVariableId =
+        insertTableVariable(
+            insertVariable(
+                type = VariableType.Table,
+                replacesVariableId = oldTableVariableId,
+                deliverableId = deliverableId,
+                stableId = "table-$stableId"))
+    val newTableUpdatedColumnId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                replacesVariableId = oldTableOutdatedColumnId,
+                deliverableId = deliverableId,
+                stableId = "col2-$stableId"),
+            minValue = BigDecimal.TEN)
+    insertTableColumn(newTableVariableId, newTableUpdatedColumnId)
+
+    val oldTableRowId1 = insertValue(variableId = oldTableVariableId, listPosition = 0)
+    val oldRowVal1Col1 =
+        insertValue(variableId = oldTableObsoleteColumnId, textValue = "obsolete 1")
+    insertValueTableRow(oldRowVal1Col1, oldTableRowId1)
+    val oldRowVal1Col2 =
+        insertValue(
+            variableId = oldTableOutdatedColumnId,
+            numberValue = BigDecimal(50),
+            citation = "citation")
+    insertValueTableRow(oldRowVal1Col2, oldTableRowId1)
+
+    val oldTableRowId2 = insertValue(variableId = oldTableVariableId, listPosition = 1)
+    val oldRowVal2Col1 =
+        insertValue(variableId = oldTableObsoleteColumnId, textValue = "obsolete 2")
+    insertValueTableRow(oldRowVal2Col1, oldTableRowId2)
+    val oldRowVal2Col2 =
+        insertValue(variableId = oldTableOutdatedColumnId, numberValue = BigDecimal(5))
+    insertValueTableRow(oldRowVal2Col2, oldTableRowId2)
+
+    assertEquals(
+        listOf(
+            // Append new rows
+            AppendValueOperation(NewTableValue(newValueProps(newTableVariableId))),
+            AppendValueOperation(
+                NewNumberValue(
+                    newValueProps(newTableUpdatedColumnId, citation = "citation"), BigDecimal(50))),
+            // Empty row because the old one didn't have any values to carry forward.
+            AppendValueOperation(NewTableValue(newValueProps(newTableVariableId))),
+        ),
+        calculateOperations(
+            mapOf(
+                oldTableVariableId to newTableVariableId,
+                oldTableOutdatedColumnId to newTableUpdatedColumnId,
+            )))
+  }
+
+  @Test
+  fun `populates value for variable that moved from a different deliverable`() {
+    val oldDeliverableVariableId =
+        insertNumberVariable(deliverableId = deliverableId, stableId = stableId)
+    insertValue(variableId = oldDeliverableVariableId, numberValue = BigDecimal(5))
+
+    val newDeliverableId = insertDeliverable()
+    val newDeliverableVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                deliverableId = newDeliverableId,
+                replacesVariableId = oldDeliverableVariableId,
+                stableId = stableId))
+
+    assertEquals(
+        listOf(
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newDeliverableVariableId), BigDecimal(5)))),
+        calculateOperations(mapOf(oldDeliverableVariableId to newDeliverableVariableId)))
+  }
+
+  @Test
+  fun `populates values across all projects`() {
+    val projectId1 = inserted.projectId
+    val projectId2 = insertProject()
+
+    val oldVariableId =
+        insertNumberVariable(decimalPlaces = 5, deliverableId = deliverableId, stableId = stableId)
+    insertValue(variableId = oldVariableId, projectId = projectId1, numberValue = BigDecimal(1))
+    insertValue(variableId = oldVariableId, projectId = projectId2, numberValue = BigDecimal(2))
+
+    val newVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                replacesVariableId = oldVariableId,
+                deliverableId = deliverableId,
+                stableId = stableId))
+
+    assertEquals(
+        listOf(
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, projectId1), BigDecimal(1))),
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, projectId2), BigDecimal(2))),
+        ),
+        calculateOperations(mapOf(oldVariableId to newVariableId)))
+  }
+
+  @Test
+  fun `only populates values for projects that do not already have values for new variables`() {
+    val projectId1 = inserted.projectId
+    val projectId2 = insertProject()
+    val projectId3 = insertProject()
+
+    val oldVariableId =
+        insertNumberVariable(decimalPlaces = 5, deliverableId = deliverableId, stableId = stableId)
+    insertValue(variableId = oldVariableId, projectId = projectId1, numberValue = BigDecimal(1))
+    insertValue(variableId = oldVariableId, projectId = projectId2, numberValue = BigDecimal(2))
+    insertValue(variableId = oldVariableId, projectId = projectId3, numberValue = BigDecimal(3))
+
+    val newVariableId =
+        insertNumberVariable(
+            insertVariable(
+                type = VariableType.Number,
+                replacesVariableId = oldVariableId,
+                deliverableId = deliverableId,
+                stableId = stableId))
+    insertValue(variableId = newVariableId, projectId = projectId2, numberValue = BigDecimal.ZERO)
+
+    assertEquals(
+        listOf(
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, projectId1), BigDecimal(1))),
+            AppendValueOperation(
+                NewNumberValue(newValueProps(newVariableId, projectId3), BigDecimal(3))),
+        ),
+        calculateOperations(mapOf(oldVariableId to newVariableId)))
+  }
+
+  private fun calculateOperations(replacements: Map<VariableId, VariableId>) =
+      VariableUpgradeCalculator(replacements, variableStore, variableValueStore)
+          .calculateOperations()
+
+  private fun newValueProps(
+      variableId: VariableId,
+      projectId: ProjectId = inserted.projectId,
+      listPosition: Int = 0,
+      rowValueId: VariableValueId? = null,
+      citation: String? = null,
+  ): BaseVariableValueProperties<Nothing?> {
+    return BaseVariableValueProperties(
+        citation = citation,
+        id = null,
+        listPosition = listPosition,
+        projectId = projectId,
+        variableId = variableId,
+        rowValueId = rowValueId,
+    )
+  }
+}


### PR DESCRIPTION
When a new version of the all-variables list is imported, we want to upgrade
the values of any variables that are being replaced by new versions. The process
is basically the same as the existing logic for upgrading documents to new
variable manifests, but unlike that upgrade process, it applies across all
variables in all projects.

Add the code that calculates the required write operations. Nothing calls this
yet; that'll be added in upcoming changes.