### PR TITLE
SW-6402 Return HTTP 409 on species name conflict

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -573,7 +573,7 @@ class SpeciesStore(
    * [SpeciesService.updateSpecies] instead of this.
    *
    * @return The updated row. This is a new object; the input row is not modified.
-   * @throws DuplicateKeyException The requested name was already in use.
+   * @throws ScientificNameExistsException The requested name was already in use.
    * @throws SpeciesNotFoundException No species with the requested ID exists.
    */
   fun updateSpecies(model: ExistingSpeciesModel): ExistingSpeciesModel {
@@ -605,7 +605,11 @@ class SpeciesStore(
             woodDensityLevelId = model.woodDensityLevel,
         )
 
-    speciesDao.update(updatedRow)
+    try {
+      speciesDao.update(updatedRow)
+    } catch (e: DuplicateKeyException) {
+      throw ScientificNameExistsException(model.scientificName)
+    }
 
     updateEcosystemTypes(model.id, model.ecosystemTypes)
     updateGrowthForms(model.id, model.growthForms)

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -398,6 +398,22 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `updateSpecies throws exception if scientific name exists in organization`() {
+    insertSpecies(scientificName = "Test 1")
+    val speciesId = insertSpecies(scientificName = "Test 2")
+
+    assertThrows<ScientificNameExistsException> {
+      store.updateSpecies(
+          ExistingSpeciesModel(
+              createdTime = Instant.EPOCH,
+              id = speciesId,
+              modifiedTime = Instant.EPOCH,
+              organizationId = organizationId,
+              scientificName = "Test 1"))
+    }
+  }
+
+  @Test
   fun `updateSpecies throws exception if user has no permission to update species`() {
     every { user.canUpdateSpecies(any()) } returns false
 


### PR DESCRIPTION
If the user tries to create a species whose scientific name already exists in the
organization, the server returns HTTP 409 (Conflict). But it wasn't catching the
case where a user tries to rename a species and the requested name already exists.
Return HTTP 409 in that case as well.