### PR TITLE
SW-6368 Allow withdrawals from backdated batches

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -577,7 +577,8 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                   createdBy = user.userId,
                   createdTime = withdrawalTime,
                   facilityId = destinationFacilityId,
-                  latestObservedTime = withdrawalTime,
+                  latestObservedTime =
+                      ZonedDateTime.of(2022, 10, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant(),
                   lossRate = 0,
                   modifiedBy = user.userId,
                   modifiedTime = withdrawalTime,
@@ -786,7 +787,10 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
   fun `nursery transfer adds to existing batch if batch number already exists`() {
     val species1Batch1 = batchesDao.fetchOneById(species1Batch1Id)!!
 
-    val destinationFacilityId = insertFacility(type = FacilityType.Nursery, facilityNumber = 2)
+    val destinationTimeZone = ZoneId.of("Asia/Tokyo")
+    val destinationFacilityId =
+        insertFacility(
+            type = FacilityType.Nursery, facilityNumber = 2, timeZone = destinationTimeZone)
 
     val newReadyByDate = LocalDate.of(2000, 1, 2)
     val firstWithdrawalTime = ZonedDateTime.of(2023, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant()
@@ -856,7 +860,9 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
                       facilityId = destinationFacilityId,
                       id = newBatch.id!!,
                       initialBatchId = species1Batch1Id,
-                      latestObservedTime = firstWithdrawalTime,
+                      latestObservedTime =
+                          ZonedDateTime.of(2022, 10, 1, 0, 0, 0, 0, destinationTimeZone)
+                              .toInstant(),
                       modifiedBy = user.userId,
                       modifiedTime = secondWithdrawalTime,
                       organizationId = organizationId,


### PR DESCRIPTION
If a user wants to record a historical nursery batch, they create it with an added
date in the past and a withdrawal date in the past. The system wasn't treating the
withdrawal as a quantity change in that case because it assumed that the seedling
quantities entered by the user when they created the batch were the quantities at
the time the batch was being created, and thus that older withdrawals shouldn't
affect the more recent quantity values supplied by the user.

Change batch creation such that if a batch's added date is in the past (based on
the nursery's time zone), we treat its quantities as having been observed at the
start of that day. Backdated withdrawals will thus be properly deducted from the
batch's quantities.