### PR TITLE
Record lower permission check in helper functions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -791,14 +791,14 @@ data class IndividualUser(
 
   /** Returns true if one of the user's global roles allows them to read an organization. */
   private fun isGlobalReader(organizationId: OrganizationId) =
-      isSuperAdmin() ||
+      GlobalRole.SuperAdmin in globalRoles ||
           (isReadOnlyOrHigher() &&
               (parentStore.hasInternalTag(organizationId, InternalTagIds.Accelerator) ||
                   parentStore.hasApplications(organizationId)))
 
   /** Returns true if one of the user's global roles allows them to write to an organization. */
   private fun isGlobalWriter(organizationId: OrganizationId) =
-      isSuperAdmin() ||
+      GlobalRole.SuperAdmin in globalRoles ||
           (isTFExpertOrHigher() &&
               (parentStore.hasInternalTag(organizationId, InternalTagIds.Accelerator) ||
                   parentStore.hasApplications(organizationId)))


### PR DESCRIPTION
Change `isGlobalReader` and `isGlobalWriter` in `IndividualUser` so they don't
record a check for the super-admin global role in the permission check history,
just the check for the less-powerful role that also requires an organization to
have an appropriate internal tag. This will let the permission inversion code
detect cases where we do one of those permission checks and later do something
that requires the super-admin role.