### PR TITLE
SW-6607 CRUD Funding Entities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -51,6 +51,11 @@ annotation class TrackingEndpoint
 annotation class AcceleratorEndpoint
 
 @Retention(AnnotationRetention.RUNTIME)
+@Tag(name = "Funder")
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class FunderEndpoint
+
+@Retention(AnnotationRetention.RUNTIME)
 @Tag(name = "internal")
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 annotation class InternalEndpoint

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -48,6 +48,8 @@ import com.terraformation.backend.db.default_schema.tables.references.SEED_FUND_
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
 import com.terraformation.backend.db.default_schema.tables.references.UPLOADS
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
@@ -334,6 +336,15 @@ class ParentStore(private val dslContext: DSLContext) {
           .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
           .where(ORGANIZATION_USERS.USER_ID.eq(userId))
           .and(PARTICIPANTS.ID.eq(participantId))
+          .fetch()
+          .isNotEmpty
+
+  fun exists(fundingEntityId: FundingEntityId, userId: UserId): Boolean =
+      dslContext
+          .selectOne()
+          .from(FUNDING_ENTITY_USERS)
+          .where(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID.eq(fundingEntityId))
+          .and(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
           .fetch()
           .isNotEmpty
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -237,7 +237,7 @@ data class IndividualUser(
 
   override fun canCreateFacility(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
-  override fun canCreateFundingEntity() = isAcceleratorAdmin()
+  override fun canCreateFundingEntities() = isAcceleratorAdmin()
 
   override fun canCreateNotification(
       targetUserId: UserId,
@@ -299,7 +299,7 @@ data class IndividualUser(
       userId == parentStore.getUserId(draftPlantingSiteId) &&
           isAdminOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
 
-  override fun canDeleteFundingEntity() = isAcceleratorAdmin()
+  override fun canDeleteFundingEntities() = isAcceleratorAdmin()
 
   override fun canDeleteOrganization(organizationId: OrganizationId) = isOwner(organizationId)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -360,6 +360,8 @@ data class IndividualUser(
 
   override fun canManageDocumentProducer() = isTFExpertOrHigher()
 
+  override fun canManageFundingEntities() = isAcceleratorAdmin()
+
   override fun canManageInternalTags() = isSuperAdmin()
 
   override fun canManageModuleEvents() = isAcceleratorAdmin()
@@ -423,6 +425,8 @@ data class IndividualUser(
       isManagerOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
 
   override fun canReadFacility(facilityId: FacilityId) = isMember(facilityId)
+
+  override fun canReadFundingEntities() = isReadOnlyOrHigher()
 
   override fun canReadGlobalRoles() = isTFExpertOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -31,6 +31,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.docprod.DocumentId
+import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -236,6 +237,8 @@ data class IndividualUser(
 
   override fun canCreateFacility(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
+  override fun canCreateFundingEntity() = isAcceleratorAdmin()
+
   override fun canCreateNotification(
       targetUserId: UserId,
       organizationId: OrganizationId
@@ -295,6 +298,8 @@ data class IndividualUser(
   override fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId) =
       userId == parentStore.getUserId(draftPlantingSiteId) &&
           isAdminOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
+
+  override fun canDeleteFundingEntity() = isAcceleratorAdmin()
 
   override fun canDeleteOrganization(organizationId: OrganizationId) = isOwner(organizationId)
 
@@ -359,8 +364,6 @@ data class IndividualUser(
   override fun canManageDeliverables() = isAcceleratorAdmin()
 
   override fun canManageDocumentProducer() = isTFExpertOrHigher()
-
-  override fun canManageFundingEntities() = isAcceleratorAdmin()
 
   override fun canManageInternalTags() = isSuperAdmin()
 
@@ -637,6 +640,13 @@ data class IndividualUser(
           isAdminOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
 
   override fun canUpdateFacility(facilityId: FacilityId) = isAdminOrHigher(facilityId)
+
+  override fun canUpdateFundingEntities() = isAcceleratorAdmin()
+
+  override fun canUpdateFundingEntityProjects() = isAcceleratorAdmin()
+
+  override fun canUpdateFundingEntityUsers(fundingEntityId: FundingEntityId) =
+      isAcceleratorAdmin() || parentStore.exists(fundingEntityId, userId)
 
   override fun canUpdateGlobalRoles(): Boolean = isSuperAdmin()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -50,6 +50,7 @@ import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.docprod.DocumentId
+import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -299,6 +300,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun createFundingEntity() {
+    user.recordPermissionChecks {
+      if (!user.canCreateFundingEntity()) {
+        throw AccessDeniedException("No permission to create funding entity")
+      }
+    }
+  }
+
   fun createNotification(userId: UserId, organizationId: OrganizationId) {
     readOrganization(organizationId)
     if (!user.canCreateNotification(userId, organizationId)) {
@@ -474,6 +483,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
         readDraftPlantingSite(draftPlantingSiteId)
         throw AccessDeniedException(
             "No permission to delete draft planting site $draftPlantingSiteId")
+      }
+    }
+  }
+
+  fun deleteFundingEntity() {
+    user.recordPermissionChecks {
+      if (!user.canDeleteFundingEntity()) {
+        throw AccessDeniedException("No permission to delete funding entity")
       }
     }
   }
@@ -654,14 +671,6 @@ class PermissionRequirements(private val user: TerrawareUser) {
     user.recordPermissionChecks {
       if (!user.canManageDeliverables()) {
         throw AccessDeniedException("No permission to manage deliverables")
-      }
-    }
-  }
-
-  fun manageFundingEntities() {
-    user.recordPermissionChecks {
-      if (!user.canManageFundingEntities()) {
-        throw AccessDeniedException("No permission to manage funding entities")
       }
     }
   }
@@ -1464,6 +1473,30 @@ class PermissionRequirements(private val user: TerrawareUser) {
       if (!user.canUpdateFacility(facilityId)) {
         readFacility(facilityId)
         throw AccessDeniedException("No permission to update facility $facilityId")
+      }
+    }
+  }
+
+  fun updateFundingEntities() {
+    user.recordPermissionChecks {
+      if (!user.canUpdateFundingEntities()) {
+        throw AccessDeniedException("No permission to update funding entities")
+      }
+    }
+  }
+
+  fun updateFundingEntityProjects() {
+    user.recordPermissionChecks {
+      if (!user.canUpdateFundingEntityProjects()) {
+        throw AccessDeniedException("No permission to update funding entity projects")
+      }
+    }
+  }
+
+  fun updateFundingEntityUsers(fundingEntityId: FundingEntityId) {
+    user.recordPermissionChecks {
+      if (!user.canUpdateFundingEntityUsers(fundingEntityId)) {
+        throw AccessDeniedException("No permission to update funding entity users")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -300,10 +300,10 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun createFundingEntity() {
+  fun createFundingEntities() {
     user.recordPermissionChecks {
-      if (!user.canCreateFundingEntity()) {
-        throw AccessDeniedException("No permission to create funding entity")
+      if (!user.canCreateFundingEntities()) {
+        throw AccessDeniedException("No permission to create funding entities")
       }
     }
   }
@@ -487,10 +487,10 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun deleteFundingEntity() {
+  fun deleteFundingEntities() {
     user.recordPermissionChecks {
-      if (!user.canDeleteFundingEntity()) {
-        throw AccessDeniedException("No permission to delete funding entity")
+      if (!user.canDeleteFundingEntities()) {
+        throw AccessDeniedException("No permission to delete funding entities")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -658,6 +658,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun manageFundingEntities() {
+    user.recordPermissionChecks {
+      if (!user.canManageFundingEntities()) {
+        throw AccessDeniedException("No permission to manage funding entities")
+      }
+    }
+  }
+
   fun manageInternalTags() {
     user.recordPermissionChecks {
       if (!user.canManageInternalTags()) {
@@ -849,6 +857,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     user.recordPermissionChecks {
       if (!user.canReadFacility(facilityId)) {
         throw FacilityNotFoundException(facilityId)
+      }
+    }
+  }
+
+  fun readFundingEntities() {
+    user.recordPermissionChecks {
+      if (!user.canReadFundingEntities()) {
+        throw AccessDeniedException("No permission to read funding entities")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -265,6 +265,8 @@ interface TerrawareUser : Principal {
 
   fun canManageDeliverables(): Boolean = defaultPermission
 
+  fun canManageFundingEntities(): Boolean = defaultPermission
+
   fun canManageDocumentProducer(): Boolean = defaultPermission
 
   fun canManageInternalTags(): Boolean = defaultPermission
@@ -315,6 +317,8 @@ interface TerrawareUser : Principal {
       defaultPermission
 
   fun canReadFacility(facilityId: FacilityId): Boolean = defaultPermission
+
+  fun canReadFundingEntities(): Boolean = defaultPermission
 
   fun canReadGlobalRoles(): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import com.terraformation.backend.db.docprod.DocumentId
+import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -177,6 +178,8 @@ interface TerrawareUser : Principal {
 
   fun canCreateFacility(organizationId: OrganizationId): Boolean = defaultPermission
 
+  fun canCreateFundingEntity(): Boolean = defaultPermission
+
   fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean =
       defaultPermission
 
@@ -219,6 +222,8 @@ interface TerrawareUser : Principal {
 
   fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean =
       defaultPermission
+
+  fun canDeleteFundingEntity(): Boolean = defaultPermission
 
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 
@@ -264,8 +269,6 @@ interface TerrawareUser : Principal {
   fun canManageDefaultProjectLeads(): Boolean = defaultPermission
 
   fun canManageDeliverables(): Boolean = defaultPermission
-
-  fun canManageFundingEntities(): Boolean = defaultPermission
 
   fun canManageDocumentProducer(): Boolean = defaultPermission
 
@@ -466,6 +469,12 @@ interface TerrawareUser : Principal {
       defaultPermission
 
   fun canUpdateFacility(facilityId: FacilityId): Boolean = defaultPermission
+
+  fun canUpdateFundingEntities(): Boolean = defaultPermission
+
+  fun canUpdateFundingEntityProjects(): Boolean = defaultPermission
+
+  fun canUpdateFundingEntityUsers(fundingEntityId: FundingEntityId): Boolean = defaultPermission
 
   fun canUpdateGlobalRoles(): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -178,7 +178,7 @@ interface TerrawareUser : Principal {
 
   fun canCreateFacility(organizationId: OrganizationId): Boolean = defaultPermission
 
-  fun canCreateFundingEntity(): Boolean = defaultPermission
+  fun canCreateFundingEntities(): Boolean = defaultPermission
 
   fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean =
       defaultPermission
@@ -223,7 +223,7 @@ interface TerrawareUser : Principal {
   fun canDeleteDraftPlantingSite(draftPlantingSiteId: DraftPlantingSiteId): Boolean =
       defaultPermission
 
-  fun canDeleteFundingEntity(): Boolean = defaultPermission
+  fun canDeleteFundingEntities(): Boolean = defaultPermission
 
   fun canDeleteOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
@@ -111,17 +111,18 @@ class FundingEntityService(
     }
   }
 
-  private fun removeProjectsFromEntity(fundingEntityId: FundingEntityId, projects: Set<ProjectId>) {
+  private fun removeProjectsFromEntity(
+      fundingEntityId: FundingEntityId,
+      projectIds: Set<ProjectId>
+  ) {
     requirePermissions { updateFundingEntityProjects() }
 
-    for (projectId in projects) {
-      with(FUNDING_ENTITY_PROJECTS) {
-        dslContext
-            .deleteFrom(FUNDING_ENTITY_PROJECTS)
-            .where(FUNDING_ENTITY_ID.eq(fundingEntityId))
-            .and(PROJECT_ID.eq(projectId))
-            .execute()
-      }
+    with(FUNDING_ENTITY_PROJECTS) {
+      dslContext
+          .deleteFrom(FUNDING_ENTITY_PROJECTS)
+          .where(FUNDING_ENTITY_ID.eq(fundingEntityId))
+          .and(PROJECT_ID.`in`(projectIds))
+          .execute()
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
@@ -31,7 +31,7 @@ class FundingEntityService(
   private val log = perClassLogger()
 
   fun create(name: String, projects: Set<ProjectId>? = null): FundingEntityModel {
-    requirePermissions { createFundingEntity() }
+    requirePermissions { createFundingEntities() }
 
     val userId = currentUser().userId
     val now = clock.instant()
@@ -95,7 +95,7 @@ class FundingEntityService(
     }
   }
 
-  fun addProjectsToEntity(fundingEntityId: FundingEntityId, projects: Set<ProjectId>) {
+  private fun addProjectsToEntity(fundingEntityId: FundingEntityId, projects: Set<ProjectId>) {
     requirePermissions { updateFundingEntityProjects() }
 
     for (projectId in projects) {
@@ -111,7 +111,7 @@ class FundingEntityService(
     }
   }
 
-  fun removeProjectsFromEntity(fundingEntityId: FundingEntityId, projects: Set<ProjectId>) {
+  private fun removeProjectsFromEntity(fundingEntityId: FundingEntityId, projects: Set<ProjectId>) {
     requirePermissions { updateFundingEntityProjects() }
 
     for (projectId in projects) {
@@ -126,7 +126,7 @@ class FundingEntityService(
   }
 
   fun deleteFundingEntity(fundingEntityId: FundingEntityId) {
-    requirePermissions { deleteFundingEntity() }
+    requirePermissions { deleteFundingEntities() }
 
     log.info("Deleting funding entity $fundingEntityId")
 

--- a/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/FundingEntityService.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.funder
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class FundingEntityService(
+    private val dslContext: DSLContext,
+) {
+  private val log = perClassLogger()
+
+  fun deleteFundingEntity(fundingEntityId: FundingEntityId) {
+    requirePermissions { manageFundingEntities() }
+
+    log.info("Deleting funding entity $fundingEntityId")
+
+    dslContext.transaction { _ ->
+      dslContext
+          .deleteFrom(FUNDING_ENTITIES)
+          .where(FUNDING_ENTITIES.ID.eq(fundingEntityId))
+          .execute()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -2,15 +2,18 @@ package com.terraformation.backend.funder.api
 
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponseSimpleSuccess
 import com.terraformation.backend.api.FunderEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
+import com.terraformation.backend.funder.FundingEntityService
 import com.terraformation.backend.funder.db.FundingEntityStore
 import com.terraformation.backend.funder.model.FundingEntityModel
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,7 +25,10 @@ import org.springframework.web.bind.annotation.RestController
 @FunderEndpoint
 @RequestMapping("/api/v1/funder/entities")
 @RestController
-class FundingEntitiesController(private val fundingEntityStore: FundingEntityStore) {
+class FundingEntitiesController(
+    private val fundingEntityService: FundingEntityService,
+    private val fundingEntityStore: FundingEntityStore
+) {
   @ApiResponse200
   @ApiResponse404
   @GetMapping("/{fundingEntityId}")
@@ -53,6 +59,18 @@ class FundingEntitiesController(private val fundingEntityStore: FundingEntitySto
       @RequestBody @Valid payload: UpdateFundingEntityRequestPayload
   ): SimpleSuccessResponsePayload {
     fundingEntityStore.update(payload.toRow().copy(id = fundingEntityId))
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponseSimpleSuccess
+  @Operation(
+      summary = "Deletes an existing funding  entity",
+  )
+  @DeleteMapping("/{fundingEntityId}")
+  fun deleteFundingEntity(
+      @PathVariable("fundingEntityId") fundingEntityId: FundingEntityId
+  ): SimpleSuccessResponsePayload {
+    fundingEntityService.deleteFundingEntity(fundingEntityId)
     return SimpleSuccessResponsePayload()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -1,0 +1,57 @@
+package com.terraformation.backend.funder.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.FunderEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.funder.db.FundingEntityStore
+import com.terraformation.backend.funder.model.FundingEntityModel
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@FunderEndpoint
+@RequestMapping("/api/v1/funder/entities")
+@RestController
+class FundingEntitiesController(private val fundingEntityStore: FundingEntityStore) {
+  @ApiResponse200
+  @ApiResponse404
+  @GetMapping("/{fundingEntityId}")
+  @Operation(summary = "Gets information about a Funding Entity")
+  fun getFundingEntity(
+      @PathVariable fundingEntityId: FundingEntityId
+  ): GetFundingEntityResponsePayload {
+    val model = fundingEntityStore.fetchOneById(fundingEntityId)
+    return GetFundingEntityResponsePayload(
+        FundingEntityPayload(model),
+    )
+  }
+
+  @Operation(summary = "Creates a new Funding entity")
+  @PostMapping
+  fun createFundingEntity(
+      @RequestBody @Valid payload: CreateFundingEntityRequestPayload
+  ): GetFundingEntityResponsePayload {
+    val model = fundingEntityStore.create(payload.name)
+
+    return GetFundingEntityResponsePayload(FundingEntityPayload(model))
+  }
+}
+
+data class FundingEntityPayload(
+    val id: FundingEntityId,
+    val name: String,
+) {
+  constructor(model: FundingEntityModel) : this(id = model.id, name = model.name)
+}
+
+data class GetFundingEntityResponsePayload(val fundingEntity: FundingEntityPayload) :
+    SuccessResponsePayload
+
+data class CreateFundingEntityRequestPayload(val name: String) {}

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -3,8 +3,10 @@ package com.terraformation.backend.funder.api
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.FunderEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
 import com.terraformation.backend.funder.db.FundingEntityStore
 import com.terraformation.backend.funder.model.FundingEntityModel
 import io.swagger.v3.oas.annotations.Operation
@@ -12,6 +14,7 @@ import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -23,7 +26,7 @@ class FundingEntitiesController(private val fundingEntityStore: FundingEntitySto
   @ApiResponse200
   @ApiResponse404
   @GetMapping("/{fundingEntityId}")
-  @Operation(summary = "Gets information about a Funding Entity")
+  @Operation(summary = "Gets information about a funding entity")
   fun getFundingEntity(
       @PathVariable fundingEntityId: FundingEntityId
   ): GetFundingEntityResponsePayload {
@@ -33,7 +36,7 @@ class FundingEntitiesController(private val fundingEntityStore: FundingEntitySto
     )
   }
 
-  @Operation(summary = "Creates a new Funding entity")
+  @Operation(summary = "Creates a new funding entity")
   @PostMapping
   fun createFundingEntity(
       @RequestBody @Valid payload: CreateFundingEntityRequestPayload
@@ -41,6 +44,16 @@ class FundingEntitiesController(private val fundingEntityStore: FundingEntitySto
     val model = fundingEntityStore.create(payload.name)
 
     return GetFundingEntityResponsePayload(FundingEntityPayload(model))
+  }
+
+  @Operation(summary = "Updates an existing funding entity")
+  @PutMapping("/{fundingEntityId}")
+  fun updateFundingEntity(
+      @PathVariable("fundingEntityId") fundingEntityId: FundingEntityId,
+      @RequestBody @Valid payload: UpdateFundingEntityRequestPayload
+  ): SimpleSuccessResponsePayload {
+    fundingEntityStore.update(payload.toRow().copy(id = fundingEntityId))
+    return SimpleSuccessResponsePayload()
   }
 }
 
@@ -55,3 +68,9 @@ data class GetFundingEntityResponsePayload(val fundingEntity: FundingEntityPaylo
     SuccessResponsePayload
 
 data class CreateFundingEntityRequestPayload(val name: String) {}
+
+data class UpdateFundingEntityRequestPayload(val name: String) {
+  fun toRow(): FundingEntitiesRow {
+    return FundingEntitiesRow(name = name)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -38,9 +38,7 @@ class FundingEntitiesController(
       @PathVariable fundingEntityId: FundingEntityId,
   ): GetFundingEntityResponsePayload {
     val model = fundingEntityStore.fetchOneById(fundingEntityId)
-    return GetFundingEntityResponsePayload(
-        FundingEntityPayload(model),
-    )
+    return GetFundingEntityResponsePayload(FundingEntityPayload(model))
   }
 
   @Operation(summary = "Creates a new funding entity")

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingEntitiesController.kt
@@ -66,7 +66,7 @@ class FundingEntitiesController(
 
   @ApiResponseSimpleSuccess
   @Operation(
-      summary = "Deletes an existing funding  entity",
+      summary = "Deletes an existing funding entity",
   )
   @DeleteMapping("/{fundingEntityId}")
   fun deleteFundingEntity(

--- a/src/main/kotlin/com/terraformation/backend/funder/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/Exceptions.kt
@@ -1,0 +1,11 @@
+package com.terraformation.backend.funder.db
+
+import com.terraformation.backend.db.EntityNotFoundException
+import com.terraformation.backend.db.MismatchedStateException
+import com.terraformation.backend.db.funder.FundingEntityId
+
+class FundingEntityNotFoundException(fundingEntityId: FundingEntityId) :
+    EntityNotFoundException("Funding entity $fundingEntityId not found")
+
+class FundingEntityExistsException(name: String) :
+    MismatchedStateException("Funding entity $name already exists")

--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityStore.kt
@@ -1,0 +1,61 @@
+package com.terraformation.backend.funder.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
+import com.terraformation.backend.funder.model.FundingEntityModel
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.Condition
+import org.jooq.DSLContext
+
+@Named
+class FundingEntityStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  fun fetchOneById(fundingEntityId: FundingEntityId): FundingEntityModel {
+    requirePermissions { readFundingEntities() }
+
+    return fetch(FUNDING_ENTITIES.ID.eq(fundingEntityId)).firstOrNull()
+        ?: throw FundingEntityNotFoundException(fundingEntityId)
+  }
+
+  fun create(name: String): FundingEntityModel {
+    requirePermissions { manageFundingEntities() }
+
+    val userId = currentUser().userId
+    val now = clock.instant()
+
+    return dslContext.transactionResult { _ ->
+      val fundingEntityId =
+          with(FUNDING_ENTITIES) {
+            dslContext
+                .insertInto(FUNDING_ENTITIES)
+                .set(NAME, name)
+                .set(CREATED_BY, userId)
+                .set(CREATED_TIME, now)
+                .set(MODIFIED_BY, userId)
+                .set(MODIFIED_TIME, now)
+                .onConflict()
+                .doNothing()
+                .returning(ID)
+                .fetchOne(ID) ?: throw FundingEntityExistsException(name)
+          }
+
+      fetchOneById(fundingEntityId)
+    }
+  }
+
+  private fun fetch(condition: Condition? = null): List<FundingEntityModel> {
+    return with(FUNDING_ENTITIES) {
+      dslContext
+          .select(asterisk())
+          .from(this)
+          .apply { condition?.let { where(it) } }
+          .orderBy(ID)
+          .fetch { FundingEntityModel.of(it) }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
@@ -13,7 +13,6 @@ class FundingEntityUserStore(private val dslContext: DSLContext) {
         .select(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
         .from(FUNDING_ENTITY_USERS)
         .where(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
-        .fetchOne()
-        ?.getValue(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
+        .fetchOne(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
@@ -1,0 +1,19 @@
+package com.terraformation.backend.funder.db
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class FundingEntityUserStore(private val dslContext: DSLContext) {
+  fun getFundingEntityId(userId: UserId): FundingEntityId? {
+    return dslContext
+        .select(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
+        .from(FUNDING_ENTITY_USERS)
+        .where(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
+        .fetchOne()
+        ?.getValue(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
@@ -12,7 +12,7 @@ data class FundingEntityModel(
     val name: String,
     val createdTime: Instant,
     val modifiedTime: Instant,
-    val projects: List<ProjectId>? = emptyList(),
+    val projects: List<ProjectId> = emptyList(),
 ) {
   constructor(
       record: Record,

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.funder.model
 
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
 import java.time.Instant
@@ -13,28 +12,16 @@ data class FundingEntityModel(
     val name: String,
     val createdTime: Instant,
     val modifiedTime: Instant,
-    val projects: List<FundingEntityProjectModel>? = emptyList(),
+    val projects: List<ProjectId>? = emptyList(),
 ) {
   constructor(
       record: Record,
-      projectsMultiset: Field<List<FundingEntityProjectModel>>? = null,
+      projectsField: Field<List<ProjectId>>,
   ) : this(
       id = record[FUNDING_ENTITIES.ID]!!,
       name = record[FUNDING_ENTITIES.NAME]!!,
       createdTime = record[FUNDING_ENTITIES.CREATED_TIME]!!,
       modifiedTime = record[FUNDING_ENTITIES.MODIFIED_TIME]!!,
-      projects = projectsMultiset?.let { record[it] })
-}
-
-data class FundingEntityProjectModel(
-    val id: ProjectId,
-    val name: String,
-    val description: String?,
-) {
-  constructor(
-      record: Record,
-  ) : this(
-      id = record[PROJECTS.ID]!!,
-      name = record[PROJECTS.NAME]!!,
-      description = record[PROJECTS.DESCRIPTION])
+      projects = record[projectsField]!!,
+  )
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
+import java.time.Instant
+import org.jooq.Record
+
+class FundingEntityModel(
+    val id: FundingEntityId,
+    val name: String,
+    val createdTime: Instant,
+    val modifiedTime: Instant,
+) {
+  companion object {
+    fun of(
+        record: Record,
+    ): FundingEntityModel {
+      return with(FUNDING_ENTITIES) {
+        FundingEntityModel(
+            id = record[ID]!!,
+            name = record[NAME]!!,
+            createdTime = record[CREATED_TIME]!!,
+            modifiedTime = record[MODIFIED_TIME]!!,
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
@@ -1,28 +1,40 @@
 package com.terraformation.backend.funder.model
 
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
 import java.time.Instant
+import org.jooq.Field
 import org.jooq.Record
 
-class FundingEntityModel(
+data class FundingEntityModel(
     val id: FundingEntityId,
     val name: String,
     val createdTime: Instant,
     val modifiedTime: Instant,
+    val projects: List<FundingEntityProjectModel>? = emptyList(),
 ) {
-  companion object {
-    fun of(
-        record: Record,
-    ): FundingEntityModel {
-      return with(FUNDING_ENTITIES) {
-        FundingEntityModel(
-            id = record[ID]!!,
-            name = record[NAME]!!,
-            createdTime = record[CREATED_TIME]!!,
-            modifiedTime = record[MODIFIED_TIME]!!,
-        )
-      }
-    }
-  }
+  constructor(
+      record: Record,
+      projectsMultiset: Field<List<FundingEntityProjectModel>>? = null,
+  ) : this(
+      id = record[FUNDING_ENTITIES.ID]!!,
+      name = record[FUNDING_ENTITIES.NAME]!!,
+      createdTime = record[FUNDING_ENTITIES.CREATED_TIME]!!,
+      modifiedTime = record[FUNDING_ENTITIES.MODIFIED_TIME]!!,
+      projects = projectsMultiset?.let { record[it] })
+}
+
+data class FundingEntityProjectModel(
+    val id: ProjectId,
+    val name: String,
+    val description: String?,
+) {
+  constructor(
+      record: Record,
+  ) : this(
+      id = record[PROJECTS.ID]!!,
+      name = record[PROJECTS.NAME]!!,
+      description = record[PROJECTS.DESCRIPTION])
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -381,7 +381,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
 
   @Test
-  fun createFundingEntity() = allow { createFundingEntity() } ifUser { canCreateFundingEntity() }
+  fun createFundingEntities() =
+      allow { createFundingEntities() } ifUser { canCreateFundingEntities() }
 
   @Test
   fun createNotification() =
@@ -469,7 +470,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
-  fun deleteFundingEntity() = allow { deleteFundingEntity() } ifUser { canDeleteFundingEntity() }
+  fun deleteFundingEntities() =
+      allow { deleteFundingEntities() } ifUser { canDeleteFundingEntities() }
 
   @Test
   fun deleteOrganization() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -46,6 +46,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SubLocationId
 import com.terraformation.backend.db.default_schema.UploadId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.seedbank.AccessionId
@@ -58,6 +59,7 @@ import com.terraformation.backend.db.tracking.PlantingId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.funder.db.FundingEntityNotFoundException
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
@@ -139,6 +141,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(EventNotFoundException::class) { canReadModuleEvent(it) }
   private val facilityId: FacilityId by
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
+  private val fundingEntityId: FundingEntityId by
+      readableId(FundingEntityNotFoundException::class) { canReadFundingEntities() }
   private val moduleId: ModuleId by readableId(ModuleNotFoundException::class) { canReadModule(it) }
   private val monitoringPlotId: MonitoringPlotId by
       readableId(PlotNotFoundException::class) { canReadMonitoringPlot(it) }
@@ -377,6 +381,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { createFacility(organizationId) } ifUser { canCreateFacility(organizationId) }
 
   @Test
+  fun createFundingEntity() = allow { createFundingEntity() } ifUser { canCreateFundingEntity() }
+
+  @Test
   fun createNotification() =
       allow { createNotification(notificationUserId, organizationId) } ifUser
           {
@@ -460,6 +467,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
           {
             canDeleteDraftPlantingSite(draftPlantingSiteId)
           }
+
+  @Test
+  fun deleteFundingEntity() = allow { deleteFundingEntity() } ifUser { canDeleteFundingEntity() }
 
   @Test
   fun deleteOrganization() =
@@ -547,10 +557,6 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { manageDefaultProjectLeads() } ifUser { canManageDefaultProjectLeads() }
 
   @Test fun manageDeliverables() = allow { manageDeliverables() } ifUser { canManageDeliverables() }
-
-  @Test
-  fun manageFundingEntities() =
-      allow { manageFundingEntities() } ifUser { canManageFundingEntities() }
 
   @Test fun manageModuleEvents() = allow { manageModuleEvents() } ifUser { canManageModuleEvents() }
 
@@ -941,6 +947,22 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test
   fun updateFacility() =
       allow { updateFacility(facilityId) } ifUser { canUpdateFacility(facilityId) }
+
+  @Test
+  fun updateFundingEntities() =
+      allow { updateFundingEntities() } ifUser { canUpdateFundingEntities() }
+
+  @Test
+  fun updateFundingEntityProjects() =
+      allow { updateFundingEntityProjects() } ifUser { canUpdateFundingEntityProjects() }
+
+  @Test
+  fun updateFundingEntityUsers() {
+    assertThrows<AccessDeniedException> { requirements.updateFundingEntityUsers(fundingEntityId) }
+
+    grant { user.canUpdateFundingEntityUsers(fundingEntityId) }
+    requirements.updateFundingEntityUsers(fundingEntityId)
+  }
 
   @Test
   fun updateGlobalNotifications() =

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -548,6 +548,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test fun manageDeliverables() = allow { manageDeliverables() } ifUser { canManageDeliverables() }
 
+  @Test
+  fun manageFundingEntities() =
+      allow { manageFundingEntities() } ifUser { canManageFundingEntities() }
+
   @Test fun manageModuleEvents() = allow { manageModuleEvents() } ifUser { canManageModuleEvents() }
 
   @Test
@@ -627,6 +631,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
   @Test fun readDraftPlantingSite() = testRead { readDraftPlantingSite(draftPlantingSiteId) }
 
   @Test fun readFacility() = testRead { readFacility(facilityId) }
+
+  @Test
+  fun readFundingEntities() = allow { readFundingEntities() } ifUser { canReadFundingEntities() }
 
   @Test fun readGlobalRoles() = allow { readGlobalRoles() } ifUser { canReadGlobalRoles() }
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3770,7 +3770,7 @@ abstract class DatabaseBackedTest {
   }
 
   protected fun insertFundingEntity(
-      name: String = "TestFundingEntity",
+      name: String = "TestFundingEntity ${UUID.randomUUID()}",
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       modifiedBy: UserId = currentUser().userId,
@@ -3787,20 +3787,20 @@ abstract class DatabaseBackedTest {
 
     fundingEntitiesDao.insert(row)
 
-    return row.id!!.also { inserted.fundingEntitiesIds.add(it) }
+    return row.id!!.also { inserted.fundingEntityIds.add(it) }
   }
 
   protected fun insertFundingEntityProject(
-      fundingEntityId: FundingEntityId,
-      projectId: ProjectId,
+      fundingEntityId: FundingEntityId = inserted.fundingEntityId,
+      projectId: ProjectId = inserted.projectId,
   ) {
     fundingEntityProjectsDao.insert(
         FundingEntityProjectsRow(fundingEntityId = fundingEntityId, projectId = projectId))
   }
 
   protected fun insertFundingEntityUser(
-      fundingEntityId: FundingEntityId,
-      userId: UserId,
+      fundingEntityId: FundingEntityId = inserted.fundingEntityId,
+      userId: UserId = inserted.userId,
   ) {
     fundingEntityUsersDao.insert(
         FundingEntityUsersRow(fundingEntityId = fundingEntityId, userId = userId))
@@ -3996,7 +3996,7 @@ abstract class DatabaseBackedTest {
     val eventIds = mutableListOf<EventId>()
     val facilityIds = mutableListOf<FacilityId>()
     val fileIds = mutableListOf<FileId>()
-    val fundingEntitiesIds = mutableListOf<FundingEntityId>()
+    val fundingEntityIds = mutableListOf<FundingEntityId>()
     val internalTagIds = mutableListOf<InternalTagId>()
     val moduleIds = mutableListOf<ModuleId>()
     val monitoringPlotHistoryIds = mutableListOf<MonitoringPlotHistoryId>()
@@ -4082,6 +4082,9 @@ abstract class DatabaseBackedTest {
 
     val fileId
       get() = fileIds.last()
+
+    val fundingEntityId
+      get() = fundingEntityIds.last()
 
     val internalTagId
       get() = internalTagIds.last()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -274,8 +274,10 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.daos.FundingEntitiesDao
 import com.terraformation.backend.db.funder.tables.daos.FundingEntityProjectsDao
+import com.terraformation.backend.db.funder.tables.daos.FundingEntityUsersDao
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntityProjectsRow
+import com.terraformation.backend.db.funder.tables.pojos.FundingEntityUsersRow
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
@@ -554,6 +556,7 @@ abstract class DatabaseBackedTest {
   protected val filesDao: FilesDao by lazyDao()
   protected val fundingEntitiesDao: FundingEntitiesDao by lazyDao()
   protected val fundingEntityProjectsDao: FundingEntityProjectsDao by lazyDao()
+  protected val fundingEntityUsersDao: FundingEntityUsersDao by lazyDao()
   protected val geolocationsDao: GeolocationsDao by lazyDao()
   protected val identifierSequencesDao: IdentifierSequencesDao by lazyDao()
   protected val internalTagsDao: InternalTagsDao by lazyDao()
@@ -3793,6 +3796,14 @@ abstract class DatabaseBackedTest {
   ) {
     fundingEntityProjectsDao.insert(
         FundingEntityProjectsRow(fundingEntityId = fundingEntityId, projectId = projectId))
+  }
+
+  protected fun insertFundingEntityUser(
+      fundingEntityId: FundingEntityId,
+      userId: UserId,
+  ) {
+    fundingEntityUsersDao.insert(
+        FundingEntityUsersRow(fundingEntityId = fundingEntityId, userId = userId))
   }
 
   protected fun setupStableIdVariables(): Map<StableId, VariableId> {

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -271,6 +271,9 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariableValueTableRows
 import com.terraformation.backend.db.docprod.tables.pojos.VariableValuesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableWorkflowHistoryRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.daos.FundingEntitiesDao
+import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
@@ -547,6 +550,7 @@ abstract class DatabaseBackedTest {
   protected val eventsDao: EventsDao by lazyDao()
   protected val facilitiesDao: FacilitiesDao by lazyDao()
   protected val filesDao: FilesDao by lazyDao()
+  protected val fundingEntitiesDao: FundingEntitiesDao by lazyDao()
   protected val geolocationsDao: GeolocationsDao by lazyDao()
   protected val identifierSequencesDao: IdentifierSequencesDao by lazyDao()
   protected val internalTagsDao: InternalTagsDao by lazyDao()
@@ -3759,6 +3763,27 @@ abstract class DatabaseBackedTest {
     }
   }
 
+  protected fun insertFundingEntity(
+      name: String = "TestFundingEntity",
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      modifiedBy: UserId = currentUser().userId,
+      modifiedTime: Instant = Instant.EPOCH,
+  ): FundingEntityId {
+    val row =
+        FundingEntitiesRow(
+            name = name,
+            createdBy = createdBy,
+            createdTime = createdTime,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
+        )
+
+    fundingEntitiesDao.insert(row)
+
+    return row.id!!.also { inserted.fundingEntitiesIds.add(it) }
+  }
+
   protected fun setupStableIdVariables(): Map<StableId, VariableId> {
     val stableIds: Map<StableId, VariableType> =
         with(StableIds) {
@@ -3949,6 +3974,7 @@ abstract class DatabaseBackedTest {
     val eventIds = mutableListOf<EventId>()
     val facilityIds = mutableListOf<FacilityId>()
     val fileIds = mutableListOf<FileId>()
+    val fundingEntitiesIds = mutableListOf<FundingEntityId>()
     val internalTagIds = mutableListOf<InternalTagId>()
     val moduleIds = mutableListOf<ModuleId>()
     val monitoringPlotHistoryIds = mutableListOf<MonitoringPlotHistoryId>()

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -273,7 +273,9 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariableWorkflowHistor
 import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.daos.FundingEntitiesDao
+import com.terraformation.backend.db.funder.tables.daos.FundingEntityProjectsDao
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
+import com.terraformation.backend.db.funder.tables.pojos.FundingEntityProjectsRow
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
@@ -551,6 +553,7 @@ abstract class DatabaseBackedTest {
   protected val facilitiesDao: FacilitiesDao by lazyDao()
   protected val filesDao: FilesDao by lazyDao()
   protected val fundingEntitiesDao: FundingEntitiesDao by lazyDao()
+  protected val fundingEntityProjectsDao: FundingEntityProjectsDao by lazyDao()
   protected val geolocationsDao: GeolocationsDao by lazyDao()
   protected val identifierSequencesDao: IdentifierSequencesDao by lazyDao()
   protected val internalTagsDao: InternalTagsDao by lazyDao()
@@ -3782,6 +3785,14 @@ abstract class DatabaseBackedTest {
     fundingEntitiesDao.insert(row)
 
     return row.id!!.also { inserted.fundingEntitiesIds.add(it) }
+  }
+
+  protected fun insertFundingEntityProject(
+      fundingEntityId: FundingEntityId,
+      projectId: ProjectId,
+  ) {
+    fundingEntityProjectsDao.insert(
+        FundingEntityProjectsRow(fundingEntityId = fundingEntityId, projectId = projectId))
   }
 
   protected fun setupStableIdVariables(): Map<StableId, VariableId> {

--- a/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
@@ -34,12 +34,15 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganization()
 
     every { user.canReadFundingEntities() } returns true
-    every { user.canManageFundingEntities() } returns true
+    every { user.canCreateFundingEntity() } returns true
+    every { user.canDeleteFundingEntity() } returns true
+    every { user.canUpdateFundingEntities() } returns true
+    every { user.canUpdateFundingEntityProjects() } returns true
   }
 
   @Test
   fun `create requires user to be able to manage funding entities`() {
-    every { user.canManageFundingEntities() } returns false
+    every { user.canCreateFundingEntity() } returns false
 
     assertThrows<AccessDeniedException> { service.create("Some Other Entity") }
   }
@@ -104,7 +107,7 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `update throws exception if user has no permission to manage funding entities`() {
-    every { user.canManageFundingEntities() } returns false
+    every { user.canUpdateFundingEntities() } returns false
 
     assertThrows<AccessDeniedException> {
       service.update(FundingEntitiesRow(id = fundingEntityId, name = "Updated Funding Entity"))
@@ -121,7 +124,7 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `update populates modified by fields`() {
+  fun `update populates modifiedBy fields`() {
     val newTime = clock.instant().plusSeconds(1000)
     clock.instant = newTime
 
@@ -200,7 +203,7 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `delete throws exception if user can't manage funding entities`() {
-    every { user.canManageFundingEntities() } returns false
+    every { user.canDeleteFundingEntity() } returns false
 
     assertThrows<AccessDeniedException> { service.deleteFundingEntity(fundingEntityId) }
   }

--- a/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
@@ -43,15 +43,15 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
     insertOrganization()
 
     every { user.canReadFundingEntities() } returns true
-    every { user.canCreateFundingEntity() } returns true
-    every { user.canDeleteFundingEntity() } returns true
+    every { user.canCreateFundingEntities() } returns true
+    every { user.canDeleteFundingEntities() } returns true
     every { user.canUpdateFundingEntities() } returns true
     every { user.canUpdateFundingEntityProjects() } returns true
   }
 
   @Test
   fun `create requires user to be able to manage funding entities`() {
-    every { user.canCreateFundingEntity() } returns false
+    every { user.canCreateFundingEntities() } returns false
 
     assertThrows<AccessDeniedException> { service.create("Some Other Entity") }
   }
@@ -220,7 +220,7 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `delete throws exception if user can't manage funding entities`() {
-    every { user.canDeleteFundingEntity() } returns false
+    every { user.canDeleteFundingEntities() } returns false
 
     assertThrows<AccessDeniedException> { service.deleteFundingEntity(fundingEntityId) }
   }

--- a/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
@@ -1,0 +1,43 @@
+package com.terraformation.backend.funder
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private lateinit var fundingEntityId: FundingEntityId
+  private lateinit var service: FundingEntityService
+
+  @BeforeEach
+  fun setUp() {
+    service = FundingEntityService(dslContext)
+
+    fundingEntityId = insertFundingEntity()
+
+    every { user.canManageFundingEntities() } returns true
+  }
+
+  @Test
+  fun `delete throws exception if user can't manage funding entities`() {
+    every { user.canManageFundingEntities() } returns false
+
+    assertThrows<AccessDeniedException> { service.deleteFundingEntity(fundingEntityId) }
+  }
+
+  @Test
+  fun `delete successfully removes funding entity`() {
+    service.deleteFundingEntity(fundingEntityId)
+
+    assertEquals(0, fundingEntitiesDao.findAll().size)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
 import com.terraformation.backend.funder.db.FundingEntityExistsException
+import com.terraformation.backend.funder.db.FundingEntityNotFoundException
 import com.terraformation.backend.funder.db.FundingEntityStore
 import com.terraformation.backend.funder.db.FundingEntityUserStore
 import com.terraformation.backend.mockUser
@@ -132,6 +133,14 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
+  fun `update throws exception when no matching entity`() {
+    assertThrows<FundingEntityNotFoundException> {
+      service.update(
+          FundingEntitiesRow(id = FundingEntityId(1093), name = "Missing Funding Entity"))
+    }
+  }
+
+  @Test
   fun `update populates modifiedBy fields`() {
     val newTime = clock.instant().plusSeconds(1000)
     clock.instant = newTime
@@ -214,6 +223,13 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
     every { user.canDeleteFundingEntity() } returns false
 
     assertThrows<AccessDeniedException> { service.deleteFundingEntity(fundingEntityId) }
+  }
+
+  @Test
+  fun `delete throws exception if entity doesn't exist`() {
+    assertThrows<FundingEntityNotFoundException> {
+      service.deleteFundingEntity(FundingEntityId(1097))
+    }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
@@ -1,14 +1,11 @@
 package com.terraformation.backend.funder.db
 
 import com.terraformation.backend.RunsAsUser
-import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.funder.FundingEntityId
-import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
 import com.terraformation.backend.mockUser
 import io.mockk.every
-import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,19 +15,17 @@ import org.springframework.security.access.AccessDeniedException
 class FundingEntityStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private val clock = TestClock()
   private lateinit var store: FundingEntityStore
 
   private lateinit var fundingEntityId: FundingEntityId
 
   @BeforeEach
   fun setUp() {
-    store = FundingEntityStore(clock, dslContext)
+    store = FundingEntityStore(dslContext)
 
     fundingEntityId = insertFundingEntity()
 
     every { user.canReadFundingEntities() } returns true
-    every { user.canManageFundingEntities() } returns true
   }
 
   @Test
@@ -51,85 +46,18 @@ class FundingEntityStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `create requires user to be able to manage funding entities`() {
-    every { user.canManageFundingEntities() } returns false
+  fun `fetchById respects fetch depth`() {
+    insertOrganization()
+    val projectId1 = insertProject()
+    val projectId2 = insertProject()
 
-    assertThrows<AccessDeniedException> { store.create("Some Other Entity") }
-  }
+    var entity = store.fetchOneById(fundingEntityId, FundingEntityStore.FetchDepth.Project)
+    assertEquals(0, entity.projects!!.size)
 
-  @Test
-  fun `create populates created and modified fields`() {
-    val row = FundingEntitiesRow(name = "New Funding Entity")
-    val createdModel = store.create(row.name!!)
+    insertFundingEntityProject(fundingEntityId, projectId1)
+    insertFundingEntityProject(fundingEntityId, projectId2)
 
-    val expected =
-        row.copy(
-            createdBy = user.userId,
-            createdTime = clock.instant(),
-            id = createdModel.id,
-            modifiedBy = user.userId,
-            modifiedTime = clock.instant(),
-        )
-    val actual = fundingEntitiesDao.fetchOneById(createdModel.id)
-
-    assertEquals(expected, actual)
-  }
-
-  @Test
-  fun `create rejects duplicates by name`() {
-    assertThrows<FundingEntityExistsException> { store.create("TestFundingEntity") }
-  }
-
-  @Test
-  fun `update throws exception when no id attached`() {
-    assertThrows<IllegalArgumentException> {
-      store.update(FundingEntitiesRow(name = "Funding Entity without Id"))
-    }
-  }
-
-  @Test
-  fun `update throws exception if user has no permission to manage funding entities`() {
-    every { user.canManageFundingEntities() } returns false
-
-    assertThrows<AccessDeniedException> {
-      store.update(FundingEntitiesRow(id = fundingEntityId, name = "Updated Funding Entity"))
-    }
-  }
-
-  @Test
-  fun `update throws exception when name conflict`() {
-    insertFundingEntity("Existing Funding Entity")
-
-    assertThrows<FundingEntityExistsException> {
-      store.update(FundingEntitiesRow(id = fundingEntityId, name = "Existing Funding Entity"))
-    }
-  }
-
-  @Test
-  fun `update populates modified by fields`() {
-    val newTime = clock.instant().plusSeconds(1000)
-    clock.instant = newTime
-
-    val newUserId = insertUser()
-
-    val updates =
-        FundingEntitiesRow(
-            id = fundingEntityId,
-            name = "New Name",
-        )
-    val expected =
-        updates.copy(
-            createdBy = user.userId,
-            createdTime = Instant.EPOCH,
-            modifiedBy = newUserId,
-            modifiedTime = newTime,
-        )
-
-    every { user.userId } returns newUserId
-
-    store.update(updates)
-
-    val actual = fundingEntitiesDao.fetchOneById(fundingEntityId)!!
-    assertEquals(expected, actual)
+    entity = store.fetchOneById(fundingEntityId, FundingEntityStore.FetchDepth.Project)
+    assertEquals(2, entity.projects!!.size)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.funder.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.pojos.FundingEntitiesRow
+import com.terraformation.backend.mockUser
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class FundingEntityStoreTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private lateinit var store: FundingEntityStore
+
+  private lateinit var fundingEntityId: FundingEntityId
+
+  @BeforeEach
+  fun setUp() {
+    store = FundingEntityStore(clock, dslContext)
+
+    fundingEntityId = insertFundingEntity()
+
+    every { user.canReadFundingEntities() } returns true
+    every { user.canManageFundingEntities() } returns true
+  }
+
+  @Test
+  fun `fetchById requires user to be able to read funding entities`() {
+    every { user.canReadFundingEntities() } returns false
+
+    assertThrows<AccessDeniedException> { store.fetchOneById(fundingEntityId) }
+  }
+
+  @Test
+  fun `fetchById throws exception when entity doesn't exist`() {
+    assertThrows<FundingEntityNotFoundException> { store.fetchOneById(FundingEntityId(1020)) }
+  }
+
+  @Test
+  fun `fetchById returns correct funding entity`() {
+    assertEquals("TestFundingEntity", store.fetchOneById(fundingEntityId).name)
+  }
+
+  @Test
+  fun `create requires user to be able to manage funding entities`() {
+    every { user.canManageFundingEntities() } returns false
+
+    assertThrows<AccessDeniedException> { store.create("Some Other Entity") }
+  }
+
+  @Test
+  fun `create populates created and modified fields`() {
+    val row = FundingEntitiesRow(name = "New Funding Entity")
+    val createdModel = store.create(row.name!!)
+
+    val expected =
+        row.copy(
+            createdBy = user.userId,
+            createdTime = clock.instant(),
+            id = createdModel.id,
+            modifiedBy = user.userId,
+            modifiedTime = clock.instant(),
+        )
+    val actual = fundingEntitiesDao.fetchOneById(createdModel.id)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `create rejects duplicates by name`() {
+    assertThrows<FundingEntityExistsException> { store.create("TestFundingEntity") }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityStoreTest.kt
@@ -46,18 +46,18 @@ class FundingEntityStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchById respects fetch depth`() {
+  fun `fetchById retrieves projectIds`() {
     insertOrganization()
     val projectId1 = insertProject()
     val projectId2 = insertProject()
 
-    var entity = store.fetchOneById(fundingEntityId, FundingEntityStore.FetchDepth.Project)
+    var entity = store.fetchOneById(fundingEntityId)
     assertEquals(0, entity.projects!!.size)
 
     insertFundingEntityProject(fundingEntityId, projectId1)
     insertFundingEntityProject(fundingEntityId, projectId2)
 
-    entity = store.fetchOneById(fundingEntityId, FundingEntityStore.FetchDepth.Project)
-    assertEquals(2, entity.projects!!.size)
+    entity = store.fetchOneById(fundingEntityId)
+    assertEquals(listOf(projectId1, projectId2), entity.projects!!)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStoreTest.kt
@@ -1,0 +1,38 @@
+package com.terraformation.backend.funder.db
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.mockUser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class FundingEntityUserStoreTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private lateinit var store: FundingEntityUserStore
+  private lateinit var fundingEntityId: FundingEntityId
+
+  @BeforeEach
+  fun setUp() {
+    store = FundingEntityUserStore(dslContext)
+
+    fundingEntityId = insertFundingEntity()
+  }
+
+  @Test
+  fun `getFundingEntityId returns null if userId isn't attached to FundingEntity`() {
+    assertNull(store.getFundingEntityId(currentUser().userId))
+  }
+
+  @Test
+  fun `getFundingEntityId returns correct funding entity id if userId attached to FundingEntity`() {
+    insertFundingEntityUser(fundingEntityId, currentUser().userId)
+
+    assertEquals(fundingEntityId, store.getFundingEntityId(currentUser().userId))
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStoreTest.kt
@@ -4,25 +4,16 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
-import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.records.FundingEntityUsersRecord
 import com.terraformation.backend.mockUser
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class FundingEntityUserStoreTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
-  private lateinit var store: FundingEntityUserStore
-  private lateinit var fundingEntityId: FundingEntityId
-
-  @BeforeEach
-  fun setUp() {
-    store = FundingEntityUserStore(dslContext)
-
-    fundingEntityId = insertFundingEntity()
-  }
+  private val store by lazy { FundingEntityUserStore(dslContext) }
+  private val fundingEntityId by lazy { insertFundingEntity() }
 
   @Test
   fun `getFundingEntityId returns null if userId isn't attached to FundingEntity`() {
@@ -33,6 +24,7 @@ class FundingEntityUserStoreTest : DatabaseTest(), RunsAsUser {
   fun `getFundingEntityId returns correct funding entity id if userId attached to FundingEntity`() {
     insertFundingEntityUser(fundingEntityId, currentUser().userId)
 
-    assertEquals(fundingEntityId, store.getFundingEntityId(currentUser().userId))
+    assertTableEquals(
+        FundingEntityUsersRecord(fundingEntityId = fundingEntityId, userId = currentUser().userId))
   }
 }


### PR DESCRIPTION
A user with the correct permissions can:
- select a funding entity (includes projectIds)
- create a funding entity with at least a name, and optionally a set of projectIds
- update a funding entity's name, and/or add/remove projects by id
- delete a funding entity
  - cascades in the db to delete `funding_entity_projects` rows and `funding_entity_users` rows

Additionally if a user is deleted, the corresponding `funding_entity_users` row is removed if one exists for the user.