### PR TITLE
SW-6055 Add cohort module management endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/CohortsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/CohortsController.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.api
 
+import com.terraformation.backend.accelerator.db.CohortModuleStore
 import com.terraformation.backend.accelerator.db.CohortStore
 import com.terraformation.backend.accelerator.model.CohortDepth
 import com.terraformation.backend.accelerator.model.ExistingCohortModel
@@ -11,13 +12,16 @@ import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.util.orNull
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.ws.rs.BadRequestException
 import java.time.Instant
+import java.time.LocalDate
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -31,13 +35,16 @@ import org.springframework.web.bind.annotation.RestController
 @AcceleratorEndpoint
 @RequestMapping("/api/v1/accelerator/cohorts")
 @RestController
-class CohortsController(private val cohortStore: CohortStore) {
+class CohortsController(
+    private val cohortModuleStore: CohortModuleStore,
+    private val cohortStore: CohortStore,
+) {
   @ApiResponse200
   @ApiResponse404
   @GetMapping("/{cohortId}")
   @Operation(summary = "Gets information about a single cohort.")
   fun getCohort(
-      @PathVariable("cohortId") cohortId: CohortId,
+      @PathVariable cohortId: CohortId,
       @Parameter(
           description =
               "If specified, retrieve associated entities to the supplied depth. For example, " +
@@ -76,7 +83,7 @@ class CohortsController(private val cohortStore: CohortStore) {
   @ApiResponse404
   @DeleteMapping("/{cohortId}")
   @Operation(summary = "Deletes a single cohort.")
-  fun deleteCohort(@PathVariable("cohortId") cohortId: CohortId): SimpleSuccessResponsePayload {
+  fun deleteCohort(@PathVariable cohortId: CohortId): SimpleSuccessResponsePayload {
     cohortStore.delete(cohortId)
     return SimpleSuccessResponsePayload()
   }
@@ -86,11 +93,44 @@ class CohortsController(private val cohortStore: CohortStore) {
   @PutMapping("/{cohortId}")
   @Operation(summary = "Updates the information within a single cohort.")
   fun updateCohort(
-      @PathVariable("cohortId") cohortId: CohortId,
+      @PathVariable cohortId: CohortId,
       @RequestBody payload: UpdateCohortRequestPayload
   ): CohortResponsePayload {
     cohortStore.update(cohortId, payload::applyChanges)
     return getCohort(cohortId)
+  }
+
+  @ApiResponse200
+  @ApiResponse404
+  @Operation(
+      summary = "Updates the information about a module's use by a cohort.",
+      description = "Adds the module to the cohort if it is not already associated.")
+  @PutMapping("/{cohortId}/modules/{moduleId}")
+  fun updateCohortModule(
+      @PathVariable cohortId: CohortId,
+      @PathVariable moduleId: ModuleId,
+      @RequestBody payload: UpdateCohortModuleRequestPayload
+  ): SimpleSuccessResponsePayload {
+    if (payload.endDate < payload.startDate) {
+      throw BadRequestException("Start date must be before end date")
+    }
+
+    cohortModuleStore.assign(cohortId, moduleId, payload.title, payload.startDate, payload.endDate)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse404
+  @DeleteMapping("/{cohortId}/modules/{moduleId}")
+  @Operation(summary = "Deletes a module from a cohort if it is currently associated.")
+  fun deleteCohortModule(
+      @PathVariable cohortId: CohortId,
+      @PathVariable moduleId: ModuleId,
+  ): SimpleSuccessResponsePayload {
+    cohortModuleStore.remove(cohortId, moduleId)
+
+    return SimpleSuccessResponsePayload()
   }
 }
 
@@ -128,6 +168,12 @@ data class CreateCohortRequestPayload(
           phase = phase,
       )
 }
+
+data class UpdateCohortModuleRequestPayload(
+    val endDate: LocalDate,
+    val startDate: LocalDate,
+    val title: String,
+)
 
 data class UpdateCohortRequestPayload(
     val name: String,


### PR DESCRIPTION
To support moving more cohort management into the web app, add API endpoints
for associating modules with cohorts and removing the associations. This mirrors
the cohort/module operations in the admin UI.