### PR TITLE
Added document payload to application deliverables controller

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ApplicationsController.kt
@@ -391,6 +391,7 @@ data class ApplicationDeliverablePayload(
     val category: DeliverableCategory,
     @Schema(description = "Optional description of the deliverable in HTML form.")
     val descriptionHtml: String?,
+    val documents: List<SubmissionDocumentPayload>,
     val id: DeliverableId,
     val internalComment: String?,
     val modifiedTime: Instant?,
@@ -409,6 +410,7 @@ data class ApplicationDeliverablePayload(
   ) : this(
       model.category,
       model.descriptionHtml,
+      model.documents.map { SubmissionDocumentPayload(it) },
       model.deliverableId,
       model.internalComment,
       model.modifiedTime,


### PR DESCRIPTION
This was an oversight previously. This is needed for the prescreen boundary deliverables to work correctly. 