### PR TITLE
SW-6624 Use Int columns to store reference for metrics

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/MetricPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/MetricPayloads.kt
@@ -17,7 +17,9 @@ data class ExistingProjectMetricPayload(
     val description: String?,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int?,
+    val subSubReference: Int?,
 ) {
   constructor(
       model: ExistingProjectMetricModel
@@ -28,7 +30,10 @@ data class ExistingProjectMetricPayload(
       description = model.description,
       component = model.component,
       type = model.type,
-      reference = model.reference)
+      reference = model.reference,
+      subReference = model.subReference,
+      subSubReference = model.subSubReference,
+  )
 
   fun toModel(): ExistingProjectMetricModel {
     return ExistingProjectMetricModel(
@@ -49,7 +54,9 @@ data class ExistingStandardMetricPayload(
     val description: String?,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int?,
+    val subSubReference: Int?,
 ) {
   constructor(
       model: ExistingStandardMetricModel
@@ -59,7 +66,10 @@ data class ExistingStandardMetricPayload(
       description = model.description,
       component = model.component,
       type = model.type,
-      reference = model.reference)
+      reference = model.reference,
+      subReference = model.subReference,
+      subSubReference = model.subSubReference,
+  )
 
   fun toModel(): ExistingStandardMetricModel {
     return ExistingStandardMetricModel(
@@ -69,6 +79,8 @@ data class ExistingStandardMetricPayload(
         component = component,
         type = type,
         reference = reference,
+        subReference = subReference,
+        subSubReference = subSubReference,
     )
   }
 }
@@ -78,7 +90,9 @@ data class NewMetricPayload(
     val description: String?,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int?,
+    val subSubReference: Int?,
 ) {
   fun toProjectMetricModel(projectId: ProjectId): NewProjectMetricModel {
     return NewProjectMetricModel(
@@ -89,6 +103,8 @@ data class NewMetricPayload(
         component = component,
         type = type,
         reference = reference,
+        subReference = subReference,
+        subSubReference = subSubReference,
     )
   }
 
@@ -100,6 +116,8 @@ data class NewMetricPayload(
         component = component,
         type = type,
         reference = reference,
+        subReference = subReference,
+        subSubReference = subSubReference,
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.accelerator.model.ExistingProjectReportConfigM
 import com.terraformation.backend.accelerator.model.NewProjectReportConfigModel
 import com.terraformation.backend.accelerator.model.ReportMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportModel
+import com.terraformation.backend.accelerator.model.ReportProjectMetricModel
 import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
 import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.ApiResponse200
@@ -281,6 +282,7 @@ data class AcceleratorReportPayload(
     val submittedBy: UserId?,
     val submittedTime: Instant?,
     val standardMetrics: List<ReportStandardMetricPayload>,
+    val projectMetrics: List<ReportProjectMetricPayload>,
 ) {
   constructor(
       model: ReportModel
@@ -296,7 +298,9 @@ data class AcceleratorReportPayload(
       modifiedTime = model.modifiedTime,
       submittedBy = model.submittedBy,
       submittedTime = model.submittedTime,
-      standardMetrics = model.standardMetrics.map { ReportStandardMetricPayload(it) })
+      standardMetrics = model.standardMetrics.map { ReportStandardMetricPayload(it) },
+      projectMetrics = model.projectMetrics.map { ReportProjectMetricPayload(it) },
+  )
 }
 
 data class ReportReviewPayload(
@@ -312,7 +316,9 @@ data class ReportStandardMetricPayload(
     val description: String?,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int?,
+    val subSubReference: Int?,
     val target: Int?,
     val value: Int?,
     val notes: String?,
@@ -327,6 +333,39 @@ data class ReportStandardMetricPayload(
       component = model.metric.component,
       type = model.metric.type,
       reference = model.metric.reference,
+      subReference = model.metric.subReference,
+      subSubReference = model.metric.subSubReference,
+      target = model.entry.target,
+      value = model.entry.value,
+      notes = model.entry.notes,
+      internalComment = model.entry.internalComment)
+}
+
+data class ReportProjectMetricPayload(
+    val id: ProjectMetricId,
+    val name: String,
+    val description: String?,
+    val component: MetricComponent,
+    val type: MetricType,
+    val reference: Int,
+    val subReference: Int?,
+    val subSubReference: Int?,
+    val target: Int?,
+    val value: Int?,
+    val notes: String?,
+    val internalComment: String?
+) {
+  constructor(
+      model: ReportProjectMetricModel
+  ) : this(
+      id = model.metric.id,
+      name = model.metric.name,
+      description = model.metric.description,
+      component = model.metric.component,
+      type = model.metric.type,
+      reference = model.metric.reference,
+      subReference = model.metric.subReference,
+      subSubReference = model.metric.subSubReference,
       target = model.entry.target,
       value = model.entry.value,
       notes = model.entry.notes,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportMetricStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportMetricStore.kt
@@ -47,6 +47,8 @@ class ReportMetricStore(
           .set(COMPONENT_ID, model.component)
           .set(TYPE_ID, model.type)
           .set(REFERENCE, model.reference)
+          .set(SUB_REFERENCE, model.subReference)
+          .set(SUB_SUB_REFERENCE, model.subSubReference)
           .returning(ID)
           .fetchOne(ID)!!
     }
@@ -69,6 +71,8 @@ class ReportMetricStore(
           .set(COMPONENT_ID, new.component)
           .set(TYPE_ID, new.type)
           .set(REFERENCE, new.reference)
+          .set(SUB_REFERENCE, new.subReference)
+          .set(SUB_SUB_REFERENCE, new.subSubReference)
           .where(ID.eq(metricId))
           .execute()
     }
@@ -78,7 +82,12 @@ class ReportMetricStore(
     return dslContext
         .selectFrom(STANDARD_METRICS)
         .where(condition)
-        .orderBy(STANDARD_METRICS.REFERENCE, STANDARD_METRICS.ID)
+        .orderBy(
+            STANDARD_METRICS.REFERENCE,
+            STANDARD_METRICS.SUB_REFERENCE.nullsFirst(),
+            STANDARD_METRICS.SUB_SUB_REFERENCE.nullsFirst(),
+            STANDARD_METRICS.ID,
+        )
         .fetch { StandardMetricModel.of(it) }
   }
 
@@ -107,6 +116,8 @@ class ReportMetricStore(
           .set(COMPONENT_ID, model.component)
           .set(TYPE_ID, model.type)
           .set(REFERENCE, model.reference)
+          .set(SUB_REFERENCE, model.subReference)
+          .set(SUB_SUB_REFERENCE, model.subSubReference)
           .returning(ID)
           .fetchOne(ID)!!
     }
@@ -130,6 +141,8 @@ class ReportMetricStore(
           .set(COMPONENT_ID, new.component)
           .set(TYPE_ID, new.type)
           .set(REFERENCE, new.reference)
+          .set(SUB_REFERENCE, new.subReference)
+          .set(SUB_SUB_REFERENCE, new.subSubReference)
           .where(ID.eq(metricId))
           .execute()
     }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -416,7 +416,11 @@ class ReportStore(
                   .leftJoin(REPORT_STANDARD_METRICS)
                   .on(STANDARD_METRICS.ID.eq(REPORT_STANDARD_METRICS.STANDARD_METRIC_ID))
                   .and(REPORTS.ID.eq(REPORT_STANDARD_METRICS.REPORT_ID))
-                  .orderBy(STANDARD_METRICS.REFERENCE, STANDARD_METRICS.ID))
+                  .orderBy(
+                      STANDARD_METRICS.REFERENCE,
+                      STANDARD_METRICS.SUB_REFERENCE.nullsFirst(),
+                      STANDARD_METRICS.SUB_SUB_REFERENCE.nullsFirst(),
+                      STANDARD_METRICS.ID))
           .convertFrom { result -> result.map { ReportStandardMetricModel.of(it) } }
 
   private val projectMetricsMultiset: Field<List<ReportProjectMetricModel>> =
@@ -430,6 +434,10 @@ class ReportStore(
                   .on(PROJECT_METRICS.ID.eq(REPORT_PROJECT_METRICS.PROJECT_METRIC_ID))
                   .and(REPORTS.ID.eq(REPORT_PROJECT_METRICS.REPORT_ID))
                   .where(PROJECT_METRICS.PROJECT_ID.eq(REPORTS.PROJECT_ID))
-                  .orderBy(PROJECT_METRICS.REFERENCE, PROJECT_METRICS.ID))
+                  .orderBy(
+                      PROJECT_METRICS.REFERENCE,
+                      PROJECT_METRICS.SUB_REFERENCE.nullsFirst(),
+                      PROJECT_METRICS.SUB_SUB_REFERENCE.nullsFirst(),
+                      PROJECT_METRICS.ID))
           .convertFrom { result -> result.map { ReportProjectMetricModel.of(it) } }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectMetricModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectMetricModel.kt
@@ -11,10 +11,12 @@ data class ProjectMetricModel<ID : ProjectMetricId?>(
     val id: ID,
     val projectId: ProjectId,
     val name: String,
-    val description: String?,
+    val description: String? = null,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int? = null,
+    val subSubReference: Int? = null,
 ) {
   companion object {
     fun of(record: Record): ExistingProjectMetricModel {
@@ -27,6 +29,8 @@ data class ProjectMetricModel<ID : ProjectMetricId?>(
             component = record[COMPONENT_ID]!!,
             type = record[TYPE_ID]!!,
             reference = record[REFERENCE]!!,
+            subReference = record[SUB_REFERENCE],
+            subSubReference = record[SUB_SUB_REFERENCE],
         )
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/StandardMetricModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/StandardMetricModel.kt
@@ -9,10 +9,12 @@ import org.jooq.Record
 data class StandardMetricModel<ID : StandardMetricId?>(
     val id: ID,
     val name: String,
-    val description: String?,
+    val description: String? = null,
     val component: MetricComponent,
     val type: MetricType,
-    val reference: String,
+    val reference: Int,
+    val subReference: Int? = null,
+    val subSubReference: Int? = null,
 ) {
   companion object {
     fun of(record: Record): ExistingStandardMetricModel {
@@ -24,6 +26,8 @@ data class StandardMetricModel<ID : StandardMetricId?>(
             component = record[COMPONENT_ID]!!,
             type = record[TYPE_ID]!!,
             reference = record[REFERENCE]!!,
+            subReference = record[SUB_REFERENCE],
+            subSubReference = record[SUB_SUB_REFERENCE],
         )
       }
     }

--- a/src/main/resources/db/migration/0300/V347__ReportMetricReference.sql
+++ b/src/main/resources/db/migration/0300/V347__ReportMetricReference.sql
@@ -1,0 +1,11 @@
+ALTER TABLE accelerator.standard_metrics
+    DROP COLUMN reference,
+    ADD COLUMN reference INTEGER NOT NULL CHECK (reference >= 0),
+    ADD COLUMN sub_reference INTEGER CHECK (sub_reference >= 0),
+    ADD COLUMN sub_sub_reference INTEGER CHECK (sub_sub_reference >= 0);
+
+ALTER TABLE accelerator.project_metrics
+    DROP COLUMN reference,
+    ADD COLUMN reference INTEGER NOT NULL CHECK (reference >= 0),
+    ADD COLUMN sub_reference INTEGER CHECK (sub_reference >= 0),
+    ADD COLUMN sub_sub_reference INTEGER CHECK (sub_sub_reference >= 0);

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportMetricStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportMetricStoreTest.kt
@@ -46,7 +46,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -56,7 +57,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             ),
             store.fetchOneStandardMetric(metricId))
@@ -76,7 +78,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -95,7 +98,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -104,7 +108,9 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Community,
                 description = "Community metric description",
                 name = "Community Metric",
-                reference = "5.0",
+                reference = 3,
+                subReference = 0,
+                subSubReference = 1,
                 type = MetricType.Outcome,
             )
 
@@ -113,7 +119,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.ProjectObjectives,
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -125,7 +132,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.Climate,
                     description = "Climate standard metric description",
                     name = "Climate Standard Metric",
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     type = MetricType.Activity,
                 ),
                 ExistingStandardMetricModel(
@@ -133,7 +141,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.ProjectObjectives,
                     description = "Project objectives metric description",
                     name = "Project Objectives Metric",
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     type = MetricType.Impact,
                 ),
                 ExistingStandardMetricModel(
@@ -141,7 +150,9 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.Community,
                     description = "Community metric description",
                     name = "Community Metric",
-                    reference = "5.0",
+                    reference = 3,
+                    subReference = 0,
+                    subSubReference = 1,
                     type = MetricType.Outcome,
                 ),
             ),
@@ -168,7 +179,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
                 projectId = projectId,
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -179,7 +191,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             ),
             store.fetchOneProjectMetric(metricId))
@@ -202,7 +215,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
                 projectId = projectId,
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -224,7 +238,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
                 projectId = projectId,
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -234,7 +249,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Community metric description",
                 name = "Community Metric",
                 projectId = projectId,
-                reference = "5.0",
+                reference = 5,
+                subReference = 0,
                 type = MetricType.Outcome,
             )
 
@@ -244,7 +260,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
                 projectId = projectId,
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -261,7 +278,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.Climate,
                     description = "Climate standard metric description",
                     name = "Climate Standard Metric",
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     type = MetricType.Activity,
                 ),
                 ExistingProjectMetricModel(
@@ -270,7 +288,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.ProjectObjectives,
                     description = "Project objectives metric description",
                     name = "Project Objectives Metric",
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     type = MetricType.Impact,
                 ),
                 ExistingProjectMetricModel(
@@ -279,7 +298,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     component = MetricComponent.Community,
                     description = "Community metric description",
                     name = "Community Metric",
-                    reference = "5.0",
+                    reference = 5,
+                    subReference = 0,
                     type = MetricType.Outcome,
                 ),
             ),
@@ -308,7 +328,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -318,7 +339,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.ProjectObjectives,
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
-                reference = "1.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -331,7 +353,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     componentId = MetricComponent.Climate,
                     description = "Climate standard metric description",
                     name = "Climate Standard Metric",
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     typeId = MetricType.Activity,
                 ),
                 StandardMetricsRecord(
@@ -339,7 +362,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     componentId = MetricComponent.ProjectObjectives,
                     description = "Project objectives metric description",
                     name = "Project Objectives Metric",
-                    reference = "1.0",
+                    reference = 1,
+                    subReference = 0,
                     typeId = MetricType.Impact,
                 )))
       }
