### PR TITLE
SW-6257 Allow internal users to update projects

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1646,7 +1646,7 @@ internal class PermissionTest : DatabaseTest() {
         removeTerraformationContact = true,
     )
 
-    // Can access accelerator-related functions on all ogs.
+    // Can access accelerator-related functions on all orgs.
     permissions.expect(
         ProjectId(3000),
         ProjectId(4000),
@@ -1662,6 +1662,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectVotes = true,
         updateDefaultVoters = true,
         updateInternalVariableWorkflowDetails = true,
+        updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
@@ -1880,6 +1881,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectScores = true,
         readProjectVotes = true,
         updateInternalVariableWorkflowDetails = true,
+        updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectDocumentSettings = true,
         updateProjectScores = true,
@@ -2081,6 +2083,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectScores = true,
         readProjectVotes = true,
         updateInternalVariableWorkflowDetails = true,
+        updateProject = true,
         updateProjectAcceleratorDetails = true,
         updateProjectScores = true,
         updateProjectVotes = true,


### PR DESCRIPTION
Commit d6d4e226 fixed a problem that caused end users to be unable to update
variables that would cause their workflow statuses to be reset to "In Review,"
but introduced a new bug: accelerator admins could no longer set variables to
that status.

Convert `VariableWorkflowStoreTest` to use `RunsAsDatabaseUser`, add a test
case to reproduce the problem, and fix the problem by updating the permission
logic for project updates to allow accelerator-related projects to be updated
by internal users with TF Expert or higher global roles.