### PR TITLE
Fix query order dependency in test

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -341,7 +341,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
                 modifiedTime = Instant.EPOCH),
         )
 
-    val actualSpecies = speciesDao.findAll()
+    val actualSpecies = speciesDao.findAll().sortedBy { it.id!!.value }
     val mappedSpeciesIds = mapTo1IndexedIds(actualSpecies, ::SpeciesId, SpeciesRow::id)
     assertEquals(
         expectedSpecies.map { it.copy(id = null) }.toSet(),


### PR DESCRIPTION
`SpeciesImporterTest` had a test method that assumed a DAO `findAll` call would
return results in insertion order, but that's not guaranteed to be the case.