### PR TITLE
SW-6319 Populate default value for new section values when a document is upgraded

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentService.kt
@@ -17,7 +17,9 @@ class DocumentService(
     return dslContext.transactionResult { _ ->
       val model = documentStore.create(newDocumentModel)
 
-      variableValueStore.populateDefaultValues(model.projectId, model.variableManifestId)
+      val operations =
+          variableValueStore.populateDefaultValues(model.projectId, model.variableManifestId)
+      variableValueStore.updateValues(operations)
 
       model
     }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentService.kt
@@ -18,7 +18,7 @@ class DocumentService(
       val model = documentStore.create(newDocumentModel)
 
       val operations =
-          variableValueStore.populateDefaultValues(model.projectId, model.variableManifestId)
+          variableValueStore.calculateDefaultValues(model.projectId, model.variableManifestId)
       variableValueStore.updateValues(operations)
 
       model

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
@@ -191,7 +191,7 @@ class DocumentUpgradeCalculator(
       if (sectionValues.isNullOrEmpty()) {
         // This is a new section being added to a project document, we should see if a default value
         // exists
-        return variableValueStore.populateDefaultValues(projectId, newManifestId, variable.id)
+        return variableValueStore.calculateDefaultValues(projectId, newManifestId, variable.id)
       }
 
       sectionValues.flatMap { sectionValue ->

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/DocumentUpgradeCalculator.kt
@@ -187,7 +187,12 @@ class DocumentUpgradeCalculator(
       val sectionValues =
           previousVariableIds[variable.id]
               ?.firstNotNullOfOrNull { existingValues[it] }
-              ?.filterIsInstance<ExistingSectionValue>() ?: return emptyList()
+              ?.filterIsInstance<ExistingSectionValue>()
+      if (sectionValues.isNullOrEmpty()) {
+        // This is a new section being added to a project document, we should see if a default value
+        // exists
+        return variableValueStore.populateDefaultValues(projectId, newManifestId, variable.id)
+      }
 
       sectionValues.flatMap { sectionValue ->
         val valueFragment: SectionValueFragment? =

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableValueStore.kt
@@ -79,7 +79,6 @@ import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import jakarta.inject.Named
 import java.net.URI
 import java.time.InstantSource
-import java.util.Collections.emptyList
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
@@ -395,10 +394,10 @@ class VariableValueStore(
   }
 
   /** Create operations to populate project document section variables defaults. */
-  fun populateDefaultValues(
+  fun calculateDefaultValues(
       projectId: ProjectId,
       manifestId: VariableManifestId,
-      specificVariableId: VariableId? = null
+      variableId: VariableId? = null
   ): List<AppendValueOperation> {
     val hasValues =
         dslContext.fetchExists(
@@ -410,7 +409,7 @@ class VariableValueStore(
                 .where(
                     listOfNotNull(
                         VARIABLE_VALUES.PROJECT_ID.eq(projectId),
-                        specificVariableId?.let { VARIABLE_VALUES.VARIABLE_ID.eq(it) }))
+                        variableId?.let { VARIABLE_VALUES.VARIABLE_ID.eq(it) }))
                 .and(VARIABLE_MANIFEST_ENTRIES.VARIABLE_MANIFEST_ID.eq(manifestId)))
     if (hasValues) {
       throw IllegalStateException("Can only populate initial values of variables without values")
@@ -422,7 +421,7 @@ class VariableValueStore(
             .where(
                 listOfNotNull(
                     VARIABLE_SECTION_DEFAULT_VALUES.VARIABLE_MANIFEST_ID.eq(manifestId),
-                    specificVariableId?.let { VARIABLE_SECTION_DEFAULT_VALUES.VARIABLE_ID.eq(it) }))
+                    variableId?.let { VARIABLE_SECTION_DEFAULT_VALUES.VARIABLE_ID.eq(it) }))
             .orderBy(
                 VARIABLE_SECTION_DEFAULT_VALUES.VARIABLE_ID,
                 VARIABLE_SECTION_DEFAULT_VALUES.LIST_POSITION)


### PR DESCRIPTION
When upgrading a document to a newer variable manifest version, if new sections are added, populate those default values for the project document being upgraded.