### PR TITLE
SW-6422 Do not re-fetch projectAcceleratorDetails variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ProjectAcceleratorDetailsService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ProjectAcceleratorDetailsService.kt
@@ -20,6 +20,16 @@ class ProjectAcceleratorDetailsService(
     return projectAcceleratorDetailsStore.fetchOneById(projectId, variableValues)
   }
 
+  fun fetchForProjectIds(
+      projectIds: Collection<ProjectId>
+  ): Map<ProjectId, ProjectAcceleratorDetailsModel> {
+    return projectAcceleratorDetailsStore
+        .fetch(PROJECTS.ID.`in`(projectIds)) {
+          acceleratorProjectVariableValuesService.fetchValues(it)
+        }
+        .associateBy { it.projectId }
+  }
+
   /** Returns accelerator details for projects that are assigned to cohorts. */
   fun fetchAllParticipantProjectDetails(): List<ProjectAcceleratorDetailsModel> {
     return projectAcceleratorDetailsStore.fetch(COHORTS.ID.isNotNull()) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/DeliverablesController.kt
@@ -104,10 +104,11 @@ class DeliverablesController(
         deliverableStore.fetchDeliverableSubmissions(
             organizationId, participantId, projectId, moduleId = moduleId)
 
+    val projectIds = models.map { it.projectId }.toSet()
+    val acceleratorDetails = projectAcceleratorDetailsService.fetchForProjectIds(projectIds)
+
     return ListDeliverablesResponsePayload(
-        models.map {
-          ListDeliverablesElement(it, projectAcceleratorDetailsService.fetchOneOrNull(it.projectId))
-        })
+        models.map { ListDeliverablesElement(it, acceleratorDetails[it.projectId]) })
   }
 
   @ApiResponse200


### PR DESCRIPTION
This fixes one inefficiency, that is caused by fetching variables per project, even if there are multiple record referencing the same projects, for documents and deliverables.

This is not a long-term solution, but a temporary one until we can determine an efficient query for arbitrary variables. 