### PR TITLE
SW-6520 Implemented system metric read structure

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -299,13 +299,6 @@ class ReportStore(
       condition: Condition,
       includeMetrics: Boolean = false
   ): List<ReportModel> {
-    val standardMetricsField =
-        if (includeMetrics) {
-          standardMetricsMultiset
-        } else {
-          null
-        }
-
     val projectMetricsField =
         if (includeMetrics) {
           projectMetricsMultiset
@@ -313,11 +306,32 @@ class ReportStore(
           null
         }
 
+    val standardMetricsField =
+        if (includeMetrics) {
+          standardMetricsMultiset
+        } else {
+          null
+        }
+
+    val systemMetricsField =
+        if (includeMetrics) {
+          systemMetricsMultiset
+        } else {
+          null
+        }
+
     return dslContext
-        .select(REPORTS.asterisk(), standardMetricsField, projectMetricsField)
+        .select(REPORTS.asterisk(), projectMetricsField, standardMetricsField, systemMetricsField)
         .from(REPORTS)
         .where(condition)
-        .fetch { ReportModel.of(it, standardMetricsField, projectMetricsField) }
+        .fetch {
+          ReportModel.of(
+              record = it,
+              projectMetricsField = projectMetricsField,
+              standardMetricsField = standardMetricsField,
+              systemMetricsField = systemMetricsField,
+          )
+        }
         .filter { currentUser().canReadReport(it.id) }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -456,11 +456,11 @@ class ReportStore(
           REPORT_SYSTEM_METRICS.SYSTEM_VALUE,
           DSL.case_()
               // ToDo: Implement each system query
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.MortalityRate), 1)
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.Seedlings), 2)
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SeedsCollected), 3)
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SpeciesPlanted), 4)
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.TreesPlanted), 5)
+              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.MortalityRate), -1)
+              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.Seedlings), -2)
+              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SeedsCollected), -3)
+              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SpeciesPlanted), -4)
+              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.TreesPlanted), -5)
               .else_(0))
 
   private val systemMetricsMultiset: Field<List<ReportSystemMetricModel>> =

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportMetricsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportMetricsModel.kt
@@ -88,6 +88,8 @@ data class ReportProjectMetricModel(
 data class ReportSystemMetricEntryModel(
     val target: Int? = null,
     val systemValue: Int,
+    /** Time when system value is recorded. If null, the system value is current. */
+    val systemTime: Instant? = null,
     val overrideValue: Int? = null,
     val modifiedBy: UserId? = null,
     val modifiedTime: Instant? = null,
@@ -100,6 +102,7 @@ data class ReportSystemMetricEntryModel(
         ReportSystemMetricEntryModel(
             target = record[TARGET],
             systemValue = record[systemValueField] ?: 0,
+            systemTime = record[SYSTEM_TIME],
             overrideValue = record[OVERRIDE_VALUE],
             modifiedBy = record[MODIFIED_BY],
             modifiedTime = record[MODIFIED_TIME],

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
@@ -29,8 +29,9 @@ data class ReportModel(
     val modifiedTime: Instant,
     val submittedBy: UserId? = null,
     val submittedTime: Instant? = null,
-    val standardMetrics: List<ReportStandardMetricModel> = emptyList(),
     val projectMetrics: List<ReportProjectMetricModel> = emptyList(),
+    val standardMetrics: List<ReportStandardMetricModel> = emptyList(),
+    val systemMetrics: List<ReportSystemMetricModel> = emptyList(),
 ) {
   fun validateForSubmission() {
     if (status != ReportStatus.NotSubmitted) {
@@ -96,8 +97,9 @@ data class ReportModel(
 
     fun of(
         record: Record,
-        standardMetricsField: Field<List<ReportStandardMetricModel>>?,
         projectMetricsField: Field<List<ReportProjectMetricModel>>?,
+        standardMetricsField: Field<List<ReportStandardMetricModel>>?,
+        systemMetricsField: Field<List<ReportSystemMetricModel>>?,
     ): ReportModel {
       return with(REPORTS) {
         ReportModel(
@@ -120,8 +122,9 @@ data class ReportModel(
             modifiedTime = record[MODIFIED_TIME]!!,
             submittedBy = record[SUBMITTED_BY],
             submittedTime = record[SUBMITTED_TIME],
-            standardMetrics = standardMetricsField?.let { record[it] } ?: emptyList(),
             projectMetrics = projectMetricsField?.let { record[it] } ?: emptyList(),
+            standardMetrics = standardMetricsField?.let { record[it] } ?: emptyList(),
+            systemMetrics = systemMetricsField?.let { record[it] } ?: emptyList(),
         )
       }
     }

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -622,6 +622,7 @@ COMMENT ON TABLE accelerator.report_system_metrics IS 'Report entries of targets
 COMMENT ON COLUMN accelerator.report_system_metrics.override_value IS 'Value inputted by accelerator admin to override system value. Null for no overrides.';
 COMMENT ON COLUMN accelerator.report_system_metrics.system_time IS 'System value recorded time. If null, the value is not recorded yet and a live query of Terraware data should be used instead.';
 COMMENT ON COLUMN accelerator.report_system_metrics.system_value IS 'Value collected via Terraware data. Null before value is submitted.';
+
 COMMENT ON TABLE accelerator.reports IS 'Accelerator project reports.';
 
 COMMENT ON TABLE accelerator.score_categories IS '(Enum) Project score categories.';

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -175,6 +175,35 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedBy = user.userId,
       )
 
+      insertReportSystemMetric(
+          reportId = reportId,
+          metric = SystemMetric.Seedlings,
+          target = 1000,
+          modifiedTime = Instant.ofEpochSecond(2500),
+          modifiedBy = user.userId,
+      )
+
+      insertReportSystemMetric(
+          reportId = reportId,
+          metric = SystemMetric.SeedsCollected,
+          target = 2000,
+          systemValue = 1800,
+          systemTime = Instant.ofEpochSecond(8000),
+          modifiedTime = Instant.ofEpochSecond(500),
+          modifiedBy = user.userId,
+      )
+
+      insertReportSystemMetric(
+          reportId = reportId,
+          metric = SystemMetric.TreesPlanted,
+          target = 600,
+          systemValue = 300,
+          systemTime = Instant.ofEpochSecond(7000),
+          overrideValue = 250,
+          modifiedTime = Instant.ofEpochSecond(700),
+          modifiedBy = user.userId,
+      )
+
       val reportModel =
           ReportModel(
               id = reportId,
@@ -264,31 +293,43 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           metric = SystemMetric.SeedsCollected,
                           entry =
                               ReportSystemMetricEntryModel(
-                                  systemValue = 3,
+                                  target = 2000,
+                                  systemValue = 1800,
+                                  systemTime = Instant.ofEpochSecond(8000),
+                                  modifiedTime = Instant.ofEpochSecond(500),
+                                  modifiedBy = user.userId,
                               )),
                       ReportSystemMetricModel(
                           metric = SystemMetric.Seedlings,
                           entry =
                               ReportSystemMetricEntryModel(
-                                  systemValue = 2,
+                                  target = 1000,
+                                  systemValue = -2,
+                                  modifiedTime = Instant.ofEpochSecond(2500),
+                                  modifiedBy = user.userId,
                               )),
                       ReportSystemMetricModel(
                           metric = SystemMetric.TreesPlanted,
                           entry =
                               ReportSystemMetricEntryModel(
-                                  systemValue = 5,
+                                  target = 600,
+                                  systemValue = 300,
+                                  systemTime = Instant.ofEpochSecond(7000),
+                                  overrideValue = 250,
+                                  modifiedTime = Instant.ofEpochSecond(700),
+                                  modifiedBy = user.userId,
                               )),
                       ReportSystemMetricModel(
                           metric = SystemMetric.SpeciesPlanted,
                           entry =
                               ReportSystemMetricEntryModel(
-                                  systemValue = 4,
+                                  systemValue = -4,
                               )),
                       ReportSystemMetricModel(
                           metric = SystemMetric.MortalityRate,
                           entry =
                               ReportSystemMetricEntryModel(
-                                  systemValue = 1,
+                                  systemValue = -1,
                               )),
                   ))
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -11,6 +11,8 @@ import com.terraformation.backend.accelerator.model.ReportMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportModel
 import com.terraformation.backend.accelerator.model.ReportProjectMetricModel
 import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
+import com.terraformation.backend.accelerator.model.ReportSystemMetricEntryModel
+import com.terraformation.backend.accelerator.model.ReportSystemMetricModel
 import com.terraformation.backend.accelerator.model.StandardMetricModel
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SystemUser
@@ -20,6 +22,7 @@ import com.terraformation.backend.db.accelerator.MetricComponent
 import com.terraformation.backend.db.accelerator.MetricType
 import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportStatus
+import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.tables.records.ProjectReportConfigsRecord
 import com.terraformation.backend.db.accelerator.tables.records.ReportProjectMetricsRecord
 import com.terraformation.backend.db.accelerator.tables.records.ReportStandardMetricsRecord
@@ -184,6 +187,26 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               createdTime = Instant.EPOCH,
               modifiedBy = user.userId,
               modifiedTime = Instant.EPOCH,
+              projectMetrics =
+                  listOf(
+                      ReportProjectMetricModel(
+                          metric =
+                              ProjectMetricModel(
+                                  id = projectMetricId,
+                                  projectId = projectId,
+                                  component = MetricComponent.ProjectObjectives,
+                                  description = "Project Metric description",
+                                  name = "Project Metric Name",
+                                  reference = "2.0",
+                                  type = MetricType.Activity,
+                              ),
+                          entry =
+                              ReportMetricEntryModel(
+                                  target = 100,
+                                  modifiedTime = Instant.ofEpochSecond(1500),
+                                  modifiedBy = user.userId,
+                              )),
+                  ),
               standardMetrics =
                   listOf(
                       // ordered by reference
@@ -235,24 +258,37 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                                   modifiedBy = user.userId,
                               )),
                   ),
-              projectMetrics =
+              systemMetrics =
                   listOf(
-                      ReportProjectMetricModel(
-                          metric =
-                              ProjectMetricModel(
-                                  id = projectMetricId,
-                                  projectId = projectId,
-                                  component = MetricComponent.ProjectObjectives,
-                                  description = "Project Metric description",
-                                  name = "Project Metric Name",
-                                  reference = "2.0",
-                                  type = MetricType.Activity,
-                              ),
+                      ReportSystemMetricModel(
+                          metric = SystemMetric.SeedsCollected,
                           entry =
-                              ReportMetricEntryModel(
-                                  target = 100,
-                                  modifiedTime = Instant.ofEpochSecond(1500),
-                                  modifiedBy = user.userId,
+                              ReportSystemMetricEntryModel(
+                                  systemValue = 3,
+                              )),
+                      ReportSystemMetricModel(
+                          metric = SystemMetric.Seedlings,
+                          entry =
+                              ReportSystemMetricEntryModel(
+                                  systemValue = 2,
+                              )),
+                      ReportSystemMetricModel(
+                          metric = SystemMetric.TreesPlanted,
+                          entry =
+                              ReportSystemMetricEntryModel(
+                                  systemValue = 5,
+                              )),
+                      ReportSystemMetricModel(
+                          metric = SystemMetric.SpeciesPlanted,
+                          entry =
+                              ReportSystemMetricEntryModel(
+                                  systemValue = 4,
+                              )),
+                      ReportSystemMetricModel(
+                          metric = SystemMetric.MortalityRate,
+                          entry =
+                              ReportSystemMetricEntryModel(
+                                  systemValue = 1,
                               )),
                   ))
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2812,17 +2812,17 @@ abstract class DatabaseBackedTest {
   }
 
   protected fun insertReportSystemMetric(
-    row: ReportSystemMetricsRow = ReportSystemMetricsRow(),
-    reportId: ReportId = row.reportId ?: inserted.reportId,
-    metric: SystemMetric = row.systemMetricId ?: SystemMetric.SeedsCollected,
-    target: Int? = row.target,
-    systemValue: Int? = row.systemValue,
-    systemTime: Instant? = row.systemTime,
-    overrideValue: Int? = row.overrideValue,
-    notes: String? = row.notes,
-    internalComment: String? = row.internalComment,
-    modifiedBy: UserId = row.modifiedBy ?: currentUser().userId,
-    modifiedTime: Instant = row.modifiedTime ?: Instant.EPOCH,
+      row: ReportSystemMetricsRow = ReportSystemMetricsRow(),
+      reportId: ReportId = row.reportId ?: inserted.reportId,
+      metric: SystemMetric = row.systemMetricId ?: SystemMetric.SeedsCollected,
+      target: Int? = row.target,
+      systemValue: Int? = row.systemValue,
+      systemTime: Instant? = row.systemTime,
+      overrideValue: Int? = row.overrideValue,
+      notes: String? = row.notes,
+      internalComment: String? = row.internalComment,
+      modifiedBy: UserId = row.modifiedBy ?: currentUser().userId,
+      modifiedTime: Instant = row.modifiedTime ?: Instant.EPOCH,
   ) {
     val rowWithDefaults =
         row.copy(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -44,6 +44,7 @@ import com.terraformation.backend.db.accelerator.SubmissionDocumentId
 import com.terraformation.backend.db.accelerator.SubmissionId
 import com.terraformation.backend.db.accelerator.SubmissionSnapshotId
 import com.terraformation.backend.db.accelerator.SubmissionStatus
+import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.VoteOption
 import com.terraformation.backend.db.accelerator.keys.COHORTS_PKEY
 import com.terraformation.backend.db.accelerator.tables.daos.ApplicationHistoriesDao
@@ -72,6 +73,7 @@ import com.terraformation.backend.db.accelerator.tables.daos.ProjectVoteDecision
 import com.terraformation.backend.db.accelerator.tables.daos.ProjectVotesDao
 import com.terraformation.backend.db.accelerator.tables.daos.ReportProjectMetricsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ReportStandardMetricsDao
+import com.terraformation.backend.db.accelerator.tables.daos.ReportSystemMetricsDao
 import com.terraformation.backend.db.accelerator.tables.daos.ReportsDao
 import com.terraformation.backend.db.accelerator.tables.daos.StandardMetricsDao
 import com.terraformation.backend.db.accelerator.tables.daos.SubmissionDocumentsDao
@@ -104,6 +106,7 @@ import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVoteDecisio
 import com.terraformation.backend.db.accelerator.tables.pojos.ProjectVotesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ReportProjectMetricsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ReportStandardMetricsRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ReportSystemMetricsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ReportsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.StandardMetricsRow
 import com.terraformation.backend.db.accelerator.tables.pojos.SubmissionDocumentsRow
@@ -613,6 +616,7 @@ abstract class DatabaseBackedTest {
   protected val recordedTreesDao: RecordedTreesDao by lazyDao()
   protected val reportProjectMetricsDao: ReportProjectMetricsDao by lazyDao()
   protected val reportStandardMetricsDao: ReportStandardMetricsDao by lazyDao()
+  protected val reportSystemMetricsDao: ReportSystemMetricsDao by lazyDao()
   protected val reportsDao: ReportsDao by lazyDao()
   protected val seedFundReportFilesDao: SeedFundReportFilesDao by lazyDao()
   protected val seedFundReportPhotosDao: SeedFundReportPhotosDao by lazyDao()
@@ -2805,6 +2809,36 @@ abstract class DatabaseBackedTest {
         )
 
     reportStandardMetricsDao.insert(rowWithDefaults)
+  }
+
+  protected fun insertReportSystemMetric(
+    row: ReportSystemMetricsRow = ReportSystemMetricsRow(),
+    reportId: ReportId = row.reportId ?: inserted.reportId,
+    metric: SystemMetric = row.systemMetricId ?: SystemMetric.SeedsCollected,
+    target: Int? = row.target,
+    systemValue: Int? = row.systemValue,
+    systemTime: Instant? = row.systemTime,
+    overrideValue: Int? = row.overrideValue,
+    notes: String? = row.notes,
+    internalComment: String? = row.internalComment,
+    modifiedBy: UserId = row.modifiedBy ?: currentUser().userId,
+    modifiedTime: Instant = row.modifiedTime ?: Instant.EPOCH,
+  ) {
+    val rowWithDefaults =
+        row.copy(
+            reportId = reportId,
+            systemMetricId = metric,
+            target = target,
+            systemValue = systemValue,
+            systemTime = systemTime,
+            overrideValue = overrideValue,
+            notes = notes,
+            internalComment = internalComment,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
+        )
+
+    reportSystemMetricsDao.insert(rowWithDefaults)
   }
 
   protected fun insertReport(


### PR DESCRIPTION
This PR implements the query steps for reading system metric values and entries for a report. It defaults to frozen value if there is one, otherwise falls back to live system queried data. Currently, this is a placeholder number. 

The actual querying of Terraware data will follow in the next PRs.