### PR TITLE
Loosen plot photo position requirements

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -179,18 +179,12 @@ class ObservationService(
   ): FileId {
     requirePermissions { updateObservation(observationId) }
 
-    when (type) {
-      ObservationPhotoType.Plot,
-      ObservationPhotoType.Quadrat -> {
-        if (position == null) {
-          throw IllegalArgumentException("Position is required for photo of type ${type.name}")
-        }
-      }
-      ObservationPhotoType.Soil -> {
-        if (position != null) {
-          throw IllegalArgumentException("Position must be null for photo of type ${type.name}")
-        }
-      }
+    if (type == ObservationPhotoType.Quadrat && position == null) {
+      throw IllegalArgumentException("Position is required for a quadrat photo")
+    }
+
+    if (type == ObservationPhotoType.Soil && position != null) {
+      throw IllegalArgumentException("Position must be null for a soil photo")
     }
 
     val fileId =

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -751,18 +751,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       }
 
       @Test
-      fun `throws exception for missing photo position for Plot and Quadrat photos`() {
-        assertThrows<IllegalArgumentException> {
-          service.storePhoto(
-              observationId,
-              plotId,
-              point(1),
-              null,
-              byteArrayOf(1).inputStream(),
-              metadata,
-              ObservationPhotoType.Plot)
-        }
-
+      fun `throws exception for missing photo position for Quadrat photos`() {
         assertThrows<IllegalArgumentException> {
           service.storePhoto(
               observationId,


### PR DESCRIPTION
Plot photos can be taken from a corner as well as not from a corner. We will allow for both cases in this scenario.