### PR TITLE
SW-5925 Optional variable decimal places in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2572,7 +2572,7 @@ abstract class DatabaseBackedTest {
 
   protected fun insertNumberVariable(
       id: VariableId? = null,
-      decimalPlaces: Int = 0,
+      decimalPlaces: Int? = null,
       deliverableId: DeliverableId? = null,
       minValue: BigDecimal? = null,
       maxValue: BigDecimal? = null,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariablesControllerTest.kt
@@ -137,8 +137,7 @@ class VariablesControllerTest : ControllerIntegrationTest() {
                         "position": 0,
                         "internalOnly": false,
                         "isRequired": false,
-                        "isList": false,
-                        "decimalPlaces": 0
+                        "isList": false
                     }
                   ],
                   "status": "ok"

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -86,7 +86,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                       replacesVariableId = variableId2,
                       stableId = stableId,
                   ),
-              decimalPlaces = 0,
+              decimalPlaces = null,
               minValue = null,
               maxValue = null)
 
@@ -260,7 +260,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                           position = 0,
                           stableId = "2",
                           replacesVariableId = variableId2),
-                  decimalPlaces = 0,
+                  decimalPlaces = null,
                   minValue = null,
                   maxValue = null),
               NumberVariable(
@@ -275,7 +275,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                           position = 0,
                           stableId = "1",
                       ),
-                  decimalPlaces = 0,
+                  decimalPlaces = null,
                   minValue = null,
                   maxValue = null))
 
@@ -390,7 +390,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                       position = 0,
                       stableId = "$stableId-1",
                   ),
-              decimalPlaces = 0,
+              decimalPlaces = null,
               minValue = null,
               maxValue = null)
       val expectedInternalOnlyVariable =
@@ -406,7 +406,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                       position = 0,
                       stableId = "$stableId-2",
                   ),
-              decimalPlaces = 0,
+              decimalPlaces = null,
               minValue = null,
               maxValue = null)
 
@@ -562,7 +562,7 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
                           name = "Number Variable",
                           position = 0,
                           stableId = "1"),
-                  decimalPlaces = 0,
+                  decimalPlaces = null,
                   minValue = null,
                   maxValue = BigDecimal(10)))
 


### PR DESCRIPTION
Commit 00af9b75 made decimal places on number variables optional, but the
`insertNumberVariable` test helper method was still requiring them.