### PR TITLE
Add missing fields to custom equals methods

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -133,7 +133,6 @@ data class PlantingSiteModel<
         id == other.id &&
         name == other.name &&
         timeZone == other.timeZone &&
-        plantingZones.size == other.plantingZones.size &&
         projectId == other.projectId &&
         areaHa.equalsIgnoreScale(other.areaHa) &&
         boundary.equalsOrBothNull(other.boundary) &&
@@ -141,6 +140,8 @@ data class PlantingSiteModel<
         gridOrigin.equalsOrBothNull(other.gridOrigin) &&
         exteriorPlots.size == other.exteriorPlots.size &&
         exteriorPlots.zip(other.exteriorPlots).all { it.first.equals(it.second, tolerance) } &&
+        plantingSeasons.size == other.plantingSeasons.size &&
+        plantingSeasons.zip(other.plantingSeasons).all { it.first == it.second } &&
         plantingZones.size == other.plantingZones.size &&
         plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -420,6 +420,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
         errorMargin.equalsIgnoreScale(other.errorMargin) &&
         studentsT.equalsIgnoreScale(other.studentsT) &&
         variance.equalsIgnoreScale(other.variance) &&
+        targetPlantingDensity.equalsIgnoreScale(other.targetPlantingDensity) &&
         plantingSubzones.zip(other.plantingSubzones).all { (a, b) -> a.equals(b, tolerance) } &&
         boundary.equalsExact(other.boundary, tolerance)
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -37,7 +37,10 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
               timeZone = timeZone,
           )
       val plantingZoneId =
-          insertPlantingZone(boundary = multiPolygon(2.0), extraPermanentClusters = 1)
+          insertPlantingZone(
+              boundary = multiPolygon(2.0),
+              extraPermanentClusters = 1,
+              targetPlantingDensity = BigDecimal.ONE)
       val plantingSubzoneId = insertPlantingSubzone(boundary = multiPolygon(1.0))
       val monitoringPlotId = insertMonitoringPlot(boundary = polygon(0.1))
       insertMonitoringPlot(
@@ -46,11 +49,13 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
       val season1StartDate = LocalDate.of(2023, 6, 1)
       val season1EndDate = LocalDate.of(2023, 7, 31)
       val plantingSeasonId1 =
-          insertPlantingSeason(startDate = season1StartDate, endDate = season1EndDate)
+          insertPlantingSeason(
+              startDate = season1StartDate, endDate = season1EndDate, timeZone = timeZone)
       val season2StartDate = LocalDate.of(2023, 1, 1)
       val season2EndDate = LocalDate.of(2023, 1, 31)
       val plantingSeasonId2 =
-          insertPlantingSeason(startDate = season2StartDate, endDate = season2EndDate)
+          insertPlantingSeason(
+              startDate = season2StartDate, endDate = season2EndDate, timeZone = timeZone)
 
       val exteriorPlotId = insertMonitoringPlot(boundary = polygon(0.2), plantingSubzoneId = null)
 
@@ -214,7 +219,6 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                           extraPermanentClusters = 0,
                           id = plantingZoneId,
                           name = "Z1",
-                          targetPlantingDensity = BigDecimal.ONE,
                           plantingSubzones =
                               listOf(
                                   PlantingSubzoneModel(


### PR DESCRIPTION
Our custom `equals` methods on `PlantingSiteModel` and `PlantingZoneModel` weren't
testing a couple fields for equality. Add them.