### PR TITLE
SW-5585 Publish event on variable edit in completed section

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/CompletedSectionVariableUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/CompletedSectionVariableUpdatedEvent.kt
@@ -1,0 +1,33 @@
+package com.terraformation.backend.documentproducer.event
+
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.DocumentId
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.ratelimit.RateLimitedEvent
+import java.time.Duration
+
+/**
+ * Published when a variable that's referenced in a section that's marked as completed, or in a
+ * child section that's marked as completed, is updated.
+ */
+data class CompletedSectionVariableUpdatedEvent(
+    val documentId: DocumentId,
+    val projectId: ProjectId,
+    /** The section that references the updated variable. */
+    val referencingSectionVariableId: VariableId,
+    /**
+     * The section that was affected. This may be a parent of the section that actually references
+     * the updated variable.
+     */
+    val sectionVariableId: VariableId,
+) : RateLimitedEvent<CompletedSectionVariableUpdatedEvent> {
+  override fun getRateLimitKey(): Any {
+    // Rate limit on the affected section, not the referencing section, so that parent section
+    // owners don't get repeatedly notified if a variable is referenced in multiple child sections.
+    return mapOf("documentId" to documentId, "sectionVariableId" to sectionVariableId)
+  }
+
+  override fun getMinimumInterval(): Duration {
+    return Duration.ofMinutes(10)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculatorTest.kt
@@ -43,8 +43,6 @@ class DocumentUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
     DocumentStore(clock, documentSavedVersionsDao, documentsDao, dslContext, documentTemplatesDao)
   }
 
-  private val eventPublisher = TestEventPublisher()
-
   private val variableStore: VariableStore by lazy {
     VariableStore(
         dslContext,
@@ -63,7 +61,7 @@ class DocumentUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
     VariableValueStore(
         clock,
         dslContext,
-        eventPublisher,
+        TestEventPublisher(),
         variableImageValuesDao,
         variableLinkValuesDao,
         variablesDao,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/VariableUpgradeCalculatorTest.kt
@@ -29,7 +29,6 @@ class VariableUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
-  private val eventPublisher = TestEventPublisher()
 
   private val variableStore: VariableStore by lazy {
     VariableStore(
@@ -49,7 +48,7 @@ class VariableUpgradeCalculatorTest : DatabaseTest(), RunsAsUser {
     VariableValueStore(
         clock,
         dslContext,
-        eventPublisher,
+        TestEventPublisher(),
         variableImageValuesDao,
         variableLinkValuesDao,
         variablesDao,


### PR DESCRIPTION
When a variable is referenced in a section that's marked as completed, and the
variable's value is updated, publish events about the update for the section
and its parents, if any. This will be used to generate notifications about the
edits.