### PR TITLE
Add convenience methods for asserting table contents

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableServiceTest.kt
@@ -20,7 +20,6 @@ import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -105,7 +104,7 @@ class DeliverableServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `updates existing submission to Complete status`() {
     insertSubmission(deliverableId = deliverable1, submissionStatus = SubmissionStatus.NotNeeded)
-    val existing = dslContext.fetchOne(SUBMISSIONS, SUBMISSIONS.ID.eq(inserted.submissionId))!!
+    val existing = dslContext.fetchSingle(SUBMISSIONS)
     service.setDeliverableCompletion(deliverable1, inserted.projectId, true)
     assertTableEquals(existing.apply { submissionStatusId = SubmissionStatus.Completed })
   }
@@ -113,11 +112,9 @@ class DeliverableServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `updates existing submission to NotSubmitted status if isComplete is false`() {
     insertSubmission(deliverableId = deliverable1, submissionStatus = SubmissionStatus.NotNeeded)
-    val existing = submissionsDao.fetchOneById(inserted.submissionId)!!
+    val existing = dslContext.fetchSingle(SUBMISSIONS)
     service.setDeliverableCompletion(deliverable1, inserted.projectId, false)
-    assertEquals(
-        existing.copy(submissionStatusId = SubmissionStatus.NotSubmitted),
-        submissionsDao.fetchOneById(inserted.submissionId))
+    assertTableEquals(existing.apply { submissionStatusId = SubmissionStatus.NotSubmitted })
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -122,7 +122,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
               modifiedTime = now,
               projectId = projectId,
               submissionStatusId = SubmissionStatus.NotSubmitted),
-          clearPrimaryKeys = true)
+          includePrimaryKeys = false)
 
       assertTableEquals(
           ParticipantProjectSpeciesRecord(
@@ -135,7 +135,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
               rationale = "rationale",
               speciesId = speciesId,
               submissionStatusId = SubmissionStatus.NotSubmitted),
-          clearPrimaryKeys = true)
+          includePrimaryKeys = false)
 
       eventPublisher.assertEventPublished(
           ParticipantProjectSpeciesAddedEvent(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -7,8 +7,9 @@ import com.terraformation.backend.accelerator.model.VoteModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.VoteOption
-import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVoteDecisionsRow
-import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVotesRow
+import com.terraformation.backend.db.accelerator.tables.records.ProjectVoteDecisionsRecord
+import com.terraformation.backend.db.accelerator.tables.records.ProjectVotesRecord
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTES
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.mockUser
@@ -232,7 +233,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.delete(projectId, phase, newUser)
 
-      assertEquals(emptyList<ProjectVotesRow>(), projectVotesDao.findAll())
+      assertTableEmpty(PROJECT_VOTES)
     }
 
     @Test
@@ -255,9 +256,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.delete(projectId, phase, user2)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
+      assertTableEquals(
+          setOf(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase,
                   userId = user1,
@@ -268,7 +269,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase,
                   userId = user3,
@@ -278,8 +279,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+              )))
     }
 
     @Test
@@ -327,9 +327,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.delete(projectId, phase1)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
+      assertTableEquals(
+          setOf(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase0,
                   userId = user1,
@@ -340,7 +340,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase0,
                   userId = user2,
@@ -350,8 +350,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = clock.instant,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+              )))
     }
 
     @Test
@@ -406,9 +405,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       store.delete(projectId, phase, user2)
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, vote1, clock.instant)),
-          projectVoteDecisionDao.findAll())
+
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, vote1, clock.instant))
     }
 
     @Test
@@ -425,9 +423,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       store.delete(projectId, phase, newUser)
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),
-          projectVoteDecisionDao.findAll())
+
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, null, clock.instant))
     }
   }
 
@@ -441,20 +438,18 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       store.upsert(projectId, phase, user.userId, null, null)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
-                  projectId = projectId,
-                  phaseId = phase,
-                  userId = user.userId,
-                  voteOptionId = null,
-                  conditionalInfo = null,
-                  createdBy = user.userId,
-                  createdTime = clock.instant,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+      assertTableEquals(
+          ProjectVotesRecord(
+              projectId = projectId,
+              phaseId = phase,
+              userId = user.userId,
+              voteOptionId = null,
+              conditionalInfo = null,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          ))
     }
 
     @Test
@@ -466,20 +461,18 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       store.upsert(projectId, phase, otherUser, null, null)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
-                  projectId = projectId,
-                  phaseId = phase,
-                  userId = otherUser,
-                  voteOptionId = null,
-                  conditionalInfo = null,
-                  createdBy = user.userId,
-                  createdTime = clock.instant,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+      assertTableEquals(
+          ProjectVotesRecord(
+              projectId = projectId,
+              phaseId = phase,
+              userId = otherUser,
+              voteOptionId = null,
+              conditionalInfo = null,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          ))
     }
 
     @Test
