### PR TITLE
SW-6533 Include all subzones in mortality rates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1441,6 +1441,7 @@ class ObservationStore(
                           DSL.select(OBSERVATIONS.COMPLETED_TIME)
                               .from(OBSERVATIONS)
                               .where(OBSERVATIONS.ID.eq(observationId))))
+                  .and(OBSERVATIONS.IS_AD_HOC.isFalse)
                   .orderBy(
                       // Prefer results from this observation if any. True is considered
                       // greater than false, so sorting by an "=" expression in descending

--- a/src/main/resources/db/migration/0300/V343__FullSiteObservationSubzones.sql
+++ b/src/main/resources/db/migration/0300/V343__FullSiteObservationSubzones.sql
@@ -1,0 +1,9 @@
+INSERT INTO tracking.observation_requested_subzones (observation_id, planting_subzone_id)
+SELECT o.id, sz.id
+FROM tracking.observations o
+JOIN tracking.planting_subzones sz ON o.planting_site_id = sz.planting_site_id
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM tracking.observation_requested_subzones ors
+    WHERE ors.observation_id = o.id
+);

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -28,6 +28,8 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservationBiomassQua
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationBiomassQuadratSpeciesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedTreesRow
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_REQUESTED_SUBZONES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
@@ -47,6 +49,7 @@ import java.io.InputStreamReader
 import java.math.BigDecimal
 import java.nio.file.NoSuchFileException
 import java.time.Instant
+import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -848,6 +851,11 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `partial observations of disjoint subzone lists`() {
+      runScenario("/tracking/observation/DisjointSubzones", numObservations = 3, sizeMeters = 30)
+    }
+
+    @Test
     fun `permanent plots being added and removed`() {
       runScenario(
           "/tracking/observation/PermanentPlotChanges", numObservations = 3, sizeMeters = 25)
@@ -1451,6 +1459,17 @@ class ObservationResultsStoreTest : DatabaseTest(), RunsAsUser {
                   statusId = status,
               )
             }
+
+        with(OBSERVATION_REQUESTED_SUBZONES) {
+          dslContext
+              .insertInto(OBSERVATION_REQUESTED_SUBZONES, OBSERVATION_ID, PLANTING_SUBZONE_ID)
+              .select(
+                  DSL.selectDistinct(DSL.value(observationId), MONITORING_PLOTS.PLANTING_SUBZONE_ID)
+                      .from(MONITORING_PLOTS)
+                      .where(
+                          MONITORING_PLOTS.PLOT_NUMBER.`in`(observedPlotNames.map { it.toLong() })))
+              .execute()
+        }
 
         // This would normally happen in ObservationService.startObservation after plot selection;
         // do it explicitly since we're specifying our own plots in the test data.

--- a/src/test/resources/tracking/observation/DisjointSubzones/Plants-1.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Plants-1.csv
@@ -1,0 +1,4 @@
+Plot,Certainty,Species,Status
+111,Known,Known 1,Live
+111,Known,Known 1,Live
+111,Known,Known 1,Dead

--- a/src/test/resources/tracking/observation/DisjointSubzones/Plants-2.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Plants-2.csv
@@ -1,0 +1,4 @@
+Plot,Certainty,Species,Status
+112,Known,Known 1,Live
+112,Known,Known 1,Dead
+112,Known,Known 1,Dead

--- a/src/test/resources/tracking/observation/DisjointSubzones/Plants-3.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Plants-3.csv
@@ -1,0 +1,4 @@
+Plot,Certainty,Species,Status
+111,Known,Known 1,Live
+111,Known,Known 1,Live
+111,Known,Known 1,Live

--- a/src/test/resources/tracking/observation/DisjointSubzones/PlotStats.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/PlotStats.csv
@@ -1,0 +1,4 @@
+Observation ->,1,1,1,1,1,1,2,2,2,2,2,2,3,3,3,3,3,3
+Plot,# Plants,# Species,Mortality Rate,Live Plants,Existing Plants,Planting Density,# Plants,# Species,Mortality Rate,Live Plants,Existing Plants,Planting Density,# Plants,# Species,Mortality Rate,Live Plants,Existing Plants,Planting Density
+111,3,1,33%,2,0,22,,,,,,,3,1,25%,3,0,33
+112,,,,,,,3,1,67%,1,0,11,,,,,,

--- a/src/test/resources/tracking/observation/DisjointSubzones/PlotStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/PlotStatsPerSpecies.csv
@@ -1,0 +1,4 @@
+Observation ->,,1,1,2,2,3,3
+Plot,Species,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate
+111,Known 1,2,33%,,,3,25%
+112,Known 1,,,1,67%,,

