### PR TITLE
SW-5768 Allow update of document statuses

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentsController.kt
@@ -249,12 +249,14 @@ data class UpdateDocumentRequestPayload(
     val internalComment: String?,
     val name: String,
     val ownedBy: UserId,
+    val status: DocumentStatus,
 ) {
   fun applyChanges(row: DocumentsRow) =
       row.copy(
           internalComment = internalComment,
           name = name,
           ownedBy = ownedBy,
+          statusId = status,
       )
 }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -253,7 +253,8 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
           """
             {
               "name": "Test Test document",
-              "ownedBy": ${inserted.userId}
+              "ownedBy": ${inserted.userId},
+              "status": "Draft"
             }"""
               .trimIndent()
 
@@ -284,15 +285,17 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
           """
             {
               "name": "Test Test document",
-              "ownedBy": ${inserted.userId}
+              "ownedBy": ${inserted.userId},
+              "status": "Submitted"
             }"""
               .trimIndent()
 
       mockMvc.put("$path/$documentId") { content = payload }.andExpect { status { isOk() } }
 
       val documentsRow = documentsDao.fetchOneById(documentId)
-      assertEquals(documentsRow!!.name, "Test Test document")
-      assertEquals(documentsRow.ownedBy, inserted.userId)
+      assertEquals("Test Test document", documentsRow!!.name, "Name")
+      assertEquals(inserted.userId, documentsRow.ownedBy, "Owned by")
+      assertEquals(DocumentStatus.Submitted, documentsRow.statusId, "Status")
     }
   }
 


### PR DESCRIPTION
There was no API to change the status of a document. Add it in the form of a
`status` field in the request payload for updating documents.

This is a breaking change (the new field is required) so clients will need
to be updated.