@@ -352,7 +376,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.ProjectObjectives,
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
-                reference = "1.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -374,7 +399,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
                 projectId = projectId,
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -385,7 +411,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.ProjectObjectives,
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
-                reference = "1.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -399,7 +426,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     description = "Climate standard metric description",
                     name = "Climate Standard Metric",
                     projectId = projectId,
-                    reference = "3.0",
+                    reference = 3,
+                    subReference = 0,
                     typeId = MetricType.Activity,
                 ),
                 ProjectMetricsRecord(
@@ -408,7 +436,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     description = "Project objectives metric description",
                     name = "Project Objectives Metric",
                     projectId = projectId,
-                    reference = "1.0",
+                    reference = 1,
+                    subReference = 0,
                     typeId = MetricType.Impact,
                 )))
       }
@@ -424,7 +453,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
                 projectId = projectId,
-                reference = "1.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -446,7 +476,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 3,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
@@ -456,7 +487,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.ProjectObjectives,
                 description = "Project objectives metric description",
                 name = "Project Objectives Metric",
-                reference = "1.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Impact,
             )
 
@@ -469,7 +501,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                     componentId = MetricComponent.ProjectObjectives,
                     description = "Project objectives metric description",
                     name = "Project Objectives Metric",
-                    reference = "1.0",
+                    reference = 1,
+                    subReference = 0,
                     typeId = MetricType.Impact,
                 )))
       }
