### PR TITLE
Remove unnecessary authentication cleanup

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -17,14 +17,11 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContextHolder
 
 class ManifestImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -69,19 +66,12 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
 
   @Nested
   inner class UploadManifest {
-    private var oldAuthentication: Authentication? = null
-
     private val header =
         "Name,ID,Description,Recommended variables,Parent,Non-numbered section?,Default Text"
 
     @BeforeEach
     fun setUp() {
       every { user.canCreateVariableManifest() } returns true
-    }
-
-    @AfterEach
-    fun tearDown() {
-      SecurityContextHolder.getContext().authentication = oldAuthentication
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.springframework.security.core.Authentication
-import org.springframework.security.core.context.SecurityContextHolder
 
 class VariableImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -51,15 +49,8 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
   @Nested
   inner class UploadManifest {
-    private var oldAuthentication: Authentication? = null
-
     private val header =
         "Name,ID,Description,Data Type,List?,Parent,Options,Minimum value,Maximum value,Decimal places,Table Style,Header?,Notes,Deliverable ID,Deliverable Question,Dependency Variable ID,Dependency Condition,Dependency Value,Internal Only,Required"
-
-    @AfterEach
-    fun tearDown() {
-      SecurityContextHolder.getContext().authentication = oldAuthentication
-    }
 
     @Test
     fun `detects duplicate stable IDs`() {


### PR DESCRIPTION
The manifest and variable importer tests had some leftover cleanup code from when
they were ported over from the document producer; the originals needed to set up
some authentication scaffolding that isn't needed in terraware-server tests.