### PR TITLE
Stop using soon-to-be-deprecated Spring Security API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.security.authorization.AuthenticatedAuthorizationManager
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInit
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.header.writers.StaticHeadersWriter
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher
@@ -61,10 +63,14 @@ class SecurityConfig(
       http: HttpSecurity,
       clientRegistrationRepository: ClientRegistrationRepository
   ): SecurityFilterChain {
+    // https://github.com/spring-projects/spring-security/issues/16162
+    val fullyAuthenticated =
+        AuthenticatedAuthorizationManager.fullyAuthenticated<RequestAuthorizationContext>()
+
     http {
       cors {}
       csrf { disable() }
-      authorizeRequests {
+      authorizeHttpRequests {
         // Allow unauthenticated users to fetch localized strings.
         authorize("/api/v1/i18n/**", permitAll)
 

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -77,6 +77,11 @@ class SecurityConfig(
         // Allow unauthenticated users to check their app versions for compatibility.
         authorize("/api/v1/versions", permitAll)
 
+        // Allow unauthenticated users to fetch OpenAPI docs.
+        authorize("/v3/**", permitAll)
+        authorize("/swagger-ui/**", permitAll)
+        authorize("/swagger-ui.html", permitAll)
+
         authorize("/api/**", fullyAuthenticated)
         authorize("/admin/**", fullyAuthenticated)
       }


### PR DESCRIPTION
Spring Security 6.4's Kotlin DSL deprecates the `authorizeRequests` block and
suggests using `authorizeHttpRequests` instead. Make that change so that the
upgrade will succeed rather than failing to compile with a deprecation warning.

The upgrade requires a workaround for a missing feature in the Kotlin DSL; when
they've addressed that, we can remove the workaround.