### PR TITLE
SW-6653 Fix stack overflow on map update

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -77,4 +77,33 @@ class ExtensionsTest {
       assertEquals(BigDecimal("101.8"), geometry.calculateAreaHectares())
     }
   }
+
+  @Nested
+  inner class ToMultiPolygon {
+    @Test
+    fun `converts GeometryCollection to MultiPolygon even if it includes Points`() {
+      val factory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
+      val polygon1 =
+          factory.createPolygon(
+              arrayOf(
+                  CoordinateXY(0.0, 0.0),
+                  CoordinateXY(0.0, 1.0),
+                  CoordinateXY(1.0, 1.0),
+                  CoordinateXY(0.0, 0.0)))
+      val polygon2 =
+          factory.createPolygon(
+              arrayOf(
+                  CoordinateXY(10.0, 0.0),
+                  CoordinateXY(10.0, 1.0),
+                  CoordinateXY(11.0, 1.0),
+                  CoordinateXY(10.0, 0.0)))
+      val geometryCollection =
+          factory.createGeometryCollection(
+              arrayOf(polygon1, polygon2, factory.createPoint(CoordinateXY(20.0, 0.0))))
+
+      assertEquals(
+          factory.createMultiPolygon(arrayOf(polygon1, polygon2)),
+          geometryCollection.toMultiPolygon())
+    }
+  }
 }


### PR DESCRIPTION
If a planting zone in an uploaded shapefile had an added area that shared a vertex
with a removed area, one of our geometry operations (calculating an intersection)
resulted in a geometry that contained a point as well as a set of polygons. This
caused infinite recursion in the code that converts arbitrary geometries to
multi-polygon objects.

Update the converter code to ignore standalone points and only pay attention to
polygons and multi-polygons.