### PR TITLE
SW-5607 Use rate-limited events for submission notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
@@ -1,138 +1,36 @@
 package com.terraformation.backend.accelerator
 
-import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadedEvent
 import com.terraformation.backend.accelerator.event.DeliverableReadyForReviewEvent
-import com.terraformation.backend.customer.model.SystemUser
-import com.terraformation.backend.documentproducer.db.VariableStore
-import com.terraformation.backend.documentproducer.db.VariableValueStore
-import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
 import com.terraformation.backend.documentproducer.event.QuestionsDeliverableReviewedEvent
 import com.terraformation.backend.documentproducer.event.QuestionsDeliverableStatusUpdatedEvent
 import com.terraformation.backend.documentproducer.event.QuestionsDeliverableSubmittedEvent
-import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import jakarta.inject.Named
-import java.time.Duration
-import java.time.InstantSource
-import org.jobrunr.scheduling.JobScheduler
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 
 @Named
 class SubmissionNotifier(
-    private val clock: InstantSource,
-    private val deliverableStore: DeliverableStore,
-    private val eventPublisher: ApplicationEventPublisher,
-    @Lazy private val scheduler: JobScheduler,
-    private val systemUser: SystemUser,
-    private val variableStore: VariableStore,
-    private val variableValueStore: VariableValueStore,
-    private val variableWorkflowStore: VariableWorkflowStore,
+    private val rateLimitedEventPublisher: RateLimitedEventPublisher,
 ) {
-  companion object {
-    /**
-     * Wait this long before notifying about new submissions to give the user time to submit
-     * additional items for a deliverable. This is the delay after the _last_ submission, that is,
-     * the user-visible behavior is that the countdown resets each time something new is submitted
-     * for a deliverable.
-     */
-    private val notificationDelay = Duration.ofMinutes(5)
-
-    private val log = perClassLogger()
-  }
-
   /** Schedules a "ready for review" notification when a document is uploaded. */
   @EventListener
   fun on(event: DeliverableDocumentUploadedEvent) {
-    scheduler.schedule<SubmissionNotifier>(clock.instant().plus(notificationDelay)) {
-      notifyIfNoNewerUploads(event)
-    }
+    rateLimitedEventPublisher.publishOrDefer(
+        DeliverableReadyForReviewEvent(event.deliverableId, event.projectId))
   }
 
   /** Schedules a "ready for review" notification when a question is answered. */
   @EventListener
   fun on(event: QuestionsDeliverableSubmittedEvent) {
-    scheduler.schedule<SubmissionNotifier>(clock.instant().plus(notificationDelay)) {
-      notifyIfNoNewerSubmissions(event)
-    }
+    rateLimitedEventPublisher.publishOrDefer(
+        DeliverableReadyForReviewEvent(event.deliverableId, event.projectId))
   }
 
   /** Schedules a "ready for review" notification when a question is answered. */
   @EventListener
   fun on(event: QuestionsDeliverableReviewedEvent) {
-    scheduler.schedule<SubmissionNotifier>(clock.instant().plus(notificationDelay)) {
-      notifyIfNoNewerReviews(event)
-    }
-  }
-
-  /**
-   * Publishes [DeliverableReadyForReviewEvent] if no documents have been uploaded for a submission
-   * since the one referenced by the event.
-   */
-  fun notifyIfNoNewerUploads(event: DeliverableDocumentUploadedEvent) {
-    systemUser.run {
-      val deliverable =
-          deliverableStore
-              .fetchDeliverableSubmissions(
-                  projectId = event.projectId, deliverableId = event.deliverableId)
-              .firstOrNull()
-
-      if (deliverable != null) {
-        val maxDocumentId = deliverable.documents.map { it.id }.maxBy { it.value }
-
-        if (maxDocumentId == event.documentId) {
-          eventPublisher.publishEvent(DeliverableReadyForReviewEvent(deliverable, event.projectId))
-        }
-      } else {
-        log.error("Deliverable ${event.deliverableId} not found for project ${event.projectId}")
-      }
-    }
-  }
-
-  /**
-   * Publishes [DeliverableReadyForReviewEvent] if no question answers have been submitted since the
-   * one referenced by the event.
-   */
-  fun notifyIfNoNewerSubmissions(event: QuestionsDeliverableSubmittedEvent) {
-    systemUser.run {
-      val deliverable =
-          deliverableStore
-              .fetchDeliverableSubmissions(
-                  projectId = event.projectId, deliverableId = event.deliverableId)
-              .firstOrNull()
-
-      val allValuesLatest =
-          event.currentValueIds.all {
-            variableValueStore.fetchMaxValueId(event.projectId, it.key) == it.value
-          }
-
-      if (deliverable != null && allValuesLatest) {
-        eventPublisher.publishEvent(DeliverableReadyForReviewEvent(deliverable, event.projectId))
-      }
-    }
-  }
-
-  /**
-   * Publishes [QuestionsDeliverableStatusUpdatedEvent] if no user-visible feedback or status has
-   * been updated since the one referenced by the event.
-   */
-  fun notifyIfNoNewerReviews(event: QuestionsDeliverableReviewedEvent) {
-    systemUser.run {
-      val deliverableVariableWorkflowsForProject =
-          variableWorkflowStore.fetchCurrentForProjectDeliverable(
-              event.projectId, event.deliverableId)
-
-      if (event.currentWorkflows.keys == deliverableVariableWorkflowsForProject.keys &&
-          deliverableVariableWorkflowsForProject.all { (variableId, historyModel) ->
-            val deliverableWorkflow = event.currentWorkflows[variableId]
-            deliverableWorkflow != null &&
-                deliverableWorkflow.status == historyModel.status &&
-                deliverableWorkflow.feedback == historyModel.feedback
-          }) {
-        eventPublisher.publishEvent(
-            QuestionsDeliverableStatusUpdatedEvent(event.deliverableId, event.projectId))
-      }
-    }
+    rateLimitedEventPublisher.publishOrDefer(
+        QuestionsDeliverableStatusUpdatedEvent(event.deliverableId, event.projectId))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableReadyForReviewEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableReadyForReviewEvent.kt
@@ -1,10 +1,16 @@
 package com.terraformation.backend.accelerator.event
 
-import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
+import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import java.time.Duration
 
 /** Published when a deliverable is ready for review */
 data class DeliverableReadyForReviewEvent(
-    val deliverable: DeliverableSubmissionModel,
+    val deliverableId: DeliverableId,
     val projectId: ProjectId,
-)
+) : RateLimitedEvent<DeliverableReadyForReviewEvent> {
+  override fun getRateLimitKey() = this
+
+  override fun getMinimumInterval(): Duration = Duration.ofMinutes(5)
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -406,15 +406,14 @@ class AppNotificationService(
       }
 
       val participant = participantStore.fetchOneById(project.participantId)
-      val deliverableCategory =
-          deliverableStore.fetchDeliverableCategory(event.deliverable.deliverableId)
+      val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
       val deliverableUrl =
-          webAppUrls.acceleratorConsoleDeliverable(event.deliverable.deliverableId, event.projectId)
+          webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
       val renderMessage = { messages.deliverableReadyForReview(participant.name) }
 
       log.info(
           "Creating app notifications for project ${event.projectId} participant " +
-              "${project.participantId} deliverable ${event.deliverable.deliverableId} ready for review")
+              "${project.participantId} deliverable ${event.deliverableId} ready for review")
 
       insertAcceleratorNotification(
           deliverableUrl,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/QuestionsDeliverableReviewedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/QuestionsDeliverableReviewedEvent.kt
@@ -2,8 +2,6 @@ package com.terraformation.backend.documentproducer.event
 
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.docprod.VariableId
-import com.terraformation.backend.documentproducer.model.ExistingVariableWorkflowHistoryModel
 
 /**
  * Published when a questions deliverable for a project was reviewed and contained user-visible
@@ -12,5 +10,4 @@ import com.terraformation.backend.documentproducer.model.ExistingVariableWorkflo
 data class QuestionsDeliverableReviewedEvent(
     val deliverableId: DeliverableId,
     val projectId: ProjectId,
-    val currentWorkflows: Map<VariableId, ExistingVariableWorkflowHistoryModel>,
 )

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/QuestionsDeliverableStatusUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/QuestionsDeliverableStatusUpdatedEvent.kt
@@ -2,9 +2,15 @@ package com.terraformation.backend.documentproducer.event
 
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import java.time.Duration
 
 /** Published when a questionnaire deliverable status is updated, for notifying users */
 data class QuestionsDeliverableStatusUpdatedEvent(
     val deliverableId: DeliverableId,
     val projectId: ProjectId,
-)
+) : RateLimitedEvent<QuestionsDeliverableStatusUpdatedEvent> {
+  override fun getRateLimitKey() = this
+
+  override fun getMinimumInterval(): Duration = Duration.ofMinutes(5)
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -624,13 +624,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertModule()
     insertCohortModule()
     val deliverableId = insertDeliverable()
-    val deliverable =
-        deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverableId).first()
 
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(DeliverableReadyForReviewEvent(deliverable, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotification(
         type = NotificationType.DeliverableReadyForReview,
@@ -651,13 +649,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
     insertUserInternalInterest(InternalInterest.GIS, user.userId)
     val deliverableId = insertDeliverable(deliverableCategoryId = DeliverableCategory.GIS)
-    val deliverable =
-        deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverableId).first()
 
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(DeliverableReadyForReviewEvent(deliverable, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotification(
         type = NotificationType.DeliverableReadyForReview,
@@ -679,13 +675,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
     insertUserInternalInterest(InternalInterest.Compliance, user.userId)
     val deliverableId = insertDeliverable(deliverableCategoryId = DeliverableCategory.GIS)
-    val deliverable =
-        deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverableId).first()
 
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(DeliverableReadyForReviewEvent(deliverable, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotifications(emptyList())
   }
@@ -706,13 +700,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     // being the contact overrides the category filtering.
     insertUserInternalInterest(InternalInterest.Compliance, tfContact)
     val deliverableId = insertDeliverable(deliverableCategoryId = DeliverableCategory.GIS)
-    val deliverable =
-        deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverableId).first()
 
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(DeliverableReadyForReviewEvent(deliverable, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotifications(
         listOf(
@@ -745,13 +737,11 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     insertModule()
     insertCohortModule()
     val deliverableId = insertDeliverable()
-    val deliverable =
-        deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverableId).first()
 
     every { messages.deliverableReadyForReview("participant1") } returns
         NotificationMessage("ready for review title", "ready for review body")
 
-    service.on(DeliverableReadyForReviewEvent(deliverable, projectId))
+    service.on(DeliverableReadyForReviewEvent(deliverableId, projectId))
 
     assertNotifications(
         listOf(

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -342,6 +342,10 @@ internal class EmailNotificationServiceTest {
     every {
       deliverableStore.fetchDeliverableSubmissions(deliverableId = deliverable.deliverableId)
     } returns listOf(deliverable)
+    every {
+      deliverableStore.fetchDeliverableSubmissions(
+          deliverableId = deliverable.deliverableId, projectId = deliverable.projectId)
+    } returns listOf(deliverable)
 
     every { sender.send(capture(mimeMessageSlot)) } answers
         { answer ->
@@ -998,7 +1002,7 @@ internal class EmailNotificationServiceTest {
   fun `deliverableReadyForReview with Terraformation contact`() {
     every { userStore.getTerraformationContactUser(any()) } returns tfContactUser
 
-    val event = DeliverableReadyForReviewEvent(deliverable, project.id)
+    val event = DeliverableReadyForReviewEvent(deliverable.deliverableId, project.id)
 
     service.on(event)
 
@@ -1014,7 +1018,7 @@ internal class EmailNotificationServiceTest {
     every { userStore.getTerraformationContactUser(any()) } returns tfContactUser
     every { userStore.fetchWithGlobalRoles() } returns listOf(acceleratorUser, tfContactUser)
 
-    val event = DeliverableReadyForReviewEvent(deliverable, project.id)
+    val event = DeliverableReadyForReviewEvent(deliverable.deliverableId, project.id)
 
     service.on(event)
 
@@ -1030,7 +1034,7 @@ internal class EmailNotificationServiceTest {
 
   @Test
   fun `deliverableReadyForReview without Terraformation contact`() {
-    val event = DeliverableReadyForReviewEvent(deliverable, project.id)
+    val event = DeliverableReadyForReviewEvent(deliverable.deliverableId, project.id)
 
     service.on(event)
 
@@ -1160,7 +1164,7 @@ internal class EmailNotificationServiceTest {
   @Test
   fun `org notification by default fetches recipients for all roles except Terraformation Contact`() {
     val rolesWithoutTerraformationContact =
-        Role.values().filter { it != Role.TerraformationContact }.toSet()
+        Role.entries.filter { it != Role.TerraformationContact }.toSet()
     every { userStore.fetchByOrganizationId(organization.id, any(), any()) } returns emptyList()
 
     emailService.sendOrganizationNotification(


### PR DESCRIPTION
Use `RateLimitedEventPublisher` to limit the rate of notifications about
deliverable submissions, replacing the code that scans for recent submission
updates.

In addition to requiring less code, this improves the notification behavior:
previously, the code would defer notifying until at least 5 minutes had passed
since the last action on the submission, no matter how long that took. Now it
will send a notification the first time an action happens, followed by
notifications at most every 5 minutes if additional actions happen.