@@ -481,14 +514,15 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 component = MetricComponent.Climate,
                 description = "Climate standard metric description",
                 name = "Climate Standard Metric",
-                reference = "3.0",
+                reference = 1,
+                subReference = 0,
                 type = MetricType.Activity,
             )
 
         deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
         insertUserGlobalRole(role = GlobalRole.TFExpert)
         assertThrows<AccessDeniedException> {
-          store.updateStandardMetric(existingMetricId) { it.copy(reference = "1.0") }
+          store.updateStandardMetric(existingMetricId) { it.copy(reference = 3) }
         }
       }
     }
@@ -506,7 +540,8 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               description = "Climate standard metric description",
               name = "Climate Standard Metric",
               projectId = projectId,
-              reference = "3.0",
+              reference = 3,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -517,7 +552,9 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               description = "Project objectives metric description",
               name = "Project Objectives Metric",
               projectId = ProjectId(99), // this field is ignored
-              reference = "1.0",
+              reference = 1,
+              subReference = 3,
+              subSubReference = 1,
               type = MetricType.Impact,
           )
 
@@ -531,7 +568,9 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   description = "Project objectives metric description",
                   name = "Project Objectives Metric",
                   projectId = projectId,
-                  reference = "1.0",
+                  reference = 1,
+                  subReference = 3,
+                  subSubReference = 1,
                   typeId = MetricType.Impact,
               )))
     }
