### PR TITLE
SW-6223 Fix permission error on variable value update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
@@ -83,7 +83,15 @@ class VariableWorkflowStore(
       feedback: String?,
       internalComment: String?,
   ): ExistingVariableWorkflowHistoryModel {
-    requirePermissions { updateInternalVariableWorkflowDetails(projectId) }
+    requirePermissions {
+      if (status == VariableWorkflowStatus.InReview) {
+        // Non-admins editing a variable causes its status to reset to In Review.
+        updateProject(projectId)
+      } else {
+        // Other statuses can only be set by admins.
+        updateInternalVariableWorkflowDetails(projectId)
+      }
+    }
 
     if (!dslContext.fetchExists(PROJECTS, PROJECTS.ID.eq(projectId))) {
       throw ProjectNotFoundException(projectId)


### PR DESCRIPTION
When a user edits the value of a deliverable variable, we reset the variable's
workflow status in the project to "In Review." Commit 0a442949 moved the logic
for that from an event handler to a method of `VariableValueService`, but didn't
include the `systemUser.run` from the event handler. Variable updates started
failing because non-admin, non-system users don't have permission to update
variable workflow statuses.

Fix it by changing the permission check to only require admin privileges for
statuses that are set via the accelerator console; regular users can set the
status to "In Review" as long as they have write access to the project.