### PR TITLE
Fix issue with section variable upgrade due to multiple projects existing with values to upgraded variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -478,7 +478,9 @@ class VariableValueStore(
           }
         }
 
-    updateValues(sectionOperations, triggerWorkflows = false)
+    sectionOperations
+        .groupBy { it.projectId }
+        .forEach { updateValues(it.value, triggerWorkflows = false) }
   }
 
   /**


### PR DESCRIPTION
Since there can be multiple projects with values for variables that can be upgraded, we need to separate the operations by project ID since there [is a check](https://github.com/terraware/terraware-server/blob/main/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt#L505-L507) to ensure that we only update a set of operations for one project at a time.