### PR TITLE
Upgrade section default value variable references

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
@@ -31,6 +31,8 @@ class VariableService(
           operationsByProject.values.forEach { operations ->
             variableValueStore.updateValues(operations, triggerWorkflows = false)
           }
+
+          variableValueStore.upgradeSectionDefaultValues(result.replacements)
         }
       }
 
@@ -71,6 +73,8 @@ class VariableService(
               operationsByProject.values.forEach { operations ->
                 variableValueStore.updateValues(operations, triggerWorkflows = false)
               }
+
+              variableValueStore.upgradeSectionDefaultValues(replacements)
             }
       }
     }

--- a/src/main/resources/db/migration/0300/V308__UsedVariableIndex.sql
+++ b/src/main/resources/db/migration/0300/V308__UsedVariableIndex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON docprod.variable_section_default_values (used_variable_id);


### PR DESCRIPTION
When a new version of the all-variables list is uploaded, there may be new
versions of variables that are referenced in default section values. Replace
those references with the updated versions of the variables so that newly-created
documents don't start off with references to outdated variables.

This change does not affect references in any existing documents, just the default
ones that are used at document creation time.