### PR TITLE
Suppress CountryDetector warning spew

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -132,3 +132,8 @@ org:
     background-job-server:
       # All terraware-server instances can run scheduled jobs.
       enabled: true
+
+logging:
+  level:
+    # Suppress warning spew when CountryDetector loads country borders
+    org.geotools.feature: ERROR


### PR DESCRIPTION
The first time CountryDetector is used, it loads a file with country border
geometries, which causes one of the GeoTools classes to spew warning messages
about feature collections. Configure logging to suppress those warnings,
which aren't useful for us.