--- a/src/test/resources/tracking/observation/DisjointSubzones/Plots.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Plots.csv
@@ -1,0 +1,3 @@
+Subzone,Name,Type,Area (ha)
+Alpha-1,111,Permanent,0.0625
+Alpha-2,112,Permanent,0.0625

--- a/src/test/resources/tracking/observation/DisjointSubzones/SiteStats.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/SiteStats.csv
@@ -1,0 +1,3 @@
+1,1,1,1,2,2,2,2,3,3,3,3
+Planting Density,Estimated # Plants,# Species,Mortality Rate,Planting Density,Estimated # Plants,# Species,Mortality Rate,Planting Density,Estimated # Plants,# Species,Mortality Rate
+22,33000,1,33%,11,16500,1,50%,33,49500,1,43%

--- a/src/test/resources/tracking/observation/DisjointSubzones/SiteStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/SiteStatsPerSpecies.csv
@@ -1,0 +1,3 @@
+Observation ->,1,1,2,2,3,3
+Species,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate
+Known 1,2,33%,1,50%,3,43%

--- a/src/test/resources/tracking/observation/DisjointSubzones/SubzoneStats.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/SubzoneStats.csv
@@ -1,0 +1,4 @@
+Observation ->,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3
+Subzone,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants
+Alpha-1,3,22,1,33%,22,,,,,,3,33,1,25%,33
+Alpha-2,,,,,,3,11,1,67%,11,,,,,

--- a/src/test/resources/tracking/observation/DisjointSubzones/SubzoneStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/SubzoneStatsPerSpecies.csv
@@ -1,0 +1,4 @@
+Observation ->,,1,1,2,2,3,3
+Subzone,Species,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate
+Alpha-1,Known 1,2,33%,,,3,25%
+Alpha-2,Known 1,,,1,67%,,

--- a/src/test/resources/tracking/observation/DisjointSubzones/Subzones.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Subzones.csv
@@ -1,0 +1,4 @@
+Observation ->,,1,2
+Zone,Name,Area,Finished planting?,Finished planting?
+Alpha,Alpha-1,1,Yes,Yes
+Alpha,Alpha-2,1,Yes,Yes

--- a/src/test/resources/tracking/observation/DisjointSubzones/ZoneStats.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/ZoneStats.csv
@@ -1,0 +1,3 @@
+Observation ->,1,1,1,1,1,2,2,2,2,2,3,3,3,3,3
+Zone,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Est Plants
+Alpha,3,22,1,33%,33000,3,11,1,50%,16500,3,33,1,43%,49500

--- a/src/test/resources/tracking/observation/DisjointSubzones/ZoneStatsPerSpecies.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/ZoneStatsPerSpecies.csv
@@ -1,0 +1,3 @@
+Observation ->,,1,1,2,2,3,3
+Zone,Species,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate,# Live Plants,Mortality Rate
+Alpha,Known 1,2,33%,1,50%,3,43%

--- a/src/test/resources/tracking/observation/DisjointSubzones/Zones.csv
+++ b/src/test/resources/tracking/observation/DisjointSubzones/Zones.csv
@@ -1,0 +1,3 @@
+Observation ->,,,1,2
+Site,Name,Area (ha),Finished planting?,Finished planting?
+Demo Site,Alpha,1500,No,Yes


### PR DESCRIPTION
Fix two problems with the mortality rate calculations for observations that don't
cover the entire planting site.

1. The cumulative dead plant count for each monitoring plot is supposed to carry
   forward from the previous observation of that plot, but we were only copying
   the value if the same plot was observed in two consecutive observations of the
   same planting site. With partial observations, it's possible for the most
   recent past observation to not include a given plot because a different set of
   subzones were observed.

   This was causing mortality rates to reset each time a different set of subzones
   was observed because past dead plants were being forgotten.

   The fix is to copy the cumulative dead counts from the most recent previous
   observation of each plot, not from the most recent observation of the site as
   a whole.

2. The plot- and subzone-level mortality rates are based on the live plants
   recorded in the current observation. But if the current observation only
   covers a subset of all the subzones in the planting site, the zone- and
   site-level rates need to also include plants that were recorded in the other
   subzones' most recent observations.

   The fix is to recalculate the zone- and site-level mortality rates when an
   observation finishes, with the recalculation taking data from the whole site
   into account, not just the parts that were included in the current observation.