### PR TITLE
SW-5607 Add rate limiting service

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEvent.kt
@@ -1,0 +1,56 @@
+package com.terraformation.backend.ratelimit
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.time.Duration
+
+/**
+ * Implemented by events that can be subject to rate limits. See [RateLimitedEventPublisher] for
+ * details about how this is used.
+ *
+ * Rate-limited events are serialized to JSON and stored in the database, so shouldn't include any
+ * non-serializable values.
+ *
+ * # Changing event classes
+ *
+ * If you make changes to a rate-limited event class, keep in mind that there may be existing
+ * instances of the previous version of the class sitting in the database at the time your change is
+ * deployed. You will need to do one of the following:
+ * 1. Make sure your change is backward-compatible. For example, adding a new nullable property is
+ *    fine since objects without the property will still be valid.
+ * 2. Write a database migration to convert the old version to the new version. For example, if you
+ *    are renaming an event class or moving it to a different package, but not changing its
+ *    contents, you can write a migration to update the class names in the `rate_limited_events`
+ *    table.
+ * 3. Make a new event and keep the old one around for one release. Once any existing pending events
+ *    have been published, you can remove the old event.
+ */
+interface RateLimitedEvent<T : RateLimitedEvent<T>> {
+  /**
+   * Returns an object that uniquely identifies the rate-limiting target of this event. For example,
+   * if the action triggered by this event should only be performed every N minutes for a given
+   * user, this would be the user ID. If the action should only be performed every N minutes for a
+   * given user in a given project, but is rate limited separately for the same user across
+   * different projects, this would be an object containing both the user ID and the project ID.
+   *
+   * The returned key will be serialized to JSON, so it shouldn't include any non-serializable
+   * values.
+   */
+  @JsonIgnore fun getRateLimitKey(): Any
+
+  /** Returns the minimum amount of time between events with the same rate limit key. */
+  @JsonIgnore fun getMinimumInterval(): Duration
+
+  /**
+   * Combines an existing pending event with this one. This can be used to, for example, generate
+   * notifications like "there have been 3 edits to such-and-such entity." The existing pending
+   * event is replaced with the return value of this function, but continues to be scheduled for the
+   * same time.
+   *
+   * If this returns [existing] (the default behavior), the effect is to discard additional events
+   * during the rate-limit period.
+   *
+   * If this returns [this], the effect is to only keep the most recent event during the rate-limit
+   * period.
+   */
+  fun combine(existing: T): T = existing
+}

--- a/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisher.kt
+++ b/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisher.kt
@@ -1,0 +1,22 @@
+package com.terraformation.backend.ratelimit
+
+import org.springframework.context.event.EventListener
+
+/**
+ * Limits the rate of events, deferring them if they are published too often.
+ *
+ * The basic flow looks like:
+ * 1. Construct a [RateLimitedEvent] that identifies the target of the rate limit, e.g., a user ID /
+ *    project ID pair.
+ * 2. Call [publishOrDefer] with the event.
+ * 3. Handle the event in an [EventListener]-annotated listener method.
+ *
+ * If the event hasn't been published recently with the same rate limit target, [publishOrDefer]
+ * publishes it immediately.
+ *
+ * Otherwise, the event is stored in the database (possibly after being combined with an existing
+ * pending event) and will be published once the minimum interval between events has elapsed.
+ */
+interface RateLimitedEventPublisher {
+  fun <T : RateLimitedEvent<T>> publishOrDefer(event: T)
+}

