### PR TITLE
SW-6251 Add monitoring plot/site link to search API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -19,6 +20,8 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
+          plantingSites.asSingleValueSublist(
+              "plantingSite", MONITORING_PLOTS.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID)),
           plantingSubzones.asSingleValueSublist(
               "plantingSubzone", MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID)),
       )
@@ -44,12 +47,12 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
           coordinateField("southwestLongitude", MONITORING_PLOTS.BOUNDARY, SOUTHWEST, LONGITUDE),
       )
 
-  override val inheritsVisibilityFrom: SearchTable = tables.plantingSubzones
+  override val inheritsVisibilityFrom: SearchTable = tables.plantingSites
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query
         .join(PLANTING_SUBZONES)
-        .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+        .on(MONITORING_PLOTS.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID))
   }
 
   companion object {

--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -51,7 +51,7 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
     return query
-        .join(PLANTING_SUBZONES)
+        .join(PLANTING_SITE_SUMMARIES)
         .on(MONITORING_PLOTS.PLANTING_SITE_ID.eq(PLANTING_SITE_SUMMARIES.ID))
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.DELIVERIES
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SEASONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_POPULATIONS
@@ -31,6 +32,8 @@ class PlantingSitesTable(tables: SearchTables) : SearchTable() {
               "country", PLANTING_SITE_SUMMARIES.COUNTRY_CODE.eq(COUNTRIES.CODE)),
           deliveries.asMultiValueSublist(
               "deliveries", PLANTING_SITE_SUMMARIES.ID.eq(DELIVERIES.PLANTING_SITE_ID)),
+          monitoringPlots.asMultiValueSublist(
+              "monitoringPlots", PLANTING_SITE_SUMMARIES.ID.eq(MONITORING_PLOTS.PLANTING_SITE_ID)),
           observations.asMultiValueSublist(
               "observations", PLANTING_SITE_SUMMARIES.ID.eq(OBSERVATIONS.PLANTING_SITE_ID)),
           organizations.asSingleValueSublist(

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -217,6 +217,13 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                     "exclusion" to postgisRenderGeoJson(exclusionGeometry),
                     "id" to "$plantingSiteId",
                     "modifiedTime" to "1970-01-01T00:00:00Z",
+                    "monitoringPlots" to
+                        listOf(
+                            mapOf("id" to "$monitoringPlotId5"),
+                            mapOf("id" to "$monitoringPlotId6"),
+                            mapOf("id" to "$monitoringPlotId7"),
+                            mapOf("id" to "$monitoringPlotId8"),
+                        ),
                     "name" to "Site 1",
                     "numPlantingZones" to "1",
                     "numPlantingSubzones" to "2",
@@ -434,6 +441,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "exclusion",
                 "id",
                 "modifiedTime",
+                "monitoringPlots.id",
                 "name",
                 "numPlantingZones",
                 "numPlantingSubzones",


### PR DESCRIPTION
Allow the search API to navigate from planting sites to monitoring plots and back.
This will support searching for plots that aren't in subzones once we support
plots outside of site boundaries.