### PR TITLE
SW-6204 Disallow replacement of 25m plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -98,6 +98,13 @@ class PlotNotInObservationException(
     EntityNotFoundException(
         "Monitoring plot $monitoringPlotId is not assigned to observation $observationId")
 
+class PlotSizeNotReplaceableException(
+    val observationId: ObservationId,
+    val monitoringPlotId: MonitoringPlotId
+) :
+    MismatchedStateException(
+        "Monitoring plot $monitoringPlotId has old size; can't replace it in observation $observationId")
+
 class ReassignmentExistsException(val plantingId: PlantingId) :
     MismatchedStateException(
         "Cannot reassign from planting $plantingId because it already has a reassignment")

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -47,6 +47,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlotAlreadyCompletedException
 import com.terraformation.backend.tracking.db.PlotNotInObservationException
+import com.terraformation.backend.tracking.db.PlotSizeNotReplaceableException
 import com.terraformation.backend.tracking.db.ScheduleObservationWithoutPlantsException
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
@@ -58,6 +59,7 @@ import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NotificationCriteria
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
@@ -138,6 +140,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
         dslContext,
         eventPublisher,
         fileService,
+        monitoringPlotsDao,
         observationPhotosDao,
         observationStore,
         plantingSiteStore,
@@ -1779,6 +1782,17 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
       assertThrows<PlotNotInObservationException> {
         service.replaceMonitoringPlot(
             observationId, otherPlotId, "justification", ReplacementDuration.LongTerm)
+      }
+    }
+
+    @Test
+    fun `throws exception if plot size is different from the size of newly-created plots`() {
+      val monitoringPlotId = insertMonitoringPlot(sizeMeters = MONITORING_PLOT_SIZE_INT - 1)
+      insertObservationPlot()
+
+      assertThrows<PlotSizeNotReplaceableException> {
+        service.replaceMonitoringPlot(
+            observationId, monitoringPlotId, "justification", ReplacementDuration.LongTerm)
       }
     }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -63,6 +63,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         dslContext,
         eventPublisher,
         mockk(),
+        monitoringPlotsDao,
         observationPhotosDao,
         observationStore,
         plantingSiteStore,


### PR DESCRIPTION
When we switch to the 30m plot size, there may be existing observations in
progress. They are able to finish as normal, but since we no longer support
creating new 4-plot clusters, we can't support the "request monitoring plot
replacement" feature for those observations since plot replacement can
trigger creation of new permanent clusters.

Add a check to reject attempts to replace plots with sizes different from
the current size we use for new plots. In practice, this means replacing 25m
plots will fail but replacing 30m plots will succeed.