### PR TITLE
SW-5607 Use rate-limited events for species notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesNotifier.kt
@@ -1,47 +1,28 @@
 package com.terraformation.backend.accelerator
 
-import com.terraformation.backend.accelerator.db.ParticipantProjectSpeciesStore
 import com.terraformation.backend.accelerator.db.SubmissionStore
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesAddedToProjectNotificationDueEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectSpeciesEditedEvent
-import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import jakarta.inject.Named
-import java.time.Duration
-import java.time.InstantSource
-import org.jobrunr.scheduling.JobScheduler
-import org.springframework.context.ApplicationEventPublisher
-import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 
 @Named
 class SpeciesNotifier(
-    private val clock: InstantSource,
-    private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore,
-    private val eventPublisher: ApplicationEventPublisher,
-    @Lazy private val scheduler: JobScheduler,
+    private val rateLimitedEventPublisher: RateLimitedEventPublisher,
     private val submissionStore: SubmissionStore,
-    private val systemUser: SystemUser,
 ) {
-  companion object {
-    /**
-     * Wait this long before notifying about species-related deliverable updates. This reduces
-     * duplicate notifications for a deliverable which may have many species being updated in short
-     * succession. This is the delay after the _last_ notification, that is, the user-visible
-     * behavior is that the countdown resets each time a species modification is made for this
-     * deliverable.
-     */
-    private val notificationDelay = Duration.ofMinutes(10)
-  }
-
   /** Schedules a "species added" notification when a new species is added to a project. */
   @EventListener
   fun on(event: ParticipantProjectSpeciesAddedEvent) {
-    scheduler.schedule<SpeciesNotifier>(clock.instant().plus(notificationDelay)) {
-      notifyIfNoNewerUpdates(event)
-    }
+    rateLimitedEventPublisher.publishOrDefer(
+        ParticipantProjectSpeciesAddedToProjectNotificationDueEvent(
+            deliverableId = event.deliverableId,
+            projectId = event.participantProjectSpecies.projectId,
+            speciesId = event.participantProjectSpecies.speciesId))
   }
 
   /** Schedules a "species edited" notification when a species associated to a project is edited. */
@@ -51,52 +32,15 @@ class SpeciesNotifier(
     val new = event.newParticipantProjectSpecies
 
     if (old.submissionStatus == SubmissionStatus.Approved && old != new) {
-      scheduler.schedule<SpeciesNotifier>(clock.instant().plus(notificationDelay)) {
-        notifyIfNoNewerUpdates(event)
-      }
-    }
-  }
+      val deliverableSubmission =
+          submissionStore.fetchMostRecentSpeciesDeliverableSubmission(event.projectId)
 
-  /**
-   * Publishes [ParticipantProjectSpeciesAddedToProjectNotificationDueEvent] if no species have been
-   * added to a participant project since the one referenced by the event.
-   */
-  fun notifyIfNoNewerUpdates(event: ParticipantProjectSpeciesAddedEvent) {
-    systemUser.run {
-      val lastCreatedTime =
-          participantProjectSpeciesStore.fetchLastCreatedSpeciesTime(
-              event.participantProjectSpecies.projectId)
-
-      if (lastCreatedTime == event.participantProjectSpecies.createdTime) {
-        eventPublisher.publishEvent(
-            ParticipantProjectSpeciesAddedToProjectNotificationDueEvent(
-                deliverableId = event.deliverableId,
-                projectId = event.participantProjectSpecies.projectId,
-                speciesId = event.participantProjectSpecies.speciesId))
-      }
-    }
-  }
-
-  /**
-   * Publishes [ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent] if no species
-   * have been edited for the participant project since the one referenced by the event.
-   */
-  fun notifyIfNoNewerUpdates(event: ParticipantProjectSpeciesEditedEvent) {
-    systemUser.run {
-      val lastModifiedTime =
-          participantProjectSpeciesStore.fetchLastModifiedSpeciesTime(event.projectId)
-
-      if (lastModifiedTime == event.newParticipantProjectSpecies.modifiedTime) {
-        val deliverableSubmission =
-            submissionStore.fetchMostRecentSpeciesDeliverableSubmission(event.projectId)
-
-        if (deliverableSubmission != null) {
-          eventPublisher.publishEvent(
-              ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent(
-                  deliverableId = deliverableSubmission.deliverableId,
-                  projectId = event.projectId,
-                  speciesId = event.newParticipantProjectSpecies.speciesId))
-        }
+      if (deliverableSubmission != null) {
+        rateLimitedEventPublisher.publishOrDefer(
+            ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent(
+                deliverableSubmission.deliverableId,
+                event.projectId,
+                event.newParticipantProjectSpecies.speciesId))
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectSpeciesAddedToProjectNotificationDueEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectSpeciesAddedToProjectNotificationDueEvent.kt
@@ -3,11 +3,11 @@ package com.terraformation.backend.accelerator.event
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import java.time.Duration
 
 /**
- * Published when a participant project species is added to a project This event is a deferred,
- * throttled event and will only be sent out if a subsequent new species has not been added within
- * the defer period
+ * Published when a participant project species is added to a project.
  *
  * @see com.terraformation.backend.accelerator.SpeciesNotifier
  */
@@ -15,4 +15,8 @@ data class ParticipantProjectSpeciesAddedToProjectNotificationDueEvent(
     val deliverableId: DeliverableId,
     val projectId: ProjectId,
     val speciesId: SpeciesId,
-)
+) : RateLimitedEvent<ParticipantProjectSpeciesAddedToProjectNotificationDueEvent> {
+  override fun getRateLimitKey() = projectId
+
+  override fun getMinimumInterval(): Duration = Duration.ofMinutes(10)
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent.kt
@@ -3,11 +3,11 @@ package com.terraformation.backend.accelerator.event
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import java.time.Duration
 
 /**
- * Published when an approved participant project species is edited This event is a deferred,
- * throttled event and will only be sent out if a subsequent qualifying species edit has not been
- * made within the defer period
+ * Published when an approved participant project species is edited.
  *
  * @see com.terraformation.backend.accelerator.SpeciesNotifier
  */
@@ -15,4 +15,8 @@ data class ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent(
     val deliverableId: DeliverableId,
     val projectId: ProjectId,
     val speciesId: SpeciesId,
-)
+) : RateLimitedEvent<ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent> {
+  override fun getRateLimitKey() = projectId
+
+  override fun getMinimumInterval(): Duration = Duration.ofMinutes(10)
+}


### PR DESCRIPTION
Use `RateLimitedEventPublisher` to limit the rate of notifications about
participant project species list additions and changes, replacing the code that
scans for recent updates.

In addition to requiring less code, this improves the notification behavior:
previously, the code would defer notifying until at least 10 minutes had passed
since the last action on the species list, no matter how long that took. Now it
will send a notification the first time an action happens, followed by
notifications at most every 10 minutes if additional actions happen.