### PR TITLE
SW-6251 Introduce exterior monitoring plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingSitesTable.kt
@@ -33,7 +33,13 @@ class PlantingSitesTable(tables: SearchTables) : SearchTable() {
           deliveries.asMultiValueSublist(
               "deliveries", PLANTING_SITE_SUMMARIES.ID.eq(DELIVERIES.PLANTING_SITE_ID)),
           monitoringPlots.asMultiValueSublist(
-              "monitoringPlots", PLANTING_SITE_SUMMARIES.ID.eq(MONITORING_PLOTS.PLANTING_SITE_ID)),
+              "exteriorPlots",
+              PLANTING_SITE_SUMMARIES.ID.eq(MONITORING_PLOTS.PLANTING_SITE_ID)
+                  .and(MONITORING_PLOTS.PLANTING_SUBZONE_ID.isNull)),
+          monitoringPlots.asMultiValueSublist(
+              "monitoringPlots",
+              PLANTING_SITE_SUMMARIES.ID.eq(MONITORING_PLOTS.PLANTING_SITE_ID)
+                  .and(MONITORING_PLOTS.PLANTING_SUBZONE_ID.isNotNull)),
           observations.asMultiValueSublist(
               "observations", PLANTING_SITE_SUMMARIES.ID.eq(OBSERVATIONS.PLANTING_SITE_ID)),
           organizations.asSingleValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -35,6 +35,7 @@ data class PlantingSiteModel<
     val countryCode: String? = null,
     val description: String? = null,
     val exclusion: MultiPolygon? = null,
