### PR TITLE
SW-6066 Added events and updater to handle file naming updates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/Constants.kt
@@ -4,3 +4,6 @@ import java.time.Duration
 
 /** Lead time for module event STARTING_SOON and notifications state */
 val MODULE_EVENT_NOTIFICATION_LEAD_TIME: Duration = Duration.ofMinutes(15)
+
+/** Suffix added to the project's file naming when creating new folders for their files. */
+const val INTERNAL_FOLDER_SUFFIX = " [Internal]"

--- a/src/main/kotlin/com/terraformation/backend/accelerator/GoogleFolderUpdater.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/GoogleFolderUpdater.kt
@@ -1,0 +1,50 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.db.ApplicationStore
+import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
+import com.terraformation.backend.accelerator.event.ApplicationInternalNameUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectFileNamingUpdatedEvent
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.file.GoogleDriveWriter
+import java.net.URI
+import javax.inject.Named
+import org.springframework.context.event.EventListener
+
+/** Event listeners for updating Google Drive folder when the names are changed */
+@Named
+class GoogleFolderUpdater(
+    private val applicationStore: ApplicationStore,
+    private val googleDriveWriter: GoogleDriveWriter,
+    private val projectAcceleratorDetailsStore: ProjectAcceleratorDetailsStore,
+    private val systemUser: SystemUser,
+) {
+
+  @EventListener
+  fun on(event: ApplicationInternalNameUpdatedEvent) {
+    systemUser.run {
+      val application = applicationStore.fetchOneById(event.applicationId)
+      val projectDetails = projectAcceleratorDetailsStore.fetchOneById(application.projectId)
+
+      // If a project has a Google folder, but doesn't have a file naming set up
+      if (projectDetails.googleFolderUrl != null && projectDetails.fileNaming == null) {
+        renameFolder(projectDetails.googleFolderUrl, application.internalName)
+      }
+    }
+  }
+
+  @EventListener
+  fun on(event: ParticipantProjectFileNamingUpdatedEvent) {
+    systemUser.run {
+      val projectDetails = projectAcceleratorDetailsStore.fetchOneById(event.projectId)
+      if (projectDetails.googleFolderUrl != null && projectDetails.fileNaming != null) {
+        renameFolder(projectDetails.googleFolderUrl, projectDetails.fileNaming)
+      }
+    }
+  }
+
+  private fun renameFolder(folderUrl: URI, fileNaming: String) {
+    val folderName = fileNaming + INTERNAL_FOLDER_SUFFIX
+    val fileId = googleDriveWriter.getFileIdForFolderUrl(folderUrl)
+    googleDriveWriter.renameFile(fileId, folderName)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -52,9 +52,6 @@ class SubmissionService(
 ) {
   private val log = perClassLogger()
 
-  /** Suffix added to the project's file naming when creating new folders for their files. */
-  private val newFolderSuffix = " [Internal]"
-
   /**
    * Matches characters that aren't allowed in filenames.
    *
@@ -320,7 +317,7 @@ class SubmissionService(
    * @return The URL of the new folder, or null if it couldn't be created.
    */
   private fun createGoogleDriveFolder(projectId: ProjectId, fileNaming: String): URI? {
-    val folderName = fileNaming + newFolderSuffix
+    val folderName = fileNaming + INTERNAL_FOLDER_SUFFIX
     val parentFolderId = config.accelerator.applicationGoogleFolderId ?: return null
     val driveId = googleDriveWriter.getDriveIdForFile(parentFolderId)
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.db
 
+import com.terraformation.backend.accelerator.event.ParticipantProjectFileNamingUpdatedEvent
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
@@ -16,11 +17,13 @@ import java.net.URI
 import java.time.InstantSource
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 
 @Named
 class ProjectAcceleratorDetailsStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
   /**
    * Returns the accelerator details for a project. If the project doesn't have any details yet,
@@ -126,6 +129,10 @@ class ProjectAcceleratorDetailsStore(
               .set(updated.landUseModelTypes.map { ProjectLandUseModelTypesRecord(projectId, it) })
               .execute()
         }
+      }
+
+      if (existing.fileNaming != updated.fileNaming) {
+        eventPublisher.publishEvent(ParticipantProjectFileNamingUpdatedEvent(projectId))
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ApplicationInternalNameUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ApplicationInternalNameUpdatedEvent.kt
@@ -1,0 +1,5 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.ApplicationId
+
+data class ApplicationInternalNameUpdatedEvent(val applicationId: ApplicationId)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectFileNamingUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ParticipantProjectFileNamingUpdatedEvent.kt
@@ -1,0 +1,5 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.default_schema.ProjectId
+
+data class ParticipantProjectFileNamingUpdatedEvent(val projectId: ProjectId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.db.ApplicationStore
 import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
 import com.terraformation.backend.accelerator.model.ApplicationSubmissionResult
@@ -43,10 +44,11 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
   private val config = mockk<TerrawareServerConfig>()
   private val countryDetector = mockk<CountryDetector>()
+  private val eventPublisher = TestEventPublisher()
   private val preScreenBoundarySubmissionFetcher = mockk<PreScreenBoundarySubmissionFetcher>()
   private val hubSpotService = mockk<HubSpotService>()
   private val projectAcceleratorDetailsStore: ProjectAcceleratorDetailsStore by lazy {
-    ProjectAcceleratorDetailsStore(clock, dslContext)
+    ProjectAcceleratorDetailsStore(clock, dslContext, eventPublisher)
   }
   private val service: ApplicationService by lazy {
     ApplicationService(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/GoogleFolderUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/GoogleFolderUpdaterTest.kt
@@ -1,0 +1,132 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.ApplicationStore
+import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
+import com.terraformation.backend.accelerator.event.ApplicationInternalNameUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectFileNamingUpdatedEvent
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.ApplicationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.file.GoogleDriveWriter
+import com.terraformation.backend.gis.CountryDetector
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.net.URI
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class GoogleFolderUpdaterTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val googleDriveWriter: GoogleDriveWriter = mockk()
+
+  private val updater: GoogleFolderUpdater by lazy {
+    GoogleFolderUpdater(
+        ApplicationStore(
+            clock,
+            countriesDao,
+            CountryDetector(),
+            dslContext,
+            eventPublisher,
+            Messages(),
+            organizationsDao,
+        ),
+        googleDriveWriter,
+        ProjectAcceleratorDetailsStore(clock, dslContext, eventPublisher),
+        SystemUser(usersDao))
+  }
+
+  private lateinit var projectId: ProjectId
+  private lateinit var applicationId: ApplicationId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    projectId = insertProject()
+    applicationId = insertApplication(internalName = "XXX_Organization")
+
+    every { googleDriveWriter.getFileIdForFolderUrl(any()) } returns "fileId"
+    every { googleDriveWriter.renameFile("fileId", any()) } returns Unit
+  }
+
+  @Nested
+  inner class ApplicationInternalNameUpdated {
+    @Test
+    fun `Updates Google folder name if drive url exists, but project file naming does not`() {
+      insertProjectAcceleratorDetails(
+          projectId = projectId, googleFolderUrl = URI.create("https://terraformation.com"))
+
+      updater.on(ApplicationInternalNameUpdatedEvent(applicationId))
+
+      verify(exactly = 1) {
+        googleDriveWriter.renameFile("fileId", "XXX_Organization$INTERNAL_FOLDER_SUFFIX")
+      }
+    }
+
+    @Test
+    fun `Does not update Google folder name if project file naming exists`() {
+      insertProjectAcceleratorDetails(
+          projectId = projectId,
+          googleFolderUrl = URI.create("https://terraformation.com"),
+          fileNaming = "Existing file naming")
+
+      updater.on(ApplicationInternalNameUpdatedEvent(applicationId))
+
+      verify(exactly = 0) { googleDriveWriter.renameFile(any(), any()) }
+    }
+
+    @Test
+    fun `Does not update Google folder name if drive url does not exist`() {
+      updater.on(ApplicationInternalNameUpdatedEvent(applicationId))
+
+      verify(exactly = 0) { googleDriveWriter.renameFile(any(), any()) }
+    }
+  }
+
+  @Nested
+  inner class ParticipantProjectNamingUpdated {
+    @Test
+    fun `Updates Google folder name if drive url and project naming exists`() {
+      insertProjectAcceleratorDetails(
+          projectId = projectId,
+          googleFolderUrl = URI.create("https://terraformation.com"),
+          fileNaming = "New file naming")
+
+      updater.on(ParticipantProjectFileNamingUpdatedEvent(projectId))
+
+      verify(exactly = 1) {
+        googleDriveWriter.renameFile("fileId", "New file naming$INTERNAL_FOLDER_SUFFIX")
+      }
+    }
+
+    @Test
+    fun `Does not update Google folder name if project file naming does not exist`() {
+      insertProjectAcceleratorDetails(
+          projectId = projectId, googleFolderUrl = URI.create("https://terraformation.com"))
+
+      updater.on(ParticipantProjectFileNamingUpdatedEvent(projectId))
+
+      verify(exactly = 0) { googleDriveWriter.renameFile(any(), any()) }
+    }
+
+    @Test
+    fun `Does not update Google folder name if drive url does not exist`() {
+      insertProjectAcceleratorDetails(projectId = projectId, fileNaming = "New file naming")
+
+      updater.on(ParticipantProjectFileNamingUpdatedEvent(projectId))
+
+      verify(exactly = 0) { googleDriveWriter.renameFile(any(), any()) }
+    }
+  }
+}


### PR DESCRIPTION
This feature keeps our project naming/application internal name in sync with the actual folder name in our Google Drive.

It depends on an already existing Google drive folder, and attempts to rename the folder according to the following order
1) Project naming if it is set
2) Application internal name (which should be always set)

This uses an event publisher/listener, because it removes a problem with stale data and race conditions. It can technically still happen if one process reads before another process updates it, but the update should fire a new event and will overwrite it basically.

