### PR TITLE
SW-6561 Fix migration PostgreSQL 17 incompatibility

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/db/FlywayConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/FlywayConfig.kt
@@ -1,0 +1,48 @@
+package com.terraformation.backend.db
+
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.CoreErrorCode
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FlywayConfig {
+  /**
+   * Version numbers of migrations that have been edited after they were originally applied in
+   * production.
+   *
+   * Numbered migrations, as a rule, should never be edited after they're already applied. But in
+   * some cases, existing migrations that were applied successfully can become invalid after the
+   * fact, e.g., if they use SQL syntax that stops being supported in newer database versions.
+   *
+   * In cases like that, we still need to run the migrations on empty databases as part of the build
+   * process, so they need to be edited to be valid. But we don't want Flyway to flag the modified
+   * migration scripts as validation errors in environments where the migrations were already
+   * applied; it should continue to treat them as if they're already complete.
+   */
+  private val editedMigrationVersions =
+      setOf(
+          "134",
+      )
+
+  /**
+   * Configures Flyway to accept edits to the migrations in [editedMigrationVersions] when it
+   * validates all the migrations at server start time.
+   */
+  @Bean
+  fun repairChecksumsOfEditedMigrations(): FlywayMigrationStrategy {
+    return FlywayMigrationStrategy { flyway: Flyway ->
+      val checksumErrors =
+          flyway.validateWithResult().invalidMigrations.filter {
+            it.errorDetails.errorCode == CoreErrorCode.CHECKSUM_MISMATCH
+          }
+      if (checksumErrors.isNotEmpty() &&
+          checksumErrors.all { it.version in editedMigrationVersions }) {
+        flyway.repair()
+      }
+
+      flyway.migrate()
+    }
+  }
+}

--- a/src/main/resources/db/migration/0100/V134__ViabilityTestsCut.sql
+++ b/src/main/resources/db/migration/0100/V134__ViabilityTestsCut.sql
@@ -29,7 +29,7 @@ WHERE (cut_test_seeds_compromised IS NOT NULL
     OR cut_test_seeds_filled IS NOT NULL)
   AND remaining_quantity IS NOT NULL;
 
-WITH system_user AS (SELECT id FROM users WHERE user_type_id = 4)
+WITH su AS (SELECT id FROM users WHERE user_type_id = 4)
 INSERT
 INTO withdrawals (accession_id,
                   created_by,
@@ -41,7 +41,7 @@ INTO withdrawals (accession_id,
                   updated_time,
                   viability_test_id)
 SELECT vt.accession_id,
-       (SELECT id FROM system_user),
+       (SELECT id FROM su),
        NOW(),
        a.modified_time::DATE,
        vt.remaining_grams,

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -665,13 +665,13 @@ ON CONFLICT (id) DO UPDATE SET name = excluded.name,
 
 -- Depends on user_types
 INSERT INTO internal_tags (id, name, description, is_system, created_by, created_time, modified_by, modified_time)
-SELECT t.id, t.name, t.description, TRUE, system_user.id, NOW(), system_user.id, NOW()
+SELECT t.id, t.name, t.description, TRUE, su.id, NOW(), su.id, NOW()
 FROM (
          SELECT id
          FROM users
          WHERE user_type_id = 4
            AND email = 'system'
-     ) AS system_user, (
+     ) AS su, (
          VALUES (1, 'Reporter', 'Organization must submit reports to Terraformation.'),
                 (2, 'Internal', 'Terraformation-managed internal organization, not a customer.'),
                 (3, 'Testing', 'Used for internal testing; may contain invalid data.'),


### PR DESCRIPTION
In PostgreSQL 17, `system_user` is now a reserved keyword, so we can't use it
unquoted as a subquery or CTE name any more.

We were using it in two migrations. One of them is a numbered migration, and
switching to a different CTE name means editing the migration script. By default,
Flyway flags edits to numbered migrations as validation errors. So we also need
to tell Flyway to not treat this specific edit as an error, but to still flag
edits to other numbered migrations.