### PR TITLE
SW-6185 Add plot size to database schema

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -61,6 +61,7 @@ import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
 import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.tracking.model.NewPlantingSiteModel
 import com.terraformation.backend.tracking.model.NewPlantingSubzoneModel
@@ -1424,6 +1425,7 @@ class PlantingSiteStore(
                   permanentCluster = clusterNumber,
                   permanentClusterSubplot = plotIndex + 1,
                   plantingSubzoneId = subzone.id,
+                  sizeMeters = MONITORING_PLOT_SIZE_INT,
               )
 
           monitoringPlotsDao.insert(monitoringPlotsRow)
@@ -1437,7 +1439,7 @@ class PlantingSiteStore(
   fun createTemporaryPlot(
       plantingSiteId: PlantingSiteId,
       plantingZoneId: PlantingZoneId,
-      plotBoundary: Polygon
+      plotBoundary: Polygon,
   ): MonitoringPlotId {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
@@ -1469,7 +1471,8 @@ class PlantingSiteStore(
                 modifiedBy = userId,
                 modifiedTime = now,
                 name = "$plotNumber",
-                plantingSubzoneId = subzone.id)
+                plantingSubzoneId = subzone.id,
+                sizeMeters = MONITORING_PLOT_SIZE_INT)
         monitoringPlotsDao.insert(monitoringPlotsRow)
 
         monitoringPlotsRow.id!!
@@ -1511,6 +1514,7 @@ class PlantingSiteStore(
                       MONITORING_PLOTS.NAME,
                       MONITORING_PLOTS.PERMANENT_CLUSTER,
                       MONITORING_PLOTS.PERMANENT_CLUSTER_SUBPLOT,
+                      MONITORING_PLOTS.SIZE_METERS,
                       monitoringPlotBoundaryField)
                   .from(MONITORING_PLOTS)
                   .where(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
@@ -1525,6 +1529,7 @@ class PlantingSiteStore(
                   name = record[MONITORING_PLOTS.NAME]!!,
                   permanentCluster = record[MONITORING_PLOTS.PERMANENT_CLUSTER],
                   permanentClusterSubplot = record[MONITORING_PLOTS.PERMANENT_CLUSTER_SUBPLOT],
+                  sizeMeters = record[MONITORING_PLOTS.SIZE_METERS]!!,
               )
             }
           }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -12,6 +12,9 @@ val MAX_SITE_ENVELOPE_AREA_HA = BigDecimal(20000)
 /** Monitoring plot width and height in meters. */
 const val MONITORING_PLOT_SIZE: Double = 25.0
 
