### PR TITLE
Use assertTableEmpty instead of empty list comparison

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -32,6 +32,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationsRow
 import com.terraformation.backend.db.accelerator.tables.records.ApplicationHistoriesRecord
 import com.terraformation.backend.db.accelerator.tables.records.ApplicationModulesRecord
 import com.terraformation.backend.db.accelerator.tables.records.ApplicationsRecord
+import com.terraformation.backend.db.accelerator.tables.references.APPLICATION_HISTORIES
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -1025,10 +1026,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(initial, applicationsDao.findAll())
 
-      assertEquals(
-          emptyList<ApplicationHistoriesRow>(),
-          applicationHistoriesDao.findAll(),
-          "Should not have inserted any history rows")
+      assertTableEmpty(APPLICATION_HISTORIES, "Should not have inserted any history rows")
     }
 
     @Test
@@ -1506,10 +1504,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
       val result = store.submit(applicationId)
       assertEquals(listOf(messages.applicationModulesIncomplete()), result.problems)
       assertEquals(initial, applicationsDao.findAll())
-      assertEquals(
-          emptyList<ApplicationHistoriesRow>(),
-          applicationHistoriesDao.findAll(),
-          "Should not have inserted any history rows")
+      assertTableEmpty(APPLICATION_HISTORIES, "Should not have inserted any history rows")
     }
 
     @Test
@@ -1550,10 +1545,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(initial, applicationsDao.findAll())
 
-      assertEquals(
-          emptyList<ApplicationHistoriesRow>(),
-          applicationHistoriesDao.findAll(),
-          "Should not have inserted any history rows")
+      assertTableEmpty(APPLICATION_HISTORIES, "Should not have inserted any history rows")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.tables.pojos.CohortModulesRow
+import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.LocalDate
@@ -307,7 +308,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsUser {
 
       store.remove(inserted.cohortId, inserted.moduleId)
 
-      assertEquals(emptyList<CohortModulesRow>(), cohortModulesDao.findAll())
+      assertTableEmpty(COHORT_MODULES)
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DefaultVoterStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DefaultVoterStoreTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.tables.pojos.DefaultVotersRow
 import com.terraformation.backend.db.accelerator.tables.records.DefaultVotersRecord
+import com.terraformation.backend.db.accelerator.tables.references.DEFAULT_VOTERS
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.mockUser
 import io.mockk.every
@@ -120,7 +121,7 @@ class DefaultVoterStoreTest : DatabaseTest(), RunsAsUser {
       insertDefaultVoter(userId)
       store.delete(userId)
 
-      assertEquals(emptyList<DefaultVotersRow>(), defaultVotersDao.findAll())
+      assertTableEmpty(DEFAULT_VOTERS)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.accelerator.model.DeliverableDueDateModel
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableCohortDueDatesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableProjectDueDatesRow
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_COHORT_DUE_DATES
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_PROJECT_DUE_DATES
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.LocalDate
@@ -306,10 +308,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
 
       store.deleteDeliverableCohortDueDate(inserted.deliverableId, inserted.cohortId)
 
-      assertEquals(
-          emptyList<DeliverableCohortDueDatesRow>(),
-          deliverableCohortDueDatesDao.findAll(),
-          "Row no longer exists after deletion")
+      assertTableEmpty(DELIVERABLE_COHORT_DUE_DATES, "Row no longer exists after deletion")
     }
 
     @Test
@@ -353,10 +352,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
 
       store.deleteDeliverableProjectDueDate(inserted.deliverableId, projectId)
 
-      assertEquals(
-          emptyList<DeliverableProjectDueDatesRow>(),
-          deliverableProjectDueDatesDao.findAll(),
-          "Row no longer exists after deletion")
+      assertTableEmpty(DELIVERABLE_PROJECT_DUE_DATES, "Row no longer exists after deletion")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.accelerator.EventType
 import com.terraformation.backend.db.accelerator.ModuleId
 import com.terraformation.backend.db.accelerator.tables.pojos.EventProjectsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.EventsRow
+import com.terraformation.backend.db.accelerator.tables.references.EVENTS
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.net.URI
@@ -630,23 +631,14 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
       val event1 = insertEvent()
       val event2 = insertEvent()
 
-      assertNotEquals(
-          emptyList<EventsRow>(),
-          eventsDao.findAll().isNotEmpty(),
-          "Events before deletion",
-      )
+      assertNotEquals(emptyList<EventsRow>(), eventsDao.findAll(), "Events before deletion")
       store.delete(event1)
       assertEquals(
           event2,
           eventsDao.findAll().firstOrNull()?.id,
-          "Events contain $event2 after one deletion",
-      )
+          "Events contain $event2 after one deletion")
       store.delete(event2)
