### PR TITLE
SW-6171 Include timestamps in species data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -124,7 +124,6 @@ class BatchImporter(
         speciesStore.importSpecies(
             NewSpeciesModel(
                 commonName = commonName,
-                id = null,
                 organizationId = organizationId,
                 scientificName = scientificName),
             overwriteExisting = false)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionImporter.kt
@@ -186,7 +186,6 @@ class AccessionImporter(
         speciesStore.importSpecies(
             NewSpeciesModel(
                 commonName = commonName,
-                id = null,
                 organizationId = organizationId,
                 scientificName = scientificName),
             overwriteExisting = false)

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -120,26 +120,24 @@ class SpeciesImporter(
           .map { rawValues -> rawValues.map { it.trim().ifEmpty { null } } }
           .map { values ->
             NewSpeciesModel(
-                scientificName = normalizeScientificName(values[0]!!),
                 commonName = values[1],
-                familyName = values[2],
                 conservationCategory =
                     values[3]?.let {
                       ConservationCategory.forJsonValue(it.trim().uppercase(Locale.ENGLISH))
                     },
-                rare = values[4]?.let { it in trueValues },
-                growthForms =
-                    values[5]?.let { setOf(GrowthForm.forDisplayName(it, locale)) } ?: emptySet(),
-                seedStorageBehavior =
-                    values[6]?.let { SeedStorageBehavior.forDisplayName(it, locale) },
                 ecosystemTypes =
                     values[7]
                         ?.split(SpeciesCsvValidator.ECOSYSTEM_TYPES_DELIMITER)
                         ?.map { EcosystemType.forDisplayName(it, locale) }
                         ?.toSet() ?: emptySet(),
-                id = null,
+                familyName = values[2],
+                growthForms =
+                    values[5]?.let { setOf(GrowthForm.forDisplayName(it, locale)) } ?: emptySet(),
                 organizationId = organizationId,
-            )
+                rare = values[4]?.let { it in trueValues },
+                scientificName = normalizeScientificName(values[0]!!),
+                seedStorageBehavior =
+                    values[6]?.let { SeedStorageBehavior.forDisplayName(it, locale) })
           }
           .forEach { row ->
             speciesStore.importSpecies(row, overwriteExisting)

--- a/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/model/SpeciesModel.kt
@@ -15,11 +15,12 @@ import java.time.Instant
 import org.jooq.Field
 import org.jooq.Record
 
-data class SpeciesModel<ID : SpeciesId?>(
+data class ExistingSpeciesModel(
     val averageWoodDensity: BigDecimal? = null,
     val checkedTime: Instant? = null,
     val commonName: String? = null,
     val conservationCategory: ConservationCategory? = null,
+    val createdTime: Instant,
     val dbhSource: String? = null,
     val dbhValue: BigDecimal? = null,
     val deletedTime: Instant? = null,
@@ -29,8 +30,9 @@ data class SpeciesModel<ID : SpeciesId?>(
     val growthForms: Set<GrowthForm> = emptySet(),
     val heightAtMaturitySource: String? = null,
     val heightAtMaturityValue: BigDecimal? = null,
-    val id: ID,
+    val id: SpeciesId,
     val localUsesKnown: String? = null,
+    val modifiedTime: Instant,
     val nativeEcosystem: String? = null,
     val organizationId: OrganizationId,
     val otherFacts: String? = null,
@@ -55,6 +57,7 @@ data class SpeciesModel<ID : SpeciesId?>(
             checkedTime = record[SPECIES.CHECKED_TIME],
             commonName = record[SPECIES.COMMON_NAME],
             conservationCategory = record[SPECIES.CONSERVATION_CATEGORY_ID],
+            createdTime = record[SPECIES.CREATED_TIME]!!,
             dbhSource = record[SPECIES.DBH_SOURCE],
             dbhValue = record[SPECIES.DBH_VALUE],
             deletedTime = record[SPECIES.DELETED_TIME],
@@ -67,6 +70,7 @@ data class SpeciesModel<ID : SpeciesId?>(
             id = record[SPECIES.ID]!!,
             initialScientificName = record[SPECIES.INITIAL_SCIENTIFIC_NAME]!!,
             localUsesKnown = record[SPECIES.LOCAL_USES_KNOWN],
+            modifiedTime = record[SPECIES.MODIFIED_TIME]!!,
             nativeEcosystem = record[SPECIES.NATIVE_ECOSYSTEM],
             organizationId = record[SPECIES.ORGANIZATION_ID]!!,
             otherFacts = record[SPECIES.OTHER_FACTS],
@@ -81,6 +85,28 @@ data class SpeciesModel<ID : SpeciesId?>(
   }
 }
 
-typealias NewSpeciesModel = SpeciesModel<Nothing?>
-
-typealias ExistingSpeciesModel = SpeciesModel<SpeciesId>
+data class NewSpeciesModel(
+    val averageWoodDensity: BigDecimal? = null,
+    val checkedTime: Instant? = null,
+    val commonName: String? = null,
+    val conservationCategory: ConservationCategory? = null,
+    val dbhSource: String? = null,
+    val dbhValue: BigDecimal? = null,
+    val deletedTime: Instant? = null,
+    val ecologicalRoleKnown: String? = null,
+    val ecosystemTypes: Set<EcosystemType> = emptySet(),
+    val familyName: String? = null,
+    val growthForms: Set<GrowthForm> = emptySet(),
+    val heightAtMaturitySource: String? = null,
+    val heightAtMaturityValue: BigDecimal? = null,
+    val localUsesKnown: String? = null,
+    val nativeEcosystem: String? = null,
+    val organizationId: OrganizationId,
+    val otherFacts: String? = null,
+    val plantMaterialSourcingMethods: Set<PlantMaterialSourcingMethod> = emptySet(),
+    val rare: Boolean? = null,
+    val scientificName: String,
+    val seedStorageBehavior: SeedStorageBehavior? = null,
+    val successionalGroups: Set<SuccessionalGroup> = emptySet(),
+    val woodDensityLevel: WoodDensityLevel? = null,
+)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -374,7 +374,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
           SpeciesEditedEvent(
               species =
                   ExistingSpeciesModel(
+                      createdTime = Instant.EPOCH,
                       id = speciesId,
+                      modifiedTime = Instant.EPOCH,
                       organizationId = inserted.organizationId,
                       scientificName = "Species 1")))
 
@@ -403,7 +405,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
           SpeciesEditedEvent(
               species =
                   ExistingSpeciesModel(
+                      createdTime = Instant.EPOCH,
                       id = speciesId,
+                      modifiedTime = Instant.EPOCH,
                       organizationId = inserted.organizationId,
                       scientificName = "Species 1")))
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -428,7 +428,9 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   species =
                       ExistingSpeciesModel(
                           commonName = null,
+                          createdTime = now,
                           id = speciesId1,
+                          modifiedTime = now,
                           organizationId = inserted.organizationId,
                           scientificName = "Acacia Kochi")),
               SpeciesForParticipantProject(
@@ -455,7 +457,9 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
                   species =
                       ExistingSpeciesModel(
                           commonName = null,
+                          createdTime = now,
                           id = speciesId2,
+                          modifiedTime = now,
                           organizationId = inserted.organizationId,
                           scientificName = "Juniperus scopulorum"))),
           store.fetchSpeciesForParticipantProject(projectId))

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -254,9 +254,11 @@ internal class EmailNotificationServiceTest {
       )
   private val species =
       ExistingSpeciesModel(
+          createdTime = Instant.EPOCH,
           id = SpeciesId(1),
-          scientificName = "A Species",
+          modifiedTime = Instant.EPOCH,
           organizationId = organization.id,
+          scientificName = "A Species",
       )
   private val upcomingObservation =
       ExistingObservationModel(

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -12,8 +12,8 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.db.SpeciesChecker
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.event.SpeciesEditedEvent
+import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.species.model.NewSpeciesModel
-import com.terraformation.backend.species.model.SpeciesModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -62,8 +62,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   fun `createSpecies checks for problems with species data`() {
     val speciesId =
         service.createSpecies(
-            NewSpeciesModel(
-                id = null, organizationId = organizationId, scientificName = "Scientific name"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "Scientific name"))
 
     verify { speciesChecker.checkSpecies(speciesId) }
   }
@@ -87,11 +86,12 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
     eventPublisher.assertEventPublished(
         SpeciesEditedEvent(
             species =
-                SpeciesModel(
+                ExistingSpeciesModel(
                     averageWoodDensity = null,
                     checkedTime = null,
                     commonName = null,
                     conservationCategory = null,
+                    createdTime = originalModel.createdTime,
                     dbhSource = null,
                     dbhValue = null,
                     deletedTime = null,
@@ -99,6 +99,7 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
                     familyName = null,
                     id = inserted.speciesId,
                     initialScientificName = "Old name",
+                    modifiedTime = clock.instant(),
                     organizationId = inserted.organizationId,
                     scientificName = "New name")))
   }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -86,7 +86,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             growthForms = setOf(GrowthForm.Shrub),
             heightAtMaturitySource = "height source",
             heightAtMaturityValue = BigDecimal(3.1),
-            id = null,
             localUsesKnown = "uses",
             nativeEcosystem = "ecosystem",
             organizationId = organizationId,
@@ -94,8 +93,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             rare = false,
             scientificName = "test",
             seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
-            woodDensityLevel = WoodDensityLevel.Family,
-        )
+            woodDensityLevel = WoodDensityLevel.Family)
 
     val speciesId = store.createSpecies(model)
     assertNotNull(speciesId, "Should have returned ID")
@@ -138,7 +136,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `createSpecies allows the same name to be used in different organizations`() {
     val otherOrgId = insertOrganization()
 
-    val model = NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "test")
+    val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
     store.createSpecies(model)
 
     assertDoesNotThrow { store.createSpecies(model.copy(organizationId = otherOrgId)) }
@@ -160,7 +158,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                 growthForms = setOf(GrowthForm.Fern),
                 heightAtMaturitySource = "original height source",
                 heightAtMaturityValue = BigDecimal(3.1),
-                id = null,
                 localUsesKnown = "original uses",
                 nativeEcosystem = "original ecosystem",
                 organizationId = organizationId,
@@ -170,8 +167,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
                 scientificName = "test",
                 seedStorageBehavior = SeedStorageBehavior.Orthodox,
                 successionalGroups = setOf(SuccessionalGroup.Pioneer),
-                woodDensityLevel = WoodDensityLevel.Family,
-            ))
+                woodDensityLevel = WoodDensityLevel.Family))
     val originalRow = speciesDao.fetchOneById(originalSpeciesId)!!
 
     store.deleteSpecies(originalSpeciesId)
