### PR TITLE
SW-6566 Support moving subzones between zones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -723,9 +723,14 @@ class PlantingSiteStore(
             })
 
         // If any subzones weren't edited, we still want to include them in the site's map history.
-        edit.existingModel.plantingSubzones.forEach { subzone ->
-          if (edit.plantingSubzoneEdits.none { it.existingModel?.id == subzone.id }) {
-            insertPlantingSubzoneHistory(subzone, plantingZoneHistoryId)
+        edit.existingModel.plantingSubzones.forEach { existingSubzone ->
+          val subzoneStillInThisZone =
+              edit.desiredModel.plantingSubzones.any { it.name == existingSubzone.name }
+          val noEditForThisSubzone =
+              edit.plantingSubzoneEdits.none { it.existingModel?.id == existingSubzone.id }
+
+          if (subzoneStillInThisZone && noEditForThisSubzone) {
+            insertPlantingSubzoneHistory(existingSubzone, plantingZoneHistoryId)
           }
         }
 
@@ -821,6 +826,7 @@ class PlantingSiteStore(
                   .set(MODIFIED_TIME, now)
                   .set(NAME, edit.desiredModel.name)
                   .let { if (markIncomplete) it.setNull(PLANTING_COMPLETED_TIME) else it }
+                  .set(PLANTING_ZONE_ID, plantingZoneId)
                   .where(ID.eq(plantingSubzoneId))
                   .execute()
           if (rowsUpdated != 1) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.util.differenceNullable
 import com.terraformation.backend.util.nearlyCoveredBy
 import com.terraformation.backend.util.toNormalizedMultiPolygon
 import java.math.BigDecimal
-import kotlin.math.max
 import kotlin.math.min
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.MultiPolygon
@@ -50,51 +49,17 @@ class PlantingSiteEditCalculatorV2(
         existingZonesByDesiredZone
             .filterValues { it == null }
             .keys
-            .map { newZone ->
-              val existingPlotsInNewZone =
-                  existingMonitoringPlots.filter {
-                    desiredZonesByMonitoringPlotId[it.id] == newZone
-                  }
-              var nextPermanentCluster = 1
-              val adoptEdits =
-                  existingPlotsInNewZone.map { plot ->
-                    val permanentCluster =
-                        if (nextPermanentCluster <= newZone.numPermanentClusters &&
-                            plot.sizeMeters == MONITORING_PLOT_SIZE_INT &&
-                            plot.isAvailable &&
-                            !plot.isAdHoc) {
-                          nextPermanentCluster++
-                        } else {
-                          // If we didn't use up all the existing permanent plots, remove the
-                          // remaining ones from the permanent list by setting their permanent
-                          // cluster numbers to null so that any permanent plots we create later
-                          // will be randomly placed in the zone. We still want to adopt them into
-                          // the correct subzones, though.
-                          null
-                        }
-                    MonitoringPlotEdit.Adopt(
-                        monitoringPlotId = plot.id, permanentCluster = permanentCluster)
-                  }
-              val numPermanentPlotsToCreate =
-                  max(0, newZone.numPermanentClusters - nextPermanentCluster + 1)
+            .map { desiredZone ->
+              val monitoringPlotEdits =
+                  calculateMonitoringPlotEdits(
+                      desiredZone, desiredZone.boundary.differenceNullable(desiredSite.exclusion))
 
               PlantingZoneEdit.Create(
-                  desiredModel = newZone,
+                  desiredModel = desiredZone,
                   monitoringPlotEdits =
-                      List(numPermanentPlotsToCreate) { index ->
-                        MonitoringPlotEdit.Create(
-                            region = newZone.boundary,
-                            permanentCluster = nextPermanentCluster + index)
-                      },
+                      monitoringPlotEdits.filterIsInstance<MonitoringPlotEdit.Create>(),
                   plantingSubzoneEdits =
-                      newZone.plantingSubzones.map { newSubzone ->
-                        PlantingSubzoneEdit.Create(
-                            newSubzone,
-                            adoptEdits.filter { adoptEdit ->
-                              desiredSubzonesByMonitoringPlotId[adoptEdit.monitoringPlotId] ==
-                                  newSubzone
-                            })
-                      })
+                      calculateSubzoneEdits(null, desiredZone, monitoringPlotEdits))
             }
 
     val deleteEdits =
@@ -122,79 +87,10 @@ class PlantingSiteEditCalculatorV2(
                   existingZone!!.boundary.differenceNullable(existingSite.exclusion)
               val desiredUsableBoundary =
                   desiredZone.boundary.differenceNullable(desiredSite.exclusion)
-
-              // Now we need two lists of existing monitoring plots: the ones in the part of the
-              // zone that overlap with the zone's old geometry, and the ones in the newly-added
-              // part of the zone, which may already have monitoring plots if this edit is
-              // changing the boundary between two existing zones.
-              //
-              // We want to pick permanent plots from both lists in proportion to the area of the
-              // two parts of the zone. For example, if 60% of the desired zone boundary overlaps
-              // with the existing zone boundary, then we want 60% of the permanent plots to come
-              // from the first list.
-              //
-              // If either list runs out of existing plots before we've assigned the required
-              // number of permanent plots to the zone, we want to create new plots in the
-              // part of the zone the list comes from.
-              val overlappingBoundary =
-                  desiredUsableBoundary
-                      .intersection(existingUsableBoundary)
-                      .toNormalizedMultiPolygon()
-              val nonOverlappingBoundary =
-                  desiredUsableBoundary
-                      .difference(existingUsableBoundary)
-                      .toNormalizedMultiPolygon()
-              val fractionOfDesiredAreaOverlappingWithExisting =
-                  min(1.0, overlappingBoundary.area / desiredUsableBoundary.area)
-
-              val existingPlotsInDesiredZone =
-                  existingMonitoringPlots.filter {
-                    it.boundary.nearlyCoveredBy(desiredUsableBoundary)
-                  }
-              val (candidatePlots, disqualifiedPlots) =
-                  existingPlotsInDesiredZone.partition {
-                    it.isAvailable && !it.isAdHoc && it.sizeMeters == MONITORING_PLOT_SIZE_INT
-                  }
-              val (existingPlotsInOverlappingArea, existingPlotsInNewArea) =
-                  candidatePlots
-                      .partition { it.boundary.nearlyCoveredBy(existingUsableBoundary) }
-                      .toList()
-                      .map { it.toMutableList() }
-
-              // Returns a function that returns the next plot edit (create or adopt operation) for
-              // either the overlapping or the non-overlapping part of the zone.
-              fun nextPlotForArea(
-                  plotList: MutableList<MonitoringPlotModel>,
-                  boundary: MultiPolygon
-              ): (Int) -> MonitoringPlotEdit {
-                return { index ->
-                  val permanentCluster = index + 1
-                  val nextExistingPlot = plotList.removeFirstOrNull()
-                  if (nextExistingPlot != null) {
-                    MonitoringPlotEdit.Adopt(nextExistingPlot.id, permanentCluster)
-                  } else {
-                    MonitoringPlotEdit.Create(boundary, permanentCluster)
-                  }
-                }
-              }
-
-              val desiredPermanentClusterEdits =
-                  (zipProportionally(
-                      desiredZone.numPermanentClusters,
-                      fractionOfDesiredAreaOverlappingWithExisting,
-                      nextPlotForArea(existingPlotsInOverlappingArea, overlappingBoundary),
-                      nextPlotForArea(existingPlotsInNewArea, nonOverlappingBoundary)))
-
-              // If we didn't use up all the existing permanent plots, remove the remaining ones
-              // from the permanent list by setting their permanent cluster numbers to null so that
-              // any permanent plots we create later will be randomly placed in the zone. We still
-              // want to adopt them into the correct subzones, though.
-              val dropExcessExistingClusterEdits =
-                  (existingPlotsInOverlappingArea + existingPlotsInNewArea + disqualifiedPlots)
-                      .map { MonitoringPlotEdit.Adopt(it.id, permanentCluster = null) }
-
               val monitoringPlotEdits =
-                  desiredPermanentClusterEdits + dropExcessExistingClusterEdits
+                  calculateMonitoringPlotEdits(
+                      desiredZone, desiredUsableBoundary, existingUsableBoundary)
+
               val createMonitoringPlotEdits =
                   monitoringPlotEdits.filterIsInstance<MonitoringPlotEdit.Create>()
 
@@ -228,17 +124,92 @@ class PlantingSiteEditCalculatorV2(
     return deleteEdits + updateEdits + createEdits
   }
 
+  private fun calculateMonitoringPlotEdits(
+      desiredZone: AnyPlantingZoneModel,
+      desiredUsableBoundary: Geometry,
+      existingUsableBoundary: Geometry = desiredUsableBoundary.factory.createMultiPolygon()
+  ): List<MonitoringPlotEdit> {
+    // Now we need two lists of existing monitoring plots: the ones in the part of the
+    // zone that overlap with the zone's old geometry, and the ones in the newly-added
+    // part of the zone, which may already have monitoring plots if this edit is
+    // changing the boundary between two existing zones.
+    //
+    // We want to pick permanent plots from both lists in proportion to the area of the
+    // two parts of the zone. For example, if 60% of the desired zone boundary overlaps
+    // with the existing zone boundary, then we want 60% of the permanent plots to come
+    // from the first list.
+    //
+    // If either list runs out of existing plots before we've assigned the required
+    // number of permanent plots to the zone, we want to create new plots in the
+    // part of the zone the list comes from.
+    val overlappingBoundary =
+        desiredUsableBoundary.intersection(existingUsableBoundary).toNormalizedMultiPolygon()
+    val nonOverlappingBoundary =
+        desiredUsableBoundary.difference(existingUsableBoundary).toNormalizedMultiPolygon()
+    val fractionOfDesiredAreaOverlappingWithExisting =
+        min(1.0, overlappingBoundary.area / desiredUsableBoundary.area)
+
+    val existingPlotsInDesiredZone =
+        existingMonitoringPlots.filter { it.boundary.nearlyCoveredBy(desiredUsableBoundary) }
+    val (candidatePlots, disqualifiedPlots) =
+        existingPlotsInDesiredZone.partition {
+          it.isAvailable && !it.isAdHoc && it.sizeMeters == MONITORING_PLOT_SIZE_INT
+        }
+    val (existingPlotsInOverlappingArea, existingPlotsInNewArea) =
+        candidatePlots
+            .partition { it.boundary.nearlyCoveredBy(existingUsableBoundary) }
+            .toList()
+            .map { it.toMutableList() }
+
+    // Returns a function that returns the next plot edit (create or adopt operation) for
+    // either the overlapping or the non-overlapping part of the zone.
+    fun nextPlotForArea(
+        plotList: MutableList<MonitoringPlotModel>,
+        boundary: MultiPolygon
+    ): (Int) -> MonitoringPlotEdit {
+      return { index ->
+        val permanentCluster = index + 1
+        val nextExistingPlot = plotList.removeFirstOrNull()
+        if (nextExistingPlot != null) {
+          MonitoringPlotEdit.Adopt(nextExistingPlot.id, permanentCluster)
+        } else {
+          MonitoringPlotEdit.Create(boundary, permanentCluster)
+        }
+      }
+    }
+
+    val desiredPermanentClusterEdits =
+        (zipProportionally(
+            desiredZone.numPermanentClusters,
+            fractionOfDesiredAreaOverlappingWithExisting,
+            nextPlotForArea(existingPlotsInOverlappingArea, overlappingBoundary),
+            nextPlotForArea(existingPlotsInNewArea, nonOverlappingBoundary),
+        ))
+
+    // If we didn't use up all the existing permanent plots, remove the remaining ones
+    // from the permanent list by setting their permanent cluster numbers to null so that
+    // any permanent plots we create later will be randomly placed in the zone. We still
+    // want to adopt them into the correct subzones, though.
+    val dropExcessExistingClusterEdits =
+        (existingPlotsInOverlappingArea + existingPlotsInNewArea + disqualifiedPlots).map {
+          MonitoringPlotEdit.Adopt(it.id, permanentCluster = null)
+        }
+
+    return desiredPermanentClusterEdits + dropExcessExistingClusterEdits
+  }
+
   private fun calculateSubzoneEdits(
-      existingZone: ExistingPlantingZoneModel,
+      existingZone: ExistingPlantingZoneModel?,
       desiredZone: AnyPlantingZoneModel,
       monitoringPlotEdits: List<MonitoringPlotEdit>,
   ): List<PlantingSubzoneEdit> {
     val subzoneMappings: Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel?> =
         desiredZone.plantingSubzones.associateWith { existingSubzonesByDesiredSubzone[it] }
     val existingSubzonesInUse =
-        existingZone.plantingSubzones
-            .filter { desiredSubzonesByExistingSubzone[it] != null }
-            .toSet()
+        existingZone
+            ?.plantingSubzones
+            ?.filter { desiredSubzonesByExistingSubzone[it] != null }
+            ?.toSet() ?: emptySet()
 
     val createEdits =
         subzoneMappings
@@ -254,13 +225,14 @@ class PlantingSiteEditCalculatorV2(
             }
 
     val deleteEdits =
-        existingZone.plantingSubzones.toSet().minus(existingSubzonesInUse).map { existingSubzone ->
+        existingZone?.plantingSubzones?.toSet()?.minus(existingSubzonesInUse)?.map { existingSubzone
+          ->
           PlantingSubzoneEdit.Delete(
               existingSubzone,
               existingSubzone.monitoringPlots
                   .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
                   .map { MonitoringPlotEdit.Eject(it.id) })
-        }
+        } ?: emptyList()
 
     val updateEdits =
         subzoneMappings
@@ -292,6 +264,7 @@ class PlantingSiteEditCalculatorV2(
 
               if (existingSubzone.boundary.equalsExact(desiredSubzone.boundary, 0.00001) &&
                   existingUsableBoundary.equalsExact(desiredUsableBoundary, 0.00001) &&
+                  existingZonesByExistingSubzone[existingSubzone] == existingZone &&
                   adoptEdits.isEmpty() &&
                   ejectEdits.isEmpty()) {
                 null
@@ -343,33 +316,81 @@ class PlantingSiteEditCalculatorV2(
     desiredSite.plantingZones.associateWith { existingZonesByName[it.name] }
   }
 
-  /** The desired version of each existing subzone, or null if the subzone is being deleted. */
+  /**
+   * The existing version of each desired planting zone, or null if the zone is being newly created.
+   */
+  private val existingZonesByExistingSubzone:
+      Map<ExistingPlantingSubzoneModel, ExistingPlantingZoneModel> by lazy {
+    existingSite.plantingZones
+        .flatMap { existingZone -> existingZone.plantingSubzones.map { it to existingZone } }
+        .toMap()
+  }
+
+  /**
+   * All the desired subzones by name. Subzone names are only required to be unique per zone, so
+   * there may be multiple subzones with the same name.
+   */
+  private val desiredSubzonesByName: Map<String, List<AnyPlantingSubzoneModel>> by lazy {
+    desiredSite.plantingZones.flatMap { it.plantingSubzones }.groupBy { it.name }
+  }
+
+  /**
+   * All the existing subzones by name. Subzone names are only required to be unique per zone, so
+   * there may be multiple subzones with the same name.
+   */
+  private val existingSubzonesByName: Map<String, List<ExistingPlantingSubzoneModel>> by lazy {
+    existingSite.plantingZones.flatMap { it.plantingSubzones }.groupBy { it.name }
+  }
+
+  /** The desired version of each existing subzone that isn't being deleted. */
   private val desiredSubzonesByExistingSubzone:
-      Map<ExistingPlantingSubzoneModel, AnyPlantingSubzoneModel?> by lazy {
+      Map<ExistingPlantingSubzoneModel, AnyPlantingSubzoneModel> by lazy {
     existingSite.plantingZones
         .flatMap { existingZone ->
-          val desiredSubzonesByName =
+          val desiredSubzonesByNameInDesiredZone =
               desiredZonesByExistingZone[existingZone]?.plantingSubzones?.associateBy { it.name }
                   ?: emptyMap()
-          existingZone.plantingSubzones.map { existingSubzone ->
-            existingSubzone to desiredSubzonesByName[existingSubzone.name]
+          existingZone.plantingSubzones.mapNotNull { existingSubzone ->
+            val desiredSubzonesFromWholeSite = desiredSubzonesByName[existingSubzone.name]
+            if (desiredSubzonesFromWholeSite == null) {
+              // No subzone by this name in the desired site, so it's a deletion.
+              null
+            } else if (desiredSubzonesFromWholeSite.size == 1) {
+              // Unambiguous name match, possibly in a different planting zone.
+              existingSubzone to desiredSubzonesFromWholeSite.first()
+            } else if (existingSubzone.name in desiredSubzonesByNameInDesiredZone) {
+              // Multiple desired zones with this name, which is fine as long as none of them are
+              // moving to new zones.
+              existingSubzone to desiredSubzonesByNameInDesiredZone[existingSubzone.name]!!
+            } else {
+              throw IllegalArgumentException("Cannot tell where to move ${existingSubzone.name}")
+            }
           }
         }
         .toMap()
   }
 
-  /**
-   * The existing version of each desired subzone, or null if the subzone is being newly created.
-   */
+  /** The existing version of each desired subzone that isn't being newly created. */
   private val existingSubzonesByDesiredSubzone:
-      Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel?> by lazy {
+      Map<AnyPlantingSubzoneModel, ExistingPlantingSubzoneModel> by lazy {
     desiredSite.plantingZones
         .flatMap { desiredZone ->
-          val existingSubzonesByName =
+          val existingSubzonesByNameInExistingZone =
               existingZonesByDesiredZone[desiredZone]?.plantingSubzones?.associateBy { it.name }
                   ?: emptyMap()
-          desiredZone.plantingSubzones.map { desiredSubzone ->
-            desiredSubzone to existingSubzonesByName[desiredSubzone.name]
+          desiredZone.plantingSubzones.mapNotNull { desiredSubzone ->
+            val existingSubzonesFromWholeSite = existingSubzonesByName[desiredSubzone.name]
+            if (existingSubzonesFromWholeSite == null) {
+              // No subzone by this name in the existing site, so it's a creation.
+              null
+            } else if (existingSubzonesFromWholeSite.size == 1) {
+              // Unambiguous name match, possibly in a different planting zone.
+              desiredSubzone to existingSubzonesFromWholeSite.first()
+            } else if (desiredSubzone.name in existingSubzonesByNameInExistingZone) {
+              desiredSubzone to existingSubzonesByNameInExistingZone[desiredSubzone.name]!!
+            } else {
+              throw IllegalArgumentException("Cannot tell where ${desiredSubzone.name} moved from")
+            }
           }
         }
         .toMap()

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingZoneEdit.kt
@@ -68,7 +68,7 @@ sealed interface PlantingZoneEdit {
   data class Create(
       override val desiredModel: AnyPlantingZoneModel,
       override val monitoringPlotEdits: List<MonitoringPlotEdit.Create>,
-      override val plantingSubzoneEdits: List<PlantingSubzoneEdit.Create>,
+      override val plantingSubzoneEdits: List<PlantingSubzoneEdit>,
   ) : PlantingZoneEdit {
     override val addedRegion: MultiPolygon
       get() = desiredModel.boundary

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -632,6 +632,33 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       assertSubzonePlotNumbers(edited, mapOf("S1" to listOf(1L), "S2" to listOf(2L)))
     }
 
+    @Test
+    fun `moves existing subzones between zones`() {
+      val initial = newSite {
+        zone(name = "A", numPermanent = 2) {
+          subzone(name = "Subzone 1", width = 250) { cluster() }
+          subzone(name = "Subzone 2", width = 250) { cluster() }
+        }
+      }
+
+      val desired = newSite {
+        zone(name = "A", numPermanent = 1, width = 250) { subzone(name = "Subzone 1") }
+        zone(name = "B", numPermanent = 1, width = 250) { subzone(name = "Subzone 2") }
+      }
+
+      val (edited, existing) =
+          runScenario(initial = initial, desired = desired, useV2Calculator = true)
+
+      val existingSubzone2 = existing.plantingZones[0].plantingSubzones[1]
+      val editedSubzone2 = edited.plantingZones[1].plantingSubzones[0]
+
+      assertEquals(existingSubzone2.id, editedSubzone2.id, "ID of moved subzone")
+      assertEquals(
+          existingSubzone2.monitoringPlots[0].copy(permanentCluster = 1),
+          editedSubzone2.monitoringPlots[0],
+          "Monitoring plot in moved subzone")
+    }
+
     private fun createSite(initial: NewPlantingSiteModel): ExistingPlantingSiteModel {
       clock.instant = Instant.EPOCH
 


### PR DESCRIPTION
Previously, if a subzone in a new shapefile had the same name as an existing
subzone but a different zone name, it was treated as a deletion of the existing
subzone and the creation of a new one. Add logic to detect this situation and
instead move the subzone from one zone to the other, preserving all its data such
as planting history and monitoring plots.

A subzone can move from one existing zone to another existing zone, or it can move
from an existing zone to a newly-created one.