### PR TITLE
Make ID wrappers comparable

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
@@ -20,8 +20,9 @@ class IdWrapper(private val className: String, includeExpressions: List<String>)
   fun render(out: JavaWriter) {
     out.println(
         """
-      class $className @JsonCreator constructor(@get:JsonValue val value: Long) {
+      class $className @JsonCreator constructor(@get:JsonValue val value: Long) : Comparable<$className> {
         constructor(value: String) : this(value.toLong())
+        override fun compareTo(other: $className) = value.compareTo(other.value)
         override fun equals(other: Any?): Boolean = other is $className && other.value == value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): String = value.toString()

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminCohortsController.kt
@@ -224,7 +224,7 @@ class AdminCohortsController(
         deliverableStore
             .fetchDeliverableSubmissions(deliverableId = deliverableId)
             .filter { cohortProjects.contains(it.projectId) }
-            .sortedBy { it.projectId.value }
+            .sortedBy { it.projectId }
 
     model.addAttribute("canManageDeliverables", currentUser().canManageDeliverables())
     model.addAttribute("cohort", cohort)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -38,8 +38,8 @@ class AdminController(
 
   @GetMapping("/")
   fun getIndex(model: Model): String {
-    val organizations = organizationStore.fetchAll().sortedBy { it.id.value }
-    val allOrganizations = organizationsDao.findAll().sortedBy { it.id!!.value }
+    val organizations = organizationStore.fetchAll().sortedBy { it.id }
+    val allOrganizations = organizationsDao.findAll().sortedBy { it.id }
 
     model.addAttribute("allOrganizations", allOrganizations)
     model.addAttribute(

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
@@ -51,7 +51,7 @@ class AdminDevicesController(
 
   @GetMapping("/deviceTemplates")
   fun getDeviceTemplates(model: Model): String {
-    val templates = deviceTemplatesDao.findAll().sortedBy { it.id!!.value }
+    val templates = deviceTemplatesDao.findAll().sortedBy { it.id }
 
     model.addAttribute("canUpdateDeviceTemplates", currentUser().canUpdateDeviceTemplates())
     model.addAttribute("categories", DeviceTemplateCategory.entries)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDocumentProducerController.kt
@@ -35,8 +35,7 @@ class AdminDocumentProducerController(
 
   @GetMapping("/")
   fun getIndex(model: Model): String {
-    model.addAttribute(
-        "documentTemplates", documentTemplatesDao.findAll().sortedBy { it.id?.value })
+    model.addAttribute("documentTemplates", documentTemplatesDao.findAll().sortedBy { it.id })
 
     return "/admin/documentProducer"
   }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminInternalTagsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminInternalTagsController.kt
@@ -31,7 +31,7 @@ class AdminInternalTagsController(
   @GetMapping("/internalTags")
   fun listInternalTags(model: Model, redirectAttributes: RedirectAttributes): String {
     val tags = internalTagStore.findAllTags()
-    val allOrganizations = organizationsDao.findAll().sortedBy { it.id!!.value }
+    val allOrganizations = organizationsDao.findAll().sortedBy { it.id }
     val organizationTags = internalTagStore.fetchAllOrganizationTagIds()
 
     model.addAttribute("allOrganizations", allOrganizations)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -92,7 +92,7 @@ class AdminPlantingSitesController(
 
     val allOrganizations =
         if (currentUser().canMovePlantingSiteToAnyOrg(plantingSiteId)) {
-          organizationsDao.findAll().sortedBy { it.id!!.value }
+          organizationsDao.findAll().sortedBy { it.id }
         } else {
           null
         }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/InternalTagStore.kt
@@ -86,7 +86,7 @@ class InternalTagStore(
   fun findAllTags(): List<InternalTagsRow> {
     requirePermissions { readInternalTags() }
 
-    return internalTagsDao.findAll().sortedBy { it.id!!.value }
+    return internalTagsDao.findAll().sortedBy { it.id }
   }
 
   fun fetchOrganizationsByTagId(tagId: InternalTagId): Collection<OrganizationsRow> {

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -655,7 +655,7 @@ class BatchStore(
           withdrawal.batchWithdrawals
               // Sort by batch ID to avoid deadlocks if two clients withdraw from the same set of
               // batches at the same time; DB locks will be acquired in the same order on both.
-              .sortedBy { it.batchId.value }
+              .sortedBy { it.batchId }
               .map { batchWithdrawal ->
                 val batchId = batchWithdrawal.batchId
                 val batchWithdrawalsRow =

--- a/src/main/kotlin/com/terraformation/backend/report/ReportFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportFileService.kt
@@ -80,7 +80,7 @@ class ReportFileService(
     return reportPhotosDao
         .fetchByReportId(reportId)
         .map { ReportPhotoModel(it, filesRows[it.fileId]!!) }
-        .sortedBy { it.metadata.id.value }
+        .sortedBy { it.metadata.id }
   }
 
   fun listFiles(reportId: ReportId): List<ReportFileModel> {

--- a/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/ReportService.kt
@@ -245,7 +245,7 @@ class ReportService(
                   ?.populate(facility, orgStats, projectStats)
                   ?: ReportBodyModelV1.Nursery(facility, orgStats, projectStats)
             }
-            .sortedBy { it.id.value }
+            .sortedBy { it.id }
 
     val plantingSiteBodies =
         plantingSiteModels
@@ -258,7 +258,7 @@ class ReportService(
                   ?.populate(plantingSiteModel, speciesModels)
                   ?: ReportBodyModelV1.PlantingSite(plantingSiteModel, speciesModels)
             }
-            .sortedBy { it.id.value }
+            .sortedBy { it.id }
 
     val seedBankBodies =
         seedBankModels
@@ -273,7 +273,7 @@ class ReportService(
                   ?.populate(facility, orgStats, projectStats)
                   ?: ReportBodyModelV1.SeedBank(facility, orgStats, projectStats)
             }
-            .sortedBy { it.id.value }
+            .sortedBy { it.id }
 
     return body?.copy(
         annualDetails = annualDetails,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/NotificationStoreTest.kt
@@ -117,7 +117,7 @@ internal class NotificationStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         expected,
-        store.fetchByOrganization(orgId).sortedBy { it.id.value },
+        store.fetchByOrganization(orgId).sortedBy { it.id },
         "Listed organizations do not match what was created")
   }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -275,7 +275,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
     assertEquals(
         listOf(userIdWithOneRole, userIdWithTwoRoles),
-        userStore.fetchWithGlobalRoles().map { it.userId }.sortedBy { it.value },
+        userStore.fetchWithGlobalRoles().map { it.userId }.sorted(),
         "IDs of users with global roles")
   }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/DocumentsControllerTest.kt
@@ -112,7 +112,7 @@ class DocumentsControllerTest : ControllerIntegrationTest() {
 
       mockMvc.post(path) { content = payload }.andExpect { status { isOk() } }
 
-      val values = variableSectionValuesDao.findAll().sortedBy { it.variableValueId!!.value }
+      val values = variableSectionValuesDao.findAll().sortedBy { it.variableValueId }
 
       assertEquals(2, values.size, "Should have copied both default value entries")
       assertEquals("Some text", values[0].textValue, "Should have copied text value")

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -668,7 +668,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
     // does not care about hierarchy and will grab the first one that matches by name in reversed
     // order
     private fun getVariableByName(name: String): VariablesRow =
-        variablesDao.fetchByName(name).sortedBy { it.id!!.value }.reversed().first()
+        variablesDao.fetchByName(name).sortedBy { it.id }.reversed().first()
   }
 }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -424,7 +424,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       val updateResult = importer.import(sizedInputStream(updatedCsv))
 
-      val variablesRows = variablesDao.findAll().sortedBy { it.id!!.value }
+      val variablesRows = variablesDao.findAll().sortedBy { it.id }
       val updatedVariableId = variablesRows.filter { it.id != originalVariableId }.single().id!!
 
       assertEquals(2, variablesRows.size, "Number of imported variables")
@@ -560,12 +560,12 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(initialCsv))
 
-      val initialVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val initialVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(3, initialVariables.size, "Should have imported 3 variables")
 
       val updateResult = importer.import(sizedInputStream(updatedCsv))
 
-      val updatedVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val updatedVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(6, updatedVariables.size, "Should have created 2 new variables")
 
       assertEquals(
@@ -657,12 +657,12 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(initialCsv))
 
-      val initialVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val initialVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(3, initialVariables.size, "Should have imported 3 variables")
 
       val updateResult = importer.import(sizedInputStream(updatedCsv))
 
-      val updatedVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val updatedVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(6, updatedVariables.size, "Should have imported new copies of all variables")
       val newTableVariableId = updatedVariables[3].id!!
 
@@ -699,12 +699,12 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(initialCsv))
 
-      val initialVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val initialVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(2, initialVariables.size, "Should have imported 2 variables")
 
       val updateResult = importer.import(sizedInputStream(updatedCsv))
 
-      val updatedVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val updatedVariables = variablesDao.findAll().sortedBy { it.id }
       assertEquals(5, updatedVariables.size, "Should have imported new copies of all variables")
       val newTableVariableId = updatedVariables[2].id!!
 
@@ -847,7 +847,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(csv1))
 
-      val variables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val variables = variablesDao.findAll().sortedBy { it.id }
 
       assertEquals(
           listOf(
@@ -888,7 +888,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
               DeliverableVariablesRow(deliverableId2, variables[1].id, 0),
               DeliverableVariablesRow(deliverableId1, variables[2].id, 1),
           ),
-          deliverableVariablesDao.findAll().sortedBy { it.variableId!!.value },
+          deliverableVariablesDao.findAll().sortedBy { it.variableId },
           "Deliverable positions are allocated as expected at creation time")
 
       val csv2 =
@@ -900,7 +900,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(csv2))
 
-      val updatedVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val updatedVariables = variablesDao.findAll().sortedBy { it.id }
 
       assertEquals(
           listOf(
@@ -981,7 +981,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
       insertNumberVariable(stableId = "1113")
       insertDeliverableVariable(deliverableId = deliverableId1, position = 1)
 
-      val variables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val variables = variablesDao.findAll().sortedBy { it.id }
 
       val csv =
           header +
@@ -991,7 +991,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.import(sizedInputStream(csv))
 
-      val updatedVariables = variablesDao.findAll().sortedBy { it.id!!.value }
+      val updatedVariables = variablesDao.findAll().sortedBy { it.id }
 
       assertEquals(
           listOf(
@@ -1177,6 +1177,6 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
     // does not care about hierarchy and will grab the first one that matches by name in reversed
     // order
     private fun getVariableByName(name: String): VariablesRow =
-        variablesDao.fetchByName(name).sortedBy { it.id!!.value }.reversed().first()
+        variablesDao.fetchByName(name).sortedBy { it.id }.reversed().first()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -361,8 +361,8 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
         uploadsDao.fetchOneById(inserted.uploadId)?.statusId,
         "Status after import")
 
-    val actualSpecies = speciesDao.findAll().sortedBy { it.id!!.value }
-    val actualBatches = batchesDao.findAll().sortedBy { it.id!!.value }
+    val actualSpecies = speciesDao.findAll().sortedBy { it.id }
+    val actualBatches = batchesDao.findAll().sortedBy { it.id }
     val mappedSpeciesIds = mapTo1IndexedIds(actualSpecies, ::SpeciesId, SpeciesRow::id)
     val mappedBatchIds = mapTo1IndexedIds(actualBatches, ::BatchId, BatchesRow::id)
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
@@ -15,7 +15,7 @@ internal class BatchStoreGetActiveSpeciesTest : BatchStoreTest() {
     val speciesId3 = insertSpecies()
     insertBatch(speciesId = speciesId3, readyQuantity = 1)
 
-    val expected = speciesDao.findAll().sortedBy { it.id!!.value }
+    val expected = speciesDao.findAll().sortedBy { it.id }
 
     val speciesId4 = insertSpecies()
     insertBatch(speciesId = speciesId4)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -384,8 +384,8 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           uploadsDao.fetchOneById(inserted.uploadId)?.statusId,
           "Status after import")
 
-      val actualSpecies = speciesDao.findAll().sortedBy { it.id!!.value }
-      val actualAccessions = accessionsDao.findAll().sortedBy { it.id!!.value }
+      val actualSpecies = speciesDao.findAll().sortedBy { it.id }
+      val actualAccessions = accessionsDao.findAll().sortedBy { it.id }
       val mappedSpeciesIds = mapTo1IndexedIds(actualSpecies, ::SpeciesId, SpeciesRow::id)
       val mappedAccessionIds = mapTo1IndexedIds(actualAccessions, ::AccessionId, AccessionsRow::id)
 
@@ -410,7 +410,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           },
           geolocationsDao
               .findAll()
-              .sortedBy { it.id!!.value }
+              .sortedBy { it.id }
               .map {
                 it.copy(
                     id = null,
@@ -832,7 +832,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
           problems.toList().map { it.copy(uploadId = inserted.uploadId) },
           uploadProblemsDao
               .findAll()
-              .sortedBy { it.id?.value }
+              .sortedBy { it.id }
               .map { it.copy(id = null, uploadId = inserted.uploadId) },
           "Upload problems")
       assertStatus(status)
@@ -1070,7 +1070,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.importCsv(uploadId, false)
 
-      val accessions = accessionsDao.findAll().sortedBy { it.id!!.value }
+      val accessions = accessionsDao.findAll().sortedBy { it.id }
       assertEquals(2, accessions.size, "Should have inserted 2 accessions")
       assertEquals(
           "UG", accessions[0].collectionSiteCountryCode, "Country code looked up from name")

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -341,7 +341,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
                 modifiedTime = Instant.EPOCH),
         )
 
-    val actualSpecies = speciesDao.findAll().sortedBy { it.id!!.value }
+    val actualSpecies = speciesDao.findAll().sortedBy { it.id }
     val mappedSpeciesIds = mapTo1IndexedIds(actualSpecies, ::SpeciesId, SpeciesRow::id)
     assertEquals(
         expectedSpecies.map { it.copy(id = null) }.toSet(),
@@ -723,7 +723,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
   }
 
   private fun assertProblems(expected: List<UploadProblemsRow>) {
-    val actual = uploadProblemsDao.findAll().sortedBy { it.id!!.value }.map { it.copy(id = null) }
+    val actual = uploadProblemsDao.findAll().sortedBy { it.id }.map { it.copy(id = null) }
     assertEquals(expected, actual)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -209,7 +209,7 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
     private fun runScenario(prefix: String, numObservations: Int) {
       importFromCsvFiles(prefix, numObservations)
       val allResults =
-          resultsStore.fetchByPlantingSiteId(plantingSiteId).sortedBy { it.observationId.value }
+          resultsStore.fetchByPlantingSiteId(plantingSiteId).sortedBy { it.observationId }
       assertResults(prefix, allResults)
     }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSeasonsTest.kt
@@ -63,7 +63,7 @@ internal class PlantingSiteStoreUpdateSeasonsTest : PlantingSiteStoreTest() {
 
       store.updatePlantingSite(plantingSiteId, desiredSeasons) { it }
 
-      val actual = plantingSeasonsDao.findAll().sortedBy { it.startDate!! }
+      val actual = plantingSeasonsDao.findAll().sortedBy { it.startDate }
 
       val expected =
           listOf(


### PR DESCRIPTION
Reduce a tiny amount of code clutter by making the ID wrapper classes implement
the `Comparable` interface, which means they can be used directly as sort keys.