### PR TITLE
SW-6187 Add overlapping plots to data model, API

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -308,8 +308,7 @@ val ID_WRAPPERS =
             listOf(
                 IdWrapper("DeliveryId", listOf("deliveries\\.id", ".*\\.delivery_id")),
                 IdWrapper("DraftPlantingSiteId", listOf("draft_planting_sites\\.id")),
-                IdWrapper(
-                    "MonitoringPlotId", listOf("monitoring_plots\\.id", ".*\\.monitoring_plot_id")),
+                IdWrapper("MonitoringPlotId", listOf("monitoring_plots\\.id", ".*\\..*_plot_id")),
                 IdWrapper("ObservationId", listOf("observations\\.id", ".*\\.observation_id")),
                 IdWrapper("ObservedPlotCoordinatesId", listOf("observed_plot_coordinates\\.id")),
                 IdWrapper("PlantingId", listOf("plantings\\.id")),

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -597,6 +597,10 @@ data class ObservationMonitoringPlotResultsPayload(
                 "all species that were dead.")
     val mortalityRate: Int?,
     val notes: String?,
+    @Schema(description = "IDs of any newer monitoring plots that overlap with this one.")
+    val overlappedByPlotIds: Set<MonitoringPlotId>,
+    @Schema(description = "IDs of any older monitoring plots this one overlaps with.")
+    val overlapsWithPlotIds: Set<MonitoringPlotId>,
     val photos: List<ObservationMonitoringPlotPhotoPayload>,
     @Schema(description = "Number of live plants per hectare.") //
     val plantingDensity: Int,
@@ -629,6 +633,8 @@ data class ObservationMonitoringPlotResultsPayload(
       monitoringPlotName = model.monitoringPlotName,
       mortalityRate = model.mortalityRate,
       notes = model.notes,
+      overlappedByPlotIds = model.overlappedByPlotIds,
+      overlapsWithPlotIds = model.overlapsWithPlotIds,
       photos = model.photos.map { ObservationMonitoringPlotPhotoPayload(it) },
       plantingDensity = model.plantingDensity,
       sizeMeters = model.sizeMeters,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -89,6 +89,10 @@ data class ObservationMonitoringPlotResultsModel(
      */
     val mortalityRate: Int?,
     val notes: String?,
+    /** IDs of newer monitoring plots that overlap with this one. */
+    val overlappedByPlotIds: Set<MonitoringPlotId>,
+    /** IDs of older monitoring plots that this one overlaps with. */
+    val overlapsWithPlotIds: Set<MonitoringPlotId>,
     val photos: List<ObservationMonitoringPlotPhotoModel>,
     /**
      * Number of live plants per hectare. This is calculated by dividing the number of live plants

--- a/src/main/resources/db/migration/0300/V311__MonitoringPlotOverlaps.sql
+++ b/src/main/resources/db/migration/0300/V311__MonitoringPlotOverlaps.sql
@@ -1,0 +1,10 @@
+CREATE TABLE tracking.monitoring_plot_overlaps (
+    monitoring_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
+    overlaps_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
+
+    PRIMARY KEY (monitoring_plot_id, overlaps_plot_id),
+
+    CONSTRAINT newer_overlaps_older CHECK (overlaps_plot_id < monitoring_plot_id)
+);
+
+CREATE INDEX ON tracking.monitoring_plot_overlaps (overlaps_plot_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -345,6 +345,10 @@ COMMENT ON COLUMN tracking.draft_planting_sites.data IS 'Client-defined state of
 COMMENT ON COLUMN tracking.draft_planting_sites.num_planting_subzones is 'Number of planting subzones defined so far.';
 COMMENT ON COLUMN tracking.draft_planting_sites.num_planting_zones is 'Number of planting zones defined so far.';
 
+COMMENT ON TABLE tracking.monitoring_plot_overlaps IS 'Which monitoring plots overlap with previously-used monitoring plots. A plot may overlap with multiple older or newer plots.';
+COMMENT ON COLUMN tracking.monitoring_plot_overlaps.monitoring_plot_id IS 'ID of the newer monitoring plot.';
+COMMENT ON COLUMN tracking.monitoring_plot_overlaps.overlaps_plot_id IS 'ID of the older monitoring plot.';
+
 COMMENT ON TABLE tracking.monitoring_plots IS 'Regions within planting subzones that can be comprehensively surveyed in order to extrapolate results for the entire zone. Any monitoring plot in a subzone is expected to have roughly the same number of plants of the same species as any other monitoring plot in the same subzone.';
 COMMENT ON COLUMN tracking.monitoring_plots.boundary IS 'Boundary of the monitoring plot. Coordinates always use SRID 4326 (WGS 84 latitude/longitude).';
 COMMENT ON COLUMN tracking.monitoring_plots.created_by IS 'Which user created the monitoring plot.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -291,6 +291,7 @@ import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.keys.PLANTING_SITES_PKEY
 import com.terraformation.backend.db.tracking.tables.daos.DeliveriesDao
 import com.terraformation.backend.db.tracking.tables.daos.DraftPlantingSitesDao
+import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotOverlapsDao
 import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPhotosDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotConditionsDao
@@ -313,6 +314,7 @@ import com.terraformation.backend.db.tracking.tables.daos.PlantingsDao
 import com.terraformation.backend.db.tracking.tables.daos.RecordedPlantsDao
 import com.terraformation.backend.db.tracking.tables.pojos.DeliveriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.DraftPlantingSitesRow
+import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotOverlapsRow
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationPhotosRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationPlotsRow
@@ -481,6 +483,7 @@ abstract class DatabaseBackedTest {
   protected val internalTagsDao: InternalTagsDao by lazyDao()
   protected val documentTemplatesDao: DocumentTemplatesDao by lazyDao()
   protected val modulesDao: ModulesDao by lazyDao()
+  protected val monitoringPlotOverlapsDao: MonitoringPlotOverlapsDao by lazyDao()
   protected val monitoringPlotsDao: MonitoringPlotsDao by lazyDao()
   protected val notificationsDao: NotificationsDao by lazyDao()
   protected val nurseryWithdrawalsDao:
@@ -1784,6 +1787,13 @@ abstract class DatabaseBackedTest {
     monitoringPlotsDao.insert(rowWithDefaults)
 
     return rowWithDefaults.id!!.also { inserted.monitoringPlotIds.add(it) }
+  }
+
+  fun insertMonitoringPlotOverlap(
+      overlapsPlotId: MonitoringPlotId,
+      monitoringPlotId: MonitoringPlotId = inserted.monitoringPlotId,
+  ) {
+    monitoringPlotOverlapsDao.insert(MonitoringPlotOverlapsRow(monitoringPlotId, overlapsPlotId))
   }
 
   private var nextDraftPlantingSiteNumber = 1

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -322,6 +322,7 @@ class SchemaDocsGenerator : DatabaseTest() {
               mapOf(
                   "deliveries" to setOf(ALL, TRACKING),
                   "draft_planting_sites" to setOf(ALL, TRACKING),
+                  "monitoring_plot_overlaps" to setOf(ALL, TRACKING),
                   "monitoring_plots" to setOf(ALL, TRACKING),
                   "observable_conditions" to setOf(ALL, TRACKING),
                   "observation_photos" to setOf(ALL, TRACKING),


### PR DESCRIPTION
Changing the plot sizes for future observation of a planting site that already has
observation results will mean that the new-sized plots will partially overlap the
old-sized ones. We want users to be able to navigate back to the old-sized plots
to see how the observation data has changed over time.

Add the concept of overlapping plots to the system. A newer plot may overlap with
some number of older plots, and may in turn be overlapped by some number of even
newer plots. Include the overlapping plot IDs in the plot-level observation results.

Currently, since plot size isn't variable yet, the list of overlapping plots will
always be empty.