### PR TITLE
Fix NPE when fetching system user by endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/UsersController.kt
@@ -212,7 +212,7 @@ data class UserProfilePayload(
       user.cookiesConsentedTime,
       user.countryCode,
       user.userId,
-      user.email!!,
+      user.email,
       user.emailNotificationsEnabled,
       user.firstName,
       user.globalRoles,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
-import com.terraformation.backend.log.perClassLogger
 import java.time.ZoneId
 import java.time.ZoneOffset
 import org.springframework.security.core.GrantedAuthority
@@ -31,14 +30,17 @@ data class DeviceManagerUser(
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
 ) : TerrawareUser {
+  companion object {
+    private const val EMAIL = "deviceManagerUser@terraformation.com"
+  }
+
   override val timeZone: ZoneId
     get() = ZoneOffset.UTC
 
   override val userType: UserType
     get() = UserType.DeviceManager
 
-  override val email: String?
-    get() = null
+  override val email = EMAIL
 
   override val organizationRoles: Map<OrganizationId, Role> by lazy {
     mapOf(organizationId to Role.Contributor)
@@ -138,9 +140,5 @@ data class DeviceManagerUser(
   ): Boolean {
     return canAccessOrganization(organizationId) &&
         organizationId in permissionStore.fetchOrganizationRoles(targetUserId)
-  }
-
-  companion object {
-    private val log = perClassLogger()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -40,7 +40,8 @@ data class DeviceManagerUser(
   override val userType: UserType
     get() = UserType.DeviceManager
 
-  override val email = EMAIL
+  override val email
+    get() = EMAIL
 
   override val organizationRoles: Map<OrganizationId, Role> by lazy {
     mapOf(organizationId to Role.Contributor)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -66,7 +66,8 @@ class SystemUser(
   override val authId: String?
     get() = null
 
-  override val email = EMAIL
+  override val email
+    get() = EMAIL
 
   /*
    * The system user has no roles per se; it always has access to everything. Reject any attempts to

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -49,6 +49,7 @@ class SystemUser(
      * system user's user ID.
      */
     private const val USERNAME = "system"
+    private const val EMAIL = "systemUser@terraformation.com"
   }
 
   override val timeZone: ZoneId
@@ -65,8 +66,7 @@ class SystemUser(
   override val authId: String?
     get() = null
 
-  override val email: String?
-    get() = null
+  override val email = EMAIL
 
   /*
    * The system user has no roles per se; it always has access to everything. Reject any attempts to

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -80,6 +80,7 @@ interface TerrawareUser : Principal, UserDetails {
 
   val userId: UserId
   val userType: UserType
+  val email: String
 
   val createdTime: Instant?
     get() = null
@@ -91,9 +92,6 @@ interface TerrawareUser : Principal, UserDetails {
     get() = null
 
   val timeZone: ZoneId?
-    get() = null
-
-  val email: String?
     get() = null
 
   val countryCode: String?


### PR DESCRIPTION
- Made email non-nullable on `TerrawareUser` interface
- Add fake emails for `SystemUser` and `DeviceManagerUser` to handle cases where they may be queried from the frontend because of `createdBy` or `modifiedBy` fields