### PR TITLE
Convert CohortModuleStoreTest to RunsAsDatabaseUser

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/RunsAsDatabaseUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/RunsAsDatabaseUser.kt
@@ -94,6 +94,10 @@ interface RunsAsDatabaseUser : RunsAsUser {
           }
         }
       }
+
+      // Allow tests to explicitly call this method if they are doing multiple permission-sensitive
+      // operations in a row where each operation should individually be checked for inversions.
+      permissionChecks.clear()
     }
   }
 }


### PR DESCRIPTION
One of its test methods checks multiple permission-sensitive operations in a row;
add the ability to check for permission inversions in such cases.