### PR TITLE
Remove references to obsolete javax.inject package

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamer.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamer.kt
@@ -15,10 +15,10 @@ import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.file.GoogleDriveWriter
 import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
 import java.net.URI
 import java.time.LocalDate
 import java.time.ZoneOffset
-import javax.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.springframework.context.event.EventListener

--- a/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/DeliverableService.kt
@@ -14,7 +14,7 @@ import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.documentproducer.event.QuestionsDeliverableSubmittedEvent
-import javax.inject.Named
+import jakarta.inject.Named
 import org.springframework.context.ApplicationEventPublisher
 
 @Named

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ModuleEventService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ModuleEventService.kt
@@ -7,8 +7,8 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.accelerator.EventStatus
 import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
 import java.time.InstantSource
-import javax.inject.Named
 import org.jobrunr.scheduling.JobScheduler
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Lazy


### PR DESCRIPTION
The old `javax.inject` package is `jakarta.inject` nowadays, but we've had some
dependencies that pull in the old version, so it's been easy to pick the wrong one
in the IDE autocomplete menu by mistake.

Switch to the new package name in the places where we were using the outdated one.