### PR TITLE
SW-6469 Always calculate planting density

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -1064,8 +1064,8 @@ data class ObservationPlantingSubzoneResultsPayload(
     @Schema(
         description =
             "Estimated planting density for the subzone based on the observed planting densities " +
-                "of monitoring plots. Only present if the subzone has completed planting.")
-    val plantingDensity: Int?,
+                "of monitoring plots.")
+    val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     val plantingSubzoneId: PlantingSubzoneId,
     val species: List<ObservationSpeciesResultsPayload>,
@@ -1121,9 +1121,8 @@ data class ObservationPlantingZoneResultsPayload(
     @Schema(
         description =
             "Estimated planting density for the zone based on the observed planting densities " +
-                "of monitoring plots. Only present if all the subzones in the zone have been " +
-                "marked as having completed planting.")
-    val plantingDensity: Int?,
+                "of monitoring plots.")
+    val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     val plantingSubzones: List<ObservationPlantingSubzoneResultsPayload>,
     val plantingZoneId: PlantingZoneId,
@@ -1183,9 +1182,8 @@ data class ObservationResultsPayload(
     @Schema(
         description =
             "Estimated planting density for the site, based on the observed planting densities " +
-                "of monitoring plots. Only present if all the subzones in the site have been " +
-                "marked as having completed planting.")
-    val plantingDensity: Int?,
+                "of monitoring plots.")
+    val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     val plantingSiteId: PlantingSiteId,
     val plantingZones: List<ObservationPlantingZoneResultsPayload>,
@@ -1243,9 +1241,8 @@ data class PlantingZoneObservationSummaryPayload(
     @Schema(
         description =
             "Estimated planting density for the zone based on the observed planting densities " +
-                "of monitoring plots. Only present if all the subzones in the zone have been " +
-                "marked as having completed planting.")
-    val plantingDensity: Int?,
+                "of monitoring plots.")
+    val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     @Schema(description = "List of subzone observations used in this summary.")
     val plantingSubzones: List<ObservationPlantingSubzoneResultsPayload>,
@@ -1308,9 +1305,8 @@ data class PlantingSiteObservationSummaryPayload(
     @Schema(
         description =
             "Estimated planting density for the site, based on the observed planting densities " +
-                "of monitoring plots. Only present if all the subzones in the site have been " +
-                "marked as having completed planting.")
-    val plantingDensity: Int?,
+                "of monitoring plots.")
+    val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     val plantingZones: List<PlantingZoneObservationSummaryPayload>,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -682,16 +682,16 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
               val plantingCompleted = record[PLANTING_SUBZONES.PLANTING_COMPLETED_TIME] != null
               val plantingDensity =
