### PR TITLE
SW-6344 Add monitoring plot edits to PlantingSiteEdit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/MonitoringPlotEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/MonitoringPlotEdit.kt
@@ -1,0 +1,74 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.util.equalsOrBothNull
+import org.locationtech.jts.geom.MultiPolygon
+
+/**
+ * Represents the changes that need to be made to a monitoring plot to make it match the zones and
+ * subzones in an updated version of a planting site.
+ */
+sealed interface MonitoringPlotEdit {
+  /**
+   * If the edit is a change to an existing monitoring plot, its ID. Null if the edit is the
+   * creation of a new plot.
+   */
+  val monitoringPlotId: MonitoringPlotId?
+
+  /**
+   * New permanent cluster number to assign to the plot. Null if the plot should not have a
+   * permanent cluster number any more, or if the plot is being deleted.
+   */
+  val permanentCluster: Int?
+
+  /** Region in which to create new plot. */
+  val region: MultiPolygon?
+    get() = null
+
+  fun equalsExact(other: MonitoringPlotEdit, tolerance: Double = 0.0000001): Boolean =
+      javaClass == other.javaClass &&
+          monitoringPlotId == other.monitoringPlotId &&
+          permanentCluster == other.permanentCluster &&
+          region.equalsOrBothNull(other.region, tolerance)
+
+  /**
+   * Represents a monitoring plot that needs to move from one subzone to another, or change its
+   * permanent cluster number, because the subzone boundaries have changed out from under the plot.
+   *
+   * This will always be on the list of monitoring plot edits for the plot's _new_ subzone, never on
+   * its existing subzone.
+   *
+   * The plot may have a different permanent cluster number, or none at all, in its new home.
+   */
+  data class Adopt(
+      override val monitoringPlotId: MonitoringPlotId,
+      override val permanentCluster: Int? = null,
+  ) : MonitoringPlotEdit
+
+  /**
+   * Represents a monitoring plot that needs to be created in a specific region. This can happen
+   * when the containing zone covers area that wasn't covered by the previous version of the
+   * planting site.
+   *
+   * This always creates permanent plots. If [permanentCluster] is null, a cluster number is chosen
+   * at random.
+   */
+  data class Create(
+      override val region: MultiPolygon,
+      override val permanentCluster: Int?,
+  ) : MonitoringPlotEdit {
+    override val monitoringPlotId: MonitoringPlotId?
+      get() = null
+  }
+
+  /**
+   * Represents a monitoring plot that should no longer be associated with any subzone at all. This
+   * happens when the plot's area is no longer within the site boundary.
+   *
+   * This will always be on the list of monitoring plot edits for the plot's existing subzone.
+   */
+  data class Eject(override val monitoringPlotId: MonitoringPlotId) : MonitoringPlotEdit {
+    override val permanentCluster: Int?
+      get() = null
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
@@ -66,6 +66,7 @@ class PlantingSiteEditCalculatorV1(
             .map { newZone ->
               PlantingZoneEdit.Create(
                   desiredModel = newZone,
+                  monitoringPlotEdits = emptyList(),
                   plantingSubzoneEdits =
                       newZone.plantingSubzones.map { newSubzone ->
                         PlantingSubzoneEdit.Create(newSubzone)
@@ -146,6 +147,7 @@ class PlantingSiteEditCalculatorV1(
                     areaHaDifference = areaHaDifference,
                     desiredModel = desiredZone,
                     existingModel = existingZone,
+                    monitoringPlotEdits = emptyList(),
                     numPermanentClustersToAdd = newClustersThatFitInAddedRegion,
                     plantingSubzoneEdits = subzoneEdits,
                     removedRegion = removedRegion,
@@ -210,6 +212,7 @@ class PlantingSiteEditCalculatorV1(
                             existingSubzone.boundary, desiredSubzone.boundary),
                     desiredModel = desiredSubzone,
                     existingModel = existingSubzone,
+                    monitoringPlotEdits = emptyList(),
                     removedRegion =
                         existingUsableBoundary
                             .difference(desiredUsableBoundary)
@@ -244,6 +247,7 @@ class PlantingSiteEditCalculatorV1(
         desiredSite.plantingZones.map { desiredZone ->
           PlantingZoneEdit.Create(
               desiredModel = desiredZone,
+              monitoringPlotEdits = emptyList(),
               plantingSubzoneEdits =
                   desiredZone.plantingSubzones.map { desiredSubzone ->
                     PlantingSubzoneEdit.Create(desiredSubzone)

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSubzoneEdit.kt
@@ -35,6 +35,12 @@ sealed interface PlantingSubzoneEdit {
   val existingModel: ExistingPlantingSubzoneModel?
 
   /**
+   * Changes to make to this subzone's monitoring plots. The mix of monitoring plot edit types
+   * depends on what change is being made to the subzone; see [MonitoringPlotEdit] for details.
+   */
+  val monitoringPlotEdits: List<MonitoringPlotEdit>
+
+  /**
    * Usable region that is being removed from this subzone. Does not include any areas that are
    * covered by the existing site's exclusion areas.
    */
@@ -46,10 +52,15 @@ sealed interface PlantingSubzoneEdit {
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
           desiredModel == other.desiredModel &&
           existingModel == other.existingModel &&
+          monitoringPlotEdits.size == other.monitoringPlotEdits.size &&
+          monitoringPlotEdits.zip(other.monitoringPlotEdits).all { (edit, otherEdit) ->
+            edit.equalsExact(otherEdit, tolerance)
+          } &&
           removedRegion.equalsOrBothNull(other.removedRegion, tolerance)
 
   data class Create(
       override val desiredModel: AnyPlantingSubzoneModel,
+      override val monitoringPlotEdits: List<MonitoringPlotEdit> = emptyList(),
   ) : PlantingSubzoneEdit {
     override val addedRegion: MultiPolygon
       get() = desiredModel.boundary
@@ -66,6 +77,7 @@ sealed interface PlantingSubzoneEdit {
 
   data class Delete(
       override val existingModel: ExistingPlantingSubzoneModel,
+      override val monitoringPlotEdits: List<MonitoringPlotEdit> = emptyList(),
   ) : PlantingSubzoneEdit {
     override val addedRegion: MultiPolygon?
       get() = null
@@ -85,6 +97,7 @@ sealed interface PlantingSubzoneEdit {
       override val areaHaDifference: BigDecimal,
       override val desiredModel: AnyPlantingSubzoneModel,
       override val existingModel: ExistingPlantingSubzoneModel,
+      override val monitoringPlotEdits: List<MonitoringPlotEdit> = emptyList(),
       override val removedRegion: MultiPolygon,
   ) : PlantingSubzoneEdit
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -35,6 +35,12 @@ sealed interface PlantingZoneEdit {
   val existingModel: ExistingPlantingZoneModel?
 
   /**
+   * New monitoring plots that need to be created in this zone as a result of its boundary or
+   * settings having changed.
+   */
+  val monitoringPlotEdits: List<MonitoringPlotEdit.Create>
+
+  /**
    * Number of permanent clusters to add to the zone. These clusters must all be located in
    * [addedRegion].
    */
@@ -56,6 +62,10 @@ sealed interface PlantingZoneEdit {
           desiredModel == other.desiredModel &&
           existingModel == other.existingModel &&
           numPermanentClustersToAdd == other.numPermanentClustersToAdd &&
+          monitoringPlotEdits.size == other.monitoringPlotEdits.size &&
+          monitoringPlotEdits.zip(other.monitoringPlotEdits).all { (edit, otherEdit) ->
+            edit.equalsExact(otherEdit, tolerance)
+          } &&
           plantingSubzoneEdits.size == other.plantingSubzoneEdits.size &&
           plantingSubzoneEdits.zip(other.plantingSubzoneEdits).all { (edit, otherEdit) ->
             edit.equalsExact(otherEdit, tolerance)
@@ -64,6 +74,7 @@ sealed interface PlantingZoneEdit {
 
   data class Create(
       override val desiredModel: AnyPlantingZoneModel,
+      override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>,
       override val plantingSubzoneEdits: List<PlantingSubzoneEdit.Create>,
   ) : PlantingZoneEdit {
     override val addedRegion: MultiPolygon
@@ -95,6 +106,9 @@ sealed interface PlantingZoneEdit {
     override val desiredModel: AnyPlantingZoneModel?
       get() = null
 
+    override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>
+      get() = emptyList()
+
     override val numPermanentClustersToAdd: Int
       get() = 0
 
@@ -107,6 +121,7 @@ sealed interface PlantingZoneEdit {
       override val areaHaDifference: BigDecimal,
       override val desiredModel: AnyPlantingZoneModel,
       override val existingModel: ExistingPlantingZoneModel,
+      override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>,
       override val numPermanentClustersToAdd: Int,
       override val plantingSubzoneEdits: List<PlantingSubzoneEdit>,
       override val removedRegion: MultiPolygon,

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
@@ -34,6 +34,7 @@ class PlantingSiteEditCalculatorV1Test {
                 listOf(
                     PlantingZoneEdit.Create(
                         desiredModel = desired.plantingZones[1],
+                        monitoringPlotEdits = emptyList(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
@@ -69,6 +70,7 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("12.5"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * (750 - 500) / 500,
                         plantingSubzoneEdits =
@@ -98,6 +100,7 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("5.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
                         plantingSubzoneEdits =
@@ -136,6 +139,7 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("10.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
                         numPermanentClustersToAdd =
                             PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 700,
                         plantingSubzoneEdits =
@@ -209,6 +213,7 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("-12.5"),
                         desiredModel = desired.plantingZones[1],
                         existingModel = existing.plantingZones[1],
+                        monitoringPlotEdits = emptyList(),
                         numPermanentClustersToAdd = 0,
                         plantingSubzoneEdits =
                             listOf(
@@ -326,18 +331,21 @@ class PlantingSiteEditCalculatorV1Test {
                     ),
                     PlantingZoneEdit.Create(
                         desiredModel = desired.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
                                     desired.plantingZones[0].plantingSubzones[0]))),
                     PlantingZoneEdit.Create(
                         desiredModel = desired.plantingZones[1],
+                        monitoringPlotEdits = emptyList(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
                                     desired.plantingZones[1].plantingSubzones[0]))),
                     PlantingZoneEdit.Create(
                         desiredModel = desired.plantingZones[2],
+                        monitoringPlotEdits = emptyList(),
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(


### PR DESCRIPTION
The flexible planting site editing feature will require fine-grained control
over how monitoring plots are treated after an edit. Add a new level to the
`PlantingSiteEdit` hierarchy to hold lists of specific monitoring plot edit
operations, analogous to `PlantingZoneEdit` and `PlantingSubzoneEdit`.

Currently, nothing consumes these values, and the lists are always empty;
this change just defines the structure. Subsequent changes will start making
use of plot edits.