@@ -493,20 +486,18 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       val conditionalInfo = "Reason why the vote is a maybe"
       store.upsert(projectId, phase, otherUser, voteOption, conditionalInfo)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
-                  projectId = projectId,
-                  phaseId = phase,
-                  userId = otherUser,
-                  voteOptionId = voteOption,
-                  conditionalInfo = conditionalInfo,
-                  createdBy = user.userId,
-                  createdTime = clock.instant,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+      assertTableEquals(
+          ProjectVotesRecord(
+              projectId = projectId,
+              phaseId = phase,
+              userId = otherUser,
+              voteOptionId = voteOption,
+              conditionalInfo = conditionalInfo,
+              createdBy = user.userId,
+              createdTime = clock.instant,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          ))
     }
 
     @Test
@@ -526,20 +517,18 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, newUser, newVote, newCondition)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
-                  projectId = projectId,
-                  phaseId = phase,
-                  userId = newUser,
-                  voteOptionId = newVote,
-                  conditionalInfo = newCondition,
-                  createdBy = user.userId,
-                  createdTime = createdTime,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+      assertTableEquals(
+          ProjectVotesRecord(
+              projectId = projectId,
+              phaseId = phase,
+              userId = newUser,
+              voteOptionId = newVote,
+              conditionalInfo = newCondition,
+              createdBy = user.userId,
+              createdTime = createdTime,
+              modifiedBy = user.userId,
+              modifiedTime = clock.instant,
+          ))
     }
 
     @Test
@@ -568,9 +557,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
       clock.instant = Instant.EPOCH.plusSeconds(1000)
       store.upsert(projectId, phase, user3, newVote, newCondition)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
+      assertTableEquals(
+          setOf(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase,
                   userId = user1,
@@ -581,7 +570,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = createdTime,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase,
                   userId = user2,
@@ -592,7 +581,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = createdTime,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase,
                   userId = user3,
@@ -602,8 +591,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = createdTime,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+              )))
     }
 
     @Test
@@ -627,9 +615,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase1, user.userId, newVote)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
+      assertTableEquals(
+          setOf(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase0,
                   userId = user.userId,
@@ -640,7 +628,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = createdTime,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = projectId,
                   phaseId = phase1,
                   userId = user.userId,
@@ -650,8 +638,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = createdTime,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+              )))
     }
 
     @Test
@@ -675,9 +662,9 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(project2, phase, user.userId, newVote)
 
-      assertEquals(
-          listOf(
-              ProjectVotesRow(
+      assertTableEquals(
+          setOf(
+              ProjectVotesRecord(
                   projectId = project1,
                   phaseId = phase,
                   userId = user.userId,
@@ -688,7 +675,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = createdTime,
               ),
-              ProjectVotesRow(
+              ProjectVotesRecord(
                   projectId = project2,
                   phaseId = phase,
                   userId = user.userId,
@@ -698,8 +685,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
                   createdTime = createdTime,
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
-              )),
-          projectVotesDao.findAll())
+              )))
     }
 
     @Test
@@ -752,9 +738,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, newUser, vote, null)
 
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, vote, clock.instant)),
-          projectVoteDecisionDao.findAll())
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, vote, clock.instant))
     }
 
     @Test
@@ -767,9 +751,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, newUser, null, null)
 
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),
-          projectVoteDecisionDao.findAll())
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, null, clock.instant))
     }
 
     @Test
@@ -787,9 +769,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, newUser, newVote, null)
 
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, newVote, clock.instant)),
-          projectVoteDecisionDao.findAll())
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, newVote, clock.instant))
     }
 
     @Test
@@ -809,9 +789,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, user2, vote2, null)
 
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),
-          projectVoteDecisionDao.findAll())
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, null, clock.instant))
     }
 
     @Test
@@ -830,9 +808,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.upsert(projectId, phase, user2, null, null)
 
-      assertEquals(
-          listOf(ProjectVoteDecisionsRow(projectId, phase, null, clock.instant)),
-          projectVoteDecisionDao.findAll())
+      assertTableEquals(ProjectVoteDecisionsRecord(projectId, phase, null, clock.instant))
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -349,10 +349,14 @@ import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.roundToInt
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.isSupertypeOf
+import org.jooq.Condition
 import org.jooq.Configuration
 import org.jooq.DSLContext
 import org.jooq.JSONB
