### PR TITLE
Add more request context to log messages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
   implementation("com.google.apis:google-api-services-drive:v3-rev20241014-2.0.0")
   implementation("com.opencsv:opencsv:5.9")
   implementation("com.squarespace.cldr-engine:cldr-engine:1.8.2")
+  implementation("commons-codec:commons-codec:1.17.1")
   implementation("commons-validator:commons-validator:1.9.0")
   implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.3.2") {
     exclude("org.apache.tomcat")

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -52,4 +52,4 @@ logging:
       %clr([%15.15t]){faint}
       %clr(%-40.40logger{39}){cyan}
       %clr(:){faint}
-      %m%replace( %X){'^ $',''}%n%wEx
+      %m%clr(%replace( %X){'^ $',''}){cyan}%n%wEx


### PR DESCRIPTION
Currently it can be a bit of a hassle to search for log messages for a particular
request or logs from all requests for a particular user, which we sometimes need
to do when looking into a bug report.

Start including the following information in the mapped diagnostic context (MDC)
for all messages that are logged in the course of handling an HTTP request:

* The user's auth (Keycloak) ID. This can be used to match a user's log messages
  with the access log entries for their requests.
* A unique request ID. This can be used to quickly find all the log messages for
  a particular request.
* The user's email address. Previously we only logged this for internal users.

For requests from internal users, the log message that records their request and
response bodies now includes the method, URI, and email address as part of the
text of the log message. Previously the log message was just "Request" which
isn't too useful when scanning logs in Datadog. The query string, if any, is
now included along with the request and response bodies.

The default log format for dev environments now renders the MDC in cyan rather
than in the default text color so it's easy to visually distinguish from the
text of the log messages.