### PR TITLE
SW-6280 API to request historical planting site maps

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -69,6 +70,9 @@ class PlantingNotFoundException(val plantingId: PlantingId) :
 
 class PlantingSeasonNotFoundException(val plantingSeasonId: PlantingSeasonId) :
     EntityNotFoundException("Planting season $plantingSeasonId not found")
+
+class PlantingSiteHistoryNotFoundException(val plantingSiteHistoryId: PlantingSiteHistoryId) :
+    EntityNotFoundException("Planting site history $plantingSiteHistoryId not found")
 
 class PlantingSiteNotFoundException(val plantingSiteId: PlantingSiteId) :
     EntityNotFoundException("Planting site $plantingSiteId not found")

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
@@ -1,0 +1,100 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingSubzoneHistoryId
+import com.terraformation.backend.db.tracking.PlantingSubzoneId
+import com.terraformation.backend.db.tracking.PlantingZoneHistoryId
+import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.util.equalsOrBothNull
+import java.time.Instant
+import org.locationtech.jts.geom.MultiPolygon
+import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.Polygon
+
+data class PlantingSiteHistoryModel(
+    val boundary: MultiPolygon,
+    val exclusion: MultiPolygon? = null,
+    val gridOrigin: Point,
+    val id: PlantingSiteHistoryId,
+    val plantingSiteId: PlantingSiteId,
+    val plantingZones: List<PlantingZoneHistoryModel>,
+) {
+  fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
+    return other is PlantingSiteHistoryModel &&
+        id == other.id &&
+        plantingSiteId == other.plantingSiteId &&
+        boundary.equalsExact(other.boundary, tolerance) &&
+        exclusion.equalsOrBothNull(other.exclusion, tolerance) &&
+        gridOrigin.equalsExact(other.gridOrigin, tolerance) &&
+        plantingZones.size == other.plantingZones.size &&
+        plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) }
+  }
+}
+
+data class PlantingZoneHistoryModel(
+    val boundary: MultiPolygon,
+    val id: PlantingZoneHistoryId,
+    val name: String,
+    val plantingSubzones: List<PlantingSubzoneHistoryModel>,
+    /** ID of planting zone if it currently exists. Null if the zone has been deleted. */
+    val plantingZoneId: PlantingZoneId?,
+) {
+  fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
+    return other is PlantingZoneHistoryModel &&
+        id == other.id &&
+        name == other.name &&
+        plantingZoneId == other.plantingZoneId &&
+        boundary.equalsExact(other.boundary, tolerance) &&
+        plantingSubzones.size == other.plantingSubzones.size &&
+        plantingSubzones.zip(other.plantingSubzones).all { it.first.equals(it.second, tolerance) }
+  }
+}
+
+data class PlantingSubzoneHistoryModel(
+    val boundary: MultiPolygon,
+    val fullName: String,
+    val id: PlantingSubzoneHistoryId,
+    val monitoringPlots: List<MonitoringPlotHistoryModel>,
+    val name: String,
+    /** ID of planting subzone if it currently exists. Null if the zone has been deleted. */
+    val plantingSubzoneId: PlantingSubzoneId?,
+) {
+  fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
+    return other is PlantingSubzoneHistoryModel &&
+        fullName == other.fullName &&
+        id == other.id &&
+        name == other.name &&
+        plantingSubzoneId == other.plantingSubzoneId &&
+        boundary.equalsExact(other.boundary, tolerance) &&
+        monitoringPlots.size == other.monitoringPlots.size &&
+        monitoringPlots.zip(other.monitoringPlots).all { it.first.equals(it.second, tolerance) }
+  }
+}
+
+data class MonitoringPlotHistoryModel(
+    /** Current monitoring plot boundary. Boundaries do not change over time. */
+    val boundary: Polygon,
+    val createdBy: UserId,
+    val createdTime: Instant,
+    val fullName: String,
+    val id: MonitoringPlotHistoryId,
+    val name: String,
+    val monitoringPlotId: MonitoringPlotId,
+    val sizeMeters: Int,
+) {
+  fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
+    return other is MonitoringPlotHistoryModel &&
+        createdBy == other.createdBy &&
+        createdTime == other.createdTime &&
+        fullName == other.fullName &&
+        id == other.id &&
+        name == other.name &&
+        monitoringPlotId == other.monitoringPlotId &&
+        sizeMeters == other.sizeMeters &&
+        boundary.equalsExact(other.boundary, tolerance)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1801,7 +1801,6 @@ abstract class DatabaseBackedTest {
   }
 
   private var nextPlantingSubzoneNumber: Int = 1
-  private var nextMonitoringPlotNumber: Int = 1
   private lateinit var lastPlantingSubzonesRow: PlantingSubzonesRow
 
   fun insertPlantingSubzone(
@@ -1861,7 +1860,7 @@ abstract class DatabaseBackedTest {
       boundary: Geometry? = null,
       fullName: String? = null,
       name: String? = null,
-      plantingSubzoneId: PlantingSubzoneId = inserted.plantingSubzoneId,
+      plantingSubzoneId: PlantingSubzoneId? = inserted.plantingSubzoneId,
       plantingZoneHistoryId: PlantingZoneHistoryId = inserted.plantingZoneHistoryId,
   ): PlantingSubzoneHistoryId {
     val row =
@@ -1917,6 +1916,7 @@ abstract class DatabaseBackedTest {
     return row.id!!.also { inserted.moduleIds.add(it) }
   }
 
+  private var nextMonitoringPlotNumber: Int = 1
   private lateinit var lastMonitoringPlotsRow: MonitoringPlotsRow
 
   fun insertMonitoringPlot(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryTest.kt
@@ -1,0 +1,162 @@
+package com.terraformation.backend.tracking.db.plantingSiteStore
+
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.point
+import com.terraformation.backend.polygon
+import com.terraformation.backend.tracking.db.PlantingSiteHistoryNotFoundException
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
+import com.terraformation.backend.tracking.model.MonitoringPlotHistoryModel
+import com.terraformation.backend.tracking.model.PlantingSiteDepth
+import com.terraformation.backend.tracking.model.PlantingSiteHistoryModel
+import com.terraformation.backend.tracking.model.PlantingSubzoneHistoryModel
+import com.terraformation.backend.tracking.model.PlantingZoneHistoryModel
+import io.mockk.every
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PlantingSiteStoreFetchSiteHistoryTest : PlantingSiteStoreTest() {
+  @Test
+  fun `fetches site history`() {
+    val gridOrigin = point(1)
+    val siteBoundary1 = multiPolygon(200)
+    val siteBoundary2 = multiPolygon(250)
+    val zoneBoundary1 = multiPolygon(150)
+    val subzoneBoundary1 = multiPolygon(100)
+    val subzoneBoundary2 = multiPolygon(90)
+    val monitoringPlotBoundary1 = polygon(30)
+    val monitoringPlotBoundary2 = polygon(25)
+
+    val plantingSiteId =
+        insertPlantingSite(boundary = siteBoundary1, gridOrigin = gridOrigin, name = "Site 1")
+    val plantingSiteHistoryId1 = inserted.plantingSiteHistoryId
+    val plantingZoneId1 = insertPlantingZone(boundary = zoneBoundary1, name = "Zone 1")
+    val plantingZoneHistoryId1 = inserted.plantingZoneHistoryId
+    val plantingSubzoneId1 = insertPlantingSubzone(boundary = subzoneBoundary1, name = "Subzone 1")
+    val subzoneHistoryId1 = inserted.plantingSubzoneHistoryId
+    val monitoringPlotId1 =
+        insertMonitoringPlot(boundary = monitoringPlotBoundary1, name = "Plot 1")
+    val monitoringPlotHistoryId1 = inserted.monitoringPlotHistoryId
+
+    // A subzone that was deleted after a monitoring plot was added to it.
+    val subzoneId2 = insertPlantingSubzone(boundary = subzoneBoundary2, name = "Subzone 2")
+    val subzoneHistoryId2 = inserted.plantingSubzoneHistoryId
+    val monitoringPlotId2 =
+        insertMonitoringPlot(boundary = monitoringPlotBoundary2, name = "Plot 2")
+    val monitoringPlotHistoryId2 = inserted.monitoringPlotHistoryId
+    plantingSubzonesDao.deleteById(subzoneId2)
+
+    // A second set of history records for the same site.
+    insertPlantingSiteHistory(boundary = siteBoundary2)
+    insertPlantingZoneHistory(boundary = siteBoundary2)
+    insertPlantingSubzoneHistory(boundary = siteBoundary2, plantingSubzoneId = null)
+    insertMonitoringPlotHistory(plantingSubzoneId = null)
+
+    // A second site with its own history.
+    insertPlantingSite(boundary = siteBoundary2, name = "Site 2")
+    insertPlantingZone(name = "Site 2 Zone")
+    insertPlantingSubzone(name = "Site 2 Subzone")
+    insertMonitoringPlot(name = "Site 2 Plot")
+
+    val expected =
+        PlantingSiteHistoryModel(
+            boundary = siteBoundary1,
+            gridOrigin = gridOrigin,
+            id = plantingSiteHistoryId1,
+            plantingSiteId = plantingSiteId,
+            plantingZones =
+                listOf(
+                    PlantingZoneHistoryModel(
+                        boundary = zoneBoundary1,
+                        id = plantingZoneHistoryId1,
+                        name = "Zone 1",
+                        plantingZoneId = plantingZoneId1,
+                        plantingSubzones =
+                            listOf(
+                                PlantingSubzoneHistoryModel(
+                                    boundary = subzoneBoundary1,
+                                    id = subzoneHistoryId1,
+                                    fullName = "Z1-Subzone 1",
+                                    name = "Subzone 1",
+                                    plantingSubzoneId = plantingSubzoneId1,
+                                    monitoringPlots =
+                                        listOf(
+                                            MonitoringPlotHistoryModel(
+                                                boundary = monitoringPlotBoundary1,
+                                                createdBy = user.userId,
+                                                createdTime = Instant.EPOCH,
+                                                fullName = "Z1-1-Plot 1",
+                                                id = monitoringPlotHistoryId1,
+                                                monitoringPlotId = monitoringPlotId1,
+                                                name = "Plot 1",
+                                                sizeMeters = MONITORING_PLOT_SIZE_INT,
+                                            ),
+                                        ),
+                                ),
+                                PlantingSubzoneHistoryModel(
+                                    boundary = subzoneBoundary2,
+                                    id = subzoneHistoryId2,
+                                    fullName = "Z1-Subzone 2",
+                                    name = "Subzone 2",
+                                    plantingSubzoneId = null,
+                                    monitoringPlots =
+                                        listOf(
+                                            MonitoringPlotHistoryModel(
+                                                boundary = monitoringPlotBoundary2,
+                                                createdBy = user.userId,
+                                                createdTime = Instant.EPOCH,
+                                                fullName = "Z1-1-Plot 2",
+                                                id = monitoringPlotHistoryId2,
+                                                monitoringPlotId = monitoringPlotId2,
+                                                name = "Plot 2",
+                                                sizeMeters = MONITORING_PLOT_SIZE_INT,
+                                            ),
+                                        )),
+                            ),
+                    ),
+                ),
+        )
+
+    val actual =
+        store.fetchSiteHistoryById(plantingSiteId, plantingSiteHistoryId1, PlantingSiteDepth.Plot)
+
+    if (!expected.equals(actual, 0.00001)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Test
+  fun `throws exception if history ID does not exist`() {
+    assertThrows<PlantingSiteHistoryNotFoundException> {
+      store.fetchSiteHistoryById(
+          PlantingSiteId(-1), PlantingSiteHistoryId(-1), PlantingSiteDepth.Site)
+    }
+  }
+
+  @Test
+  fun `throws exception if history is for a different site`() {
+    insertPlantingSite(boundary = multiPolygon(1))
+    val historyId1 = inserted.plantingSiteHistoryId
+    val plantingSiteId2 = insertPlantingSite()
+
+    assertThrows<PlantingSiteHistoryNotFoundException> {
+      store.fetchSiteHistoryById(plantingSiteId2, historyId1, PlantingSiteDepth.Site)
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to read planting site`() {
+    val plantingSiteId = insertPlantingSite(boundary = multiPolygon(1), name = "Site 1")
+    val historyId = inserted.plantingSiteHistoryId
+
+    every { user.canReadPlantingSite(any()) } returns false
+
+    assertThrows<PlantingSiteNotFoundException> {
+      store.fetchSiteHistoryById(plantingSiteId, historyId, PlantingSiteDepth.Site)
+    }
+  }
+}


### PR DESCRIPTION
Add an API endpoint to retrieve older versions of planting site maps so that past
observations can be shown in the context of the planting sites as they were
defined at the time.