### PR TITLE
SW-6338 Return submissions in more scenarios

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableStoreTest.kt
@@ -515,6 +515,90 @@ class DeliverableStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `returns application submissions for participant projects if deliverable ID is specified`() {
+      val participantName = "Participant ${UUID.randomUUID()}"
+      val organizationId = insertOrganization()
+      val cohortId = insertCohort()
+      val participantId = insertParticipant(cohortId = cohortId, name = participantName)
+      val projectId = insertProject(participantId = participantId)
+      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val deliverableId = insertDeliverable()
+      val submissionId = insertSubmission(submissionStatus = SubmissionStatus.Approved)
+      insertModule(phase = CohortPhase.Phase0DueDiligence)
+      insertCohortModule()
+
+      assertEquals(
+          listOf(
+              DeliverableSubmissionModel(
+                  category = DeliverableCategory.FinancialViability,
+                  deliverableId = deliverableId,
+                  descriptionHtml = "Description 1",
+                  documents = emptyList(),
+                  dueDate = null,
+                  feedback = null,
+                  internalComment = null,
+                  modifiedTime = Instant.EPOCH,
+                  moduleId = moduleId,
+                  moduleName = "Module 1",
+                  moduleTitle = null,
+                  name = "Deliverable 1",
+                  organizationId = organizationId,
+                  organizationName = "Organization 1",
+                  participantId = participantId,
+                  participantName = participantName,
+                  position = 1,
+                  projectId = projectId,
+                  projectName = "Project 1",
+                  required = false,
+                  sensitive = false,
+                  status = SubmissionStatus.Approved,
+                  submissionId = submissionId,
+                  templateUrl = null,
+                  type = DeliverableType.Document,
+              )),
+          store.fetchDeliverableSubmissions(deliverableId = deliverableId))
+    }
+
+    @Test
+    fun `returns default submission for non-participant project if deliverable and project IDs are specified`() {
+      val organizationId = insertOrganization()
+      val projectId = insertProject()
+      val moduleId = insertModule(phase = CohortPhase.PreScreen)
+      val deliverableId = insertDeliverable()
+
+      assertEquals(
+          listOf(
+              DeliverableSubmissionModel(
+                  category = DeliverableCategory.FinancialViability,
+                  deliverableId = deliverableId,
+                  descriptionHtml = "Description 1",
+                  documents = emptyList(),
+                  dueDate = null,
+                  feedback = null,
+                  internalComment = null,
+                  modifiedTime = null,
+                  moduleId = moduleId,
+                  moduleName = "Module 1",
+                  moduleTitle = null,
+                  name = "Deliverable 1",
+                  organizationId = organizationId,
+                  organizationName = "Organization 1",
+                  participantId = null,
+                  participantName = null,
+                  position = 1,
+                  projectId = projectId,
+                  projectName = "Project 1",
+                  required = false,
+                  sensitive = false,
+                  status = SubmissionStatus.NotSubmitted,
+                  submissionId = null,
+                  templateUrl = null,
+                  type = DeliverableType.Document,
+              )),
+          store.fetchDeliverableSubmissions(deliverableId = deliverableId, projectId = projectId))
+    }
+
+    @Test
     fun `returns due dates according to cohort or project overrides`() {
       val cohortWithDueDate = insertCohort()
       val cohortWithoutDueDate = insertCohort()


### PR DESCRIPTION
When an accelerator console user tried to retrieve submission data for a specific
project and deliverable, we weren't returning it in two situations:

* The project was in a participant in a cohort, but the deliverable was in a
  module in the Pre-Screen or Application phase. The logic for querying
  application deliverables was incorrectly filtering out results from projects
  associated with cohorts.

* The project wasn't in a participant, there was no submission for the
  deliverable, and the deliverable was in a module in a phase other than
  Pre-Screen or Application. This was sometimes the case when browsing
  deliverables for projects that were imported from the Project Data Hub,
  which can have submissions for deliverables that would ordinarily require
  the projects to be in cohort participants. In that case, we should return
  a submission with a default "Not Submitted" status.