### PR TITLE
SW-6256 Fix permission inversions in AccessionStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -355,6 +355,9 @@ class AccessionStore(
 
   fun update(updated: AccessionModel, updateContext: AccessionUpdateContext? = null) {
     val accessionId = updated.id ?: throw IllegalArgumentException("No accession ID specified")
+
+    requirePermissions { updateAccession(accessionId) }
+
     val existing = fetchOneById(accessionId)
     val existingFacilityId =
         existing.facilityId ?: throw IllegalStateException("Accession has no facility ID")
@@ -677,9 +680,9 @@ class AccessionStore(
    *   current user.
    */
   fun checkIn(accessionId: AccessionId): AccessionModel {
-    val accession = fetchOneById(accessionId)
-
     requirePermissions { updateAccession(accessionId) }
+
+    val accession = fetchOneById(accessionId)
 
     if (accession.state != AccessionState.AwaitingCheckIn) {
       log.info("Accession $accessionId is already checked in; ignoring request to check in again")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreCheckInTest.kt
@@ -1,11 +1,14 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionStateHistoryRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_STATE_HISTORY
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
 
 internal class AccessionStoreCheckInTest : AccessionStoreTest() {
   @Test
@@ -47,5 +50,14 @@ internal class AccessionStoreCheckInTest : AccessionStoreTest() {
 
     val updatedRow = accessionsDao.fetchOneById(accessionId)
     assertEquals(checkInTime, updatedRow?.modifiedTime, "Modified time")
+  }
+
+  @Test
+  fun `throws exception if no permission to check in`() {
+    insertOrganizationUser(role = Role.Contributor)
+
+    val accessionId = create().id!!
+
+    assertThrows<AccessDeniedException> { store.checkIn(accessionId) }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreDatabaseTest.kt
@@ -179,7 +179,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     val speciesId2 = insertSpecies()
     val initial = store.create(accessionModel(speciesId = speciesId1))
 
-    val nurseryFacilityId = insertFacility(type = FacilityType.Nursery)
+    insertFacility(type = FacilityType.Nursery)
     insertBatch(BatchesRow(accessionId = initial.id!!))
     insertWithdrawal()
     insertBatchWithdrawal()
@@ -195,6 +195,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
   fun `update throws exception if project is in a different organization`() {
     val projectId = insertProject()
     insertOrganization()
+    insertOrganizationUser()
     val otherOrgProjectId = insertProject()
 
     val initial = store.create(accessionModel(projectId = projectId))
@@ -294,7 +295,7 @@ internal class AccessionStoreDatabaseTest : AccessionStoreTest() {
     insertPlantingSite()
     insertDelivery()
 
-    val withDelivery = store.fetchOneById(initial.id!!)
+    val withDelivery = store.fetchOneById(initial.id)
     assertTrue(withDelivery.hasDeliveries, "Delivery should be indicated in accession")
 
     val otherAccession =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreHistoryTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.seedbank.AccessionQuantityHistoryType
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
@@ -14,7 +15,6 @@ import com.terraformation.backend.seedbank.model.AccessionUpdateContext
 import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
-import io.mockk.every
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -118,18 +118,24 @@ internal class AccessionStoreHistoryTest : AccessionStoreTest() {
     val firstWithdrawerUserId = insertUser(firstName = "First", lastName = "Withdrawer")
     val viabilityTesterUserId = insertUser(firstName = "Viability", lastName = "Tester")
 
+    insertOrganizationUser(userId = createUserId)
+    insertOrganizationUser(userId = checkInUserId, role = Role.Manager)
+    insertOrganizationUser(userId = processUserId, role = Role.Manager)
+    insertOrganizationUser(userId = firstWithdrawerUserId, role = Role.Manager)
+    insertOrganizationUser(userId = viabilityTesterUserId, role = Role.Manager)
+
     clock.instant = createTime
-    every { user.userId } returns createUserId
+    switchToUser(createUserId)
 
     val initial = store.create(accessionModel())
 
     clock.instant = checkInTime
-    every { user.userId } returns checkInUserId
+    switchToUser(checkInUserId)
 
     store.checkIn(initial.id!!)
 
     clock.instant = processTime
-    every { user.userId } returns processUserId
+    switchToUser(processUserId)
 
     val withSeedQuantity =
         store.updateAndFetch(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreMultiFacilityTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.seedbank.db.accessionStore
 
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.default_schema.FacilityId
-import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -37,7 +36,6 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
   fun `update writes new facility id if it belongs to the same organization as previous facility`() {
     val anotherFacilityId = insertFacility()
 
-    every { user.canUpdateAccession(any()) } returns true
     val initial = store.create(accessionModel())
 
     store.update(initial.copy(facilityId = anotherFacilityId))
@@ -52,9 +50,9 @@ internal class AccessionStoreMultiFacilityTest : AccessionStoreTest() {
   fun `update does not write to database if facility id to update does not belong to same organization as previous facility`() {
     val initialFacilityId = inserted.facilityId
     insertOrganization()
+    insertOrganizationUser()
     val facilityIdInAnotherOrg = insertFacility()
 
-    every { user.canUpdateAccession(any()) } returns true
     val initial = store.create(accessionModel(facilityId = initialFacilityId))
 
     assertThrows<FacilityNotFoundException> {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStorePermissionTest.kt
@@ -3,9 +3,8 @@ package com.terraformation.backend.seedbank.db.accessionStore
 import com.terraformation.backend.db.AccessionNotFoundException
 import com.terraformation.backend.db.FacilityNotFoundException
 import com.terraformation.backend.db.OrganizationNotFoundException
-import io.mockk.every
+import com.terraformation.backend.db.default_schema.Role
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
@@ -16,64 +15,53 @@ internal class AccessionStorePermissionTest : AccessionStoreTest() {
     val initial = store.create(accessionModel())
     assertNotNull(initial, "Should have created accession successfully")
 
-    every { user.canReadAccession(any()) } returns false
+    deleteOrganizationUser()
 
     assertThrows<AccessionNotFoundException> { store.fetchOneById(initial.id!!) }
-  }
-
-  @Test
-  fun `update does not write to database if user does not have permission`() {
-    every { user.canUpdateAccession(any()) } returns false
-    val initial = store.create(accessionModel())
-
-    assertThrows<AccessDeniedException> { store.update(initial.copy(numberOfTrees = 1)) }
-
-    val afterUpdate = store.fetchOneById(initial.id!!)
-    assertNotNull(afterUpdate, "Should be able to read accession after updating")
-    assertNull(afterUpdate.numberOfTrees, "Update should not have been written")
   }
 
   @Test
   fun `fetchHistory throws exception if user does not have permission`() {
     val initial = store.create(accessionModel())
 
-    every { user.canReadAccession(any()) } returns false
+    deleteOrganizationUser()
 
     assertThrows<AccessionNotFoundException> { store.fetchHistory(initial.id!!) }
   }
 
   @Test
   fun `delete throws exception if user does not have permission`() {
-    every { user.canDeleteAccession(any()) } returns false
     val initial = store.create(accessionModel())
+
+    insertOrganizationUser(role = Role.Contributor)
 
     assertThrows<AccessDeniedException> { store.delete(initial.id!!) }
   }
 
   @Test
   fun `countByState throws exception when no permission to read facility`() {
-    every { user.canReadFacility(facilityId) } returns false
+    deleteOrganizationUser()
 
     assertThrows<FacilityNotFoundException> { store.countByState(facilityId) }
   }
 
   @Test
   fun `countByState throws exception when no permission to read organization`() {
-    every { user.canReadOrganization(organizationId) } returns false
+    deleteOrganizationUser()
 
     assertThrows<OrganizationNotFoundException> { store.countByState(organizationId) }
   }
 
   @Test
   fun `getSummaryStatistics throws exception when no permission to read facility`() {
-    every { user.canReadFacility(facilityId) } returns false
+    deleteOrganizationUser()
 
     assertThrows<FacilityNotFoundException> { store.getSummaryStatistics(facilityId) }
   }
 
   @Test
   fun `getSummaryStatistics throws exception when no permission to read organization`() {
-    every { user.canReadOrganization(organizationId) } returns false
+    deleteOrganizationUser()
 
     assertThrows<OrganizationNotFoundException> { store.getSummaryStatistics(organizationId) }
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.tables.pojos.AccessionsRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.seedbank.model.AccessionSummaryStatistics
-import io.mockk.every
 import java.math.BigDecimal
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -560,8 +559,6 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
 
   @Test
   fun `countActiveInSubLocation only counts active accessions in location`() {
-    every { user.canReadSubLocation(any()) } returns true
-
     val subLocationId = insertSubLocation()
     val otherSubLocationId = insertSubLocation()
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreTest.kt
@@ -1,21 +1,21 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
-import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.customer.db.ParentStore
-import com.terraformation.backend.customer.model.IndividualUser
+import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.DataSource
 import com.terraformation.backend.db.seedbank.ViabilityTestType
 import com.terraformation.backend.i18n.Messages
-import com.terraformation.backend.mockUser
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.seedbank.db.BagStore
 import com.terraformation.backend.seedbank.db.GeolocationStore
@@ -28,14 +28,13 @@ import com.terraformation.backend.seedbank.model.ViabilityTestModel
 import com.terraformation.backend.seedbank.model.WithdrawalModel
 import com.terraformation.backend.seedbank.seeds
 import com.terraformation.backend.species.db.SpeciesStore
-import io.mockk.every
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 
-internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
-  override val user: IndividualUser = mockUser()
+internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
 
   protected val clock = TestClock()
   protected val publisher = TestEventPublisher()
@@ -51,22 +50,9 @@ internal abstract class AccessionStoreTest : DatabaseTest(), RunsAsUser {
   protected fun init() {
     organizationId = insertOrganization()
     facilityId = insertFacility()
+    insertOrganizationUser(role = Role.Admin)
 
     parentStore = ParentStore(dslContext)
-
-    every { user.canCreateAccession(any()) } returns true
-    every { user.canCreateSpecies(organizationId) } returns true
-    every { user.canDeleteAccession(any()) } returns true
-    every { user.canDeleteSpecies(any()) } returns true
-    every { user.canReadAccession(any()) } returns true
-    every { user.canReadFacility(any()) } returns true
-    every { user.canReadOrganization(any()) } returns true
-    every { user.canReadOrganizationUser(organizationId, any()) } returns true
-    every { user.canReadProject(any()) } returns true
-    every { user.canReadSpecies(any()) } returns true
-    every { user.canSetWithdrawalUser(any()) } returns true
-    every { user.canUpdateAccession(any()) } returns true
-    every { user.canUpdateSpecies(any()) } returns true
 
     val messages = Messages()
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreViabilityTest.kt
@@ -254,7 +254,7 @@ internal class AccessionStoreViabilityTest : AccessionStoreTest() {
                 purpose = WithdrawalPurpose.ViabilityTesting,
                 viabilityTestId = test.id,
                 withdrawn = SeedQuantityModel(BigDecimal(5), SeedQuantityUnits.Seeds),
-                withdrawnByName = user.fullName,
+                withdrawnByName = "First Last",
                 withdrawnByUserId = user.userId,
             )),
         accession.withdrawals.map { it.copy(id = null) })


### PR DESCRIPTION
Switch the `AccessionStore` test suite to `RunsAsDatabaseUser` and fix the
permission inversions flagged by the tests, one of which was also flagged in
production.