### PR TITLE
SW-6561 Fix docs, CI builds

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,11 +45,6 @@ jobs:
         # Use the same cache key as in main.yml to pick up cached dependencies
         key: 4-${{ hashFiles('*.gradle.kts', 'gradle.properties', 'yarn.lock') }}
 
-    - name: Download Docker images
-      run: |
-        docker pull postgis/postgis:13-3.0
-        docker pull schemaspy/schemaspy:6.1.0
-
     - name: Compile
       run: ./gradlew testClasses
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,6 @@ jobs:
 
     - name: Download dependencies
       run: |
-        docker pull postgres:13
         ./gradlew downloadDependencies yarn
 
     - name: Generate jOOQ classes

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -78,7 +78,7 @@ import org.testcontainers.utility.DockerImageName
  */
 class SchemaDocsGenerator : DatabaseTest() {
   /** Docker image to use to generate docs. */
-  private val schemaSpyDockerImage = DockerImageName.parse("schemaspy/schemaspy:6.1.0")
+  private val schemaSpyDockerImage = DockerImageName.parse("schemaspy/schemaspy:6.2.4")
 
   /**
    * Name of environment variable specifying where the schema subdirectories should live. If not


### PR DESCRIPTION
Update the SchemaSpy tool that's used to generate the schema documentation to a
version that's compatible with PostgreSQL 17. Stop trying to pre-download Docker
images (both SchemaSpy and PostgreSQL) in CI; at one point this was needed
because the Java Docker client couldn't pull images, but it can now.