### PR TITLE
SW-6533 Recalculate mortality rates from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -63,6 +63,8 @@ class AdminController(
     model.addAttribute("canManageParticipants", currentUser().canCreateParticipant())
     model.addAttribute("canReadCohorts", currentUser().canReadCohorts())
     model.addAttribute(
+        "canRecalculateMortalityRates", GlobalRole.SuperAdmin in currentUser().globalRoles)
+    model.addAttribute(
         "canSendTestEmail",
         config.email.enabled && GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1423,10 +1423,7 @@ class ObservationStore(
    * observation finishes, rather than when it starts, means we can include data from observations
    * that weren't done yet at the time the current one started.
    */
-  private fun recalculateMortalityRates(
-      observationId: ObservationId,
-      plantingSiteId: PlantingSiteId
-  ) {
+  fun recalculateMortalityRates(observationId: ObservationId, plantingSiteId: PlantingSiteId) {
     val liveAndDeadTotals: Map<RecordedSpeciesKey, Map<PlantingZoneId, List<Pair<Int, Int>>>> =
         with(OBSERVED_SUBZONE_SPECIES_TOTALS) {
           val observationIdForSubzoneField =

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -174,6 +174,27 @@
 <details id="migrations" class="section">
     <summary>Migrations</summary>
 
+    <th:block th:if="${canRecalculateMortalityRates}">
+        <h3>Recalculate Mortality Rates</h3>
+
+        <p>
+            This updates the zone- and site-level mortality rates for a partial observation of a
+            planting site to take into account plants from subzones weren't observed this time.
+        </p>
+
+        <form method="POST" action="/admin/recalculateMortalityRates">
+            <label>
+                Planting Site ID:
+                <input type="text" name="plantingSiteId"/>
+            </label>
+            <label>
+                Observation ID:
+                <input type="text" name="observationId"/>
+            </label>
+            <input type="submit" value="Recalculate"/>
+        </form>
+    </th:block>
+
     <th:block th:if="${canMigrateAcceleratorProjectDetails}">
         <h3>Update Deal Names</h3>
 

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -179,7 +179,7 @@
 
         <p>
             This updates the zone- and site-level mortality rates for a partial observation of a
-            planting site to take into account plants from subzones weren't observed this time.
+            planting site to take into account plants from subzones that weren't observed this time.
         </p>
 
         <form method="POST" action="/admin/recalculateMortalityRates">


### PR DESCRIPTION
Add an admin UI form where we can explicitly recalculate the zone- and site-level
mortality rates for a specific observation. We can use this to test the
recalculation logic as well as to clean up the handful of incorrect mortality
rates in the production environment.