### PR TITLE
Make PlantingSiteBuilder usage more concise

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -92,7 +92,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     @Test
     fun `creates new subzones in existing zones`() {
       runScenario(
-          initial = newSite(width = 500) { zone { numPermanentClusters = 7 } },
+          initial = newSite(width = 500) { zone(numPermanent = 7) },
           desired =
               newSite(width = 750) {
                 zone {
@@ -102,9 +102,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               },
           expected =
               newSite(width = 750) {
-                zone {
-                  extraPermanentClusters = 3
-                  numPermanentClusters = 10
+                zone(numPermanent = 10, extraPermanent = 3) {
                   subzone(width = 500)
                   subzone()
                 }
@@ -146,20 +144,10 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       runScenario(
           initial =
               newSite(width = 500) {
-                zone {
-                  numPermanentClusters = 7
-                  subzone { repeat(7) { cluster() } }
-                }
+                zone(numPermanent = 7) { subzone { repeat(7) { cluster() } } }
               },
           desired = newSite(width = 750),
-          expected =
-              newSite(width = 750) {
-                zone {
-                  extraPermanentClusters = 3
-                  numPermanentClusters = 10
-                  subzone()
-                }
-              },
+          expected = newSite(width = 750) { zone(numPermanent = 10, extraPermanent = 3) },
           expectedPlotCounts =
               listOf(
                   rectangle(x = 0, width = 500, height = 500) to 7,
@@ -217,8 +205,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                       nextPlotNumber =
                           identifierGenerator.generateNumericIdentifier(
                               inserted.organizationId, NumericIdentifierType.PlotNumber)
-                      zone {
-                        numPermanentClusters = 2
+                      zone(numPermanent = 2) {
                         subzone {
                           cluster()
                           cluster()
@@ -229,11 +216,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                 expected =
                     newSite(width = 1000) {
                       name = "Site $currentAttempt"
-                      zone {
-                        extraPermanentClusters = 2
-                        numPermanentClusters = 4
-                        subzone()
-                      }
+                      zone(numPermanent = 4, extraPermanent = 2)
                     },
                 expectedPlotCounts =
                     listOf(
@@ -356,8 +339,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       runScenario(
           initial =
               newSite {
-                zone {
-                  numPermanentClusters = 1
+                zone(numPermanent = 1) {
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                 }
@@ -379,9 +361,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           },
           expected =
               newSite(height = 600) {
-                zone {
-                  extraPermanentClusters = 1
-                  numPermanentClusters = 2
+                zone(numPermanent = 2, extraPermanent = 1) {
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                   subzone(width = 250) { plantingCompletedTime = null }
                 }
@@ -394,8 +374,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       runScenario(
           initial =
               newSite {
-                zone {
-                  numPermanentClusters = 1
+                zone(numPermanent = 1) {
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                 }
@@ -414,9 +393,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           },
           expected =
               newSite(width = 600) {
-                zone {
-                  extraPermanentClusters = 1
-                  numPermanentClusters = 2
+                zone(numPermanent = 2, extraPermanent = 1) {
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                   subzone(width = 350) { plantingCompletedTime = null }
                 }
@@ -429,22 +406,18 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       runScenario(
           initial =
               newSite(width = 1000) {
-                zone(width = 500) { subzone() }
-                zone(width = 500) { subzone() }
+                zone(width = 500)
+                zone(width = 500)
               },
           desired =
               newSite(width = 1100) {
-                zone(width = 500) { subzone() }
-                zone(width = 600) { subzone() }
+                zone(width = 500)
+                zone(width = 600)
               },
           expected =
               newSite(width = 1100) {
-                zone(width = 500) { subzone() }
-                zone(width = 600) {
-                  extraPermanentClusters = 1
-                  numPermanentClusters = 9
-                  subzone()
-                }
+                zone(width = 500)
+                zone(width = 600, numPermanent = 9, extraPermanent = 1)
               },
       )
 
@@ -460,12 +433,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           runScenario(
               newSite(),
               newSite(width = 600),
-              newSite(width = 600) {
-                zone {
-                  extraPermanentClusters = 1
-                  numPermanentClusters = 9
-                }
-              })
+              newSite(width = 600) { zone(numPermanent = 9, extraPermanent = 1) })
 
       val monitoringPlotIds =
           results.edited.plantingZones[0].plantingSubzones[0].monitoringPlots.map { it.id }.toSet()

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -138,11 +138,24 @@ private constructor(
       width: Int = this.width - (x - this.x),
       height: Int = this.height - (y - this.y),
       name: String? = null,
+      numPermanent: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      numTemporary: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
+      extraPermanent: Int = 0,
       func: ZoneBuilder.() -> Unit = {}
   ): ExistingPlantingZoneModel {
     ++currentZoneId
 
-    val builder = ZoneBuilder(x, y, width, height, name ?: "Z$currentZoneId")
+    val builder =
+        ZoneBuilder(
+            x = x,
+            y = y,
+            width = width,
+            height = height,
+            name = name ?: "Z$currentZoneId",
+            numPermanentClusters = numPermanent,
+            numTemporaryPlots = numTemporary,
+            extraPermanentClusters = extraPermanent,
+        )
     builder.func()
 
     nextZoneX = x + width
@@ -157,12 +170,11 @@ private constructor(
       private val y: Int,
       private val width: Int,
       private val height: Int,
-      val name: String,
+      private val name: String,
+      private val numPermanentClusters: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      private val numTemporaryPlots: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
+      private val extraPermanentClusters: Int = 0,
   ) {
-    var extraPermanentClusters: Int = 0
-    var numPermanentClusters: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS
-    var numTemporaryPlots: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS
-
     private val boundary: MultiPolygon = rectangle(width, height, x, y)
     private var nextPermanentCluster = 1
     private var nextSubzoneX = x
@@ -255,7 +267,7 @@ private constructor(
         val plot =
             MonitoringPlotModel(
                 boundary = rectanglePolygon(size, size, x, y),
-                id = MonitoringPlotId(nextPlotNumber),
+                id = MonitoringPlotId(plotNumber),
                 isAdHoc = false,
                 isAvailable = isAvailable,
                 permanentCluster = cluster,
@@ -275,8 +287,9 @@ private constructor(
           y: Int = this.y,
           cluster: Int = nextPermanentCluster++,
           isAvailable: Boolean = true,
+          plotNumber: Long = nextPlotNumber,
       ): MonitoringPlotModel {
-        return plot(x, y, cluster, isAvailable = isAvailable)
+        return plot(x, y, cluster, isAvailable = isAvailable, plotNumber = plotNumber)
       }
     }
   }


### PR DESCRIPTION
The `zone()` function in `PlantingSiteBuilder` didn't allow callers to set the
plot counts because initially only a handful of tests needed to change them.
But the number of such tests has grown over time and will shortly grow even more.
Add optional parameters to allow the counts to be set more concisely, and update
the existing test code to use them.

Some unnecessary calls to `ZoneBuilder.subzone()` are removed here as well; the
default behavior is to create a single subzone with the same boundary as its zone
so there's no need to do it explicitly.

Finally, it is now possible to set the plot number when creating a permanent
cluster via `SubzoneBuilder.cluster()` (previously this required calling `plot()`
which has more required parameters) and the plot number is correctly used as
the plot ID.