### PR TITLE
Stop using incorrect "use" function

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -43,7 +43,6 @@ import com.terraformation.backend.tracking.model.ObservationResultsModel
 import com.terraformation.backend.tracking.model.ObservationRollupResultsModel
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
 import com.terraformation.backend.tracking.model.ObservedPlotCoordinatesModel
-import io.ktor.utils.io.core.use
 import io.mockk.every
 import java.io.InputStreamReader
 import java.math.BigDecimal


### PR DESCRIPTION
The `use` function from Ktor was imported in one of the tests, causing it to override
the standard library `use`. Remove the incorrect import.