### PR TITLE
SW-6251 Populate monitoring plot histories table

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzoneHistor
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZoneHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.point
@@ -411,6 +412,8 @@ internal class PlantingSiteStoreCreateSiteTest : PlantingSiteStoreTest() {
           ),
           plantingSubzoneHistoriesDao.findAll().map { it.copy(id = null) },
           "Planting subzone histories")
+
+      assertTableEmpty(MONITORING_PLOT_HISTORIES)
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
@@ -56,12 +57,7 @@ internal class PlantingSiteStoreCreateTemporaryTest : PlantingSiteStoreTest() {
       val actual = monitoringPlotsDao.fetchOneById(newPlotId)!!
 
       assertEquals(expected, actual.copy(boundary = null))
-
-      // PostGIS geometry representation isn't identical to GeoTools in-memory representation; do a
-      // fuzzy comparison with a very small tolerance.
-      if (!plotBoundary.equalsExact(actual.boundary!!, 0.00000000001)) {
-        assertEquals(plotBoundary, actual.boundary!!, "Plot boundary")
-      }
+      assertGeometryEquals(plotBoundary, actual.boundary, "Plot boundary")
 
       assertTableEquals(
           listOf(


### PR DESCRIPTION
When monitoring plots are created or planting site maps are edited, record their
details in the new `monitoring_plot_histories` table.