### PR TITLE
SW-6462 Populate default text for unmodified sections

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
@@ -202,7 +202,9 @@ class ManifestImporter(
               parentVariableId = parentVariable?.variableId,
               parentVariableTypeId = if (parentVariable != null) VariableType.Section else null,
               renderHeading = !csvVariable.isNonNumberedSection))
+    }
 
+    private fun importDefaultSectionText(csvVariable: CsvSectionVariable) {
       if (csvVariable.defaultSectionText != null) {
         val regex =
             Regex("(.*?)(?:\\{\\{(?:[^}]*-\\s*)?([0-9]+)}}|\$)", RegexOption.DOT_MATCHES_ALL)
@@ -326,6 +328,7 @@ class ManifestImporter(
         importSectionVariable(csvVariable)
       }
 
+      importDefaultSectionText(csvVariable)
       importRecommendedVariables(csvVariable)
     }
 


### PR DESCRIPTION
If a section variable's definition hasn't changed since the previous manifest
for the same document template, we reuse the existing variable ID. However, the
default section text is per-manifest data (changing it doesn't prevent existing
variables from being reused) so it needs to be inserted into the database with
the new variable manifest ID even if it's the same as in the previous manifest.

This was causing newly-created documents to be missing default text if they used
a template whose manifest had been uploaded more than once.