### PR TITLE
Add labels to Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,6 @@
 {
     "extends": ["config:base"],
+    "labels": ["bot", "renovate"],
     "packageRules": [
         {
             "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Add the "bot" and "renovate" labels to PRs generated by Renovate so we can easily
differentiate them in tools that work with GitHub.