### PR TITLE
Use new name for Renovate base config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
-    "extends": ["config:base"],
+    "extends": ["config:recommended"],
     "labels": ["bot", "renovate"],
     "packageRules": [
         {


### PR DESCRIPTION
Renovate is changing the name of their old "base" configuration preset to
"recommended" and the original name will stop working at some point.