### PR TITLE
SW-6061 Allow accelerator admins to not trigger workflows after updating variable values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -198,7 +198,7 @@ data class UpdateVariableValuesRequestPayload(
         description =
             "Whether to update variable statuses. Defaults to true. Accelerator admins can " +
                 "bypass the status updates by setting the flag to false.")
-    val updateStatuses: Boolean = true,
+    val updateStatuses: Boolean? = true,
 ) {
   companion object {
     /** Examples are added to the OpenAPI schema programmatically in OpenApiConfig. */

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -162,7 +162,7 @@ class ValuesController(
 
     variableValueService.validate(operations)
 
-    variableValueStore.updateValues(operations)
+    variableValueStore.updateValues(operations, payload.triggerWorkflow)
 
     return SimpleSuccessResponsePayload()
   }
@@ -194,6 +194,11 @@ data class UpdateVariableValuesRequestPayload(
                         "applied in order, and atomically: if any of them fail, none of them " +
                         "will be applied."))
     val operations: List<ValueOperationPayload>,
+    @Schema(
+        description =
+            "Whether to trigger workflow. Defaults to true. Accelerator admins can bypass the " +
+                "workflows by setting the flag to false.")
+    val triggerWorkflow: Boolean = true,
 ) {
   companion object {
     /** Examples are added to the OpenAPI schema programmatically in OpenApiConfig. */

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -198,7 +198,7 @@ data class UpdateVariableValuesRequestPayload(
         description =
             "Whether to update variable statuses. Defaults to true. Accelerator admins can " +
                 "bypass the status updates by setting the flag to false.")
-    val updateStatuses: Boolean?,
+    val updateStatuses: Boolean? = true,
 ) {
   companion object {
     /** Examples are added to the OpenAPI schema programmatically in OpenApiConfig. */

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -162,7 +162,7 @@ class ValuesController(
 
     variableValueService.validate(operations)
 
-    variableValueStore.updateValues(operations, payload.triggerWorkflow)
+    variableValueStore.updateValues(operations, payload.updateStatuses)
 
     return SimpleSuccessResponsePayload()
   }
@@ -196,9 +196,9 @@ data class UpdateVariableValuesRequestPayload(
     val operations: List<ValueOperationPayload>,
     @Schema(
         description =
-            "Whether to trigger workflow. Defaults to true. Accelerator admins can bypass the " +
-                "workflows by setting the flag to false.")
-    val triggerWorkflow: Boolean = true,
+            "Whether to update variable statuses. Defaults to true. Accelerator admins can " +
+                "bypass the status updates by setting the flag to false.")
+    val updateStatuses: Boolean = true,
 ) {
   companion object {
     /** Examples are added to the OpenAPI schema programmatically in OpenApiConfig. */

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -162,7 +162,7 @@ class ValuesController(
 
     variableValueService.validate(operations)
 
-    variableValueStore.updateValues(operations, payload.updateStatuses)
+    variableValueStore.updateValues(operations, payload.updateStatuses ?: true)
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -198,7 +198,7 @@ data class UpdateVariableValuesRequestPayload(
         description =
             "Whether to update variable statuses. Defaults to true. Accelerator admins can " +
                 "bypass the status updates by setting the flag to false.")
-    val updateStatuses: Boolean? = true,
+    val updateStatuses: Boolean?,
 ) {
   companion object {
     /** Examples are added to the OpenAPI schema programmatically in OpenApiConfig. */

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.documentproducer.db
 
 import com.terraformation.backend.accelerator.event.VariableValueUpdatedEvent
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -444,6 +445,11 @@ class VariableValueStore(
       triggerWorkflows: Boolean = true
   ): List<ExistingValue> {
     val projectId = operations.firstOrNull()?.projectId ?: return emptyList()
+
+    if (!triggerWorkflows) {
+      // Require internal workflow permission to not use default workflow update
+      requirePermissions { updateInternalVariableWorkflowDetails(projectId) }
+    }
 
     val latestRowIds = mutableMapOf<VariableId, VariableValueId>()
     if (operations.any { it.projectId != projectId }) {


### PR DESCRIPTION
Added a flag in our update values endpoint to bypass running update statuses. This is intended for use by accelerator admins while reviewing variable values.

1) We reused the existing `triggerWorkflow` flag that is added for importing and upgrading variables
2) Since we are exposing the flag, we added a permission for by passing the workflow. We reused `updateInternalWorkflowDetails`. (since it is choosing not to update here)
