### PR TITLE
Remove hardwired ID in DocumentStoreTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/DocumentStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/DocumentStoreTest.kt
@@ -155,7 +155,8 @@ class DocumentStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `returns an empty list for a project ID with no documents`() {
-      assertEquals(emptyList<ProjectId>(), store.fetchByProjectId(ProjectId(3)))
+      val projectIdWithNoDocuments = insertProject(name = "Empty Project")
+      assertEquals(emptyList<ProjectId>(), store.fetchByProjectId(projectIdWithNoDocuments))
     }
 
     @Test


### PR DESCRIPTION
DocumentStoreTest was assuming that a specific project ID would be unused, which
was untrue if it was the first test in the test suite to be run.