### PR TITLE
SW-6296 Fix error counting plots of empty observation

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -2249,6 +2249,17 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       }
 
       @Test
+      fun `returns plot counts of zero if no plots have been assigned to observation`() {
+        val observationId = insertObservation()
+
+        val expected = ObservationPlotCounts(0, 0, 0)
+
+        val actual = store.countPlots(observationId)
+
+        assertEquals(expected, actual)
+      }
+
+      @Test
       fun `throws exception if observation does not exist`() {
         assertThrows<ObservationNotFoundException> { store.countPlots(ObservationId(-1)) }
       }


### PR DESCRIPTION
Counting the plots of an observation that had no plots assigned to it was
causing a bogus "observation not found" error, which prevented users from
rescheduling observations of sites without any planted subzones.