### PR TITLE
Use structured logging for access logs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/RequestResponseLoggingFilter.kt
@@ -61,13 +61,16 @@ class RequestResponseLoggingFilter(
   override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
     val user = CurrentUserHolder.getCurrentUser()
     val oldMdc = MDC.getCopyOfContextMap()
+    val requestId = "${requestIdPrefix}_${request.requestId}"
 
     try {
       mdcPut("authId", user?.authId)
-      mdcPut("requestId", "${requestIdPrefix}_${request.requestId}")
+      mdcPut("requestId", requestId)
+      request.setAttribute("terrawareRequestId", requestId)
 
       if (user is IndividualUser) {
         mdcPut("email", user.email)
+        request.setAttribute("terrawareEmail", user.email)
 
         if (log.isDebugEnabled &&
             requestLogConfig.emailRegex != null &&

--- a/src/main/resources/logback-access-spring.xml
+++ b/src/main/resources/logback-access-spring.xml
@@ -1,0 +1,59 @@
+<configuration>
+  <springProfile name="jsonlog">
+    <appender name="JSONFILE" class="ch.qos.logback.core.FileAppender">
+      <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
+        <providers>
+          <timestamp/>
+          <version/>
+
+          <!-- Standard access log fields -->
+          <contentLength/>
+          <elapsedTime/>
+          <method/>
+          <protocol/>
+          <remoteHost/>
+          <remoteUser/>
+          <requestedUri/>
+          <requestedUrl/>
+          <statusCode/>
+
+          <requestHeaders>
+            <fieldName>headers</fieldName>
+            <lowerCaseHeaderNames>true</lowerCaseHeaderNames>
+            <filter>
+              <include>Referer</include>
+              <include>User-Agent</include>
+            </filter>
+          </requestHeaders>
+
+          <pattern>
+            <omitEmptyFields>true</omitEmptyFields>
+            <pattern>
+              {
+                "authId": "#nullNA{%u}",
+                "email": "#nullNA{%reqAttribute{terrawareEmail}}",
+                "message": "%h - %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\"",
+                "requestId": "#nullNA{%reqAttribute{terrawareRequestId}}"
+              }
+            </pattern>
+          </pattern>
+        </providers>
+      </encoder>
+
+      <!-- This log file is automatically rolled over by the configuration in logback-spring.xml;
+           we don't configure rollover here because we don't want the main log appender and this
+           one to both try to roll at the same time. -->
+      <file>${LOG_FILE}</file>
+    </appender>
+    <appender-ref ref="JSONFILE"/>
+  </springProfile>
+
+  <springProfile name="!jsonlog">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>combined</pattern>
+      </encoder>
+    </appender>
+    <appender-ref ref="CONSOLE"/>
+  </springProfile>
+</configuration>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,8 +1,0 @@
-<configuration>
-  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>combined</pattern>
-    </encoder>
-  </appender>
-  <appender-ref ref="CONSOLE"/>
-</configuration>


### PR DESCRIPTION
Currently, access logs are sent to Datadog as plain text. Update the logging
configuration to send them as JSON objects instead. Using structured logging
means that the various fields like status code are exposed as searchable
attributes rather than opaque text.

The access log events now also include the request ID and email address, meaning
that searching for either of those attributes will match both the access logs and
other log messages from the server. This should make it easier to trace the user's
activity when we get a bug report.