### PR TITLE
SW-6227 Allow Read Only users to list cohort modules

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStore.kt
@@ -34,7 +34,7 @@ class CohortModuleStore(
         projectId != null -> readProjectModules(projectId)
         participantId != null -> readParticipant(participantId)
         cohortId != null -> readCohort(cohortId)
-        else -> manageModules()
+        else -> readCohorts()
       }
 
       moduleId?.let { readModule(it) }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
@@ -26,6 +26,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     every { user.canReadModule(any()) } returns true
     every { user.canReadCohort(any()) } returns true
+    every { user.canReadCohorts() } returns true
     every { user.canReadParticipant(any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectModules(any()) } returns true
@@ -46,7 +47,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsUser {
       insertParticipant(cohortId = inserted.cohortId)
       insertProject(participantId = inserted.participantId)
 
-      every { user.canManageModules() } returns false
+      every { user.canReadCohorts() } returns false
       assertThrows<AccessDeniedException> { store.fetch() }
 
       every { user.canReadProjectModules(any()) } returns false


### PR DESCRIPTION
Fetching the full list of cohort modules used to require the Accelerator Admin
global role. Change it to require Read Only or higher so that the modules lists
in the accelerator console will include cohort data for all the users who have
access to the console.