### PR TITLE
SW-6313 Allow TF Expert users to read global roles

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -422,7 +422,7 @@ data class IndividualUser(
 
   override fun canReadFacility(facilityId: FacilityId) = isMember(facilityId)
 
-  override fun canReadGlobalRoles() = isAcceleratorAdmin()
+  override fun canReadGlobalRoles() = isTFExpertOrHigher()
 
   override fun canReadInternalOnlyVariables(): Boolean = isReadOnlyOrHigher()
 
@@ -528,7 +528,7 @@ data class IndividualUser(
 
   override fun canReadUser(userId: UserId) = isReadOnlyOrHigher()
 
-  override fun canReadUserInternalInterests(userId: UserId) = isAcceleratorAdmin()
+  override fun canReadUserInternalInterests(userId: UserId) = isTFExpertOrHigher()
 
   override fun canReadViabilityTest(viabilityTestId: ViabilityTestId) =
       isMember(parentStore.getFacilityId(viabilityTestId))

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2132,6 +2132,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
         readUser = true,
+        readUserInternalInterests = true,
     )
 
     permissions.expect(
@@ -2154,7 +2155,7 @@ internal class PermissionTest : DatabaseTest() {
         readCohort = true,
         readCohortParticipants = true,
         readCohorts = true,
-        readGlobalRoles = false,
+        readGlobalRoles = true,
         readModuleEventParticipants = true,
         readInternalTags = true,
         readParticipant = true,


### PR DESCRIPTION
TF Expert users can edit projects' accelerator profiles, which means they need to
be able to fetch the list of internal users for the Project Lead dropdown. Update
the permissions to allow them to list users with global roles and to list the
internal interests of those users.