+import org.jooq.Table
+import org.jooq.UpdatableRecord
 import org.jooq.impl.DAOImpl
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
@@ -3045,6 +3049,128 @@ abstract class DatabaseBackedTest {
     variableWorkflowHistoryDao.insert(row)
 
     return row.id!!.also { inserted.variableWorkflowHistoryIds.add(it) }
+  }
+
+  /**
+   * Asserts that a table (or a filtered subset of it) contains an expected set of records and
+   * nothing else.
+   *
+   * @param table The table whose contents should be examined.
+   * @param expected The set of records the table should contain.
+   * @param message Assertion failure message; defaults to the table name.
+   * @param where Optional query condition to assert on a subset of a table's contents. Only rows
+   *   matching the condition will be considered.
+   * @param clearPrimaryKeys If true, the primary key field(s) of the records from the database will
+   *   be cleared before comparing against [expected]. This can be used to ignore database-generated
+   *   IDs.
+   * @param transform Function to apply to records from the database before comparing them to
+   *   [expected]. Can be used to clear or hardwire specific fields that aren't relevant to the
+   *   behavior being tested.
+   */
+  protected fun <R : UpdatableRecord<R>> assertTableEquals(
+      table: Table<R>,
+      expected: Set<R>,
+      message: String = table.name,
+      where: Condition? = null,
+      clearPrimaryKeys: Boolean = false,
+      transform: (R) -> R = { it },
+  ) {
+    val actual =
+        dslContext
+            .selectFrom(table)
+            .where(where)
+            .fetch()
+            .map { record: R ->
+              val transformed = transform(record)
+              if (clearPrimaryKeys) {
+                transformed.copy()
+              } else {
+                transformed
+              }
+            }
+            .toSet()
+
+    assertEquals(expected, actual, message)
+  }
+
+  /**
+   * Asserts that a table (or a filtered subset of it) contains an expected set of records and
+   * nothing else.
+   *
+   * @param expected The set of records the table should contain. Must be non-empty.
+   * @param message Assertion failure message; defaults to the table name.
+   * @param where Optional query condition to assert on a subset of a table's contents. Only rows
+   *   matching the condition will be considered.
+   * @param clearPrimaryKeys If true, the primary key field(s) of the records from the database will
+   *   be cleared before comparing against [expected]. This can be used to ignore database-generated
+   *   IDs.
+   * @param transform Function to apply to records from the database before comparing them to
+   *   [expected]. Can be used to clear or hardwire specific fields that aren't relevant to the
+   *   behavior being tested.
+   */
+  protected fun <R : UpdatableRecord<R>> assertTableEquals(
+      expected: Set<R>,
+      message: String? = null,
+      where: Condition? = null,
+      clearPrimaryKeys: Boolean = false,
+      transform: (R) -> R = { it },
+  ) {
+    val table =
+        expected.firstOrNull()?.table
+            ?: throw IllegalArgumentException("Use assertTableEmpty to check for empty tables")
+
+    assertTableEquals(
+        table = table,
+        expected = expected,
+        message = message ?: table.name,
+        where = where,
+        clearPrimaryKeys = clearPrimaryKeys,
+        transform = transform)
+  }
+
+  /**
+   * Asserts that a table (or a filtered subset of it) contains exactly one row.
+   *
+   * @param expected The single row that the table should contain.
+   * @param message Assertion failure message; defaults to the table name.
+   * @param where Optional query condition to assert on a subset of a table's contents. Only rows
+   *   matching the condition will be considered.
+   * @param clearPrimaryKeys If true, the primary key field(s) of the records from the database will
+   *   be cleared before comparing against [expected]. This can be used to ignore database-generated
+   *   IDs.
+   * @param transform Function to apply to records from the database before comparing them to
+   *   [expected]. Can be used to clear or hardwire specific fields that aren't relevant to the
+   *   behavior being tested.
+   */
+  protected fun <R : UpdatableRecord<R>> assertTableEquals(
+      expected: R,
+      message: String? = null,
+      where: Condition? = null,
+      clearPrimaryKeys: Boolean = false,
+      transform: (R) -> R = { it },
+  ) {
+    assertTableEquals(
+        expected = setOf(expected),
+        message = message,
+        where = where,
+        clearPrimaryKeys = clearPrimaryKeys,
+        transform = transform)
+  }
+
+  /**
+   * Asserts that a table (or a filtered subset of it) contains no rows.
+   *
+   * @param table The table whose contents should be examined.
+   * @param message Assertion failure message; defaults to the table name.
+   * @param where Optional query condition to assert on a subset of a table's contents. Only rows
+   *   matching the condition will be considered.
+   */
+  protected fun <R : UpdatableRecord<R>> assertTableEmpty(
+      table: Table<R>,
+      message: String = table.name,
+      where: Condition? = null,
+  ) {
+    assertTableEquals(table = table, expected = emptySet(), message = message, where = where)
   }
 
   @Suppress("unused")


### PR DESCRIPTION
A common pattern in our tests is to call some application code and then verify
that the database was updated correctly. This usually looks something like

    assertEquals(
        listOf(
            SomeTableRow(col1 = "foo", col2 = "bar"),
        ),
        someTableDao.findAll().map { it.id = null })

This pattern is an occasional source of spurious test failures when we forget
that `findAll()` doesn't guarantee any particular order of results.

Introduce a new set of methods in `DatabaseBackedTest` that are more succinct to
call, offer more flexibility, and avoid the possibility of test failures due to
assumptions about result order.