### PR TITLE
SW-6587 Ask Terraware implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,7 @@ dependencies {
   implementation("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
   implementation("net.coobird:thumbnailator:0.4.20")
   implementation("org.apache.tika:tika-core:3.1.0")
+  implementation("org.commonmark:commonmark:0.24.0")
   implementation("org.flywaydb:flyway-core:$flywayVersion")
   implementation("org.flywaydb:flyway-database-postgresql:$flywayVersion")
   implementation("org.freemarker:freemarker:2.3.34")

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
@@ -1,0 +1,120 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.ask.ChatService
+import com.terraformation.backend.ask.ConditionalOnSpringAi
+import com.terraformation.backend.ask.EmbeddingService
+import com.terraformation.backend.customer.db.ProjectStore
+import com.terraformation.backend.customer.model.ExistingProjectModel
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.ProjectId
+import java.util.UUID
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@ConditionalOnSpringAi
+@Controller
+@RequestMapping("/admin/ask")
+@RequireGlobalRole(
+    [GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin, GlobalRole.TFExpert, GlobalRole.ReadOnly])
+@Validated
+class AdminAskController(
+    private val chatService: ChatService,
+    private val embeddingService: EmbeddingService,
+    private val projectStore: ProjectStore,
+    private val systemUser: SystemUser,
+) {
+  @GetMapping fun askIndexRedirect() = "redirect:/admin/ask/"
+
+  @GetMapping("/")
+  fun askIndex(model: Model): String {
+    model.addAttribute("projects", projectsSortedByName())
+
+    return "/admin/ask/index"
+  }
+
+  @PostMapping("/select")
+  fun askProjectRedirect(@RequestParam("projectId") projectId: ProjectId?): String {
+    return "redirect:/admin/ask/projects/${projectId}"
+  }
+
+  @GetMapping("/projects/{projectId}")
+  fun getProjectChat(
+      @PathVariable projectId: ProjectId,
+      model: Model,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      val project = projectStore.fetchOneById(projectId)
+
+      model.addAttribute("answer", null)
+      model.addAttribute("conversationId", UUID.randomUUID().toString())
+      model.addAttribute("project", project)
+      model.addAttribute("question", null)
+      model.addAttribute("showVariables", false)
+
+      return "/admin/ask/chat"
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = e.message
+      return askIndexRedirect()
+    }
+  }
+
+  @PostMapping("/projects/{projectId}")
+  fun postAskQuestion(
+      @PathVariable projectId: ProjectId,
+      query: String,
+      conversationId: String,
+      showVariables: String?,
+      model: Model
+  ): String {
+    try {
+      val project = projectStore.fetchOneById(projectId)
+
+      val answer =
+          chatService.askQuestion(projectId, query, conversationId, showVariables != null)
+              ?: "No answer received from chat service"
+      val markdownAnswer = Parser.builder().build().parse(answer)
+      val htmlAnswer = HtmlRenderer.builder().build().render(markdownAnswer)
+
+      model.addAttribute("answer", htmlAnswer)
+      model.addAttribute("conversationId", conversationId)
+      model.addAttribute("project", project)
+      model.addAttribute("query", query)
+      model.addAttribute("showVariables", showVariables != null)
+    } catch (e: Exception) {
+      model.addAttribute("failureMessage", e.message)
+    }
+
+    return "/admin/ask/exchange"
+  }
+
+  @PostMapping("/prepare")
+  fun prepareProject(
+      @RequestParam projectId: ProjectId,
+      redirectAttributes: RedirectAttributes
+  ): String {
+    try {
+      systemUser.run { embeddingService.embedProjectData(projectId) }
+
+      redirectAttributes.successMessage = "Project $projectId processed."
+      return askProjectRedirect(projectId)
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = e.message
+      return askIndexRedirect()
+    }
+  }
+
+  private fun projectsSortedByName(): List<ExistingProjectModel> =
+      embeddingService.listEmbeddedProjects().sortedBy { "${it.name.trim()} ${it.id}" }
+}

--- a/src/main/kotlin/com/terraformation/backend/ask/ChatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/ChatService.kt
@@ -1,0 +1,126 @@
+package com.terraformation.backend.ask
+
+import com.terraformation.backend.ask.db.TerrawareChatMemory
+import com.terraformation.backend.db.default_schema.ProjectId
+import jakarta.inject.Named
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor
+import org.springframework.ai.chat.client.advisor.QuestionAnswerAdvisor
+import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor
+import org.springframework.ai.vectorstore.SearchRequest
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder
+
+@ConditionalOnSpringAi
+@Named
+class ChatService(
+    private val chatClientBuilder: ChatClient.Builder,
+    private val chatMemory: TerrawareChatMemory,
+    private val injectMetadataAdvisor: InjectMetadataAdvisor,
+    private val vectorStore: VectorStore,
+) {
+  /**
+   * Number of items to include in context. Items are always sorted in decreasing order of
+   * similarity of embedding vectors, i.e., most relevant first.
+   */
+  private val contextItemsToInclude = 10
+
+  /**
+   * Text to append to user's question. The string `{question_answer_context}` will be replaced with
+   * chunks of content that look relevant to the conversation based on embedding similarity.
+   *
+   * This is based on Spring AI's built-in template, but with some added instructions.
+   */
+  private val basePromptTemplate: String =
+      """
+      
+      Context information is below, surrounded by ---------------------
+
+      ---------------------
+      {question_answer_context}
+      ---------------------
+
+      Given the context and provided history information, reply to the user comment. If the answer
+      is not in the context, inform the user that you can't answer the question. You may use general
+      knowledge of geography and science to interpret the context. If there are multiple entries in
+      the context with similar information, prefer the newer ones if you can determine their dates.
+      """
+          .trimIndent()
+
+  private val includeVariablesAndDocumentsPrompt =
+      """
+      
+      Include a list of the submission document names and a list of the variable names of any
+      documents or variables that support the answer.
+      """
+          .trimIndent()
+
+  /**
+   * Logs requests and responses so you can see what exact prompts we're sending. To see the log
+   * messages, set `logging.level.org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor` to
+   * `DEBUG` in the application properties.
+   */
+  private val loggerAdvisor =
+      SimpleLoggerAdvisor(
+          { request -> request.toPrompt().contents },
+          { response -> response.result.output.text },
+          100)
+
+  /**
+   * Asks an LLM a question and returns the answer. Automatically includes contextual information in
+   * the prompt based on the project ID and the previous questions and answers in the conversation.
+   *
+   * @param projectId If non-null, only this project's information will be included as context.
+   *   Otherwise context may be pulled from all projects.
+   * @param conversationId If non-null, include previous messages from the conversation in the
+   *   prompt so the LLM knows what any followup questions are referring to. The current question
+   *   and answer will also be added to the conversation's history.
+   * @param showVariables If true, ask the LLM to say which variables and/or uploaded documents it
+   *   referenced when generating the answer.
+   */
+  fun askQuestion(
+      projectId: ProjectId?,
+      question: String,
+      conversationId: String? = null,
+      showVariables: Boolean = false
+  ): String? {
+    val template =
+        listOfNotNull(
+                basePromptTemplate,
+                if (showVariables) includeVariablesAndDocumentsPrompt else null,
+            )
+            .joinToString("\n")
+
+    val questionAnswerAdvisor =
+        QuestionAnswerAdvisor(
+            vectorStore,
+            SearchRequest.builder()
+                .apply {
+                  if (projectId != null) {
+                    filterExpression(FilterExpressionBuilder().eq("projectId", projectId).build())
+                  }
+                }
+                .topK(contextItemsToInclude)
+                .build(),
+            template)
+
+    return chatClientBuilder
+        .build()
+        .prompt()
+        .advisors(
+            questionAnswerAdvisor,
+            injectMetadataAdvisor,
+            MessageChatMemoryAdvisor(chatMemory),
+            loggerAdvisor,
+        )
+        .user(question)
+        .advisors { a ->
+          if (conversationId != null) {
+            a.param(AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY, conversationId)
+          }
+        }
+        .call()
+        .content()
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
@@ -1,0 +1,288 @@
+package com.terraformation.backend.ask
+
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.accelerator.db.ProjectAcceleratorDetailsStore
+import com.terraformation.backend.accelerator.model.ModuleDeliverableModel
+import com.terraformation.backend.accelerator.model.SubmissionDocumentModel
+import com.terraformation.backend.accelerator.variables.AcceleratorProjectVariableValuesService
+import com.terraformation.backend.customer.db.OrganizationStore
+import com.terraformation.backend.customer.db.ProjectStore
+import com.terraformation.backend.customer.model.ExistingProjectModel
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.DeliverableType
+import com.terraformation.backend.db.accelerator.DocumentStore
+import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
+import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_DOCUMENTS
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.default_schema.tables.references.VECTOR_STORE
+import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.tables.references.VARIABLE_VALUES
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.model.ExistingSelectValue
+import com.terraformation.backend.documentproducer.model.ExistingValue
+import com.terraformation.backend.documentproducer.model.SelectVariable
+import com.terraformation.backend.documentproducer.model.TableVariable
+import com.terraformation.backend.file.GoogleDriveWriter
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import org.apache.tika.exception.UnsupportedFormatException
+import org.jooq.DSLContext
+import org.jooq.conf.ParamType
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.springframework.ai.document.Document
+import org.springframework.ai.reader.tika.TikaDocumentReader
+import org.springframework.ai.transformer.splitter.TokenTextSplitter
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.ai.vectorstore.filter.FilterExpressionBuilder
+import org.springframework.core.io.InputStreamResource
+
+@ConditionalOnSpringAi
+@Named
+class EmbeddingService(
+    private val acceleratorProjectVariableValuesService: AcceleratorProjectVariableValuesService,
+    private val deliverableStore: DeliverableStore,
+    private val dslContext: DSLContext,
+    private val googleDriveWriter: GoogleDriveWriter,
+    private val organizationStore: OrganizationStore,
+    private val projectAcceleratorDetailsStore: ProjectAcceleratorDetailsStore,
+    private val projectStore: ProjectStore,
+    private val variableStore: VariableStore,
+    private val variableValueStore: VariableValueStore,
+    private val vectorStore: VectorStore,
+) {
+  /**
+   * Matches MIME types of documents for which embeddings should be generated. We don't want to
+   * waste cycles feeding photos or files of unknown types to the embedding API. This regex selects
+   * the files whose contents are useful to include as context in prompts.
+   */
+  private val supportedDocumentMimeTypes =
+      Regex(
+          """
+          application/(?:
+            pdf
+            | vnd\.openxmlformats.*
+          )
+          | text/.*
+          """
+              .trimIndent(),
+          RegexOption.COMMENTS)
+
+  private val log = perClassLogger()
+
+  /** Returns the list of projects that have had their embeddings generated. */
+  fun listEmbeddedProjects(): List<ExistingProjectModel> {
+    requirePermissions { readAllAcceleratorDetails() }
+
+    val projectIdField = DSL.jsonbGetAttributeAsText(VECTOR_STORE.METADATA, "projectId")
+
+    return dslContext
+        .select(PROJECTS.asterisk())
+        .from(PROJECTS)
+        .where(
+            PROJECTS.ID.`in`(
+                DSL.select(
+                        DSL.cast(projectIdField, SQLDataType.BIGINT).convertFrom { ProjectId(it) })
+                    .from(VECTOR_STORE)
+                    .where(projectIdField.isNotNull)))
+        .orderBy(PROJECTS.ID)
+        .also { log.info("Query: ${it.getSQL(ParamType.INLINED)}") }
+        .fetch { ExistingProjectModel.of(it) }
+  }
+
+  /**
+   * Generates and stores embeddings for the data of a single project. This overwrites any previous
+   * embeddings for the project.
+   *
+   * Currently, there is no way to do an incremental update of a project's embeddings.
+   */
+  fun embedProjectData(projectId: ProjectId) {
+    val project = projectStore.fetchOneById(projectId)
+    val organization = organizationStore.fetchOneById(project.organizationId)
+    val valuesByVariableId = variableValueStore.listValues(projectId).groupBy { it.variableId }
+    val projectDetails =
+        projectAcceleratorDetailsStore.fetchOneById(
+            projectId, acceleratorProjectVariableValuesService.fetchValues(projectId))
+
+    val baseMetadata =
+        mapOf(
+            "organizationId" to organization.id,
+            "organizationName" to organization.name,
+            "projectId" to projectId,
+            "projectName" to project.name,
+        )
+
+    val documents =
+        valuesByVariableId
+            .filterValues { values -> values.any { it.rowValueId == null } }
+            .map { (variableId, values) ->
+              val variable = variableStore.fetchOneVariable(variableId)
+              val metadata =
+                  baseMetadata +
+                      listOfNotNull(
+                              "variableId" to variableId,
+                              "question" to (variable.deliverableQuestion ?: variable.name),
+                              variable.description?.let { "description" to it },
+                          )
+                          .toMap()
+              val text =
+                  if (variable is TableVariable) {
+                    renderTableAsMarkdown(variable, valuesByVariableId)
+                  } else {
+                    values.joinToString("\n") { variableValue ->
+                      if (variable is SelectVariable && variableValue is ExistingSelectValue) {
+                        variableValue.value
+                            .mapNotNull { optionId ->
+                              variable.options.firstOrNull { it.id == optionId }?.name
+                            }
+                            .joinToString("\n")
+                      } else {
+                        variableValue.value.toString()
+                      }
+                    }
+                  }
+
+              Document(text, metadata)
+            } +
+            Document(
+                "Here is some accelerator-related information about the project:\n$projectDetails",
+                baseMetadata)
+
+    vectorStore.delete(FilterExpressionBuilder().eq("projectId", projectId).build())
+
+    log.info("Embedding ${documents.size} documents for project $projectId ${project.name}")
+
+    vectorStore.add(documents)
+
+    embedGoogleDriveFiles(projectId, baseMetadata)
+  }
+
+  /**
+   * Renders the value of a table variable in Markdown form so that the embedding API can treat it
+   * as tabular data and extract relevant information from it.
+   */
+  private fun renderTableAsMarkdown(
+      variable: TableVariable,
+      valuesByVariableId: Map<VariableId, List<ExistingValue>>,
+  ): String {
+    val rows = valuesByVariableId[variable.id] ?: return ""
+    val headerLines: List<List<String>> =
+        listOf(
+            variable.columns.map { it.variable.name },
+            variable.columns.map { "---" },
+        )
+
+    val dataLines: List<List<String>> =
+        rows.map { row ->
+          variable.columns.map { column ->
+            valuesByVariableId[column.variable.id]
+                ?.filter { it.rowValueId == row.id }
+                ?.joinToString("; ") { it.value.toString() } ?: "-"
+          }
+        }
+
+    return (headerLines + dataLines).joinToString("\n") { lineCells ->
+      lineCells.joinToString(" | ", "| ", " |")
+    }
+  }
+
+  private fun embedGoogleDriveFiles(projectId: ProjectId, baseMetadata: Map<String, Any?>) {
+    dslContext
+        .selectDistinct(SUBMISSIONS.DELIVERABLE_ID)
+        .from(SUBMISSIONS)
+        .join(DELIVERABLES)
+        .on(SUBMISSIONS.DELIVERABLE_ID.eq(DELIVERABLES.ID))
+        .join(SUBMISSION_DOCUMENTS)
+        .on(SUBMISSIONS.ID.eq(SUBMISSION_DOCUMENTS.SUBMISSION_ID))
+        .where(SUBMISSIONS.PROJECT_ID.eq(projectId))
+        .and(DELIVERABLES.IS_SENSITIVE.isFalse)
+        .and(DELIVERABLES.DELIVERABLE_TYPE_ID.eq(DeliverableType.Document))
+        .fetch(SUBMISSIONS.DELIVERABLE_ID.asNonNullable())
+        .forEach { deliverableId ->
+          deliverableStore
+              .fetchDeliverableSubmissions(projectId = projectId, deliverableId = deliverableId)
+              .forEach { submission ->
+                val deliverable =
+                    deliverableStore.fetchDeliverables(submission.deliverableId).first()
+
+                submission.documents
+                    .filter { it.documentStore == DocumentStore.Google }
+                    .forEach { submissionDocument ->
+                      embedGoogleDriveFile(projectId, deliverable, submissionDocument, baseMetadata)
+                    }
+              }
+        }
+  }
+
+  private fun embedGoogleDriveFile(
+      projectId: ProjectId,
+      deliverable: ModuleDeliverableModel,
+      submissionDocument: SubmissionDocumentModel,
+      baseMetadata: Map<String, Any?>,
+  ) {
+    log.info(
+        "Embedding project $projectId deliverable ${deliverable.id} file ${submissionDocument.name}")
+
+    val metadata =
+        baseMetadata +
+            listOfNotNull(
+                    "deliverableId" to deliverable.id,
+                    "deliverableName" to deliverable.name,
+                    deliverable.descriptionHtml?.let { "deliverableDescriptionHtml" to it },
+                    "deliverableCategory" to deliverable.category,
+                    submissionDocument.description?.let { "documentDescription" to it },
+                    "submissionDocumentId" to submissionDocument.id,
+                    "submissionDocumentName" to submissionDocument.name,
+                )
+                .toMap()
+
+    try {
+      val mimeType = googleDriveWriter.getFileContentType(submissionDocument.location)
+      if (mimeType == null || !supportedDocumentMimeTypes.matches(mimeType)) {
+        log.info("Skipping file with unsupported type $mimeType")
+        return
+      }
+
+      val chunks =
+          TikaDocumentReader(
+                  InputStreamResource {
+                    googleDriveWriter.downloadFile(submissionDocument.location)
+                  })
+              .read()
+              .filter { it.isText }
+              .map { document -> document.mutate().metadata(metadata).build() }
+              .flatMap { document -> TokenTextSplitter().split(document) }
+
+      vectorStore.add(chunks)
+    } catch (e: Exception) {
+      if (e.cause is UnsupportedFormatException) {
+        log.info(
+            "Unsupported file format for project $projectId deliverable ${deliverable.id} " +
+                "submission document ${submissionDocument.id} ${submissionDocument.name}")
+      } else {
+        throw e
+      }
+    }
+  }
+
+  fun embedAllProjectData() {
+    val projectsWithoutEmbeddings =
+        dslContext
+            .selectDistinct(VARIABLE_VALUES.PROJECT_ID)
+            .from(VARIABLE_VALUES)
+            .whereNotExists(
+                DSL.selectOne()
+                    .from(VECTOR_STORE)
+                    .where(
+                        DSL.jsonbGetAttributeAsText(VECTOR_STORE.METADATA, "projectId")
+                            .eq(VARIABLE_VALUES.PROJECT_ID.cast(SQLDataType.VARCHAR))))
+            .orderBy(VARIABLE_VALUES.PROJECT_ID)
+            .fetch(VARIABLE_VALUES.PROJECT_ID.asNonNullable())
+
+    projectsWithoutEmbeddings.forEach { embedProjectData(it) }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/ask/InjectMetadataAdvisor.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/InjectMetadataAdvisor.kt
@@ -1,0 +1,47 @@
+package com.terraformation.backend.ask
+
+import jakarta.inject.Named
+import org.springframework.ai.chat.client.advisor.QuestionAnswerAdvisor
+import org.springframework.ai.chat.client.advisor.api.AdvisedRequest
+import org.springframework.ai.chat.client.advisor.api.AdvisedResponse
+import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisor
+import org.springframework.ai.chat.client.advisor.api.CallAroundAdvisorChain
+import org.springframework.ai.document.Document
+
+@Named
+class InjectMetadataAdvisor(private val order: Int = 1) : CallAroundAdvisor {
+  private val ignoredKeys =
+      setOf(
+          "distance",
+      )
+
+  override fun getOrder(): Int = order
+
+  override fun getName(): String = javaClass.simpleName
+
+  override fun aroundCall(
+      advisedRequest: AdvisedRequest,
+      chain: CallAroundAdvisorChain
+  ): AdvisedResponse {
+    val documents =
+        advisedRequest.adviseContext[QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS] as? List<*>
+            ?: emptyList<Document>()
+    val userParams = advisedRequest.userParams.toMutableMap()
+
+    val documentContext =
+        documents.filterIsInstance<Document>().joinToString("\n\n---\n") { document ->
+          val metadataText =
+              document.metadata
+                  .filterKeys { !it.endsWith("Id") && it !in ignoredKeys }
+                  .entries
+                  .joinToString("\n") { (key, value) -> "$key: $value" }
+
+          metadataText + "\n\n" + document.text
+        }
+
+    userParams["question_answer_context"] = documentContext
+
+    val request = AdvisedRequest.from(advisedRequest).userParams(userParams).build()
+    return chain.nextAroundCall(request)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/ask/db/TerrawareChatMemory.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/db/TerrawareChatMemory.kt
@@ -1,0 +1,110 @@
+package com.terraformation.backend.ask.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.default_schema.ChatMemoryMessageType
+import com.terraformation.backend.db.default_schema.tables.references.CHAT_MEMORY_CONVERSATIONS
+import com.terraformation.backend.db.default_schema.tables.references.CHAT_MEMORY_MESSAGES
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import java.time.InstantSource
+import java.util.UUID
+import org.jooq.DSLContext
+import org.springframework.ai.chat.memory.ChatMemory
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+
+/**
+ * Stores the messages from chat conversations in the database. This is an implementation of the
+ * Spring AI [ChatMemory] interface; the built-in implementations in Spring AI aren't suitable for
+ * our environment.
+ *
+ * TODO: Prune old conversations. Currently the conversation history tables will grow without bound.
+ */
+@Named
+class TerrawareChatMemory(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) : ChatMemory {
+  private val log = perClassLogger()
+
+  override fun add(conversationId: String, messages: List<Message>) {
+    dslContext.transaction { _ ->
+      with(CHAT_MEMORY_CONVERSATIONS) {
+        dslContext
+            .insertInto(CHAT_MEMORY_CONVERSATIONS)
+            .set(ID, UUID.fromString(conversationId))
+            .set(CREATED_BY, currentUser().userId)
+            .set(CREATED_TIME, clock.instant())
+            .set(MODIFIED_TIME, clock.instant())
+            .onConflict(ID)
+            .doUpdate()
+            .set(MODIFIED_TIME, clock.instant())
+            .execute()
+      }
+
+      messages.forEach { message ->
+        val messageType =
+            when (message.messageType) {
+              MessageType.ASSISTANT -> ChatMemoryMessageType.Assistant
+              MessageType.SYSTEM -> ChatMemoryMessageType.System
+              MessageType.TOOL -> ChatMemoryMessageType.ToolResponse
+              MessageType.USER -> ChatMemoryMessageType.User
+              else -> null
+            }
+
+        if (messageType != null) {
+          with(CHAT_MEMORY_MESSAGES) {
+            dslContext
+                .insertInto(CHAT_MEMORY_MESSAGES)
+                .set(CONVERSATION_ID, UUID.fromString(conversationId))
+                .set(CREATED_TIME, clock.instant())
+                .set(MESSAGE_TYPE_ID, messageType)
+                .set(CONTENT, message.text)
+                .execute()
+          }
+        } else {
+          log.error("Unknown message type ${message.messageType}")
+        }
+      }
+    }
+  }
+
+  override fun get(conversationId: String, lastN: Int): List<Message> {
+    return with(CHAT_MEMORY_MESSAGES) {
+      dslContext
+          .select(CONTENT, MESSAGE_TYPE_ID)
+          .from(CHAT_MEMORY_MESSAGES)
+          .where(CONVERSATION_ID.eq(UUID.fromString(conversationId)))
+          .and(chatMemoryConversations.CREATED_BY.eq(currentUser().userId))
+          .orderBy(ID.desc())
+          .limit(lastN)
+          .fetch { record ->
+            val content = record[CONTENT]
+            when (record[MESSAGE_TYPE_ID]!!) {
+              ChatMemoryMessageType.Assistant -> AssistantMessage(content)
+              ChatMemoryMessageType.System -> SystemMessage(content)
+              // TODO: Figure out if we need to handle tool responses at all; they aren't simple
+              //       text values
+              ChatMemoryMessageType.ToolResponse -> null
+              ChatMemoryMessageType.User -> UserMessage(content)
+            }
+          }
+          .filterNotNull()
+          .reversed()
+    }
+  }
+
+  override fun clear(conversationId: String) {
+    with(CHAT_MEMORY_CONVERSATIONS) {
+      // Cascading delete will clean up the messages.
+      dslContext
+          .deleteFrom(CHAT_MEMORY_CONVERSATIONS)
+          .where(ID.eq(UUID.fromString(conversationId)))
+          .and(CREATED_BY.eq(currentUser().userId))
+          .execute()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/GoogleDriveWriter.kt
@@ -147,6 +147,18 @@ class GoogleDriveWriter(
     return result.id
   }
 
+  fun getFileContentType(googleFileId: String): String? {
+    return driveClient.files().get(googleFileId).setSupportsAllDrives(true).execute().mimeType
+  }
+
+  fun downloadFile(googleFileId: String): InputStream {
+    return driveClient
+        .files()
+        .get(googleFileId)
+        .setSupportsAllDrives(true)
+        .executeMediaAsInputStream()
+  }
+
   /** Copies a file from a [FileStore] to Google Drive. */
   fun copyFile(
       driveId: String,

--- a/src/main/resources/application-dev.yaml.sample
+++ b/src/main/resources/application-dev.yaml.sample
@@ -1,6 +1,6 @@
 spring:
   ai:
-    openapi:
+    openai:
       api-key:
 
   security:

--- a/src/main/resources/templates/admin/ask/chat.html
+++ b/src/main/resources/templates/admin/ask/chat.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        .question {
+            color: darkgreen;
+            white-space: preserve-breaks;
+        }
+        .answer {
+            color: blue;
+            margin-left: 10em;
+        }
+    </style>
+
+    <th:block th:fragment="additionalScript">
+        <script src="https://unpkg.com/htmx.org@2.0.4" integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+" crossorigin="anonymous"></script>
+
+        <script>
+            function submitOnEnter(event) {
+                if (event.key === "Enter" && !event.shiftKey) {
+                    htmx.trigger("#queryForm", "submit");
+                    event.preventDefault();
+                }
+            }
+        </script>
+    </th:block>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin">Home</a> -
+<a href="/admin/ask/">Ask Terraware (select project)</a>
+
+<h3 th:text="|Ask Terraware: ${project.name} (${project.id})|"></h3>
+
+<th:block th:replace="~{/admin/ask/exchange}"/>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/ask/exchange.html
+++ b/src/main/resources/templates/admin/ask/exchange.html
@@ -1,0 +1,24 @@
+<div class="question" th:text="${query}" th:if="${query} != null" />
+<div class="answer" th:utext="${answer}" th:if="${answer} != null" />
+
+<form id="queryForm" th:hx-post="|/admin/ask/projects/${project.id}|" hx-swap="outerHTML"
+      hx-disabled-elt="input, textarea">
+    <label>
+        Question (Enter to submit, Shift-Enter for line break):
+        <br/>
+        <textarea id="query" rows=4 cols=80 name="query" autofocus></textarea>
+    </label>
+    <br/>
+    <input type="hidden" name="projectId" th:value="${project.id}"/>
+    <input type="hidden" name="conversationId" th:value="${conversationId}"/>
+    <input id="submitButton" type="submit" value="Submit"/>
+    <br/>
+    <label>
+        <input type="checkbox" name="showVariables" value="true" th:checked="${showVariables}"/>
+        Show the variables and documents that were referenced when generating the answer.
+    </label>
+</form>
+
+<script>
+    document.getElementById('query').addEventListener('keydown', submitOnEnter);
+</script>

--- a/src/main/resources/templates/admin/ask/index.html
+++ b/src/main/resources/templates/admin/ask/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin">Home</a>
+
+<h2>Ask Terraware</h2>
+
+<h3>Chat</h3>
+
+<p>
+    Choose a project to chat about.
+    Only projects that have been prepared are available for chat.
+</p>
+
+<form method="POST" action="/admin/ask/select">
+    <label>
+        Project:
+        <select name="projectId">
+            <option th:each="project : ${projects}" th:value="${project.id}" th:text="|${project.name} (${project.id})|"/>
+        </select>
+    </label>
+    <br/>
+    <input type="submit" value="Ask Terraware"/>
+</form>
+
+<p>
+    Or enter a project ID.
+</p>
+
+<form method="POST" action="/admin/ask/select">
+    <label>
+        Project ID:
+        <input name="projectId" required/>
+    </label>
+    <input type="submit" value="Ask Terraware"/>
+</form>
+
+<h3>Prepare Project</h3>
+
+<p>
+    Walks through a project's data and prepares it for use by the chat system.
+    Preparing a project that was already prepared will update the chat system
+    with any changes to the project's data since the last time it was prepared.
+</p>
+
+<p>
+    <b>Preparing a project that has a lot of documents can take time.</b>
+    If you get a request timeout, don't try again! Come back in 5 minutes and see if the
+    project appears in the chat menu.
+</p>
+
+<form method="POST" action="/admin/ask/prepare">
+    <label>
+        Project ID:
+        <input name="projectId" required/>
+    </label>
+    <input type="submit" value="Prepare Project"/>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
This experimental change adds integration with the OpenAI API to Terraware.

It is exposed via a page in the admin UI, `/admin/ask/`. Currently that page isn't
linked from elsewhere in the admin UI; we want to roll this feature out to a small
handful of specific internal users initially but we don't want to forbid others
from using it.

The chat UI uses the "htmx" library to do lightweight dynamic updates rather than
full page reloads.

Currently, projects must be "prepared" before you can ask the chat UI about them.
The "prepare" process generates embeddings for all the project's variable values
and uploaded documents as well as for some non-variable metadata like the project
accelerator details.

While we'll deploy this change to production for limited testing, it's still a
prototype; there are no tests and the technical documentation is incomplete.