### PR TITLE
SW-6368 Fix withdrawal backfill migration

### DIFF
--- a/src/main/resources/db/migration/0300/V329__BackfillWholeBatchWithdrawals.sql
+++ b/src/main/resources/db/migration/0300/V329__BackfillWholeBatchWithdrawals.sql
@@ -27,6 +27,11 @@ CREATE TEMPORARY TABLE backfill_withdrawals AS
        FROM nursery.batch_quantity_history bqh
        WHERE bqh.batch_id = b.id
        AND bqh.version > 1
+    )
+    AND 1 = (
+        SELECT COUNT(*)
+        FROM nursery.batch_withdrawals bw2
+        WHERE b.id = bw2.batch_id
     );
 
 INSERT INTO nursery.batch_quantity_history (


### PR DESCRIPTION
The backfill migration from commit b2cf7e7 wasn't handling cases where a user
retried a full-batch withdrawal after seeing the quantity not change the first
time they withdrew. There were no cases of this in the production database but
there were some in the staging database, which caused the migration to fail
because it tried to insert duplicate quantity history entries.