### PR TITLE
SW-6280 Observation planting site history IDs in API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
@@ -32,6 +33,9 @@ class ObservationsTable(private val tables: SearchTables) : SearchTable() {
           timestampField("createdTime", OBSERVATIONS.CREATED_TIME),
           dateField("endDate", OBSERVATIONS.END_DATE),
           idWrapperField("id", OBSERVATIONS.ID) { ObservationId(it) },
+          idWrapperField("plantingSiteHistoryId", OBSERVATIONS.PLANTING_SITE_HISTORY_ID) {
+            PlantingSiteHistoryId(it)
+          },
           dateField("startDate", OBSERVATIONS.START_DATE),
       )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -442,6 +443,11 @@ data class ObservationPayload(
     val numPlots: Int,
     @Schema(description = "Total number of monitoring plots that haven't been claimed yet.")
     val numUnclaimedPlots: Int,
+    @Schema(
+        description =
+            "If this observation has already started, the version of the planting site that was " +
+                "used to place its monitoring plots.")
+    val plantingSiteHistoryId: PlantingSiteHistoryId?,
     val plantingSiteId: PlantingSiteId,
     val plantingSiteName: String,
     @ArraySchema(
@@ -464,6 +470,7 @@ data class ObservationPayload(
       numIncompletePlots = counts?.totalIncomplete ?: 0,
       numPlots = counts?.totalPlots ?: 0,
       numUnclaimedPlots = counts?.totalUnclaimed ?: 0,
+      plantingSiteHistoryId = model.plantingSiteHistoryId,
       plantingSiteId = model.plantingSiteId,
       plantingSiteName = plantingSiteName,
       requestedSubzoneIds = model.requestedSubzoneIds.ifEmpty { null },

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -571,6 +571,7 @@ search.observations.completedTime=Observation completed time
 search.observations.createdTime=Observation created time
 search.observations.endDate=Observation end date
 search.observations.id=Observation ID
+search.observations.plantingSiteHistoryId=Observation planting site history ID
 search.observations.startDate=Observation start date
 search.organizationInternalTags.name=Organization internal tag name
 search.organizationUsers.createdTime=Organization membership creation time

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -60,6 +60,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
             countryCode = "CI",
             exclusion = exclusionGeometry,
             projectId = projectId)
+    val plantingSiteHistoryId = inserted.plantingSiteHistoryId
 
     val plantingSeasonId1 =
         insertPlantingSeason(
@@ -242,6 +243,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                 "createdTime" to "1970-01-01T00:00:01Z",
                                 "endDate" to "2023-01-30",
                                 "id" to "$observationId1",
+                                "plantingSiteHistoryId" to "$plantingSiteHistoryId",
                                 "startDate" to "2023-01-01",
                                 "observationPlots" to
                                     listOf(
@@ -268,6 +270,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                 "createdTime" to "1970-01-01T00:00:00Z",
                                 "endDate" to "2024-02-28",
                                 "id" to "$observationId2",
+                                "plantingSiteHistoryId" to "$plantingSiteHistoryId",
                                 "startDate" to "2024-02-02",
                                 "observationPlots" to
                                     listOf(
@@ -463,6 +466,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "observations.observationPlots.isPermanent",
                 "observations.observationPlots.monitoringPlot.id",
                 "observations.observationPlots.notes",
+                "observations.plantingSiteHistoryId",
                 "observations.startDate",
                 "plantingSeasons.endDate",
                 "plantingSeasons.id",


### PR DESCRIPTION
Update the observation query and search APIs to include the planting site
history ID that was active at the time the observation started. Clients can
use it to fetch the correct historical site map for a given observation.