### PR TITLE
SW-6251 Populate planting site histories in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
@@ -128,6 +128,7 @@ class ObservationTestHelper(
             height = height,
             timeZone = timeZone,
             width = width,
+            x = 0,
         )
     test.insertPlantingZone(
         height = height,


### PR DESCRIPTION
Add support for the planting-site-related history tables in tests. By default,
the site, zone, and subzone histories will now be populated when tests insert
sites with boundaries.

Fix tests that were inserting planting zones whose planting sites didn't have
boundaries, which, while it's not prevented by any integrity constraints in
the database, isn't a valid configuration.