### PR TITLE
SW-5951 Don't notify about variable upgrades

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
@@ -28,7 +28,9 @@ class VariableService(
               VariableUpgradeCalculator(result.replacements, variableStore, variableValueStore)
                   .calculateOperations()
                   .groupBy { it.projectId }
-          operationsByProject.values.forEach { variableValueStore.updateValues(it) }
+          operationsByProject.values.forEach { operations ->
+            variableValueStore.updateValues(operations, triggerWorkflows = false)
+          }
         }
       }
 
@@ -66,7 +68,9 @@ class VariableService(
                       .calculateOperations()
                       .groupBy { it.projectId }
 
-              operationsByProject.values.forEach { variableValueStore.updateValues(it) }
+              operationsByProject.values.forEach { operations ->
+                variableValueStore.updateValues(operations, triggerWorkflows = false)
+              }
             }
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -465,6 +465,18 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
       }
 
       @Test
+      fun `does not publishes event if a deliverable is associated and triggerWorkflows is false`() {
+        val variableId =
+            insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
+
+        store.updateValues(
+            listOf(AppendValueOperation(NewTextValue(newValueProps(variableId), "new"))),
+            triggerWorkflows = false)
+
+        eventPublisher.assertEventNotPublished<QuestionsDeliverableSubmittedEvent>()
+      }
+
+      @Test
       fun `does not publish event if a deliverable is not associated`() {
         val variableId = insertVariableManifestEntry(insertTextVariable(deliverableId = null))
         store.updateValues(
@@ -486,6 +498,18 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
           eventPublisher.assertEventPublished(
               VariableValueUpdatedEvent(inserted.projectId, value.variableId))
         }
+      }
+
+      @Test
+      fun `does not publish event if a variable value is updated and triggerWorkflows is false`() {
+        val variableId =
+            insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
+
+        store.updateValues(
+            listOf(AppendValueOperation(NewTextValue(newValueProps(variableId), "new"))),
+            triggerWorkflows = false)
+
+        eventPublisher.assertEventNotPublished<VariableValueUpdatedEvent>()
       }
     }
   }


### PR DESCRIPTION
When variable values are created as a result of importing a new version of the
all-variables list, just write the new values but don't trigger notifications
about the updates.