### PR TITLE
Fix plot replacement permission bug

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -510,7 +510,9 @@ class ObservationStore(
       plotIds: Collection<MonitoringPlotId>,
       isPermanent: Boolean
   ) {
-    requirePermissions { manageObservation(observationId) }
+    if (!currentUser().canManageObservation(observationId)) {
+      requirePermissions { replaceObservationPlot(observationId) }
+    }
 
     if (plotIds.isEmpty()) {
       return
@@ -541,7 +543,9 @@ class ObservationStore(
       observationId: ObservationId,
       plotIds: Collection<MonitoringPlotId>
   ) {
-    requirePermissions { manageObservation(observationId) }
+    if (!currentUser().canManageObservation(observationId)) {
+      requirePermissions { replaceObservationPlot(observationId) }
+    }
 
     if (plotIds.isEmpty()) {
       return

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -1414,6 +1414,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
       helper.insertPlantedSite(width = 2, height = 7, subzoneCompletedTime = Instant.EPOCH)
       observationId = insertObservation()
 
+      every { user.canManageObservation(observationId) } returns false
       every { user.canReplaceObservationPlot(any()) } returns true
       every { user.canUpdatePlantingSite(any()) } returns true
     }


### PR DESCRIPTION
Organization admins are supposed to be able to replace monitoring plots of
in-progress observations, but part of the process required super-admin privileges.