### PR TITLE
SW-6099 Added feature to specify grid origin when importing planting sites

### DIFF
--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -256,6 +256,12 @@
     <label for="siteName">Name</label>
     <input type="text" name="siteName" id="siteName" required/>
     <br/>
+    Grid Origin (optional). To specify grid origin for generating monitoring plots.
+    <label for="gridOriginLat">Latitude</label>
+    <input type="text" name="gridOriginLat" id="gridOriginLat"/>
+    <label for="gridOriginLong">Longitude</label>
+    <input type="text" name="gridOriginLong" id="gridOriginLong"/>
+    <br/>
     <label for="zipfile">Zipfile</label>
     <input type="file" name="zipfile" id="zipfile" required/>
     Must contain either one or two shapefiles (exclusions shapefile is optional) and their

--- a/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
@@ -7,6 +7,7 @@ import org.geotools.referencing.CRS
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.geom.PrecisionModel
 
@@ -91,5 +92,10 @@ class ShapefileGenerator(
    */
   fun multiPolygon(vararg points: Pair<Int, Int>): MultiPolygon {
     return geometryFactory.createMultiPolygon(arrayOf(polygon(*points)))
+  }
+
+  /** Returns a point in UTM 20S coordinate space. */
+  fun point(point: Pair<Int, Int>): Point {
+    return geometryFactory.createPoint(Coordinate(point.first.toDouble(), point.second.toDouble()))
   }
 }


### PR DESCRIPTION
Our plot size detection uses a grid system that is aligned to the bounding box of the planting site boundary. 

For a small bounding site, this can cause issues because the grid alignment may lead to a lack of solutions.

This temporary fix adds the ability for the user to specify a grid origin point (easiest way is to use a SW corner of a valid permanent plot). Screenshot belows show the lat-long to make this work for this site.

In longer term, a more complete solution is to think about ways to automatically compute a grid system that will not split up potential solution (likely some topography/convex hull problem so maybe this is not worth the effort at all).

But given that this is a very small edge case for very small planting sites. This should be okay for now. 

![Screenshot 2024-10-07 at 4.04.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NOxkRPuhAfT4F7nmdXtG/1cb6269b-65b7-4b29-be6b-53e98a2eb3fa.png)

