### PR TITLE
SW-6280 Track observation site versions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -133,10 +133,9 @@ class ObservationService(
         }
 
         observationStore.populateCumulativeDead(observationId)
-        observationStore.updateObservationState(observationId, ObservationState.InProgress)
+        val startedObservation = observationStore.recordObservationStart(observationId)
 
-        eventPublisher.publishEvent(
-            ObservationStartedEvent(observation.copy(state = ObservationState.InProgress)))
+        eventPublisher.publishEvent(ObservationStartedEvent(startedObservation))
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationModel.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -14,6 +15,7 @@ data class ObservationModel<ID : ObservationId?>(
     val completedTime: Instant? = null,
     val endDate: LocalDate,
     val id: ID,
+    val plantingSiteHistoryId: PlantingSiteHistoryId? = null,
     val plantingSiteId: PlantingSiteId,
     val requestedSubzoneIds: Set<PlantingSubzoneId> = emptySet(),
     val startDate: LocalDate,
@@ -46,6 +48,7 @@ data class ObservationModel<ID : ObservationId?>(
           completedTime = record[OBSERVATIONS.COMPLETED_TIME],
           endDate = record[OBSERVATIONS.END_DATE]!!,
           id = record[OBSERVATIONS.ID]!!,
+          plantingSiteHistoryId = record[OBSERVATIONS.PLANTING_SITE_HISTORY_ID],
           plantingSiteId = record[OBSERVATIONS.PLANTING_SITE_ID]!!,
           requestedSubzoneIds = record[requestedSubzoneIdsField],
           startDate = record[OBSERVATIONS.START_DATE]!!,

--- a/src/main/resources/db/migration/0300/V323__ObservationsSiteHistory.sql
+++ b/src/main/resources/db/migration/0300/V323__ObservationsSiteHistory.sql
@@ -1,0 +1,20 @@
+ALTER TABLE tracking.observations
+    ADD COLUMN planting_site_history_id BIGINT
+        REFERENCES tracking.planting_site_histories ON DELETE CASCADE;
+
+CREATE INDEX ON tracking.observations (planting_site_history_id);
+
+UPDATE tracking.observations o
+SET planting_site_history_id = (
+    SELECT MAX(id)
+    FROM tracking.planting_site_histories psh
+    WHERE o.planting_site_id = psh.planting_site_id
+)
+WHERE o.state_id <> 1;
+
+ALTER TABLE tracking.observations
+    ADD CONSTRAINT history_id_required_at_start
+        CHECK (
+            state_id = 1 AND observations.planting_site_history_id IS NULL
+            OR state_id <> 1 AND observations.planting_site_history_id IS NOT NULL
+        );

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -384,6 +384,7 @@ COMMENT ON TABLE tracking.observation_states IS '(Enum) Where in the observation
 COMMENT ON TABLE tracking.observations IS 'Scheduled observations of planting sites. This table may contain rows describing future observations as well as current and past ones.';
 COMMENT ON COLUMN tracking.observations.completed_time IS 'Server-generated date and time the final piece of data for the observation was received.';
 COMMENT ON COLUMN tracking.observations.end_date IS 'Last day of the observation. This is typically the last day of the same month as `start_date`.';
+COMMENT ON COLUMN tracking.observations.planting_site_history_id IS 'Which version of the planting site map was used for the observation. Null for upcoming observations since monitoring plots are only placed on the map when an observation starts.';
 COMMENT ON COLUMN tracking.observations.start_date IS 'First day of the observation. This is either the first day of the month following the end of the planting season, or 6 months after that day.';
 COMMENT ON COLUMN tracking.observations.upcoming_notification_sent_time IS 'When the notification that the observation is starting in 1 month was sent. Null if the notification has not been sent yet.';
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -58,6 +58,7 @@ import com.terraformation.backend.db.tracking.DeliveryId
 import com.terraformation.backend.db.tracking.DraftPlantingSiteId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
@@ -350,7 +351,9 @@ internal class PermissionTest : DatabaseTest() {
     observationIds.forEach { observationId ->
       putDatabaseId(
           observationId,
-          insertObservation(plantingSiteId = getDatabaseId(PlantingSiteId(observationId.value))))
+          insertObservation(
+              plantingSiteId = getDatabaseId(PlantingSiteId(observationId.value)),
+              state = ObservationState.Upcoming))
     }
 
     cohortIds.forEach { cohortId -> putDatabaseId(cohortId, insertCohort(createdBy = userId)) }

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1649,20 +1649,20 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertPlantingSiteHistory(
-      boundary: Geometry? = null,
-      createdBy: UserId = currentUser().userId,
-      createdTime: Instant = Instant.EPOCH,
-      exclusion: Geometry? = null,
-      gridOrigin: Geometry? = null,
+      boundary: Geometry = lastPlantingSitesRow.boundary!!,
+      createdBy: UserId = lastPlantingSitesRow.createdBy!!,
+      createdTime: Instant = lastPlantingSitesRow.createdTime!!,
+      exclusion: Geometry? = lastPlantingSitesRow.exclusion,
+      gridOrigin: Geometry? = lastPlantingSitesRow.gridOrigin,
       plantingSiteId: PlantingSiteId = inserted.plantingSiteId,
   ): PlantingSiteHistoryId {
     val row =
         PlantingSiteHistoriesRow(
-            boundary = boundary ?: lastPlantingSitesRow.boundary,
+            boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,
-            exclusion = exclusion ?: lastPlantingSitesRow.exclusion,
-            gridOrigin = gridOrigin ?: lastPlantingSitesRow.gridOrigin,
+            exclusion = exclusion,
+            gridOrigin = gridOrigin,
             plantingSiteId = plantingSiteId,
         )
 
@@ -1917,6 +1917,8 @@ abstract class DatabaseBackedTest {
     return row.id!!.also { inserted.moduleIds.add(it) }
   }
 
+  private lateinit var lastMonitoringPlotsRow: MonitoringPlotsRow
+
   fun insertMonitoringPlot(
       row: MonitoringPlotsRow = MonitoringPlotsRow(),
       x: Number = 0,
@@ -1962,6 +1964,7 @@ abstract class DatabaseBackedTest {
         )
 
     monitoringPlotsDao.insert(rowWithDefaults)
+    lastMonitoringPlotsRow = rowWithDefaults
 
     val monitoringPlotId = rowWithDefaults.id!!
     inserted.monitoringPlotIds.add(monitoringPlotId)
@@ -1974,11 +1977,11 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertMonitoringPlotHistory(
-      createdBy: UserId = currentUser().userId,
-      createdTime: Instant = Instant.EPOCH,
-      fullName: String? = null,
+      createdBy: UserId = lastMonitoringPlotsRow.createdBy!!,
+      createdTime: Instant = lastMonitoringPlotsRow.createdTime!!,
+      fullName: String = lastMonitoringPlotsRow.fullName!!,
       monitoringPlotId: MonitoringPlotId = inserted.monitoringPlotId,
-      name: String? = null,
+      name: String = lastMonitoringPlotsRow.name!!,
       plantingSiteId: PlantingSiteId = inserted.plantingSiteId,
       plantingSiteHistoryId: PlantingSiteHistoryId = inserted.plantingSiteHistoryId,
       plantingSubzoneId: PlantingSubzoneId? =
@@ -1990,9 +1993,9 @@ abstract class DatabaseBackedTest {
         MonitoringPlotHistoriesRow(
             createdBy = createdBy,
             createdTime = createdTime,
-            fullName = fullName ?: lastPlantingSubzonesRow.fullName,
+            fullName = fullName,
             monitoringPlotId = monitoringPlotId,
-            name = name ?: lastPlantingSubzonesRow.name,
+            name = name,
             plantingSiteHistoryId = plantingSiteHistoryId,
             plantingSiteId = plantingSiteId,
             plantingSubzoneHistoryId = plantingSubzoneHistoryId,
@@ -2274,6 +2277,13 @@ abstract class DatabaseBackedTest {
               } else {
                 ObservationState.InProgress
               },
+      plantingSiteHistoryId: PlantingSiteHistoryId? =
+          row.plantingSiteHistoryId
+              ?: if (state != ObservationState.Upcoming) {
+                inserted.plantingSiteHistoryId
+              } else {
+                null
+              },
       upcomingNotificationSentTime: Instant? = row.upcomingNotificationSentTime,
   ): ObservationId {
     val rowWithDefaults =
@@ -2281,6 +2291,7 @@ abstract class DatabaseBackedTest {
             completedTime = completedTime,
             createdTime = createdTime,
             endDate = endDate,
+            plantingSiteHistoryId = plantingSiteHistoryId,
             plantingSiteId = plantingSiteId,
             startDate = startDate,
             stateId = state,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -37,7 +37,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
     DeliveryStore(clock, deliveriesDao, dslContext, ParentStore(dslContext), plantingsDao)
   }
 
-  private val plantingSiteId by lazy { insertPlantingSite() }
+  private val plantingSiteId by lazy { insertPlantingSite(x = 0) }
   private val plantingZoneId by lazy { insertPlantingZone(plantingSiteId = plantingSiteId) }
   private val plantingSubzoneId by lazy { insertPlantingSubzone(plantingZoneId = plantingZoneId) }
   private val speciesId1 by lazy { insertSpecies() }


### PR DESCRIPTION
Record which version of a planting site is used at observation start time.
Knowing the site history ID for each observation will allow the app to show the
correct version of a site map if the map is edited between observations; the
history IDs will be exposed in the API in subsequent code changes.