### PR TITLE
SW-6205 Make workflow history follow variable replacements

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingVariableWorkflowHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/ExistingVariableWorkflowHistoryModel.kt
@@ -1,14 +1,15 @@
 package com.terraformation.backend.documentproducer.model
 
+import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.VariableWorkflowHistoryId
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
-import com.terraformation.backend.db.docprod.tables.pojos.VariableWorkflowHistoryRow
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_WORKFLOW_HISTORY
 import java.time.Instant
+import org.jooq.Field
 import org.jooq.Record
 
 data class ExistingVariableWorkflowHistoryModel(
@@ -18,35 +19,42 @@ data class ExistingVariableWorkflowHistoryModel(
     val id: VariableWorkflowHistoryId,
     val internalComment: String?,
     val maxVariableValueId: VariableValueId,
+    /** The ID of the variable at the time the workflow event happened. */
+    val originalVariableId: VariableId,
     val projectId: ProjectId,
     val status: VariableWorkflowStatus,
+    /**
+     * The current ID of the variable. May differ from [originalVariableId] if the variable was
+     * replaced after the workflow event happened; in that case this will be the most recent
+     * variable in the chain of replacements of the original one.
+     */
     val variableId: VariableId,
 ) {
-  constructor(
-      record: Record
-  ) : this(
-      createdBy = record[VARIABLE_WORKFLOW_HISTORY.CREATED_BY]!!,
-      createdTime = record[VARIABLE_WORKFLOW_HISTORY.CREATED_TIME]!!,
-      feedback = record[VARIABLE_WORKFLOW_HISTORY.FEEDBACK],
-      id = record[VARIABLE_WORKFLOW_HISTORY.ID]!!,
-      internalComment = record[VARIABLE_WORKFLOW_HISTORY.INTERNAL_COMMENT],
-      maxVariableValueId = record[VARIABLE_WORKFLOW_HISTORY.MAX_VARIABLE_VALUE_ID]!!,
-      projectId = record[VARIABLE_WORKFLOW_HISTORY.PROJECT_ID]!!,
-      status = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_WORKFLOW_STATUS_ID]!!,
-      variableId = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_ID]!!,
-  )
+  companion object {
+    fun of(
+        record: Record,
+        currentVariableIdField: Field<VariableId?> = VARIABLE_WORKFLOW_HISTORY.VARIABLE_ID,
+    ): ExistingVariableWorkflowHistoryModel {
+      val projectId = record[VARIABLE_WORKFLOW_HISTORY.PROJECT_ID]!!
+      val internalComment =
+          if (currentUser().canReadInternalVariableWorkflowDetails(projectId)) {
+            record[VARIABLE_WORKFLOW_HISTORY.INTERNAL_COMMENT]
+          } else {
+            null
+          }
 
-  constructor(
-      row: VariableWorkflowHistoryRow
-  ) : this(
-      row.createdBy!!,
-      row.createdTime!!,
-      row.feedback,
-      row.id!!,
-      row.internalComment,
-      row.maxVariableValueId!!,
-      row.projectId!!,
-      row.variableWorkflowStatusId!!,
-      row.variableId!!,
-  )
+      return ExistingVariableWorkflowHistoryModel(
+          createdBy = record[VARIABLE_WORKFLOW_HISTORY.CREATED_BY]!!,
+          createdTime = record[VARIABLE_WORKFLOW_HISTORY.CREATED_TIME]!!,
+          feedback = record[VARIABLE_WORKFLOW_HISTORY.FEEDBACK],
+          id = record[VARIABLE_WORKFLOW_HISTORY.ID]!!,
+          internalComment = internalComment,
+          maxVariableValueId = record[VARIABLE_WORKFLOW_HISTORY.MAX_VARIABLE_VALUE_ID]!!,
+          originalVariableId = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_ID]!!,
+          projectId = projectId,
+          status = record[VARIABLE_WORKFLOW_HISTORY.VARIABLE_WORKFLOW_STATUS_ID]!!,
+          variableId = record[currentVariableIdField]!!,
+      )
+    }
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStoreTest.kt
@@ -4,12 +4,15 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.event.QuestionsDeliverableReviewedEvent
 import com.terraformation.backend.documentproducer.model.ExistingVariableWorkflowHistoryModel
 import com.terraformation.backend.mockUser
 import io.mockk.every
