### PR TITLE
SW-6625 Support annual reporting targets

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -186,7 +186,10 @@ class ProjectReportsController(
       @PathVariable projectId: ProjectId,
       @RequestBody payload: CreateAcceleratorReportConfigRequestPayload,
   ): SimpleSuccessResponsePayload {
-    reportStore.insertProjectReportConfig(payload.config.toModel(projectId))
+    reportStore.insertProjectReportConfig(
+        payload.config.toModel(projectId, ReportFrequency.Quarterly))
+    reportStore.insertProjectReportConfig(payload.config.toModel(projectId, ReportFrequency.Annual))
+
     return SimpleSuccessResponsePayload()
   }
 
@@ -206,18 +209,28 @@ class ProjectReportsController(
   @ApiResponse200
   @ApiResponse400
   @ApiResponse404
+  @PostMapping("/configs")
+  @Operation(summary = "Update accelerator report configuration.")
+  fun updateProjectAcceleratorReportConfig(
+      @PathVariable projectId: ProjectId,
+      @RequestBody payload: UpdateProjectAcceleratorReportConfigRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    reportStore.updateProjectReportConfig(
+        projectId, payload.config.reportingStartDate, payload.config.reportingEndDate)
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponse200
+  @ApiResponse400
+  @ApiResponse404
   @PostMapping("/configs/{configId}")
   @Operation(summary = "Update accelerator report configuration.")
   fun updateAcceleratorReportConfig(
       @PathVariable configId: ProjectReportConfigId,
       @RequestBody payload: UpdateAcceleratorReportConfigRequestPayload,
   ): SimpleSuccessResponsePayload {
-    reportStore.updateProjectReportConfig(configId) {
-      it.copy(
-          reportingStartDate = payload.config.reportingStartDate,
-          reportingEndDate = payload.config.reportingEndDate,
-      )
-    }
+    reportStore.updateProjectReportConfig(
+        configId, payload.config.reportingStartDate, payload.config.reportingEndDate)
     return SimpleSuccessResponsePayload()
   }
 
@@ -277,11 +290,10 @@ data class UpdateAcceleratorReportConfigPayload(
 )
 
 data class NewAcceleratorReportConfigPayload(
-    val frequency: ReportFrequency,
     val reportingStartDate: LocalDate,
     val reportingEndDate: LocalDate,
 ) {
-  fun toModel(projectId: ProjectId): NewProjectReportConfigModel =
+  fun toModel(projectId: ProjectId, frequency: ReportFrequency): NewProjectReportConfigModel =
       NewProjectReportConfigModel(
           id = null,
           projectId = projectId,
@@ -294,6 +306,7 @@ data class NewAcceleratorReportConfigPayload(
 data class AcceleratorReportPayload(
     val id: ReportId,
     val projectId: ProjectId,
+    val frequency: ReportFrequency,
     val status: ReportStatus,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -312,6 +325,7 @@ data class AcceleratorReportPayload(
   ) : this(
       id = model.id,
       projectId = model.projectId,
+      frequency = model.frequency,
       status = model.status,
       startDate = model.startDate,
       endDate = model.endDate,
@@ -471,6 +485,10 @@ data class CreateAcceleratorReportConfigRequestPayload(
 )
 
 data class UpdateAcceleratorReportConfigRequestPayload(
+    val config: UpdateAcceleratorReportConfigPayload
+)
+
+data class UpdateProjectAcceleratorReportConfigRequestPayload(
     val config: UpdateAcceleratorReportConfigPayload
 )
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectReportsController.kt
@@ -210,7 +210,7 @@ class ProjectReportsController(
   @ApiResponse400
   @ApiResponse404
   @PostMapping("/configs")
-  @Operation(summary = "Update accelerator report configuration.")
+  @Operation(summary = "Update all accelerator report configurations for a project.")
   fun updateProjectAcceleratorReportConfig(
       @PathVariable projectId: ProjectId,
       @RequestBody payload: UpdateProjectAcceleratorReportConfigRequestPayload,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ReportModel.kt
@@ -3,10 +3,12 @@ package com.terraformation.backend.accelerator.model
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.accelerator.ProjectMetricId
 import com.terraformation.backend.db.accelerator.ProjectReportConfigId
+import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportStatus
 import com.terraformation.backend.db.accelerator.StandardMetricId
 import com.terraformation.backend.db.accelerator.tables.pojos.ReportsRow
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_REPORT_CONFIGS
 import com.terraformation.backend.db.accelerator.tables.references.REPORTS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
@@ -19,6 +21,7 @@ data class ReportModel(
     val id: ReportId,
     val configId: ProjectReportConfigId,
     val projectId: ProjectId,
+    val frequency: ReportFrequency,
     val status: ReportStatus,
     val startDate: LocalDate,
     val endDate: LocalDate,
@@ -133,6 +136,7 @@ data class ReportModel(
             id = record[ID]!!,
             configId = record[CONFIG_ID]!!,
             projectId = record[PROJECT_ID]!!,
+            frequency = record[PROJECT_REPORT_CONFIGS.REPORT_FREQUENCY_ID]!!,
             status = record[STATUS_ID]!!,
             startDate = record[START_DATE]!!,
             endDate = record[END_DATE]!!,

--- a/src/main/resources/db/migration/0350/V353__UniqueReportConfigs.sql
+++ b/src/main/resources/db/migration/0350/V353__UniqueReportConfigs.sql
@@ -1,0 +1,10 @@
+-- Keep only one row per (project_id, frequency)
+DELETE FROM accelerator.project_report_configs
+WHERE id NOT IN (
+    SELECT DISTINCT ON (project_id, report_frequency_id) id
+    FROM accelerator.project_report_configs
+    ORDER BY project_id, report_frequency_id, id
+);
+
+ALTER TABLE accelerator.project_report_configs
+    ADD CONSTRAINT unique_project_frequency UNIQUE (project_id, report_frequency_id);


### PR DESCRIPTION
This is likely a temporary change for MVP. This includes a few changes to our features. The MVP specifies that a project should only have one config for now, although this will change (and this PR will be reverted) when Annual or other cadences of reports are supported

Key Changes:
1) Updated PUT /configs endpoint to not require frequency, and instead create both a quarterly and annual report. The quarterly report will be visible and publishable. The annual report will exist only for setting targets. The expectation is that it will still be functionally possible to edit and submit an annual report.
2) Added a new endpoint to update all report config dates for a project. This is so that every project config is kept in sync. This is a temporary endpoint to enable keeping annual report and quarterly reports dates matched up. In the future, when multiple report types are allowed, this endpoint will likely be deprecated.
3) Make report frequency easily visible to the FE. This will be helpful to determine which to show as full reports, and which to show as targets only.