@@ -546,14 +585,15 @@ class ReportMetricStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               description = "Climate standard metric description",
               name = "Climate Standard Metric",
               projectId = projectId,
-              reference = "3.0",
+              reference = 3,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
       deleteUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       insertUserGlobalRole(role = GlobalRole.TFExpert)
       assertThrows<AccessDeniedException> {
-        store.updateProjectMetric(existingMetricId) { it.copy(reference = "1.0") }
+        store.updateProjectMetric(existingMetricId) { it.copy(reference = 1) }
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -111,7 +111,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Climate,
               description = "Climate standard metric description",
               name = "Climate Standard Metric",
-              reference = "3.0",
+              reference = 3,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -120,7 +121,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Community,
               description = "Community metric description",
               name = "Community Metric",
-              reference = "5.0",
+              reference = 5,
+              subReference = 0,
               type = MetricType.Outcome,
           )
 
@@ -129,7 +131,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project objectives metric description",
               name = "Project Objectives Metric",
-              reference = "1.0",
+              reference = 1,
+              subReference = 0,
               type = MetricType.Impact,
           )
 
@@ -138,7 +141,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project Metric description",
               name = "Project Metric Name",
-              reference = "2.0",
+              reference = 2,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -194,7 +198,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                                   component = MetricComponent.ProjectObjectives,
                                   description = "Project objectives metric description",
                                   name = "Project Objectives Metric",
