### PR TITLE
SW-6182 Populate planting site countries as system user

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -76,6 +78,7 @@ class AdminPlantingSitesController(
     private val organizationStore: OrganizationStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val plantingSiteImporter: PlantingSiteImporter,
+    private val systemUser: SystemUser,
 ) {
   private val log = perClassLogger()
 
@@ -722,8 +725,10 @@ class AdminPlantingSitesController(
 
   @PostMapping("/plantingSite/populateCountries")
   fun populatePlantingSiteCountries(redirectAttributes: RedirectAttributes): String {
+    requirePermissions { populatePlantingSiteCountries() }
+
     try {
-      plantingSiteStore.populateExistingSiteCountries()
+      systemUser.run { plantingSiteStore.populateExistingSiteCountries() }
       redirectAttributes.successMessage = "Populated countries of existing planting sites"
     } catch (e: Exception) {
       redirectAttributes.failureMessage = "Failed to populate planting site countries: $e"


### PR DESCRIPTION
The admin UI function to populate the countries of existing planting sites added
in commit d2cfe32e required that the user have write access to all planting sites
in all organizations, which admin users don't have. Run the operation as the
system user instead.