### PR TITLE
SW-6222 Add observed species to subzone species list

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -35,7 +35,9 @@ import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.species.SpeciesService
 import com.terraformation.backend.species.model.ExistingSpeciesModel
@@ -182,7 +184,16 @@ class SpeciesStore(
             SPECIES.ID.`in`(
                 DSL.select(PLANTINGS.SPECIES_ID)
                     .from(PLANTINGS)
-                    .where(PLANTINGS.PLANTING_SUBZONE_ID.eq(plantingSubzoneId))))
+                    .where(PLANTINGS.PLANTING_SUBZONE_ID.eq(plantingSubzoneId))
+                    .union(
+                        DSL.select(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID)
+                            .from(OBSERVED_SITE_SPECIES_TOTALS)
+                            .join(PLANTING_SUBZONES)
+                            .on(
+                                OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_ID.eq(
+                                    PLANTING_SUBZONES.PLANTING_SITE_ID))
+                            .where(PLANTING_SUBZONES.ID.eq(plantingSubzoneId))
+                            .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.isNotNull))))
         .and(SPECIES.DELETED_TIME.isNull)
         .orderBy(SPECIES.ID)
         .fetch {


### PR DESCRIPTION
When the client requests the list of species in a subzone (the mobile app uses
this to populate the list of options when observing a monitoring plot), we
currently return the species that were reported to have been planted in the
subzone.

Start also including all the species that have been observed at the planting site,
even if they were never reported as planted in the subzone. Among other things,
this will cover cases where a plant has spread naturally from one subzone to
another.