### PR TITLE
Support regular events in RateLimitedEventPublisher

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SpeciesNotifier.kt
@@ -18,7 +18,7 @@ class SpeciesNotifier(
   /** Schedules a "species added" notification when a new species is added to a project. */
   @EventListener
   fun on(event: ParticipantProjectSpeciesAddedEvent) {
-    rateLimitedEventPublisher.publishOrDefer(
+    rateLimitedEventPublisher.publishEvent(
         ParticipantProjectSpeciesAddedToProjectNotificationDueEvent(
             deliverableId = event.deliverableId,
             projectId = event.participantProjectSpecies.projectId,
@@ -36,7 +36,7 @@ class SpeciesNotifier(
           submissionStore.fetchMostRecentSpeciesDeliverableSubmission(event.projectId)
 
       if (deliverableSubmission != null) {
-        rateLimitedEventPublisher.publishOrDefer(
+        rateLimitedEventPublisher.publishEvent(
             ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent(
                 deliverableSubmission.deliverableId,
                 event.projectId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionNotifier.kt
@@ -16,21 +16,21 @@ class SubmissionNotifier(
   /** Schedules a "ready for review" notification when a document is uploaded. */
   @EventListener
   fun on(event: DeliverableDocumentUploadedEvent) {
-    rateLimitedEventPublisher.publishOrDefer(
+    rateLimitedEventPublisher.publishEvent(
         DeliverableReadyForReviewEvent(event.deliverableId, event.projectId))
   }
 
   /** Schedules a "ready for review" notification when a question is answered. */
   @EventListener
   fun on(event: QuestionsDeliverableSubmittedEvent) {
-    rateLimitedEventPublisher.publishOrDefer(
+    rateLimitedEventPublisher.publishEvent(
         DeliverableReadyForReviewEvent(event.deliverableId, event.projectId))
   }
 
   /** Schedules a "ready for review" notification when a question is answered. */
   @EventListener
   fun on(event: QuestionsDeliverableReviewedEvent) {
-    rateLimitedEventPublisher.publishOrDefer(
+    rateLimitedEventPublisher.publishEvent(
         QuestionsDeliverableStatusUpdatedEvent(event.deliverableId, event.projectId))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisher.kt
+++ b/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisher.kt
@@ -1,22 +1,28 @@
 package com.terraformation.backend.ratelimit
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 
 /**
- * Limits the rate of events, deferring them if they are published too often.
+ * Publishes application events. For most events, this can be used in place of
+ * [ApplicationEventPublisher]. But for events that implement [RateLimitedEvent], this class defers
+ * them if they are published too often.
  *
  * The basic flow looks like:
  * 1. Construct a [RateLimitedEvent] that identifies the target of the rate limit, e.g., a user ID /
  *    project ID pair.
- * 2. Call [publishOrDefer] with the event.
+ * 2. Call [publishEvent] with the event.
  * 3. Handle the event in an [EventListener]-annotated listener method.
  *
- * If the event hasn't been published recently with the same rate limit target, [publishOrDefer]
+ * If the event hasn't been published recently with the same rate limit target, [publishEvent]
  * publishes it immediately.
  *
  * Otherwise, the event is stored in the database (possibly after being combined with an existing
  * pending event) and will be published once the minimum interval between events has elapsed.
  */
 interface RateLimitedEventPublisher {
-  fun <T : RateLimitedEvent<T>> publishOrDefer(event: T)
+  fun <T : RateLimitedEvent<T>> publishEvent(event: T)
+
+  /** Publishes a non-rate-limited event immediately. */
+  fun publishEvent(event: Any)
 }

--- a/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherImpl.kt
+++ b/src/main/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherImpl.kt
@@ -32,7 +32,11 @@ class RateLimitedEventPublisherImpl(
 ) : RateLimitedEventPublisher {
   private val log = perClassLogger()
 
-  override fun <T : RateLimitedEvent<T>> publishOrDefer(event: T) {
+  override fun publishEvent(event: Any) {
+    eventPublisher.publishEvent(event)
+  }
+
+  override fun <T : RateLimitedEvent<T>> publishEvent(event: T) {
     publishOrDefer(event, true)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -22,7 +22,7 @@ class TestEventPublisher : ApplicationEventPublisher, RateLimitedEventPublisher 
     publishedEvents.add(event)
   }
 
-  override fun <T : RateLimitedEvent<T>> publishOrDefer(event: T) {
+  override fun <T : RateLimitedEvent<T>> publishEvent(event: T) {
     publishedEvents.add(event)
   }
 


### PR DESCRIPTION
Allow regular events to be published using `RateLimitedEventPublisher` so that
callers that need a mix of immediate and rate-limited publication don't have to
depend on both `ApplicationEventPublisher` and `RateLimitedEventPublisher`.

Rename `publishOrDefer` to `publishEvent` to match the regular event publishing
API; callers shouldn't have to care if the event will be deferred or not.