### PR TITLE
SW-6221 Merge "Other" species into known ones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -407,6 +407,20 @@ class ObservationsController(
 
     return SimpleSuccessResponsePayload()
   }
+
+  @Operation(
+      summary =
+          "Replaces a user-entered 'Other' species with one of the organization's species in " +
+              "an observation.")
+  @PostMapping("/{observationId}/mergeOtherSpecies")
+  fun mergeOtherSpecies(
+      @PathVariable observationId: ObservationId,
+      @RequestBody payload: MergeOtherSpeciesRequestPayload
+  ): SimpleSuccessResponsePayload {
+    observationStore.mergeOtherSpecies(observationId, payload.otherSpeciesName, payload.speciesId)
+
+    return SimpleSuccessResponsePayload()
+  }
 }
 
 data class ObservationPayload(
@@ -941,6 +955,19 @@ data class GetObservationResultsResponsePayload(val observation: ObservationResu
 data class ListObservationResultsResponsePayload(
     val observations: List<ObservationResultsPayload>
 ) : SuccessResponsePayload
+
+data class MergeOtherSpeciesRequestPayload(
+    @Schema(
+        description =
+            "Name of the species of certainty Other whose recorded plants should be updated to " +
+                "refer to the known species.")
+    val otherSpeciesName: String,
+    @Schema(
+        description =
+            "ID of the existing species that the Other species' recorded plants should be merged " +
+                "into.")
+    val speciesId: SpeciesId,
+)
 
 data class GetPlantingSiteObservationSummaryPayload(
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.MismatchedStateException
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
@@ -142,6 +143,9 @@ class ShapefilesInvalidException(val problems: List<String>) :
     RuntimeException("Found problems in planting site map data") {
   constructor(problem: String) : this(listOf(problem))
 }
+
+class SpeciesInWrongOrganizationException(val speciesId: SpeciesId) :
+    MismatchedStateException("Species $speciesId is in the wrong organization")
 
 class WithdrawalNotUndoException(val withdrawalId: WithdrawalId) :
     MismatchedStateException("Withdrawal $withdrawalId is not an undo withdrawal")

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2113,7 +2113,13 @@ abstract class DatabaseBackedTest {
       isPermanent: Boolean = row.isPermanent ?: false,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
-      statusId: ObservationPlotStatus = row.statusId ?: ObservationPlotStatus.Unclaimed,
+      statusId: ObservationPlotStatus =
+          row.statusId
+              ?: when {
+                completedTime != null -> ObservationPlotStatus.Completed
+                claimedTime != null -> ObservationPlotStatus.Claimed
+                else -> ObservationPlotStatus.Unclaimed
+              },
   ) {
     val rowWithDefaults =
         row.copy(

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -119,6 +119,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        parentStore,
         recordedPlantsDao)
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -30,6 +30,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
+  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
@@ -38,9 +39,9 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        parentStore,
         recordedPlantsDao)
   }
-  private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
   private val plantingSiteStore: PlantingSiteStore by lazy {
     PlantingSiteStore(
         clock,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db
 import com.opencsv.CSVReader
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -60,6 +61,7 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        ParentStore(dslContext),
         recordedPlantsDao)
   }
   private val resultsStore by lazy { ObservationResultsStore(dslContext) }


### PR DESCRIPTION
`POST /api/v1/tracking/observations/{observationId}/mergeOtherSpecies` will 
merge a species whose name was manually entered by users in the field via the
"Other" option in the mobile app into one of the organization's existing
species, updating all the observation's statistics to look as if users had 
selected the target species in the first place.