### PR TITLE
SW-6339 Add email variable type

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectVariablesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/migration/ProjectVariablesImporter.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.model.BaseVariableValueProperties
 import com.terraformation.backend.documentproducer.model.DateValue
 import com.terraformation.backend.documentproducer.model.DeleteValueOperation
+import com.terraformation.backend.documentproducer.model.EmailValue
 import com.terraformation.backend.documentproducer.model.LinkValue
 import com.terraformation.backend.documentproducer.model.LinkValueDetails
 import com.terraformation.backend.documentproducer.model.NumberValue
@@ -121,6 +122,14 @@ class ProjectVariablesImporter(
                             if ((currentValues[variable.id]?.value as? DateValue<*>)?.value !=
                                 localDate) {
                               DateValue(baseProperties, localDate)
+                            } else {
+                              null
+                            }
+                          }
+                          VariableType.Email -> {
+                            if ((currentValues[variable.id]?.value as? EmailValue<*>)?.value !=
+                                value) {
+                              EmailValue(baseProperties, value)
                             } else {
                               null
                             }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
@@ -12,8 +12,10 @@ import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.VariableWorkflowStatus
 import com.terraformation.backend.documentproducer.model.DateValue
 import com.terraformation.backend.documentproducer.model.DeletedValue
+import com.terraformation.backend.documentproducer.model.EmailValue
 import com.terraformation.backend.documentproducer.model.ExistingDateValue
 import com.terraformation.backend.documentproducer.model.ExistingDeletedValue
+import com.terraformation.backend.documentproducer.model.ExistingEmailValue
 import com.terraformation.backend.documentproducer.model.ExistingImageValue
 import com.terraformation.backend.documentproducer.model.ExistingLinkValue
 import com.terraformation.backend.documentproducer.model.ExistingNumberValue
@@ -40,6 +42,7 @@ import java.time.LocalDate
 enum class ExistingValuePayloadType {
   Date,
   Deleted,
+  Email,
   Image,
   Link,
   Number,
@@ -53,6 +56,7 @@ enum class ExistingValuePayloadType {
 @JsonSubTypes(
     JsonSubTypes.Type(value = ExistingDateValuePayload::class, name = "Date"),
     JsonSubTypes.Type(value = ExistingDeletedValuePayload::class, name = "Deleted"),
+    JsonSubTypes.Type(value = ExistingEmailValuePayload::class, name = "Email"),
     JsonSubTypes.Type(value = ExistingLinkValuePayload::class, name = "Link"),
     JsonSubTypes.Type(value = ExistingImageValuePayload::class, name = "Image"),
     JsonSubTypes.Type(value = ExistingNumberValuePayload::class, name = "Number"),
@@ -68,6 +72,7 @@ enum class ExistingValuePayloadType {
         [
             DiscriminatorMapping(schema = ExistingDateValuePayload::class, value = "Date"),
             DiscriminatorMapping(schema = ExistingDeletedValuePayload::class, value = "Deleted"),
+            DiscriminatorMapping(schema = ExistingEmailValuePayload::class, value = "Email"),
             DiscriminatorMapping(schema = ExistingImageValuePayload::class, value = "Image"),
             DiscriminatorMapping(schema = ExistingLinkValuePayload::class, value = "Link"),
             DiscriminatorMapping(schema = ExistingNumberValuePayload::class, value = "Number"),
@@ -91,6 +96,7 @@ sealed interface ExistingValuePayload {
       return when (model) {
         is DateValue -> ExistingDateValuePayload(model)
         is DeletedValue -> ExistingDeletedValuePayload(model)
+        is EmailValue -> ExistingEmailValuePayload(model)
         is ImageValue -> ExistingImageValuePayload(model)
         is LinkValue -> ExistingLinkValuePayload(model)
         is NumberValue -> ExistingNumberValuePayload(model)
@@ -136,6 +142,20 @@ data class ExistingDeletedValuePayload(
 
   override val citation: String?
     @JsonIgnore get() = null
+}
+
+data class ExistingEmailValuePayload(
+    override val id: VariableValueId,
+    override val listPosition: Int,
+    override val citation: String?,
+    val emailValue: String,
+) : ExistingValuePayload {
+  constructor(
+      model: ExistingEmailValue
+  ) : this(model.id, model.listPosition, model.citation, model.value)
+
+  override val type: ExistingValuePayloadType
+    get() = ExistingValuePayloadType.Email
 }
 
 @Schema(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.docprod.VariableUsageType
 import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.documentproducer.model.BaseVariableValueProperties
 import com.terraformation.backend.documentproducer.model.DateValue
+import com.terraformation.backend.documentproducer.model.EmailValue
 import com.terraformation.backend.documentproducer.model.ImageValue
 import com.terraformation.backend.documentproducer.model.ImageValueDetails
 import com.terraformation.backend.documentproducer.model.LinkValue
@@ -32,6 +33,7 @@ import java.time.LocalDate
 
 @JsonSubTypes(
     JsonSubTypes.Type(value = NewDateValuePayload::class, name = "Date"),
+    JsonSubTypes.Type(value = NewEmailValuePayload::class, name = "Email"),
     JsonSubTypes.Type(value = NewImageValuePayload::class, name = "Image"),
     JsonSubTypes.Type(value = NewLinkValuePayload::class, name = "Link"),
     JsonSubTypes.Type(value = NewNumberValuePayload::class, name = "Number"),
@@ -49,6 +51,7 @@ import java.time.LocalDate
     discriminatorMapping =
         [
             DiscriminatorMapping(schema = NewDateValuePayload::class, value = "Date"),
+            DiscriminatorMapping(schema = NewEmailValuePayload::class, value = "Email"),
             DiscriminatorMapping(schema = NewImageValuePayload::class, value = "Image"),
             DiscriminatorMapping(schema = NewLinkValuePayload::class, value = "Link"),
             DiscriminatorMapping(schema = NewNumberValuePayload::class, value = "Number"),
@@ -80,6 +83,17 @@ data class NewDateValuePayload(
 
   override fun <ID : VariableValueId?> toValueModel(base: BaseVariableValueProperties<ID>) =
       DateValue(base, dateValue)
+}
+
+data class NewEmailValuePayload(
+    @get:JsonIgnore(false) override val citation: String?,
+    val emailValue: String,
+) : NewValuePayload {
+  override val type: VariableValuePayloadType
+    get() = VariableValuePayloadType.Email
+
+  override fun <ID : VariableValueId?> toValueModel(base: BaseVariableValueProperties<ID>) =
+      EmailValue(base, emailValue)
 }
 
 @Schema(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableValuePayloadType.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableValuePayloadType.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.documentproducer.api
 
 enum class VariableValuePayloadType {
   Date,
+  Email,
   Image,
   Link,
   Number,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.docprod.DocumentId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.model.DateVariable
+import com.terraformation.backend.documentproducer.model.EmailVariable
 import com.terraformation.backend.documentproducer.model.ImageVariable
 import com.terraformation.backend.documentproducer.model.LinkVariable
 import com.terraformation.backend.documentproducer.model.NumberVariable
@@ -88,6 +89,7 @@ class VariablesController(
 
 @JsonSubTypes(
     Type(value = DateVariablePayload::class, name = "Date"),
+    Type(value = EmailVariablePayload::class, name = "Email"),
     Type(value = ImageVariablePayload::class, name = "Image"),
     Type(value = LinkVariablePayload::class, name = "Link"),
     Type(value = NumberVariablePayload::class, name = "Number"),
@@ -101,6 +103,7 @@ class VariablesController(
     discriminatorMapping =
         [
             DiscriminatorMapping(schema = DateVariablePayload::class, value = "Date"),
+            DiscriminatorMapping(schema = EmailVariablePayload::class, value = "Email"),
             DiscriminatorMapping(schema = ImageVariablePayload::class, value = "Image"),
             DiscriminatorMapping(schema = LinkVariablePayload::class, value = "Link"),
             DiscriminatorMapping(schema = NumberVariablePayload::class, value = "Number"),
@@ -164,6 +167,7 @@ interface VariablePayload {
     fun of(model: Variable): VariablePayload {
       return when (model) {
         is DateVariable -> DateVariablePayload(model)
+        is EmailVariable -> EmailVariablePayload(model)
         is ImageVariable -> ImageVariablePayload(model)
         is LinkVariable -> LinkVariablePayload(model)
         is NumberVariable -> NumberVariablePayload(model)
@@ -177,6 +181,8 @@ interface VariablePayload {
 }
 
 data class DateVariablePayload(override val model: DateVariable) : VariablePayload
+
+data class EmailVariablePayload(override val model: EmailVariable) : VariablePayload
 
 data class ImageVariablePayload(override val model: ImageVariable) : VariablePayload
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -41,6 +41,7 @@ import com.terraformation.backend.db.docprod.tables.references.VARIABLE_TABLE_CO
 import com.terraformation.backend.db.docprod.tables.references.VARIABLE_VALUES
 import com.terraformation.backend.documentproducer.model.BaseVariableProperties
 import com.terraformation.backend.documentproducer.model.DateVariable
+import com.terraformation.backend.documentproducer.model.EmailVariable
 import com.terraformation.backend.documentproducer.model.ImageVariable
 import com.terraformation.backend.documentproducer.model.LinkVariable
 import com.terraformation.backend.documentproducer.model.NumberVariable
@@ -435,6 +436,7 @@ class VariableStore(
         val variable =
             when (variablesRow.variableTypeId!!) {
               VariableType.Date -> DateVariable(base)
+              VariableType.Email -> EmailVariable(base)
               VariableType.Number -> fetchNumber(base)
               VariableType.Text -> fetchText(base)
               VariableType.Image -> ImageVariable(base)

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
@@ -92,6 +92,7 @@ enum class AllVariableCsvVariableType(val value: String, val variableType: Varia
   SingleSelect("Select (single)", VariableType.Select),
   MultiSelect("Select (multiple)", VariableType.Select),
   Date("Date", VariableType.Date),
+  Email("Email", VariableType.Email),
   Link("Link", VariableType.Link),
   Image("Image", VariableType.Image),
   Table("Table", VariableType.Table);

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariableTablesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableTextsRow
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.model.DateVariable
+import com.terraformation.backend.documentproducer.model.EmailVariable
 import com.terraformation.backend.documentproducer.model.HierarchicalVariableType
 import com.terraformation.backend.documentproducer.model.ImageVariable
 import com.terraformation.backend.documentproducer.model.LinkVariable
@@ -443,6 +444,7 @@ class VariableImporter(
                     variable.isMultiple &&
                     hasSameOptions(csvVariable, variable)
             AllVariableCsvVariableType.Date -> variable is DateVariable
+            AllVariableCsvVariableType.Email -> variable is EmailVariable
             AllVariableCsvVariableType.Link -> variable is LinkVariable
             AllVariableCsvVariableType.Image -> variable is ImageVariable
             AllVariableCsvVariableType.Table ->

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableValue.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableValue.kt
@@ -60,6 +60,14 @@ data class DeletedValue<ID : VariableValueId?>(
     get() = null
 }
 
+data class EmailValue<ID : VariableValueId?>(
+    private val base: BaseVariableValueProperties<ID>,
+    override val value: String,
+) : VariableValue<ID, String>, BaseVariableValue<ID> by base {
+  override val type: VariableType
+    get() = VariableType.Email
+}
+
 data class ImageValueDetails(
     val caption: String?,
     val fileId: FileId,
@@ -143,6 +151,8 @@ typealias ExistingDateValue = DateValue<VariableValueId>
 
 typealias ExistingDeletedValue = DeletedValue<VariableValueId>
 
+typealias ExistingEmailValue = EmailValue<VariableValueId>
+
 typealias ExistingImageValue = ImageValue<VariableValueId>
 
 typealias ExistingLinkValue = LinkValue<VariableValueId>
@@ -160,6 +170,8 @@ typealias ExistingTextValue = TextValue<VariableValueId>
 typealias ExistingValue = VariableValue<VariableValueId, *>
 
 typealias NewDateValue = DateValue<Nothing?>
+
+typealias NewEmailValue = EmailValue<Nothing?>
 
 typealias NewImageValue = ImageValue<Nothing?>
 

--- a/src/main/resources/db/migration/0300/V324__EmailVariable.sql
+++ b/src/main/resources/db/migration/0300/V324__EmailVariable.sql
@@ -1,0 +1,3 @@
+ALTER TABLE docprod.variable_values DROP CONSTRAINT variable_values_check1;
+ALTER TABLE docprod.variable_values ADD CONSTRAINT text_value_is_text_or_email
+    CHECK (text_value IS NULL OR variable_type_id IN (2, 9));

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -641,6 +641,7 @@ COMMENT ON TABLE docprod.variable_usage_types IS '(Enum) When a variable is used
 COMMENT ON TABLE docprod.variable_value_table_rows IS 'Linking table that defines which variable values are in which rows of a table.';
 
 COMMENT ON TABLE docprod.variable_values IS 'Insert-only table with all historical and current values of all inputs.';
+COMMENT ON COLUMN docprod.variable_values.text_value IS 'For text or email variables, the variable''s value. May contain newlines if the text variable is multi-line.';
 
 COMMENT ON TABLE docprod.variables IS 'variables that can be supplied by the user. This table stores the variables themselves, not the values of the variables in a particular document. Type-specific information is in child tables such as `variable_numbers`.';
 COMMENT ON COLUMN docprod.variables.is_list IS 'True if this variable is a list of values rather than a single value. If the variable is a table, true if the table can contain multiple rows.';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -170,7 +170,8 @@ VALUES (1, 'Number'),
        (5, 'Select'),
        (6, 'Table'),
        (7, 'Link'),
-       (8, 'Section')
+       (8, 'Section'),
+       (9, 'Email')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO docprod.variable_usage_types (id, name)

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -88,6 +88,7 @@ docprod.VariableTableStyle.Vertical=Vertical
 docprod.VariableTextType.MultiLine=Multi Line
 docprod.VariableTextType.SingleLine=Single Line
 docprod.VariableType.Date=Date
+docprod.VariableType.Email=Email
 docprod.VariableType.Image=Image
 docprod.VariableType.Link=Link
 docprod.VariableType.Number=Number

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -37,6 +37,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     @Test
     fun `returns appropriate data structures for all value types`() {
       val dateVariableId = insertVariable(type = VariableType.Date)
+      val emailVariableId = insertVariable(type = VariableType.Email)
       val imageVariableId = insertVariable(type = VariableType.Image)
       val numberVariableId = insertNumberVariable()
       val textVariableId = insertTextVariable()
@@ -49,6 +50,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
       val dateValueId =
           insertValue(variableId = dateVariableId, dateValue = LocalDate.of(2023, 9, 25))
+      val emailValueId = insertValue(variableId = emailVariableId, textValue = "email@example.com")
       val imageValueId = insertImageValue(imageVariableId, insertFile(), caption = "Image caption")
       val numberValueId =
           insertValue(variableId = numberVariableId, numberValue = BigDecimal(12345))
@@ -82,6 +84,18 @@ class ValuesControllerTest : ControllerIntegrationTest() {
                           "listPosition": 0,
                           "type": "Date",
                           "dateValue": "2023-09-25"
+                        }
+                      ]
+                    },
+                    {
+                      "variableId": $emailVariableId,
+                      "status": "Not Submitted",
+                      "values": [
+                        {
+                          "id": $emailValueId,
+                          "listPosition": 0,
+                          "type": "Email",
+                          "emailValue": "email@example.com"
                         }
                       ]
                     },
@@ -685,6 +699,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
       val numberVariableId = insertNumberVariable()
       val linkVariableId = insertVariable(type = VariableType.Link)
       val dateVariableId = insertVariable(type = VariableType.Date)
+      val emailVariableId = insertVariable(type = VariableType.Email)
       val selectVariableId = insertSelectVariable()
       val selectOptionId = insertSelectOption(selectVariableId, "Option")
 
@@ -754,6 +769,15 @@ class ValuesControllerTest : ControllerIntegrationTest() {
                     "type": "Date",
                     "citation": "Citation",
                     "dateValue": "2023-01-01T11:22:33Z"
+                  }
+                },
+                {
+                  "operation": "Append",
+                  "variableId": $emailVariableId,
+                  "value": {
+                    "type": "Email",
+                    "citation": "Citation",
+                    "emailValue": "append@example.com"
                   }
                 },
                 {
@@ -832,7 +856,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     }
 
     @Test
-    fun `Returns not found error if user has no permission to read internal only variable`() {
+    fun `returns not found error if user has no permission to read internal only variable`() {
       val variableId =
           insertTextVariable(
               insertVariable(internalOnly = true, isList = true, type = VariableType.Text))
@@ -862,7 +886,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
     }
 
     @Test
-    fun `Returns unauthorized error if user has no permission to update internal only variable`() {
+    fun `returns unauthorized error if user has no permission to update internal only variable`() {
       val variableId =
           insertTextVariable(
               insertVariable(internalOnly = true, isList = true, type = VariableType.Text))

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/model/VariableTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/model/VariableTest.kt
@@ -106,6 +106,37 @@ class VariableTest {
   }
 
   @Nested
+  inner class ValidateEmail {
+    @Test
+    fun `allows valid email address`() {
+      testValidate(EmailVariable(baseVariable()), NewEmailValue(baseValue(), "valid@example.com"))
+    }
+
+    @Test
+    fun `rejects valid email address with name`() {
+      assertThrows<VariableValueInvalidException> {
+        testValidate(
+            EmailVariable(baseVariable()),
+            NewEmailValue(baseValue(), "Real Person <valid@example.com>"))
+      }
+    }
+
+    @Test
+    fun `rejects text that is not an email address`() {
+      assertThrows<VariableValueInvalidException> {
+        testValidate(EmailVariable(baseVariable()), NewEmailValue(baseValue(), "invalid"))
+      }
+    }
+
+    @Test
+    fun `rejects lists of email addresses`() {
+      assertThrows<VariableValueInvalidException> {
+        testValidate(EmailVariable(baseVariable()), NewEmailValue(baseValue(), "a@b.com,c@d.com"))
+      }
+    }
+  }
+
+  @Nested
   inner class ValidateText {
     @Test
     fun `allows single-line value if variable is single-line`() {
@@ -367,6 +398,40 @@ class VariableTest {
             oldVariable = TextVariable(baseVariable(1), VariableTextType.SingleLine),
             oldValue = NewTextValue(baseValue(1), "xyzzy"),
             newVariable = DateVariable(baseVariable(2)))
+      }
+    }
+
+    @Nested
+    inner class ConvertEmail {
+      @Test
+      fun `preserves existing email value`() {
+        val emailValue = "existing@example.com"
+
+        assertConversionResult(
+            expectedValue = emailValue,
+            oldVariable = EmailVariable(baseVariable(1)),
+            oldValue = NewEmailValue(baseValue(1), emailValue),
+            newVariable = EmailVariable(baseVariable(2)))
+      }
+
+      @Test
+      fun `converts valid email text to email`() {
+        val emailValue = "existing@example.com"
+
+        assertConversionResult(
+            expectedValue = emailValue,
+            oldVariable = TextVariable(baseVariable(1), VariableTextType.SingleLine),
+            oldValue = NewTextValue(baseValue(1), emailValue),
+            newVariable = EmailVariable(baseVariable(2)))
+      }
+
+      @Test
+      fun `does not convert text that is not a valid email address`() {
+        assertConversionResult(
+            expectedValue = null,
+            oldVariable = TextVariable(baseVariable(1), VariableTextType.SingleLine),
+            oldValue = NewTextValue(baseValue(1), "xyzzy"),
+            newVariable = EmailVariable(baseVariable(2)))
       }
     }
 


### PR DESCRIPTION
For questionnaire deliverables such as the accelerator application, we ask users
for email addresses, but there's currently nothing to prevent people from entering
random text. Add a new variable type that only accepts syntactically valid email
addresses.