### PR TITLE
SW-6629 Set report dates to be within reporting config dates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -284,6 +284,10 @@ class ReportStore(
           ))
     } while (!startDate.isAfter(config.reportingEndDate))
 
+    // Set the first and last report to take account of config dates
+    rows[0] = rows[0].copy(startDate = config.reportingStartDate)
+    rows[rows.lastIndex] = rows[rows.lastIndex].copy(endDate = config.reportingEndDate)
+
     return rows
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -1236,7 +1236,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   configId = configId,
                   projectId = projectId,
                   statusId = ReportStatus.NotSubmitted,
-                  startDate = LocalDate.of(2025, Month.JANUARY, 1),
+                  startDate = LocalDate.of(2025, Month.MAY, 5),
                   endDate = LocalDate.of(2025, Month.DECEMBER, 31),
                   createdBy = systemUser.userId,
                   createdTime = clock.instant,
@@ -1270,7 +1270,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2028, Month.JANUARY, 1),
-                  endDate = LocalDate.of(2028, Month.DECEMBER, 31),
+                  endDate = LocalDate.of(2028, Month.MARCH, 2),
                   createdBy = systemUser.userId,
                   createdTime = clock.instant,
                   modifiedBy = systemUser.userId,
@@ -1290,7 +1290,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectId = projectId,
               frequency = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
-              reportingEndDate = LocalDate.of(2026, Month.MARCH, 31),
+              reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
           )
 
       store.insertProjectReportConfig(config)
@@ -1303,7 +1303,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               projectId = projectId,
               reportFrequencyId = ReportFrequency.Quarterly,
               reportingStartDate = LocalDate.of(2025, Month.MAY, 5),
-              reportingEndDate = LocalDate.of(2026, Month.MARCH, 31),
+              reportingEndDate = LocalDate.of(2026, Month.MARCH, 29),
           ),
           "Project report config tables")
 
@@ -1313,7 +1313,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   configId = configId,
                   projectId = projectId,
                   statusId = ReportStatus.NotSubmitted,
-                  startDate = LocalDate.of(2025, Month.APRIL, 1),
+                  startDate = LocalDate.of(2025, Month.MAY, 5),
                   endDate = LocalDate.of(2025, Month.JUNE, 30),
                   createdBy = systemUser.userId,
                   createdTime = clock.instant,
@@ -1347,7 +1347,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   projectId = projectId,
                   statusId = ReportStatus.NotSubmitted,
                   startDate = LocalDate.of(2026, Month.JANUARY, 1),
-                  endDate = LocalDate.of(2026, Month.MARCH, 31),
+                  endDate = LocalDate.of(2026, Month.MARCH, 29),
                   createdBy = systemUser.userId,
                   createdTime = clock.instant,
                   modifiedBy = systemUser.userId,


### PR DESCRIPTION
This prepares for a future feature for system metrics, where we will be querying for Terraware data according to report date ranges.

No SQL migration included since there is no report data yet. 