### PR TITLE
SW-6244 Don't log error if GBIF species not found

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -113,7 +113,6 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
       ex: WebApplicationException,
       request: WebRequest
   ): ResponseEntity<*> {
-    logError(ex, request)
     return simpleErrorResponse(
         ex.message ?: "An internal error has occurred.",
         HttpStatus.valueOf(ex.response.status),

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -173,9 +173,6 @@ class SpeciesInUseException(val speciesId: SpeciesId) :
 class ScientificNameExistsException(val name: String?) :
     DuplicateEntityException("Scientific name $name already exists")
 
-class ScientificNameNotFoundException(val name: String) :
-    EntityNotFoundException("Scientific name $name not found")
-
 class SpeciesNotFoundException(val speciesId: SpeciesId) :
     EntityNotFoundException("Species $speciesId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/api/SpeciesLookupController.kt
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.ws.rs.BadRequestException
+import jakarta.ws.rs.NotFoundException
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -78,7 +79,9 @@ class SpeciesLookupController(private val gbifStore: GbifStore) {
           example = "en")
       language: String? = null,
   ): SpeciesLookupDetailsResponsePayload {
-    val model = gbifStore.fetchOneByScientificName(scientificName, language)
+    val model =
+        gbifStore.fetchOneByScientificName(scientificName, language)
+            ?: throw NotFoundException("$scientificName not found")
     val problem = gbifStore.checkScientificName(scientificName)
     return SpeciesLookupDetailsResponsePayload(model, problem)
   }

--- a/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/GbifStore.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.species.db
 
-import com.terraformation.backend.db.ScientificNameNotFoundException
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
 import com.terraformation.backend.db.default_schema.tables.pojos.GbifNamesRow
@@ -114,7 +113,7 @@ class GbifStore(private val dslContext: DSLContext) {
   fun fetchOneByScientificName(
       scientificName: String,
       vernacularNameLanguage: String? = null
-  ): GbifTaxonModel {
+  ): GbifTaxonModel? {
     val languageCondition =
         if (vernacularNameLanguage != null) {
           GBIF_VERNACULAR_NAMES.LANGUAGE.isNull.or(
@@ -169,7 +168,7 @@ class GbifStore(private val dslContext: DSLContext) {
               vernacularNames = record[vernacularNamesMultiset] ?: emptyList(),
               threatStatus = record[GBIF_DISTRIBUTIONS.THREAT_STATUS],
           )
-        } ?: throw ScientificNameNotFoundException(scientificName)
+        }
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/GbifStoreTest.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.species.db
 
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.ScientificNameNotFoundException
 import com.terraformation.backend.db.default_schema.GbifTaxonId
 import com.terraformation.backend.db.default_schema.SpeciesProblemField
 import com.terraformation.backend.db.default_schema.SpeciesProblemType
@@ -162,10 +161,8 @@ internal class GbifStoreTest : DatabaseTest() {
   @Nested
   inner class FetchOneByScientificName {
     @Test
-    fun `throws exception if scientific name does not exist`() {
-      assertThrows<ScientificNameNotFoundException> {
-        store.fetchOneByScientificName("nonexistent")
-      }
+    fun `returns null if scientific name does not exist`() {
+      assertNull(store.fetchOneByScientificName("nonexistent"))
     }
 
     @Test


### PR DESCRIPTION
If the user searches for a species that's not in the GBIF database, we shouldn't
consider it a server error, just a normal outcome of the request.

Update the GBIF lookup endpoint to throw an explicit web-server "not found"
exception rather than an application-defined exception, and remove the error
logging for that kind of exception since when we throw it, it will always mean
the code is deliberately returning a response to the user.