### PR TITLE
SW-5959 Support backfilling old variable upgrades

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
@@ -59,6 +59,18 @@ class AdminDocumentProducerController(
     return documentProducerAdminHome()
   }
 
+  @PostMapping("/upgradeAllVariables")
+  fun upgradeAllVariables(redirectAttributes: RedirectAttributes): String {
+    try {
+      variableService.upgradeAllVariables()
+      redirectAttributes.successMessage = "Upgrades complete."
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = "Failed to upgrade: ${e.message}"
+    }
+
+    return documentProducerAdminHome()
+  }
+
   @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE], path = ["/uploadAllVariables"])
   fun uploadAllVariables(
       @RequestPart("file") file: MultipartFile,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.db.variable.VariableImportResult
 import com.terraformation.backend.documentproducer.db.variable.VariableImporter
+import com.terraformation.backend.documentproducer.model.TableVariable
 import jakarta.inject.Named
 import java.io.InputStream
 import org.jooq.DSLContext
@@ -32,6 +33,42 @@ class VariableService(
       }
 
       result
+    }
+  }
+
+  fun upgradeAllVariables() {
+    dslContext.transaction { _ ->
+      variableStore.fetchAllNonSectionVariables().forEach { newVariable ->
+        variableStore
+            .fetchReplacedVariables(newVariable.id)
+            .reversed() // Walk backward through the replacement chain
+            .map { variableStore.fetchVariable(it) }
+            .forEach { oldVariable ->
+              val columnReplacements =
+                  if (newVariable is TableVariable && oldVariable is TableVariable) {
+                    newVariable.columns
+                        .mapNotNull { newColumn ->
+                          oldVariable.columns
+                              .firstOrNull { oldColumn ->
+                                oldColumn.variable.stableId == newColumn.variable.stableId
+                              }
+                              ?.let { oldColumn -> oldColumn.variable.id to newColumn.variable.id }
+                        }
+                        .toMap()
+                  } else {
+                    emptyMap()
+                  }
+
+              val replacements = mapOf(oldVariable.id to newVariable.id) + columnReplacements
+
+              val operationsByProject =
+                  VariableUpgradeCalculator(replacements, variableStore, variableValueStore)
+                      .calculateOperations()
+                      .groupBy { it.projectId }
+
+              operationsByProject.values.forEach { variableValueStore.updateValues(it) }
+            }
+      }
     }
   }
 }

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -48,5 +48,13 @@
     <input type="submit" value="Import"/>
 </form>
 
+<p>
+    Upgrade values of old versions of variables to the latest versions. This is normally done
+    automatically when importing the all-variables CSV.
+</p>
+
+<form method="POST" action="/admin/document-producer/upgradeAllVariables">
+    <input type="submit" value="Upgrade Old Variable Values"/>
+</form>
 </body>
 </html>


### PR DESCRIPTION
We imported new all-variables CSVs in local dev environments and the staging
environment before adding support for automatically upgrading variables,
meaning that there are values of out-of-date variables that haven't been
brought forward to the replacement variables.

Add a button to the admin UI to walk back through the replacement history of
all the variables and upgrade any values that need it.

This should only need to be done once, since future changes to the all-variables
list will trigger automatic upgrades.