### PR TITLE
Increase Gradle memory limit to fix test failures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8 -Xmx4096m
+org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8 -Xmx5120m
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 
 # Version numbers of dependencies that come in multiple related artifacts. This ensures we have


### PR DESCRIPTION
Tests are running out of memory in CI; the underlying problem will require a more
involved fix so for now, bump up the memory limit to give them breathing room.