### PR TITLE
Stop accessing project in task execution phase

### DIFF
--- a/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/terraformation/gradle/RenderMjmlTask.kt
@@ -10,34 +10,52 @@ import java.io.File
 import java.nio.file.Files
 import javax.inject.Inject
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileType
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.ChangeType
 import org.gradle.work.FileChange
 import org.gradle.work.InputChanges
 
 /** Renders MJML email bodies to FreeMarker templates that can be evaluated at runtime. */
-abstract class RenderMjmlTask : DefaultTask() {
+abstract class RenderMjmlTask
+@Inject
+constructor(
+    layout: ProjectLayout,
+    private val objectFactory: ObjectFactory,
+    sourceSets: SourceSetContainer,
+) : DefaultTask() {
+  private val nodeExtension = NodeExtension[project]
+  private val resourcesSourceDir =
+      sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).resources.srcDirs.first()
+  private val resourcesBuildDir = layout.buildDirectory.dir("resources/main").get().asFile
+
   @get:IgnoreEmptyDirectories
   @get:InputFiles
   @get:SkipWhenEmpty
-  val mjmlFiles =
-      project.files(
-          project.fileTree("src/main/resources/templates/email") { include("**/body.ftlh.mjml") })
+  val mjmlFiles: ConfigurableFileCollection =
+      objectFactory
+          .fileCollection()
+          .from(
+              objectFactory
+                  .fileTree()
+                  .from(resourcesSourceDir.resolve("templates/email"))
+                  .include("**/body.ftlh.mjml"))
 
-  @get:OutputDirectory
-  val outputDir = project.layout.buildDirectory.dir("resources/main/templates/email")
-
-  @get:Inject abstract val objects: ObjectFactory
+  @get:OutputDirectory val outputDir = resourcesBuildDir.resolve("templates/email")
 
   init {
     group = "build"
     description = "Renders MJML templates."
+    @Suppress("LeakingThis") // dependsOn is non-final, but that's harmless here.
     dependsOn(YarnInstallTask.NAME)
   }
 
@@ -59,11 +77,11 @@ abstract class RenderMjmlTask : DefaultTask() {
   /** Runs Yarn to format a single MJML file. */
   private fun renderMjmlFile(mjmlFile: File, targetFile: File) {
     Files.createDirectories(targetFile.toPath().parent)
-    val runner = objects.newInstance(YarnExecRunner::class.java)
+    val runner = objectFactory.newInstance(YarnExecRunner::class.java)
 
     runner.executeYarnCommand(
-        project.objects.newInstance(DefaultProjectApiHelper::class.java),
-        NodeExtension[project],
+        objectFactory.newInstance(DefaultProjectApiHelper::class.java),
+        nodeExtension,
         NodeExecConfiguration(
             listOf(
                 "mjml", "--config.useMjmlConfigOptions", "true", "-o", "$targetFile", "$mjmlFile")),
@@ -86,12 +104,8 @@ abstract class RenderMjmlTask : DefaultTask() {
 
     val targetRelativeToResourcesDir =
         File(change.file.path.substring(0, change.file.path.length - mjmlExtension.length))
-            .relativeTo(project.projectDir.resolve("src/main/resources"))
+            .relativeTo(resourcesSourceDir)
 
-    return project.layout.buildDirectory
-        .get()
-        .asFile
-        .resolve("resources/main")
-        .resolve(targetRelativeToResourcesDir)
+    return resourcesBuildDir.resolve(targetRelativeToResourcesDir)
   }
 }


### PR DESCRIPTION
Gradle 8.12 adds a deprecation warning to tell us that accessing the current
project's configuration during the execution phase of a task will stop working in
a future Gradle version. Update our custom task classes to stop doing that.