### PR TITLE
Enable Spring virtual threads

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,6 +80,10 @@ spring:
   session:
     store-type: jdbc
 
+  threads:
+    virtual:
+      enabled: true
+
 server:
   tomcat:
     max-http-form-post-size: 200MB


### PR DESCRIPTION
Configure Spring to use virtual threads where possible. This should reduce the
server's memory footprint.