### PR TITLE
SW-5585 Notify completed parent section owners

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend
 import com.terraformation.backend.ratelimit.RateLimitedEvent
 import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.springframework.context.ApplicationEventPublisher
 
 /**
@@ -90,6 +91,14 @@ class TestEventPublisher : ApplicationEventPublisher, RateLimitedEventPublisher 
     if (!publishedEvents.any(predicate)) {
       // Fail with an assertion that shows which events were actually published.
       assertEquals("Event matching predicate", publishedEvents as Any, message)
+    }
+  }
+
+  /** Asserts that a particular event has not been published. */
+  fun assertEventNotPublished(event: Any, message: String = "Expected event not to be published") {
+    if (event in publishedEvents) {
+      // Fail with an assertion that shows which events were actually published.
+      assertNotEquals(listOf(event), publishedEvents, message)
     }
   }
 


### PR DESCRIPTION
The notification logic in commit 9f22cf7 wasn't quite right: it only notified
owners of parent sections about edits to variables referenced by child sections if
the child sections were marked as completed. But the typical scenario is that the
child section has no completion status at all (because it's unnumbered) and the
parent section is marked as completed.

Change the code to always look at the completion status of parent sections
regardless of the status of the child section that actually has the reference to
the updated variable.