### PR TITLE
SW-5905 Fetch contact name, email, and website variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcher.kt
@@ -30,10 +30,13 @@ class ApplicationVariableValuesFetcher(
     val preScreenDeliverableId: DeliverableId,
 ) {
   companion object {
+    const val STABLE_ID_CONTACT_EMAIL = "26"
+    const val STABLE_ID_CONTACT_NAME = "25"
     const val STABLE_ID_COUNTRY = "1"
     const val STABLE_ID_NUM_SPECIES = "22"
     const val STABLE_ID_PROJECT_TYPE = "3"
     const val STABLE_ID_TOTAL_EXPANSION_POTENTIAL = "24"
+    const val STABLE_ID_WEBSITE = "27"
 
     val stableIdsByLandUseModelType =
         mapOf(
@@ -52,10 +55,13 @@ class ApplicationVariableValuesFetcher(
 
   private val variablesById: Map<VariableId, Variable> by lazy {
     (listOf(
+            STABLE_ID_CONTACT_EMAIL,
+            STABLE_ID_CONTACT_NAME,
             STABLE_ID_COUNTRY,
             STABLE_ID_NUM_SPECIES,
             STABLE_ID_PROJECT_TYPE,
             STABLE_ID_TOTAL_EXPANSION_POTENTIAL,
+            STABLE_ID_WEBSITE,
         ) + stableIdsByLandUseModelType.values)
         .map {
           variableStore.fetchByStableId(it)
@@ -111,15 +117,21 @@ class ApplicationVariableValuesFetcher(
           }
         }
 
+    val contactEmail = getTextValue(valuesByStableId, STABLE_ID_CONTACT_EMAIL)
+    val contactName = getTextValue(valuesByStableId, STABLE_ID_CONTACT_NAME)
     val totalExpansionPotential =
         getNumberValue(valuesByStableId, STABLE_ID_TOTAL_EXPANSION_POTENTIAL)
+    val website = getTextValue(valuesByStableId, STABLE_ID_WEBSITE)
 
     return ApplicationVariableValues(
+        contactEmail = contactEmail,
+        contactName = contactName,
         countryCode = countryCode,
         landUseModelHectares = landUseHectares,
         numSpeciesToBePlanted = numSpeciesToBePlanted,
         projectType = projectType,
         totalExpansionPotential = totalExpansionPotential,
+        website = website,
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationVariableValues.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ApplicationVariableValues.kt
@@ -14,9 +14,12 @@ enum class PreScreenProjectType {
  * submitting for review. This does not include values that are part of [ExistingApplicationModel].
  */
 data class ApplicationVariableValues(
+    val contactEmail: String? = null,
+    val contactName: String? = null,
     val countryCode: String?,
     val landUseModelHectares: Map<LandUseModelType, BigDecimal>,
     val numSpeciesToBePlanted: Int?,
     val projectType: PreScreenProjectType?,
     val totalExpansionPotential: BigDecimal?,
+    val website: String? = null,
 )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcherTest.kt
@@ -59,9 +59,12 @@ class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
   private lateinit var countryVariableId: VariableId
   private lateinit var deliverableId: DeliverableId
 
+  private lateinit var contactEmailVariableId: VariableId
+  private lateinit var contactNameVariableId: VariableId
   private lateinit var numSpeciesVariableId: VariableId
   private lateinit var projectTypeVariableId: VariableId
   private lateinit var totalExpansionPotentialVariableId: VariableId
+  private lateinit var websiteVariableId: VariableId
   private lateinit var landUseHectaresVariableIds: Map<LandUseModelType, VariableId>
 
   private lateinit var brazilOptionId: VariableSelectOptionId
@@ -74,6 +77,16 @@ class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
     insertModule(phase = CohortPhase.PreScreen)
     deliverableId = insertDeliverable()
 
+    contactEmailVariableId =
+        insertTextVariable(
+            insertVariable(
+                type = VariableType.Text,
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_CONTACT_EMAIL))
+    contactNameVariableId =
+        insertTextVariable(
+            insertVariable(
+                type = VariableType.Text,
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_CONTACT_NAME))
     countryVariableId =
         insertSelectVariable(
             insertVariable(
@@ -100,6 +113,11 @@ class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
                 deliverableId = inserted.deliverableId,
                 deliverablePosition = 3,
                 stableId = ApplicationVariableValuesFetcher.STABLE_ID_TOTAL_EXPANSION_POTENTIAL))
+    websiteVariableId =
+        insertTextVariable(
+            insertVariable(
+                type = VariableType.Text,
+                stableId = ApplicationVariableValuesFetcher.STABLE_ID_WEBSITE))
 
     projectTypeVariableId =
         insertSelectVariable(
@@ -131,15 +149,18 @@ class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `returns null or empty values if variables not set`() {
     assertEquals(
-        ApplicationVariableValues(null, emptyMap(), null, null, null),
+        ApplicationVariableValues(null, null, null, emptyMap(), null, null, null, null),
         fetcher.fetchValues(inserted.projectId))
   }
 
   @Test
   fun `fetches values for all variables`() {
+    insertValue(variableId = contactEmailVariableId, textValue = "a@b.com")
+    insertValue(variableId = contactNameVariableId, textValue = "John Smith")
     insertSelectValue(variableId = countryVariableId, optionIds = setOf(brazilOptionId))
     insertValue(variableId = numSpeciesVariableId, numberValue = BigDecimal(123))
     insertValue(variableId = totalExpansionPotentialVariableId, numberValue = BigDecimal(5555))
+    insertValue(variableId = websiteVariableId, textValue = "https://example.com/")
     insertSelectValue(variableId = projectTypeVariableId, optionIds = setOf(terrestrialOptionId))
     LandUseModelType.entries.forEach { type ->
       insertValue(
@@ -148,11 +169,14 @@ class ApplicationVariableValuesFetcherTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         ApplicationVariableValues(
+            contactEmail = "a@b.com",
+            contactName = "John Smith",
             countryCode = "BR",
             landUseModelHectares = LandUseModelType.entries.associateWith { BigDecimal(it.id) },
             numSpeciesToBePlanted = 123,
             projectType = PreScreenProjectType.Terrestrial,
             totalExpansionPotential = BigDecimal(5555),
+            website = "https://example.com/",
         ),
         fetcher.fetchValues(inserted.projectId))
   }


### PR DESCRIPTION
Include the values of the contact name, email, and website variables in the
application variables data. They will be used to populate a HubSpot contact
when an application is submitted.