### PR TITLE
SW-6406 Abandon observations of edited zones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1394,11 +1394,13 @@ class ObservationStore(
 
     if (hasCompletedPlots) {
       dslContext.transaction { _ ->
+        log.info("Marking observation $observationId as abandoned")
         abandonPlots(observationId)
         updateObservationState(observationId, ObservationState.Abandoned)
         resetPlantPopulationSinceLastObservation(observation.plantingSiteId)
       }
     } else {
+      log.info("Deleting abandoned observation $observationId since it has no completed plots")
       deleteObservation(observationId)
     }
   }


### PR DESCRIPTION
When a flexible planting site map edit affects a planting zone, abandon any
assigned observations with incomplete plots in the zone since its plot
selection may no longer be valid.