-      assertEquals(
-          emptyList<EventsRow>(),
-          eventsDao.findAll(),
-          "Events after all deletions",
-      )
+      assertTableEmpty(EVENTS, "Events after all deletions")
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationUsersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationUsersRecord
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.dummyKeycloakInfo
 import com.terraformation.backend.mockUser
@@ -227,10 +228,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     // Now run the job that was just enqueued.
     slot.captured.accept(service)
 
-    assertEquals(
-        emptyList<OrganizationsRow>(),
-        organizationsDao.findAll(),
-        "Scheduled job should have deleted organization")
+    assertTableEmpty(ORGANIZATIONS, "Scheduled job should have deleted organization")
 
     publisher.assertEventPublished(OrganizationDeletionStartedEvent(organizationId))
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.default_schema.tables.pojos.UserGlobalRolesRow
 import com.terraformation.backend.db.default_schema.tables.records.UserGlobalRolesRecord
 import com.terraformation.backend.db.default_schema.tables.records.UserPreferencesRecord
+import com.terraformation.backend.db.default_schema.tables.references.USER_GLOBAL_ROLES
 import com.terraformation.backend.db.default_schema.tables.references.USER_PREFERENCES
 import com.terraformation.backend.dummyKeycloakInfo
 import com.terraformation.backend.i18n.Locales
@@ -881,7 +882,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
 
       userStore.updateGlobalRoles(setOf(userId1, userId2), emptySet())
 
-      assertEquals(emptyList<Any>(), userGlobalRolesDao.findAll())
+      assertTableEmpty(USER_GLOBAL_ROLES)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
@@ -16,7 +16,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.UserType
-import com.terraformation.backend.db.default_schema.tables.pojos.NotificationsRow
+import com.terraformation.backend.db.default_schema.tables.references.NOTIFICATIONS
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.time.ClockAdvancedEvent
@@ -87,10 +87,7 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
             .copy(nextNotificationTime = Instant.EPOCH + increment))
 
     scanner.sendNotifications()
-    assertEquals(
-        emptyList<NotificationsRow>(),
-        notificationsDao.findAll(),
-        "Should not have inserted notification before clock advanced")
+    assertTableEmpty(NOTIFICATIONS, "Should not have inserted notification before clock advanced")
 
     clock.instant = Instant.EPOCH + increment
 
@@ -135,7 +132,7 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
 
     scanner.sendNotifications()
 
-    assertEquals(emptyList<NotificationsRow>(), notificationsDao.findAll())
+    assertTableEmpty(NOTIFICATIONS)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/DeviceServiceTest.kt
@@ -17,6 +17,8 @@ import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.tables.pojos.AutomationsRow
 import com.terraformation.backend.db.default_schema.tables.pojos.DeviceTemplatesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
+import com.terraformation.backend.db.default_schema.tables.references.AUTOMATIONS
+import com.terraformation.backend.db.default_schema.tables.references.DEVICES
 import com.terraformation.backend.device.db.DeviceStore
 import com.terraformation.backend.device.event.DeviceUnresponsiveEvent
 import com.terraformation.backend.i18n.Messages
