### PR TITLE
SW-6203 Attempt to fix slow test suite shutdown

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,6 +140,7 @@ dependencies {
   testImplementation("io.mockk:mockk:1.13.13")
   testImplementation("org.geotools:gt-epsg-hsql:$geoToolsVersion")
   testImplementation("org.hsqldb:hsqldb:2.7.4")
+  testImplementation("org.junit.platform:junit-platform-launcher")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.4"))

--- a/src/test/kotlin/com/terraformation/backend/SpringShutdownListener.kt
+++ b/src/test/kotlin/com/terraformation/backend/SpringShutdownListener.kt
@@ -1,0 +1,35 @@
+package com.terraformation.backend
+
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestPlan
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * Workaround for a race between the Spring and Testcontainers JVM shutdown hooks.
+ *
+ * JVM shutdown hooks are executed in an undefined order on an undefined number of threads. If the
+ * Testcontainers hook runs first and stops the database container, and there are Spring services
+ * (such as JobRunr) that try to update the database as part of their shutdown processes, the Spring
+ * services can fail to shut down cleanly once the Spring shutdown hook runs. This causes error spew
+ * at the end of the test run and can cause the suite to take longer to finish because it has to
+ * wait for the shutdown to time out.
+ *
+ * The workaround is to shut down the Spring application contexts before the JVM exits. By the time
+ * the Testcontainers hook stops the database container, nothing is using the database any more.
+ */
+class SpringShutdownListener : TestExecutionListener {
+  companion object {
+    private val springContexts = mutableSetOf<ConfigurableApplicationContext>()
+
+    fun register(applicationContext: ApplicationContext) {
+      if (applicationContext is ConfigurableApplicationContext) {
+        synchronized(springContexts) { springContexts.add(applicationContext) }
+      }
+    }
+  }
+
+  override fun testPlanExecutionFinished(testPlan: TestPlan) {
+    springContexts.forEach { it.close() }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.SpringShutdownListener
 import com.terraformation.backend.accelerator.variables.StableId
 import com.terraformation.backend.accelerator.variables.StableIds
 import com.terraformation.backend.api.ArbitraryJsonObject
@@ -386,6 +387,7 @@ import org.locationtech.jts.geom.Polygon
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationContextInitializer
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.ComponentScan
@@ -442,6 +444,11 @@ abstract class DatabaseBackedTest {
 
   /** IDs of entities that have been inserted using the `insert` helper methods during this test. */
   val inserted = Inserted()
+
+  @Autowired
+  fun registerApplicationContext(context: ApplicationContext) {
+    SpringShutdownListener.register(context)
+  }
 
   /**
    * Creates a lazily-instantiated jOOQ DAO object. In most cases, type inference will figure out

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+com.terraformation.backend.SpringShutdownListener


### PR DESCRIPTION
Try to fix a race condition at the end of a test suite run that can cause the
suite to pause for 10 seconds after all the tests have finished executing and to
spew errors about database connections failing.