### PR TITLE
SW-5999 Fix failure when deleting empty table row

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2812,7 +2812,10 @@ abstract class DatabaseBackedTest {
     val actualId =
         id
             ?: insertVariable(
-                type = VariableType.Table, deliverableId = deliverableId, stableId = stableId)
+                type = VariableType.Table,
+                deliverableId = deliverableId,
+                stableId = stableId,
+                isList = true)
 
     val row =
         VariableTablesRow(

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -342,6 +342,25 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
             round2Values.map { it.listPosition to it.value },
             "Values after append, append, delete, append, delete, append")
       }
+
+      @Test
+      fun `can delete a table row whose values are all deleted`() {
+        val tableVariableId = insertTableVariable()
+        val columnVariableId = insertTextVariable()
+        insertTableColumn(tableVariableId, columnVariableId)
+
+        val row0Id = insertValue(variableId = tableVariableId, listPosition = 0)
+        val row0OriginalValueId = insertValue(variableId = columnVariableId, textValue = "A")
+        val row0DeletedValueId = insertValue(variableId = columnVariableId, isDeleted = true)
+        insertValueTableRow(row0OriginalValueId, row0Id)
+        insertValueTableRow(row0DeletedValueId, row0Id)
+
+        store.updateValues(listOf(DeleteValueOperation(inserted.projectId, row0Id)))
+
+        val updatedValues =
+            store.listValues(inserted.projectId, listOf(tableVariableId, columnVariableId), false)
+        assertEquals(emptyList<ExistingValue>(), updatedValues)
+      }
     }
 
     @Nested


### PR DESCRIPTION
If a table row's values were all deleted, attempting to delete the row itself was
failing because the code was trying to delete the already-deleted values of its
cells.