@@ -150,7 +152,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
             deviceType = "random",
             make = "company",
             model = "product"))
-    assertEquals(emptyList<AutomationsRow>(), automationsDao.findAll())
+    assertTableEmpty(AUTOMATIONS)
   }
 
   @Test
@@ -225,7 +227,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
 
     assertThrows<AccessDeniedException> { service.create(omniSenseRow.copy(name = "Fridge 1")) }
 
-    assertEquals(emptyList<DevicesRow>(), devicesDao.findAll())
+    assertTableEmpty(DEVICES)
     assertAutomationConfigsEqual(emptySet())
   }
 
@@ -297,7 +299,7 @@ internal class DeviceServiceTest : DatabaseTest(), RunsAsUser {
 
     service.createDefaultDevices(desalFacilityId)
 
-    assertEquals(emptyList<DevicesRow>(), devicesDao.findAll())
+    assertTableEmpty(DEVICES)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.db.default_schema.tables.references.USER_GLOBA
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.db.docprod.tables.pojos.VariableImageValuesRow
-import com.terraformation.backend.db.docprod.tables.pojos.VariableValuesRow
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_VALUES
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
@@ -674,10 +674,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
       mockMvc.post(path()) { content = payload }.andExpect { status { isBadRequest() } }
 
-      assertEquals(
-          emptyList<VariableValuesRow>(),
-          variableValuesDao.findAll(),
-          "Should not have stored invalid value")
+      assertTableEmpty(VARIABLE_VALUES, "Should not have stored invalid value")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.docprod.VariableUsageType
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSectionDefaultValuesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSectionsRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_MANIFEST_ENTRIES
 import com.terraformation.backend.documentproducer.db.manifest.ManifestImporter
 import com.terraformation.backend.documentproducer.db.variable.VariableImporter
 import com.terraformation.backend.file.SizedInputStream
@@ -432,10 +433,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
                   "variable stable ID: 1001"),
           importResult.errors,
           "Import errors")
-      assertEquals(
-          emptyList<Any>(),
-          variableManifestEntriesDao.findAll(),
-          "Should not have imported bad manifest")
+      assertTableEmpty(VARIABLE_MANIFEST_ENTRIES, "Should not have imported bad manifest")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ThumbnailsRow
+import com.terraformation.backend.db.default_schema.tables.references.THUMBNAILS
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.util.ImageUtils
 import io.mockk.CapturingSlot
@@ -323,7 +324,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
     verify { fileStore.delete(rows[0].storageUrl!!) }
     verify { fileStore.delete(rows[1].storageUrl!!) }
 
-    assertEquals(emptyList<ThumbnailsRow>(), thumbnailsDao.findAll())
+    assertTableEmpty(THUMBNAILS)
   }
 
   @Test
@@ -350,7 +351,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
 
     verify { fileStore.delete(row.storageUrl!!) }
 
-    assertEquals(emptyList<ThumbnailsRow>(), thumbnailsDao.findAll())
+    assertTableEmpty(THUMBNAILS)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/UploadServiceTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UploadStatus
 import com.terraformation.backend.db.default_schema.UploadType
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadsRow
+import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
 import com.terraformation.backend.i18n.Locales
 import com.terraformation.backend.i18n.use
 import com.terraformation.backend.mockUser
@@ -94,7 +95,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
       service.receive(ByteArrayInputStream(ByteArray(1)), "test", "text/csv", UploadType.SpeciesCSV)
     }
 
-    assertEquals(emptyList<UploadsRow>(), uploadsDao.findAll())
+    assertTableEmpty(UPLOADS)
     verify { fileStore.delete(storageUrl) }
   }
 
@@ -106,7 +107,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
     service.delete(uploadId)
 
-    assertEquals(emptyList<UploadsRow>(), uploadsDao.findAll())
+    assertTableEmpty(UPLOADS)
     verifySequence { fileStore.delete(storageUrl) }
   }
 
