### PR TITLE
SW-5801 Import scores with multi-word category names

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectSetUpImporter.kt
@@ -150,7 +150,7 @@ class ProjectSetUpImporter(
 
     columnNamePrefixes.forEach { (phasePrefix, phase) ->
       ScoreCategory.entries.forEach { category ->
-        val prefix = "$phasePrefix${category.name}"
+        val prefix = "$phasePrefix${category.jsonValue}"
         val score = getInt(valuesByName, "$prefix Score")
 
         // Qualitative column names sometimes include the word "Score" and sometimes not.


### PR DESCRIPTION
The PDH project setup importer was looking for spreadsheet column headers using
the enum symbols for score categories, not their full names with whitespace, so
it was ignoring the scores for categories with multi-word names like "Climate
Impact."