### PR TITLE
SW-6344 Remove unused monitoring plot edit calculation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking.edit
 
-import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.AnyPlantingSubzoneModel
@@ -83,10 +82,6 @@ class PlantingSiteEditCalculatorV1(
 
           PlantingZoneEdit.Delete(
               existingModel = existingZone,
-              monitoringPlotsRemoved =
-                  existingZone.plantingSubzones
-                      .flatMap { it.monitoringPlots.map { plot -> plot.id } }
-                      .toSet(),
               plantingSubzoneEdits = plantingSubzoneEdits,
           )
         }
@@ -144,19 +139,12 @@ class PlantingSiteEditCalculatorV1(
                     existingUsableBoundary
                         .difference(desiredUsableBoundary)
                         .toNormalizedMultiPolygon()
-                val monitoringPlotsRemoved: Set<MonitoringPlotId> =
-                    existingZone.plantingSubzones
-                        .flatMap { it.monitoringPlots }
-                        .filter { it.boundary.coveragePercent(removedRegion) > 0.00001 }
-                        .map { it.id }
-                        .toSet()
 
                 PlantingZoneEdit.Update(
                     addedRegion = addedRegion,
                     areaHaDifference = areaHaDifference,
                     desiredModel = desiredZone,
                     existingModel = existingZone,
-                    monitoringPlotsRemoved = monitoringPlotsRemoved,
                     numPermanentClustersToAdd = newClustersThatFitInAddedRegion,
                     plantingSubzoneEdits = subzoneEdits,
                     removedRegion = removedRegion,
@@ -244,7 +232,6 @@ class PlantingSiteEditCalculatorV1(
         existingSite.plantingZones.map { existingZone ->
           PlantingZoneEdit.Delete(
               existingModel = existingZone,
-              monitoringPlotsRemoved = emptySet(),
               plantingSubzoneEdits =
                   existingZone.plantingSubzones.map { existingSubzone ->
                     PlantingSubzoneEdit.Delete(existingSubzone)

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking.edit
 
-import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.tracking.model.AnyPlantingZoneModel
 import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.util.equalsIgnoreScale
@@ -36,12 +35,6 @@ sealed interface PlantingZoneEdit {
   val existingModel: ExistingPlantingZoneModel?
 
   /**
-   * IDs of existing monitoring plots that are no longer contained in the zone's usable area and
-   * should be removed.
-   */
-  val monitoringPlotsRemoved: Set<MonitoringPlotId>
-
-  /**
    * Number of permanent clusters to add to the zone. These clusters must all be located in
    * [addedRegion].
    */
@@ -62,7 +55,6 @@ sealed interface PlantingZoneEdit {
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
           desiredModel == other.desiredModel &&
           existingModel == other.existingModel &&
-          monitoringPlotsRemoved == other.monitoringPlotsRemoved &&
           numPermanentClustersToAdd == other.numPermanentClustersToAdd &&
           plantingSubzoneEdits.size == other.plantingSubzoneEdits.size &&
           plantingSubzoneEdits.zip(other.plantingSubzoneEdits).all { (edit, otherEdit) ->
@@ -83,9 +75,6 @@ sealed interface PlantingZoneEdit {
     override val existingModel: ExistingPlantingZoneModel?
       get() = null
 
-    override val monitoringPlotsRemoved: Set<MonitoringPlotId>
-      get() = emptySet()
-
     override val numPermanentClustersToAdd: Int
       get() = 0
 
@@ -95,7 +84,6 @@ sealed interface PlantingZoneEdit {
 
   data class Delete(
       override val existingModel: ExistingPlantingZoneModel,
-      override val monitoringPlotsRemoved: Set<MonitoringPlotId>,
       override val plantingSubzoneEdits: List<PlantingSubzoneEdit.Delete>,
   ) : PlantingZoneEdit {
     override val areaHaDifference: BigDecimal
@@ -119,7 +107,6 @@ sealed interface PlantingZoneEdit {
       override val areaHaDifference: BigDecimal,
       override val desiredModel: AnyPlantingZoneModel,
       override val existingModel: ExistingPlantingZoneModel,
-      override val monitoringPlotsRemoved: Set<MonitoringPlotId>,
       override val numPermanentClustersToAdd: Int,
       override val plantingSubzoneEdits: List<PlantingSubzoneEdit>,
       override val removedRegion: MultiPolygon,

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking.edit
 
-import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
@@ -68,7 +67,6 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("12.5"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * (750 - 500) / 500,
                         plantingSubzoneEdits =
@@ -97,7 +95,6 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("5.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
                         plantingSubzoneEdits =
@@ -135,7 +132,6 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("10.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 700,
                         plantingSubzoneEdits =
@@ -170,7 +166,6 @@ class PlantingSiteEditCalculatorV1Test {
                 listOf(
                     PlantingZoneEdit.Delete(
                         existingModel = existing.plantingZones[1],
-                        monitoringPlotsRemoved = emptySet(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(
@@ -208,7 +203,6 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("-12.5"),
                         desiredModel = desired.plantingZones[1],
                         existingModel = existing.plantingZones[1],
-                        monitoringPlotsRemoved = emptySet(),
                         numPermanentClustersToAdd = 0,
                         plantingSubzoneEdits =
                             listOf(
@@ -271,48 +265,6 @@ class PlantingSiteEditCalculatorV1Test {
   }
 
   @Test
-  fun `removes monitoring plots that overlap with added exclusion area`() {
-    val existing = existingSite {
-      zone {
-        subzone {
-          plot()
-          plot()
-        }
-      }
-    }
-    val desired = newSite { exclusion = rectangle(1) }
-
-    assertEquals(
-        setOf(MonitoringPlotId(1)),
-        calculateSiteEdit(existing, desired)
-            .plantingZoneEdits
-            .firstOrNull()
-            ?.monitoringPlotsRemoved,
-        "Monitoring plots removed")
-  }
-
-  @Test
-  fun `removes monitoring plots that no longer lie in site`() {
-    val existing = existingSite {
-      zone {
-        subzone {
-          plot()
-          plot()
-        }
-      }
-    }
-    val desired = newSite(x = 1)
-
-    assertEquals(
-        setOf(MonitoringPlotId(1)),
-        calculateSiteEdit(existing, desired)
-            .plantingZoneEdits
-            .firstOrNull()
-            ?.monitoringPlotsRemoved,
-        "Monitoring plots removed")
-  }
-
-  @Test
   fun `returns empty list of edits if nothing changed`() {
     val existing = existingSite()
     val desired = existing.toNew()
@@ -352,7 +304,6 @@ class PlantingSiteEditCalculatorV1Test {
                 listOf(
                     PlantingZoneEdit.Delete(
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotsRemoved = emptySet(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(
@@ -360,7 +311,6 @@ class PlantingSiteEditCalculatorV1Test {
                     ),
                     PlantingZoneEdit.Delete(
                         existingModel = existing.plantingZones[1],
-                        monitoringPlotsRemoved = emptySet(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(


### PR DESCRIPTION
The planting site edit calculator was returning a list of monitoring plots to
remove, but that list was never actually used for anything; plots are deleted by
different logic in `PlantingSiteStore`, and the upcoming changes to planting
site editing will deal with plots in a completely different way. Remove the
unused field.