### PR TITLE
SW-6230 Allow fetching of application submissions

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -464,6 +464,57 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `returns application submissions for non-participant projects if deliverable ID is specified`() {
+      val organizationId = insertOrganization()
+      val projectId = insertProject()
+      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val deliverableId = insertDeliverable()
+      val submissionId = insertSubmission(submissionStatus = SubmissionStatus.Approved)
+      val documentId = insertSubmissionDocument()
+
+      assertEquals(
+          listOf(
+              DeliverableSubmissionModel(
+                  category = DeliverableCategory.FinancialViability,
+                  deliverableId = deliverableId,
+                  descriptionHtml = "Description 1",
+                  documents =
+                      listOf(
+                          SubmissionDocumentModel(
+                              Instant.EPOCH,
+                              null,
+                              DocumentStore.Google,
+                              documentId,
+                              "Submission Document 1",
+                              "Original Name 1",
+                          ),
+                      ),
+                  dueDate = null,
+                  feedback = null,
+                  internalComment = null,
+                  modifiedTime = Instant.EPOCH,
+                  moduleId = moduleId,
+                  moduleName = "Module 1",
+                  moduleTitle = null,
+                  name = "Deliverable 1",
+                  organizationId = organizationId,
+                  organizationName = "Organization 1",
+                  participantId = null,
+                  participantName = null,
+                  position = 1,
+                  projectId = projectId,
+                  projectName = "Project 1",
+                  required = false,
+                  sensitive = false,
+                  status = SubmissionStatus.Approved,
+                  submissionId = submissionId,
+                  templateUrl = null,
+                  type = DeliverableType.Document,
+              )),
+          store.fetchDeliverableSubmissions(deliverableId = deliverableId))
+    }
+
+    @Test
     fun `returns due dates according to cohort or project overrides`() {
       val cohortWithDueDate = insertCohort()
       val cohortWithoutDueDate = insertCohort()


### PR DESCRIPTION
When the web app saves changes to fields such as the internal comment on an
application deliverable, it tries to refresh the deliverable data using
`GET /api/v1/accelerator/deliverables/{id}/submissions/{projectId}`. Currently,
that endpoint only supports non-application deliverables (application deliverables
are exposed via an alternate endpoint) because the underlying query code needs
to avoid returning lists of application deliverables on the Deliverables page
in the app.

This doesn't appear to cause any user-visible problems, but it does cause an
error message to be logged by the server.

Since the client is requesting a specific deliverable in this case, there's no
danger of returning a list that mixes application and non-application
deliverables. Update the query to only exclude application deliverables if the
caller didn't supply a specific deliverable ID.