### PR TITLE
SW-6176 Fix adding species to approved species list

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.ApiResponseSimpleSuccess
+import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.api.ResponsePayload
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessOrError
@@ -26,6 +27,7 @@ import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.ParticipantId
 import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.importer.CsvImportFailedException
@@ -195,6 +197,7 @@ class DeliverablesController(
   @Operation(
       summary = "Updates the state of a submission from a project.",
       description = "Only permitted for users with accelerator admin privileges.")
+  @RequireGlobalRole([GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
   @PutMapping("/{deliverableId}/submissions/{projectId}")
   fun updateSubmission(
       @PathVariable deliverableId: DeliverableId,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -139,7 +139,14 @@ class SubmissionStore(
       feedback: String? = null,
       internalComment: String? = null,
   ): SubmissionId {
-    requirePermissions { updateSubmissionStatus(deliverableId, projectId) }
+    requirePermissions {
+      // Non-admin user actions can cause status to be reset to Not Submitted.
+      if (status == SubmissionStatus.NotSubmitted) {
+        createSubmission(projectId)
+      } else {
+        updateSubmissionStatus(deliverableId, projectId)
+      }
+    }
 
     val now = clock.instant()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -247,7 +247,7 @@ data class IndividualUser(
   override fun canCreateSubLocation(facilityId: FacilityId) = isAdminOrHigher(facilityId)
 
   override fun canCreateSubmission(projectId: ProjectId) =
-      isAcceleratorAdmin() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
+      isTFExpertOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
 
   override fun canCreateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesSubmissionUpdaterTest.kt
@@ -37,9 +37,9 @@ class SpeciesSubmissionUpdaterTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
 
+    every { user.canCreateSubmission(any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canReadSubmission(any()) } returns true
-    every { user.canUpdateSubmissionStatus(any(), any()) } returns true
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/api/ParticipantProjectSpeciesControllerTest.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.accelerator.api
+
+import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.customer.model.InternalTagIds
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.accelerator.DeliverableCategory
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.default_schema.Role
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.post
+
+class ParticipantProjectSpeciesControllerTest : ControllerIntegrationTest() {
+  private val path = "/api/v1/accelerator/projects/species"
+
+  @Nested
+  inner class CreateParticipantProjectSpecies {
+    @Test
+    fun `can add species to approved species list`() {
+      insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId)
+      insertOrganization()
+      insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
+      insertOrganizationUser(role = Role.Owner)
+      val projectId = insertProject(participantId = participantId)
+      val speciesId = insertSpecies()
+      insertCohortModule()
+      insertDeliverable(
+          deliverableTypeId = DeliverableType.Species,
+          deliverableCategoryId = DeliverableCategory.CarbonEligibility)
+      insertSubmission(submissionStatus = SubmissionStatus.Approved)
+
+      val payload =
+          """
+            {
+              "projectId": $projectId,
+              "speciesId": $speciesId,
+              "speciesNativeCategory": "Native"
+            }
+          """
+              .trimIndent()
+
+      mockMvc
+          .post(path) { content = payload }
+          .andExpect { status { is2xxSuccessful() } }
+          .andExpectJson {
+            val participantProjectSpeciesId = participantProjectSpeciesDao.findAll().first().id
+
+            """
+                {
+                  "participantProjectSpecies": {
+                    "id": $participantProjectSpeciesId,
+                    "projectId": $projectId,
+                    "speciesId": $speciesId,
+                    "speciesNativeCategory": "Native",
+                    "submissionStatus": "Not Submitted"
+                  },
+                  "status": "ok"
+                }
+              """
+                .trimIndent()
+          }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -414,17 +414,35 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `allows non-admin users to reset submission status to Not Submitted`() {
+      insertModule()
+      val projectId = insertProject()
+      val deliverableId = insertDeliverable()
+      insertSubmission(submissionStatus = SubmissionStatus.InReview)
+
+      every { user.canCreateSubmission(projectId) } returns true
+      every { user.canUpdateSubmissionStatus(deliverableId, projectId) } returns false
+
+      store.updateSubmissionStatus(
+          deliverableId, projectId, SubmissionStatus.NotSubmitted, null, null)
+
+      assertEquals(
+          SubmissionStatus.NotSubmitted, submissionsDao.findAll().first().submissionStatusId)
+    }
+
+    @Test
     fun `throws exception if no permission to update submission status`() {
       insertModule()
       val projectId = insertProject()
       val deliverableId = insertDeliverable()
       insertSubmission()
 
+      every { user.canCreateSubmission(projectId) } returns true
       every { user.canUpdateSubmissionStatus(deliverableId, projectId) } returns false
 
       assertThrows<AccessDeniedException> {
         store.updateSubmissionStatus(
-            deliverableId, projectId, SubmissionStatus.NotSubmitted, null, null)
+            deliverableId, projectId, SubmissionStatus.Rejected, null, null)
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2053,6 +2053,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(4000),
         createParticipantProjectSpecies = true,
+        createSubmission = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,


### PR DESCRIPTION
Adding a species to a species list that was already approved was failing if the
user didn't have accelerator admin privileges because it required resetting the
submission status, which was a privileged operation.

Update the permission check to allow resetting submission status to "Not
Submitted" if the user has permission to create a new submission.