### PR TITLE
SW-6387 Include filenames in upload failure reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/SubmissionService.kt
@@ -176,6 +176,7 @@ class SubmissionService(
               documentStore,
               originalName,
               folder.toString(),
+              fileName,
               e)
         }
 
@@ -275,6 +276,7 @@ class SubmissionService(
               documentStore,
               originalName,
               folder.toString(),
+              submissionDocument.name,
               e)
         }
       }
@@ -355,6 +357,7 @@ class SubmissionService(
       documentStore: DocumentStore,
       originalName: String?,
       documentStoreFolder: String? = null,
+      fileName: String? = null,
       exception: Exception? = null,
   ): Nothing {
     eventPublisher.publishEvent(
@@ -365,6 +368,7 @@ class SubmissionService(
             documentStore,
             originalName,
             documentStoreFolder,
+            fileName,
             exception))
 
     if (exception != null) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverableDocumentUploadFailedEvent.kt
@@ -18,6 +18,11 @@ data class DeliverableDocumentUploadFailedEvent(
     val originalName: String?,
     /** Which folder on the document store would have been used, or null if none is configured. */
     val documentStoreFolder: String? = null,
+    /**
+     * The name of the file we tried to create, or null if we didn't get as far as attempting to
+     * save the file.
+     */
+    val fileName: String? = null,
     /** Exception that caused the failure, if any. */
     val exception: Throwable? = null,
 ) {

--- a/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
@@ -44,6 +44,7 @@ class FailureReportingService(
             
             Service: ${event.documentStore}
             Folder: ${event.documentStoreFolder ?: "Not configured"}
+            File: ${event.fileName ?: "N/A"}
             
             System error: ${event.exception}
           """

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SubmissionServiceTest.kt
@@ -177,6 +177,7 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
           FailureReason.CouldNotUpload,
           DocumentStore.Google,
           googleDriveFolder,
+          "Deliverable 1_1970-01-01_${fileNaming}_description.doc",
           ProjectDocumentStorageFailedException(projectId, cause = exception))
     }
 
@@ -192,6 +193,7 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
         reason: FailureReason,
         documentStore: DocumentStore = DocumentStore.Google,
         folder: String? = null,
+        fileName: String? = null,
         exception: E? = null,
     ) {
       assertThrows<E> { receiveDocument() }
@@ -200,7 +202,14 @@ class SubmissionServiceTest : DatabaseTest(), RunsAsUser {
 
       eventPublisher.assertEventPublished(
           DeliverableDocumentUploadFailedEvent(
-              deliverableId, projectId, reason, documentStore, originalName, folder, cause))
+              deliverableId,
+              projectId,
+              reason,
+              documentStore,
+              originalName,
+              folder,
+              fileName,
+              cause))
     }
 
     private fun receiveDocument(description: String = "description"): SubmissionDocumentId =


### PR DESCRIPTION
When we generate a support issue for a failed deliverable document upload, include
the filename we tried to create. This will make it easier to diagnose future
failures involving invalid filenames.