### PR TITLE
SW-6193 Validate that zones can fit 1-plot clusters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -312,24 +312,15 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   fun validate(newModel: PlantingSiteModel<*, *, *>): List<PlantingSiteValidationFailure> {
     val problems = mutableListOf<PlantingSiteValidationFailure>()
 
-    // Find 5 squares: 4 for the cluster and one for a temporary plot.
+    // Find two squares: one for a permanent plot and one for a temporary plot.
     val plotBoundaries =
         findUnusedSquares(
-            count = 5,
+            count = 2,
             exclusion = newModel.exclusion,
             gridOrigin = newModel.gridOrigin!!,
         )
 
-    // Make sure we have room for an actual cluster.
-    val clusterBoundaries =
-        findUnusedSquares(
-            count = 1,
-            exclusion = newModel.exclusion,
-            gridOrigin = newModel.gridOrigin,
-            sizeMeters = MONITORING_PLOT_SIZE * 2,
-        )
-
-    if (clusterBoundaries.isEmpty() || plotBoundaries.size < 5) {
+    if (plotBoundaries.size < 2) {
       problems.add(PlantingSiteValidationFailure.zoneTooSmall(name))
     }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -55,10 +55,10 @@ class PlantingSiteModelTest {
     }
 
     @Test
-    fun `checks that zones are big enough for observations`() {
-      val site = newSite(width = 50, height = 50)
+    fun `allows zone that is only big enough for two plots`() {
+      val site = newSite(width = MONITORING_PLOT_SIZE_INT, height = MONITORING_PLOT_SIZE_INT * 2)
 
-      assertHasProblem(site, PlantingSiteValidationFailure.zoneTooSmall("Z1"))
+      assertHasNoProblems(site)
     }
 
     @Test
@@ -96,16 +96,11 @@ class PlantingSiteModelTest {
     }
 
     @Test
-    fun `checks that zone is big enough for a permanent cluster and a temporary plot`() {
+    fun `checks that zone is big enough for a permanent plot and a temporary plot`() {
       assertHasProblem(
-          newSite(width = 51, height = 50),
+          newSite(width = MONITORING_PLOT_SIZE_INT * 2 - 1, height = MONITORING_PLOT_SIZE_INT),
           PlantingSiteValidationFailure.zoneTooSmall("Z1"),
-          "Site is big enough for permanent cluster but not also for temporary plot")
-
-      assertHasProblem(
-          newSite(width = 500, height = 30),
-          PlantingSiteValidationFailure.zoneTooSmall("Z1"),
-          "Site is big enough for 5 plots but not a permanent cluster")
+          "Site is big enough for permanent plot but not also for temporary plot")
     }
 
     @Test
@@ -132,6 +127,12 @@ class PlantingSiteModelTest {
       if (problems!!.none { it == problem }) {
         assertEquals(listOf(problem), problems, message)
       }
+    }
+
+    private fun assertHasNoProblems(site: PlantingSiteModel<*, *, *>) {
+      val problems = site.validate()
+
+      assertNull(problems, "Validation returned problems")
     }
   }
 }


### PR DESCRIPTION
Previously, the validation logic for planting zone geometries checked whether
there was room for a 4-plot permanent cluster and a single temporary plot.
Remove the 4-plot cluster check and instead validate that there's room for two
monitoring plots (which will allow an observation with one permanent and one
temporary plot).