### PR TITLE
SW-6182 Populate countries of existing planting sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -62,6 +62,8 @@ class AdminController(
         currentUser().canManageModules() || currentUser().canManageDeliverables())
     model.addAttribute("canManageInternalTags", currentUser().canManageInternalTags())
     model.addAttribute("canManageParticipants", currentUser().canCreateParticipant())
+    model.addAttribute(
+        "canPopulatePlantingSiteCountries", currentUser().canPopulatePlantingSiteCountries())
     model.addAttribute("canReadCohorts", currentUser().canReadCohorts())
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())
     model.addAttribute("canUpdateAppVersions", currentUser().canUpdateAppVersions())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -720,6 +720,20 @@ class AdminPlantingSitesController(
     return redirectToPlantingSite(plantingSiteId)
   }
 
+  @PostMapping("/plantingSite/populateCountries")
+  fun populatePlantingSiteCountries(redirectAttributes: RedirectAttributes): String {
+    try {
+      plantingSiteStore.populateExistingSiteCountries()
+      redirectAttributes.successMessage = "Populated countries of existing planting sites"
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = "Failed to populate planting site countries: $e"
+    }
+
+    return redirectToAdminHome()
+  }
+
+  private fun redirectToAdminHome() = "redirect:/admin/"
+
   private fun redirectToOrganization(organizationId: OrganizationId) =
       "redirect:/admin/organization/$organizationId"
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -352,6 +352,8 @@ data class IndividualUser(
   override fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId) =
       canUpdatePlantingSite(plantingSiteId) && isSuperAdmin()
 
+  override fun canPopulatePlantingSiteCountries() = isSuperAdmin()
+
   override fun canReadAccession(accessionId: AccessionId) =
       isMember(parentStore.getFacilityId(accessionId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -582,6 +582,12 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun populatePlantingSiteCountries() {
+    if (!user.canPopulatePlantingSiteCountries()) {
+      throw AccessDeniedException("No permission to populate planting site countries")
+    }
+  }
+
   fun readAccession(accessionId: AccessionId) {
     if (!user.canReadAccession(accessionId)) {
       throw AccessionNotFoundException(accessionId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -268,6 +268,8 @@ interface TerrawareUser : Principal {
 
   fun canMovePlantingSiteToAnyOrg(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
+  fun canPopulatePlantingSiteCountries(): Boolean = defaultPermission
+
   fun canReadAccession(accessionId: AccessionId): Boolean = defaultPermission
 
   fun canReadAllAcceleratorDetails(): Boolean = defaultPermission

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1492,6 +1492,37 @@ class PlantingSiteStore(
     }
   }
 
+  fun populateExistingSiteCountries() {
+    requirePermissions { populatePlantingSiteCountries() }
+
+    with(PLANTING_SITES) {
+      dslContext
+          .select(ID.asNonNullable(), BOUNDARY.asNonNullable())
+          .from(PLANTING_SITES)
+          .where(BOUNDARY.isNotNull)
+          .and(COUNTRY_CODE.isNull)
+          .fetch()
+          .forEach { (plantingSiteId, boundary) ->
+            val countryCode = countryDetector.getCountries(boundary).singleOrNull()
+            if (countryCode != null) {
+              log.debug("Detected country code $countryCode for planting site $plantingSiteId")
+
+              withLockedPlantingSite(plantingSiteId) {
+                dslContext
+                    .update(PLANTING_SITES)
+                    .set(COUNTRY_CODE, countryCode)
+                    .set(MODIFIED_BY, currentUser().userId)
+                    .set(MODIFIED_TIME, clock.instant())
+                    .where(ID.eq(plantingSiteId))
+                    .execute()
+              }
+            } else {
+              log.debug("No country code detected for planting site $plantingSiteId")
+            }
+          }
+    }
+  }
+
   private val plantingSeasonsMultiset =
       DSL.multiset(
               DSL.select(

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -196,6 +196,19 @@
     </form>
 </th:block>
 
+<th:block th:if="${canPopulatePlantingSiteCountries}">
+    <h2>Populate Planting Site Countries</h2>
+
+    <p>
+        This is a one-time operation to calculate the country codes of existing planting sites
+        based on their site boundaries.
+    </p>
+
+    <form method="POST" action="/admin/plantingSite/populateCountries">
+        <input type="submit" value="Populate Countries"/>
+    </form>
+</th:block>
+
 <th:block th:if="${canImportGlobalSpeciesData}">
     <h2>PDH Migration</h2>
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -560,6 +560,11 @@ internal class PermissionRequirementsTest : RunsAsUser {
     requirements.movePlantingSiteToAnyOrg(plantingSiteId)
   }
 
+  @Test
+  fun populatePlantingSiteCountries() {
+    allow { populatePlantingSiteCountries() } ifUser { canPopulatePlantingSiteCountries() }
+  }
+
   @Test fun readAccession() = testRead { readAccession(accessionId) }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1381,6 +1381,7 @@ internal class PermissionTest : DatabaseTest() {
         manageDefaultProjectLeads = true,
         manageModuleEventStatuses = true,
         manageNotifications = true,
+        populatePlantingSiteCountries = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
         readCohort = true,
@@ -1729,6 +1730,7 @@ internal class PermissionTest : DatabaseTest() {
         manageInternalTags = true,
         manageModuleEvents = true,
         manageModules = true,
+        populatePlantingSiteCountries = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
         readCohort = true,
@@ -2762,6 +2764,7 @@ internal class PermissionTest : DatabaseTest() {
         manageModules: Boolean = false,
         manageNotifications: Boolean = false,
         manageDefaultProjectLeads: Boolean = false,
+        populatePlantingSiteCountries: Boolean = false,
         readAllAcceleratorDetails: Boolean = false,
         readAllDeliverables: Boolean = false,
         readCohort: Boolean = false,
@@ -2829,6 +2832,10 @@ internal class PermissionTest : DatabaseTest() {
           "Can manage module event statuses")
       assertEquals(manageModules, user.canManageModules(), "Can manage modules")
       assertEquals(manageNotifications, user.canManageNotifications(), "Can manage notifications")
+      assertEquals(
+          populatePlantingSiteCountries,
+          user.canPopulatePlantingSiteCountries(),
+          "Can populate planting site countries")
       assertEquals(
           readAllAcceleratorDetails,
           user.canReadAllAcceleratorDetails(),


### PR DESCRIPTION
Add a button to the admin UI to scan the existing planting sites and populate the
country codes of the ones that have boundaries.

This change can be reverted once the existing planting sites in all our
environments have been updated.