### PR TITLE
Fixed planting site summaries null-pointer exception

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -111,7 +111,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
         }
 
     val numObservations = completedObservations.size
-    val depth = max(0, limit?.let { min(it, numObservations) } ?: numObservations)
+    val depth = max(1, limit?.let { min(it, numObservations) } ?: numObservations)
 
     // Remove observations one at a time, to build a historical summary
     return List(depth) {
@@ -141,7 +141,9 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
     val observationsBySubzone =
         completedObservations
-            .flatMap { observation -> observation.plantingZones.flatMap { it.plantingSubzones } }
+            .flatMap { it.plantingZones }
+            .flatMap { it.plantingSubzones }
+            .filter { it.completedTime != null }
             .groupBy { it.plantingSubzoneId }
 
     val latestPerSubzone =


### PR DESCRIPTION
I was not successful in reproducing this issue, but I suspect that a completed observation can somehow contain a subzone without a completed time. This does not solve the root cause but can alleviate the symptoms for now. 

Logs of error:
```
java.lang.NullPointerException: null
	at com.terraformation.backend.tracking.db.ObservationResultsStore.plantingSiteSummary(ObservationResultsStore.kt:148)
	at com.terraformation.backend.tracking.db.ObservationResultsStore.fetchSummariesForPlantingSite(ObservationResultsStore.kt:119)
	at com.terraformation.backend.tracking.db.ObservationResultsStore.fetchSummariesForPlantingSite$default(ObservationResultsStore.kt:103)
	at com.terraformation.backend.tracking.api.ObservationsController.listObservationSummaries(ObservationsController.kt:189)
	at com.terraformation.backend.tracking.api.ObservationsController.listObservationSummaries$default(ObservationsController.kt:178)
```