@@ -118,7 +119,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
     service.delete(uploadId)
 
-    assertEquals(emptyList<UploadsRow>(), uploadsDao.findAll())
+    assertTableEmpty(UPLOADS)
   }
 
   @Test
@@ -162,7 +163,7 @@ internal class UploadServiceTest : DatabaseTest(), RunsAsUser {
 
     service.expireOldUploads(DailyTaskTimeArrivedEvent())
 
-    assertEquals(emptyList<UploadsRow>(), uploadsDao.findAll())
+    assertTableEmpty(UPLOADS)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.tables.pojos.BatchPhotosRow
 import com.terraformation.backend.file.FileService
@@ -182,7 +183,7 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
       clock.instant = deletedTime
       service.deletePhoto(batchId, fileId)
 
-      assertEquals(emptyList<Any>(), filesDao.findAll())
+      assertTableEmpty(FILES)
       assertEquals(
           listOf(
               BatchPhotosRow(

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.nursery.db.batchStore
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
 import io.mockk.every
 import java.time.Instant
@@ -71,7 +72,7 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
     store.changeStatuses(batchId, 0, 0)
 
     assertEquals(before, batchesDao.fetchOneById(batchId))
-    assertEquals(emptyList<Any>(), batchQuantityHistoryDao.findAll(), "Quantity history")
+    assertTableEmpty(BATCH_QUANTITY_HISTORY)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreDeleteBatchTest.kt
@@ -4,7 +4,8 @@ import com.terraformation.backend.db.default_schema.tables.pojos.FacilitiesRow
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
-import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.nursery.event.BatchDeletionStartedEvent
 import com.terraformation.backend.nursery.event.WithdrawalDeletionStartedEvent
 import com.terraformation.backend.nursery.model.SpeciesSummary
@@ -37,8 +38,8 @@ internal class BatchStoreDeleteBatchTest : BatchStoreTest() {
 
     store.delete(batchId)
 
-    assertEquals(emptyList<BatchesRow>(), batchesDao.findAll(), "Batches")
-    assertEquals(emptyList<BatchQuantityHistoryRow>(), batchQuantityHistoryDao.findAll(), "History")
+    assertTableEmpty(BATCHES)
+    assertTableEmpty(BATCH_QUANTITY_HISTORY)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.nursery.BatchSubstrate
 import com.terraformation.backend.db.nursery.tables.pojos.BatchDetailsHistoryRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchDetailsHistorySubLocationsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
+import com.terraformation.backend.db.nursery.tables.references.BATCH_DETAILS_HISTORY
+import com.terraformation.backend.db.nursery.tables.references.BATCH_SUB_LOCATIONS
 import com.terraformation.backend.nursery.db.BatchStaleException
 import java.time.Instant
 import java.time.LocalDate
@@ -120,7 +122,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
   fun `does not insert details history entry if nothing was edited`() {
     store.updateDetails(batchId, 1) { it }
 
-    assertEquals(emptyList<Any>(), batchDetailsHistoryDao.findAll())
+    assertTableEmpty(BATCH_DETAILS_HISTORY)
   }
 
   @Test
@@ -141,8 +143,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
             readyByDate = null,
             version = 2),
         after)
-    assertEquals(
-        emptyList<Any>(), batchSubLocationsDao.findAll(), "Should have removed sub-locations")
+    assertTableEmpty(BATCH_SUB_LOCATIONS, "Should have removed sub-locations")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateQuantitiesTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.nursery.db.batchStore
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
+import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.nursery.db.BatchStaleException
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -121,7 +122,7 @@ internal class BatchStoreUpdateQuantitiesTest : BatchStoreTest() {
         historyType = BatchQuantityHistoryType.Observed)
 
     assertEquals(before, batchesDao.fetchOneById(batchId))
-    assertEquals(emptyList<Any>(), batchQuantityHistoryDao.findAll(), "Quantity history")
+    assertTableEmpty(BATCH_QUANTITY_HISTORY)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRo
 import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.BatchesRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
+import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
 import com.terraformation.backend.nursery.db.CrossOrganizationNurseryTransferNotAllowedException
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
@@ -217,10 +218,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
               "Should not have deducted withdrawn quantities from batch")
         },
         {
-          assertEquals(
-              emptyList<BatchQuantityHistoryRow>(),
-              batchQuantityHistoryDao.findAll(),
-              "Should not have inserted quantity history row")
+          assertTableEmpty(BATCH_QUANTITY_HISTORY, "Should not have inserted quantity history row")
         },
         {
           assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportFileServiceTest.kt
@@ -13,6 +13,8 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ReportId
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportFilesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.ReportPhotosRow
+import com.terraformation.backend.db.default_schema.tables.references.REPORT_FILES
+import com.terraformation.backend.db.default_schema.tables.references.REPORT_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.SizedInputStream
@@ -99,8 +101,8 @@ class ReportFileServiceTest : DatabaseTest(), RunsAsUser {
 
       service.on(ReportDeletionStartedEvent(reportId))
 
-      assertEquals(emptyList<ReportPhotosRow>(), reportPhotosDao.findAll(), "Report photos")
-      assertEquals(emptyList<ReportFilesRow>(), reportFilesDao.findAll(), "Report files")
+      assertTableEmpty(REPORT_PHOTOS)
+      assertTableEmpty(REPORT_FILES)
 
       storageUrls.forEach { verify { fileStore.delete(it) } }
       confirmVerified(fileStore)

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportStatus
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.default_schema.tables.references.REPORTS
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
@@ -577,7 +578,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
 
       service.createMissingReports(DailyTaskTimeArrivedEvent())
 
-      assertEquals(emptyList<Any>(), reportsDao.findAll())
+      assertTableEmpty(REPORTS)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/AccessionImporterTest.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.db.seedbank.tables.pojos.AccessionQuantityHist
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.GeolocationsRow
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.SizedInputStream
@@ -1041,7 +1042,7 @@ internal class AccessionImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.importCsv(uploadId, true)
 
-      assertEquals(emptyList<AccessionsRow>(), accessionsDao.findAll())
+      assertTableEmpty(ACCESSIONS)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -10,8 +10,10 @@ import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.seedbank.AccessionId
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.PathGenerator
@@ -264,8 +266,8 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
       assertThrows<NoSuchFileException>("$url should be deleted") { fileStore.size(url) }
     }
 
-    assertEquals(emptyList<AccessionPhotosRow>(), accessionPhotosDao.findAll(), "Accession photos")
-    assertEquals(emptyList<FilesRow>(), filesDao.findAll(), "Photos")
+    assertTableEmpty(ACCESSION_PHOTOS)
+    assertTableEmpty(FILES)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCreateTest.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionQuantityHistoryRow
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_QUANTITY_HISTORY
 import com.terraformation.backend.seedbank.api.AccessionStateV2
 import com.terraformation.backend.seedbank.api.CreateAccessionRequestPayloadV2
 import com.terraformation.backend.seedbank.model.AccessionModel
@@ -153,7 +154,7 @@ internal class AccessionStoreCreateTest : AccessionStoreTest() {
   fun `create does not insert quantity history row if quantity is not specified`() {
     store.create(accessionModel())
 
-    assertEquals(emptyList<AccessionQuantityHistoryRow>(), accessionQuantityHistoryDao.findAll())
+    assertTableEmpty(ACCESSION_QUANTITY_HISTORY)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -9,14 +9,15 @@ import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.BagsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.GeolocationsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestResultsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.ViabilityTestsRow
-import com.terraformation.backend.db.seedbank.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.db.seedbank.tables.records.AccessionStateHistoryRecord
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
+import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_COLLECTORS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
+import com.terraformation.backend.db.seedbank.tables.references.BAGS
+import com.terraformation.backend.db.seedbank.tables.references.GEOLOCATIONS
+import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TESTS
+import com.terraformation.backend.db.seedbank.tables.references.VIABILITY_TEST_RESULTS
+import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
 import com.terraformation.backend.seedbank.api.AccessionStateV2
 import com.terraformation.backend.seedbank.api.CreateViabilityTestRequestPayload
 import com.terraformation.backend.seedbank.api.CreateWithdrawalRequestPayload
@@ -252,21 +253,19 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
 
     store.delete(accessionId)
 
-    assertEquals(
-        emptyList<AccessionCollectorsRow>(), accessionCollectorsDao.findAll(), "Collectors")
-    assertEquals(emptyList<AccessionsRow>(), accessionsDao.findAll(), "Accessions")
+    assertTableEmpty(ACCESSION_COLLECTORS)
+    assertTableEmpty(ACCESSIONS)
+    assertTableEmpty(BAGS)
+    assertTableEmpty(GEOLOCATIONS)
+    assertTableEmpty(VIABILITY_TESTS)
+    assertTableEmpty(VIABILITY_TEST_RESULTS)
+    assertTableEmpty(WITHDRAWALS)
+
+    // This table has no primary key, so can't use assertTableEmpty
     assertEquals(
         emptyList<AccessionStateHistoryRecord>(),
         dslContext.selectFrom(ACCESSION_STATE_HISTORY).fetch(),
         "Accession State History")
-    assertEquals(emptyList<BagsRow>(), bagsDao.findAll(), "Bags")
-    assertEquals(emptyList<GeolocationsRow>(), geolocationsDao.findAll(), "Geolocations")
-    assertEquals(emptyList<ViabilityTestsRow>(), viabilityTestsDao.findAll(), "Viability Tests")
-    assertEquals(
-        emptyList<ViabilityTestResultsRow>(),
-        viabilityTestResultsDao.findAll(),
-        "Viability test results")
-    assertEquals(emptyList<WithdrawalsRow>(), withdrawalsDao.findAll(), "Withdrawals")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesGrowthFo
 import com.terraformation.backend.db.default_schema.tables.pojos.SpeciesRow
 import com.terraformation.backend.db.default_schema.tables.pojos.UploadProblemsRow
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
+import com.terraformation.backend.db.default_schema.tables.references.UPLOAD_PROBLEMS
 import com.terraformation.backend.file.FileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.UploadService
@@ -138,7 +139,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.validateCsv(uploadId)
 
-      assertEquals(emptyList<UploadProblemsRow>(), uploadProblemsDao.findAll())
+      assertTableEmpty(UPLOAD_PROBLEMS)
     }
   }
 
@@ -256,7 +257,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
 
     importer.validateCsv(uploadId)
 
-    assertEquals(emptyList<UploadProblemsRow>(), uploadProblemsDao.findAll(), "Upload problems")
+    assertTableEmpty(UPLOAD_PROBLEMS)
     assertStatus(UploadStatus.AwaitingProcessing)
   }
 
@@ -295,7 +296,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
 
     importer.validateCsv(uploadId)
 
-    assertEquals(emptyList<UploadProblemsRow>(), uploadProblemsDao.findAll(), "Upload problems")
+    assertTableEmpty(UPLOAD_PROBLEMS)
     assertStatus(UploadStatus.AwaitingProcessing)
     verify { scheduler.enqueue<SpeciesImporter>(any()) }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -23,6 +23,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedPlotSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedSiteSpeciesTotalsRow
 import com.terraformation.backend.db.tracking.tables.pojos.ObservedZoneSpeciesTotalsRow
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.SizedInputStream
@@ -1080,8 +1081,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
           ObservationState.Upcoming, updatedObservation.state, "State should show as Upcoming")
       assertEquals(startDate, updatedObservation.startDate, "Start date should be updated")
       assertEquals(endDate, updatedObservation.endDate, "End date should be updated")
