### PR TITLE
SW-6652 Save planting zone settings on edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -692,6 +692,7 @@ class PlantingSiteStore(
                           .set(BOUNDARY_MODIFIED_TIME, now)
                     }
                   }
+                  .set(ERROR_MARGIN, edit.desiredModel.errorMargin)
                   .set(EXTRA_PERMANENT_CLUSTERS, totalExtraPermanentClusters)
                   .set(MODIFIED_BY, currentUser().userId)
                   .set(MODIFIED_TIME, now)
@@ -699,7 +700,9 @@ class PlantingSiteStore(
                   .set(
                       NUM_PERMANENT_CLUSTERS,
                       edit.desiredModel.numPermanentClusters + totalExtraPermanentClusters)
+                  .set(STUDENTS_T, edit.desiredModel.studentsT)
                   .set(TARGET_PLANTING_DENSITY, edit.desiredModel.targetPlantingDensity)
+                  .set(VARIANCE, edit.desiredModel.variance)
                   .where(ID.eq(edit.existingModel.id))
                   .execute()
           if (rowsUpdated != 1) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2.kt
@@ -99,6 +99,10 @@ class PlantingSiteEditCalculatorV2(
 
               if (subzoneEdits.isEmpty() &&
                   createMonitoringPlotEdits.isEmpty() &&
+                  existingZone.errorMargin == desiredZone.errorMargin &&
+                  existingZone.studentsT == desiredZone.studentsT &&
+                  existingZone.targetPlantingDensity == desiredZone.targetPlantingDensity &&
+                  existingZone.variance == desiredZone.variance &&
                   existingUsableBoundary.equalsExact(desiredUsableBoundary, 0.00001)) {
                 null
               } else {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -84,6 +84,36 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     }
 
     @Test
+    fun `updates settings`() {
+      val newErrorMargin = BigDecimal(101)
+      val newStudentsT = BigDecimal("1.646")
+      val newTargetPlantingDensity = BigDecimal(1100)
+      val newVariance = BigDecimal(40001)
+
+      val (edited) =
+          runScenario(
+              initial = newSite(),
+              desired =
+                  newSite {
+                    zone {
+                      errorMargin = newErrorMargin
+                      studentsT = newStudentsT
+                      targetPlantingDensity = newTargetPlantingDensity
+                      variance = newVariance
+                    }
+                  },
+              useV2Calculator = true)
+
+      assertEquals(newErrorMargin, edited.plantingZones[0].errorMargin, "Error margin")
+      assertEquals(newStudentsT, edited.plantingZones[0].studentsT, "Student's t")
+      assertEquals(
+          newTargetPlantingDensity,
+          edited.plantingZones[0].targetPlantingDensity,
+          "Target planting density")
+      assertEquals(newVariance, edited.plantingZones[0].variance, "Variance")
+    }
+
+    @Test
     fun `creates new zones`() {
       runScenario(
           newSite(width = 500),

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorV2Test.kt
@@ -118,6 +118,43 @@ class PlantingSiteEditCalculatorV2Test {
   }
 
   @Test
+  fun `returns zone update for settings change`() {
+    val newErrorMargin = BigDecimal(101)
+    val newStudentsT = BigDecimal("1.646")
+    val newTargetPlantingDensity = BigDecimal(1100)
+    val newVariance = BigDecimal(40001)
+
+    val existing = existingSite { zone { subzone { repeat(8) { cluster() } } } }
+    val desired = newSite {
+      zone {
+        errorMargin = newErrorMargin
+        studentsT = newStudentsT
+        targetPlantingDensity = newTargetPlantingDensity
+        variance = newVariance
+      }
+    }
+
+    assertEditResult(
+        PlantingSiteEdit(
+            areaHaDifference = BigDecimal.ZERO,
+            behavior = PlantingSiteEditBehavior.Flexible,
+            desiredModel = desired,
+            existingModel = existing,
+            plantingZoneEdits =
+                listOf(
+                    PlantingZoneEdit.Update(
+                        addedRegion = rectangle(0),
+                        areaHaDifference = BigDecimal.ZERO,
+                        desiredModel = desired.plantingZones[0],
+                        existingModel = existing.plantingZones[0],
+                        monitoringPlotEdits = emptyList(),
+                        plantingSubzoneEdits = emptyList(),
+                        removedRegion = rectangle(0)))),
+        existing,
+        desired)
+  }
+
+  @Test
   fun `returns updates with both added and removed regions if boundary change was not a simple expansion`() {
     val existing = existingSite(x = 0, width = 500, height = 500)
     val desired = newSite(x = 100, width = 600, height = 500) { zone(numPermanent = 1) }

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.rectangle
 import com.terraformation.backend.rectanglePolygon
 import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.differenceNullable
+import java.math.BigDecimal
 import java.time.Instant
 import org.locationtech.jts.geom.GeometryFactory
 import org.locationtech.jts.geom.MultiPolygon
@@ -206,6 +207,11 @@ private constructor(
       private val numTemporaryPlots: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
       private val extraPermanentClusters: Int = 0,
   ) {
+    var errorMargin: BigDecimal = PlantingZoneModel.DEFAULT_ERROR_MARGIN
+    var studentsT: BigDecimal = PlantingZoneModel.DEFAULT_STUDENTS_T
+    var targetPlantingDensity: BigDecimal = PlantingZoneModel.DEFAULT_TARGET_PLANTING_DENSITY
+    var variance: BigDecimal = PlantingZoneModel.DEFAULT_VARIANCE
+
     private val boundary: MultiPolygon = rectangle(width, height, x, y)
     private var nextPermanentCluster = 1
     private var nextSubzoneX = x
@@ -216,12 +222,16 @@ private constructor(
           areaHa = boundary.differenceNullable(exclusion).calculateAreaHectares(),
           boundary = boundary,
           boundaryModifiedTime = Instant.EPOCH,
+          errorMargin = errorMargin,
           extraPermanentClusters = extraPermanentClusters,
           id = PlantingZoneId(currentZoneId),
           name = name,
           numPermanentClusters = numPermanentClusters,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = plantingSubzones.ifEmpty { listOf(subzone()) },
+          studentsT = studentsT,
+          targetPlantingDensity = targetPlantingDensity,
+          variance = variance,
       )
     }
 


### PR DESCRIPTION
If a new shapefile included changes to planting zone settings such as error
margin, the new settings were used to calculate the correct number of monitoring
plots but they weren't written to the database. The zone thus showed up with the
old settings in the admin UI.