### PR TITLE
Upgrade to Java 23 JVM

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: "corretto"
-        java-version: "20"
+        java-version: "23"
 
     - name: Tell Gradle where the Java installation is
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: "corretto"
-        java-version: "21"
+        java-version: "23"
 
     - name: Tell Gradle where the Java installation is
       run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,8 +257,8 @@ sourceSets.main { java.srcDir("build/generated/kotlin") }
 sourceSets.test { java.srcDir("build/generated-test/kotlin") }
 
 java {
-  toolchain { languageVersion = JavaLanguageVersion.of(21) }
-  targetCompatibility = JavaVersion.VERSION_21
+  toolchain { languageVersion = JavaLanguageVersion.of(23) }
+  targetCompatibility = JavaVersion.VERSION_23
 }
 
 node { yarnVersion = "1.22.17" }
@@ -266,7 +266,7 @@ node { yarnVersion = "1.22.17" }
 tasks.withType<KotlinCompile> {
   compilerOptions {
     // Kotlin and Java target compatibility must be the same.
-    jvmTarget = JvmTarget.JVM_21
+    jvmTarget = JvmTarget.JVM_23
     allWarningsAsErrors = true
 
     extraWarnings = true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21.0.5
+FROM amazoncorretto:23.0.1-al2023-headless
 
 ARG USER_ID=1001
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,9 +16,9 @@ image: prepare
 run: image
     # This will not work on Windows
 	@if [ -f .env ]; then\
-		docker-compose -f docker-compose.yml --env-file .env up;\
+		docker compose -f docker-compose.yml --env-file .env up;\
 	else\
-		docker-compose -f docker-compose.yml up;\
+		docker compose -f docker-compose.yml up;\
 	fi
 
 run-postgres:

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -4,7 +4,7 @@ Code should be written in idiomatic Kotlin and should generally follow the guide
 
 It runs on the JVM, and thus makes extensive use of Java libraries. There are no plans to support multiplatform builds. If you find a Java library that does just what you need, use it rather than reinventing the wheel!
 
-Currently, the build targets the Java 21 JVM. We use the Amazon Corretto JVM and will generally target the most recent Corretto release.
+Currently, the build targets the Java 23 JVM. We use the Amazon Corretto JVM and will generally target the most recent Corretto release.
 
 ## Formatting
 


### PR DESCRIPTION
Use AWS's distribution of Java 23 instead of Java 21, which should give us
performance and memory footprint improvements.