### PR TITLE
SW-6131 Move deliverable positions to new table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
@@ -74,8 +74,6 @@ data class AllVariableCsvVariable(
 ) {
   fun mapToVariablesRow() =
       VariablesRow(
-          deliverableId = deliverableId,
-          deliverablePosition = deliverablePosition,
           deliverableQuestion = deliverableQuestion,
           dependencyVariableStableId = dependencyVariableStableId,
           dependencyConditionId = dependencyCondition,

--- a/src/main/resources/db/migration/0300/V309__DeliverableVariables.sql
+++ b/src/main/resources/db/migration/0300/V309__DeliverableVariables.sql
@@ -1,0 +1,16 @@
+CREATE TABLE accelerator.deliverable_variables(
+    deliverable_id BIGINT NOT NULL REFERENCES accelerator.deliverables ON DELETE CASCADE,
+    variable_id BIGINT NOT NULL REFERENCES docprod.variables ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+
+    PRIMARY KEY (variable_id, deliverable_id)
+);
+
+INSERT INTO accelerator.deliverable_variables (deliverable_id, variable_id, position)
+SELECT deliverable_id, id, deliverable_position
+FROM docprod.variables
+WHERE deliverable_id IS NOT NULL
+AND deliverable_position IS NOT NULL;
+
+ALTER TABLE docprod.variables DROP COLUMN deliverable_id;
+ALTER TABLE docprod.variables DROP COLUMN deliverable_position;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -508,6 +508,8 @@ COMMENT ON TABLE accelerator.deliverable_project_due_dates IS 'Deliverable due d
 
 COMMENT ON TABLE accelerator.deliverable_types IS '(Enum) Types of deliverables for an accelerator module.';
 
+COMMENT ON TABLE accelerator.deliverable_variables IS 'Which variables are associated with which deliverables. Note that this includes variables that have been replaced by newer versions, and the newer versions might be associated with different deliverables.';
+
 COMMENT ON TABLE accelerator.deliverables IS 'Information about expected deliverables. This describes what we request from users; the data we get back from users in response is recorded in `project_deliverables` and its child tables.';
 COMMENT ON COLUMN accelerator.deliverables.position IS 'Which position this deliverable appears in the module''s list of deliverables, starting with 1.';
 COMMENT ON COLUMN accelerator.deliverables.is_sensitive IS 'If true, the data users provide in response to this deliverable will be visible to a smaller subset of accelerator admins. Secure documents are saved to a different document store than non-secure ones.';

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VariableValueStatusUpdaterTest.kt
@@ -29,7 +29,7 @@ class VariableValueStatusUpdaterTest : DatabaseTest(), RunsAsUser {
   private val systemUser: SystemUser by lazy { SystemUser(usersDao) }
 
   private val variableWorkflowStore: VariableWorkflowStore by lazy {
-    VariableWorkflowStore(clock, dslContext, eventPublisher, variablesDao)
+    VariableWorkflowStore(clock, dslContext, eventPublisher)
   }
 
   private val updater: VariableValueStatusUpdater by lazy {

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -143,6 +143,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "deliverable_documents" to setOf(ALL, ACCELERATOR),
                   "deliverable_project_due_dates" to setOf(ALL, ACCELERATOR),
                   "deliverable_types" to setOf(ALL, ACCELERATOR),
+                  "deliverable_variables" to setOf(ALL, ACCELERATOR),
                   "deliverables" to setOf(ALL, ACCELERATOR),
                   "document_stores" to setOf(ALL, ACCELERATOR),
                   "events" to setOf(ALL, ACCELERATOR),

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
@@ -18,14 +18,7 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
-  private val store by lazy {
-    VariableWorkflowStore(
-        clock,
-        dslContext,
-        eventPublisher,
-        variablesDao,
-    )
-  }
+  private val store by lazy { VariableWorkflowStore(clock, dslContext, eventPublisher) }
 
   @BeforeEach
   fun setUp() {


### PR DESCRIPTION
Add a new `deliverable_variables` table to hold the list of which variables are
associated with which deliverables, including their positions within the
deliverables. This replaces the `deliverable_id` and `deliverable_position`
columns on the `variables` table.

This is a prerequisite for associating variables with multiple deliverables,
but that functionality isn't introduced here. This change should have no
user-visible effect on the system's behavior.