### PR TITLE
Make deploy script fail if any step fails

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 mkdir -p ~/.ssh
 echo "$SSH_KEY" > ~/.ssh/key


### PR DESCRIPTION
The deploy script wasn't exiting with a nonzero exit code if the command
to list EC2 instances was failing. Set the "pipefail" option to fix that.