### PR TITLE
SW-6228 Allow TF Expert users to set TF contacts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -473,10 +473,11 @@ class OrganizationStore(
     val isTerraformationContact = role == Role.TerraformationContact
 
     requirePermissions {
-      if (getUserRole(organizationId, userId) == Role.TerraformationContact) {
-        updateTerraformationContact(organizationId)
+      if (getUserRole(organizationId, userId) == Role.TerraformationContact &&
+          !isTerraformationContact) {
+        removeTerraformationContact(organizationId)
       } else if (isTerraformationContact) {
-        setTerraformationContact(organizationId)
+        addTerraformationContact(organizationId)
       } else {
         setOrganizationUserRole(organizationId, role)
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -177,7 +177,7 @@ data class IndividualUser(
   override fun canAddParticipantProject(participantId: ParticipantId, projectId: ProjectId) =
       isAcceleratorAdmin()
 
-  override fun canAddTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
+  override fun canAddTerraformationContact(organizationId: OrganizationId) = isTFExpertOrHigher()
 
   // all users can count their unread notifications
   override fun canCountNotifications() = true
@@ -519,7 +519,7 @@ data class IndividualUser(
     return isMember(organizationId) && (userId == this.userId || isAdminOrHigher(organizationId))
   }
 
-  override fun canRemoveTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
+  override fun canRemoveTerraformationContact(organizationId: OrganizationId) = isTFExpertOrHigher()
 
   override fun canReplaceObservationPlot(observationId: ObservationId) =
       isAdminOrHigher(parentStore.getOrganizationId(observationId))
@@ -533,8 +533,6 @@ data class IndividualUser(
 
   override fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role) =
       isSuperAdmin() || isAdminOrHigher(organizationId)
-
-  override fun canSetTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 
   override fun canSetTestClock() = isSuperAdmin()
 
@@ -670,8 +668,6 @@ data class IndividualUser(
 
   override fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId) =
       isTFExpertOrHigher()
-
-  override fun canUpdateTerraformationContact(organizationId: OrganizationId) = isSuperAdmin()
 
   override fun canUpdateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
-import com.terraformation.backend.db.InvalidRoleUpdateException
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
@@ -978,14 +977,6 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun setTerraformationContact(organizationId: OrganizationId) {
-    if (!user.canSetTerraformationContact(organizationId)) {
-      readOrganization(organizationId)
-      throw AccessDeniedException(
-          "No permission to grant Terraformation Contact to users in organization $organizationId")
-    }
-  }
-
   fun setTestClock() {
     if (!user.canSetTestClock()) {
       throw AccessDeniedException("No permission to set test clock")
@@ -1292,13 +1283,6 @@ class PermissionRequirements(private val user: TerrawareUser) {
     if (!user.canUpdateSubmissionStatus(deliverableId, projectId)) {
       readProject(projectId)
       throw AccessDeniedException("No permission to update submission status")
-    }
-  }
-
-  fun updateTerraformationContact(organizationId: OrganizationId) {
-    if (!user.canUpdateTerraformationContact(organizationId)) {
-      readOrganization(organizationId)
-      throw InvalidRoleUpdateException(Role.TerraformationContact)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -398,8 +398,6 @@ interface TerrawareUser : Principal {
   fun canSetOrganizationUserRole(organizationId: OrganizationId, role: Role): Boolean =
       defaultPermission
 
-  fun canSetTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
-
   fun canSetTestClock(): Boolean = defaultPermission
 
   fun canSetWithdrawalUser(accessionId: AccessionId): Boolean = defaultPermission
@@ -492,8 +490,6 @@ interface TerrawareUser : Principal {
 
   fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId): Boolean =
       defaultPermission
-
-  fun canUpdateTerraformationContact(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.db.default_schema.NotificationId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.ReportId
-import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesProblemId
 import com.terraformation.backend.db.default_schema.SubLocationId
@@ -112,9 +111,6 @@ class InternalTagIsSystemDefinedException(val internalTagId: InternalTagId) :
 
 class InternalTagNotFoundException(val internalTagId: InternalTagId) :
     EntityNotFoundException("Tag $internalTagId not found")
-
-class InvalidRoleUpdateException(val role: Role) :
-    RuntimeException("Cannot set role $role on user")
 
 class InvalidTerraformationContactEmail(val email: String) :
     RuntimeException("Invalid Terraformation Contact email $email")

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -349,7 +349,6 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
     every { user.canAddTerraformationContact(organizationId) } returns true
     every { user.canRemoveTerraformationContact(organizationId) } returns true
-    every { user.canSetTerraformationContact(organizationId) } returns true
     every { user.canAddOrganizationUser(organizationId) } returns true
     every { user.canSetOrganizationUserRole(organizationId, Role.Admin) } returns true
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -14,7 +14,6 @@ import com.terraformation.backend.db.DeviceNotFoundException
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
-import com.terraformation.backend.db.InvalidRoleUpdateException
 import com.terraformation.backend.db.NotificationNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.ProjectNotFoundException
@@ -310,13 +309,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { removeTerraformationContact(organizationId) } ifUser
           {
             canRemoveTerraformationContact(organizationId)
-          }
-
-  @Test
-  fun setTerraformationContact() =
-      allow { setTerraformationContact(organizationId) } ifUser
-          {
-            canSetTerraformationContact(organizationId)
           }
 
   @Test fun manageInternalTags() = allow { manageInternalTags() } ifUser { canManageInternalTags() }
@@ -1016,21 +1008,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
           {
             canUpdateSubmissionStatus(deliverableId, projectId)
           }
-
-  @Test
-  fun updateTerraformationContact() {
-    assertThrows<OrganizationNotFoundException> {
-      requirements.updateTerraformationContact(organizationId)
-    }
-
-    grant { user.canReadOrganization(organizationId) }
-    assertThrows<InvalidRoleUpdateException> {
-      requirements.updateTerraformationContact(organizationId)
-    }
-
-    grant { user.canUpdateTerraformationContact(organizationId) }
-    requirements.updateTerraformationContact(organizationId)
-  }
 
   @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1268,6 +1268,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *organizationIds.toTypedArray(),
         addOrganizationUser = true,
+        addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
         createPlantingSite = true,
@@ -1284,6 +1285,7 @@ internal class PermissionTest : DatabaseTest() {
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
+        removeTerraformationContact = true,
         updateOrganization = true,
     )
 
@@ -1559,6 +1561,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *organizationIds.forOrg1(),
         addOrganizationUser = true,
+        addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
         createPlantingSite = true,
@@ -1574,6 +1577,7 @@ internal class PermissionTest : DatabaseTest() {
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
+        removeTerraformationContact = true,
         updateOrganization = true,
     )
 
@@ -1633,11 +1637,13 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *organizationIds.filterNot { it == org1Id }.toTypedArray(),
         addOrganizationUser = true,
+        addTerraformationContact = true,
         createReport = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationUser = true,
+        removeTerraformationContact = true,
     )
 
     // Can access accelerator-related functions on all ogs.
@@ -1768,6 +1774,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         org1Id,
         addOrganizationUser = true,
+        addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
         createPlantingSite = true,
@@ -1782,6 +1789,7 @@ internal class PermissionTest : DatabaseTest() {
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
+        removeTerraformationContact = true,
         updateOrganization = true,
     )
 
@@ -1839,19 +1847,23 @@ internal class PermissionTest : DatabaseTest() {
     // Not an admin of this org but can still access it because it has an application.
     permissions.expect(
         OrganizationId(3),
+        addTerraformationContact = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationUser = true,
         readOrganizationDeliverables = true,
+        removeTerraformationContact = true,
     )
 
     // Can read and perform certain operations on orgs with Accelerator internal tag.
     permissions.expect(
         OrganizationId(4),
+        addTerraformationContact = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationUser = true,
+        removeTerraformationContact = true,
     )
 
     // Can access this project because it has an application.
@@ -1976,6 +1988,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         org1Id,
         addOrganizationUser = true,
+        addTerraformationContact = true,
         createDraftPlantingSite = true,
         createFacility = true,
         createPlantingSite = true,
@@ -1990,6 +2003,7 @@ internal class PermissionTest : DatabaseTest() {
         readOrganizationUser = true,
         removeOrganizationSelf = true,
         removeOrganizationUser = true,
+        removeTerraformationContact = true,
         updateOrganization = true,
     )
 
@@ -2046,10 +2060,12 @@ internal class PermissionTest : DatabaseTest() {
     // Not an admin of this org but can still access accelerator-related functions.
     permissions.expect(
         OrganizationId(4),
+        addTerraformationContact = true,
         listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationUser = true,
+        removeTerraformationContact = true,
     )
 
     permissions.expect(
@@ -2429,6 +2445,7 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg organizations: OrganizationId,
         addOrganizationUser: Boolean = false,
+        addTerraformationContact: Boolean = false,
         createDraftPlantingSite: Boolean = false,
         createFacility: Boolean = false,
         createPlantingSite: Boolean = false,
@@ -2445,6 +2462,7 @@ internal class PermissionTest : DatabaseTest() {
         readOrganizationUser: Boolean = false,
         removeOrganizationSelf: Boolean = false,
         removeOrganizationUser: Boolean = false,
+        removeTerraformationContact: Boolean = false,
         updateOrganization: Boolean = false,
     ) {
       organizations.forEach { organizationId ->
@@ -2453,6 +2471,10 @@ internal class PermissionTest : DatabaseTest() {
             addOrganizationUser,
             user.canAddOrganizationUser(idInDatabase),
             "Can add organization $organizationId user")
+        assertEquals(
+            addTerraformationContact,
+            user.canAddTerraformationContact(idInDatabase),
+            "Can add TF contact for organization $organizationId")
         assertEquals(
             createDraftPlantingSite,
             user.canCreateDraftPlantingSite(idInDatabase),
@@ -2517,6 +2539,10 @@ internal class PermissionTest : DatabaseTest() {
             removeOrganizationUser,
             user.canRemoveOrganizationUser(idInDatabase, otherUserIds[organizationId]!!),
             "Can remove user from organization $organizationId")
+        assertEquals(
+            removeTerraformationContact,
+            user.canRemoveTerraformationContact(idInDatabase),
+            "Can remove TF contact from organization $organizationId")
         assertEquals(
             updateOrganization,
             user.canUpdateOrganization(idInDatabase),


### PR DESCRIPTION
Previously, modifying the Terraformation contact for an organization required
super-admin privileges, but now we want to treat the contact as part of the
organization's accelerator profile which means it needs to be editable by the
same user types that can edit other profile data, namely TF Expert or higher.
Change the permission check accprdingly.

We had four permissions for modifying the TF contact, but the differences
among them were kind of fuzzy. Remove two of the permissions to make the
intent of the remaining two clearer.