### PR TITLE
SW-6297 Don't notify contributors about events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -454,7 +454,11 @@ class AppNotificationService(
         val eventUrl =
             webAppUrls.moduleEvent(moduleEvent.moduleId, moduleEvent.id, organizationId, projectId)
         insertOrganizationNotifications(
-            organizationId, NotificationType.EventReminder, renderMessage, eventUrl)
+            organizationId,
+            NotificationType.EventReminder,
+            renderMessage,
+            eventUrl,
+            setOf(Role.Owner, Role.Admin, Role.Manager))
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -931,16 +931,18 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   fun `should store module event starting notification for all projects`() {
     val moduleId = insertModule()
     val eventId = insertEvent(moduleId = moduleId)
+    val projectId = insertProject()
 
     insertOrganizationUser(role = Role.Admin)
-    // Other user in same project
-    insertOrganizationUser(otherUserId)
-    val projectId = insertProject()
+    // Other user in same org
+    insertOrganizationUser(otherUserId, role = Role.Manager)
+    // Contributor in same org; shouldn't be notified
+    insertOrganizationUser(insertUser(), role = Role.Contributor)
 
     // Other project in different org
     val thirdUserId = insertUser()
     val otherOrgId = insertOrganization()
-    insertOrganizationUser(thirdUserId, otherOrgId)
+    insertOrganizationUser(thirdUserId, otherOrgId, Role.Manager)
     val otherProjectId = insertProject(organizationId = otherOrgId)
 
     insertEventProject(eventId, projectId)


### PR DESCRIPTION
Contributors can't view accelerator-related information. We were sending them
in-app notifications about accelerator events they weren't allowed to access.