### PR TITLE
Upgrade to Spring Boot 3.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
   id("dev.monosoul.jooq-docker") version "6.1.12"
   id("com.diffplug.spotless") version "7.0.0.BETA4"
-  id("org.springframework.boot") version "3.3.5"
+  id("org.springframework.boot") version "3.4.0"
   id("io.spring.dependency-management") version "1.1.6"
 
   // Add the build target to generate Swagger docs
@@ -99,7 +99,7 @@ dependencies {
   implementation("com.squarespace.cldr-engine:cldr-engine:1.8.3")
   implementation("commons-codec:commons-codec:1.17.1")
   implementation("commons-validator:commons-validator:1.9.0")
-  implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.3.2") {
+  implementation("dev.akkinoc.spring.boot:logback-access-spring-boot-starter:4.4.0") {
     exclude("org.apache.tomcat")
   }
   implementation("io.ktor:ktor-client-auth:$ktorVersion")
@@ -120,7 +120,7 @@ dependencies {
   implementation("org.geotools:gt-xml:$geoToolsVersion")
   implementation("org.geotools.xsd:gt-xsd-core:$geoToolsVersion")
   implementation("org.geotools.xsd:gt-xsd-kml:$geoToolsVersion")
-  implementation("org.jobrunr:jobrunr-spring-boot-3-starter:7.3.1")
+  implementation("org.jobrunr:jobrunr-spring-boot-3-starter:7.3.2")
   implementation("org.jooq:jooq:$jooqVersion")
   implementation("org.locationtech.jts:jts-core:$jtsVersion")
   implementation("org.locationtech.jts.io:jts-io-common:$jtsVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlinVersion=2.1.0
 ktfmtVersion=0.53
 ktorVersion=3.0.1
 postgresJdbcVersion=42.7.4
-springDocVersion=2.5.0
+springDocVersion=2.7.0
 
 # For code generation, we run database migrations against an ephemeral database in a Docker
 # container using this image. If you change this, make sure you also change DatabaseTest.kt.

--- a/src/test/kotlin/com/terraformation/backend/api/ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/ControllerIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers
+import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActionsDsl
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
@@ -68,8 +69,10 @@ abstract class ControllerIntegrationTest :
       json: String,
       strict: Boolean = false
   ): ResultActionsDsl {
+    val compareMode = if (strict) JsonCompareMode.STRICT else JsonCompareMode.LENIENT
+
     return andExpect {
-      content { json(json, strict) }
+      content { json(json, compareMode) }
       status { isOk() }
     }
   }


### PR DESCRIPTION
Spring Boot 3.4.0 has some backward-incompatible changes that require upgrading
some other dependencies at the same time, as well as a change to one of the test
assertion APIs, so Renovate can't handle the update automatically.