### PR TITLE
Add assertGeometryEquals function for tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -9,11 +9,13 @@ import com.terraformation.backend.auth.KeycloakInfo
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.seedbank.db.AccessionImporterTest
 import com.terraformation.backend.util.Turtle
+import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.CoordinateXY
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
@@ -45,6 +47,17 @@ fun assertJsonEquals(expected: Any, actual: Any, message: String? = null) {
         prettyPrintingObjectMapper.writeValueAsString(expected),
         prettyPrintingObjectMapper.writeValueAsString(actual),
         message)
+  }
+}
+
+/**
+ * Asserts that two Geometry objects are approximately equal. The regular assertEquals function can
+ * fail due to loss of precision when geometries are stored in the database.
+ */
+fun assertGeometryEquals(expected: Geometry?, actual: Geometry?, message: String? = null) {
+  if (!expected.equalsOrBothNull(actual)) {
+    // Let the regular assertEquals output the failure message.
+    assertEquals(expected, actual, message)
   }
 }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.accelerator.model.ApplicationVariableValues
 import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
 import com.terraformation.backend.accelerator.model.ExistingApplicationModel
 import com.terraformation.backend.accelerator.model.PreScreenProjectType
+import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -38,7 +39,6 @@ import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.calculateAreaHectares
-import com.terraformation.backend.util.equalsOrBothNull
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
@@ -1614,11 +1614,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
           ),
           applicationRow.copy(boundary = null))
 
-      // Produce a meaningful assertion failure message if the boundary isn't as expected within
-      // the default floating-point inaccuracy tolerance.
-      if (!boundary.equalsOrBothNull(applicationRow.boundary)) {
-        assertEquals(boundary, applicationRow.boundary, "Boundary in applications row")
-      }
+      assertGeometryEquals(boundary, applicationRow.boundary, "Boundary in applications row")
 
       assertEquals(
           listOf(

--- a/src/test/kotlin/com/terraformation/backend/gis/GeometryFileParserTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/GeometryFileParserTest.kt
@@ -1,9 +1,9 @@
 package com.terraformation.backend.gis
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.db.GeometryModule
 import com.terraformation.backend.db.SRID
-import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.toMultiPolygon
 import org.geotools.util.ContentFormatException
 import org.junit.jupiter.api.Assertions.*
@@ -80,9 +80,7 @@ class GeometryFileParserTest {
 
       val geometry = parser.parse(bytes, resourcePath)
 
-      if (!triangle.equalsOrBothNull(geometry.toMultiPolygon().norm())) {
-        assertEquals(triangle, geometry.toMultiPolygon())
-      }
+      assertGeometryEquals(triangle, geometry.toMultiPolygon().norm())
     }
   }
 }


### PR DESCRIPTION
Reduce a little code clutter in tests with an assertion function to compare two
geometries for approximate equality.