### PR TITLE
SW-6260 Add more detail to variable value logs

### DIFF
--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -38,3 +38,15 @@ logging:
   level:
     com.terraformation: DEBUG
     org.springframework: WARN
+  pattern:
+    # This is the default Spring Boot console log format, but with the MDC values (%X) in between
+    # the log message and the exception stacktrace.
+    console: >-
+      %clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint}
+      %clr(%5p)
+      %clr(${PID:- }){magenta}
+      %clr(---){faint}
+      %clr([%15.15t]){faint}
+      %clr(%-40.40logger{39}){cyan}
+      %clr(:){faint}
+      %m%clr(%replace( %X){'^ $',''}){cyan}%n%wEx


### PR DESCRIPTION
To make it easier to troubleshoot issues with variable updates, log more details
about variable value operations, and do it in a structured way using MDC so it's
searchable using attribute filters in Datadog.

Make tests use the default log format that's used in local dev environments, which
includes the MDC values.