### PR TITLE
Use separate file for access logs

### DIFF
--- a/src/main/resources/logback-access-spring.xml
+++ b/src/main/resources/logback-access-spring.xml
@@ -42,7 +42,7 @@
 
       <file>${ACCESS_LOG_FILE}</file>
       <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
+        <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${ACCESS_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
         <cleanHistoryOnStart>${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
         <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}</maxFileSize>
         <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}</totalSizeCap>

--- a/src/main/resources/logback-access-spring.xml
+++ b/src/main/resources/logback-access-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
   <springProfile name="jsonlog">
-    <appender name="JSONFILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
         <providers>
           <timestamp/>
@@ -40,10 +40,14 @@
         </providers>
       </encoder>
 
-      <!-- This log file is automatically rolled over by the configuration in logback-spring.xml;
-           we don't configure rollover here because we don't want the main log appender and this
-           one to both try to roll at the same time. -->
-      <file>${LOG_FILE}</file>
+      <file>${ACCESS_LOG_FILE}</file>
+      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
+        <cleanHistoryOnStart>${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
+        <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}</maxFileSize>
+        <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}</totalSizeCap>
+        <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}</maxHistory>
+      </rollingPolicy>
     </appender>
     <appender-ref ref="JSONFILE"/>
   </springProfile>


### PR DESCRIPTION
Commit 789b3e00 switched HTTP access logs to use JSON format so we could get
richer context information about requests. It put the access logs in the same
log file as the main server logs. This worked after the server started, but
when logs were rotated, the access logs didn't switch over to the newly-created
server logfile.

Switch to a separate file for access logs. The new file will be rotated on the
same schedule as the main server log.