### PR TITLE
Add zipProportionally function

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/ZipProportionally.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/ZipProportionally.kt
@@ -1,0 +1,50 @@
+package com.terraformation.backend.tracking.edit
+
+/**
+ * Returns a list of elements pulled from two sources with a specified proportion of elements coming
+ * from each source. This is done in a round-robin-style fashion that attempts to spread each
+ * source's elements as evenly as possible across the returned list.
+ *
+ * For example, if the number of elements is 13 and the fraction from the first source is 0.75, the
+ * result would be `FFFSFFFSFFFSF` (where F and S mean the first and second sources).
+ *
+ * @param numElements Total number of elements to pull from both sources combined. The returned list
+ *   will always have this many elements.
+ * @param fractionFromFirstSource Value between 0 and 1 specifying how many elements should come
+ *   from the first source.
+ * @param firstSource Returns an element from the first source. Its parameter is the index in the
+ *   combined list.
+ * @param secondSource Returns an element from the second source. Its parameter is the index in the
+ *   combined list.
+ */
+fun <T> zipProportionally(
+    numElements: Int,
+    fractionFromFirstSource: Double,
+    firstSource: (Int) -> T,
+    secondSource: (Int) -> T,
+): List<T> {
+  if (fractionFromFirstSource < 0.0 || fractionFromFirstSource > 1.0) {
+    throw IllegalArgumentException("Fraction must be between 0 and 1")
+  }
+  if (numElements < 0) {
+    throw IllegalArgumentException("Number of elements must not be negative")
+  }
+
+  // This works by awarding "credits" to each source when the OTHER source is chosen, and picking
+  // whichever source currently has the most credits. The less-chosen source will eventually build
+  // up enough credits to be chosen next.
+
+  val fractionFromSecondSource = 1.0 - fractionFromFirstSource
+  var firstSourceCredits = fractionFromFirstSource
+  var secondSourceCredits = fractionFromSecondSource
+
+  return List(numElements) { index ->
+    if (firstSourceCredits >= secondSourceCredits) {
+      secondSourceCredits += fractionFromSecondSource
+      firstSource(index)
+    } else {
+      firstSourceCredits += fractionFromFirstSource
+      secondSource(index)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/ZipProportionallyTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/ZipProportionallyTest.kt
@@ -1,0 +1,70 @@
+package com.terraformation.backend.tracking.edit
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ZipProportionallyTest {
+  @Test
+  fun `does simple round-robin when fraction is half`() {
+    assertEquals(
+        listOf("F", "S", "F", "S", "F", "S"),
+        zipProportionally(6, 0.5, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `only pulls from first source when fraction is 1`() {
+    assertEquals(
+        List(1000) { "F" },
+        zipProportionally(1000, 1.0, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `only pulls from second source when fraction is 0`() {
+    assertEquals(
+        List(1000) { "S" },
+        zipProportionally(1000, 0.0, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `interleaves elements from both sources starting with second source when fraction is less than half`() {
+    assertEquals(
+        listOf("S", "S", "F", "S", "S", "F", "S"),
+        zipProportionally(7, 1.0 / 3.0, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `interleaves elements from both sources starting with first source when fraction is greater than half`() {
+    assertEquals(
+        listOf("F", "F", "F", "S", "F", "F", "F", "S", "F"),
+        zipProportionally(9, 0.75, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `only picks elements from one source if number of elements is too low for fraction`() {
+    assertEquals(
+        listOf("F", "F", "F", "F", "F"),
+        zipProportionally(5, 0.9, { "F" }, { "S" }),
+    )
+  }
+
+  @Test
+  fun `throws exception if fraction is out of bounds`() {
+    assertThrows<IllegalArgumentException>("Less than 0") {
+      zipProportionally(10, -0.1, { "F" }, { "S" })
+    }
+    assertThrows<IllegalArgumentException>("Greater than 1") {
+      zipProportionally(10, 1.1, { "F" }, { "S" })
+    }
+  }
+
+  @Test
+  fun `throws exception if element count is negative`() {
+    assertThrows<IllegalArgumentException> { zipProportionally(-1, 0.1, { "F" }, { "S" }) }
+  }
+}


### PR DESCRIPTION
The new planting site editing code will support changing planting zone boundaries
and will assign monitoring plots to the newly-added area based on how big a
fraction of the zone's total area is newly added. This will require constructing
a list of monitoring plots that come from the old and new areas in the right
proportions.

The algorithm for proportional allocation isn't specific to monitoring plots, so
add a general-purpose function that zips together elements from two sources with
a specified ratio between the two. The term "zip" is already used in the Kotlin
standard library for the concept of interleaving elements from two lists.