### PR TITLE
SW-6444 Track zone boundary modification time

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/PlantingZonesTable.kt
@@ -32,6 +32,7 @@ class PlantingZonesTable(tables: SearchTables) : SearchTable() {
   override val fields: List<SearchField> =
       listOf(
           geometryField("boundary", PLANTING_ZONES.BOUNDARY),
+          timestampField("boundaryModifiedTime", PLANTING_ZONES.BOUNDARY_MODIFIED_TIME),
           timestampField("createdTime", PLANTING_ZONES.CREATED_TIME),
           idWrapperField("id", PLANTING_ZONES.ID) { PlantingZoneId(it) },
           timestampField("modifiedTime", PLANTING_ZONES.MODIFIED_TIME),

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -199,6 +199,11 @@ data class PlantingZonePayload(
     @Schema(description = "Area of planting zone in hectares.") //
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
+    @Schema(
+        description =
+            "When the boundary of this planting zone was last modified. Modifications of other " +
+                "attributes of the planting zone do not cause this timestamp to change.")
+    val boundaryModifiedTime: Instant,
     val id: PlantingZoneId,
     val name: String,
     val plantingSubzones: List<PlantingSubzonePayload>,
@@ -209,6 +214,7 @@ data class PlantingZonePayload(
   ) : this(
       model.areaHa,
       model.boundary,
+      model.boundaryModifiedTime,
       model.id,
       model.name,
       model.plantingSubzones.map { PlantingSubzonePayload(it) },

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.nearlyCoveredBy
 import java.math.BigDecimal
 import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import org.geotools.geometry.jts.JTS
@@ -29,6 +30,7 @@ data class PlantingSiteModel<
     PSID : PlantingSiteId?,
     PZID : PlantingZoneId?,
     PSZID : PlantingSubzoneId?,
+    TIMESTAMP : Instant?,
 >(
     val areaHa: BigDecimal? = null,
     val boundary: MultiPolygon?,
@@ -47,7 +49,7 @@ data class PlantingSiteModel<
     val name: String,
     val organizationId: OrganizationId,
     val plantingSeasons: List<ExistingPlantingSeasonModel> = emptyList(),
-    val plantingZones: List<PlantingZoneModel<PZID, PSZID>> = emptyList(),
+    val plantingZones: List<PlantingZoneModel<PZID, PSZID, TIMESTAMP>> = emptyList(),
     val projectId: ProjectId? = null,
     val timeZone: ZoneId? = null,
 ) {
@@ -72,7 +74,7 @@ data class PlantingSiteModel<
    */
   fun findZoneWithMonitoringPlot(
       monitoringPlotId: MonitoringPlotId
-  ): PlantingZoneModel<PZID, PSZID>? {
+  ): PlantingZoneModel<PZID, PSZID, TIMESTAMP>? {
     return plantingZones.firstOrNull { zone ->
       zone.findSubzoneWithMonitoringPlot(monitoringPlotId) != null
     }
@@ -127,7 +129,7 @@ data class PlantingSiteModel<
   }
 
   fun equals(other: Any?, tolerance: Double): Boolean {
-    return other is PlantingSiteModel<*, *, *> &&
+    return other is AnyPlantingSiteModel &&
         countryCode == other.countryCode &&
         description == other.description &&
         id == other.id &&
@@ -250,9 +252,10 @@ data class PlantingSiteModel<
 }
 
 typealias AnyPlantingSiteModel =
-    PlantingSiteModel<out PlantingSiteId?, out PlantingZoneId?, out PlantingSubzoneId?>
+    PlantingSiteModel<
+        out PlantingSiteId?, out PlantingZoneId?, out PlantingSubzoneId?, out Instant?>
 
 typealias ExistingPlantingSiteModel =
-    PlantingSiteModel<PlantingSiteId, PlantingZoneId, PlantingSubzoneId>
+    PlantingSiteModel<PlantingSiteId, PlantingZoneId, PlantingSubzoneId, Instant>
 
-typealias NewPlantingSiteModel = PlantingSiteModel<Nothing?, Nothing?, Nothing?>
+typealias NewPlantingSiteModel = PlantingSiteModel<Nothing?, Nothing?, Nothing?, Nothing?>

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.util.nearlyCoveredBy
 import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Instant
 import kotlin.math.max
 import kotlin.math.roundToInt
 import org.locationtech.jts.geom.Coordinate
@@ -19,9 +20,11 @@ import org.locationtech.jts.geom.MultiPolygon
 import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 
-data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>(
+data class PlantingZoneModel<
+    PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?, TIMESTAMP : Instant?>(
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
+    val boundaryModifiedTime: TIMESTAMP,
     val errorMargin: BigDecimal = DEFAULT_ERROR_MARGIN,
     val extraPermanentClusters: Int = 0,
     val id: PZID,
@@ -301,7 +304,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
     }
   }
 
-  fun validate(newModel: PlantingSiteModel<*, *, *>): List<PlantingSiteValidationFailure> {
+  fun validate(newModel: AnyPlantingSiteModel): List<PlantingSiteValidationFailure> {
     val problems = mutableListOf<PlantingSiteValidationFailure>()
 
     // Find two squares: one for a permanent plot and one for a temporary plot.
@@ -400,9 +403,10 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 
   fun equals(other: Any?, tolerance: Double): Boolean {
-    return other is PlantingZoneModel<*, *> &&
+    return other is AnyPlantingZoneModel &&
         id == other.id &&
         name == other.name &&
+        boundaryModifiedTime == other.boundaryModifiedTime &&
         extraPermanentClusters == other.extraPermanentClusters &&
         numPermanentClusters == other.numPermanentClusters &&
         numTemporaryPlots == other.numTemporaryPlots &&
@@ -419,6 +423,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
       NewPlantingZoneModel(
           areaHa = areaHa,
           boundary = boundary,
+          boundaryModifiedTime = null,
           errorMargin = errorMargin,
           extraPermanentClusters = extraPermanentClusters,
           id = null,
@@ -470,6 +475,7 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
       return NewPlantingZoneModel(
           areaHa = areaHa,
           boundary = boundary,
+          boundaryModifiedTime = null,
           errorMargin = errorMargin,
           extraPermanentClusters = extraPermanentClusters,
           id = null,
@@ -485,8 +491,9 @@ data class PlantingZoneModel<PZID : PlantingZoneId?, PSZID : PlantingSubzoneId?>
   }
 }
 
-typealias AnyPlantingZoneModel = PlantingZoneModel<out PlantingZoneId?, out PlantingSubzoneId?>
+typealias AnyPlantingZoneModel =
+    PlantingZoneModel<out PlantingZoneId?, out PlantingSubzoneId?, out Instant?>
 
-typealias ExistingPlantingZoneModel = PlantingZoneModel<PlantingZoneId, PlantingSubzoneId>
+typealias ExistingPlantingZoneModel = PlantingZoneModel<PlantingZoneId, PlantingSubzoneId, Instant>
 
-typealias NewPlantingZoneModel = PlantingZoneModel<Nothing?, Nothing?>
+typealias NewPlantingZoneModel = PlantingZoneModel<Nothing?, Nothing?, Nothing?>

--- a/src/main/resources/db/migration/0300/V335__ZoneBoundaryModified.sql
+++ b/src/main/resources/db/migration/0300/V335__ZoneBoundaryModified.sql
@@ -1,0 +1,9 @@
+ALTER TABLE tracking.planting_zones ADD COLUMN boundary_modified_by BIGINT REFERENCES users;
+ALTER TABLE tracking.planting_zones ADD COLUMN boundary_modified_time TIMESTAMP WITH TIME ZONE;
+
+UPDATE tracking.planting_zones
+SET boundary_modified_by = modified_by,
+    boundary_modified_time = modified_time;
+
+ALTER TABLE tracking.planting_zones ALTER COLUMN boundary_modified_by SET NOT NULL;
+ALTER TABLE tracking.planting_zones ALTER COLUMN boundary_modified_time SET NOT NULL;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -482,6 +482,8 @@ COMMENT ON TABLE tracking.planting_zone_populations IS 'Total number of plants o
 
 COMMENT ON TABLE tracking.planting_zones IS 'Regions within planting sites that have a consistent set of conditions such that survey results from any part of the zone can be extrapolated to the entire zone. Planting zones are subdivided into plots. Every planting zone has at least one plot.';
 COMMENT ON COLUMN tracking.planting_zones.boundary IS 'Boundary of the planting zone. This area is further subdivided into plots. This will typically be a single polygon but may be multiple polygons if a planting zone has several disjoint areas. Coordinates always use SRID 4326 (WGS 84 latitude/longitude).';
+COMMENT ON COLUMN tracking.planting_zones.boundary_modified_by IS 'Which user most recently edited the planting zone''s boundary.';
+COMMENT ON COLUMN tracking.planting_zones.boundary_modified_time IS 'When the planting zone''s boundary was most recently modified.';
 COMMENT ON COLUMN tracking.planting_zones.created_by IS 'Which user created the planting zone.';
 COMMENT ON COLUMN tracking.planting_zones.created_time IS 'When the planting zone was originally created.';
 COMMENT ON COLUMN tracking.planting_zones.extra_permanent_clusters IS 'Number of clusters to add to observation in addition to the number that is derived from the statistical formula. Typically this is due to additional area being added to a zone after initial creation. This is included in the value of `num_permanent_clusters`, that is, it is an input to the calculation of that column''s value.';

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -633,6 +633,7 @@ search.plantingSubzones.totalPlants=Planting subzone total plants (all species)
 search.plantingZonePopulations.plantsSinceLastObservation=Planting zone plants added since last observation
 search.plantingZonePopulations.totalPlants=Planting zone total plants
 search.plantingZones.boundary=Planting zone boundary
+search.plantingZones.boundaryModifiedTime=Planting zone boundary modified time
 search.plantingZones.createdTime=Planting zone created time
 search.plantingZones.id=Planting zone ID
 search.plantingZones.modifiedTime=Planting zone modified time

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1807,11 +1807,15 @@ abstract class DatabaseBackedTest {
       targetPlantingDensity: BigDecimal? = row.targetPlantingDensity,
       variance: BigDecimal = row.variance ?: PlantingZoneModel.DEFAULT_VARIANCE,
       insertHistory: Boolean = true,
+      boundaryModifiedBy: UserId = row.boundaryModifiedBy ?: modifiedBy,
+      boundaryModifiedTime: Instant = row.boundaryModifiedTime ?: modifiedTime,
   ): PlantingZoneId {
     val rowWithDefaults =
         row.copy(
             areaHa = areaHa,
             boundary = boundary,
+            boundaryModifiedBy = boundaryModifiedBy,
+            boundaryModifiedTime = boundaryModifiedTime,
             createdBy = createdBy,
             createdTime = createdTime,
             errorMargin = errorMargin,

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -303,6 +303,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                         listOf(
                             mapOf(
                                 "boundary" to postgisRenderGeoJson(plantingZoneGeometry),
+                                "boundaryModifiedTime" to "1970-01-01T00:00:00Z",
                                 "createdTime" to "1970-01-01T00:00:00Z",
                                 "id" to "$plantingZoneId2",
                                 "modifiedTime" to "1970-01-01T00:00:00Z",
@@ -477,6 +478,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                 "plantingSeasons.isActive",
                 "plantingSeasons.startDate",
                 "plantingZones.boundary",
+                "plantingZones.boundaryModifiedTime",
                 "plantingZones.createdTime",
                 "plantingZones.id",
                 "plantingZones.modifiedTime",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.PlantingSiteMapInvalidException
 import com.terraformation.backend.tracking.model.CannotCreatePastPlantingSeasonException
-import com.terraformation.backend.tracking.model.NewPlantingZoneModel
 import com.terraformation.backend.tracking.model.PlantingSeasonTooFarInFutureException
 import com.terraformation.backend.tracking.model.PlantingSeasonTooLongException
 import com.terraformation.backend.tracking.model.PlantingSeasonTooShortException
@@ -216,6 +215,8 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       val commonZonesRow =
           PlantingZonesRow(
               areaHa = BigDecimal("1.5"),
+              boundaryModifiedBy = user.userId,
+              boundaryModifiedTime = Instant.EPOCH,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
@@ -504,11 +505,9 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
               organizationId = organizationId,
               plantingZones =
                   listOf(
-                      NewPlantingZoneModel(
-                          areaHa = BigDecimal.ONE,
+                      PlantingZoneModel.create(
                           boundary = boundary,
                           name = "name",
-                          id = null,
                           // Empty subzone list is invalid.
                           plantingSubzones = emptyList())))
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -6,14 +6,15 @@ import com.terraformation.backend.polygon
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.model.ExistingPlantingSeasonModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
 import com.terraformation.backend.tracking.model.MonitoringPlotModel
 import com.terraformation.backend.tracking.model.PlantingSiteDepth
-import com.terraformation.backend.tracking.model.PlantingSiteModel
 import com.terraformation.backend.tracking.model.PlantingSubzoneModel
 import com.terraformation.backend.tracking.model.PlantingZoneModel
 import com.terraformation.backend.util.toInstant
 import io.mockk.every
 import java.math.BigDecimal
+import java.time.Instant
 import java.time.LocalDate
 import org.geotools.geometry.jts.JTS
 import org.geotools.referencing.CRS
@@ -36,9 +37,11 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
               gridOrigin = point(9, 10),
               timeZone = timeZone,
           )
+      val boundaryModifiedTime = Instant.ofEpochSecond(5001)
       val plantingZoneId =
           insertPlantingZone(
               boundary = multiPolygon(2.0),
+              boundaryModifiedTime = boundaryModifiedTime,
               extraPermanentClusters = 1,
               targetPlantingDensity = BigDecimal.ONE)
       val plantingSubzoneId = insertPlantingSubzone(boundary = multiPolygon(1.0))
@@ -95,9 +98,10 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
           expectedWithSite.copy(
               plantingZones =
                   listOf(
-                      PlantingZoneModel(
+                      ExistingPlantingZoneModel(
                           areaHa = BigDecimal.TEN,
                           boundary = multiPolygon(2.0),
+                          boundaryModifiedTime = boundaryModifiedTime,
                           extraPermanentClusters = 1,
                           id = plantingZoneId,
                           name = "Z1",
@@ -201,7 +205,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
       val monitoringPlotId = insertMonitoringPlot(boundary = monitoringPlotBoundary3857)
 
       val expected =
-          PlantingSiteModel(
+          ExistingPlantingSiteModel(
               boundary = siteBoundary4326,
               description = null,
               exclusion = exclusion4326,
@@ -213,6 +217,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                       PlantingZoneModel(
                           areaHa = BigDecimal.TEN,
                           boundary = zoneBoundary4326,
+                          boundaryModifiedTime = Instant.EPOCH,
                           extraPermanentClusters = 0,
                           id = plantingZoneId,
                           name = "Z1",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
@@ -23,6 +23,8 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
       val initialRow =
           PlantingZonesRow(
               areaHa = BigDecimal.ONE,
+              boundaryModifiedBy = createdBy,
+              boundaryModifiedTime = createdTime,
               boundary = multiPolygon(1),
               createdBy = createdBy,
               createdTime = createdTime,
@@ -74,6 +76,8 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
             targetPlantingDensity = newTargetPlantingDensity,
             variance = newVariance,
             // Not editable
+            boundaryModifiedBy = user.userId,
+            boundaryModifiedTime = Instant.ofEpochSecond(5000),
             createdBy = user.userId,
             createdTime = Instant.ofEpochSecond(5000),
             modifiedBy = createdBy,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -172,6 +172,7 @@ private constructor(
       return ExistingPlantingZoneModel(
           areaHa = boundary.differenceNullable(exclusion).calculateAreaHectares(),
           boundary = boundary,
+          boundaryModifiedTime = Instant.EPOCH,
           extraPermanentClusters = extraPermanentClusters,
           id = PlantingZoneId(currentZoneId),
           name = name,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModelTest.kt
@@ -117,7 +117,7 @@ class PlantingSiteModelTest {
     }
 
     private fun assertHasProblem(
-        site: PlantingSiteModel<*, *, *>,
+        site: AnyPlantingSiteModel,
         problem: PlantingSiteValidationFailure,
         message: String = "Expected problems list to contain entry",
     ) {
@@ -129,7 +129,7 @@ class PlantingSiteModelTest {
       }
     }
 
-    private fun assertHasNoProblems(site: PlantingSiteModel<*, *, *>) {
+    private fun assertHasNoProblems(site: AnyPlantingSiteModel) {
       val problems = site.validate()
 
       assertNull(problems, "Validation returned problems")

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
+import java.time.Instant
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -774,6 +775,7 @@ class PlantingZoneModelTest {
       ExistingPlantingZoneModel(
           areaHa = BigDecimal.ONE,
           boundary = boundary,
+          boundaryModifiedTime = Instant.EPOCH,
           errorMargin = BigDecimal.ONE,
           extraPermanentClusters = 0,
           id = PlantingZoneId(1),


### PR DESCRIPTION
When the user is selecting subzones to observe, we want to include an indication
of when the zone boundary was last edited. Add a boundary modification time (and
user ID) to the planting zones table and bump it whenever a zone edit causes an
actual change to the boundary geometry. Edits that affect things other than the
boundary, e.g., changes to plot counts, don't affect this new timestamp.

The timestamp is included in the planting zone API payload and is also available
via the search API.