### PR TITLE
SW-5905 Create HubSpot deal on application submit

### DIFF
--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -1,0 +1,180 @@
+# Configuring HubSpot integration in dev envrionments
+
+When accelerator applications are submitted, terraware-server can create a deal and associated entities in HubSpot to track communication with the applicant.
+
+HubSpot offers a sandbox that can be used to test the integration without affecting any production data. This document describes how to set it up and test it.
+
+## Setup
+
+### Create a HubSpot developer account
+
+[The HubSpot API overview page](https://developers.hubspot.com/docs/api/overview) includes a link to create a developer account; click that link. Don't click the "private app" link; that's not the setup we use.
+
+Go through the signup and developer account creation flow. It's fine to use Google login here, even if you already use your Google account to log into the regular HubSpot site.
+
+You'll be prompted for a company name. This can be anything you want; the UI says it has to be "unique" but it just means "unique among your personal developer accounts."
+
+### Create an app
+
+Once you're through the account creation process, you'll end up on the developer home page. (Exact URL will vary since it includes an account ID.)
+
+Click the "Create app" button. On the next page, click "Create app" again.
+
+Give your app a name, e.g., "Terraware".
+
+Switch to the "Auth" tab and scroll down to the "Redirect URLs" section.
+
+Enter this URL, assuming your local Terraware instance is running on the default terraware-web proxy port of 3000:
+
+        http://localhost:3000/admin/hubSpotCallback
+
+Add the following required scopes, in addition to the default `oauth` one:
+
+* `crm.objects.companies.read`
+* `crm.objects.companies.write`
+* `crm.objects.contacts.read`
+* `crm.objects.contacts.write`
+* `crm.objects.deals.read`
+* `crm.objects.deals.write`
+
+Click "Create app".
+
+### Create a test account
+
+You'll need a "test account" in addition to your developer account. The test account acts like a regular HubSpot account and can have deals, companies, and so forth; you can log into it with the regular HubSpot UI. The developer account, on the other hand, is just for managing apps and API access.
+
+Click the "Home" icon in the HubSpot left nav to go back to the developer home page.
+
+Click "Create test account".
+
+Click "Create developer test account".
+
+Give it a name; doesn't matter what, but pick something you won't confuse with the real HubSpot account.
+
+### Get the app's credentials
+
+Click the "Apps" icon (the cube) in the HubSpot left nav.
+
+Click the link for your app.
+
+Switch to the "Auth" tab.
+
+Hit the "Show" link under the client secret. You will need the client ID and client secret, but not the app ID.
+
+### Configure terraware-server
+
+Add the client ID and secret to your terraware-server configuration, either by editing your local `application-dev.yaml` like:
+
+```yaml
+terraware:
+  hubspot:
+    enabled: true
+    client-id: "YOUR APP'S CLIENT ID"
+    client-secret: "YOUR APP'S CLIENT SECRET"
+```
+
+or via environment variables, if you're running terraware-server using a Docker image:
+
+* `TERRAWARE_HUBSPOT_ENABLED` (set this to `true`)
+* `TERRAWARE_HUBSPOT_CLIENTID`
+* `TERRAWARE_HUBSPOT_CLIENTSECRET`
+
+### Configure the test account
+
+The HubSpot integration expects the HubSpot account to have some customizations in place; you'll need to configure them using HubSpot's web UI.
+
+In the HubSpot console's top nav, click the account dropdown and then click on the account ID. You should see a menu of accounts including your newly-created test account. Click it.
+
+You'll be taken to the regular HubSpot home page, logged in as the test account.
+
+#### Create a pipeline
+
+Click the settings button in the top nav (gear icon).
+
+Under "Data Management" in the settings menu, expand the "Objects" menu and click "Deals".
+
+Switch to the "Pipelines" tab and open the pipelines menu. Select "Create pipeline".
+
+Enter a pipeline name of `Accelerator Projects` and hit the "Create pipeline" button.
+
+Change the name of the first stage to `Application` and hit the "Save" button.
+
+#### Create custom properties
+
+Under "Data Management" in the settings menu, click "Properties".
+
+##### Deal: Application Reforestable Land
+
+In the "Select an object" menu, choose "Deal properties".
+
+Click "Create property".
+
+Enter a label of `Application Reforestable Land`.
+
+Change the internal name to `project_hectares`.
+
+Set the group to anything you like.
+
+On the "Field type" page (left nav), select "Number".
+
+Click "Create".
+
+##### Deal: Project Country
+
+Click "Create property".
+
+Enter a label of `Project Country`. (The default internal name is fine this time.)
+
+Set the group to anything you like.
+
+On the "Field type" page, select "Multiple checkboxes".
+
+Enter whichever country names you're going to be using for your test applications. These should be the full English names, the same as the `name` column in the Terraware database's `countries` table. For example, `United States` or `Kenya` or `Brazil`.
+
+_Make sure the internal name is the same as the label!_ By default, HubSpot will give you internal names with underscores and lower-case letters, but you want the internal names to be identical to the labels with spaces and mixed case.
+
+Note that you can add more countries later, so it's fine to start with just a few.
+
+When you're done adding countries, click "Create".
+
+##### Contact: Full Name
+
+In the "Select an object" menu, choose "Contact properties".
+
+Click "Create property".
+
+Enter a label of `Full Name`.
+
+Set the group to anything you like.
+
+On the "Field type" page, select "Single-line text".
+
+Click "Create".
+
+### Connect terraware-server to your app
+
+Start terraware-server and log in with a super-admin account.
+
+In the admin UI, click the management link under the "HubSpot integration" section.
+
+There will be a message saying no HubSpot credentials are configured.
+
+Click the "Authorize" button, which will redirect you to HubSpot.
+
+If HubSpot shows you a list of accounts, choose the _test account_ (not your developer account).
+
+Click "Connect app".
+
+HubSpot should redirect you back to the admin UI, which should show a message saying the integration is configured.
+
+## Testing
+
+The admin UI has some controls you can use to test the HubSpot integration. They should be fairly self-explanatory.
+
+You'll need to create a deal before you can create a contact or a company since the integration associates deals with contacts and companies. The deal ID will be shown in the success message and you'll need to copy-paste it into the text fields.
+
+### Resetting the credentials
+
+The "Reset" button on the HubSpot integration page in the admin UI will delete the HubSpot credentials (refresh token) from the Terraware database.
+
+You will normally not want to do this unless you're testing the credentials setup process or you want to switch to a different HubSpot account.

--- a/src/main/kotlin/com/terraformation/backend/accelerator/HubSpotService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/HubSpotService.kt
@@ -1,0 +1,538 @@
+package com.terraformation.backend.accelerator
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.accelerator.tables.references.HUBSPOT_TOKEN
+import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
+import com.terraformation.backend.log.perClassLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
+import jakarta.inject.Named
+import jakarta.ws.rs.core.UriBuilder
+import java.math.BigDecimal
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.InstantSource
+import kotlinx.coroutines.runBlocking
+import org.jooq.DSLContext
+import org.springframework.security.access.AccessDeniedException
+
+@Named
+class HubSpotService(
+    private val clock: InstantSource,
+    private val config: TerrawareServerConfig,
+    private val countriesDao: CountriesDao,
+    private val dslContext: DSLContext,
+    private val httpClient: HttpClient,
+) {
+  companion object {
+    private const val ACCELERATOR_PIPELINE_LABEL = "Accelerator Projects"
+    private const val APPLICATION_STAGE_LABEL = "Application"
+
+    // HubSpot-defined properties
+    private const val COMPANY_PROPERTY_NAME = "name"
+    private const val COMPANY_PROPERTY_WEBSITE = "website"
+    private const val CONTACT_PROPERTY_EMAIL = "email"
+    private const val CONTACT_PROPERTY_FIRST_NAME = "firstname"
+    private const val DEAL_PROPERTY_NAME = "dealname"
+    private const val DEAL_PROPERTY_PIPELINE = "pipeline"
+    private const val DEAL_PROPERTY_STAGE = "dealstage"
+
+    // Custom properties
+    private const val CONTACT_PROPERTY_FULL_NAME = "full_name"
+    private const val DEAL_PROPERTY_APPLICATION_REFORESTABLE_LAND = "project_hectares"
+    private const val DEAL_PROPERTY_PROJECT_COUNTRY = "project_country"
+
+    // From https://developers.hubspot.com/docs/api/crm/associations#association-type-id-values
+    private const val ASSOCIATION_CATEGORY = "HUBSPOT_DEFINED"
+    private const val ASSOCIATION_TYPE_CONTACT_TO_DEAL = 4
+    private const val ASSOCIATION_TYPE_COMPANY_TO_DEAL = 342
+
+    private val hubSpotBaseUrl = URI("https://api.hubapi.com/")
+
+    private val log = perClassLogger()
+  }
+
+  private var accessToken: String? = null
+  private var accessTokenExpiration = Instant.EPOCH
+  private var acceleratorPipelineId: String? = null
+  private var applicationStageId: String? = null
+  private val dealPageUrlPrefix: URI by lazy { initDealPageUrlPrefix() }
+
+  private val redirectUri = config.webAppUrl.resolve("/admin/hubSpotCallback").toString()
+
+  private val projectCountryOptions: Set<String> by lazy {
+    sendRequest<GetProjectCountryPropertyResponse>(
+            "/crm/v3/properties/deals/$DEAL_PROPERTY_PROJECT_COUNTRY")
+        .options
+        .map { it.value }
+        .toSet()
+  }
+
+  /**
+   * Creates a deal and associates a contact and a company with it.
+   *
+   * @return The URL of the deal's page in the HubSpot UI.
+   */
+  fun createApplicationObjects(
+      applicationReforestableLand: BigDecimal?,
+      companyName: String,
+      contactEmail: String?,
+      contactName: String?,
+      countryCode: String?,
+      dealName: String,
+      website: String?
+  ): URI {
+    val countryName = countryCode?.let { countriesDao.fetchOneByCode(it)?.name }
+
+    val dealId = createDeal(dealName, countryName, applicationReforestableLand)
+    val contactId = contactEmail?.let { createContact(contactEmail, contactName, dealId) }
+    val companyId = website?.let { createCompany(companyName, website, dealId) }
+
+    log.info("Created deal $dealId, contact $contactId, company $companyId for $dealName")
+
+    return getDealPageUrl(dealId)
+  }
+
+  /**
+   * Creates a new deal and populates its properties.
+   *
+   * @return The deal's unique ID.
+   */
+  fun createDeal(
+      dealName: String,
+      countryName: String?,
+      applicationReforestableLand: BigDecimal?,
+  ): String {
+    val hubSpotCountryName =
+        if (countryName != null && countryName in projectCountryOptions) {
+          countryName
+        } else {
+          null
+        }
+
+    val request =
+        CreateDealRequest(
+            CreateDealRequest.Properties(
+                applicationReforestableLand = applicationReforestableLand,
+                countryName = hubSpotCountryName,
+                dealName = dealName,
+                pipeline = getAcceleratorPipelineId(),
+                stage = getApplicationStageId()))
+
+    val response: CreateDealResponse = sendRequest("/crm/v3/objects/deals", request)
+
+    return response.id
+  }
+
+  /**
+   * Creates a new contact and associates it with a deal.
+   *
+   * @return The contact's unique ID.
+   */
+  fun createContact(email: String, name: String?, dealId: String): String {
+    return try {
+      val escapedEmail = URLEncoder.encode(email, StandardCharsets.UTF_8)
+      val existingContactResponse: ResponseWithId =
+          sendRequest("/crm/v3/objects/contacts/$escapedEmail?idProperty=email")
+      val existingContactId = existingContactResponse.id
+
+      sendRequest<Any>(
+          "/crm/v3/objects/contacts/$existingContactId/associations/deals/$dealId/$ASSOCIATION_TYPE_CONTACT_TO_DEAL",
+          method = HttpMethod.Put)
+
+      existingContactId
+    } catch (e: ClientRequestException) {
+      if (e.response.status == HttpStatusCode.NotFound) {
+        val request = CreateContactRequest(email, name, dealId)
+        val response: ResponseWithId = sendRequest("/crm/v3/objects/contacts", request)
+        response.id
+      } else {
+        throw e
+      }
+    }
+  }
+
+  /**
+   * Creates a new company and associates it with a deal.
+   *
+   * @return The company's unique ID.
+   */
+  fun createCompany(name: String, website: String, dealId: String): String {
+    val searchRequest = SearchObjectsRequest(COMPANY_PROPERTY_WEBSITE, "EQ", website)
+    val searchResponse: SearchObjectsResponse =
+        sendRequest("/crm/v3/objects/companies/search", searchRequest)
+
+    return if (searchResponse.results.isNotEmpty()) {
+      val existingCompanyId = searchResponse.results.first().id
+
+      sendRequest<Any>(
+          "/crm/v3/objects/companies/$existingCompanyId/associations/deals/$dealId/$ASSOCIATION_TYPE_COMPANY_TO_DEAL",
+          method = HttpMethod.Put)
+
+      existingCompanyId
+    } else {
+      val createRequest = CreateCompanyRequest(name, website, dealId)
+      val createResponse: ResponseWithId = sendRequest("/crm/v3/objects/companies", createRequest)
+
+      createResponse.id
+    }
+  }
+
+  /**
+   * Returns true if this server has gone through the HubSpot authorization flow and has a refresh
+   * token.
+   */
+  fun isAuthorized(): Boolean {
+    return dslContext.fetchExists(HUBSPOT_TOKEN)
+  }
+
+  /** Removes the HubSpot refresh token from the database. */
+  fun clearCredentials() {
+    dslContext.deleteFrom(HUBSPOT_TOKEN).execute()
+  }
+
+  /** Returns a URL to get the user's authorization to connect this server to HubSpot. */
+  fun getAuthorizationUrl(): URI {
+    ensureEnabled()
+
+    val scopes =
+        listOf(
+            "crm.objects.companies.read",
+            "crm.objects.companies.write",
+            "crm.objects.contacts.read",
+            "crm.objects.contacts.write",
+            "crm.objects.deals.read",
+            "crm.objects.deals.write",
+            "oauth",
+        )
+
+    return UriBuilder.fromUri("https://app.hubspot.com/oauth/authorize")
+        .queryParam("client_id", config.hubSpot.clientId)
+        .queryParam("scope", scopes.joinToString(" "))
+        .queryParam("redirect_uri", redirectUri)
+        .build()
+  }
+
+  /**
+   * Requests a refresh token from HubSpot and stores it in the database. This is called at the end
+   * of the authorization flow.
+   *
+   * @param code The authorization code passed to the server by HubSpot when it redirects the user
+   *   back to the admin UI at the end of the authorization flow.
+   */
+  fun populateRefreshToken(code: String) {
+    ensureEnabled()
+
+    runBlocking {
+      val response =
+          httpClient.submitForm(
+              "https://api.hubapi.com/oauth/v1/token",
+              formParameters =
+                  parameters {
+                    append("grant_type", "authorization_code")
+                    append("client_id", config.hubSpot.clientId!!)
+                    append("client_secret", config.hubSpot.clientSecret!!)
+                    append("redirect_uri", redirectUri)
+                    append("code", code)
+                  })
+
+      if (response.status == HttpStatusCode.OK) {
+        val payload: TokenResponse = response.body()
+
+        val rowsUpdated =
+            dslContext
+                .update(HUBSPOT_TOKEN)
+                .set(HUBSPOT_TOKEN.REFRESH_TOKEN, payload.refreshToken)
+                .execute()
+        if (rowsUpdated == 0) {
+          dslContext
+              .insertInto(HUBSPOT_TOKEN)
+              .set(HUBSPOT_TOKEN.REFRESH_TOKEN, payload.refreshToken)
+              .execute()
+        }
+
+        accessToken = payload.accessToken
+        accessTokenExpiration = clock.instant().plusSeconds(payload.expiresIn)
+      } else {
+        throw AccessDeniedException(
+            "Unable to request refresh token from HubSpot (HTTP ${response.status.value})")
+      }
+    }
+  }
+
+  /** Returns the unique ID of the deal pipeline that's used for accelerator projects. */
+  fun getAcceleratorPipelineId(): String {
+    return acceleratorPipelineId
+        ?: run {
+          val pipelinesResponse: ListPipelinesResponse = sendRequest("/crm/v3/pipelines/deals")
+
+          val pipeline =
+              pipelinesResponse.results.firstOrNull { it.label == ACCELERATOR_PIPELINE_LABEL }
+                  ?: throw IllegalStateException("Pipeline not found: $ACCELERATOR_PIPELINE_LABEL")
+
+          applicationStageId =
+              pipeline.stages.firstOrNull { it.label == APPLICATION_STAGE_LABEL }?.id
+                  ?: throw IllegalStateException(
+                      "Pipeline stage not found: $APPLICATION_STAGE_LABEL")
+          acceleratorPipelineId = pipeline.id
+
+          pipeline.id
+        }
+  }
+
+  /** Returns the unique ID of the deal stage that's used for new accelerator applications. */
+  fun getApplicationStageId(): String {
+    getAcceleratorPipelineId()
+
+    return applicationStageId
+        ?: throw IllegalStateException("Application state not set after fetching pipeline info")
+  }
+
+  private fun fetchRefreshToken(): String? {
+    return dslContext
+        .select(HUBSPOT_TOKEN.REFRESH_TOKEN)
+        .from(HUBSPOT_TOKEN)
+        .fetchOne(HUBSPOT_TOKEN.REFRESH_TOKEN)
+  }
+
+  private fun getAccessToken(): String {
+    if (accessTokenExpiration.isBefore(clock.instant())) {
+      accessToken = null
+    }
+
+    return accessToken
+        ?: runBlocking {
+          val refreshToken =
+              fetchRefreshToken()
+                  ?: throw IllegalStateException("No HubSpot credentials appear to be configured")
+
+          log.debug("Requesting new access token")
+
+          val response =
+              httpClient.submitForm(
+                  "https://api.hubapi.com/oauth/v1/token",
+                  formParameters =
+                      parameters {
+                        append("grant_type", "refresh_token")
+                        append("client_id", config.hubSpot.clientId!!)
+                        append("client_secret", config.hubSpot.clientSecret!!)
+                        append("redirect_uri", redirectUri)
+                        append("refresh_token", refreshToken)
+                      })
+
+          if (response.status == HttpStatusCode.OK) {
+            val payload: TokenResponse = response.body()
+
+            accessToken = payload.accessToken
+            accessTokenExpiration = clock.instant().plusSeconds(payload.expiresIn)
+
+            payload.accessToken
+          } else {
+            throw AccessDeniedException(
+                "Unable to request access token from HubSpot (HTTP ${response.status.value})")
+          }
+        }
+  }
+
+  private fun initDealPageUrlPrefix(): URI {
+    val response: AccountDetailsResponse = sendRequest("/account-info/v3/details")
+
+    return URI.create("https://${response.uiDomain}/contacts/${response.portalId}/deal/")
+  }
+
+  private fun getDealPageUrl(dealId: String): URI {
+    return dealPageUrlPrefix.resolve(dealId)
+  }
+
+  private suspend fun doSendRequest(
+      path: String,
+      body: Any? = null,
+      httpMethod: HttpMethod,
+      retryOnAuthFailure: Boolean = true,
+  ): HttpResponse {
+    val url = hubSpotBaseUrl.resolve(path).toString()
+
+    return try {
+      val response =
+          httpClient.request(url) {
+            method = httpMethod
+            bearerAuth(getAccessToken())
+            if (body != null) {
+              setBody(body)
+            }
+          }
+
+      if (response.status == HttpStatusCode.Unauthorized && retryOnAuthFailure) {
+        // Access token may have expired; fetch a new one and try this request again.
+        accessToken = null
+        doSendRequest(path, body, httpMethod, false)
+      } else {
+        response
+      }
+    } catch (e: ClientRequestException) {
+      log.debug("HubSpot response ${e.response.status}: ${e.response.bodyAsText()}")
+      throw e
+    }
+  }
+
+  private inline fun <reified T> sendRequest(
+      path: String,
+      body: Any? = null,
+      method: HttpMethod = if (body != null) HttpMethod.Post else HttpMethod.Get,
+  ): T {
+    ensureEnabled()
+
+    return runBlocking {
+      val response = doSendRequest(path, body, method)
+      if (T::class.java == Unit.javaClass) {
+        T::class.objectInstance!!
+      } else {
+        response.body()
+      }
+    }
+  }
+
+  private fun ensureEnabled() {
+    if (!config.hubSpot.enabled) {
+      throw IllegalStateException("HubSpot is not enabled")
+    }
+  }
+
+  data class AccountDetailsResponse(
+      val portalId: Long,
+      val uiDomain: String,
+  )
+
+  data class Association(
+      val to: To,
+      val types: List<Type>,
+  ) {
+    constructor(to: String, typeId: Int) : this(To(to), listOf(Type(typeId)))
+
+    data class To(
+        val id: String,
+    )
+
+    data class Type(
+        val associationTypeId: Int,
+        val associationCategory: String = ASSOCIATION_CATEGORY
+    )
+  }
+
+  data class CreateContactRequest(
+      val properties: Properties,
+      val associations: List<Association>,
+  ) {
+    constructor(
+        email: String,
+        name: String?,
+        dealId: String
+    ) : this(Properties(email, name), listOf(Association(dealId, ASSOCIATION_TYPE_CONTACT_TO_DEAL)))
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class Properties(
+        @JsonProperty(CONTACT_PROPERTY_EMAIL) val email: String,
+        @JsonProperty(CONTACT_PROPERTY_FIRST_NAME) val firstName: String?,
+        @JsonProperty(CONTACT_PROPERTY_FULL_NAME) val fullName: String? = firstName,
+    )
+  }
+
+  data class CreateCompanyRequest(
+      val properties: Properties,
+      val associations: List<Association>,
+  ) {
+    constructor(
+        name: String,
+        website: String,
+        dealId: String
+    ) : this(
+        Properties(name, website), listOf(Association(dealId, ASSOCIATION_TYPE_COMPANY_TO_DEAL)))
+
+    data class Properties(
+        @JsonProperty(COMPANY_PROPERTY_NAME) val name: String,
+        @JsonProperty(COMPANY_PROPERTY_WEBSITE) val website: String,
+    )
+  }
+
+  data class CreateDealRequest(val properties: Properties) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    data class Properties(
+        @JsonProperty(DEAL_PROPERTY_APPLICATION_REFORESTABLE_LAND)
+        val applicationReforestableLand: BigDecimal?,
+        @JsonProperty(DEAL_PROPERTY_PROJECT_COUNTRY) val countryName: String?,
+        @JsonProperty(DEAL_PROPERTY_NAME) val dealName: String,
+        @JsonProperty(DEAL_PROPERTY_PIPELINE) val pipeline: String,
+        @JsonProperty(DEAL_PROPERTY_STAGE) val stage: String,
+    )
+  }
+
+  data class CreateDealResponse(val id: String)
+
+  data class ResponseWithId(val id: String)
+
+  data class GetProjectCountryPropertyResponse(val options: List<Option>) {
+    data class Option(
+        val label: String,
+        val value: String,
+    )
+  }
+
+  data class ListPipelinesResponse(val results: List<Pipeline>) {
+    data class Pipeline(
+        val id: String,
+        val label: String,
+        val stages: List<Stage>,
+    ) {
+      data class Stage(
+          val id: String,
+          val label: String,
+      )
+    }
+  }
+
+  data class SearchObjectsRequest(
+      val filterGroups: List<FilterGroup>,
+      val limit: Int = 1,
+      val properties: List<String> = listOf("id"),
+  ) {
+    constructor(
+        propertyName: String,
+        operator: String,
+        value: String
+    ) : this(listOf(FilterGroup(listOf(Filter(propertyName, operator, value)))))
+
+    data class FilterGroup(
+        val filters: List<Filter>,
+    )
+
+    data class Filter(
+        val propertyName: String,
+        val operator: String,
+        val value: String,
+    )
+  }
+
+  data class SearchObjectsResponse(val results: List<Result>) {
+    data class Result(val id: String)
+  }
+
+  data class TokenResponse(
+      @JsonProperty("access_token") val accessToken: String,
+      @JsonProperty("refresh_token") val refreshToken: String,
+      @JsonProperty("expires_in") val expiresIn: Long,
+  )
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -48,6 +48,9 @@ class AdminController(
     model.addAttribute("canManageDefaultProjectLeads", currentUser().canManageDefaultProjectLeads())
     model.addAttribute("canManageDocumentProducer", currentUser().canManageDocumentProducer())
     model.addAttribute(
+        "canManageHubSpot",
+        config.hubSpot.enabled && GlobalRole.SuperAdmin in currentUser().globalRoles)
+    model.addAttribute(
         "canManageModules",
         currentUser().canManageModules() || currentUser().canManageDeliverables())
     model.addAttribute("canManageInternalTags", currentUser().canManageInternalTags())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminHubSpotController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminHubSpotController.kt
@@ -1,0 +1,169 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.accelerator.HubSpotService
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.log.perClassLogger
+import java.math.BigDecimal
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminHubSpotController(
+    private val config: TerrawareServerConfig,
+    private val hubSpotService: HubSpotService,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/hubSpot")
+  fun getHubSpotPage(model: Model): String {
+    model.addAttribute("enabled", config.hubSpot.enabled)
+    model.addAttribute("hasToken", hubSpotService.isAuthorized())
+
+    return "/admin/hubSpot"
+  }
+
+  @PostMapping("/hubSpotReset")
+  fun resetHubSpot(redirectAttributes: RedirectAttributes): String {
+    hubSpotService.clearCredentials()
+
+    redirectAttributes.successMessage = "HubSpot credentials reset."
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotAuthorize")
+  fun hubSpotAuthorize(): String {
+    val hubSpotUrl = hubSpotService.getAuthorizationUrl()
+
+    return "redirect:$hubSpotUrl"
+  }
+
+  @GetMapping("/hubSpotCallback")
+  fun hubSpotCallback(
+      @RequestParam code: String,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      hubSpotService.populateRefreshToken(code)
+      redirectAttributes.successMessage = "Successfully authenticated with HubSpot"
+    } catch (e: Exception) {
+      log.error("Failed to authenticate with HubSpot", e)
+      redirectAttributes.failureMessage = "Failed to authenticate with HubSpot: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotTestGetAcceleratorPipelineId")
+  fun hubSpotTestGetAcceleratorPipelineId(redirectAttributes: RedirectAttributes): String {
+    try {
+      val pipelineId = hubSpotService.getAcceleratorPipelineId()
+      val stageId = hubSpotService.getApplicationStageId()
+      redirectAttributes.successMessage = "Got pipeline ID: $pipelineId and stage ID: $stageId"
+    } catch (e: Exception) {
+      log.error("Failed to get pipeline ID", e)
+      redirectAttributes.failureMessage = "Failed: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotTestCreateApplication")
+  fun hubSpotTestCreateApplication(
+      @RequestParam contactEmail: String?,
+      @RequestParam contactName: String?,
+      @RequestParam countryCode: String?,
+      @RequestParam dealName: String,
+      @RequestParam orgName: String,
+      @RequestParam reforestableLand: BigDecimal?,
+      @RequestParam website: String?,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      val dealUrl =
+          hubSpotService.createApplicationObjects(
+              applicationReforestableLand = reforestableLand,
+              companyName = orgName,
+              contactEmail = contactEmail?.ifBlank { null },
+              contactName = contactName,
+              countryCode = countryCode?.ifBlank { null },
+              dealName = dealName,
+              website = website?.ifBlank { null },
+          )
+
+      redirectAttributes.successMessage = "Successfully created deal: $dealUrl"
+    } catch (e: Exception) {
+      log.error("Failed to create deal", e)
+      redirectAttributes.failureMessage = "Failed: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotTestCreateDeal")
+  fun hubSpotTestCreateDeal(
+      @RequestParam dealName: String,
+      @RequestParam countryName: String,
+      @RequestParam reforestableLand: BigDecimal,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      val dealId = hubSpotService.createDeal(dealName, countryName, reforestableLand)
+      redirectAttributes.successMessage = "Successfully created deal with ID: $dealId"
+    } catch (e: Exception) {
+      log.error("Failed to create deal", e)
+      redirectAttributes.failureMessage = "Failed: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotTestCreateContact")
+  fun hubSpotTestCreateContact(
+      @RequestParam name: String,
+      @RequestParam email: String,
+      @RequestParam dealId: String,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      val contactId = hubSpotService.createContact(email, name, dealId)
+      redirectAttributes.successMessage = "Successfully created contact with ID: $contactId"
+    } catch (e: Exception) {
+      log.error("Failed to create contact", e)
+      redirectAttributes.failureMessage = "Failed: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  @PostMapping("/hubSpotTestCreateCompany")
+  fun hubSpotTestCreateCompany(
+      @RequestParam name: String,
+      @RequestParam website: String,
+      @RequestParam dealId: String,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      val companyId = hubSpotService.createCompany(name, website, dealId)
+      redirectAttributes.successMessage = "Successfully created company with ID: $companyId"
+    } catch (e: Exception) {
+      log.error("Failed to create company", e)
+      redirectAttributes.failureMessage = "Failed: ${e.message}"
+    }
+
+    return redirectToHubSpotHome()
+  }
+
+  private fun redirectToHubSpotHome() = "redirect:/admin/hubSpot"
+}

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -99,6 +99,9 @@ class TerrawareServerConfig(
     /** Configures how the server interacts with Dropbox. */
     val dropbox: DropboxConfig = DropboxConfig(),
 
+    /** Configures how the server interacts with HubSpot. */
+    val hubSpot: HubSpotConfig = HubSpotConfig(),
+
     /** Configures how the server interacts with the Mapbox service. */
     val mapbox: MapboxConfig = MapboxConfig(),
 
@@ -290,6 +293,21 @@ class TerrawareServerConfig(
         if (appKey == null || appSecret == null || refreshToken == null) {
           throw IllegalArgumentException(
               "App key, app secret, and refresh token are required if Dropbox is enabled")
+        }
+      }
+    }
+  }
+
+  class HubSpotConfig(
+      val clientId: String? = null,
+      val clientSecret: String? = null,
+      @DefaultValue("false") val enabled: Boolean = false,
+  ) {
+    init {
+      if (enabled) {
+        if (clientId == null || clientSecret == null) {
+          throw IllegalArgumentException(
+              "Client ID and client secret are required if HubSpot is enabled")
         }
       }
     }

--- a/src/main/resources/db/migration/0300/V306__HubSpotToken.sql
+++ b/src/main/resources/db/migration/0300/V306__HubSpotToken.sql
@@ -1,0 +1,6 @@
+CREATE TABLE accelerator.hubspot_token (
+    refresh_token TEXT NOT NULL
+);
+
+-- Only allow one row in the table.
+CREATE UNIQUE INDEX ON accelerator.hubspot_token ((0));

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -519,6 +519,8 @@ COMMENT ON TABLE accelerator.event_types IS '(Enum) Types of events for an accel
 
 COMMENT ON TABLE accelerator.events IS 'Events with meeting links and time within an acclerator module.';
 
+COMMENT ON TABLE accelerator.hubspot_token IS 'If the server has been authorized to make HubSpot API requests, the refresh token to use to generate new access tokens.';
+
 COMMENT ON TABLE accelerator.internal_interests IS '(Enum) Types of notification categories for internal users.';
 
 COMMENT ON TABLE accelerator.modules IS 'Possible steps in the workflow of a cohort phase.';

--- a/src/main/resources/templates/admin/hubSpot.html
+++ b/src/main/resources/templates/admin/hubSpot.html
@@ -1,0 +1,145 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        form { padding-bottom: 1em; }
+    </style>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>HubSpot Integration</h2>
+
+<th:block th:if="!${hasToken}">
+    <h3>No HubSpot credentials configured.</h3>
+
+    <p>
+        Click the button to authorize Terraware to make HubSpot API requests. You will be redirected
+        to HubSpot, which may ask you to authorize the Terraware app.
+    </p>
+
+    <form method="POST" action="/admin/hubSpotAuthorize">
+        <input type="submit" value="Authorize"/>
+    </form>
+</th:block>
+
+<th:block th:if="${hasToken}">
+    <h3>Configured!</h3>
+
+    <p>
+        The server is configured with HubSpot credentials already. No further action needed.
+    </p>
+
+    <hr/>
+
+    <h3>Test</h3>
+
+    <p>
+        These buttons test interactions with the HubSpot API.
+    </p>
+
+    <form method="POST" action="/admin/hubSpotTestGetAcceleratorPipelineId">
+        <input type="submit" value="Get Accelerator Pipeline ID"/>
+    </form>
+
+    <h4>Create full set of objects</h4>
+
+    <form method="POST" action="/admin/hubSpotTestCreateApplication">
+        <label>
+            Deal Name
+            <input type="text" name="dealName" required/>
+        </label>
+        <label>
+            Country Code (2-letter)
+            <input type="text" name="countryCode"/>
+        </label>
+        <label>
+            Hectares
+            <input type="number" name="reforestableLand"/>
+        </label>
+        <label>
+            Contact Name
+            <input type="text" name="contactName"/>
+        </label>
+        <label>
+            Email
+            <input type="email" name="contactEmail"/>
+        </label>
+        <label>
+            Org Name
+            <input type="text" name="orgName" required/>
+        </label>
+        <label>
+            Website
+            <input type="text" name="website"/>
+        </label>
+        <input type="submit" value="Create Deal"/>
+    </form>
+
+    <h4>Create individual objects with associations</h4>
+
+    <form method="POST" action="/admin/hubSpotTestCreateDeal">
+        <label>
+            Deal Name
+            <input type="text" name="dealName" required/>
+        </label>
+        <label>
+            Country
+            <input type="text" name="countryName" required/>
+        </label>
+        <label>
+            Hectares
+            <input type="number" name="reforestableLand" required/>
+        </label>
+        <input type="submit" value="Create Deal"/>
+    </form>
+
+    <form method="POST" action="/admin/hubSpotTestCreateContact">
+        <label>
+            Name
+            <input type="text" name="name" required/>
+        </label>
+        <label>
+            Email
+            <input type="email" name="email" required/>
+        </label>
+        <label>
+            Deal ID
+            <input type="text" name="dealId" required/>
+        </label>
+        <input type="submit" value="Create Contact"/>
+    </form>
+
+    <form method="POST" action="/admin/hubSpotTestCreateCompany">
+        <label>
+            Name
+            <input type="text" name="name" required/>
+        </label>
+        <label>
+            Website
+            <input type="text" name="website"/>
+        </label>
+        <label>
+            Deal ID
+            <input type="text" name="dealId" required/>
+        </label>
+        <input type="submit" value="Create Company"/>
+    </form>
+
+    <h3>Reset HubSpot Credentials</h3>
+
+    <p>
+        <b>This will break the HubSpot integration until new credentials are configured!</b>
+        Use with caution.
+    </p>
+
+    <form method="POST" action="/admin/hubSpotReset">
+        <input type="submit" value="Reset"/>
+    </form>
+</th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -163,5 +163,13 @@
     </p>
 </th:block>
 
+<th:block th:if="${canManageHubSpot}">
+    <h2>HubSpot Integration</h2>
+
+    <p>
+        <a href="/admin/hubSpot">Manage HubSpot integration</a>
+    </p>
+</th:block>
+
 </body>
 </html>

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -149,6 +149,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "event_projects" to setOf(ALL, ACCELERATOR),
                   "event_statuses" to setOf(ALL, ACCELERATOR),
                   "event_types" to setOf(ALL, ACCELERATOR),
+                  "hubspot_token" to setOf(ALL, ACCELERATOR),
                   "internal_interests" to setOf(ALL, ACCELERATOR),
                   "modules" to setOf(ALL, ACCELERATOR),
                   "participants" to setOf(ALL, ACCELERATOR),


### PR DESCRIPTION
When an application is submitted for review for the first time, create information
about it in HubSpot and update the project's details with a link to its HubSpot
deal.

The bulk of this change is to add integration with HubSpot's API. There are three
new server configuration options, and there is also a new authorization flow,
available in the admin UI, that authorizes terraware-server to connect to a
HubSpot account. The credentials from that authorization flow are stored in the
database since they aren't known in advance.

Instructions for configuring a dev environment to connect to a HubSpot sandbox
account are in `docs/HUBSPOT.md`.