+import java.time.Instant
+import java.util.UUID
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -24,6 +27,8 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
   private val eventPublisher = TestEventPublisher()
   private val store by lazy { VariableWorkflowStore(clock, dslContext, eventPublisher) }
 
+  private val stableId = "${UUID.randomUUID()}"
+
   @BeforeEach
   fun setUp() {
     insertOrganization()
@@ -33,7 +38,8 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
     insertDocument()
     insertModule()
     insertDeliverable()
-    insertVariableManifestEntry(insertTextVariable(deliverableId = inserted.deliverableId))
+    insertVariableManifestEntry(
+        insertTextVariable(deliverableId = inserted.deliverableId, stableId = stableId))
 
     insertValue(variableId = inserted.variableId)
 
@@ -43,9 +49,154 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
+  inner class FetchCurrentForProject {
+    @Test
+    fun `returns latest workflow details from previous versions of variables if none on current versions`() {
+      val originalVariableId1 = inserted.variableId
+
+      insertVariableWorkflowHistory(
+          createdTime = Instant.EPOCH, status = VariableWorkflowStatus.NotSubmitted)
+
+      val currentHistoryId1 =
+          insertVariableWorkflowHistory(
+              createdTime = Instant.EPOCH.plusSeconds(1),
+              feedback = "feedback 1",
+              status = VariableWorkflowStatus.InReview)
+
+      val newVariableId1 =
+          insertTextVariable(
+              insertVariable(
+                  deliverableId = inserted.deliverableId,
+                  replacesVariableId = originalVariableId1,
+                  stableId = stableId,
+                  type = VariableType.Text))
+
+      val stableId2 = "$stableId-2"
+      val originalVariableId2 = insertTextVariable(stableId = stableId2)
+
+      val currentHistoryId2 =
+          insertVariableWorkflowHistory(
+              createdTime = Instant.EPOCH,
+              feedback = "feedback 2",
+              status = VariableWorkflowStatus.InReview)
+
+      val newVariableId2 =
+          insertTextVariable(
+              insertVariable(
+                  replacesVariableId = originalVariableId2,
+                  stableId = stableId2,
+                  type = VariableType.Text))
+
+      val stableId3 = "$stableId-3"
+      val originalVariableId3 = insertTextVariable(stableId = stableId3)
+
+      insertVariableWorkflowHistory(
+          createdTime = Instant.EPOCH, status = VariableWorkflowStatus.NotSubmitted)
+
+      val newVariableId3 =
+          insertTextVariable(
+              insertVariable(
+                  replacesVariableId = originalVariableId3,
+                  stableId = stableId3,
+                  type = VariableType.Text))
+
+      val currentHistoryId3 =
+          insertVariableWorkflowHistory(
+              createdTime = Instant.EPOCH.plusSeconds(2),
+              feedback = "feedback 3",
+              internalComment = "internal 3",
+              status = VariableWorkflowStatus.Approved)
+
+      val expected =
+          mapOf(
+              newVariableId1 to
+                  ExistingVariableWorkflowHistoryModel(
+                      createdBy = user.userId,
+                      createdTime = Instant.EPOCH.plusSeconds(1),
+                      feedback = "feedback 1",
+                      id = currentHistoryId1,
+                      internalComment = null,
+                      maxVariableValueId = inserted.variableValueId,
+                      originalVariableId = originalVariableId1,
+                      projectId = inserted.projectId,
+                      status = VariableWorkflowStatus.InReview,
+                      variableId = newVariableId1,
+                  ),
+              newVariableId2 to
+                  ExistingVariableWorkflowHistoryModel(
+                      createdBy = user.userId,
+                      createdTime = Instant.EPOCH,
+                      feedback = "feedback 2",
+                      id = currentHistoryId2,
+                      internalComment = null,
+                      maxVariableValueId = inserted.variableValueId,
+                      originalVariableId = originalVariableId2,
+                      projectId = inserted.projectId,
+                      status = VariableWorkflowStatus.InReview,
+                      variableId = newVariableId2,
+                  ),
+              newVariableId3 to
+                  ExistingVariableWorkflowHistoryModel(
+                      createdBy = user.userId,
+                      createdTime = Instant.EPOCH.plusSeconds(2),
+                      feedback = "feedback 3",
+                      id = currentHistoryId3,
+                      internalComment = "internal 3",
+                      maxVariableValueId = inserted.variableValueId,
+                      // This history entry is from the current version of the variable
+                      originalVariableId = newVariableId3,
+                      projectId = inserted.projectId,
+                      status = VariableWorkflowStatus.Approved,
+                      variableId = newVariableId3,
+                  ),
+          )
+
+      assertEquals(expected, store.fetchCurrentForProject(inserted.projectId))
+    }
+
+    @Test
+    fun `does not populate internal comment if user lacks permission to see it`() {
+      every { user.canReadInternalVariableWorkflowDetails(inserted.projectId) } returns false
+
+      val historyId =
+          insertVariableWorkflowHistory(
+              feedback = "feedback",
+              internalComment = "internal comment",
+              status = VariableWorkflowStatus.InReview)
+
+      val expected =
+          mapOf(
+              inserted.variableId to
+                  ExistingVariableWorkflowHistoryModel(
+                      createdBy = user.userId,
+                      createdTime = Instant.EPOCH,
+                      feedback = "feedback",
+                      id = historyId,
+                      internalComment = null,
+                      maxVariableValueId = inserted.variableValueId,
+                      originalVariableId = inserted.variableId,
+                      projectId = inserted.projectId,
+                      status = VariableWorkflowStatus.InReview,
+                      variableId = inserted.variableId,
+                  ))
+
+      assertEquals(expected, store.fetchCurrentForProject(inserted.projectId))
+    }
+
+    @Test
+    fun `throws exception if no permission to read project`() {
+      every { user.canReadProject(inserted.projectId) } returns false
+
+      assertThrows<ProjectNotFoundException> { store.fetchCurrentForProject(inserted.projectId) }
+    }
+  }
+
+  @Nested
   inner class FetchProjectVariableHistory {
     @Test
     fun `returns list of workflow details sorted by createdTime`() {
+      val originalVariableId = inserted.variableId
+
       val oldWorkflowId =
           insertVariableWorkflowHistory(
               createdTime = clock.instant.plusSeconds(600),
@@ -59,6 +210,14 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
               createdTime = clock.instant.plusSeconds(300),
               status = VariableWorkflowStatus.NotSubmitted,
           )
+
+      val newVariableId =
+          insertTextVariable(
+              insertVariable(
+                  deliverableId = inserted.deliverableId,
+                  replacesVariableId = originalVariableId,
+                  stableId = stableId,
+                  type = VariableType.Text))
 
       val newWorkflowId =
           insertVariableWorkflowHistory(
@@ -77,9 +236,10 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
                   id = newWorkflowId,
                   internalComment = "new comment",
                   maxVariableValueId = inserted.variableValueId,
+                  originalVariableId = newVariableId,
                   projectId = inserted.projectId,
                   status = VariableWorkflowStatus.Approved,
-                  variableId = inserted.variableId,
+                  variableId = newVariableId,
               ),
               ExistingVariableWorkflowHistoryModel(
                   createdBy = user.userId,
@@ -88,9 +248,10 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
                   id = oldWorkflowId,
                   internalComment = "old comment",
                   maxVariableValueId = inserted.variableValueId,
+                  originalVariableId = originalVariableId,
                   projectId = inserted.projectId,
                   status = VariableWorkflowStatus.InReview,
-                  variableId = inserted.variableId,
+                  variableId = newVariableId,
               ),
               ExistingVariableWorkflowHistoryModel(
                   createdBy = user.userId,
@@ -99,12 +260,13 @@ class VariableWorkflowStoreTest : DatabaseTest(), RunsAsUser {
                   id = oldestWorkflowId,
                   internalComment = null,
                   maxVariableValueId = inserted.variableValueId,
+                  originalVariableId = originalVariableId,
                   projectId = inserted.projectId,
                   status = VariableWorkflowStatus.NotSubmitted,
-                  variableId = inserted.variableId,
+                  variableId = newVariableId,
               ),
           ),
-          store.fetchProjectVariableHistory(inserted.projectId, inserted.variableId))
+          store.fetchProjectVariableHistory(inserted.projectId, newVariableId))
     }
 
     @Test


### PR DESCRIPTION
If a variable is replaced by a newer version, we want the workflow history of the
old variable to be considered part of the history of the new variable too.

This should fix the system appearing to forget the statuses and comments of
variables when an upload of the all-variables CSV causes variables to be replaced.