### PR TITLE
Add "Home" link to document producer admin page

### DIFF
--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -5,6 +5,8 @@
 
 <span th:replace="~{/admin/header :: top}"/>
 
+<a href="/admin/">Home</a>
+
 <h2>Document Templates</h2>
 
 <table>


### PR DESCRIPTION
The admin UI should have navigation links at the top of every page, but the
document producer page didn't.