### PR TITLE
Explicitly set OpenAPI version

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -99,6 +99,8 @@ management:
 # and serving real requests; there are also settings in application-apidoc.yaml that are used when
 # generating the API documentation from the command line.
 springdoc:
+  api-docs:
+    version: "openapi_3_0"
   # Limit the package scan to just the API classes. Otherwise the schema will include a bunch of
   # internal data model classes we don't actually expose to clients.
   packages-to-scan:


### PR DESCRIPTION
New versions of springdoc-openapi default to generating OpenAPI 3.1 schemas, which
currently cause terraware-web's type generator to produce incorrect TypeScript
types. Configure the server to generate OpenAPI 3.0 schemas for now.