### PR TITLE
SW-6556 Added migration to update existing observations time

### DIFF
--- a/src/main/resources/db/migration/0300/V345__ObservationsCompletedTime.sql
+++ b/src/main/resources/db/migration/0300/V345__ObservationsCompletedTime.sql
@@ -1,0 +1,9 @@
+-- Update "Completed" and "Abandoned" observations to have the latest completed plot time
+UPDATE tracking.observations as observations
+SET completed_time = (
+    SELECT max(plots.completed_time)
+    FROM tracking.observation_plots as plots
+    WHERE plots.observation_id = observations.id
+    AND plots.status_id = 3
+    )
+WHERE (observations.state_id = 3 OR observations.state_id = 5);


### PR DESCRIPTION
This migration will visit all existing "Completed" or "Abandoned" observations, and set completion time to the latest completed plot time, instead of the time where the observation state was changed. 