--- a/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherImpl.kt
+++ b/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherImpl.kt
@@ -1,0 +1,203 @@
+package com.terraformation.backend.ratelimit
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.tables.references.RATE_LIMITED_EVENTS
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jobrunr.jobs.annotations.Job
+import org.jobrunr.jobs.annotations.Recurring
+import org.jooq.DSLContext
+import org.jooq.JSONB
+import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * Limits the rate of events, deferring them if they are published too often.
+ *
+ * Users of this service should generally use the interface [RateLimitedEventPublisher] instead of
+ * depending directly on this implementation, so that an alternate implementation can be used in
+ * unit tests.
+ *
+ * @see RateLimitedEventPublisher
+ */
+@Named
+class RateLimitedEventPublisherImpl(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val objectMapper: ObjectMapper,
+) : RateLimitedEventPublisher {
+  private val log = perClassLogger()
+
+  override fun <T : RateLimitedEvent<T>> publishOrDefer(event: T) {
+    publishOrDefer(event, true)
+  }
+
+  private fun <T : RateLimitedEvent<T>> publishOrDefer(event: T, canRetry: Boolean) {
+    val now = clock.instant()
+    val eventClass = event.javaClass.name
+    val rateLimitKey = toJsonb(event.getRateLimitKey())
+    var canPublishEventNow = false
+    var eventRecordVanished = false
+
+    // First try the optimistic approach: the event hasn't been published recently so there is
+    // no rate limiting record for it.
+    val rowsInserted =
+        with(RATE_LIMITED_EVENTS) {
+          dslContext
+              .insertInto(RATE_LIMITED_EVENTS)
+              .set(EVENT_CLASS, eventClass)
+              .set(RATE_LIMIT_KEY, rateLimitKey)
+              .set(NEXT_TIME, now + event.getMinimumInterval())
+              .onConflictDoNothing()
+              .execute()
+        }
+
+    if (rowsInserted == 1) {
+      canPublishEventNow = true
+    } else {
+      dslContext.transaction { _ ->
+        with(RATE_LIMITED_EVENTS) {
+          val existingRecord =
+              dslContext
+                  .select(NEXT_TIME.asNonNullable(), PENDING_EVENT)
+                  .from(RATE_LIMITED_EVENTS)
+                  .where(EVENT_CLASS.eq(eventClass))
+                  .and(RATE_LIMIT_KEY.eq(rateLimitKey))
+                  .forUpdate()
+                  .fetchOne()
+
+          if (existingRecord != null) {
+            val (nextTime, pendingEventJsonb) = existingRecord
+            if (nextTime < now) {
+              // Minimum interval has passed but we haven't deleted the rate limit record yet;
+              // it's safe to publish this event immediately.
+              dslContext
+                  .update(RATE_LIMITED_EVENTS)
+                  .set(NEXT_TIME, now + event.getMinimumInterval())
+                  .where(EVENT_CLASS.eq(eventClass))
+                  .and(RATE_LIMIT_KEY.eq(rateLimitKey))
+                  .execute()
+
+              canPublishEventNow = true
+            } else {
+              // If there is already an event waiting to be published when the interval expires,
+              // combine it with this event if needed.
+              val existingEvent =
+                  pendingEventJsonb?.let { objectMapper.readValue(it.data(), event.javaClass) }
+              val combinedEvent = if (existingEvent != null) event.combine(existingEvent) else event
+
+              if (combinedEvent != existingEvent) {
+                dslContext
+                    .update(RATE_LIMITED_EVENTS)
+                    .set(PENDING_EVENT, toJsonb(combinedEvent))
+                    .where(EVENT_CLASS.eq(eventClass))
+                    .and(RATE_LIMIT_KEY.eq(rateLimitKey))
+                    .execute()
+              }
+            }
+          } else {
+            eventRecordVanished = true
+          }
+        }
+      }
+    }
+
+    if (canPublishEventNow) {
+      eventPublisher.publishEvent(event)
+    } else if (eventRecordVanished) {
+      if (canRetry) {
+        publishOrDefer(event, false)
+      } else {
+        log.error("Rate limiting record for $eventClass $rateLimitKey vanished twice in a row")
+        log.info("Unable to defer event: $event")
+        throw IllegalStateException("Unable to defer event")
+      }
+    }
+  }
+
+  @Job(name = SCAN_PENDING_EVENTS_JOB_NAME, retries = 0)
+  @Recurring(id = SCAN_PENDING_EVENTS_JOB_NAME, cron = "* * * * *")
+  fun scanPendingEvents() {
+    val now = clock.instant()
+
+    val eventsToPublish =
+        dslContext.transactionResult { _ ->
+          with(RATE_LIMITED_EVENTS) {
+            val recordsPastInterval =
+                dslContext
+                    .selectFrom(RATE_LIMITED_EVENTS)
+                    .where(NEXT_TIME.le(now))
+                    .forUpdate()
+                    .skipLocked()
+                    .fetch()
+
+            recordsPastInterval.mapNotNull { record ->
+              if (record.pendingEvent != null) {
+                try {
+                  val event =
+                      objectMapper.readValue(
+                          record.pendingEvent!!.data(), Class.forName(record.eventClass))
+                          as RateLimitedEvent<*>
+
+                  // Reset the timer so that any subsequent events within the interval will get
+                  // deferred.
+                  dslContext
+                      .update(RATE_LIMITED_EVENTS)
+                      .set(NEXT_TIME, now + event.getMinimumInterval())
+                      .set(PENDING_EVENT, DSL.castNull(PENDING_EVENT))
+                      .where(EVENT_CLASS.eq(record.eventClass))
+                      .and(RATE_LIMIT_KEY.eq(record.rateLimitKey))
+                      .execute()
+
+                  event
+                } catch (e: ClassNotFoundException) {
+                  log.error("Pending event class ${record.eventClass} no longer exists")
+                  null
+                } catch (e: JsonMappingException) {
+                  log.error("Cannot deserialize pending event of type ${record.eventClass}")
+                  log.info("JSON that failed to deserialize: ${record.pendingEvent?.data()}")
+                  null
+                } catch (e: Exception) {
+                  log.error("Error processing pending event of type ${record.eventClass}")
+                  log.info("JSON of event that failed to process: ${record.pendingEvent?.data()}")
+                  null
+                }
+              } else {
+                // We're past the minimum interval since the last event of this class/key and no
+                // event has been deferred in the meantime; delete the rate limiting record since it
+                // no longer matters.
+                log.debug(
+                    "Deleting rate limit record for event ${record.eventClass} ${record.rateLimitKey}")
+                dslContext
+                    .deleteFrom(RATE_LIMITED_EVENTS)
+                    .where(EVENT_CLASS.eq(record.eventClass))
+                    .and(RATE_LIMIT_KEY.eq(record.rateLimitKey))
+                    .execute()
+
+                null
+              }
+            }
+          }
+        }
+
+    eventsToPublish.forEach { event ->
+      try {
+        eventPublisher.publishEvent(event)
+      } catch (e: Exception) {
+        log.error("Error publishing pending event $event", e)
+      }
+    }
+  }
+
+  private fun toJsonb(obj: Any): JSONB {
+    return JSONB.valueOf(objectMapper.writeValueAsString(obj))
+  }
+
+  companion object {
+    private const val SCAN_PENDING_EVENTS_JOB_NAME = "RateLimitedEventPublisher.scanPendingEvents"
+  }
+}

