### PR TITLE
SW-6131 Associate variables from deliverables sheet

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
@@ -1,0 +1,161 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.DeliverableId
+import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableVariablesRow
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.docprod.VariableType
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.importer.CsvImportFailedException
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+
+  private val importer: DeliverablesImporter by lazy {
+    DeliverablesImporter(
+        TestClock(),
+        dslContext,
+        VariableStore(
+            dslContext,
+            variableNumbersDao,
+            variablesDao,
+            variableSectionDefaultValuesDao,
+            variableSectionRecommendationsDao,
+            variableSectionsDao,
+            variableSelectsDao,
+            variableSelectOptionsDao,
+            variableTablesDao,
+            variableTableColumnsDao,
+            variableTextsDao))
+  }
+
+  private val stableIdSuffix = "${UUID.randomUUID()}"
+
+  private val header =
+      "Name,ID,Description,Template,Module ID,Category,Sensitive?,Required?,Deliverable Type,Variable IDs"
+
+  @BeforeEach
+  fun setUp() {
+    every { user.canManageDeliverables() } returns true
+  }
+
+  @Nested
+  inner class ImportDeliverables {
+    @Test
+    fun `associates variables with deliverables`() {
+      val moduleId = insertModule()
+      val deliverableId1 = getUnusedDeliverableId()
+      val deliverableId2 = getUnusedDeliverableId()
+      val stableId1 = "1-$stableIdSuffix"
+      val stableId2 = "2-$stableIdSuffix"
+      val stableId3 = "3-$stableIdSuffix"
+      val variableId1 = insertTextVariable(stableId = stableId1)
+      val variableId2 = insertTextVariable(stableId = stableId2)
+      val variableId3 = insertTextVariable(stableId = stableId3)
+
+      val csv =
+          header +
+              "\nDeliverable 1,$deliverableId1,Description,,$moduleId,Compliance,no,no,Questions,\"$stableId1\n$stableId2\"" +
+              "\nDeliverable 2,$deliverableId2,Description,,$moduleId,Compliance,no,no,Questions,\"$stableId2\n$stableId1\n$stableId3\""
+
+      importer.importDeliverables(csv.byteInputStream())
+
+      assertEquals(
+          setOf(
+              DeliverableVariablesRow(deliverableId1, variableId1, 0),
+              DeliverableVariablesRow(deliverableId1, variableId2, 1),
+              DeliverableVariablesRow(deliverableId2, variableId2, 0),
+              DeliverableVariablesRow(deliverableId2, variableId1, 1),
+              DeliverableVariablesRow(deliverableId2, variableId3, 2),
+          ),
+          deliverableVariablesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `uses latest variable versions`() {
+      val moduleId = insertModule()
+      val deliverableId = getUnusedDeliverableId()
+      val stableId = "1-$stableIdSuffix"
+      val oldVariableId =
+          insertTextVariable(insertVariable(type = VariableType.Text, stableId = stableId))
+      val newVariableId =
+          insertTextVariable(
+              insertVariable(
+                  type = VariableType.Text,
+                  stableId = stableId,
+                  replacesVariableId = oldVariableId))
+
+      val csv =
+          header +
+              "\nDeliverable 1,$deliverableId,Description,,$moduleId,Compliance,no,no,Questions,$stableId"
+
+      importer.importDeliverables(csv.byteInputStream())
+
+      assertEquals(
+          listOf(DeliverableVariablesRow(deliverableId, newVariableId, 0)),
+          deliverableVariablesDao.findAll())
+    }
+
+    @Test
+    fun `updates variable positions if list is updated`() {
+      val moduleId = insertModule()
+      val deliverableId = insertDeliverable()
+      val stableId1 = "1-$stableIdSuffix"
+      val stableId2 = "2-$stableIdSuffix"
+      val stableId3 = "3-$stableIdSuffix"
+      val variableId1 = insertTextVariable(stableId = stableId1)
+      insertDeliverableVariable(position = 0)
+      insertTextVariable(stableId = stableId2)
+      insertDeliverableVariable(position = 1)
+      val variableId3 = insertTextVariable(stableId = stableId3)
+      insertDeliverableVariable(position = 2)
+
+      val csv =
+          header +
+              "\nDeliverable 1,$deliverableId,Description,,$moduleId,Compliance,no,no,Questions,\"$stableId3\n$stableId1\""
+
+      importer.importDeliverables(csv.byteInputStream())
+
+      assertEquals(
+          setOf(
+              DeliverableVariablesRow(deliverableId, variableId3, 0),
+              DeliverableVariablesRow(deliverableId, variableId1, 1),
+          ),
+          deliverableVariablesDao.findAll().toSet())
+    }
+
+    @Test
+    fun `rejects variable IDs for non-question deliverables`() {
+      val moduleId = insertModule()
+      val deliverableId = getUnusedDeliverableId()
+      val stableId = "1-$stableIdSuffix"
+      insertTextVariable(stableId = stableId)
+
+      val csv =
+          header +
+              "\nDeliverable 1,$deliverableId,Description,,$moduleId,Compliance,no,no,Document,$stableId"
+
+      assertThrows<CsvImportFailedException> { importer.importDeliverables(csv.byteInputStream()) }
+    }
+  }
+
+  /**
+   * Returns a deliverable ID that doesn't exist in the database and won't conflict with IDs from
+   * other tests running in parallel.
+   */
+  private fun getUnusedDeliverableId(): DeliverableId {
+    val deliverableId = insertDeliverable()
+    dslContext.deleteFrom(DELIVERABLES).where(DELIVERABLES.ID.eq(deliverableId)).execute()
+    return deliverableId
+  }
+}


### PR DESCRIPTION
Make DeliverablesImporter populate the list of variables for each deliverable
if present in the deliverables sheet.

A variable may be associated with more than one deliverable.

If the "Variables" column is empty for a deliverable, the deliverable's existing
list of variables is left untouched; this is to support gradually transitioning
from the old scheme where deliverable IDs were specified on the all-variables
sheet by moving the associations from that sheet one deliverable at a time.