### PR TITLE
SW-6370 Updated list users permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -348,7 +348,7 @@ data class IndividualUser(
   }
 
   override fun canListOrganizationUsers(organizationId: OrganizationId) =
-      isManagerOrHigher(organizationId) || isGlobalReader(organizationId)
+      isMember(organizationId) || isGlobalReader(organizationId)
 
   override fun canListReports(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1072,8 +1072,10 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         org1Id,
         listFacilities = true,
+        listOrganizationUsers = true,
         readOrganization = true,
         readOrganizationSelf = true,
+        readOrganizationUser = true,
         removeOrganizationSelf = true,
     )
 


### PR DESCRIPTION
Allow contributor to list users. Contributors will be able to view the list of organization users, without the ability to add and edit any of them. This will also fixed some issues with contributors not being able to view batch edit history correctly.