### PR TITLE
SW-6293 Fix seed withdrawals of weight-based accessions

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/Helpers.kt
@@ -5,11 +5,15 @@ import com.terraformation.backend.seedbank.api.SeedQuantityPayload
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
 import java.math.BigDecimal
 
-inline fun <reified T> quantity(quantity: Int, units: SeedQuantityUnits): T {
+inline fun <reified T> quantity(quantity: BigDecimal, units: SeedQuantityUnits): T {
   return when (T::class.java) {
-    SeedQuantityPayload::class.java -> SeedQuantityPayload(BigDecimal(quantity), units) as T
-    else -> SeedQuantityModel(BigDecimal(quantity), units) as T
+    SeedQuantityPayload::class.java -> SeedQuantityPayload(quantity, units) as T
+    else -> SeedQuantityModel(quantity, units) as T
   }
+}
+
+inline fun <reified T> quantity(quantity: Int, units: SeedQuantityUnits): T {
+  return quantity(BigDecimal(quantity), units) as T
 }
 
 inline fun <reified T> grams(quantity: Int): T {
@@ -18,6 +22,10 @@ inline fun <reified T> grams(quantity: Int): T {
 
 inline fun <reified T> milligrams(quantity: Int): T {
   return quantity(quantity, SeedQuantityUnits.Milligrams)
+}
+
+inline fun <reified T> kilograms(quantity: BigDecimal): T {
+  return quantity(quantity, SeedQuantityUnits.Kilograms)
 }
 
 inline fun <reified T> kilograms(quantity: Int): T {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.seedbank.AccessionState
 import com.terraformation.backend.db.seedbank.SeedQuantityUnits
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.seedbank.grams
+import com.terraformation.backend.seedbank.kilograms
 import com.terraformation.backend.seedbank.milligrams
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.seedbank.model.SeedQuantityModel
@@ -104,29 +105,19 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
     }
 
     @Test
-    fun `withdrawal of estimated seed count rounds fractional remaining weight to zero`() {
+    fun `withdrawal of estimated seed count sets remaining quantity to zero`() {
       val accession =
-          accession(remaining = grams(11), subsetCount = 10000, subsetWeight = grams(3))
+          accession(
+                  remaining = kilograms(BigDecimal("0.005324")),
+                  subsetCount = 100,
+                  subsetWeight = kilograms(BigDecimal("0.000364")))
               .withCalculatedValues()
 
+      assertEquals(1463, accession.estimatedSeedCount)
       val afterWithdrawal =
           accession.addWithdrawal(withdrawal(seeds(accession.estimatedSeedCount!!), id = null))
 
-      assertEquals(grams(0), afterWithdrawal.remaining)
-      assertEquals(AccessionState.UsedUp, afterWithdrawal.state)
-    }
-
-    @Test
-    fun `withdrawal of estimated seed count rounds negative fractional remaining weight to zero`() {
-      val accession =
-          accession(remaining = grams(8), subsetCount = 1, subsetWeight = grams(3))
-              .withCalculatedValues()
-
-      assertEquals(3, accession.estimatedSeedCount)
-      val afterWithdrawal =
-          accession.addWithdrawal(withdrawal(seeds(accession.estimatedSeedCount!!), id = null))
-
-      assertEquals(grams(0), afterWithdrawal.remaining)
+      assertEquals(kilograms(0), afterWithdrawal.remaining)
       assertEquals(AccessionState.UsedUp, afterWithdrawal.state)
     }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -106,6 +106,8 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
 
     @Test
     fun `withdrawal of estimated seed count sets remaining quantity to zero`() {
+      // Regression test: the values here are from an accession that couldn't be fully withdrawn
+      // due to the way we used to handle checking for withdrawal of the estimated seed count.
       val accession =
           accession(
                   remaining = kilograms(BigDecimal("0.005324")),


### PR DESCRIPTION
If a user withdraws a seed quantity from a weight-based accession, we use the
subset weight and count to calculate how much weight to subtract from the
accession. This can be off by a bit due to the limited precision of subset weight
measurements, so we had a fudge factor to try to detect if the user was trying to
withdraw all the remaining seeds and set the remaining weight to zero if so.

Unfortunately, the fudge factor wasn't enough for accessions measured in
kilograms or pounds where the weight of a single seed can round down to zero.

Replace the fudge factor with a more direct approach: see if the withdrawal
quantity is the same as the estimated seed count.