### PR TITLE
SW-6348 Add plot numbers to monitoring plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/MonitoringPlotModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/MonitoringPlotModel.kt
@@ -13,6 +13,7 @@ data class MonitoringPlotModel(
     val name: String,
     val permanentCluster: Int? = null,
     val permanentClusterSubplot: Int? = null,
+    val plotNumber: Long,
     val sizeMeters: Int,
 ) {
   val areaHa: Double
@@ -27,6 +28,7 @@ data class MonitoringPlotModel(
         name == other.name &&
         permanentCluster == other.permanentCluster &&
         permanentClusterSubplot == other.permanentClusterSubplot &&
+        plotNumber == other.plotNumber &&
         sizeMeters == other.sizeMeters &&
         boundary.equalsExact(other.boundary, tolerance)
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -187,19 +187,6 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 
   /**
-   * Returns the highest-valued monitoring plot name from all the plots that have numeric names.
-   * This is used for generating names for new monitoring plots. If there are no monitoring plots,
-   * returns 0.
-   */
-  fun getMaxPlotName(): Int {
-    return plantingSubzones
-        .flatMap { subzone ->
-          subzone.monitoringPlots.mapNotNull { plot -> plot.name.toIntOrNull() }
-        }
-        .maxOrNull() ?: 0
-  }
-
-  /**
    * Returns a square Polygon of the requested width/height that is completely contained in the zone
    * and does not intersect with an exclusion area.
    *

--- a/src/main/resources/db/migration/0300/V328__MonitoringPlotNumbers.sql
+++ b/src/main/resources/db/migration/0300/V328__MonitoringPlotNumbers.sql
@@ -1,0 +1,31 @@
+ALTER TABLE tracking.monitoring_plots ADD COLUMN organization_id BIGINT REFERENCES organizations ON DELETE CASCADE;
+
+UPDATE tracking.monitoring_plots mp
+SET organization_id = (
+    SELECT ps.organization_id
+    FROM tracking.planting_sites ps
+    WHERE ps.id = mp.planting_site_id
+);
+
+ALTER TABLE tracking.monitoring_plots ALTER COLUMN organization_id SET NOT NULL;
+
+ALTER TABLE tracking.monitoring_plots ADD COLUMN plot_number BIGINT;
+
+WITH plot_numbers AS (
+    SELECT id,
+           row_number() OVER (PARTITION BY organization_id ORDER BY id) AS plot_number
+    FROM tracking.monitoring_plots
+)
+UPDATE tracking.monitoring_plots mp
+SET plot_number = pn.plot_number
+FROM plot_numbers AS pn
+WHERE mp.id = pn.id;
+
+ALTER TABLE tracking.monitoring_plots ALTER COLUMN plot_number SET NOT NULL;
+
+ALTER TABLE tracking.monitoring_plots ADD UNIQUE (organization_id, plot_number);
+
+INSERT INTO identifier_sequences (organization_id, prefix, next_value)
+SELECT organization_id, 'PlotNumber', MAX(plot_number) + 1
+FROM tracking.monitoring_plots
+GROUP BY organization_id;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -362,6 +362,7 @@ COMMENT ON COLUMN tracking.monitoring_plots.modified_time IS 'When the monitorin
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster IS 'If this plot is a candidate to be a permanent monitoring plot, its position in the randomized list of plots for the planting zone. Starts at 1 for each planting zone. There are always 4 plots with a given sequence number in a given zone. If null, this plot is not part of a 4-plot cluster but may still be chosen as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.monitoring_plots.permanent_cluster_subplot IS 'If this plot is a candidate to be a permanent monitoring plot, its ordinal position from 1 to 4 in the 4-plot cluster. 1=southwest, 2=southeast, 3=northeast, 4=northwest.';
 COMMENT ON COLUMN tracking.monitoring_plots.planting_subzone_id IS 'Which planting subzone this monitoring plot is currently part of, if any. May be null if the subzone was edited or removed after the plot was created, or if the plot was created outside the site boundary.';
+COMMENT ON COLUMN tracking.monitoring_plots.plot_number IS 'User-visible identifier of this plot. Plot numbers are sequential and start at 1 for each organization.';
 COMMENT ON COLUMN tracking.monitoring_plots.size_meters IS 'Length in meters of one side of the monitoring plot. Plots are always squares, so for a 30x30m plot, this would be 30.';
 
 COMMENT ON TABLE tracking.observable_conditions IS '(Enum) Conditions that can be observed in a monitoring plot.';

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -191,6 +191,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
             TestSingletons.countryDetector,
             dslContext,
             publisher,
+            IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
             plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -75,6 +75,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
             TestSingletons.countryDetector,
             dslContext,
             publisher,
+            IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
             plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/PlantingSeasonSchedulerTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.PlantingSiteStore
@@ -39,6 +40,7 @@ class PlantingSeasonSchedulerTest : DatabaseTest(), RunsAsUser {
             TestSingletons.countryDetector,
             dslContext,
             eventPublisher,
+            IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             ParentStore(dslContext),
             plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/ReportServiceTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.ReportAlreadySubmittedException
 import com.terraformation.backend.db.ReportLockedException
 import com.terraformation.backend.db.ReportNotLockedException
@@ -138,6 +139,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsUser {
             TestSingletons.countryDetector,
             dslContext,
             publisher,
+            IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             parentStore,
             plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -136,6 +137,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         TestSingletons.countryDetector,
         dslContext,
         TestEventPublisher(),
+        IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
         plantingSeasonsDao,
@@ -1901,7 +1903,9 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
               name = "Ad-hoc plot name",
+              organizationId = inserted.organizationId,
               plantingSiteId = plantingSiteId,
+              plotNumber = 1,
               sizeMeters = MONITORING_PLOT_SIZE_INT,
           ),
           actual?.copy(boundary = null),

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlantingSiteServiceTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.PlantingSiteInUseException
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.mockUser
@@ -29,13 +30,15 @@ import org.springframework.security.access.AccessDeniedException
 class PlantingSiteServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
+  private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val plantingSiteStore by lazy {
     PlantingSiteStore(
-        TestClock(),
+        clock,
         TestSingletons.countryDetector,
         dslContext,
         eventPublisher,
+        IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         ParentStore(dslContext),
         plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.ObservationState
@@ -48,6 +49,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         TestSingletons.countryDetector,
         dslContext,
         eventPublisher,
+        IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         parentStore,
         plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.ShapefileGenerator
@@ -32,6 +33,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
             TestSingletons.countryDetector,
             dslContext,
             TestEventPublisher(),
+            IdentifierGenerator(clock, dslContext),
             monitoringPlotsDao,
             ParentStore(dslContext),
             plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.PlantingSiteStore
@@ -18,12 +19,16 @@ internal abstract class BasePlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
   protected val clock = TestClock()
   protected val eventPublisher = TestEventPublisher()
+  protected val identifierGenerator: IdentifierGenerator by lazy {
+    IdentifierGenerator(clock, dslContext)
+  }
   protected val store: PlantingSiteStore by lazy {
     PlantingSiteStore(
         clock,
         TestSingletons.countryDetector,
         dslContext,
         eventPublisher,
+        identifierGenerator,
         monitoringPlotsDao,
         ParentStore(dslContext),
         plantingSeasonsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.multiPolygon
@@ -31,6 +32,7 @@ class PlantingSiteStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         TestSingletons.countryDetector,
         dslContext,
         eventPublisher,
+        IdentifierGenerator(clock, dslContext),
         monitoringPlotsDao,
         ParentStore(dslContext),
         plantingSeasonsDao,
@@ -68,8 +70,10 @@ class PlantingSiteStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
               name = "ad-hoc-plot",
+              organizationId = inserted.organizationId,
               plantingSiteId = plantingSiteId,
               plantingSubzoneId = null,
+              plotNumber = 1,
               sizeMeters = MONITORING_PLOT_SIZE_INT,
           )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
@@ -27,14 +28,8 @@ internal class PlantingSiteStoreCreateTemporaryTest : BasePlantingSiteStoreTest(
       val plantingSubzoneId = insertPlantingSubzone(boundary = siteBoundary, insertHistory = false)
       val plantingSubzoneHistoryId = insertPlantingSubzoneHistory()
 
-      insertMonitoringPlot(
-          boundary =
-              Turtle(point(0)).makePolygon {
-                north(25)
-                square(25)
-              },
-          name = "17",
-          insertHistory = false)
+      identifierGenerator.generateNumericIdentifier(
+          organizationId, NumericIdentifierType.PlotNumber)
 
       val plotBoundary = Turtle(point(0)).makePolygon { square(25) }
       val newPlotId = store.createTemporaryPlot(plantingSiteId, plantingZoneId, plotBoundary)
@@ -43,15 +38,17 @@ internal class PlantingSiteStoreCreateTemporaryTest : BasePlantingSiteStoreTest(
           MonitoringPlotsRow(
               createdBy = user.userId,
               createdTime = clock.instant,
-              fullName = "Z1-1-18",
+              fullName = "Z1-1-2",
               id = newPlotId,
               isAdHoc = false,
               isAvailable = true,
               modifiedBy = user.userId,
               modifiedTime = clock.instant,
-              name = "18",
+              name = "2",
+              organizationId = organizationId,
               plantingSiteId = plantingSiteId,
               plantingSubzoneId = plantingSubzoneId,
+              plotNumber = 2,
               sizeMeters = MONITORING_PLOT_SIZE_INT,
           )
 
@@ -65,9 +62,9 @@ internal class PlantingSiteStoreCreateTemporaryTest : BasePlantingSiteStoreTest(
               MonitoringPlotHistoriesRecord(
                   createdBy = user.userId,
                   createdTime = Instant.EPOCH,
-                  fullName = "Z1-1-18",
+                  fullName = "Z1-1-2",
                   monitoringPlotId = newPlotId,
-                  name = "18",
+                  name = "2",
                   plantingSiteHistoryId = plantingSiteHistoryId,
                   plantingSiteId = plantingSiteId,
                   plantingSubzoneHistoryId = plantingSubzoneHistoryId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -134,8 +134,9 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                           id = exteriorPlotId,
                           isAdHoc = false,
                           isAvailable = true,
-                          name = "2",
-                          fullName = "2",
+                          name = "3",
+                          fullName = "3",
+                          plotNumber = 3,
                           sizeMeters = 30)),
               plantingZones =
                   listOf(
@@ -154,6 +155,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                                       isAvailable = true,
                                                       name = "1",
                                                       fullName = "Z1-1-1",
+                                                      plotNumber = 1,
                                                       sizeMeters = 30)),
                                       )))))
 
@@ -237,6 +239,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                                   isAvailable = true,
                                                   name = "1",
                                                   fullName = "Z1-1-1",
+                                                  plotNumber = 1,
                                                   sizeMeters = 30)),
                                   )))))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -254,15 +254,18 @@ private constructor(
         val plot =
             MonitoringPlotModel(
                 boundary = rectanglePolygon(size, size, x, y),
-                id = MonitoringPlotId(nextMonitoringPlotId++),
+                id = MonitoringPlotId(nextMonitoringPlotId),
                 isAdHoc = false,
                 isAvailable = isAvailable,
                 fullName = "$fullName-$name",
                 name = name,
                 permanentCluster = cluster,
                 permanentClusterSubplot = subplot,
+                plotNumber = nextMonitoringPlotId,
                 sizeMeters = size,
             )
+
+        nextMonitoringPlotId++
 
         monitoringPlots.add(plot)
         return plot

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -687,6 +687,7 @@ class PlantingZoneModelTest {
         name = "name",
         permanentCluster = permanentCluster,
         permanentClusterSubplot = if (permanentCluster != null) 1 else null,
+        plotNumber = id.toLong(),
         sizeMeters = MONITORING_PLOT_SIZE_INT,
     )
   }


### PR DESCRIPTION
Each monitoring plot now has a "plot number" which is unique within the
planting site's organization.

We plan to use plot numbers in place of plot names, but this code change only
introduces plot numbers; it doesn't change how plot names work. Plot numbers
are not exposed via the API yet.