-                                  reference = "1.0",
+                                  reference = 1,
+                                  subReference = 0,
                                   type = MetricType.Impact,
                               ),
                           // all fields are null because no target/value have been set yet
@@ -206,7 +211,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                                   component = MetricComponent.Climate,
                                   description = "Climate standard metric description",
                                   name = "Climate Standard Metric",
-                                  reference = "3.0",
+                                  reference = 3,
+                                  subReference = 0,
                                   type = MetricType.Activity,
                               ),
                           entry =
@@ -225,7 +231,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                                   component = MetricComponent.Community,
                                   description = "Community metric description",
                                   name = "Community Metric",
-                                  reference = "5.0",
+                                  reference = 5,
+                                  subReference = 0,
                                   type = MetricType.Outcome,
                               ),
                           entry =
@@ -245,7 +252,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                                   component = MetricComponent.ProjectObjectives,
                                   description = "Project Metric description",
                                   name = "Project Metric Name",
-                                  reference = "2.0",
+                                  reference = 2,
+                                  subReference = 0,
                                   type = MetricType.Activity,
                               ),
                           entry =
@@ -607,7 +615,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Climate,
               description = "Climate standard metric description",
               name = "Climate Standard Metric",
-              reference = "3.0",
+              reference = 3,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -616,7 +625,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Community,
               description = "Community metric description",
               name = "Community Metric",
