### PR TITLE
SW-6246 Don't flag application documents as errors

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -404,8 +404,7 @@ class AppNotificationService(
     systemUser.run {
       val project = projectStore.fetchOneById(event.projectId)
       if (project.participantId == null) {
-        log.error(
-            "Got deliverable ready notification for non-participant project ${event.projectId}")
+        // We don't send notifications about individual deliverables in applications.
         return@run
       }
 

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -611,8 +611,7 @@ class EmailNotificationService(
     systemUser.run {
       val project = projectStore.fetchOneById(event.projectId)
       if (project.participantId == null) {
-        log.error(
-            "Got deliverable ready notification for non-participant project ${event.projectId}")
+        // We don't send notifications about individual deliverables in applications.
         return@run
       }
 


### PR DESCRIPTION
We notify the accelerator team when a participant project uploads a document
for a document deliverable, but not when a document is uploaded as part of an
in-progress application. We were logging an error in the latter case thanks to
an outdated sanity check.