### PR TITLE
SW-5933 Make table variables lists by default

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
@@ -24,7 +24,10 @@ class CsvVariableNormalizer {
 
       val dataType =
           AllVariableCsvVariableType.create(rawValues[VARIABLE_CSV_COLUMN_INDEX_DATA_TYPE])
-      val isList = normalizeBoolean(values[VARIABLE_CSV_COLUMN_INDEX_IS_LIST])
+      val isList =
+          normalizeBoolean(
+              values[VARIABLE_CSV_COLUMN_INDEX_IS_LIST],
+              defaultValue = dataType == AllVariableCsvVariableType.Table)
       val name = rawValues[VARIABLE_CSV_COLUMN_INDEX_NAME].trim()
 
       val parent = values[VARIABLE_CSV_COLUMN_INDEX_PARENT]?.trim()
@@ -103,7 +106,13 @@ class CsvVariableNormalizer {
 
   private fun normalizeFloat(input: String?): BigDecimal? = input?.toBigDecimalOrNull()
 
-  private fun normalizeBoolean(input: String?): Boolean = input?.lowercase() in setOf("yes", "true")
+  private fun normalizeBoolean(input: String?, defaultValue: Boolean = false): Boolean {
+    return when (input?.lowercase()) {
+      in setOf("yes", "true") -> true
+      in setOf("no", "false") -> false
+      else -> defaultValue
+    }
+  }
 
   private val renderedTextRegex = """\[\[(?<renderedText>.*)]]""".toRegex()
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -735,6 +735,28 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `tables are lists by default`() {
+      val csv = "$header\nTable,1,,Table,,,,,,,,,,,,,,,,"
+
+      importer.import(sizedInputStream(csv))
+
+      val variables = variablesDao.findAll()
+
+      assertEquals(true, variables[0].isList, "Table is list")
+    }
+
+    @Test
+    fun `tables can be specified as non-lists`() {
+      val csv = "$header\nTable,1,,Table,No,,,,,,,,,,,,,,,"
+
+      importer.import(sizedInputStream(csv))
+
+      val variables = variablesDao.findAll()
+
+      assertEquals(false, variables[0].isList, "Table is list")
+    }
+
+    @Test
     fun `saves deliverable related fields as expected`() {
       every { user.canReadAllDeliverables() } returns true
 


### PR DESCRIPTION
If the all-variables sheet doesn't specify whether or not a table variable is a
list, treat it as one by default since we usually want tables to allow multiple
rows.