### PR TITLE
SW-6267 Publish rate-limited events as system user

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/ratelimit/RateLimitedEventPublisherTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -25,6 +26,7 @@ class RateLimitedEventPublisherTest : DatabaseTest(), RunsAsUser {
         dslContext,
         eventPublisher,
         jacksonObjectMapper(),
+        SystemUser(usersDao),
     )
   }
 


### PR DESCRIPTION
Rate-limited events were being published as the current user the first time they
fired during the rate limiting period, and without any current user at all if they
were deferred until the end of the period. The latter caused event handlers to
fail if they included permission checks.

Make the behavior of deferred and immediate publication consistent by publishing
the events as the system user.