### PR TITLE
SW-6321 Allow unplanted subzones to be observed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -59,8 +59,8 @@ class ObservationAlreadyEndedException(val observationId: ObservationId) :
 class ObservationAlreadyStartedException(val observationId: ObservationId) :
     MismatchedStateException("Observation $observationId is already started")
 
-class ObservationHasNoPlotsException(val observationId: ObservationId) :
-    MismatchedStateException("No plots are eligible for observation $observationId")
+class ObservationHasNoSubzonesException(val observationId: ObservationId) :
+    MismatchedStateException("No subzones were requested for observation $observationId")
 
 class ObservationNotFoundException(val observationId: ObservationId) :
     EntityNotFoundException("Observation $observationId not found")

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationStoreTest.kt
@@ -579,7 +579,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `only returns observations whose planting sites have plants`() {
+    fun `only returns observations with requested subzones`() {
       val timeZone = ZoneId.of("America/Denver")
       val startDate = LocalDate.of(2023, 4, 1)
       val endDate = LocalDate.of(2023, 4, 30)
@@ -591,8 +591,9 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       val startableObservationId =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
-      // Another planting site with no plants.
+      // Another planting site with no requested subzone.
       insertPlantingSite(timeZone = timeZone)
       insertPlantingZone()
       insertPlantingSubzone()
@@ -628,26 +629,31 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       val observationId1 =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       // Start date is an hour ago.
       helper.insertPlantedSite(timeZone = zone3)
       val observationId2 =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       // Start date hasn't arrived yet in the site's time zone.
       helper.insertPlantedSite(timeZone = zone1)
       insertObservation(endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       // Observation already in progress; shouldn't be started
       helper.insertPlantedSite(timeZone = zone3)
       insertObservation(
           endDate = endDate, startDate = startDate, state = ObservationState.InProgress)
+      insertObservationRequestedSubzone()
 
       // Start date is still in the future.
       helper.insertPlantedSite(timeZone = zone3)
       insertObservation(
           endDate = endDate, startDate = startDate.plusDays(1), state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       val expected = setOf(observationId1, observationId2)
       val actual = store.fetchStartableObservations().map { it.id }.toSet()
@@ -669,9 +675,13 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       val observationId =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       insertPlantingSite(timeZone = timeZone)
+      insertPlantingZone()
+      insertPlantingSubzone()
       insertObservation(endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       val expected = setOf(observationId)
       val actual = store.fetchStartableObservations(plantingSiteId).map { it.id }.toSet()
@@ -711,7 +721,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `does not returns observations whose planting sites have no planted subzones`() {
+    fun `does not returns observations with no requested subzones`() {
       val timeZone = ZoneId.of("America/Denver")
       val startDate = LocalDate.of(2023, 4, 1)
       val endDate = LocalDate.of(2023, 4, 30)
@@ -730,7 +740,7 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `only returns observations whose planting sites have plants`() {
+    fun `only returns observations with requested subzones`() {
       val timeZone = ZoneId.of("America/Denver")
       val startDate = LocalDate.of(2023, 4, 1)
       val endDate = LocalDate.of(2023, 4, 30)
@@ -742,8 +752,9 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       val startableObservationId =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
-      // Another planting site with no plants.
+      // Another planting site with no requested subzones.
       insertPlantingSite(timeZone = timeZone)
       insertPlantingZone()
       insertPlantingSubzone()
@@ -779,16 +790,19 @@ class ObservationStoreTest : DatabaseTest(), RunsAsUser {
       val observationId1 =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       // Start date plus 1 month is an hour ago.
       helper.insertPlantedSite(timeZone = zone3)
       val observationId2 =
           insertObservation(
               endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       // Start date plus 1 month hasn't arrived yet in the site's time zone.
       helper.insertPlantedSite(timeZone = zone1)
       insertObservation(endDate = endDate, startDate = startDate, state = ObservationState.Upcoming)
+      insertObservationRequestedSubzone()
 
       val expected = setOf(observationId1, observationId2)
       val actual = store.fetchNonNotifiedUpcomingObservations().map { it.id }.toSet()

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -31,7 +31,7 @@ class PlantingZoneModelTest {
   @Nested
   inner class ChoosePermanentPlots {
     @Test
-    fun `chooses 4-plot cluster if all plots lie in planted subzones`() {
+    fun `chooses 4-plot cluster if all plots lie in requested subzones`() {
       val model =
           plantingZoneModel(
               subzones =
@@ -44,11 +44,11 @@ class PlantingZoneModelTest {
 
       assertEquals(
           setOf(MonitoringPlotId(1), MonitoringPlotId(2), MonitoringPlotId(3), MonitoringPlotId(4)),
-          model.choosePermanentPlots(plantingSubzoneIds(1, 2), emptySet()))
+          model.choosePermanentPlots(plantingSubzoneIds(1, 2)))
     }
 
     @Test
-    fun `chooses 1-plot cluster if plot lies in planted subzone`() {
+    fun `chooses 1-plot cluster if plot lies in requested subzone`() {
       val model =
           plantingZoneModel(
               subzones =
@@ -56,12 +56,11 @@ class PlantingZoneModelTest {
                       plantingSubzoneModel(
                           id = 1, plots = monitoringPlotModels(permanentIds = listOf(1)))))
 
-      assertEquals(
-          setOf(MonitoringPlotId(1)), model.choosePermanentPlots(plantingSubzoneIds(1), emptySet()))
+      assertEquals(setOf(MonitoringPlotId(1)), model.choosePermanentPlots(plantingSubzoneIds(1)))
     }
 
     @Test
-    fun `does not choose cluster if some plots lie in unplanted subzones`() {
+    fun `does not choose cluster if some plots lie in unrequested subzones`() {
       val model =
           plantingZoneModel(
               subzones =
@@ -72,7 +71,7 @@ class PlantingZoneModelTest {
                           id = 2, plots = monitoringPlotModels(permanentIds = listOf(3, 4))),
                   ))
 
-      assertEquals(emptySet<Any>(), model.choosePermanentPlots(plantingSubzoneIds(1), emptySet()))
+      assertEquals(emptySet<Any>(), model.choosePermanentPlots(plantingSubzoneIds(1)))
     }
   }
 
@@ -161,7 +160,7 @@ class PlantingZoneModelTest {
     fun `does not choose plots that lie partially outside subzone`() {
       // Zone is three plots wide by one plot high, split horizontally into two equal-sized subzones
       // such that there are three plot locations but the middle one sits on the subzone boundary.
-      // Only subzone 1 is planted.
+      // Only subzone 1 is requested.
       val subzoneWidth = MONITORING_PLOT_SIZE * 1.5
       val subzoneHeight = MONITORING_PLOT_SIZE + 1
       val subzone1Boundary =
@@ -315,7 +314,7 @@ class PlantingZoneModelTest {
     }
 
     @Test
-    fun `places excess plots in requested and planted subzones if no difference in permanent plots`() {
+    fun `places excess plots in requested subzones if no difference in permanent plots`() {
       val model =
           plantingZoneModel(
               numPermanentClusters = 3,
@@ -362,33 +361,12 @@ class PlantingZoneModelTest {
 
         val numChosenPerSubzone = availablePlotIds.map { ids -> ids.intersect(chosenIds).size }
 
-        assertEquals(
-            listOf(2, 1, 0),
-            numChosenPerSubzone,
-            "Number of plots chosen in each subzone (with unplanted)")
-      }
-
-      repeatTest {
-        val chosenIds =
-            model
-                .chooseTemporaryPlots(
-                    plantingSubzoneIds(1, 2, 3),
-                    siteOrigin,
-                    requestedSubzoneIds = plantingSubzoneIds(1, 2))
-                .map { model.findMonitoringPlot(it)?.id }
-                .toSet()
-
-        val numChosenPerSubzone = availablePlotIds.map { ids -> ids.intersect(chosenIds).size }
-
-        assertEquals(
-            listOf(2, 1, 0),
-            numChosenPerSubzone,
-            "Number of plots chosen in each subzone (with unrequested)")
+        assertEquals(listOf(2, 1, 0), numChosenPerSubzone, "Number of plots chosen in each subzone")
       }
     }
 
     @Test
-    fun `excludes plots that would have been placed in unplanted or unrequested subzones`() {
+    fun `excludes plots that would have been placed in unrequested subzones`() {
       val model =
           plantingZoneModel(
               numTemporaryPlots = 5,
@@ -420,28 +398,7 @@ class PlantingZoneModelTest {
 
         val numChosenPerSubzone = availablePlotIds.map { ids -> ids.intersect(chosenIds).size }
 
-        assertEquals(
-            listOf(0, 2, 2),
-            numChosenPerSubzone,
-            "Number of plots chosen in each subzone (with unplanted)")
-      }
-
-      repeatTest {
-        val chosenIds =
-            model
-                .chooseTemporaryPlots(
-                    plantingSubzoneIds(1, 2, 3),
-                    siteOrigin,
-                    requestedSubzoneIds = plantingSubzoneIds(2, 3))
-                .map { model.findMonitoringPlot(it)?.id }
-                .toSet()
-
-        val numChosenPerSubzone = availablePlotIds.map { ids -> ids.intersect(chosenIds).size }
-
-        assertEquals(
-            listOf(0, 2, 2),
-            numChosenPerSubzone,
-            "Number of plots chosen in each subzone (with unrequested)")
+        assertEquals(listOf(0, 2, 2), numChosenPerSubzone, "Number of plots chosen in each subzone")
       }
     }
 


### PR DESCRIPTION
Previously, we only allowed observation of plots in subzones where plants had
previously been delivered from nurseries, so as to avoid asking people to
survey parts of a planting site they hadn't started working on yet. Now that
users are required to list the subzones they want to observe, this restriction
isn't useful, and it forces users who aren't tracking plants in nurseries to
create fake nursery batches just to be able to schedule observations.

Remove all the "is the subzone planted?" checks from the plot selection logic,
and instead rely solely on the observation's list of requested subzones.