### PR TITLE
SW-6287 Fold email addresses to lower case

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -235,7 +235,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `UserAddedToOrganization event is published when existing user is added to an organization`() {
-    val otherUserId = insertUser(email = "existingUser@email.com")
+    val otherUserId = insertUser(email = "existinguser@email.com")
 
     val organizationId = insertOrganization()
 


### PR DESCRIPTION
Keycloak treats email addresses case-insensitively by folding them to lower case.
When we were creating new users from the Terraware side (e.g., because someone
invited them to an organization) we were preserving upper-case characters, meaning
there was a mismatch between the email addresses in our users table and in
Keycloak.

When those users clicked on the registration links and signed up, they weren't
members of their expected organizations because we created brand-new accounts for
them with Keycloak's folded-to-lower-case email addresses; the organization
memberships were tied to the user IDs with mixed-case addresses.

Terraware will now fold email addresses to lower case when searching for users
by email and when creating new users from email addresses.