### PR TITLE
SW-6052 Fetch variables by stable ID

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -51,9 +51,16 @@ class VariablesController(
       @RequestParam documentId: DocumentId?,
       @Parameter(
           description =
+              "If specified, return the definition of a specific variable given its stable ID. " +
+                  "May be specified more than once to return multiple variables. deliverableId " +
+                  "and documentId are ignored if this is specified.")
+      @RequestParam
+      stableId: List<String>?,
+      @Parameter(
+          description =
               "If specified, return the definition of a specific variable. May be specified more " +
-                  "than once to return multiple variables. deliverableId and documentId are " +
-                  "ignored if this is specified.")
+                  "than once to return multiple variables. deliverableId, documentId, and " +
+                  "stableId are ignored if this is specified.")
       @RequestParam
       variableId: List<VariableId>?,
   ): ListVariablesResponsePayload {
@@ -64,6 +71,8 @@ class VariablesController(
     val variables =
         if (!variableId.isNullOrEmpty()) {
           variableId.distinct().mapNotNull { variableStore.fetchVariableOrNull(it) }
+        } else if (!stableId.isNullOrEmpty()) {
+          stableId.distinct().mapNotNull { variableStore.fetchByStableId(it) }
         } else if (deliverableId != null) {
           variableStore.fetchDeliverableVariables(deliverableId)
         } else if (documentId != null) {


### PR DESCRIPTION
Add the ability to fetch specific variables and their values by stable ID
regardless of which deliverable they're in. Stable IDs are specified using the
new optional `stableId` query string parameter on the GET endpoints for variables
and values.

Multiple variables may be fetched in one request by adding the `stableId` query
string parameter more than once in the URL.