@@ -189,7 +185,6 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             growthForms = setOf(GrowthForm.Shrub),
             heightAtMaturitySource = "edited height source",
             heightAtMaturityValue = BigDecimal(3.99),
-            id = null,
             localUsesKnown = "edited uses",
             nativeEcosystem = "edited ecosystem",
             organizationId = organizationId,
@@ -199,8 +194,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             scientificName = "test",
             seedStorageBehavior = SeedStorageBehavior.Recalcitrant,
             successionalGroups = setOf(SuccessionalGroup.Mature),
-            woodDensityLevel = WoodDensityLevel.Species,
-        )
+            woodDensityLevel = WoodDensityLevel.Species)
 
     val newInstant = Instant.ofEpochSecond(500)
     clock.instant = newInstant
@@ -262,7 +256,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `createSpecies throws exception if name already exists for organization`() {
-    val model = NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "test")
+    val model = NewSpeciesModel(organizationId = organizationId, scientificName = "test")
     store.createSpecies(model)
 
     assertThrows<DuplicateKeyException> { store.createSpecies(model) }
@@ -273,7 +267,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canCreateSpecies(organizationId) } returns false
     assertThrows<AccessDeniedException> {
       store.createSpecies(
-          NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "dummy"))
+          NewSpeciesModel(organizationId = organizationId, scientificName = "dummy"))
     }
   }
 