-      assertEquals(
-          emptyList<Any>(), observationPlotsDao.findAll(), "Observation plots should be removed")
+      assertTableEmpty(OBSERVATION_PLOTS, "Observation plots should be removed")
 
       eventPublisher.assertExactEventsPublished(
           setOf(ObservationRescheduledEvent(originalObservation, updatedObservation)))
@@ -1551,8 +1551,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
 
       assertEquals(ReplacementResult(emptySet(), setOf(monitoringPlotId)), result)
 
-      assertEquals(
-          emptyList<Any>(), observationPlotsDao.findAll(), "Observation should not have any plots")
+      assertTableEmpty(OBSERVATION_PLOTS, "Observation should not have any plots")
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzoneHistor
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZoneHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.PlantingSiteMapInvalidException
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
@@ -68,11 +70,8 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
           plantingSitesDao.findAll(),
           "Planting sites")
 
-      assertEquals(
-          emptyList<PlantingSiteHistoriesRow>(),
-          plantingSiteHistoriesDao.findAll(),
-          "Planting site histories")
-      assertEquals(emptyList<PlantingZonesRow>(), plantingZonesDao.findAll(), "Planting zones")
+      assertTableEmpty(PLANTING_SITE_HISTORIES)
+      assertTableEmpty(PLANTING_ZONES)
     }
 
     @Test