-              reference = "5.0",
+              reference = 5,
+              subReference = 0,
               type = MetricType.Outcome,
           )
 
@@ -625,7 +635,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project objectives metric description",
               name = "Project Objectives Metric",
-              reference = "1.0",
+              reference = 1,
+              subReference = 0,
               type = MetricType.Impact,
           )
 
@@ -634,7 +645,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           component = MetricComponent.Biodiversity,
           description = "Biodiversity metric description",
           name = "Biodiversity Metric",
-          reference = "7.0",
+          reference = 7,
+          subReference = 0,
           type = MetricType.Impact,
       )
 
@@ -643,7 +655,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project Metric description",
               name = "Project Metric Name",
-              reference = "2.0",
+              reference = 2,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -834,7 +847,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Climate,
               description = "Climate standard metric description",
               name = "Climate Standard Metric",
-              reference = "3.0",
+              reference = 3,
+              subReference = 0,
               type = MetricType.Activity,
           )
 
@@ -843,7 +857,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.Community,
               description = "Community metric description",
               name = "Community Metric",
-              reference = "5.0",
+              reference = 5,
+              subReference = 0,
               type = MetricType.Outcome,
           )
 
@@ -852,7 +867,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project objectives metric description",
               name = "Project Objectives Metric",
-              reference = "1.0",
+              reference = 1,
+              subReference = 0,
               type = MetricType.Impact,
           )
 
@@ -861,7 +877,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           component = MetricComponent.Biodiversity,
           description = "Biodiversity metric description",
           name = "Biodiversity Metric",
-          reference = "7.0",
+          reference = 7,
+          subReference = 0,
           type = MetricType.Impact,
       )
 
@@ -870,7 +887,8 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               component = MetricComponent.ProjectObjectives,
               description = "Project Metric description",
               name = "Project Metric Name",
-              reference = "2.0",
+              reference = 2,
+              subReference = 0,
               type = MetricType.Activity,
           )
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -835,7 +835,9 @@ abstract class DatabaseBackedTest {
       component: MetricComponent = row.componentId ?: MetricComponent.ProjectObjectives,
       description: String? = row.description,
       name: String = row.name ?: "Metric name",
-      reference: String = row.reference ?: "1.1",
+      reference: Int = row.reference ?: 1,
+      subReference: Int? = row.subReference,
+      subSubReference: Int? = row.subSubReference,
       projectId: ProjectId = row.projectId ?: inserted.projectId,
       type: MetricType = row.typeId ?: MetricType.Impact,
   ): ProjectMetricId {
@@ -845,6 +847,8 @@ abstract class DatabaseBackedTest {
             description = description,
             name = name,
             reference = reference,
+            subReference = subReference,
+            subSubReference = subSubReference,
             projectId = projectId,
             typeId = type,
         )
@@ -2358,7 +2362,9 @@ abstract class DatabaseBackedTest {
       component: MetricComponent = row.componentId ?: MetricComponent.ProjectObjectives,
       description: String? = row.description,
       name: String = row.name ?: "Metric name",
-      reference: String = row.reference ?: "1.1",
+      reference: Int = row.reference ?: 1,
+      subReference: Int? = row.subReference,
+      subSubReference: Int? = row.subSubReference,
       type: MetricType = row.typeId ?: MetricType.Impact,
   ): StandardMetricId {
     val rowWithDefaults =
@@ -2367,6 +2373,8 @@ abstract class DatabaseBackedTest {
             description = description,
             name = name,
             reference = reference,
+            subReference = subReference,
+            subSubReference = subSubReference,
             typeId = type,
         )
 


### PR DESCRIPTION
To avoid sorting issues and complications, product team was able to confirmed that this will always be numbers, and up to 3. So we updated the columns to reflect that. 