### PR TITLE
SW-6008 Fix submission failure for unprivileged users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationService.kt
@@ -58,7 +58,7 @@ class ApplicationService(
       result
     } else {
       val result = applicationStore.submit(applicationId)
-      val details = projectAcceleratorDetailsStore.fetchOneById(projectId)
+      val details = systemUser.run { projectAcceleratorDetailsStore.fetchOneById(projectId) }
 
       if (config.hubSpot.enabled &&
           result.isSuccessful &&

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -568,24 +568,27 @@ class AppNotificationService(
       renderMessage: () -> NotificationMessage,
       internalInterest: InternalInterest? = null,
   ) {
-    val internalInterestCondition =
-        internalInterest?.let { userInternalInterestsStore.conditionForUsers(it) }
-    val recipients =
-        userStore
-            .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
-            .toMutableSet()
+    systemUser.run {
+      val internalInterestCondition =
+          internalInterest?.let { userInternalInterestsStore.conditionForUsers(it) }
+      val recipients =
+          userStore
+              .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
+              .toMutableSet()
 
-    val tfContact = userStore.getTerraformationContactUser(organizationId)
+      val tfContact = userStore.getTerraformationContactUser(organizationId)
 
-    if (tfContact != null) {
-      recipients.add(tfContact)
-    }
+      if (tfContact != null) {
+        recipients.add(tfContact)
+      }
 
-    dslContext.transaction { _ ->
-      recipients.forEach { user ->
-        // this is a global notification not scoped to any specific org permission, for accelerator
-        // purposes
-        insert(notificationType, user, null, renderMessage, localUrl, organizationId)
+      dslContext.transaction { _ ->
+        recipients.forEach { user ->
+          // this is a global notification not scoped to any specific org permission, for
+          // accelerator
+          // purposes
+          insert(notificationType, user, null, renderMessage, localUrl, organizationId)
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -585,8 +585,7 @@ class AppNotificationService(
       dslContext.transaction { _ ->
         recipients.forEach { user ->
           // this is a global notification not scoped to any specific org permission, for
-          // accelerator
-          // purposes
+          // accelerator purposes
           insert(notificationType, user, null, renderMessage, localUrl, organizationId)
         }
       }

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -727,23 +727,25 @@ class EmailNotificationService(
       model: EmailTemplateModel,
       internalInterest: InternalInterest? = null,
   ) {
-    val internalInterestCondition =
-        internalInterest?.let { userInternalInterestsStore.conditionForUsers(it) }
-    val recipients =
-        userStore
-            .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
-            .toMutableSet()
+    systemUser.run {
+      val internalInterestCondition =
+          internalInterest?.let { userInternalInterestsStore.conditionForUsers(it) }
+      val recipients =
+          userStore
+              .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
+              .toMutableSet()
 
-    val tfContact = userStore.getTerraformationContactUser(organizationId)
+      val tfContact = userStore.getTerraformationContactUser(organizationId)
 
-    // The TF contact will not have access to the accelerator console, this email notification
-    // gives the contact an opportunity to acquire global roles. Ideally we won't be sending
-    // these emails.
-    if (tfContact != null) {
-      recipients.add(tfContact)
+      // The TF contact will not have access to the accelerator console, this email notification
+      // gives the contact an opportunity to acquire global roles. Ideally we won't be sending
+      // these emails.
+      if (tfContact != null) {
+        recipients.add(tfContact)
+      }
+
+      recipients.forEach { user -> emailService.sendUserNotification(user, model, false) }
     }
-
-    recipients.forEach { user -> emailService.sendUserNotification(user, model, false) }
   }
 
   data class EmailRequest(val user: IndividualUser, val emailTemplateModel: EmailTemplateModel)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -74,7 +74,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    projectId = insertProject()
+    projectId = insertProject(countryCode = "KE")
 
     every { user.canReadProject(any()) } returns true
     every { user.canUpdateApplicationSubmissionStatus(any()) } returns true
@@ -167,22 +167,18 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
         hubSpotService.createApplicationObjects(any(), any(), any(), any(), any(), any(), any())
       } returns dealUrl
       every { user.canReadProject(projectId) } returns true
-      every { user.canReadProjectAcceleratorDetails(projectId) } returns true
-      every { user.canUpdateProjectAcceleratorDetails(projectId) } returns true
 
-      projectAcceleratorDetailsStore.update(projectId) {
-        it.copy(
-            applicationReforestableLand = applicationReforestableLand,
-            countryCode = "KE",
-            fileNaming = internalName,
-        )
-      }
+      insertProjectAcceleratorDetails(
+          applicationReforestableLand = applicationReforestableLand,
+          fileNaming = internalName,
+          projectId = projectId,
+      )
 
       assertEquals(submissionResult, service.submit(applicationId))
 
       assertEquals(
           dealUrl,
-          projectAcceleratorDetailsStore.fetchOneById(projectId).hubSpotUrl,
+          projectAcceleratorDetailsDao.fetchOneByProjectId(projectId)?.hubspotUrl,
           "HubSpot URL in project accelerator details")
 
       verify(exactly = 1) { applicationStore.submit(applicationId, null, null) }


### PR DESCRIPTION
If an unprivileged user submitted an application, the request failed because
submission requires accessing some privileged data (e.g., the list of internal
users to notify about the submission) and the code wasn't elevating its
privileges correctly. Run the code in question as the system user.