### PR TITLE
SW-6405 Support flexible site edits in admin UI

### DIFF
--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -317,7 +317,8 @@
             <label>
                 Edit Behavior
                 <select name="editVersion">
-                    <option value="1" selected>Original (some edits not allowed)</option>
+                    <option value="1">Restricted (some edits not allowed)</option>
+                    <option value="2" selected>Flexible (may affect monitoring plots)</option>
                 </select>
             </label>
             <br/>


### PR DESCRIPTION
Add an option to the planting site shapefile upload form to allow selecting which
edit behavior to use. The new "Flexible" option is selected by default.

Show a more detailed preview of the edits that would be applied. This will be
critical for manual testing of the feature, but will also be useful for
sanity-checking real site changes.