### PR TITLE
SW-6344 Use MonitoringPlotEdit.Create in zone edits

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
@@ -147,8 +147,10 @@ class PlantingSiteEditCalculatorV1(
                     areaHaDifference = areaHaDifference,
                     desiredModel = desiredZone,
                     existingModel = existingZone,
-                    monitoringPlotEdits = emptyList(),
-                    numPermanentClustersToAdd = newClustersThatFitInAddedRegion,
+                    monitoringPlotEdits =
+                        List(newClustersThatFitInAddedRegion) {
+                          MonitoringPlotEdit.Create(addedRegion, null)
+                        },
                     plantingSubzoneEdits = subzoneEdits,
                     removedRegion = removedRegion,
                 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -40,12 +40,6 @@ sealed interface PlantingZoneEdit {
    */
   val monitoringPlotEdits: List<MonitoringPlotEdit.Create>
 
-  /**
-   * Number of permanent clusters to add to the zone. These clusters must all be located in
-   * [addedRegion].
-   */
-  val numPermanentClustersToAdd: Int
-
   /** Edits to this zone's subzones. */
   val plantingSubzoneEdits: List<PlantingSubzoneEdit>
 
@@ -61,7 +55,6 @@ sealed interface PlantingZoneEdit {
           areaHaDifference.equalsIgnoreScale(other.areaHaDifference) &&
           desiredModel == other.desiredModel &&
           existingModel == other.existingModel &&
-          numPermanentClustersToAdd == other.numPermanentClustersToAdd &&
           monitoringPlotEdits.size == other.monitoringPlotEdits.size &&
           monitoringPlotEdits.zip(other.monitoringPlotEdits).all { (edit, otherEdit) ->
             edit.equalsExact(otherEdit, tolerance)
@@ -86,9 +79,6 @@ sealed interface PlantingZoneEdit {
     override val existingModel: ExistingPlantingZoneModel?
       get() = null
 
-    override val numPermanentClustersToAdd: Int
-      get() = 0
-
     override val removedRegion: MultiPolygon?
       get() = null
   }
@@ -109,9 +99,6 @@ sealed interface PlantingZoneEdit {
     override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>
       get() = emptyList()
 
-    override val numPermanentClustersToAdd: Int
-      get() = 0
-
     override val removedRegion: MultiPolygon
       get() = existingModel.boundary
   }
@@ -122,7 +109,6 @@ sealed interface PlantingZoneEdit {
       override val desiredModel: AnyPlantingZoneModel,
       override val existingModel: ExistingPlantingZoneModel,
       override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>,
-      override val numPermanentClustersToAdd: Int,
       override val plantingSubzoneEdits: List<PlantingSubzoneEdit>,
       override val removedRegion: MultiPolygon,
   ) : PlantingZoneEdit

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -95,7 +95,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           initial = newSite(width = 500) { zone(numPermanent = 7) },
           desired =
               newSite(width = 750) {
-                zone {
+                zone(numPermanent = 7) {
                   subzone(width = 500)
                   subzone()
                 }
@@ -146,7 +146,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               newSite(width = 500) {
                 zone(numPermanent = 7) { subzone { repeat(7) { cluster() } } }
               },
-          desired = newSite(width = 750),
+          desired = newSite(width = 750) { zone(numPermanent = 7) },
           expected = newSite(width = 750) { zone(numPermanent = 10, extraPermanent = 3) },
           expectedPlotCounts =
               listOf(
@@ -212,7 +212,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                         }
                       }
                     },
-                desired = newSite(width = 1000),
+                desired = newSite(width = 1000) { zone(numPermanent = 2) },
                 expected =
                     newSite(width = 1000) {
                       name = "Site $currentAttempt"
@@ -346,7 +346,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               },
           desired =
               newSite(height = 600) {
-                zone {
+                zone(numPermanent = 1) {
                   subzone(width = 250)
                   subzone(width = 250)
                 }
@@ -381,7 +381,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               },
           desired =
               newSite(width = 600) {
-                zone {
+                zone(numPermanent = 1) {
                   subzone(width = 250)
                   subzone(width = 350)
                 }
@@ -482,7 +482,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
      * 3. Applies the edit
      * 4. Compares the result to an expected configuration
      *
-     * Since monitoring plots can be created at random locations, we can't compare them to a fix
+     * Since monitoring plots can be created at random locations, we can't compare them to a fixed
      * list of expected values. Instead, we assert that there are the expected number of plots in
      * specific regions.
      */

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1Test.kt
@@ -70,9 +70,8 @@ class PlantingSiteEditCalculatorV1Test {
                         areaHaDifference = BigDecimal("12.5"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotEdits = emptyList(),
-                        numPermanentClustersToAdd =
-                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * (750 - 500) / 500,
+                        monitoringPlotEdits =
+                            List(4) { MonitoringPlotEdit.Create(newSubzoneBoundary, null) },
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Create(
@@ -86,6 +85,7 @@ class PlantingSiteEditCalculatorV1Test {
   fun `returns updates with both added and removed regions if boundary change was not a simple expansion`() {
     val existing = existingSite(x = 0, width = 500, height = 500)
     val desired = newSite(x = 100, width = 600, height = 500)
+    val addedRegion = rectangle(x = 500, width = 200, height = 500)
 
     assertEditResult(
         PlantingSiteEdit(
@@ -96,13 +96,12 @@ class PlantingSiteEditCalculatorV1Test {
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
-                        addedRegion = rectangle(x = 500, width = 200, height = 500),
+                        addedRegion = addedRegion,
                         areaHaDifference = BigDecimal("5.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotEdits = emptyList(),
-                        numPermanentClustersToAdd =
-                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 500,
+                        monitoringPlotEdits =
+                            List(3) { MonitoringPlotEdit.Create(addedRegion, null) },
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Update(
@@ -125,6 +124,7 @@ class PlantingSiteEditCalculatorV1Test {
         }
     val desired =
         newSite(width = 1000, height = 500) { exclusion = rectangle(width = 100, height = 500) }
+    val addedRegion = rectangle(x = 100, width = 200, height = 500)
 
     assertEditResult(
         PlantingSiteEdit(
@@ -135,17 +135,16 @@ class PlantingSiteEditCalculatorV1Test {
             plantingZoneEdits =
                 listOf(
                     PlantingZoneEdit.Update(
-                        addedRegion = rectangle(x = 100, width = 200, height = 500),
+                        addedRegion = addedRegion,
                         areaHaDifference = BigDecimal("10.0"),
                         desiredModel = desired.plantingZones[0],
                         existingModel = existing.plantingZones[0],
-                        monitoringPlotEdits = emptyList(),
-                        numPermanentClustersToAdd =
-                            PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS * 200 / 700,
+                        monitoringPlotEdits =
+                            List(2) { MonitoringPlotEdit.Create(addedRegion, null) },
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Update(
-                                    addedRegion = rectangle(x = 100, width = 200, height = 500),
+                                    addedRegion = addedRegion,
                                     areaHaDifference = BigDecimal("10.0"),
                                     desiredModel = desired.plantingZones[0].plantingSubzones[0],
                                     existingModel = existing.plantingZones[0].plantingSubzones[0],
@@ -214,7 +213,6 @@ class PlantingSiteEditCalculatorV1Test {
                         desiredModel = desired.plantingZones[1],
                         existingModel = existing.plantingZones[1],
                         monitoringPlotEdits = emptyList(),
-                        numPermanentClustersToAdd = 0,
                         plantingSubzoneEdits =
                             listOf(
                                 PlantingSubzoneEdit.Delete(
@@ -234,21 +232,23 @@ class PlantingSiteEditCalculatorV1Test {
 
     assertEquals(
         PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
-        calculateSiteEdit(existing, doubleSize).plantingZoneEdits.first().numPermanentClustersToAdd,
+        calculateSiteEdit(existing, doubleSize).plantingZoneEdits.first().monitoringPlotEdits.size,
         "Number of permanent clusters to add when doubling zone size")
     assertEquals(
         PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS / 2,
         calculateSiteEdit(existing, halfAgainSize)
             .plantingZoneEdits
             .first()
-            .numPermanentClustersToAdd,
+            .monitoringPlotEdits
+            .size,
         "Number of permanent clusters to add when increasing zone size by half")
     assertEquals(
         1,
         calculateSiteEdit(existing, slightlyLargerSize)
             .plantingZoneEdits
             .first()
-            .numPermanentClustersToAdd,
+            .monitoringPlotEdits
+            .size,
         "Number of permanent clusters to add when increasing zone size slightly")
   }
 
@@ -259,7 +259,7 @@ class PlantingSiteEditCalculatorV1Test {
 
     assertEquals(
         0,
-        calculateSiteEdit(existing, desired).plantingZoneEdits.first().numPermanentClustersToAdd,
+        calculateSiteEdit(existing, desired).plantingZoneEdits.first().monitoringPlotEdits.size,
         "Number of permanent clusters to add")
   }
 
@@ -271,7 +271,7 @@ class PlantingSiteEditCalculatorV1Test {
 
     assertEquals(
         0,
-        calculateSiteEdit(existing, desired).plantingZoneEdits.first().numPermanentClustersToAdd,
+        calculateSiteEdit(existing, desired).plantingZoneEdits.first().monitoringPlotEdits.size,
         "Number of permanent clusters to add")
   }
 


### PR DESCRIPTION
`PlantingZoneEdit` has a field to indicate how many new permanent clusters
need to be created after an edit. The cluster numbers are assigned randomly
by `PlantingSiteStore`.

Replace that field with a list of `MonitoringPlotEdit.Create` objects; explicit
plot creation is how post-edit monitoring plot creation will work in the new
flexible planting site editing code, so this allows more sharing of logic
between the two edit behaviors.