### PR TITLE
SW-6344 Add behavior field to PlantingSiteEdit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEdit.kt
@@ -24,6 +24,12 @@ data class PlantingSiteEdit(
      */
     val areaHaDifference: BigDecimal,
 
+    /**
+     * Which map editing behavior to use. This controls things like how active observations are
+     * affected by edits.
+     */
+    val behavior: PlantingSiteEditBehavior,
+
     /** Desired planting site model. The intended end result after edits are applied. */
     val desiredModel: AnyPlantingSiteModel,
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditBehavior.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditBehavior.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.tracking.edit
+
+/** Which version of site editing behavior to use for a given planting site edit. */
+enum class PlantingSiteEditBehavior {
+  /**
+   * Original behavior with restrictions on which boundaries can be edited once a site has
+   * observations.
+   */
+  Restricted
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
@@ -39,6 +39,7 @@ class PlantingSiteEditCalculatorV1(
 
     return PlantingSiteEdit(
         areaHaDifference = calculateAreaHaDifference(existingSite.boundary, desiredSite.boundary),
+        behavior = PlantingSiteEditBehavior.Restricted,
         desiredModel = desiredSite,
         existingModel = existingSite,
         plantingZoneEdits = zoneEdits,

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -93,6 +93,7 @@ import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
+import com.terraformation.backend.tracking.edit.PlantingSiteEditBehavior
 import com.terraformation.backend.tracking.event.ObservationNotScheduledNotificationEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
@@ -1275,6 +1276,7 @@ internal class EmailNotificationServiceTest {
             existingModel,
             PlantingSiteEdit(
                 areaHaDifference = BigDecimal("-13.2"),
+                behavior = PlantingSiteEditBehavior.Restricted,
                 desiredModel = PlantingSiteBuilder.newSite { name = siteName },
                 existingModel = existingModel,
                 plantingZoneEdits = emptyList()),
@@ -1309,6 +1311,7 @@ internal class EmailNotificationServiceTest {
             existingModel,
             PlantingSiteEdit(
                 areaHaDifference = BigDecimal("-13.2"),
+                behavior = PlantingSiteEditBehavior.Restricted,
                 desiredModel = PlantingSiteBuilder.newSite { name = siteName },
                 existingModel = existingModel,
                 plantingZoneEdits = emptyList()),
@@ -1345,6 +1348,7 @@ internal class EmailNotificationServiceTest {
             existingModel,
             PlantingSiteEdit(
                 areaHaDifference = BigDecimal("-13.2"),
+                behavior = PlantingSiteEditBehavior.Restricted,
                 desiredModel = PlantingSiteBuilder.newSite { name = siteName },
                 existingModel = existingModel,
                 plantingZoneEdits = emptyList()),

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -73,6 +73,7 @@ import com.terraformation.backend.tracking.db.PlotNotInObservationException
 import com.terraformation.backend.tracking.db.PlotSizeNotReplaceableException
 import com.terraformation.backend.tracking.db.ScheduleObservationWithoutPlantsException
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
+import com.terraformation.backend.tracking.edit.PlantingSiteEditBehavior
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
@@ -2226,7 +2227,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(emptySet(), monitoringPlotIds))
 
       service.on(event)
@@ -2269,7 +2275,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(emptySet(), setOf(removedPlotId)))
 
       service.on(event)
@@ -2301,7 +2312,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(emptySet(), setOf(inserted.monitoringPlotId)))
 
       service.on(event)
@@ -2333,7 +2349,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(emptySet(), originalPermanentPlotIds))
 
       service.on(event)
@@ -2363,7 +2384,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(newPermanentPlotIds, emptySet()))
 
       service.on(event)
@@ -2453,7 +2479,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val event =
           PlantingSiteMapEditedEvent(
               plantingSite,
-              PlantingSiteEdit(BigDecimal.ONE, plantingSite, plantingSite, listOf()),
+              PlantingSiteEdit(
+                  areaHaDifference = BigDecimal.ONE,
+                  behavior = PlantingSiteEditBehavior.Restricted,
+                  desiredModel = plantingSite,
+                  existingModel = plantingSite,
+                  plantingZoneEdits = listOf()),
               ReplacementResult(emptySet(), plotIdsInRemovedArea))
 
       service.on(event)

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
@@ -27,6 +27,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("12.5"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -58,6 +59,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("12.5"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -86,6 +88,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("5.0"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -123,6 +126,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("10.0"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -160,6 +164,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("-12.5"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -194,6 +199,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("-12.5"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =
@@ -272,6 +278,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("0.0"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits = emptyList()),
@@ -298,6 +305,7 @@ class PlantingSiteEditCalculatorV1Test {
     assertEditResult(
         PlantingSiteEdit(
             areaHaDifference = BigDecimal("2.5"),
+            behavior = PlantingSiteEditBehavior.Restricted,
             desiredModel = desired,
             existingModel = existing,
             plantingZoneEdits =


### PR DESCRIPTION
Some of the downstream behavior of planting site edits, e.g., the effect on active
observations, will need to differ depending on whether an edit uses the original
restricted editing feature or the upcoming more flexible editing style. In
preparation, add a field to `PlantingSiteEdit` to indicate which behavior to use.

In this change, there is only one possible value; an additional one will be added
later.