### PR TITLE
Remove Commons Logging from classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,11 @@ dependencies {
   developmentOnly("com.h2database:h2")
 }
 
+configurations.configureEach {
+  // Spring includes its own Commons Logging implementation which can conflict with the official one
+  exclude("commons-logging")
+}
+
 tasks.register("downloadDependencies") {
   fun ConfigurationContainer.resolveAll() =
       this.filter {


### PR DESCRIPTION
Spring includes its own implementation of the Commons Logging API, and at startup
it warns about potential conflicts and recommends removing the official library
from the classpath.

Add an exclusion rule to prevent it from being pulled in transitively by other
dependencies.