### PR TITLE
SW-6344 Reuse exterior plots when zone expands

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -840,7 +840,6 @@ class PlantingSiteStore(
         with(MONITORING_PLOTS) {
           dslContext
               .update(MONITORING_PLOTS)
-              .set(IS_AVAILABLE, false)
               .setNull(PERMANENT_CLUSTER)
               .setNull(PERMANENT_CLUSTER_SUBPLOT)
               .setNull(PLANTING_SUBZONE_ID)

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
@@ -375,11 +375,14 @@ class PlantingSiteEditCalculatorV2(
         .toMap()
   }
 
-  /** Flattened list of all the monitoring plots in all existing zones. */
+  /** Flattened list of all the site's monitoring plots. */
   private val existingMonitoringPlots: List<MonitoringPlotModel> by lazy {
-    existingSite.plantingZones
-        .flatMap { plantingZone -> plantingZone.plantingSubzones.flatMap { it.monitoringPlots } }
-        .sortedWith(compareBy({ it.permanentCluster ?: Int.MAX_VALUE }, { it.plotNumber }))
+    val plotsInSubzones =
+        existingSite.plantingZones.flatMap { plantingZone ->
+          plantingZone.plantingSubzones.flatMap { it.monitoringPlots }
+        }
+    (plotsInSubzones + existingSite.exteriorPlots).sortedWith(
+        compareBy({ it.permanentCluster ?: Int.MAX_VALUE }, { it.plotNumber }))
   }
 
   private val existingMonitoringPlotsById: Map<MonitoringPlotId, MonitoringPlotModel> by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -256,15 +256,17 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     }
 
     @Test
-    fun `marks existing temporary plots as unavailable if they are outside the new usable area`() {
+    fun `retains availability of existing temporary plots even if they are outside the new usable area`() {
       val exclusionAreaPlotNumber = 1L
       val plantableAreaPlotNumber = 2L
+      val unavailablePlotNumber = 3L
       runScenario(
           newSite {
             zone {
               subzone {
                 plot(plotNumber = exclusionAreaPlotNumber)
                 plot(plotNumber = plantableAreaPlotNumber)
+                plot(plotNumber = unavailablePlotNumber, isAvailable = false)
               }
             }
           },
@@ -274,7 +276,10 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           })
 
       assertEquals(
-          mapOf(exclusionAreaPlotNumber to false, plantableAreaPlotNumber to true),
+          mapOf(
+              exclusionAreaPlotNumber to true,
+              plantableAreaPlotNumber to true,
+              unavailablePlotNumber to false),
           monitoringPlotsDao.findAll().associate { it.plotNumber to it.isAvailable },
           "isAvailable flags")
     }
@@ -298,7 +303,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           allPlots.associate { it.plotNumber to it.permanentCluster },
           "Cluster numbers of monitoring plots")
       assertEquals(
-          mapOf(1L to false, 2L to true),
+          mapOf(1L to true, 2L to true),
           allPlots.associate { it.plotNumber to it.isAvailable },
           "isAvailable flags")
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
@@ -399,6 +399,42 @@ class PlantingSiteEditCalculatorV2Test {
   }
 
   @Test
+  fun `adopts existing exterior plots when site expands to cover them`() {
+    val existing = existingSite(width = 100) { exteriorPlot(x = 500) }
+    val desired = newSite(width = 600) { zone(numPermanent = 1) }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal(25),
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(x = 100, width = 500, height = 500),
+                        areaHaDifference = BigDecimal(25),
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits =
+                            listOf(
+                                PlantingSubzoneEdit.Update(
+                                    addedRegion = rectangle(x = 100, width = 500, height = 500),
+                                    areaHaDifference = BigDecimal(25),
+                                    desiredModel = desired.plantingZones[0].plantingSubzones[0],
+                                    existingModel = existing.plantingZones[0].plantingSubzones[0],
+                                    monitoringPlotEdits =
+                                        listOf(
+                                            MonitoringPlotEdit.Adopt(
+                                                MonitoringPlotId(1), permanentCluster = 1)),
+                                    removedRegion = rectangle(0))),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
   fun `does not adopt 25-meter, ad-hoc, or unavailable plots as new permanent plots`() {
     val existing =
         existingSite(width = 400) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -116,6 +116,8 @@ private constructor(
   private var currentSubzoneId: Long = 0
   private var currentZoneId: Long = 0
   private var nextZoneX = x
+  private var nextMonitoringPlotX: Int = x + width
+  private val exteriorPlots = mutableListOf<MonitoringPlotModel>()
   private val plantingZones = mutableListOf<ExistingPlantingZoneModel>()
 
   fun build(): ExistingPlantingSiteModel {
@@ -124,6 +126,7 @@ private constructor(
         boundary = boundary,
         countryCode = countryCode,
         exclusion = exclusion,
+        exteriorPlots = exteriorPlots,
         gridOrigin = gridOrigin,
         id = PlantingSiteId(1),
         name = name,
@@ -163,6 +166,34 @@ private constructor(
     val newZone = builder.build()
     plantingZones.add(newZone)
     return newZone
+  }
+
+  fun exteriorPlot(
+      x: Int = nextMonitoringPlotX,
+      y: Int = this.y,
+      isAdHoc: Boolean = false,
+      isAvailable: Boolean = true,
+      size: Int = MONITORING_PLOT_SIZE_INT,
+      plotNumber: Long = nextPlotNumber,
+  ): MonitoringPlotModel {
+    nextMonitoringPlotX = x + size
+
+    val plot =
+        MonitoringPlotModel(
+            boundary = rectanglePolygon(size, size, x, y),
+            id = MonitoringPlotId(plotNumber),
+            isAdHoc = isAdHoc,
+            isAvailable = isAvailable,
+            permanentCluster = null,
+            permanentClusterSubplot = null,
+            plotNumber = plotNumber,
+            sizeMeters = size,
+        )
+
+    nextPlotNumber++
+
+    exteriorPlots.add(plot)
+    return plot
   }
 
   inner class ZoneBuilder(


### PR DESCRIPTION
If a planting site edit causes a monitoring plot to fall outside the site
boundary, and then a later edit causes the plot to be part of the site again,
we should use it as a permanent plot before we resort to creating a brand-new
plot in the added area. This will increase the amount of observation data we
collect in the same locations over time.

Practically speaking, this means we no longer mark the plot as unavailable
when it's ejected. This is a change from the previous site editing behavior,
but previously we only needed to mark such plots as unavailable because they
were still associated with their original subzones.