### PR TITLE
SW-6344 Flexible planting site edit calculator

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditBehavior.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditBehavior.kt
@@ -6,5 +6,10 @@ enum class PlantingSiteEditBehavior {
    * Original behavior with restrictions on which boundaries can be edited once a site has
    * observations.
    */
-  Restricted
+  Restricted,
+  /**
+   * New behavior that allows arbitrary map edits including changing boundaries between planting
+   * zones, even on sites with observations.
+   */
+  Flexible
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV1.kt
@@ -12,12 +12,11 @@ import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.coveragePercent
 import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.nearlyCoveredBy
-import com.terraformation.backend.util.toMultiPolygon
+import com.terraformation.backend.util.toNormalizedMultiPolygon
 import java.math.BigDecimal
 import java.math.RoundingMode
 import kotlin.math.max
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.MultiPolygon
 
 class PlantingSiteEditCalculatorV1(
     private val existingSite: ExistingPlantingSiteModel,
@@ -337,9 +336,4 @@ class PlantingSiteEditCalculatorV1(
         .groupBy({ it.value!! }, { it.key })
         .filter { it.value.size > 1 }
   }
-
-  private fun MultiPolygon.orEmpty(): MultiPolygon =
-      if (isEmpty) factory.createMultiPolygon() else this
-
-  private fun Geometry.toNormalizedMultiPolygon() = norm().toMultiPolygon().orEmpty()
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
@@ -1,0 +1,436 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
+import com.terraformation.backend.tracking.model.AnyPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.AnyPlantingZoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSubzoneModel
+import com.terraformation.backend.tracking.model.ExistingPlantingZoneModel
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
+import com.terraformation.backend.tracking.model.MonitoringPlotModel
+import com.terraformation.backend.tracking.model.PlantingSiteValidationFailure
+import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
+import com.terraformation.backend.util.nearlyCoveredBy
+import com.terraformation.backend.util.toNormalizedMultiPolygon
+import java.math.BigDecimal
+import kotlin.math.max
+import kotlin.math.min
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.MultiPolygon
+
+class PlantingSiteEditCalculatorV2(
+    private val existingSite: ExistingPlantingSiteModel,
+    private val desiredSite: AnyPlantingSiteModel,
+) : PlantingSiteEditCalculator {
+  private val problems = mutableListOf<PlantingSiteValidationFailure>()
+
+  override fun calculateSiteEdit(): PlantingSiteEdit {
+    if (desiredSite.boundary == null) {
+      throw IllegalArgumentException("Cannot remove map from site")
+    }
+
+    val zoneEdits = calculateZoneEdits()
+
+    return PlantingSiteEdit(
+        areaHaDifference = calculateAreaHaDifference(existingSite.boundary, desiredSite.boundary),
+        behavior = PlantingSiteEditBehavior.Flexible,
+        desiredModel = desiredSite,
+        existingModel = existingSite,
+        plantingZoneEdits = zoneEdits,
+        problems = problems,
+    )
+  }
+
+  private fun calculateZoneEdits(): List<PlantingZoneEdit> {
+    val existingZonesInUse = existingZonesByDesiredZone.values.filterNotNull().toSet()
+
+    val createEdits =
+        existingZonesByDesiredZone
+            .filterValues { it == null }
+            .keys
+            .map { newZone ->
+              val existingPlotsInNewZone =
+                  existingMonitoringPlots.filter {
+                    desiredZonesByMonitoringPlotId[it.id] == newZone
+                  }
+              var nextPermanentCluster = 1
+              val adoptEdits =
+                  existingPlotsInNewZone.map { plot ->
+                    val permanentCluster =
+                        if (nextPermanentCluster <= newZone.numPermanentClusters &&
+                            plot.sizeMeters == MONITORING_PLOT_SIZE_INT &&
+                            plot.isAvailable &&
+                            !plot.isAdHoc) {
+                          nextPermanentCluster++
+                        } else {
+                          // If we didn't use up all the existing permanent plots, remove the
+                          // remaining ones from the permanent list by setting their permanent
+                          // cluster numbers to null so that any permanent plots we create later
+                          // will be randomly placed in the zone. We still want to adopt them into
+                          // the correct subzones, though.
+                          null
+                        }
+                    MonitoringPlotEdit.Adopt(
+                        monitoringPlotId = plot.id, permanentCluster = permanentCluster)
+                  }
+              val numPermanentPlotsToCreate =
+                  max(0, newZone.numPermanentClusters - nextPermanentCluster + 1)
+
+              PlantingZoneEdit.Create(
+                  desiredModel = newZone,
+                  monitoringPlotEdits =
+                      List(numPermanentPlotsToCreate) { index ->
+                        MonitoringPlotEdit.Create(
+                            region = newZone.boundary,
+                            permanentCluster = nextPermanentCluster + index)
+                      },
+                  plantingSubzoneEdits =
+                      newZone.plantingSubzones.map { newSubzone ->
+                        PlantingSubzoneEdit.Create(
+                            newSubzone,
+                            adoptEdits.filter { adoptEdit ->
+                              desiredSubzonesByMonitoringPlotId[adoptEdit.monitoringPlotId] ==
+                                  newSubzone
+                            })
+                      })
+            }
+
+    val deleteEdits =
+        existingSite.plantingZones.toSet().minus(existingZonesInUse).map { existingZone ->
+          val plantingSubzoneEdits =
+              existingZone.plantingSubzones.map { existingSubzone ->
+                PlantingSubzoneEdit.Delete(
+                    existingSubzone,
+                    existingSubzone.monitoringPlots
+                        .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
+                        .map { MonitoringPlotEdit.Eject(it.id) })
+              }
+
+          PlantingZoneEdit.Delete(
+              existingModel = existingZone,
+              plantingSubzoneEdits = plantingSubzoneEdits,
+          )
+        }
+
+    val updateEdits =
+        existingZonesByDesiredZone
+            .filterValues { it != null }
+            .mapNotNull { (desiredZone, existingZone) ->
+              val existingUsableBoundary =
+                  existingZone!!.boundary.differenceNullable(existingSite.exclusion)
+              val desiredUsableBoundary =
+                  desiredZone.boundary.differenceNullable(desiredSite.exclusion)
+
+              // Now we need two lists of existing monitoring plots: the ones in the part of the
+              // zone that overlap with the zone's old geometry, and the ones in the newly-added
+              // part of the zone, which may already have monitoring plots if this edit is
+              // changing the boundary between two existing zones.
+              //
+              // We want to pick permanent plots from both lists in proportion to the area of the
+              // two parts of the zone. For example, if 60% of the desired zone boundary overlaps
+              // with the existing zone boundary, then we want 60% of the permanent plots to come
+              // from the first list.
+              //
+              // If either list runs out of existing plots before we've assigned the required
+              // number of permanent plots to the zone, we want to create new plots in the
+              // part of the zone the list comes from.
+              val overlappingBoundary =
+                  desiredUsableBoundary
+                      .intersection(existingUsableBoundary)
+                      .toNormalizedMultiPolygon()
+              val nonOverlappingBoundary =
+                  desiredUsableBoundary
+                      .difference(existingUsableBoundary)
+                      .toNormalizedMultiPolygon()
+              val fractionOfDesiredAreaOverlappingWithExisting =
+                  min(1.0, overlappingBoundary.area / desiredUsableBoundary.area)
+
+              val existingPlotsInDesiredZone =
+                  existingMonitoringPlots.filter {
+                    it.boundary.nearlyCoveredBy(desiredUsableBoundary)
+                  }
+              val (candidatePlots, disqualifiedPlots) =
+                  existingPlotsInDesiredZone.partition {
+                    it.isAvailable && !it.isAdHoc && it.sizeMeters == MONITORING_PLOT_SIZE_INT
+                  }
+              val (existingPlotsInOverlappingArea, existingPlotsInNewArea) =
+                  candidatePlots
+                      .partition { it.boundary.nearlyCoveredBy(existingUsableBoundary) }
+                      .toList()
+                      .map { it.toMutableList() }
+
+              // Returns a function that returns the next plot edit (create or adopt operation) for
+              // either the overlapping or the non-overlapping part of the zone.
+              fun nextPlotForArea(
+                  plotList: MutableList<MonitoringPlotModel>,
+                  boundary: MultiPolygon
+              ): (Int) -> MonitoringPlotEdit {
+                return { index ->
+                  val permanentCluster = index + 1
+                  val nextExistingPlot = plotList.removeFirstOrNull()
+                  if (nextExistingPlot != null) {
+                    MonitoringPlotEdit.Adopt(nextExistingPlot.id, permanentCluster)
+                  } else {
+                    MonitoringPlotEdit.Create(boundary, permanentCluster)
+                  }
+                }
+              }
+
+              val desiredPermanentClusterEdits =
+                  (zipProportionally(
+                      desiredZone.numPermanentClusters,
+                      fractionOfDesiredAreaOverlappingWithExisting,
+                      nextPlotForArea(existingPlotsInOverlappingArea, overlappingBoundary),
+                      nextPlotForArea(existingPlotsInNewArea, nonOverlappingBoundary)))
+
+              // If we didn't use up all the existing permanent plots, remove the remaining ones
+              // from the permanent list by setting their permanent cluster numbers to null so that
+              // any permanent plots we create later will be randomly placed in the zone. We still
+              // want to adopt them into the correct subzones, though.
+              val dropExcessExistingClusterEdits =
+                  (existingPlotsInOverlappingArea + existingPlotsInNewArea + disqualifiedPlots)
+                      .map { MonitoringPlotEdit.Adopt(it.id, permanentCluster = null) }
+
+              val monitoringPlotEdits =
+                  desiredPermanentClusterEdits + dropExcessExistingClusterEdits
+              val createMonitoringPlotEdits =
+                  monitoringPlotEdits.filterIsInstance<MonitoringPlotEdit.Create>()
+
+              val subzoneEdits =
+                  calculateSubzoneEdits(existingZone, desiredZone, monitoringPlotEdits)
+
+              if (subzoneEdits.isEmpty() &&
+                  createMonitoringPlotEdits.isEmpty() &&
+                  existingUsableBoundary.equalsExact(desiredUsableBoundary, 0.00001)) {
+                null
+              } else {
+                PlantingZoneEdit.Update(
+                    addedRegion =
+                        desiredUsableBoundary
+                            .difference(existingUsableBoundary)
+                            .toNormalizedMultiPolygon(),
+                    areaHaDifference =
+                        calculateAreaHaDifference(existingUsableBoundary, desiredUsableBoundary),
+                    desiredModel = desiredZone,
+                    existingModel = existingZone,
+                    monitoringPlotEdits = createMonitoringPlotEdits,
+                    plantingSubzoneEdits = subzoneEdits,
+                    removedRegion =
+                        existingUsableBoundary
+                            .difference(desiredUsableBoundary)
+                            .toNormalizedMultiPolygon(),
+                )
+              }
+            }
+
+    return deleteEdits + updateEdits + createEdits
+  }
+
+  private fun calculateSubzoneEdits(
+      existingZone: ExistingPlantingZoneModel,
+      desiredZone: AnyPlantingZoneModel,
+      monitoringPlotEdits: List<MonitoringPlotEdit>,
+  ): List<PlantingSubzoneEdit> {
+    val subzoneMappings: Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel?> =
+        desiredZone.plantingSubzones.associateWith { existingSubzonesByDesiredSubzone[it] }
+    val existingSubzonesInUse =
+        existingZone.plantingSubzones
+            .filter { desiredSubzonesByExistingSubzone[it] != null }
+            .toSet()
+
+    val createEdits =
+        subzoneMappings
+            .filterValues { it == null }
+            .keys
+            .map { newSubzone ->
+              val adoptEdits =
+                  monitoringPlotEdits.filter {
+                    it is MonitoringPlotEdit.Adopt &&
+                        desiredSubzonesByMonitoringPlotId[it.monitoringPlotId] == newSubzone
+                  }
+              PlantingSubzoneEdit.Create(newSubzone, adoptEdits)
+            }
+
+    val deleteEdits =
+        existingZone.plantingSubzones.toSet().minus(existingSubzonesInUse).map { existingSubzone ->
+          PlantingSubzoneEdit.Delete(
+              existingSubzone,
+              existingSubzone.monitoringPlots
+                  .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
+                  .map { MonitoringPlotEdit.Eject(it.id) })
+        }
+
+    val updateEdits =
+        subzoneMappings
+            .filterValues { it != null }
+            .mapNotNull { (desiredSubzone, existingSubzone) ->
+              val desiredUsableBoundary =
+                  desiredSubzone.boundary.differenceNullable(desiredSite.exclusion)
+              val existingUsableBoundary =
+                  existingSubzone!!.boundary.differenceNullable(existingSite.exclusion)
+              val adoptEdits =
+                  monitoringPlotEdits
+                      .filterIsInstance<MonitoringPlotEdit.Adopt>()
+                      .filter { plotEdit ->
+                        desiredSubzonesByMonitoringPlotId[plotEdit.monitoringPlotId] ==
+                            desiredSubzone
+                      }
+                      .filter { plotEdit ->
+                        // If the plot is already in the right subzone with the right cluster
+                        // number, no need to adopt it.
+                        val monitoringPlotId = plotEdit.monitoringPlotId
+                        val existingMonitoringPlot = existingMonitoringPlotsById[monitoringPlotId]
+                        existingSubzonesByMonitoringPlotId[monitoringPlotId] != existingSubzone ||
+                            existingMonitoringPlot?.permanentCluster != plotEdit.permanentCluster
+                      }
+              val ejectEdits =
+                  existingSubzone.monitoringPlots
+                      .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
+                      .map { MonitoringPlotEdit.Eject(it.id) }
+
+              if (existingSubzone.boundary.equalsExact(desiredSubzone.boundary, 0.00001) &&
+                  existingUsableBoundary.equalsExact(desiredUsableBoundary, 0.00001) &&
+                  adoptEdits.isEmpty() &&
+                  ejectEdits.isEmpty()) {
+                null
+              } else {
+                PlantingSubzoneEdit.Update(
+                    addedRegion =
+                        desiredUsableBoundary
+                            .difference(existingUsableBoundary)
+                            .toNormalizedMultiPolygon(),
+                    areaHaDifference =
+                        calculateAreaHaDifference(
+                            existingSubzone.boundary, desiredSubzone.boundary),
+                    desiredModel = desiredSubzone,
+                    existingModel = existingSubzone,
+                    monitoringPlotEdits = ejectEdits + adoptEdits,
+                    removedRegion =
+                        existingUsableBoundary
+                            .difference(desiredUsableBoundary)
+                            .toNormalizedMultiPolygon(),
+                )
+              }
+            }
+
+    return deleteEdits + createEdits + updateEdits
+  }
+
+  private fun calculateAreaHaDifference(existing: Geometry?, desired: Geometry): BigDecimal {
+    val desiredArea = desired.differenceNullable(desiredSite.exclusion).calculateAreaHectares()
+    return if (existing != null) {
+      desiredArea - existing.differenceNullable(existingSite.exclusion).calculateAreaHectares()
+    } else {
+      desiredArea
+    }
+  }
+
+  /** The desired version of each existing planting zone, or null if the zone is being deleted. */
+  private val desiredZonesByExistingZone:
+      Map<ExistingPlantingZoneModel, AnyPlantingZoneModel?> by lazy {
+    val desiredZonesByName = desiredSite.plantingZones.associateBy { it.name }
+    existingSite.plantingZones.associateWith { desiredZonesByName[it.name] }
+  }
+
+  /**
+   * The existing version of each desired planting zone, or null if the zone is being newly created.
+   */
+  private val existingZonesByDesiredZone:
+      Map<AnyPlantingZoneModel, ExistingPlantingZoneModel?> by lazy {
+    val existingZonesByName = existingSite.plantingZones.associateBy { it.name }
+    desiredSite.plantingZones.associateWith { existingZonesByName[it.name] }
+  }
+
+  /** The desired version of each existing subzone, or null if the subzone is being deleted. */
+  private val desiredSubzonesByExistingSubzone:
+      Map<ExistingPlantingSubzoneModel, AnyPlantingSubzoneModel?> by lazy {
+    existingSite.plantingZones
+        .flatMap { existingZone ->
+          val desiredSubzonesByName =
+              desiredZonesByExistingZone[existingZone]?.plantingSubzones?.associateBy { it.name }
+                  ?: emptyMap()
+          existingZone.plantingSubzones.map { existingSubzone ->
+            existingSubzone to desiredSubzonesByName[existingSubzone.name]
+          }
+        }
+        .toMap()
+  }
+
+  /**
+   * The existing version of each desired subzone, or null if the subzone is being newly created.
+   */
+  private val existingSubzonesByDesiredSubzone:
+      Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel?> by lazy {
+    desiredSite.plantingZones
+        .flatMap { desiredZone ->
+          val existingSubzonesByName =
+              existingZonesByDesiredZone[desiredZone]?.plantingSubzones?.associateBy { it.name }
+                  ?: emptyMap()
+          desiredZone.plantingSubzones.map { desiredSubzone ->
+            desiredSubzone to existingSubzonesByName[desiredSubzone.name]
+          }
+        }
+        .toMap()
+  }
+
+  /** Flattened list of all the monitoring plots in all existing zones. */
+  private val existingMonitoringPlots: List<MonitoringPlotModel> by lazy {
+    existingSite.plantingZones
+        .flatMap { plantingZone -> plantingZone.plantingSubzones.flatMap { it.monitoringPlots } }
+        .sortedWith(compareBy({ it.permanentCluster ?: Int.MAX_VALUE }, { it.plotNumber }))
+  }
+
+  private val existingMonitoringPlotsById: Map<MonitoringPlotId, MonitoringPlotModel> by lazy {
+    existingMonitoringPlots.associateBy { it.id }
+  }
+
+  /**
+   * For each existing monitoring plot, the desired zone that covers it, or null if it isn't covered
+   * by any zone. Plots that straddle two zones aren't considered to be in either zone.
+   */
+  private val desiredZonesByMonitoringPlotId: Map<MonitoringPlotId, AnyPlantingZoneModel?> by lazy {
+    existingMonitoringPlots.associate { plot ->
+      plot.id to
+          desiredSite.plantingZones.firstOrNull { zone ->
+            plot.boundary.nearlyCoveredBy(zone.boundary.differenceNullable(desiredSite.exclusion))
+          }
+    }
+  }
+
+  /**
+   * For each existing monitoring plot, the desired subzone that covers the largest fraction of it,
+   * or null if the plot is outside all subzones.
+   */
+  private val desiredSubzonesByMonitoringPlotId:
+      Map<MonitoringPlotId, AnyPlantingSubzoneModel?> by lazy {
+    existingMonitoringPlots.associate { plot ->
+      plot.id to
+          desiredZonesByMonitoringPlotId[plot.id]?.let { desiredZone ->
+            desiredZone.plantingSubzones
+                .mapNotNull { desiredSubzone ->
+                  if (desiredSubzone.boundary.intersects(plot.boundary)) {
+                    desiredSubzone to desiredSubzone.boundary.intersection(plot.boundary).area
+                  } else {
+                    null
+                  }
+                }
+                .maxByOrNull { it.second }
+                ?.first
+          }
+    }
+  }
+
+  /** Which subzone each each existing monitoring plot is in. */
+  private val existingSubzonesByMonitoringPlotId:
+      Map<MonitoringPlotId, ExistingPlantingSubzoneModel> by lazy {
+    existingSite.plantingZones
+        .flatMap { zone ->
+          zone.plantingSubzones.flatMap { subzone ->
+            subzone.monitoringPlots.map { plot -> plot.id to subzone }
+          }
+        }
+        .toMap()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -141,6 +141,10 @@ fun Geometry.toMultiPolygon(): MultiPolygon {
   }
 }
 
+fun MultiPolygon.orEmpty(): MultiPolygon = if (isEmpty) factory.createMultiPolygon() else this
+
+fun Geometry.toNormalizedMultiPolygon() = norm().toMultiPolygon().orEmpty()
+
 /**
  * Fixes problems with invalid geometries if possible. Geometries that are calculated using
  * operations like intersections and unions can suffer from floating-point inaccuracy which causes

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
@@ -1,0 +1,814 @@
+package com.terraformation.backend.tracking.edit
+
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.rectangle
+import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.existingSite
+import com.terraformation.backend.tracking.model.PlantingSiteBuilder.Companion.newSite
+import com.terraformation.backend.tracking.model.PlantingSiteValidationFailure
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class PlantingSiteEditCalculatorV2Test {
+  @Test
+  fun `returns create edits for newly added zone and subzone`() {
+    val existing = existingSite(width = 500) { zone(numPermanent = 1) { subzone { cluster() } } }
+    val desired =
+        newSite(width = 750) {
+          zone(width = 500, numPermanent = 1)
+          zone(width = 250, numPermanent = 1)
+        }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("12.5"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Create(
+                        desiredModel = desired.plantingZones[1],
+                        monitoringPlotEdits =
+                            listOf(MonitoringPlotEdit.Create(desired.plantingZones[1].boundary, 1)),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desiredModel =
+                                        desired.plantingZones[1].plantingSubzones[0]))))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `returns zone update and subzone create for expansion of zone with new subzone`() {
+    val newSubzoneBoundary = rectangle(x = 500, width = 250, height = 500)
+
+    val existing =
+        existingSite(width = 500) {
+          zone {
+            subzone {
+              cluster()
+              cluster()
+              plot(x = 600, isAdHoc = true)
+            }
+          }
+        }
+    val existingBoundary = existing.boundary!!
+    val desired =
+        newSite(width = 750) {
+          zone(numPermanent = 6) {
+            subzone(width = 500)
+            subzone()
+          }
+        }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("12.5"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = newSubzoneBoundary,
+                        areaHaDifference = BigDecimal("12.5"),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                // Cluster 1 is already in the existing subzone
+                                MonitoringPlotEdit.Create(newSubzoneBoundary, 2),
+                                // Cluster 3 will be the old cluster 2 from the existing subzone
+                                MonitoringPlotEdit.Create(existingBoundary, 4),
+                                MonitoringPlotEdit.Create(newSubzoneBoundary, 5),
+                                MonitoringPlotEdit.Create(existingBoundary, 6),
+                            ),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[1],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(3)),
+                                        ),
+                                ),
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(2), 3),
+                                        ),
+                                    removedRegion = rectangle(0),
+                                ),
+                            ),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `returns updates with both added and removed regions if boundary change was not a simple expansion`() {
+    val existing = existingSite(x = 0, width = 500, height = 500)
+    val desired = newSite(x = 100, width = 600, height = 500) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("5.0"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 500, width = 200, height = 500),
+                        areaHaDifference = BigDecimal("5.0"),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                MonitoringPlotEdit.Create(
+                                    rectangle(x = 100, width = 400, height = 500), 1)),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 500, width = 200, height = 500),
+                                    areaHaDifference = BigDecimal("5.0"),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    removedRegion = rectangle(x = 0, width = 100, height = 500),
+                                )),
+                        removedRegion = rectangle(x = 0, width = 100, height = 500)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `matches existing and new zones based on names, not locations`() {
+    val existing =
+        existingSite(width = 1000, height = 500) {
+          zone(name = "A", width = 800) { subzone(name = "A-1") { cluster() } }
+          zone(name = "B", width = 200) { subzone(name = "B-1") { cluster() } }
+        }
+    val desired =
+        newSite(width = 1000, height = 500) {
+          zone(name = "B", width = 500, numPermanent = 1) { subzone(name = "B-1") }
+          zone(name = "A", width = 500, numPermanent = 1) { subzone(name = "A-1") }
+        }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    // Zone B moves to west edge of site and grows from 200m to 500m wide
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 0, width = 500, height = 500),
+                        areaHaDifference = BigDecimal(15),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[1],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 0, width = 500, height = 500),
+                                    areaHaDifference = BigDecimal(15),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[1].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(1), 1),
+                                        ),
+                                    removedRegion = rectangle(x = 800, width = 200, height = 500),
+                                )),
+                        removedRegion = rectangle(x = 800, width = 200, height = 500),
+                    ),
+                    // Zone A moves to east edge of site and shrinks from 800m to 500m wide
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 800, width = 200, height = 500),
+                        areaHaDifference = BigDecimal(-15),
+                        desiredModel = desired.plantingZones[1],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                // The permanent plot should be created in the part of the zone that
+                                // overlaps with its old boundary.
+                                MonitoringPlotEdit.Create(
+                                    rectangle(x = 500, width = 300, height = 500), 1),
+                            ),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 800, width = 200, height = 500),
+                                    areaHaDifference = BigDecimal(-15),
+                                    desiredModel = desired.plantingZones[1].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            // Plot 2 was in the area that overlapped with the old
+                                            // area of the zone, which is smaller than the newly
+                                            // added area, so it is removed from the permanent
+                                            // cluster list.
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(2), null),
+                                        ),
+                                    removedRegion = rectangle(x = 0, width = 500, height = 500),
+                                )),
+                        removedRegion = rectangle(x = 0, width = 500, height = 500),
+                    ),
+                ),
+        ),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `moves monitoring plots to new subzones`() {
+    val existing =
+        existingSite(width = 1000, height = 500) {
+          zone(name = "A") {
+            subzone(name = "A-1") {
+              plot(x = 600, plotNumber = 1, cluster = 1)
+              plot(x = 630, plotNumber = 2)
+              plot(x = 660, plotNumber = 3, isAdHoc = true)
+            }
+          }
+        }
+    val desired =
+        newSite(width = 1000, height = 500) {
+          zone(name = "A", width = 500, numPermanent = 1) { subzone(name = "A-1") }
+          zone(name = "B", width = 500, numPermanent = 1) { subzone(name = "B-1") }
+        }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal(-25),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                MonitoringPlotEdit.Create(
+                                    rectangle(x = 0, width = 500, height = 500), 1)),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal(-25),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits = emptyList(),
+                                    removedRegion = rectangle(x = 500, width = 500, height = 500),
+                                )),
+                        removedRegion = rectangle(x = 500, width = 500, height = 500),
+                    ),
+                    PlantingZoneEdit.Create(
+                        desiredModel = desired.plantingZones[1],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Create(
+                                    desiredModel = desired.plantingZones[1].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(
+                                                monitoringPlotId = MonitoringPlotId(1),
+                                                permanentCluster = 1),
+                                            MonitoringPlotEdit.Adopt(
+                                                monitoringPlotId = MonitoringPlotId(2)),
+                                            MonitoringPlotEdit.Adopt(
+                                                monitoringPlotId = MonitoringPlotId(3)))))))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `adopts existing permanent plots proportionally when combining zones`() {
+    val existing =
+        existingSite(x = 0, width = 1000) {
+          zone(name = "A", x = 0, width = 500) {
+            subzone {
+              cluster(plotNumber = 1, x = 300, y = 0)
+              cluster(plotNumber = 2, x = 300, y = 30)
+              cluster(plotNumber = 4, x = 300, y = 60)
+              cluster(plotNumber = 7, x = 300, y = 90)
+            }
+          }
+          zone(name = "B", x = 500, width = 500) {
+            subzone {
+              cluster(plotNumber = 16, x = 600, y = 0)
+              cluster(plotNumber = 18, x = 600, y = 30)
+              cluster(plotNumber = 19, x = 600, y = 60)
+              cluster(plotNumber = 23, x = 600, y = 90)
+              cluster(plotNumber = 25, x = 600, y = 120)
+              cluster(plotNumber = 26, x = 600, y = 150)
+              cluster(plotNumber = 27, x = 600, y = 180)
+            }
+          }
+        }
+
+    // 44% overlaps with old zone A, 56% doesn't.
+    val desired =
+        newSite(x = 280, width = 500) { zone(name = "A", numPermanent = 11, numTemporary = 3) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("-25.0"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Delete(
+                        existingModel = existing.plantingZones[1],
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Delete(
+                                    existingModel = existing.plantingZones[1].plantingSubzones[0],
+                                    monitoringPlotEdits = emptyList(),
+                                ))),
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 500, width = 280, height = 500),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                MonitoringPlotEdit.Create(
+                                    region = rectangle(x = 280, width = 220, height = 500),
+                                    permanentCluster = 11),
+                            ),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 500, width = 280, height = 500),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(16), permanentCluster = 1),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(1), permanentCluster = 2),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(18), permanentCluster = 3),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(2), permanentCluster = 4),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(19), permanentCluster = 5),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(4), permanentCluster = 6),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(23), permanentCluster = 7),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(25), permanentCluster = 8),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(7), permanentCluster = 9),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(26), permanentCluster = 10),
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(27), permanentCluster = null),
+                                        ),
+                                    removedRegion = rectangle(x = 0, width = 280, height = 500),
+                                ),
+                            ),
+                        removedRegion = rectangle(x = 0, width = 280, height = 500),
+                    ),
+                ),
+        ),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `does not adopt 25-meter, ad-hoc, or unavailable plots as new permanent plots`() {
+    val existing =
+        existingSite(width = 400) {
+          zone {
+            subzone {
+              plot(size = 25)
+              plot(isAdHoc = true)
+              plot(isAvailable = false)
+            }
+          }
+        }
+    val desired = newSite(width = 500) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal(5),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        areaHaDifference = BigDecimal(5),
+                        addedRegion = rectangle(x = 400, width = 100, height = 500),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                MonitoringPlotEdit.Create(existing.boundary!!, 1),
+                            ),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 400, width = 100, height = 500),
+                                    areaHaDifference = BigDecimal(5),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    // The unqualified plots are already in the correct subzone and
+                                    // already have null permanent cluster numbers, so no need to
+                                    // update any of them.
+                                    monitoringPlotEdits = emptyList(),
+                                    removedRegion = rectangle(0),
+                                ),
+                            ),
+                        removedRegion = rectangle(0),
+                    ),
+                )),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `treats removal of exclusion area as an expansion of the site`() {
+    val existing =
+        existingSite(x = 0, width = 1000, height = 500) {
+          exclusion = rectangle(width = 300, height = 500)
+        }
+    val desired =
+        newSite(width = 1000, height = 500) {
+          exclusion = rectangle(width = 100, height = 500)
+          zone(numPermanent = 10)
+        }
+    val addedRegion = rectangle(x = 100, width = 200, height = 500)
+    val existingRegion = rectangle(x = 300, width = 700, height = 500)
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("10.0"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = addedRegion,
+                        areaHaDifference = BigDecimal("10.0"),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(
+                                // Added region is 200 meters wide; existing region is 700 meters
+                                // wide. So 22.2% of the permanent plots should go in the added
+                                // region and 77.7% in the existing region.
+                                MonitoringPlotEdit.Create(existingRegion, 1),
+                                MonitoringPlotEdit.Create(existingRegion, 2),
+                                MonitoringPlotEdit.Create(existingRegion, 3),
+                                MonitoringPlotEdit.Create(addedRegion, 4),
+                                MonitoringPlotEdit.Create(existingRegion, 5),
+                                MonitoringPlotEdit.Create(existingRegion, 6),
+                                MonitoringPlotEdit.Create(existingRegion, 7),
+                                MonitoringPlotEdit.Create(addedRegion, 8),
+                                MonitoringPlotEdit.Create(existingRegion, 9),
+                                MonitoringPlotEdit.Create(existingRegion, 10),
+                            ),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = addedRegion,
+                                    areaHaDifference = BigDecimal("10.0"),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits = emptyList(),
+                                    removedRegion = rectangle(0),
+                                )),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `increases number of permanent clusters even if geometry stayed the same`() {
+    val existing = existingSite {
+      zone(numPermanent = 2) {
+        subzone {
+          cluster()
+          cluster()
+        }
+      }
+    }
+    val desired = newSite { zone(numPermanent = 3) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(MonitoringPlotEdit.Create(existing.boundary!!, 3)),
+                        plantingSubzoneEdits = emptyList(),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `reduces number of permanent clusters even if geometry stayed the same`() {
+    val existing = existingSite {
+      zone(numPermanent = 3) {
+        subzone {
+          cluster()
+          cluster()
+          cluster()
+        }
+      }
+    }
+    val desired = newSite { zone(numPermanent = 2) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Adopt(MonitoringPlotId(3), null)),
+                                    removedRegion = rectangle(0),
+                                )),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `returns deletion of zone that no longer exists`() {
+    val existing =
+        existingSite(width = 1000) {
+          zone(width = 750, numPermanent = 1) { subzone { cluster() } }
+          zone(width = 250, numPermanent = 1) { subzone { cluster() } }
+        }
+    val desired = newSite(width = 750) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("-12.5"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Delete(
+                        existingModel = existing.plantingZones[1],
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Delete(
+                                    existingModel = existing.plantingZones[1].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(MonitoringPlotEdit.Eject(MonitoringPlotId(2)))))))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `returns deletion of subzone that no longer exists`() {
+    val existing =
+        existingSite(width = 1000) {
+          zone {
+            subzone(width = 500)
+            subzone(width = 500)
+          }
+        }
+    val desired = newSite(width = 500) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal(-25),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal(-25),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits =
+                            listOf(MonitoringPlotEdit.Create(desired.boundary!!, 1)),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Delete(
+                                    existingModel = existing.plantingZones[0].plantingSubzones[1],
+                                )),
+                        removedRegion = rectangle(x = 500, width = 500, height = 500)))),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `ejects monitoring plots that overlap with added exclusion area`() {
+    val existing = existingSite {
+      zone {
+        subzone {
+          plot(cluster = 2)
+          plot(cluster = 1)
+        }
+      }
+    }
+    val desired = newSite {
+      exclusion = rectangle(25)
+      zone(numPermanent = 1)
+    }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("-0.1"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal("-0.1"),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(0),
+                                    areaHaDifference = BigDecimal("-0.1"),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Eject(MonitoringPlotId(1)),
+                                            // Plot ID 2 is already in the correct subzone with the
+                                            // correct cluster number.
+                                        ),
+                                    removedRegion = rectangle(25),
+                                ),
+                            ),
+                        removedRegion = rectangle(25),
+                    )),
+        ),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `ejects monitoring plots that no longer lie in site`() {
+    val existing = existingSite {
+      zone(numPermanent = 1) {
+        subzone {
+          plot(cluster = 1)
+          plot(cluster = 2)
+        }
+      }
+    }
+    val desired = newSite(x = 10) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 500, width = 10, height = 500),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 500, width = 10, height = 500),
+                                    areaHaDifference = BigDecimal.ZERO,
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Eject(MonitoringPlotId(1)),
+                                            MonitoringPlotEdit.Adopt(MonitoringPlotId(2), 1),
+                                        ),
+                                    removedRegion = rectangle(width = 10, height = 500),
+                                ),
+                            ),
+                        removedRegion = rectangle(width = 10, height = 500),
+                    )),
+        ),
+        existing,
+        desired)
+  }
+
+  @Test
+  fun `returns empty list of edits if nothing changed`() {
+    val existing = existingSite { zone(numPermanent = 1) { subzone { cluster() } } }
+    val desired = existing.toNew()
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal("0.0"),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits = emptyList()),
+        existing,
+        desired)
+  }
+
+  @Nested
+  inner class Validation {
+    @Test
+    fun `allows completely moving existing site`() {
+      val existing = existingSite(x = 0, width = 1000)
+      val desired = newSite(x = 5000, width = 100)
+
+      assertHasNoProblems(existing, desired)
+    }
+
+    @Test
+    fun `throws exception if desired site has no boundary`() {
+      assertThrows<IllegalArgumentException> {
+        PlantingSiteEditCalculatorV2(
+                existingSite(),
+                newSite().copy(boundary = null),
+            )
+            .calculateSiteEdit()
+      }
+    }
+  }
+
+  private fun calculateSiteEdit(
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel,
+  ): PlantingSiteEdit = PlantingSiteEditCalculatorV2(existing, desired).calculateSiteEdit()
+
+  private fun assertEditResult(
+      expected: PlantingSiteEdit,
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel,
+  ) {
+    val actual = calculateSiteEdit(existing, desired)
+
+    if (!actual.equalsExact(expected)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  private fun assertHasNoProblems(
+      existing: ExistingPlantingSiteModel,
+      desired: AnyPlantingSiteModel,
+  ) {
+    val edit = calculateSiteEdit(existing, desired)
+    assertEquals(emptyList<PlantingSiteValidationFailure>(), edit.problems, "Unexpected problems")
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -253,6 +253,7 @@ private constructor(
                 lastCluster -> nextSubplot
                 else -> 1
               },
+          isAdHoc: Boolean = false,
           isAvailable: Boolean = true,
           size: Int = MONITORING_PLOT_SIZE_INT,
           plotNumber: Long = nextPlotNumber,
@@ -268,7 +269,7 @@ private constructor(
             MonitoringPlotModel(
                 boundary = rectanglePolygon(size, size, x, y),
                 id = MonitoringPlotId(plotNumber),
-                isAdHoc = false,
+                isAdHoc = isAdHoc,
                 isAvailable = isAvailable,
                 permanentCluster = cluster,
                 permanentClusterSubplot = subplot,


### PR DESCRIPTION
Add a second `PlantingSiteEditCalculator` class that implements the flexible
planting site edit behavior, including moving monitoring plots between subzones
and more precise creation of new monitoring plots based on boundary changes.

This change is just the calculator itself; nothing calls this code yet.