### PR TITLE
SW-6251 Associate monitoring plots with sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1500,6 +1500,7 @@ class PlantingSiteStore(
                 name = "$plotNumber",
                 permanentCluster = clusterNumber,
                 permanentClusterSubplot = 1,
+                plantingSiteId = plantingSite.id,
                 plantingSubzoneId = subzone.id,
                 sizeMeters = MONITORING_PLOT_SIZE_INT,
             )
@@ -1546,6 +1547,7 @@ class PlantingSiteStore(
                 modifiedBy = userId,
                 modifiedTime = now,
                 name = "$plotNumber",
+                plantingSiteId = plantingSiteId,
                 plantingSubzoneId = subzone.id,
                 sizeMeters = MONITORING_PLOT_SIZE_INT)
         monitoringPlotsDao.insert(monitoringPlotsRow)

--- a/src/main/resources/db/migration/0300/V316__MonitoringPlotSite.sql
+++ b/src/main/resources/db/migration/0300/V316__MonitoringPlotSite.sql
@@ -1,0 +1,13 @@
+ALTER TABLE tracking.monitoring_plots
+    ADD COLUMN planting_site_id BIGINT
+        REFERENCES tracking.planting_sites ON DELETE CASCADE;
+
+UPDATE tracking.monitoring_plots mp
+SET planting_site_id = (
+    SELECT planting_site_id
+    FROM tracking.planting_subzones ps
+    WHERE ps.id = mp.planting_subzone_id
+);
+
+ALTER TABLE tracking.monitoring_plots
+    ALTER COLUMN planting_site_id SET NOT NULL;

--- a/src/main/resources/db/migration/0300/V316__MonitoringPlotSite.sql
+++ b/src/main/resources/db/migration/0300/V316__MonitoringPlotSite.sql
@@ -11,3 +11,5 @@ SET planting_site_id = (
 
 ALTER TABLE tracking.monitoring_plots
     ALTER COLUMN planting_site_id SET NOT NULL;
+
+CREATE INDEX ON tracking.monitoring_plots (planting_site_id);

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1810,6 +1810,7 @@ abstract class DatabaseBackedTest {
       permanentCluster: Int? = row.permanentCluster,
       permanentClusterSubplot: Int? =
           row.permanentClusterSubplot ?: if (permanentCluster != null) 1 else null,
+      plantingSiteId: PlantingSiteId = row.plantingSiteId ?: inserted.plantingSiteId,
       plantingSubzoneId: PlantingSubzoneId = row.plantingSubzoneId ?: inserted.plantingSubzoneId,
   ): MonitoringPlotId {
     val rowWithDefaults =
@@ -1824,6 +1825,7 @@ abstract class DatabaseBackedTest {
             name = name,
             permanentCluster = permanentCluster,
             permanentClusterSubplot = permanentClusterSubplot,
+            plantingSiteId = plantingSiteId,
             plantingSubzoneId = plantingSubzoneId,
             sizeMeters = sizeMeters,
         )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -513,6 +513,7 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
                 name = initialPlot.name,
                 permanentCluster = initialPlot.permanentCluster,
                 permanentClusterSubplot = initialPlot.permanentClusterSubplot,
+                plantingSiteId = existingWithoutPlots.id,
                 plantingSubzoneId = existingSubzone.id,
             )
           }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -42,6 +42,7 @@ internal class PlantingSiteStoreCreateTemporaryTest : PlantingSiteStoreTest() {
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
               name = "18",
+              plantingSiteId = plantingSiteId,
               plantingSubzoneId = plantingSubzoneId,
               sizeMeters = MONITORING_PLOT_SIZE_INT,
           )


### PR DESCRIPTION
In preparation for allowing monitoring plots to fall outside of subzone
boundaries, add a direct association between monitoring plots and planting sites
to the database schema.

The new column is populated by the code that creates monitoring plots, but nothing
makes use of it yet.