### PR TITLE
Improve assertTableEquals usability

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -121,8 +121,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
               modifiedBy = userId,
               modifiedTime = now,
               projectId = projectId,
-              submissionStatusId = SubmissionStatus.NotSubmitted),
-          includePrimaryKeys = false)
+              submissionStatusId = SubmissionStatus.NotSubmitted))
 
       assertTableEquals(
           ParticipantProjectSpeciesRecord(
@@ -134,8 +133,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
               projectId = projectId,
               rationale = "rationale",
               speciesId = speciesId,
-              submissionStatusId = SubmissionStatus.NotSubmitted),
-          includePrimaryKeys = false)
+              submissionStatusId = SubmissionStatus.NotSubmitted))
 
       eventPublisher.assertEventPublished(
           ParticipantProjectSpeciesAddedEvent(

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchImporterTest.kt
@@ -301,9 +301,7 @@ internal class BatchImporterTest : DatabaseTest(), RunsAsUser {
             position = 2,
             typeId = UploadProblemType.MalformedValue,
             uploadId = uploadId,
-            value = "ShortName",
-        ),
-        includePrimaryKeys = false)
+            value = "ShortName"))
 
     assertStatus(UploadStatus.Invalid)
   }


### PR DESCRIPTION
Make a few improvements to the assertTableEquals functions:

* The "include primary keys" flag is now inferred from the list of expected
  records; callers no longer have to specify it explicitly.

* The expected records can now be any kind of collection, not just a Set.

* The lists of expected and actual records are now sorted before they're passed
  to assertEquals, rather than passed as sets. This should make it easier to
  spot the differences in assertion failure messages, especially when the test
  is run in an IDE that can diff the expected and actual values.