### PR TITLE
Limit size of parallel test thread pool

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -2,3 +2,9 @@
 # many test-running threads as there are CPUs on the host (its default behavior).
 junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.mode.default = concurrent
+
+# Stop the test thread pool from growing over time when application code calls
+# ForkJoinPool.managedBlock(), which jOOQ's transaction management code does. By default, that
+# method grows the pool if all the threads are currently busy, which they will be during a test run.
+junit.jupiter.execution.parallel.config.dynamic.saturate = true
+junit.jupiter.execution.parallel.config.dynamic.max-pool-size-factor = 1.0


### PR DESCRIPTION
Currently, new threads are added to the thread pool for parallel test execution
over time, which causes the test suite's memory and CPU usage to grow as it runs.
In some cases, such as on CI runners, this can cause the tests to run out of
memory and abort.

Add configuration options to limit the size of the thread pool.