### PR TITLE
Migration to convert remaining 25-meter plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -48,6 +48,7 @@ class AdminController(
     model.addAttribute(
         "canMigrateAcceleratorProjectDetails", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canAddAnyOrganizationUser", currentUser().canAddAnyOrganizationUser())
+    model.addAttribute("canConvertPlots", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canCreateDeviceManager", currentUser().canCreateDeviceManager())
     model.addAttribute("canDeleteUsers", currentUser().canDeleteUsers())
     model.addAttribute("canImportGlobalSpeciesData", currentUser().canImportGlobalSpeciesData())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
@@ -18,6 +20,7 @@ import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.file.useAndDelete
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.time.DatabaseBackedClock
@@ -45,6 +48,7 @@ import java.time.LocalDate
 import java.time.Month
 import java.time.format.TextStyle
 import java.util.Locale
+import org.jooq.DSLContext
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.Polygon
@@ -70,6 +74,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 class AdminPlantingSitesController(
     private val clock: DatabaseBackedClock,
     private val countriesDao: CountriesDao,
+    private val dslContext: DSLContext,
     private val mapboxService: MapboxService,
     private val objectMapper: ObjectMapper,
     private val observationService: ObservationService,
@@ -78,6 +83,7 @@ class AdminPlantingSitesController(
     private val organizationStore: OrganizationStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val plantingSiteImporter: PlantingSiteImporter,
+    private val systemUser: SystemUser,
 ) {
   private val log = perClassLogger()
 
@@ -729,6 +735,37 @@ class AdminPlantingSitesController(
     }
 
     return redirectToPlantingSite(plantingSiteId)
+  }
+
+  @PostMapping("/convert25")
+  @RequireGlobalRole([GlobalRole.SuperAdmin])
+  fun convert25MeterPlots(redirectAttributes: RedirectAttributes): String {
+    val plantingSiteIds =
+        dslContext
+            .selectDistinct(MONITORING_PLOTS.PLANTING_SITE_ID)
+            .from(MONITORING_PLOTS)
+            .where(MONITORING_PLOTS.SIZE_METERS.eq(25))
+            .and(MONITORING_PLOTS.PERMANENT_CLUSTER.isNotNull)
+            .fetch(MONITORING_PLOTS.PLANTING_SITE_ID.asNonNullable())
+
+    val messages = mutableListOf<String>()
+
+    systemUser.run {
+      plantingSiteIds.forEach { plantingSiteId ->
+        try {
+          plantingSiteStore.convert25MeterClusters(plantingSiteId)
+          messages.add("Converted $plantingSiteId")
+        } catch (e: Exception) {
+          log.warn("Failed to convert $plantingSiteId", e)
+          messages.add("Failed to convert $plantingSiteId: $e")
+        }
+      }
+    }
+
+    redirectAttributes.successMessage = "Finished scanning planting sites"
+    redirectAttributes.successDetails = messages
+
+    return redirectToAdminHome()
   }
 
   private fun redirectToAdminHome() = "redirect:/admin/"

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/UnusedSquareFinder.kt
@@ -116,10 +116,10 @@ class UnusedSquareFinder(
   /**
    * Returns true if a polygon is sufficiently covered by the zone geometry. If an edge of the site
    * geometry is axis-aligned, rounding errors can cause a polygon on the edge to test as not
-   * completely covered by the zone. So instead we test that the polygon is at least 99.99% covered.
+   * completely covered by the zone. So instead we test that the polygon is at least 99.9% covered.
    */
   private fun coveredByZone(polygon: Geometry): Boolean {
-    return polygon.nearlyCoveredBy(zoneGeometry)
+    return polygon.nearlyCoveredBy(zoneGeometry, 99.9)
   }
 
   /**

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -185,6 +185,20 @@
             <input type="submit" value="Update"/>
         </form>
     </th:block>
+
+    <th:block th:if="${canConvertPlots}">
+        <h3>Convert 25-meter permanent clusters</h3>
+
+        <p>
+            This is a one-time operation to convert clusters of 25-meter permanent monitoring plots
+            to 30-meter plots on any planting sites that haven't had observations since the
+            introduction of 30-meter plots.
+        </p>
+
+        <form method="POST" action="/admin/convert25">
+            <input type="submit" value="Convert"/>
+        </form>
+    </th:block>
 </details>
 
 <details id="sendTestEmail" class="section" th:if="${canSendTestEmail}">


### PR DESCRIPTION
Add a migration to the admin UI to replace the remaining permanent clusters of
25-meter monitoring plots with 30-meter plots.

This will only affect sites that haven't had observations since the introduction
of 30-meter plots, since the conversion also happens when an observation starts.

To account for very large test sites where floating-point inaccuracy becomes more
significant in coordinate calculations and can cause replacement plots to appear
to fall slightly outside the boundary of the old cluster, relax the "is this plot
located inside the search boundary?" check slightly, from 99.99% coverage to 99.9%.

Once this has been run, we can start to remove support for multi-plot clusters,
which will mean we don't need to account for them as we add support for more
flexible site map editing.