### PR TITLE
SW-6029 Use application cohort phases for projects

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectCohortData.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectCohortData.kt
@@ -2,19 +2,8 @@ package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
-import com.terraformation.backend.db.accelerator.tables.references.COHORTS
-import org.jooq.Record
 
 data class ProjectCohortData(
-    val cohortId: CohortId,
+    val cohortId: CohortId? = null,
     val cohortPhase: CohortPhase,
-) {
-  companion object {
-    fun of(record: Record): ProjectCohortData {
-      return ProjectCohortData(
-          cohortId = record[COHORTS.ID]!!,
-          cohortPhase = record[COHORTS.PHASE_ID]!!,
-      )
-    }
-  }
-}
+)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -65,15 +65,16 @@ class ProjectStore(
         .fetchOne { (cohortId, cohortPhase, applicationStatus) ->
           if (cohortId != null && cohortPhase != null) {
             ProjectCohortData(cohortId, cohortPhase)
-          } else
-              when (applicationStatus) {
-                ApplicationStatus.NotSubmitted,
-                ApplicationStatus.FailedPreScreen,
-                ApplicationStatus.PassedPreScreen ->
-                    ProjectCohortData(cohortPhase = CohortPhase.PreScreen)
-                null -> null
-                else -> ProjectCohortData(cohortPhase = CohortPhase.Application)
-              }
+          } else {
+            when (applicationStatus) {
+              ApplicationStatus.NotSubmitted,
+              ApplicationStatus.FailedPreScreen,
+              ApplicationStatus.PassedPreScreen ->
+                  ProjectCohortData(cohortPhase = CohortPhase.PreScreen)
+              null -> null
+              else -> ProjectCohortData(cohortPhase = CohortPhase.Application)
+            }
+          }
         }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -12,7 +12,10 @@ import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNameInUseException
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.ApplicationStatus
+import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -47,17 +50,31 @@ class ProjectStore(
   }
 
   fun fetchCohortData(projectId: ProjectId): ProjectCohortData? {
+    requirePermissions { readProject(projectId) }
+
     return dslContext
-        .select(COHORTS.ID, COHORTS.PHASE_ID)
+        .select(COHORTS.ID, COHORTS.PHASE_ID, APPLICATIONS.APPLICATION_STATUS_ID)
         .from(PROJECTS)
-        .join(PARTICIPANTS)
+        .leftJoin(PARTICIPANTS)
         .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
-        .join(COHORTS)
+        .leftJoin(COHORTS)
         .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+        .leftJoin(APPLICATIONS)
+        .on(PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID))
         .where(PROJECTS.ID.eq(projectId))
-        .fetch()
-        .map { ProjectCohortData.of(it) }
-        .firstOrNull { currentUser().canReadCohort(it.cohortId) }
+        .fetchOne { (cohortId, cohortPhase, applicationStatus) ->
+          if (cohortId != null && cohortPhase != null) {
+            ProjectCohortData(cohortId, cohortPhase)
+          } else
+              when (applicationStatus) {
+                ApplicationStatus.NotSubmitted,
+                ApplicationStatus.FailedPreScreen,
+                ApplicationStatus.PassedPreScreen ->
+                    ProjectCohortData(cohortPhase = CohortPhase.PreScreen)
+                null -> null
+                else -> ProjectCohortData(cohortPhase = CohortPhase.Application)
+              }
+        }
   }
 
   fun findAll(): List<ExistingProjectModel> {

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -15,7 +15,9 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNameInUseException
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.ApplicationStatus
 import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
@@ -378,15 +380,64 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns null if no permission to read cohort`() {
+    fun `uses cohort data even if project has an application`() {
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId1 = insertProject(participantId = participantId)
+      insertApplication(projectId = projectId1)
+
+      val expected =
+          ProjectCohortData(cohortId = cohortId, cohortPhase = CohortPhase.Phase0DueDiligence)
+      val actual = store.fetchCohortData(projectId1)
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `returns correct cohort phase for each application state`() {
+      insertApplication(projectId = projectId)
+
+      val phasesByState =
+          ApplicationStatus.entries.associateWith { state ->
+            dslContext.update(APPLICATIONS).set(APPLICATIONS.APPLICATION_STATUS_ID, state).execute()
+
+            val cohortData = store.fetchCohortData(projectId)
+
+            assertNotNull(cohortData, "Cohort data")
+            assertNull(cohortData!!.cohortId, "Cohort ID")
+
+            cohortData.cohortPhase
+          }
+
+      assertEquals(
+          mapOf(
+              ApplicationStatus.Accepted to CohortPhase.Application,
+              ApplicationStatus.CarbonEligible to CohortPhase.Application,
+              ApplicationStatus.FailedPreScreen to CohortPhase.PreScreen,
+              ApplicationStatus.IssueActive to CohortPhase.Application,
+              ApplicationStatus.IssuePending to CohortPhase.Application,
+              ApplicationStatus.IssueResolved to CohortPhase.Application,
+              ApplicationStatus.NeedsFollowUp to CohortPhase.Application,
+              ApplicationStatus.NotAccepted to CohortPhase.Application,
+              ApplicationStatus.NotSubmitted to CohortPhase.PreScreen,
+              ApplicationStatus.PassedPreScreen to CohortPhase.PreScreen,
+              ApplicationStatus.PLReview to CohortPhase.Application,
+              ApplicationStatus.PreCheck to CohortPhase.Application,
+              ApplicationStatus.ReadyForReview to CohortPhase.Application,
+              ApplicationStatus.Submitted to CohortPhase.Application,
+          ),
+          phasesByState)
+    }
+
+    @Test
+    fun `throws exception if no permission to read project`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
       val projectId1 = insertProject(participantId = participantId)
 
-      every { user.canReadCohort(any()) } returns false
+      every { user.canReadProject(projectId1) } returns false
 
-      val actual = store.fetchCohortData(projectId1)
-      assertNull(actual)
+      assertThrows<ProjectNotFoundException> { store.fetchCohortData(projectId1) }
     }
 
     @Test
@@ -399,7 +450,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns null if the project is not associated to a participant`() {
+    fun `returns null if the project is not associated to a participant and has no application`() {
       val actual = store.fetchCohortData(projectId)
       assertNull(actual)
     }


### PR DESCRIPTION
If a project isn't in a cohort but has an accelerator application, it is
considered to be in one of the two cohort phases related to applications, but the
API wasn't returning the phase as part of the project data.