### PR TITLE
Update upstream docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:23.0.1-al2023-headless
+FROM amazoncorretto:23.0.2-al2023-headless
 
 ARG USER_ID=1001
 


### PR DESCRIPTION
Fixes SIGILL java issue on M4 macs with java 18-23