-                  if (plantingCompleted && monitoringPlots.isNotEmpty()) {
+                  if (monitoringPlots.isNotEmpty()) {
                     monitoringPlots.map { it.plantingDensity }.average()
                   } else {
-                    null
+                    0.0
                   }
               val plantingDensityStdDev =
                   monitoringPlots.map { it.plantingDensity }.calculateStandardDeviation()
 
               val estimatedPlants =
-                  if (plantingDensity != null && areaHa != null) {
+                  if (plantingCompleted && areaHa != null) {
                     areaHa.toDouble() * plantingDensity
                   } else {
                     null
@@ -705,7 +705,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   mortalityRate = mortalityRate,
                   mortalityRateStdDev = mortalityRateStdDev,
                   plantingCompleted = plantingCompleted,
-                  plantingDensity = plantingDensity?.roundToInt(),
+                  plantingDensity = plantingDensity.roundToInt(),
                   plantingDensityStdDev = plantingDensityStdDev,
                   plantingSubzoneId = record[PLANTING_SUBZONES.ID.asNonNullable()],
                   species = species,
@@ -798,10 +798,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
               val plantingCompleted = record[zonePlantingCompletedField]
               val plantingDensity =
-                  if (plantingCompleted && monitoringPlots.isNotEmpty()) {
+                  if (monitoringPlots.isNotEmpty()) {
                     monitoringPlots.map { it.plantingDensity }.average()
                   } else {
-                    null
+                    0.0
                   }
               val plantingDensityStdDev =
                   subzones
@@ -810,7 +810,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       .calculateStandardDeviation()
 
               val estimatedPlants =
-                  if (plantingDensity != null && areaHa != null) {
+                  if (plantingCompleted && areaHa != null) {
                     areaHa.toDouble() * plantingDensity
                   } else {
                     null
@@ -823,7 +823,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   mortalityRate = mortalityRate,
                   mortalityRateStdDev = mortalityRateStdDev,
                   plantingCompleted = plantingCompleted,
-                  plantingDensity = plantingDensity?.roundToInt(),
+                  plantingDensity = plantingDensity.roundToInt(),
                   plantingDensityStdDev = plantingDensityStdDev,
                   plantingSubzones = subzones,
                   plantingZoneId = record[PLANTING_ZONES.ID.asNonNullable()],
@@ -881,10 +881,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
           val monitoringPlots = zones.flatMap { it.plantingSubzones }.flatMap { it.monitoringPlots }
           val plantingDensity =
-              if (plantingCompleted && monitoringPlots.isNotEmpty()) {
+              if (monitoringPlots.isNotEmpty()) {
                 monitoringPlots.map { it.plantingDensity }.average()
               } else {
-                null
+                0.0
               }
           val plantingDensityStdDev =
               monitoringPlots.map { it.plantingDensity }.calculateStandardDeviation()
@@ -913,7 +913,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               observationId = record[OBSERVATIONS.ID.asNonNullable()],
               observationType = record[OBSERVATIONS.OBSERVATION_TYPE_ID.asNonNullable()],
               plantingCompleted = plantingCompleted,
-              plantingDensity = plantingDensity?.roundToInt(),
+              plantingDensity = plantingDensity.roundToInt(),
               plantingDensityStdDev = plantingDensityStdDev,
               plantingSiteId = record[OBSERVATIONS.PLANTING_SITE_ID.asNonNullable()],
               plantingZones = zones,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -151,9 +151,9 @@ interface BaseMonitoringResult {
 
   /**
    * Estimated planting density for the region based on the observed planting densities of
-   * monitoring plots. Only present if planting is completed.
+   * monitoring plots.
    */
-  val plantingDensity: Int?
+  val plantingDensity: Int
 }
 
 data class ObservationPlantingSubzoneResultsModel(
@@ -164,7 +164,7 @@ data class ObservationPlantingSubzoneResultsModel(
     override val mortalityRateStdDev: Int?,
     val monitoringPlots: List<ObservationMonitoringPlotResultsModel>,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int?,
+    override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     val plantingSubzoneId: PlantingSubzoneId,
     /** List of species result used for this rollup */
@@ -189,7 +189,7 @@ data class ObservationPlantingZoneResultsModel(
     override val mortalityRate: Int,
     override val mortalityRateStdDev: Int?,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int?,
+    override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     val plantingSubzones: List<ObservationPlantingSubzoneResultsModel>,
     val plantingZoneId: PlantingZoneId,
@@ -218,7 +218,7 @@ data class ObservationResultsModel(
     val observationId: ObservationId,
     val observationType: ObservationType,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int?,
+    override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     val plantingSiteId: PlantingSiteId,
     val plantingZones: List<ObservationPlantingZoneResultsModel>,
@@ -238,7 +238,7 @@ data class ObservationPlantingZoneRollupResultsModel(
     override val mortalityRate: Int,
     override val mortalityRateStdDev: Int?,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int?,
+    override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     /** List of subzone observation results used for this rollup */
     val plantingSubzones: List<ObservationPlantingSubzoneResultsModel>,
@@ -278,17 +278,12 @@ data class ObservationPlantingZoneRollupResultsModel(
                 (it.totalLive + it.totalExisting) > 0
           }
 
-      val plantingDensity =
-          if (plantingCompleted) {
-            monitoringPlots.map { it.plantingDensity }.average().roundToInt()
-          } else {
-            null
-          }
+      val plantingDensity = monitoringPlots.map { it.plantingDensity }.average().roundToInt()
       val plantingDensityStdDev =
           monitoringPlots.map { it.plantingDensity }.calculateStandardDeviation()
 
       val estimatedPlants =
-          if (plantingDensity != null) {
+          if (plantingCompleted) {
             areaHa.toDouble() * plantingDensity
           } else {
             null
@@ -327,7 +322,7 @@ data class ObservationRollupResultsModel(
     override val mortalityRate: Int,
     override val mortalityRateStdDev: Int?,
     override val plantingCompleted: Boolean,
-    override val plantingDensity: Int?,
+    override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     val plantingSiteId: PlantingSiteId,
     /** List of subzone observation results used for this rollup */
@@ -367,18 +362,13 @@ data class ObservationRollupResultsModel(
                 (it.totalLive + it.totalExisting) > 0
           }
 
-      val plantingDensity =
-          if (plantingCompleted) {
-            monitoringPlots.map { it.plantingDensity }.average().roundToInt()
-          } else {
-            null
-          }
+      val plantingDensity = monitoringPlots.map { it.plantingDensity }.average().roundToInt()
 
       val plantingDensityStdDev =
           monitoringPlots.map { it.plantingDensity }.calculateStandardDeviation()
 
       val estimatedPlants =
-          if (plantingDensity != null) {
+          if (plantingCompleted) {
             nonNullZoneResults.sumOf { it.estimatedPlants ?: 0 }
           } else {
             null

--- a/src/test/resources/tracking/observation/ObservationsSummary/SiteStats.csv
+++ b/src/test/resources/tracking/observation/ObservationsSummary/SiteStats.csv
@@ -1,3 +1,3 @@
 1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3
 Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev
-,309,,4,25%,12%,1053,496,2220000,4,22%,10%,1614,859,4571000,4,23%,8%
+762,309,,4,25%,12%,1053,496,2220000,4,22%,10%,1614,859,4571000,4,23%,8%

--- a/src/test/resources/tracking/observation/TwoObservations/SiteStats.csv
+++ b/src/test/resources/tracking/observation/TwoObservations/SiteStats.csv
@@ -1,3 +1,3 @@
 1,1,1,1,2,2,2,2
 Planting Density,Estimated # Plants,# Species,Mortality Rate,Planting Density,Estimated # Plants,# Species,Mortality Rate
-,,7,33%,29,74400,8,44%
+26,,7,33%,29,74400,8,44%

--- a/src/test/resources/tracking/observation/TwoObservations/ZoneStats.csv
+++ b/src/test/resources/tracking/observation/TwoObservations/ZoneStats.csv
@@ -1,4 +1,4 @@
 Observation ->,1,1,1,1,1,2,2,2,2,2
 Zone,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants
-Alpha,14,,6,42%,,16,35,7,44%,52000
+Alpha,14,29,6,42%,,16,35,7,44%,52000
 Beta,12,24,2,22%,24000,9,22,3,44%,22400

--- a/src/test/resources/tracking/observation/TwoObservations30m/SiteStats.csv
+++ b/src/test/resources/tracking/observation/TwoObservations30m/SiteStats.csv
@@ -1,3 +1,3 @@
 1,1,1,1,2,2,2,2
 Planting Density,Estimated # Plants,# Species,Mortality Rate,Planting Density,Estimated # Plants,# Species,Mortality Rate
-,,7,33%,20,51400,8,44%
+18,,7,33%,20,51400,8,44%

--- a/src/test/resources/tracking/observation/TwoObservations30m/ZoneStats.csv
+++ b/src/test/resources/tracking/observation/TwoObservations30m/ZoneStats.csv
@@ -1,4 +1,4 @@
 Observation ->,1,1,1,1,1,2,2,2,2,2
 Zone,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants
-Alpha,14,,6,42%,,16,24,7,44%,36000
+Alpha,14,20,6,42%,,16,24,7,44%,36000
 Beta,12,17,2,22%,16500,9,15,3,44%,15400


### PR DESCRIPTION
Make planting density always available even if plantings are not all completed. 

Estimated plants is only computed if planting is completed because this will be inherently noisy depending on observed samples. 