### PR TITLE
SW-6191 Change monitoring plot size to 30 meters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/Constants.kt
@@ -9,7 +9,7 @@ const val HECTARES_SCALE = 1
 val MAX_SITE_ENVELOPE_AREA_HA = BigDecimal(20000)
 
 /** Monitoring plot width and height in meters. */
-const val MONITORING_PLOT_SIZE: Double = 25.0
+const val MONITORING_PLOT_SIZE: Double = 30.0
 
 /** Monitoring plot width and height in meters. */
 const val MONITORING_PLOT_SIZE_INT = MONITORING_PLOT_SIZE.toInt()

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -298,14 +298,16 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 
   /**
-   * Returns the monitoring plot that contains the center point of a shape, or null if the shape
-   * isn't in any plot.
+   * Returns the monitoring plot that is of the correct size and contains the center point of a
+   * shape, or null if the shape isn't in any plot.
    */
   fun findMonitoringPlot(geometry: Geometry): MonitoringPlotModel? {
     val centroid = geometry.centroid
 
     return plantingSubzones.firstNotNullOfOrNull { subzone ->
-      subzone.monitoringPlots.firstOrNull { plot -> plot.boundary.contains(centroid) }
+      subzone.monitoringPlots.firstOrNull { plot ->
+        plot.boundary.contains(centroid) && plot.sizeMeters == MONITORING_PLOT_SIZE_INT
+      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -81,7 +81,8 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
             plantingCompletedTime = Instant.ofEpochSecond(1),
             name = "4")
     val monitoringPlotId7 = insertMonitoringPlot(boundary = monitoringPlotGeometry7)
-    val monitoringPlotId8 = insertMonitoringPlot(boundary = monitoringPlotGeometry8)
+    val monitoringPlotId8 =
+        insertMonitoringPlot(boundary = monitoringPlotGeometry8, sizeMeters = 25)
 
     val speciesId1 = insertSpecies()
     val speciesId2 = insertSpecies()
@@ -314,7 +315,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                         "northeastLongitude" to "7",
                                                         "northwestLatitude" to "8",
                                                         "northwestLongitude" to "5",
-                                                        "sizeMeters" to "25",
+                                                        "sizeMeters" to "30",
                                                         "southeastLatitude" to "6",
                                                         "southeastLongitude" to "7",
                                                         "southwestLatitude" to "6",
@@ -326,7 +327,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                         "northeastLongitude" to "8",
                                                         "northwestLatitude" to "9",
                                                         "northwestLongitude" to "6",
-                                                        "sizeMeters" to "25",
+                                                        "sizeMeters" to "30",
                                                         "southeastLatitude" to "7",
                                                         "southeastLongitude" to "8",
                                                         "southwestLatitude" to "7",
@@ -362,7 +363,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                         "northeastLongitude" to "9",
                                                         "northwestLatitude" to "10",
                                                         "northwestLongitude" to "7",
-                                                        "sizeMeters" to "25",
+                                                        "sizeMeters" to "30",
                                                         "southeastLatitude" to "8",
                                                         "southeastLongitude" to "9",
                                                         "southwestLatitude" to "8",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -207,7 +207,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   plantingSubzoneId = plantingSubzoneId1,
                   plantingSubzoneName = "Z1-S1",
                   plotName = "Z1-S1-1",
-                  sizeMeters = 25,
+                  sizeMeters = 30,
               ),
               AssignedPlotDetails(
                   model =
@@ -225,7 +225,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   plantingSubzoneId = plantingSubzoneId1,
                   plantingSubzoneName = "Z1-S1",
                   plotName = "Z1-S1-2",
-                  sizeMeters = 25,
+                  sizeMeters = 30,
               ),
               AssignedPlotDetails(
                   model =
@@ -247,7 +247,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   plantingSubzoneId = plantingSubzoneId2,
                   plantingSubzoneName = "Z1-S2",
                   plotName = "Z1-S2-1",
-                  sizeMeters = 25,
+                  sizeMeters = 30,
               ))
 
       val actual = store.fetchObservationPlotDetails(observationId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
@@ -76,13 +76,16 @@ internal class PlantingSiteStoreEnsurePermanentTest : PlantingSiteStoreTest() {
     @Test
     fun `can use temporary plot from previous observation as permanent plot`() {
       val gridOrigin = point(0)
-      val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { rectangle(51, 26) }
+      val siteBoundary =
+          Turtle(gridOrigin).makeMultiPolygon {
+            rectangle(MONITORING_PLOT_SIZE * 2 + 1, MONITORING_PLOT_SIZE + 1)
+          }
 
       // Temporary plot is in the east half of the site.
       val existingPlotBoundary =
           Turtle(gridOrigin).makePolygon {
-            east(25)
-            square(25)
+            east(MONITORING_PLOT_SIZE)
+            square(MONITORING_PLOT_SIZE)
           }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreReadTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreReadTest.kt
@@ -376,7 +376,7 @@ internal class PlantingSiteStoreReadTest : PlantingSiteStoreTest() {
                                                       isAvailable = true,
                                                       name = "1",
                                                       fullName = "Z1-1-1",
-                                                      sizeMeters = 25)),
+                                                      sizeMeters = 30)),
                                       )))))
 
       val allExpected =
@@ -459,7 +459,7 @@ internal class PlantingSiteStoreReadTest : PlantingSiteStoreTest() {
                                                   isAvailable = true,
                                                   name = "1",
                                                   fullName = "Z1-1-1",
-                                                  sizeMeters = 25)),
+                                                  sizeMeters = 30)),
                                   )))))
 
       val actual = store.fetchSiteById(plantingSiteId, PlantingSiteDepth.Plot)


### PR DESCRIPTION
Update the monitoring plot size so that any newly-created plots will be 30 meters
wide and aligned on a 30-meter-interval grid from the planting site's grid origin.

Existing 25-meter plots are not affected; this only changes the size that's used
for new plots going forward.