### PR TITLE
SW-5905 Rename PreScreenVariableValues

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationVariableValues.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationVariableValues.kt
@@ -10,10 +10,10 @@ enum class PreScreenProjectType {
 }
 
 /**
- * Values of variables that are relevant to the pre-screen logic. This does not include values that
- * are part of [ExistingApplicationModel].
+ * Values of variables that are relevant to the application submission logic, both pre-screening and
+ * submitting for review. This does not include values that are part of [ExistingApplicationModel].
  */
-data class PreScreenVariableValues(
+data class ApplicationVariableValues(
     val countryCode: String?,
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>,
     val numSpeciesToBePlanted: Int?,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -178,7 +178,7 @@ class VariableValueStore(
    * Returns a single project's values for a list of variable IDs, useful for getting injected
    * variable values
    */
-  fun listValues(projectId: ProjectId, variableIds: List<VariableId>): List<ExistingValue> {
+  fun listValues(projectId: ProjectId, variableIds: Collection<VariableId>): List<ExistingValue> {
     val conditions =
         listOf(
             VARIABLE_VALUES.PROJECT_ID.eq(projectId),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcherTest.kt
@@ -3,8 +3,8 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.model.ApplicationVariableValues
 import com.terraformation.backend.accelerator.model.PreScreenProjectType
-import com.terraformation.backend.accelerator.model.PreScreenVariableValues
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
-class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
+class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private val fetcher: PreScreenVariableValuesFetcher by lazy {
-    PreScreenVariableValuesFetcher(
+  private val fetcher: ApplicationVariableValuesFetcher by lazy {
+    ApplicationVariableValuesFetcher(
         countriesDao,
         VariableStore(
             dslContext,
@@ -58,6 +58,7 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
 
   private lateinit var countryVariableId: VariableId
   private lateinit var deliverableId: DeliverableId
+
   private lateinit var numSpeciesVariableId: VariableId
   private lateinit var projectTypeVariableId: VariableId
   private lateinit var totalExpansionPotentialVariableId: VariableId
@@ -79,7 +80,7 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
                 type = VariableType.Select,
                 deliverableId = inserted.deliverableId,
                 deliverablePosition = 1,
-                stableId = PreScreenVariableValuesFetcher.STABLE_ID_COUNTRY))
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_COUNTRY))
 
     brazilOptionId = insertSelectOption(inserted.variableId, "Brazil")
     insertSelectOption(inserted.variableId, "Chile")
@@ -91,14 +92,14 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
                 type = VariableType.Number,
                 deliverableId = inserted.deliverableId,
                 deliverablePosition = 2,
-                stableId = PreScreenVariableValuesFetcher.STABLE_ID_NUM_SPECIES))
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_NUM_SPECIES))
     totalExpansionPotentialVariableId =
         insertNumberVariable(
             insertVariable(
                 type = VariableType.Number,
                 deliverableId = inserted.deliverableId,
                 deliverablePosition = 3,
-                stableId = PreScreenVariableValuesFetcher.STABLE_ID_TOTAL_EXPANSION_POTENTIAL))
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_TOTAL_EXPANSION_POTENTIAL))
 
     projectTypeVariableId =
         insertSelectVariable(
@@ -106,14 +107,13 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
                 type = VariableType.Select,
                 deliverableId = inserted.deliverableId,
                 deliverablePosition = 4,
-                stableId = PreScreenVariableValuesFetcher.STABLE_ID_PROJECT_TYPE))
-
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_PROJECT_TYPE))
     terrestrialOptionId = insertSelectOption(inserted.variableId, "Terrestrial")
     insertSelectOption(inserted.variableId, "Mangrove")
     insertSelectOption(inserted.variableId, "Mixed")
 
     landUseHectaresVariableIds =
-        PreScreenVariableValuesFetcher.stableIdsByLandUseModelType.entries
+        ApplicationVariableValuesFetcher.stableIdsByLandUseModelType.entries
             .mapIndexed { index, (landUseType, stableId) ->
               landUseType to
                   insertNumberVariable(
@@ -131,7 +131,7 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `returns null or empty values if variables not set`() {
     assertEquals(
-        PreScreenVariableValues(null, emptyMap(), null, null, null),
+        ApplicationVariableValues(null, emptyMap(), null, null, null),
         fetcher.fetchValues(inserted.projectId))
   }
 
@@ -147,12 +147,13 @@ class PreScreenVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
     }
 
     assertEquals(
-        PreScreenVariableValues(
+        ApplicationVariableValues(
             countryCode = "BR",
             landUseModelHectares = LandUseModelType.entries.associateWith { BigDecimal(it.id) },
             numSpeciesToBePlanted = 123,
             projectType = PreScreenProjectType.Terrestrial,
-            totalExpansionPotential = BigDecimal(5555)),
+            totalExpansionPotential = BigDecimal(5555),
+        ),
         fetcher.fetchValues(inserted.projectId))
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -5,10 +5,10 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.ApplicationSubmittedEvent
 import com.terraformation.backend.accelerator.model.ApplicationModuleModel
+import com.terraformation.backend.accelerator.model.ApplicationVariableValues
 import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
 import com.terraformation.backend.accelerator.model.ExistingApplicationModel
 import com.terraformation.backend.accelerator.model.PreScreenProjectType
-import com.terraformation.backend.accelerator.model.PreScreenVariableValues
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -1191,7 +1191,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result =
           store.submit(
               applicationId,
-              PreScreenVariableValues(
+              ApplicationVariableValues(
                   countryCode = countryCode,
                   landUseModelHectares =
                       mapOf(LandUseModelType.NativeForest to BigDecimal(minHectares - 10)),
@@ -1227,7 +1227,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result =
           store.submit(
               applicationId,
-              PreScreenVariableValues(
+              ApplicationVariableValues(
                   countryCode = "US",
                   landUseModelHectares =
                       mapOf(
@@ -1265,7 +1265,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result =
           store.submit(
               applicationId,
-              PreScreenVariableValues(
+              ApplicationVariableValues(
                   countryCode = "US",
                   landUseModelHectares =
                       mapOf(
@@ -1351,7 +1351,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = Instant.ofEpochSecond(30)
 
       val validVariables =
-          PreScreenVariableValues(
+          ApplicationVariableValues(
               countryCode = "US",
               landUseModelHectares =
                   mapOf(
@@ -1534,9 +1534,9 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       assertThrows<AccessDeniedException> { store.submit(applicationId) }
     }
 
-    private fun validVariables(boundary: Geometry): PreScreenVariableValues {
+    private fun validVariables(boundary: Geometry): ApplicationVariableValues {
       val projectHectares = boundary.calculateAreaHectares()
-      return PreScreenVariableValues(
+      return ApplicationVariableValues(
           countryCode = "US",
           landUseModelHectares =
               mapOf(


### PR DESCRIPTION
We'll be populating HubSpot with some of the values from the same variables we use
for pre-screening. Rename `PreScreenVariableValues` to `ApplicationVariableValues`
to reflect the fact that it will no longer be specific to pre-screening.