### PR TITLE
SW-6621 Make UsersController general and finalizations for home page

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -335,7 +335,7 @@ class UserStore(
    * Updates a user's profile information. Applies changes to the `users` table as well as Keycloak.
    * Currently, only the first and last name can be modified.
    */
-  fun updateUser(model: IndividualUser) {
+  fun updateUser(model: TerrawareUser) {
     if (currentUser().userId != model.userId) {
       throw AccessDeniedException("Cannot modify another user's profile information")
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.customer.model
 
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
 import java.time.Instant
@@ -26,4 +27,8 @@ data class FunderUser(
 
   override val defaultPermission: Boolean
     get() = false
+
+  override fun canReadUser(userId: UserId) = userId == this.userId
+
+  override fun canListNotifications(organizationId: OrganizationId?) = organizationId == null
 }

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -286,6 +286,6 @@ class WebAppUrls(
   }
 
   private fun fullFunderPortalHome(): URI {
-    return UriBuilder.fromUri(config.webAppUrl).path("/funderHome").build()
+    return UriBuilder.fromUri(config.webAppUrl).path("/funder/home").build()
   }
 }


### PR DESCRIPTION
- Update `UsersController` to work with multiple user types
  - not sure if there's a better way to do this in kotlin
- Update `UserStore` to be able to update any TerrawareUser type
- Update FunderUser to be able to load home page without server errors
- Update registration url for funders to match frontend