### PR TITLE
SW-6170 Add org-wide nursery summary stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/NurserySummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/NurserySummaryController.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.nursery.api
+
+import com.terraformation.backend.api.NurseryEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.model.NurseryStats
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@NurseryEndpoint
+@RequestMapping("/api/v1/nursery/summary")
+@RestController
+class NurserySummaryController(
+    private val batchStore: BatchStore,
+) {
+  @GetMapping
+  @Operation(
+      summary = "Get a summary of the numbers of plants in all the nurseries in an organization.")
+  fun getOrganizationNurserySummary(
+      @RequestParam organizationId: OrganizationId
+  ): GetOrganizationNurserySummaryResponsePayload {
+    val stats = batchStore.getNurseryStats(organizationId = organizationId)
+
+    return GetOrganizationNurserySummaryResponsePayload(OrganizationNurserySummaryPayload(stats))
+  }
+}
+
+data class OrganizationNurserySummaryPayload(
+    val germinatingQuantity: Long,
+    val germinationRate: Int?,
+    @Schema(
+        description = "Percentage of current and past inventory that was withdrawn due to death.",
+        minimum = "0",
+        maximum = "100")
+    val lossRate: Int?,
+    val notReadyQuantity: Long,
+    val readyQuantity: Long,
+    @Schema(description = "Total number of plants that have been withdrawn due to death.")
+    val totalDead: Long,
+    @Schema(description = "Total number of germinated plants currently in inventory.")
+    val totalQuantity: Long,
+    @Schema(description = "Total number of plants that have been withdrawn in the past.")
+    val totalWithdrawn: Long,
+) {
+  constructor(
+      stats: NurseryStats
+  ) : this(
+      germinatingQuantity = stats.totalGerminating,
+      germinationRate = stats.germinationRate,
+      lossRate = stats.lossRate,
+      notReadyQuantity = stats.totalNotReady,
+      readyQuantity = stats.totalReady,
+      totalDead = stats.totalWithdrawnByPurpose[WithdrawalPurpose.Dead] ?: 0L,
+      totalQuantity = stats.totalInventory,
+      totalWithdrawn = stats.totalWithdrawn,
+  )
+}
+
+data class GetOrganizationNurserySummaryResponsePayload(
+    val summary: OrganizationNurserySummaryPayload
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryStats.kt
@@ -4,9 +4,13 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import kotlin.math.roundToInt
 
-/** Aggregated statistics for a nursery. Totals are across all batches and withdrawals. */
+/**
+ * Aggregated statistics for a nursery or an organization. Totals are across all batches and
+ * withdrawals.
+ */
 data class NurseryStats(
-    val facilityId: FacilityId,
+    /** If null, stats are organization-wide. */
+    val facilityId: FacilityId?,
     val germinationRate: Int?,
     val lossRate: Int?,
     val totalGerminating: Long,


### PR DESCRIPTION
`GET /api/v1/nursery/summary?organizationId={id}` will return summary stats for
all the nurseries in an organization. These are the same stats as the per-nursery
ones already available via `GET /api/v1/nursery/facilities/{id}/summary`, minus
the per-species withdrawal breakdowns.