+    val exteriorPlots: List<MonitoringPlotModel> = emptyList(),
     val gridOrigin: Point? = null,
     /**
      * If this model is associated with a particular history entry, its ID. This property is not
@@ -135,10 +136,13 @@ data class PlantingSiteModel<
         plantingZones.size == other.plantingZones.size &&
         projectId == other.projectId &&
         areaHa.equalsIgnoreScale(other.areaHa) &&
-        plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) } &&
         boundary.equalsOrBothNull(other.boundary) &&
         exclusion.equalsOrBothNull(other.exclusion) &&
-        gridOrigin.equalsOrBothNull(other.gridOrigin)
+        gridOrigin.equalsOrBothNull(other.gridOrigin) &&
+        exteriorPlots.size == other.exteriorPlots.size &&
+        exteriorPlots.zip(other.exteriorPlots).all { it.first.equals(it.second, tolerance) } &&
+        plantingZones.size == other.plantingZones.size &&
+        plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) }
   }
 
   fun toNew(): NewPlantingSiteModel =
@@ -169,7 +173,8 @@ data class PlantingSiteModel<
     fun of(
         record: Record,
         plantingSeasonsMultiset: Field<List<ExistingPlantingSeasonModel>>?,
-        plantingZonesMultiset: Field<List<ExistingPlantingZoneModel>>? = null
+        plantingZonesMultiset: Field<List<ExistingPlantingZoneModel>>? = null,
+        exteriorPlotsMultiset: Field<List<MonitoringPlotModel>>? = null,
     ) =
         ExistingPlantingSiteModel(
             areaHa = record[PLANTING_SITES.AREA_HA],
@@ -177,6 +182,7 @@ data class PlantingSiteModel<
             countryCode = record[PLANTING_SITES.COUNTRY_CODE],
             description = record[PLANTING_SITES.DESCRIPTION],
             exclusion = record[PLANTING_SITES.EXCLUSION] as? MultiPolygon,
+            exteriorPlots = exteriorPlotsMultiset?.let { record[it] } ?: emptyList(),
             gridOrigin = record[PLANTING_SITES.GRID_ORIGIN] as? Point,
             id = record[PLANTING_SITES.ID]!!,
             name = record[PLANTING_SITES.NAME]!!,

--- a/src/main/resources/db/migration/0300/V322__MonitoringPlotNullSubzone.sql
+++ b/src/main/resources/db/migration/0300/V322__MonitoringPlotNullSubzone.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tracking.monitoring_plots ALTER COLUMN planting_subzone_id DROP NOT NULL;
+
+ALTER TABLE tracking.monitoring_plots DROP CONSTRAINT monitoring_plots_planting_subzone_id_fkey;
+ALTER TABLE tracking.monitoring_plots ADD
+    FOREIGN KEY (planting_subzone_id)
+        REFERENCES tracking.planting_subzones
+        ON DELETE SET NULL;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -361,7 +361,7 @@ COMMENT ON COLUMN tracking.monitoring_plots.modified_by IS 'Which user most rece
 COMMENT ON COLUMN tracking.monitoring_plots.modified_time IS 'When the monitoring plot was most recently modified.';
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster_subplot IS 'If this plot is a candidate to be a permanent monitoring plot, its ordinal position from 1 to 4 in the 4-plot cluster. 1=southwest, 2=southeast, 3=northeast, 4=northwest.';
-COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is part of.';
+COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is currently part of, if any. May be null if the subzone was edited or removed after the plot was created, or if the plot was created outside the site boundary.';
 COMMENT ON COLUMN tracking.monitoring_plots.size_meters IS 'Length in meters of one side of the monitoring plot. Plots are always squares, so for a 30x30m plot, this would be 30.';
 
 COMMENT ON TABLE tracking.observable_conditions IS '(Enum) Conditions that can be observed in a monitoring plot.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1935,12 +1935,13 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: "${nextMonitoringPlotNumber++}",
-      fullName: String = "Z1-1-$name",
       permanentCluster: Int? = row.permanentCluster,
       permanentClusterSubplot: Int? =
           row.permanentClusterSubplot ?: if (permanentCluster != null) 1 else null,
       plantingSiteId: PlantingSiteId = row.plantingSiteId ?: inserted.plantingSiteId,
-      plantingSubzoneId: PlantingSubzoneId = row.plantingSubzoneId ?: inserted.plantingSubzoneId,
+      plantingSubzoneId: PlantingSubzoneId? =
+          row.plantingSubzoneId ?: inserted.plantingSubzoneIds.lastOrNull(),
+      fullName: String = if (plantingSubzoneId != null) "Z1-1-$name" else name,
       insertHistory: Boolean = true,
   ): MonitoringPlotId {
     val rowWithDefaults =

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -53,6 +53,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val monitoringPlotGeometry6 = polygon(6, 7, 8, 9)
     val monitoringPlotGeometry7 = polygon(7, 8, 9, 10)
     val monitoringPlotGeometry8 = polygon(8, 9, 10, BigDecimal("11.0123456789"))
+    val exteriorPlotGeometry9 = polygon(9, 10, 11, 12)
     val plantingSiteId =
         insertPlantingSite(
             boundary = plantingSiteGeometry,
@@ -83,6 +84,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val monitoringPlotId7 = insertMonitoringPlot(boundary = monitoringPlotGeometry7)
     val monitoringPlotId8 =
         insertMonitoringPlot(boundary = monitoringPlotGeometry8, sizeMeters = 25)
+
+    val exteriorPlotId9 =
+        insertMonitoringPlot(boundary = exteriorPlotGeometry9, plantingSubzoneId = null)
 
     val speciesId1 = insertSpecies()
     val speciesId2 = insertSpecies()
@@ -215,6 +219,10 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                             ),
                         ),
                     "exclusion" to postgisRenderGeoJson(exclusionGeometry),
+                    "exteriorPlots" to
+                        listOf(
+                            mapOf("id" to "$exteriorPlotId9"),
+                        ),
                     "id" to "$plantingSiteId",
                     "modifiedTime" to "1970-01-01T00:00:00Z",
                     "monitoringPlots" to
@@ -439,6 +447,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "deliveries.reassignedTime",
                 "deliveries.withdrawal_facility_name",
                 "exclusion",
+                "exteriorPlots.id",
                 "id",
                 "modifiedTime",
                 "monitoringPlots.id",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -49,6 +49,8 @@ internal class PlantingSiteStoreFetchSiteTest : PlantingSiteStoreTest() {
       val plantingSeasonId2 =
           insertPlantingSeason(startDate = season2StartDate, endDate = season2EndDate)
 
+      val exteriorPlotId = insertMonitoringPlot(boundary = polygon(0.2), plantingSubzoneId = null)
+
       val expectedWithSite =
           ExistingPlantingSiteModel(
               boundary = multiPolygon(3),
@@ -117,6 +119,15 @@ internal class PlantingSiteStoreFetchSiteTest : PlantingSiteStoreTest() {
 
       val expectedWithPlot =
           expectedWithSubzone.copy(
+              exteriorPlots =
+                  listOf(
+                      MonitoringPlotModel(
+                          boundary = polygon(0.2),
+                          id = exteriorPlotId,
+                          isAvailable = true,
+                          name = "2",
+                          fullName = "2",
+                          sizeMeters = 30)),
               plantingZones =
                   listOf(
                       expectedWithSubzone.plantingZones[0].copy(


### PR DESCRIPTION
Add the concept of an "exterior" monitoring plot, which is associated with a
planting site but not with a subzone.

This change updates the data model and adds internal support for reading
exterior plots, but there isn't yet any way to create an exterior plot outside
the test suite.

Other upcoming changes will make it possible for a monitoring plot to become
exterior if the site map is edited such that the plot no longer falls within
any subzone, or if the plot is created for an ad-hoc observation.