@@ -286,13 +280,12 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             conservationCategory = ConservationCategory.Extinct,
             dbhSource = "original db source",
             dbhValue = BigDecimal(2.1),
-            ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
             ecologicalRoleKnown = "original role",
+            ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
             familyName = "original family",
             growthForms = setOf(GrowthForm.Shrub),
             heightAtMaturitySource = "original height source",
             heightAtMaturityValue = BigDecimal(3.1),
-            id = null,
             localUsesKnown = "original uses",
             nativeEcosystem = "original ecosystem",
             organizationId = organizationId,
@@ -302,8 +295,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             scientificName = "original scientific",
             seedStorageBehavior = SeedStorageBehavior.Unknown,
             successionalGroups = setOf(SuccessionalGroup.Pioneer),
-            woodDensityLevel = WoodDensityLevel.Family,
-        )
+            woodDensityLevel = WoodDensityLevel.Family)
     val speciesId = store.createSpecies(initial)
 
     val bogusOrganizationId = OrganizationId(-1)
@@ -317,6 +309,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             averageWoodDensity = BigDecimal(1.99),
             commonName = "new common",
             conservationCategory = ConservationCategory.ExtinctInTheWild,
+            createdTime = Instant.EPOCH,
             dbhSource = "new db source",
             dbhValue = BigDecimal(2.99),
             deletedTime = bogusInstant,
