### PR TITLE
Add TF Contact info to organization list API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/OrganizationsController.kt
@@ -68,10 +68,18 @@ class OrganizationsController(
       @Schema(description = "Return this level of information about the organization's contents.")
       depth: OrganizationStore.FetchDepth,
   ): ListOrganizationsResponsePayload {
+    val currentUser = currentUser()
     val elements =
         organizationStore.fetchAll(depth).map { model ->
           OrganizationPayload(
-              model, getRole(model), userStore.getTerraformationContactUser(model.id))
+              model = model,
+              role = getRole(model),
+              tfContactUser =
+                  if (currentUser.canListOrganizationUsers(model.id)) {
+                    userStore.getTerraformationContactUser(model.id)
+                  } else {
+                    null
+                  })
         }
 
     return ListOrganizationsResponsePayload(elements)


### PR DESCRIPTION
The FE requires the TF Contact information for organizations, including those which do not include a project that is part of an accelerator participant. This PR pulls TF Contact, if it exists and is allowed for the current user, for each organization that is returned by the API in the same way as for the `AcceleratorOrganizationsController`.