### PR TITLE
Reduce level of Balena update failure log message

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/BalenaPoller.kt
@@ -98,7 +98,7 @@ class BalenaPoller(
         }
       }
     } catch (e: Exception) {
-      log.error("Unable to process Balena device updates", e)
+      log.warn("Unable to process Balena device updates", e)
     }
   }
 }


### PR DESCRIPTION
Occasionally Balena's API returns a server error when we poll for device updates.
It's not a problem that warrants our attention every time it happens, so reduce
the log message about it from "error" to "warn" level.