@@ -329,6 +322,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             id = speciesId,
             initialScientificName = "new initial",
             localUsesKnown = "new uses",
+            modifiedTime = Instant.EPOCH,
             nativeEcosystem = "new ecosystem",
             organizationId = bogusOrganizationId,
             otherFacts = "new facts",
@@ -406,26 +400,28 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "dummy"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy"))
 
     assertThrows<AccessDeniedException> {
       store.updateSpecies(
           ExistingSpeciesModel(
-              id = speciesId, organizationId = organizationId, scientificName = "other"))
+              createdTime = Instant.EPOCH,
+              id = speciesId,
+              modifiedTime = Instant.EPOCH,
+              organizationId = organizationId,
+              scientificName = "other"))
     }
   }
 
   @Test
   fun `deleteSpecies marks species as deleted`() {
     // Make sure it only deletes the species in question, not the whole table
-    store.createSpecies(
-        NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "other"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "other"))
     val expected = store.findAllSpecies(organizationId)
 
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(
-                id = null, organizationId = organizationId, scientificName = "to delete"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "to delete"))
 
     store.deleteSpecies(speciesId)
 
@@ -439,7 +435,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "dummy"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy"))
 
     assertThrows<AccessDeniedException> { store.deleteSpecies(speciesId) }
   }
@@ -455,15 +451,16 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
         store.createSpecies(
             NewSpeciesModel(
                 ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
-                id = null,
                 organizationId = organizationId,
                 scientificName = "test"))
 
     val expected =
         ExistingSpeciesModel(
+            createdTime = Instant.EPOCH,
             ecosystemTypes = setOf(EcosystemType.Mangroves, EcosystemType.Tundra),
             id = speciesId,
             initialScientificName = "test",
+            modifiedTime = Instant.EPOCH,
             organizationId = organizationId,
             scientificName = "test",
         )
