### PR TITLE
Updated plot photo position requirements

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -183,12 +183,12 @@ class ObservationService(
       ObservationPhotoType.Plot,
       ObservationPhotoType.Quadrat -> {
         if (position == null) {
-          throw IllegalArgumentException("Position is required for plot photo ${type.name}")
+          throw IllegalArgumentException("Position is required for photo of type ${type.name}")
         }
       }
       ObservationPhotoType.Soil -> {
         if (position != null) {
-          throw IllegalArgumentException("Position must be null for plot photo ${type.name}")
+          throw IllegalArgumentException("Position must be null for photo of type ${type.name}")
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -172,12 +172,26 @@ class ObservationService(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,
       gpsCoordinates: Point,
-      position: ObservationPlotPosition,
+      position: ObservationPlotPosition?,
       data: InputStream,
       metadata: NewFileMetadata,
       type: ObservationPhotoType = ObservationPhotoType.Plot,
   ): FileId {
     requirePermissions { updateObservation(observationId) }
+
+    when (type) {
+      ObservationPhotoType.Plot,
+      ObservationPhotoType.Quadrat -> {
+        if (position == null) {
+          throw IllegalArgumentException("Position is required for plot photo ${type.name}")
+        }
+      }
+      ObservationPhotoType.Soil -> {
+        if (position != null) {
+          throw IllegalArgumentException("Position must be null for plot photo ${type.name}")
+        }
+      }
+    }
 
     val fileId =
         fileService.storeFile("observation", data, metadata) { fileId ->

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -899,7 +899,7 @@ data class RecordedTreePayload(
 data class ObservationMonitoringPlotPhotoPayload(
     val fileId: FileId,
     val gpsCoordinates: Point,
-    val position: ObservationPlotPosition,
+    val position: ObservationPlotPosition?,
     val type: ObservationPhotoType,
 ) {
   constructor(
@@ -1491,7 +1491,7 @@ data class UpdatePlotObservationRequestPayload(
 
 data class UploadPlotPhotoRequestPayload(
     val gpsCoordinates: Point,
-    val position: ObservationPlotPosition,
+    val position: ObservationPlotPosition?,
     @Schema(
         description = "Type of observation plot photo.",
         defaultValue = "Plot",

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -419,7 +419,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               ObservationMonitoringPlotPhotoModel(
                   fileId = record[OBSERVATION_PHOTOS.FILE_ID.asNonNullable()],
                   gpsCoordinates = record[photosGpsField.asNonNullable()] as Point,
-                  position = record[OBSERVATION_PHOTOS.POSITION_ID.asNonNullable()],
+                  position = record[OBSERVATION_PHOTOS.POSITION_ID],
                   type = record[OBSERVATION_PHOTOS.TYPE_ID.asNonNullable()],
               )
             }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -26,7 +26,7 @@ import org.locationtech.jts.geom.Polygon
 data class ObservationMonitoringPlotPhotoModel(
     val fileId: FileId,
     val gpsCoordinates: Point,
-    val position: ObservationPlotPosition,
+    val position: ObservationPlotPosition?,
     val type: ObservationPhotoType,
 )
 

--- a/src/main/resources/db/migration/0300/V337__ObservationPhotosPosition.sql
+++ b/src/main/resources/db/migration/0300/V337__ObservationPhotosPosition.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracking.observation_photos ALTER COLUMN position_id DROP NOT NULL;

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -322,7 +322,7 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO tracking.observation_photo_types (id, name)
 VALUES (1, 'Plot'),
-       (2, 'Quadrant'),
+       (2, 'Quadrat'),
        (3, 'Soil')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -778,16 +778,14 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       @Test
       fun `throws exception for providing photo position for Soil photos`() {
         assertThrows<IllegalArgumentException> {
-          assertThrows<ObservationNotFoundException> {
-            service.storePhoto(
-                observationId,
-                plotId,
-                point(1),
-                ObservationPlotPosition.SoutheastCorner,
-                byteArrayOf(1).inputStream(),
-                metadata,
-                ObservationPhotoType.Soil)
-          }
+          service.storePhoto(
+              observationId,
+              plotId,
+              point(1),
+              ObservationPlotPosition.SoutheastCorner,
+              byteArrayOf(1).inputStream(),
+              metadata,
+              ObservationPhotoType.Soil)
         }
       }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -728,7 +728,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 observationId,
                 plotId,
                 point(1),
-                ObservationPlotPosition.SouthwestCorner,
+                null,
                 byteArrayOf(1).inputStream(),
                 metadata,
                 ObservationPhotoType.Soil)
@@ -746,13 +746,53 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                     point(1),
                     ObservationPhotoType.Plot),
                 ObservationPhotosRecord(
-                    fileId2,
-                    observationId,
-                    plotId,
-                    ObservationPlotPosition.SouthwestCorner,
-                    point(1),
-                    ObservationPhotoType.Soil),
+                    fileId2, observationId, plotId, null, point(1), ObservationPhotoType.Soil),
             ))
+      }
+
+      @Test
+      fun `throws exception for missing photo position for Plot and Quadrat photos`() {
+        assertThrows<IllegalArgumentException> {
+          assertThrows<ObservationNotFoundException> {
+            service.storePhoto(
+                observationId,
+                plotId,
+                point(1),
+                null,
+                byteArrayOf(1).inputStream(),
+                metadata,
+                ObservationPhotoType.Plot)
+          }
+        }
+
+        assertThrows<IllegalArgumentException> {
+          assertThrows<ObservationNotFoundException> {
+            service.storePhoto(
+                observationId,
+                plotId,
+                point(1),
+                null,
+                byteArrayOf(1).inputStream(),
+                metadata,
+                ObservationPhotoType.Quadrat)
+          }
+        }
+      }
+
+      @Test
+      fun `throws exception for providing photo position for Soil photos`() {
+        assertThrows<IllegalArgumentException> {
+          assertThrows<ObservationNotFoundException> {
+            service.storePhoto(
+                observationId,
+                plotId,
+                point(1),
+                ObservationPlotPosition.SoutheastCorner,
+                byteArrayOf(1).inputStream(),
+                metadata,
+                ObservationPhotoType.Soil)
+          }
+        }
       }
 
       @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -753,29 +753,25 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       @Test
       fun `throws exception for missing photo position for Plot and Quadrat photos`() {
         assertThrows<IllegalArgumentException> {
-          assertThrows<ObservationNotFoundException> {
-            service.storePhoto(
-                observationId,
-                plotId,
-                point(1),
-                null,
-                byteArrayOf(1).inputStream(),
-                metadata,
-                ObservationPhotoType.Plot)
-          }
+          service.storePhoto(
+              observationId,
+              plotId,
+              point(1),
+              null,
+              byteArrayOf(1).inputStream(),
+              metadata,
+              ObservationPhotoType.Plot)
         }
 
         assertThrows<IllegalArgumentException> {
-          assertThrows<ObservationNotFoundException> {
-            service.storePhoto(
-                observationId,
-                plotId,
-                point(1),
-                null,
-                byteArrayOf(1).inputStream(),
-                metadata,
-                ObservationPhotoType.Quadrat)
-          }
+          service.storePhoto(
+              observationId,
+              plotId,
+              point(1),
+              null,
+              byteArrayOf(1).inputStream(),
+              metadata,
+              ObservationPhotoType.Quadrat)
         }
       }
 


### PR DESCRIPTION
We introduced a new photo type `Soil` previously. A `Soil` photo should not have a position while `Plot` and `Quadrat` do. Updated the service to validate both and the table column to handle the data accordingly. 