### PR TITLE
SW-6348 Add numeric identifiers to IdentifierGenerator

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -207,7 +207,7 @@ class BatchStore(
             .copy(
                 batchNumber =
                     newModel.batchNumber
-                        ?: identifierGenerator.generateIdentifier(
+                        ?: identifierGenerator.generateTextIdentifier(
                             organizationId, IdentifierType.BATCH, facilityNumber),
                 createdBy = userId,
                 createdTime = now,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -256,7 +256,7 @@ class AccessionStore(
     while (attemptsRemaining-- > 0) {
       val accessionNumber =
           accession.accessionNumber
-              ?: identifierGenerator.generateIdentifier(
+              ?: identifierGenerator.generateTextIdentifier(
                   organizationId, IdentifierType.ACCESSION, facility.facilityNumber!!)
 
       try {

--- a/src/main/resources/db/migration/0300/V327__IdentifierSequencesCascade.sql
+++ b/src/main/resources/db/migration/0300/V327__IdentifierSequencesCascade.sql
@@ -1,0 +1,4 @@
+-- Identifier sequences weren't being deleted when their organizations were deleted.
+ALTER TABLE identifier_sequences DROP CONSTRAINT identifier_sequences_organization_id_fkey;
+
+ALTER TABLE identifier_sequences ADD FOREIGN KEY (organization_id) REFERENCES organizations ON DELETE CASCADE;


### PR DESCRIPTION
In preparation for adding organization-wide plot numbers to monitoring plots, make
`IdentifierGenerator` support returning simple numeric sequence numbers in
addition to its existing compound identifiers.