### PR TITLE
Skip internal-only variables for unprivileged users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -132,7 +132,7 @@ class VariableStore(
                   .where(replacementVariables.REPLACES_VARIABLE_ID.eq(ID)))
           .groupBy(STABLE_ID)
           .fetch()
-          .map { fetchVariable(it[DSL.max(ID)]!!) }
+          .mapNotNull { fetchVariable(it[DSL.max(ID)]!!) }
           .sortedBy { it.deliverablePosition }
     }
   }


### PR DESCRIPTION
If a user without permission to read internal-only variables requested the variable
list for a questionnaire deliverable that included internal-only variables, the request
would fail because the code was trying to sort them but couldn't access them.