### PR TITLE
SW-6251 Add history IDs to observation plots

### DIFF
--- a/src/main/resources/db/migration/0300/V319__ObservationPlotHistory.sql
+++ b/src/main/resources/db/migration/0300/V319__ObservationPlotHistory.sql
@@ -1,0 +1,16 @@
+-- Record which version of a plot was observed so we can link it to its correct subzone at the
+-- time of the observation.
+ALTER TABLE tracking.observation_plots
+    ADD COLUMN monitoring_plot_history_id BIGINT
+        REFERENCES tracking.monitoring_plot_histories ON DELETE CASCADE;
+CREATE INDEX ON tracking.observation_plots (monitoring_plot_history_id);
+
+UPDATE tracking.observation_plots op
+SET monitoring_plot_history_id = (
+    SELECT id
+    FROM tracking.monitoring_plot_histories mph
+    WHERE mph.monitoring_plot_id = op.monitoring_plot_id
+);
+
+ALTER TABLE tracking.observation_plots
+    ALTER COLUMN monitoring_plot_history_id SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2295,6 +2295,8 @@ abstract class DatabaseBackedTest {
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       isPermanent: Boolean = row.isPermanent ?: false,
+      monitoringPlotHistoryId: MonitoringPlotHistoryId =
+          row.monitoringPlotHistoryId ?: inserted.monitoringPlotHistoryId,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
       statusId: ObservationPlotStatus =
@@ -2317,6 +2319,7 @@ abstract class DatabaseBackedTest {
             observationId = observationId,
             modifiedBy = createdBy,
             modifiedTime = createdTime,
+            monitoringPlotHistoryId = monitoringPlotHistoryId,
             monitoringPlotId = monitoringPlotId,
             statusId = statusId,
         )

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -556,7 +556,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertSpecies(scientificName = "Unused species")
 
       insertFacility(type = FacilityType.Nursery)
-      insertPlantingSite()
+      insertPlantingSite(x = 0)
       insertPlantingZone()
       val subzoneId = insertPlantingSubzone()
       insertMonitoringPlot()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -75,7 +75,7 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite(areaHa = BigDecimal(2500))
+    plantingSiteId = insertPlantingSite(x = 0, areaHa = BigDecimal(2500))
 
     every { user.canReadObservation(any()) } returns true
     every { user.canReadOrganization(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -93,7 +93,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    plantingSiteId = insertPlantingSite()
+    plantingSiteId = insertPlantingSite(x = 0)
 
     every { user.canCreateObservation(any()) } returns true
     every { user.canManageObservation(any()) } returns true
@@ -1971,7 +1971,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `does not insert anything if this is the first observation of a site`() {
-      insertPlantingSite()
+      insertPlantingSite(x = 0)
       insertPlantingZone()
       insertPlantingSubzone()
       insertMonitoringPlot()
@@ -1993,7 +1993,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
       val totalsForOtherSite = helper.fetchAllTotals()
 
-      insertPlantingSite()
+      insertPlantingSite(x = 0)
       insertPlantingZone()
       insertPlantingSubzone()
       insertMonitoringPlot()
@@ -2014,7 +2014,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
               speciesName = "Species name",
               statusId = Dead)
 
-      insertPlantingSite()
+      insertPlantingSite(x = 0)
       insertPlantingZone()
       insertPlantingSubzone()
       val plotId1 = insertMonitoringPlot()
@@ -2099,7 +2099,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
               speciesName = "Species name",
               statusId = Live)
 
-      insertPlantingSite()
+      insertPlantingSite(x = 0)
       insertPlantingZone()
       insertPlantingSubzone()
       insertMonitoringPlot()
@@ -2142,7 +2142,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
 
     @BeforeEach
     fun setUp() {
-      plantingSiteId = insertPlantingSite()
+      plantingSiteId = insertPlantingSite(x = 0)
       insertPlantingZone()
       insertPlantingSubzone()
     }


### PR DESCRIPTION
To prepare for the ability to redefine subzones that already contain monitoring
plots, start recording which versions of plots were included in observations.
This will allow us to tell the user which subzone a plot was in at the time of
the observation, even if the site map has subsequently changed.