### PR TITLE
SW-6131 Deliverable positions in variable model

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -113,7 +113,7 @@ interface VariablePayload {
   @get:JsonIgnore val model: Variable
 
   val deliverableId: DeliverableId?
-    get() = model.deliverableId
+    get() = model.deliverablePositions.keys.firstOrNull()
 
   val deliverableQuestion: String?
     get() = model.deliverableQuestion

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -153,7 +153,7 @@ class VariableStore(
           .groupBy(STABLE_ID)
           .fetch()
           .mapNotNull { fetchVariableOrNull(it[DSL.max(ID)]!!) }
-          .sortedBy { it.deliverablePosition }
+          .sortedBy { it.deliverablePositions[deliverableId] }
     }
   }
 
@@ -399,10 +399,13 @@ class VariableStore(
         val manifestRecord = fetchManifestRecord(variableId)
         val recommendedBy = fetchRecommendedBy(variableId)
 
+        val deliverablePositions =
+            variablesRow.deliverableId?.let { mapOf(it to variablesRow.deliverablePosition!!) }
+                ?: emptyMap()
+
         val base =
             BaseVariableProperties(
-                deliverableId = variablesRow.deliverableId,
-                deliverablePosition = variablesRow.deliverablePosition,
+                deliverablePositions = deliverablePositions,
                 deliverableQuestion = variablesRow.deliverableQuestion,
                 dependencyCondition = variablesRow.dependencyConditionId,
                 dependencyValue = variablesRow.dependencyValue,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
@@ -402,9 +402,15 @@ class VariableImporter(
         csvVariable: AllVariableCsvVariable,
         variable: Variable
     ): Boolean {
+      val csvPositions =
+          if (csvVariable.deliverableId != null) {
+            mapOf(csvVariable.deliverableId to csvVariable.deliverablePosition)
+          } else {
+            emptyMap()
+          }
+
       return csvVariable.description == variable.description &&
-          csvVariable.deliverableId == variable.deliverableId &&
-          csvVariable.deliverablePosition == variable.deliverablePosition &&
+          csvPositions == variable.deliverablePositions &&
           csvVariable.dependencyCondition == variable.dependencyCondition &&
           csvVariable.dependencyValue == variable.dependencyValue &&
           csvVariable.dependencyVariableStableId == variable.dependencyVariableStableId &&

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
@@ -28,11 +28,8 @@ import java.time.format.DateTimeParseException
  * implementations can delegate to [BaseVariableProperties] to cut down on needless repetition.
  */
 interface BaseVariable {
-  /** The ID of its associated deliverable, if applicable * */
-  val deliverableId: DeliverableId?
-
-  /** The position of this variable within its associated deliverable, if applicable * */
-  val deliverablePosition: Int?
+  /** The position of this variable in each of its associated deliverables, if applicable. */
+  val deliverablePositions: Map<DeliverableId, Int>
 
   /** The display question of this variable, if applicable * */
   val deliverableQuestion: String?
@@ -93,8 +90,7 @@ interface BaseVariable {
  * classes that implement [Variable].
  */
 data class BaseVariableProperties(
-    override val deliverableId: DeliverableId? = null,
-    override val deliverablePosition: Int? = null,
+    override val deliverablePositions: Map<DeliverableId, Int> = emptyMap(),
     override val deliverableQuestion: String? = null,
     override val dependencyCondition: DependencyCondition? = null,
     override val dependencyValue: String? = null,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -251,8 +251,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
               NumberVariable(
                   base =
                       BaseVariableProperties(
-                          deliverableId = deliverableId1,
-                          deliverablePosition = 0,
+                          deliverablePositions = mapOf(deliverableId1 to 0),
                           deliverableQuestion = "Question 3",
                           id = variableId3,
                           isRequired = true,
@@ -267,8 +266,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
               NumberVariable(
                   base =
                       BaseVariableProperties(
-                          deliverableId = deliverableId1,
-                          deliverablePosition = 1,
+                          deliverablePositions = mapOf(deliverableId1 to 1),
                           deliverableQuestion = "Question 1",
                           id = variableId1,
                           isRequired = false,
@@ -309,8 +307,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
               TableVariable(
                   base =
                       BaseVariableProperties(
-                          deliverableId = deliverableId,
-                          deliverablePosition = 1,
+                          deliverablePositions = mapOf(deliverableId to 1),
                           id = tableId,
                           isList = true,
                           manifestId = null,
@@ -327,8 +324,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                                   TextVariable(
                                       base =
                                           BaseVariableProperties(
-                                              deliverableId = deliverableId,
-                                              deliverablePosition = 2,
+                                              deliverablePositions = mapOf(deliverableId to 2),
                                               id = columnId,
                                               isList = false,
                                               manifestId = null,
@@ -386,8 +382,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
           NumberVariable(
               base =
                   BaseVariableProperties(
-                      deliverableId = deliverableId,
-                      deliverablePosition = 1,
+                      deliverablePositions = mapOf(deliverableId to 1),
                       id = publicVariableId,
                       isRequired = false,
                       manifestId = null,
@@ -402,8 +397,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
           NumberVariable(
               base =
                   BaseVariableProperties(
-                      deliverableId = deliverableId,
-                      deliverablePosition = 2,
+                      deliverablePositions = mapOf(deliverableId to 2),
                       id = internalOnlyVariableId,
                       internalOnly = true,
                       isRequired = false,


### PR DESCRIPTION
In preparation for supporting variables appearing in multiple deliverables,
replace the deliverable ID and position fields in the `Variable` classes with a
map of deliverable IDs to positions.

This is purely an internal data structure change; the data model and API still
only support a single deliverable ID per variable.