@@ -105,7 +104,7 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
           plantingSitesDao.findAll(),
           "Planting sites")
 
-      assertEquals(emptyList<PlantingZonesRow>(), plantingZonesDao.findAll(), "Planting zones")
+      assertTableEmpty(PLANTING_ZONES)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreDeleteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreDeleteTest.kt
@@ -1,11 +1,19 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.default_schema.FacilityType
+import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_COORDINATES
+import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.tracking.event.PlantingSiteDeletionStartedEvent
 import io.mockk.every
 import java.time.Instant
-import org.jooq.DAO
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -34,20 +42,16 @@ internal class PlantingSiteStoreDeleteTest : PlantingSiteStoreTest() {
 
       store.deletePlantingSite(plantingSiteId)
 
-      fun assertAllDeleted(dao: DAO<*, *, *>) {
-        assertEquals(emptyList<Any>(), dao.findAll())
-      }
-
-      assertAllDeleted(plantingSitesDao)
-      assertAllDeleted(plantingZonesDao)
-      assertAllDeleted(plantingSubzonesDao)
-      assertAllDeleted(monitoringPlotsDao)
-      assertAllDeleted(deliveriesDao)
-      assertAllDeleted(plantingsDao)
-      assertAllDeleted(observationsDao)
-      assertAllDeleted(observationPlotsDao)
-      assertAllDeleted(observedPlotCoordinatesDao)
-      assertAllDeleted(recordedPlantsDao)
+      assertTableEmpty(PLANTING_SITES)
+      assertTableEmpty(PLANTING_ZONES)
+      assertTableEmpty(PLANTING_SUBZONES)
+      assertTableEmpty(MONITORING_PLOTS)
+      assertTableEmpty(DELIVERIES)
+      assertTableEmpty(PLANTINGS)
+      assertTableEmpty(OBSERVATIONS)
+      assertTableEmpty(OBSERVATION_PLOTS)
+      assertTableEmpty(OBSERVED_PLOT_COORDINATES)
+      assertTableEmpty(RECORDED_PLANTS)
 
       eventPublisher.assertEventPublished(PlantingSiteDeletionStartedEvent(plantingSiteId))
     }


### PR DESCRIPTION
Replace assertions like

    assertEquals(emptyList<SomeTableRow>(), someTableDao.findAll())

with the more succinct and self-documenting

    assertTableEmpty(SOME_TABLE)