### PR TITLE
SW-6295 Fix deleting projects with submitted reports

### DIFF
--- a/src/main/resources/db/migration/0300/V321__DeletedProjectReport.sql
+++ b/src/main/resources/db/migration/0300/V321__DeletedProjectReport.sql
@@ -1,0 +1,4 @@
+ALTER TABLE reports DROP CONSTRAINT one_org_report_per_quarter;
+ALTER TABLE reports ADD CONSTRAINT one_org_report_per_quarter
+    EXCLUDE (organization_id WITH =, year WITH =, quarter WITH =)
+    WHERE (project_id IS NULL AND project_name IS NULL);

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -626,6 +626,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `keeps submitted project-level reports for deleted projects`() {
       val projectId = insertProject(name = "Test Project")
+      val orgLevelReportId = insertReport(year = 1990)
       val submittedReportId =
           insertReport(projectId = projectId, year = 1990, submittedBy = user.userId)
 
@@ -640,6 +641,8 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
           "Test Project",
           reportsRow?.projectName,
           "Should have kept project name on submitted report")
+      assertNotNull(
+          reportsDao.fetchOneById(orgLevelReportId), "Should not have deleted org-level report")
     }
 
     @Test


### PR DESCRIPTION
If you delete a project for which you had previously submitted reports, we keep
the reports around but set their project IDs to null. This caused problems if
you also had org-level reports for the same year and quarter because we have a
constraint to allow only one org-level report per quarter.

The constraint was assuming any report with a null project ID was an org-level
report, meaning that when the project ID was set to null on the project-level
reports, they conflicted with the actual org-level reports.

Fix it by making the constraint verify that both the project ID and the project
name are null. For reports from deleted projects, the project name is retained,
but both the ID and name are null for org-level reports.