--- a/src/main/resources/db/migration/0300/V307__RateLimitedEvents.sql
+++ b/src/main/resources/db/migration/0300/V307__RateLimitedEvents.sql
@@ -1,0 +1,8 @@
+CREATE TABLE rate_limited_events (
+    event_class TEXT NOT NULL,
+    rate_limit_key JSONB NOT NULL,
+    next_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    pending_event JSONB,
+
+    PRIMARY KEY (event_class, rate_limit_key)
+);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -138,6 +138,9 @@ COMMENT ON TABLE project_report_settings IS 'Which projects require reports to b
 
 COMMENT ON TABLE projects IS 'Distinguishes among an organization''s projects.';
 
+COMMENT ON TABLE rate_limited_events IS 'Tracks events such as notifications that should have a minimum interval between instances.';
+COMMENT ON COLUMN rate_limited_events.event_class IS 'Fully-qualified class name of the event whose rate limit is being tracked.';
+
 COMMENT ON TABLE regions IS '(Enum) Parts of the world where countries are located.';
 
 COMMENT ON TABLE report_files IS 'Linking table between `reports` and `files` for non-photo files.';

--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -1,12 +1,28 @@
 package com.terraformation.backend
 
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.springframework.context.ApplicationEventPublisher
 
-class TestEventPublisher : ApplicationEventPublisher {
+/**
+ * Test double for event publication. This doesn't call any event listeners, just collects the
+ * published events and allows tests to assert things about them.
+ *
+ * This class implements both [ApplicationEventPublisher] (the Spring interface) and
+ * [RateLimitedEventPublisher], and can be used as a double for either. If your calling class
+ * publishes both regular and rate-limited events, and depends on both [ApplicationEventPublisher]
+ * and [RateLimitedEventPublisher], you will probably want two instances of this class so you can
+ * assert that your events were published with (or without) rate limiting.
+ */
+class TestEventPublisher : ApplicationEventPublisher, RateLimitedEventPublisher {
   private val publishedEvents = mutableListOf<Any>()
 
   override fun publishEvent(event: Any) {
+    publishedEvents.add(event)
+  }
+
+  override fun <T : RateLimitedEvent<T>> publishOrDefer(event: T) {
     publishedEvents.add(event)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -223,6 +223,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "project_land_use_model_types" to setOf(ALL, ACCELERATOR, CUSTOMER),
                   "project_report_settings" to setOf(ALL, CUSTOMER),
                   "projects" to setOf(ALL, ACCELERATOR, CUSTOMER),
+                  "rate_limited_events" to setOf(ALL),
                   "regions" to setOf(ALL, CUSTOMER),
                   "report_files" to setOf(ALL, CUSTOMER),
                   "report_photos" to setOf(ALL, CUSTOMER),

--- a/src/test/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherTest.kt
@@ -1,0 +1,148 @@
+package com.terraformation.backend.ratelimit
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.RATE_LIMITED_EVENTS
+import com.terraformation.backend.mockUser
+import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RateLimitedEventPublisherTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+
+  private val rateLimitedEventPublisher: RateLimitedEventPublisherImpl by lazy {
+    RateLimitedEventPublisherImpl(
+        clock,
+        dslContext,
+        eventPublisher,
+        jacksonObjectMapper(),
+    )
+  }
+
+  @Test
+  fun `publishes event immediately if there is no record of a recent one with the same key`() {
+    val event = TestEvent()
+    val otherKeyEvent = TestEvent(UserId(2))
+
+    rateLimitedEventPublisher.publishOrDefer(otherKeyEvent)
+    eventPublisher.clear()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+
+    eventPublisher.assertEventPublished(event)
+  }
+
+  @Test
+  fun `does not publish event immediately if another one has just been published`() {
+    val event = TestEvent()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+    eventPublisher.clear()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+
+    eventPublisher.assertEventNotPublished<TestEvent>()
+  }
+
+  @Test
+  fun `publishes event immediately if previous one was longer ago than the minimum interval`() {
+    val event = TestEvent()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+    eventPublisher.clear()
+
+    clock.instant += event.getMinimumInterval().plusSeconds(1)
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+
+    eventPublisher.assertEventPublished(event)
+  }
+
+  @Test
+  fun `combines pending event with current event`() {
+    val event1 = TestEvent(data = 1)
+    val event2 = TestEvent(data = 2)
+    val event4 = TestEvent(data = 4)
+    val combinedEvent2And4 = TestEvent(data = 6)
+
+    rateLimitedEventPublisher.publishOrDefer(event1)
+    eventPublisher.clear()
+    rateLimitedEventPublisher.publishOrDefer(event2)
+
+    clock.instant += event1.getMinimumInterval().minusSeconds(1)
+    rateLimitedEventPublisher.publishOrDefer(event4)
+
+    clock.instant += Duration.ofSeconds(1)
+    rateLimitedEventPublisher.scanPendingEvents()
+
+    eventPublisher.assertEventPublished(combinedEvent2And4)
+  }
+
+  @Test
+  fun `does not publish pending event until the minimum interval has elapsed`() {
+    val event = TestEvent()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+    eventPublisher.clear()
+    rateLimitedEventPublisher.publishOrDefer(event)
+
+    clock.instant += event.getMinimumInterval().minusSeconds(1)
+    rateLimitedEventPublisher.scanPendingEvents()
+
+    eventPublisher.assertNoEventsPublished("Published event before initial interval")
+
+    clock.instant += Duration.ofSeconds(1)
+    rateLimitedEventPublisher.scanPendingEvents()
+
+    eventPublisher.assertEventPublished(event, "Published event after initial interval")
+    eventPublisher.clear()
+
+    clock.instant += event.getMinimumInterval().minusSeconds(1)
+    rateLimitedEventPublisher.publishOrDefer(event)
+
+    eventPublisher.assertNoEventsPublished("Published event before second interval")
+
+    clock.instant += Duration.ofSeconds(1)
+    rateLimitedEventPublisher.scanPendingEvents()
+
+    eventPublisher.assertEventPublished(event, "Published event after second interval")
+  }
+
+  @Test
+  fun `cleans up rate limit records once they are no longer relevant`() {
+    val event = TestEvent()
+
+    rateLimitedEventPublisher.publishOrDefer(event)
+    eventPublisher.clear()
+
+    clock.instant += event.getMinimumInterval()
+    rateLimitedEventPublisher.scanPendingEvents()
+
+    eventPublisher.assertNoEventsPublished()
+
+    assertEquals(
+        emptyList<Any>(), dslContext.selectFrom(RATE_LIMITED_EVENTS).fetch(), "Rate limit records")
+  }
+
+  data class TestEvent(
+      val userId: UserId = UserId(1),
+      val projectId: ProjectId = ProjectId(2),
+      val data: Int = 1,
+  ) : RateLimitedEvent<TestEvent> {
+    override fun getRateLimitKey() = mapOf("userId" to userId, "projectId" to projectId)
+
+    override fun getMinimumInterval(): Duration = Duration.ofMinutes(5)
+
+    override fun combine(existing: TestEvent) = TestEvent(userId, projectId, data + existing.data)
+  }
+}


### PR DESCRIPTION
To support rate limiting of notifications without requiring a lot of
special-case code to implement the rates on a per-notification-type basis,
add a general-purpose rate limiting service.

From callers' point of view, this service acts like an alternate interface
to `ApplicationEventPublisher`: the callers publish an event and at some
point, event listeners get called. The difference is that the listeners might be
called asynchronously, after time has passed.

Initially, we'll use this for notification rate limiting, but it is not
notification-specific and can be used to throttle any kind of application event.

The rate limiting behavior implemented here differs from the behavior of the
existing notification rate limits; this rate limiter will immediately publish
the first event and then defer any subsequent ones until the minimum interval
has passed. Our other rate-limited notifications always defer until no new
notifications have been generated for that long.