### PR TITLE
Share CountryDetector instance across tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/TestSingletons.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestSingletons.kt
@@ -1,0 +1,14 @@
+package com.terraformation.backend
+
+import com.terraformation.backend.gis.CountryDetector
+
+/*
+ * Objects that should only be instantiated once per test suite, rather than once per test.
+ *
+ * Typically this is used for objects that have high initialization cost.
+ *
+ * All objects declared here must be thread-safe.
+ */
+object TestSingletons {
+  val countryDetector: CountryDetector by lazy { CountryDetector() }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ApplicationServiceTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.accelerator.db.ApplicationStore
 import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
 import com.terraformation.backend.accelerator.model.ApplicationSubmissionResult
@@ -24,7 +25,6 @@ import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
-import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.util.Turtle
@@ -67,7 +67,7 @@ class ApplicationServiceTest : DatabaseTest(), RunsAsUser {
         applicationVariableValuesService,
         config,
         countriesDao,
-        CountryDetector(),
+        TestSingletons.countryDetector,
         defaultProjectLeadsDao,
         hubSpotService,
         preScreenBoundarySubmissionFetcher,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableCompleterTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.accelerator.db.ApplicationStore
 import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.db.ModuleStore
@@ -27,7 +28,6 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
-import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -47,7 +47,7 @@ class DeliverableCompleterTest : DatabaseTest(), RunsAsUser {
         ApplicationStore(
             clock,
             countriesDao,
-            CountryDetector(),
+            TestSingletons.countryDetector,
             dslContext,
             eventPublisher,
             Messages(),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/DeliverableFilesRenamerTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.accelerator.db.ApplicationStore
 import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
@@ -18,7 +19,6 @@ import com.terraformation.backend.db.accelerator.DeliverableType
 import com.terraformation.backend.db.accelerator.DocumentStore
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.file.GoogleDriveWriter
-import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.util.toInstant
@@ -50,7 +50,7 @@ class DeliverableFilesRenamerTest : DatabaseTest(), RunsAsUser {
         ApplicationStore(
             clock,
             countriesDao,
-            CountryDetector(),
+            TestSingletons.countryDetector,
             dslContext,
             eventPublisher,
             Messages(),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.accelerator.event.ApplicationInternalNameUpdatedEvent
 import com.terraformation.backend.accelerator.event.ApplicationSubmittedEvent
 import com.terraformation.backend.accelerator.model.ApplicationModuleModel
@@ -31,7 +32,6 @@ import com.terraformation.backend.db.accelerator.tables.records.ApplicationHisto
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.gis.CountryDetector
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
@@ -66,7 +66,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
     ApplicationStore(
         clock,
         countriesDao,
-        CountryDetector(),
+        TestSingletons.countryDetector,
         dslContext,
         eventPublisher,
         messages,

--- a/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.gis
 
+import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.point
 import com.terraformation.backend.util.Turtle
 import org.assertj.core.api.Assertions.assertThat
@@ -7,7 +8,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class CountryDetectorTest {
-  private val detector = CountryDetector()
+  private val detector = TestSingletons.countryDetector
 
   @Test
   fun `detects a geometry that is in one country`() {


### PR DESCRIPTION
CountryDetector has to load a big list of geometries the first time it's called,
meaning we spend time loading the list multiple times when running the test suite.

Add a singleton instance that's referenced by all the tests; it will load its
geometry list the first time any test calls it, and then stick around for
subsequent tests.