### PR TITLE
SW-6259 Allow all internal users to read user details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -526,7 +526,7 @@ data class IndividualUser(
 
   override fun canReadUpload(uploadId: UploadId) = userId == parentStore.getUserId(uploadId)
 
-  override fun canReadUser(userId: UserId) = isAcceleratorAdmin()
+  override fun canReadUser(userId: UserId) = isReadOnlyOrHigher()
 
   override fun canReadUserInternalInterests(userId: UserId) = isAcceleratorAdmin()
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2130,6 +2130,11 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *otherUserIds.values.toTypedArray(),
+        readUser = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = false,
         addCohortParticipant = false,
         addParticipantProject = false,
@@ -2272,6 +2277,11 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+    )
+
+    permissions.expect(
+        *otherUserIds.values.toTypedArray(),
+        readUser = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
Previously, only users with Accelerator Admin or Super-Admin global roles were
allowed to see information about users systemwide including other internal
users. But we now need to show "created by" and "modified by" user information
on project profile pages, which are also accessible with Read Only and TF
Expert global roles.

Update the permission check to allow those users to read (but not update)
information about all users.