### PR TITLE
Expand assertTableEquals table support; improve assertion

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionCollectorsRow
-import com.terraformation.backend.db.seedbank.tables.records.AccessionStateHistoryRecord
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_COLLECTORS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
@@ -254,18 +253,13 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     store.delete(accessionId)
 
     assertTableEmpty(ACCESSION_COLLECTORS)
+    assertTableEmpty(ACCESSION_STATE_HISTORY)
     assertTableEmpty(ACCESSIONS)
     assertTableEmpty(BAGS)
     assertTableEmpty(GEOLOCATIONS)
     assertTableEmpty(VIABILITY_TESTS)
     assertTableEmpty(VIABILITY_TEST_RESULTS)
     assertTableEmpty(WITHDRAWALS)
-
-    // This table has no primary key, so can't use assertTableEmpty
-    assertEquals(
-        emptyList<AccessionStateHistoryRecord>(),
-        dslContext.selectFrom(ACCESSION_STATE_HISTORY).fetch(),
-        "Accession State History")
   }
 
   @Test


### PR DESCRIPTION
Previously, assertTableEquals and assertTableEmpty only worked on tables with
primary keys that jOOQ could generate code for, which excluded tables with
compound primary keys where we didn't configure a synthetic primary key type
in `Config.kt`. This was because we needed to empty out the primary key fields
of the records from the query result.

Modify the code to only empty the primary key fields if the records actually
have them.

Also make assertion failure messages look nicer by using the jOOQ Result class
instead of generic Kotlin collections. Result has logic to pretty-print lists
of records in a compact, consistently-aligned style.