### PR TITLE
SW-6052 Support getting specific variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ApplicationVariableValuesFetcher.kt
@@ -75,7 +75,7 @@ class ApplicationVariableValuesFetcher(
 
     val valuesByStableId: Map<String, ExistingValue> =
         variableValueStore
-            .listValues(projectId, variablesById.keys)
+            .listValues(projectId = projectId, variableIds = variablesById.keys)
             .mapNotNull { value ->
               val stableId = variablesById[value.variableId]?.stableId
               if (stableId != null) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectVariablesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectVariablesImporter.kt
@@ -74,7 +74,9 @@ class ProjectVariablesImporter(
                         "Deal $dealName has not been imported yet; import the project setup sheet first.")
             val currentValues =
                 variableValueStore
-                    .listValues(application.projectId, variables.mapNotNull { it?.id })
+                    .listValues(
+                        projectId = application.projectId,
+                        variableIds = variables.mapNotNull { it?.id })
                     .associateBy { it.variableId }
 
             val operations =

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -109,7 +109,8 @@ class VariableStore(
    *   children.
    */
   fun fetchOneVariable(variableId: VariableId, manifestId: VariableManifestId? = null): Variable {
-    return fetchVariable(variableId, manifestId) ?: throw VariableNotFoundException(variableId)
+    return fetchVariableOrNull(variableId, manifestId)
+        ?: throw VariableNotFoundException(variableId)
   }
 
   fun fetchByStableId(stableId: String): Variable? =
@@ -121,7 +122,7 @@ class VariableStore(
             .orderBy(ID.desc())
             .limit(1)
             .fetchOne(VARIABLES.ID)
-            ?.let { fetchVariable(it) }
+            ?.let { fetchVariableOrNull(it) }
       }
 
   fun fetchDeliverableVariables(deliverableId: DeliverableId): List<Variable> {
@@ -151,7 +152,7 @@ class VariableStore(
                   .where(replacementVariables.REPLACES_VARIABLE_ID.eq(ID)))
           .groupBy(STABLE_ID)
           .fetch()
-          .mapNotNull { fetchVariable(it[DSL.max(ID)]!!) }
+          .mapNotNull { fetchVariableOrNull(it[DSL.max(ID)]!!) }
           .sortedBy { it.deliverablePosition }
     }
   }
@@ -175,7 +176,7 @@ class VariableStore(
                   .and(VARIABLE_SECTIONS.PARENT_VARIABLE_ID.isNotNull))
           .orderBy(POSITION)
           .fetch()
-          .mapNotNull { fetchVariable(it[VARIABLE_ID]!!, it[VARIABLE_MANIFEST_ID]!!) }
+          .mapNotNull { fetchVariableOrNull(it[VARIABLE_ID]!!, it[VARIABLE_MANIFEST_ID]!!) }
     }
   }
 
@@ -201,7 +202,7 @@ class VariableStore(
                   .and(VARIABLE_SECTIONS.PARENT_VARIABLE_ID.isNotNull))
           .orderBy(POSITION)
           .fetch(VARIABLE_ID.asNonNullable())
-          .mapNotNull { fetchVariable(it, manifestId) }
+          .mapNotNull { fetchVariableOrNull(it, manifestId) }
     }
   }
 
@@ -224,7 +225,7 @@ class VariableStore(
                   .where(VARIABLE_ID.eq(VARIABLE_TABLE_COLUMNS.VARIABLE_ID)))
           .orderBy(POSITION)
           .fetch(VARIABLE_ID.asNonNullable())
-          .mapNotNull { fetchVariable(it, manifestId) }
+          .mapNotNull { fetchVariableOrNull(it, manifestId) }
     }
   }
 
@@ -245,7 +246,7 @@ class VariableStore(
                   .where(ID.eq(VARIABLE_TABLE_COLUMNS.VARIABLE_ID)))
           .groupBy(STABLE_ID)
           .fetch(DSL.max(ID))
-          .mapNotNull { variableId -> variableId?.let { fetchVariable(it) } }
+          .mapNotNull { variableId -> variableId?.let { fetchVariableOrNull(it) } }
     }
   }
 