+/** Monitoring plot width and height in meters. */
+const val MONITORING_PLOT_SIZE_INT = MONITORING_PLOT_SIZE.toInt()
+
 /** Number of square meters in a monitoring plot. */
 const val SQUARE_METERS_PER_MONITORING_PLOT: Double = MONITORING_PLOT_SIZE * MONITORING_PLOT_SIZE
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/MonitoringPlotModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/MonitoringPlotModel.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.util.SQUARE_METERS_PER_HECTARE
 import org.locationtech.jts.geom.Polygon
 
 data class MonitoringPlotModel(
@@ -11,7 +12,11 @@ data class MonitoringPlotModel(
     val name: String,
     val permanentCluster: Int? = null,
     val permanentClusterSubplot: Int? = null,
+    val sizeMeters: Int,
 ) {
+  val areaHa: Double
+    get() = sizeMeters * sizeMeters / SQUARE_METERS_PER_HECTARE
+
   fun equals(other: Any?, tolerance: Double): Boolean {
     return other is MonitoringPlotModel &&
         id == other.id &&
@@ -20,6 +25,7 @@ data class MonitoringPlotModel(
         name == other.name &&
         permanentCluster == other.permanentCluster &&
         permanentClusterSubplot == other.permanentClusterSubplot &&
+        sizeMeters == other.sizeMeters &&
         boundary.equalsExact(other.boundary, tolerance)
   }
 }

--- a/src/main/resources/db/migration/0300/V310__MonitoringPlotSize.sql
+++ b/src/main/resources/db/migration/0300/V310__MonitoringPlotSize.sql
@@ -1,0 +1,8 @@
+ALTER TABLE tracking.monitoring_plots ADD COLUMN size_meters INTEGER;
+
+-- Monitoring plots are currently fixed-size.
+UPDATE tracking.monitoring_plots
+SET size_meters = 25
+WHERE size_meters IS NULL;
+
+ALTER TABLE tracking.monitoring_plots ALTER COLUMN size_meters SET NOT NULL;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -354,6 +354,7 @@ COMMENT ON COLUMN tracking.monitoring_plots.modified_time IS 'When the monitorin
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster_subplot IS 'If this plot is a candidate to be a permanent monitoring plot, its ordinal position from 1 to 4 in the 4-plot cluster. 1=southwest, 2=southeast, 3=northeast, 4=northwest.';
 COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is part of.';
+COMMENT ON COLUMN tracking.monitoring_plots.size_meters IS 'Length in meters of one side of the monitoring plot. Plots are always squares, so for a 30x30m plot, this would be 30.';
 
 COMMENT ON TABLE tracking.observable_conditions IS '(Enum) Conditions that can be observed in a monitoring plot.';
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -336,6 +336,7 @@ import com.terraformation.backend.rectangle
 import com.terraformation.backend.rectanglePolygon
 import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.util.toInstant
 import jakarta.ws.rs.NotFoundException
@@ -1744,13 +1745,14 @@ abstract class DatabaseBackedTest {
       row: MonitoringPlotsRow = MonitoringPlotsRow(),
       x: Number = 0,
       y: Number = 0,
+      sizeMeters: Int = row.sizeMeters ?: MONITORING_PLOT_SIZE_INT,
       boundary: Polygon =
           (row.boundary as? Polygon)
               ?: rectanglePolygon(
-                  MONITORING_PLOT_SIZE,
-                  MONITORING_PLOT_SIZE,
-                  x.toDouble() * MONITORING_PLOT_SIZE,
-                  y.toDouble() * MONITORING_PLOT_SIZE),
+                  sizeMeters,
+                  sizeMeters,
+                  x.toDouble() * sizeMeters.toDouble(),
+                  y.toDouble() * sizeMeters.toDouble()),
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       isAvailable: Boolean = row.isAvailable ?: true,
@@ -1776,6 +1778,7 @@ abstract class DatabaseBackedTest {
             permanentCluster = permanentCluster,
             permanentClusterSubplot = permanentClusterSubplot,
             plantingSubzoneId = plantingSubzoneId,
+            sizeMeters = sizeMeters,
         )
 
     monitoringPlotsDao.insert(rowWithDefaults)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.point
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.util.Turtle
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.*
@@ -42,6 +43,7 @@ internal class PlantingSiteStoreCreateTemporaryTest : PlantingSiteStoreTest() {
               modifiedTime = clock.instant,
               name = "18",
               plantingSubzoneId = plantingSubzoneId,
+              sizeMeters = MONITORING_PLOT_SIZE_INT,
           )
 
       val actual = monitoringPlotsDao.fetchOneById(newPlotId)!!

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreReadTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreReadTest.kt
@@ -373,7 +373,8 @@ internal class PlantingSiteStoreReadTest : PlantingSiteStoreTest() {
                                                       id = monitoringPlotId,
                                                       isAvailable = true,
                                                       name = "1",
-                                                      fullName = "Z1-1-1")),
+                                                      fullName = "Z1-1-1",
+                                                      sizeMeters = 25)),
                                       )))))
 
       val allExpected =
@@ -455,7 +456,8 @@ internal class PlantingSiteStoreReadTest : PlantingSiteStoreTest() {
                                                   id = monitoringPlotId,
                                                   isAvailable = true,
                                                   name = "1",
-                                                  fullName = "Z1-1-1")),
+                                                  fullName = "Z1-1-1",
+                                                  sizeMeters = 25)),
                                   )))))
 
       val actual = store.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -238,9 +238,10 @@ private constructor(
               },
           isAvailable: Boolean = true,
           name: String = "$nextMonitoringPlotId",
+          size: Int = MONITORING_PLOT_SIZE_INT,
       ): MonitoringPlotModel {
         lastCluster = cluster
-        nextMonitoringPlotX = x + MONITORING_PLOT_SIZE.toInt()
+        nextMonitoringPlotX = x + size.toInt()
 
         if (subplot != null) {
           nextSubplot = subplot + 1
@@ -248,13 +249,14 @@ private constructor(
 
         val plot =
             MonitoringPlotModel(
-                boundary = rectanglePolygon(MONITORING_PLOT_SIZE, MONITORING_PLOT_SIZE, x, y),
+                boundary = rectanglePolygon(size, size, x, y),
                 id = MonitoringPlotId(nextMonitoringPlotId++),
                 isAvailable = isAvailable,
                 fullName = "$fullName-$name",
                 name = name,
                 permanentCluster = cluster,
                 permanentClusterSubplot = subplot,
+                sizeMeters = size,
             )
 
         monitoringPlots.add(plot)
@@ -267,7 +269,7 @@ private constructor(
           cluster: Int = nextPermanentCluster++,
           isAvailable: Boolean = true,
       ): List<MonitoringPlotModel> {
-        val plotSize = MONITORING_PLOT_SIZE.toInt()
+        val plotSize = MONITORING_PLOT_SIZE_INT
         val plots =
             listOf(
                 plot(x, y, cluster, isAvailable = isAvailable),

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -634,6 +634,7 @@ class PlantingZoneModelTest {
         name = "name",
         permanentCluster = permanentCluster,
         permanentClusterSubplot = if (permanentCluster != null) 1 else null,
+        sizeMeters = 25,
     )
   }
 


### PR DESCRIPTION
In preparation for supporting different monitoring plot sizes, add a column to the
`monitoring_plots` table to keep track of the size of each plot, and mirror that
value in the monitoring plot model class. For now, the size is always 25 meters,
such that this doesn't change any existing behavior.