@@ -476,7 +473,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchSpeciesById throws exception if species is deleted`() {
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "test"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "test"))
     store.deleteSpecies(speciesId)
 
     assertThrows<SpeciesNotFoundException> { store.fetchSpeciesById(speciesId) }
@@ -525,15 +522,19 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       val expected =
           listOf(
               ExistingSpeciesModel(
+                  createdTime = Instant.EPOCH,
                   id = speciesId1,
                   initialScientificName = "Species 1",
+                  modifiedTime = Instant.EPOCH,
                   organizationId = organizationId,
                   scientificName = "Species 1",
               ),
               ExistingSpeciesModel(
                   commonName = "Common 2",
+                  createdTime = Instant.EPOCH,
                   id = speciesId2,
                   initialScientificName = "Species 2",
+                  modifiedTime = Instant.EPOCH,
                   organizationId = organizationId,
                   scientificName = "Species 2",
               ),
@@ -562,7 +563,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `fetchAllUncheckedSpeciesIds does not return deleted species`() {
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "dummy"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy"))
     store.deleteSpecies(speciesId)
 
     assertEquals(emptyList<SpeciesId>(), store.fetchUncheckedSpeciesIds(organizationId))
@@ -572,7 +573,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `findAllProblems does not return problems with deleted species`() {
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "dummy"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "dummy"))
     speciesProblemsDao.insert(
         SpeciesProblemsRow(
             createdTime = Instant.EPOCH,
@@ -591,8 +592,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     val scientificName = "species"
     val speciesId =
         store.createSpecies(
-            NewSpeciesModel(
-                id = null, organizationId = organizationId, scientificName = scientificName))
+            NewSpeciesModel(organizationId = organizationId, scientificName = scientificName))
 
     every { user.canReadOrganization(organizationId) } returns false
     every { user.canReadSpecies(speciesId) } returns false
@@ -607,12 +607,10 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `acceptProblemSuggestion throws exception if suggested scientific name is already in use`() {
     store.createSpecies(
-        NewSpeciesModel(
-            id = null, organizationId = organizationId, scientificName = "Correct name"))
+        NewSpeciesModel(organizationId = organizationId, scientificName = "Correct name"))
     val speciesIdWithOutdatedName =
         store.createSpecies(
-            NewSpeciesModel(
-                id = null, organizationId = organizationId, scientificName = "Outdated name"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "Outdated name"))
     val problemsRow =
         SpeciesProblemsRow(
             createdTime = Instant.EPOCH,
@@ -627,8 +625,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `find all species in use returns no species when none in use`() {
-    store.createSpecies(
-        NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "other"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "other"))
 
     val actual = store.findAllSpecies(organizationId, true)
 
@@ -639,9 +636,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `find all species in use returns species used in batches`() {
     val created =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "batch"))
-    store.createSpecies(
-        NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "batch"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
 
     // create a batch with 'other' species
     insertFacility()
@@ -650,8 +646,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     // create another org batch
     val otherOrgId = insertOrganization()
     val other =
-        store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
+        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
     insertFacility()
     insertBatch(speciesId = other)
 
@@ -665,9 +660,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `find all species in use returns species used in accessions`() {
     val created =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "batch"))
-    store.createSpecies(
-        NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "batch"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
 
     // create an accession with 'other' species
     insertFacility()
@@ -676,8 +670,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     // create another org accession
     val otherOrgId = insertOrganization()
     val other =
-        store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
+        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
     insertFacility()
     insertAccession(row = AccessionsRow(speciesId = other))
 
@@ -691,9 +684,8 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   fun `find all species in use returns species used in plantings`() {
     val created =
         store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "batch"))
-    store.createSpecies(
-        NewSpeciesModel(id = null, organizationId = organizationId, scientificName = "unused"))
+            NewSpeciesModel(organizationId = organizationId, scientificName = "batch"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
 
     // create plantings with 'other' species
     insertFacility()
@@ -707,8 +699,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
     // create another org planting
     val otherOrgId = insertOrganization()
     val other =
-        store.createSpecies(
-            NewSpeciesModel(id = null, organizationId = otherOrgId, scientificName = "other"))
+        store.createSpecies(NewSpeciesModel(organizationId = otherOrgId, scientificName = "other"))
     insertFacility()
     insertPlantingSite()
     insertPlantingZone()


### PR DESCRIPTION
Add `createdTime` and `modifiedTime` fields to the response payloads of the "get
species" and "list species" API endpoints.

Those fields weren't included in `SpeciesModel`, which is used internally.
Rather than adding a second type parameter to make them null-only for new species
and non-nullable for existing species like we do for the species ID, change
`NewSpeciesModel` and `ExistingSpeciesModel` into actual classes rather than
typealiases.