### PR TITLE
SW-6146 Remove unused list of supported locales

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Locales.kt
@@ -9,14 +9,6 @@ import org.springframework.context.i18n.LocaleContextHolder
 
 object Locales {
   val GIBBERISH = Locale.forLanguageTag("gx")
-  val SPANISH = Locale.forLanguageTag("es")
-
-  val supported =
-      listOf(
-          Locale.ENGLISH,
-          SPANISH,
-          GIBBERISH,
-      )
 }
 
 /**


### PR DESCRIPTION
We used to configure Spring with an explicit list of supported locales, but we
removed that in commit 51b589f7 to support adding country codes to locales to get
country-specific date and number formatting.

Remove the list of locales we used to pass to Spring; people might think they
need to edit it when adding languages, when in fact it isn't referenced anywhere.