@@ -271,7 +272,7 @@ class VariableStore(
         .orderBy(
             VARIABLE_VALUES.VARIABLE_ID, VARIABLE_VALUES.LIST_POSITION, VARIABLE_VALUES.ID.desc())
         .fetchSet(VARIABLE_SECTION_VALUES.USED_VARIABLE_ID.asNonNullable())
-        .mapNotNull { fetchVariable(it) }
+        .mapNotNull { fetchVariableOrNull(it) }
   }
 
   fun importVariable(variable: VariablesRow): VariableId {
@@ -346,7 +347,7 @@ class VariableStore(
   }
 
   /** Returns variable if found. */
-  private fun fetchVariable(
+  fun fetchVariableOrNull(
       variableId: VariableId,
       manifestId: VariableManifestId? = null
   ): Variable? {

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -467,6 +467,73 @@ class ValuesControllerTest : ControllerIntegrationTest() {
                   .trimIndent(),
               strict = true)
     }
+
+    @Test
+    fun `returns values across multiple deliverables if variable IDs are specified`() {
+      insertModule()
+      val deliverableId1 = insertDeliverable()
+      val deliverable1VariableId1 = insertTextVariable(deliverableId = deliverableId1)
+      val deliverable1ValueId1 =
+          insertValue(variableId = deliverable1VariableId1, textValue = "Value 1")
+      val deliverableId2 = insertDeliverable()
+      val deliverable2VariableId1 = insertTextVariable(deliverableId = deliverableId2)
+      val deliverable2ValueId1 =
+          insertValue(variableId = deliverable2VariableId1, textValue = "Value 3")
+
+      // Has a value, but we won't request it so it shouldn't be included in the response.
+      val deliverable1VariableId2 = insertTextVariable(deliverableId = deliverableId1)
+      val deliverable2ValueId2 =
+          insertValue(variableId = deliverable1VariableId2, textValue = "Value 2")
+
+      // Has no value; we'll request it but it shouldn't be included in the response.
+      val deliverable2VariableId2 = insertTextVariable(deliverableId = deliverableId2)
+
+      val queryString =
+          listOf(
+                  deliverable1VariableId1,
+                  deliverable2VariableId1,
+                  deliverable2VariableId2,
+              )
+              .joinToString(separator = "&") { "variableId=$it" }
+
+      mockMvc
+          .get("${path()}?$queryString")
+          .andExpectJson(
+              """
+                {
+                  "nextValueId": ${deliverable2ValueId2.value + 1},
+                  "values": [
+                    {
+                      "variableId": $deliverable1VariableId1,
+                      "status": "Not Submitted",
+                      "values": [
+                        {
+                          "id": $deliverable1ValueId1,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Value 1"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $deliverable2VariableId1,
+                      "status": "Not Submitted",
+                      "values": [
+                        {
+                          "id": $deliverable2ValueId1,
+                          "listPosition": 0,
+                          "type": "Text",
+                          "textValue": "Value 3"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "ok"
+                }
+              """
+                  .trimIndent(),
+              strict = true)
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStoreTest.kt
@@ -358,7 +358,10 @@ class VariableValueStoreTest : DatabaseTest(), RunsAsUser {
         store.updateValues(listOf(DeleteValueOperation(inserted.projectId, row0Id)))
 
         val updatedValues =
-            store.listValues(inserted.projectId, listOf(tableVariableId, columnVariableId), false)
+            store.listValues(
+                projectId = inserted.projectId,
+                variableIds = listOf(tableVariableId, columnVariableId),
+                includeDeletedValues = false)
         assertEquals(emptyList<ExistingValue>(), updatedValues)
       }
     }


### PR DESCRIPTION
Currently, the APIs for fetching variables and variable values operate in bulk:
they return all the variables for a given deliverable or document.

To support cross-deliverable variable dependencies, where the client needs to
reference the value of a variable that isn't part of the deliverable it's focused
on, add optional `variableId` query parameters to both the variable and variable
value GET endpoints to access variables regardless of which deliverable or
document they're in. Multiple variables may be fetched in one request by
specifying the `variableId` parameter more than once in the URL.