### PR TITLE
SW-6348 Return plot numbers as names in API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -296,7 +296,7 @@ class AdminPlantingSitesController(
                             mapOf(
                                 "cluster" to cluster,
                                 "id" to "${plot.id}",
-                                "name" to plot.fullName,
+                                "plotNumber" to plot.plotNumber,
                                 "subzone" to subzone.name,
                                 "zone" to zone.name,
                             ) + plotTypeProperty

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -147,17 +147,17 @@ class Messages {
 
   fun batchCsvQuantityInvalid() = getMessage("batchCsvQuantityInvalid")
 
-  fun monitoringPlotNortheastCorner(plotName: String) =
-      getMessage("monitoringPlotNortheastCorner", plotName)
+  fun monitoringPlotNortheastCorner(plotNumber: Long) =
+      getMessage("monitoringPlotNortheastCorner", plotNumber)
 
-  fun monitoringPlotNorthwestCorner(plotName: String) =
-      getMessage("monitoringPlotNorthwestCorner", plotName)
+  fun monitoringPlotNorthwestCorner(plotNumber: Long) =
+      getMessage("monitoringPlotNorthwestCorner", plotNumber)
 
-  fun monitoringPlotSoutheastCorner(plotName: String) =
-      getMessage("monitoringPlotSoutheastCorner", plotName)
+  fun monitoringPlotSoutheastCorner(plotNumber: Long) =
+      getMessage("monitoringPlotSoutheastCorner", plotNumber)
 
-  fun monitoringPlotSouthwestCorner(plotName: String) =
-      getMessage("monitoringPlotSouthwestCorner", plotName)
+  fun monitoringPlotSouthwestCorner(plotNumber: Long) =
+      getMessage("monitoringPlotSouthwestCorner", plotNumber)
 
   fun speciesCsvColumnName(position: Int) = getMessage("speciesCsvColumnName.$position")
 

--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -33,12 +33,14 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
       listOf(
           geometryField("boundary", MONITORING_PLOTS.BOUNDARY),
           timestampField("createdTime", MONITORING_PLOTS.CREATED_TIME),
-          textField("fullName", MONITORING_PLOTS.FULL_NAME),
+          // For backward compatibility; remove once clients aren't searching this anymore.
+          longField("fullName", MONITORING_PLOTS.PLOT_NUMBER),
           idWrapperField("id", MONITORING_PLOTS.ID) { MonitoringPlotId(it) },
           booleanField("isAdHoc", MONITORING_PLOTS.IS_AD_HOC),
           booleanField("isAvailable", MONITORING_PLOTS.IS_AVAILABLE),
           timestampField("modifiedTime", MONITORING_PLOTS.MODIFIED_TIME),
-          textField("name", MONITORING_PLOTS.NAME),
+          // For backward compatibility; remove once clients aren't searching this anymore.
+          longField("name", MONITORING_PLOTS.PLOT_NUMBER),
           coordinateField("northeastLatitude", MONITORING_PLOTS.BOUNDARY, NORTHEAST, LATITUDE),
           coordinateField("northeastLongitude", MONITORING_PLOTS.BOUNDARY, NORTHEAST, LONGITUDE),
           coordinateField("northwestLatitude", MONITORING_PLOTS.BOUNDARY, NORTHWEST, LATITUDE),

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -590,6 +590,7 @@ data class AssignedPlotPayload(
     val plantingSubzoneName: String,
     val plotId: MonitoringPlotId,
     val plotName: String,
+    val plotNumber: Long,
     @Schema(description = "Length of each edge of the monitoring plot in meters.")
     val sizeMeters: Int,
 ) {
@@ -608,7 +609,8 @@ data class AssignedPlotPayload(
       plantingSubzoneId = details.plantingSubzoneId,
       plantingSubzoneName = details.plantingSubzoneName,
       plotId = details.model.monitoringPlotId,
-      plotName = details.plotName,
+      plotName = "${details.plotNumber}",
+      plotNumber = details.plotNumber,
       sizeMeters = details.sizeMeters,
   )
 }
@@ -761,7 +763,7 @@ data class ObservationMonitoringPlotResultsPayload(
       coordinates = model.coordinates.map { ObservationMonitoringPlotCoordinatesPayload(it) },
       isPermanent = model.isPermanent,
       monitoringPlotId = model.monitoringPlotId,
-      monitoringPlotName = model.monitoringPlotName,
+      monitoringPlotName = "${model.monitoringPlotNumber}",
       monitoringPlotNumber = model.monitoringPlotNumber,
       mortalityRate = model.mortalityRate,
       notes = model.notes,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -186,9 +186,9 @@ class ObservationStore(
             OBSERVATION_PLOTS.OBSERVED_TIME,
             OBSERVATION_PLOTS.OBSERVATION_ID,
             OBSERVATION_PLOTS.monitoringPlots.BOUNDARY,
-            OBSERVATION_PLOTS.monitoringPlots.FULL_NAME,
             OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME,
             OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID,
+            OBSERVATION_PLOTS.monitoringPlots.PLOT_NUMBER,
             OBSERVATION_PLOTS.monitoringPlots.SIZE_METERS,
             claimedByNameField,
             completedByNameField,
@@ -207,7 +207,7 @@ class ObservationStore(
               plantingSubzoneId = record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID]!!,
               plantingSubzoneName =
                   record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME]!!,
-              plotName = record[OBSERVATION_PLOTS.monitoringPlots.FULL_NAME]!!,
+              plotNumber = record[OBSERVATION_PLOTS.monitoringPlots.PLOT_NUMBER]!!,
               sizeMeters = record[OBSERVATION_PLOTS.monitoringPlots.SIZE_METERS]!!,
           )
         }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
@@ -16,7 +16,7 @@ data class AssignedPlotDetails(
     val isFirstObservation: Boolean,
     val plantingSubzoneId: PlantingSubzoneId,
     val plantingSubzoneName: String,
-    val plotName: String,
+    val plotNumber: Long,
     val sizeMeters: Int,
 ) {
   fun gpxWaypoints(messages: Messages): List<GpxWaypoint> {
@@ -24,22 +24,22 @@ data class AssignedPlotDetails(
         GpxWaypoint(
             boundary.coordinates[SOUTHWEST].y,
             boundary.coordinates[SOUTHWEST].x,
-            messages.monitoringPlotSouthwestCorner(plotName),
+            messages.monitoringPlotSouthwestCorner(plotNumber),
         ),
         GpxWaypoint(
             boundary.coordinates[SOUTHEAST].y,
             boundary.coordinates[SOUTHEAST].x,
-            messages.monitoringPlotSoutheastCorner(plotName),
+            messages.monitoringPlotSoutheastCorner(plotNumber),
         ),
         GpxWaypoint(
             boundary.coordinates[NORTHEAST].y,
             boundary.coordinates[NORTHEAST].x,
-            messages.monitoringPlotNortheastCorner(plotName),
+            messages.monitoringPlotNortheastCorner(plotNumber),
         ),
         GpxWaypoint(
             boundary.coordinates[NORTHWEST].y,
             boundary.coordinates[NORTHWEST].x,
-            messages.monitoringPlotNorthwestCorner(plotName),
+            messages.monitoringPlotNorthwestCorner(plotNumber),
         ),
     )
   }

--- a/src/main/resources/templates/admin/plantingSiteMap.html
+++ b/src/main/resources/templates/admin/plantingSiteMap.html
@@ -269,7 +269,7 @@
             const plotClickHandler = (e) => {
                 const props = e.features[0].properties;
                 const description =
-                        `<h4>${props.name}</h4>` + [
+                        `<h4>${props.plotNumber}</h4>` + [
                             `ID: ${props.id}`,
                             `Zone: ${props.zone}`,
                             `Subzone: ${props.subzone}`,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -261,7 +261,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   isFirstObservation = false,
                   plantingSubzoneId = plantingSubzoneId1,
                   plantingSubzoneName = "Z1-S1",
-                  plotName = "Z1-S1-1",
+                  plotNumber = 1,
                   sizeMeters = 30,
               ),
               AssignedPlotDetails(
@@ -279,7 +279,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   isFirstObservation = true,
                   plantingSubzoneId = plantingSubzoneId1,
                   plantingSubzoneName = "Z1-S1",
-                  plotName = "Z1-S1-2",
+                  plotNumber = 2,
                   sizeMeters = 30,
               ),
               AssignedPlotDetails(
@@ -301,7 +301,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
                   isFirstObservation = true,
                   plantingSubzoneId = plantingSubzoneId2,
                   plantingSubzoneName = "Z1-S2",
-                  plotName = "Z1-S2-1",
+                  plotNumber = 3,
                   sizeMeters = 30,
               ))
 


### PR DESCRIPTION
In preparation for getting rid of plot names, start returning plot numbers in the
various "plot name" payload fields in the API. This will decouple getting rid of
plot names on the server side from updating clients to use plot numbers instead.