### PR TITLE
SW-6285 Reduce number of permanent clusters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -449,7 +449,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
     val DEFAULT_ERROR_MARGIN = BigDecimal(100)
     val DEFAULT_STUDENTS_T = BigDecimal("1.645")
     val DEFAULT_VARIANCE = BigDecimal(40000)
-    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 11
+    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 8
     const val DEFAULT_NUM_TEMPORARY_PLOTS = 3
 
     /** Target planting density to use if not included in zone properties. */

--- a/src/main/resources/db/migration/0300/V325__ReducePermanentPlots.sql
+++ b/src/main/resources/db/migration/0300/V325__ReducePermanentPlots.sql
@@ -1,0 +1,5 @@
+UPDATE tracking.planting_zones
+SET num_permanent_clusters =
+    greatest(
+        1,
+        round((num_permanent_clusters - extra_permanent_clusters) * 0.75) + extra_permanent_clusters);

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -47,17 +47,26 @@
                 const totalPlotsField = document.getElementById(`total-${zoneId}`);
                 const varianceField = document.getElementById(`variance-${zoneId}`);
 
+                const calculateDefaultTotalPlots = () => {
+                    const errorMargin = Number.parseFloat(errorMarginField.value);
+                    const studentsT = Number.parseFloat(studentsTField.value);
+                    const variance = Number.parseFloat(varianceField.value);
+                    const extraPermanent = Number.parseFloat(extraPermanentField.value);
+                    return Math.ceil((studentsT * studentsT) * variance / errorMargin / errorMargin + extraPermanent);
+                };
+
                 const recalculateTotalPlots = () => {
                     const permanentClusters = Number.parseFloat(permanentClustersField.value) || 0;
                     const temporaryPlots = Number.parseFloat(temporaryPlotsField.value) || 0;
-                    const totalPlots = (permanentClusters * 4) + temporaryPlots;
+                    const totalPlots = permanentClusters + temporaryPlots;
 
                     totalPlotsField.innerText = `${totalPlots}`;
                 };
 
                 const recalculateTemporaryPlots = () => {
+                    const defaultTotalPlots = calculateDefaultTotalPlots();
                     const permanentClusters = Number.parseFloat(permanentClustersField.value);
-                    const temporaryPlots = Math.max(1, Math.floor(permanentClusters / 3));
+                    const temporaryPlots = Math.max(1, defaultTotalPlots - permanentClusters);
 
                     temporaryPlotsField.value = `${temporaryPlots}`;
 
@@ -65,12 +74,8 @@
                 };
 
                 const recalculatePermanentClusters = () => {
-                    const errorMargin = Number.parseFloat(errorMarginField.value);
-                    const studentsT = Number.parseFloat(studentsTField.value);
-                    const variance = Number.parseFloat(varianceField.value);
-                    const extraPermanent = Number.parseFloat(extraPermanentField.value);
-                    const permanentClusters =
-                            Math.ceil((studentsT * studentsT) * variance / errorMargin / errorMargin + extraPermanent);
+                    const defaultTotalPlots = calculateDefaultTotalPlots();
+                    const permanentClusters = Math.round(defaultTotalPlots * 0.75);
 
                     permanentClustersField.value = `${permanentClusters}`;
 
@@ -273,7 +278,7 @@
                 </td>
                 <td>
                     <span th:id="|total-${zone.id}|"
-                          th:text="${zone.numPermanentClusters != null || zone.numTemporaryPlots != null ? (zone.numPermanentClusters ?: 0) * 4 + (zone.numTemporaryPlots ?: 0) : ''}">
+                          th:text="${zone.numPermanentClusters != null || zone.numTemporaryPlots != null ? (zone.numPermanentClusters ?: 0) + (zone.numTemporaryPlots ?: 0) : ''}">
                         123
                     </span>
                 </td>

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -426,8 +426,8 @@ internal class PlantingSiteStoreApplyEditTest : PlantingSiteStoreTest() {
               newSite(width = 600),
               newSite(width = 600) {
                 zone {
-                  extraPermanentClusters = 2
-                  numPermanentClusters = 13
+                  extraPermanentClusters = 1
+                  numPermanentClusters = 9
                 }
               })
 


### PR DESCRIPTION
Previously, we used a statistical formula to determine the number of permanent
clusters to assign in an observation, and then we created 1/4 as many temporary
plots as the number of permanent clusters.

We want to change that so that the statistical formula determines the _total_
number of plots, including both permanent and temporary ones, with a 3:1 ratio
between the number of permanent and temporary plots and a minimum of 1 temporary
plot. In effect, we want to subtract temporary plots from the total rather than
adding them to the total, except in cases where the math would leave us with no
temporary plots at all.

The only place we do this math on the fly is in the site editing form in the admin
UI. Update it to use the new calculations. For new planting zones, update the
hardwired default number of permanent clusters.

In addition, update the permanent cluster counts of existing planting zones to
reflect the new formula by reducing them by 25%. The number of temporary plots
stays the same since it was already based on the result of the statistical
formula.