### PR TITLE
SW-6561 Use custom PostgreSQL 17 image for build/test

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.8"
 
 services:
   postgres:
-    image: "postgis/postgis:13-3.0"
+    image: "terraware/postgres:release"
     ports:
       - "5432:5432"
     volumes:

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ postgresJdbcVersion=42.7.5
 springDocVersion=2.8.5
 
 # For code generation, we run database migrations against an ephemeral database in a Docker
-# container using this image. If you change this, make sure you also change DatabaseTest.kt.
+# container using this image.
 
-postgresDockerRepository=postgis/postgis
-postgresDockerTag=13-3.0
+postgresDockerRepository=terraware/postgres
+postgresDockerTag=v20250227.1


### PR DESCRIPTION
Make builds and tests use a custom version of PostgreSQL 17 that has the
extensions required by Terraware and is available for both ARM and x86.
This replaces the x86-only PostgreSQL 13 image we were using.

For now, we will continue to stick with PostgreSQL 13-compatible SQL since
the production environment hasn't been upgraded to 17 yet.

The build/test configuration in `gradle.properties` uses a specific version
tag while the demo configuration in `docker/docker-compose.yml` uses a
generic `release` tag. The assumption is that the latter is used for quick
one-off runs of the server where you don't need fine control over the
exact version, whereas for builds, we want repeatability which means
we need to be specific about dependency versions.