### PR TITLE
SW-6587 Add Spring AI libraries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,11 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.session:spring-session-jdbc")
 
+  implementation(platform("org.springframework.ai:spring-ai-bom:1.0.0-M6"))
+  implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter")
+  implementation("org.springframework.ai:spring-ai-pgvector-store-spring-boot-starter")
+  implementation("org.springframework.ai:spring-ai-tika-document-reader")
+
   implementation("ch.qos.logback.access:logback-access-tomcat:2.0.6")
   implementation("com.drewnoakes:metadata-extractor:2.19.0")
   implementation("com.dropbox.core:dropbox-core-sdk:7.0.0")

--- a/src/main/kotlin/com/terraformation/backend/ask/ConditionalOnSpringAi.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/ConditionalOnSpringAi.kt
@@ -1,0 +1,6 @@
+package com.terraformation.backend.ask
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+/** Annotation for beans that should only be instantiated if Spring AI is configured. */
+@ConditionalOnProperty("spring.ai.openai.api-key") annotation class ConditionalOnSpringAi

--- a/src/main/kotlin/com/terraformation/backend/ask/SpringAiAutoConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/SpringAiAutoConfig.kt
@@ -1,0 +1,25 @@
+package com.terraformation.backend.ask
+
+import org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration
+import org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Enables configuration of OpenAI client classes if there is an OpenAI API key set in the
+ * environment or in the application properties. By default, Spring Boot will try to create all the
+ * beans and will bomb out if the creation fails, which it will if there's no API key configured.
+ *
+ * We don't want to require dev environments to set OpenAI API keys, so we configure Spring to
+ * ignore the auto-configuration classes (this is done via an exclude rule in `application.yaml`)
+ * and subclass them here, with an additional rule to make them conditional on the presence of the
+ * API key. This gives us the easy configuration of the Spring Boot starter packages without the
+ * "bomb out if there's no API key" behavior.
+ *
+ * TODO: If/when we decide to make OpenAI integration a core part of Terraware rather than just an
+ *   experiment, we'll want to get rid of this setup and make the API key required everywhere.
+ */
+@ConditionalOnSpringAi @Configuration class OpenAiConditionalAutoConfig : OpenAiAutoConfiguration()
+
+@ConditionalOnSpringAi
+@Configuration
+class PgVectorStoreConditionalAutoConfig : PgVectorStoreAutoConfiguration()

--- a/src/main/resources/application-dev.yaml.sample
+++ b/src/main/resources/application-dev.yaml.sample
@@ -1,4 +1,8 @@
 spring:
+  ai:
+    openapi:
+      api-key:
+
   security:
     oauth2:
       client:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,11 @@ terraware:
     api-client-id: "api"
 
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration
+      - org.springframework.ai.autoconfigure.vectorstore.pgvector.PgVectorStoreAutoConfiguration
+
   datasource:
     url: "${DATABASE_URL:jdbc:postgresql://localhost:5432/terraware}"
     username: "${DATABASE_USER:${USER:postgres}}"


### PR DESCRIPTION
The experimental Ask Terraware feature will use Spring AI to talk to OpenAI's API.
Add the dependencies we'll need.

By default, Spring AI's autoconfiguration requires an OpenAI API key to be
present if the OpenAI client library is available. Override that behavior so that
developers who aren't working on Ask Terraware don't have to configure API keys.