### PR TITLE
SW-6696 Make subzone species list include entire site

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -167,7 +167,15 @@ class SpeciesStore(
         }
   }
 
-  fun fetchSpeciesByPlantingSubzoneId(
+  /**
+   * Returns a list of species that may be present in a given planting subzone.
+   *
+   * This is a combined list of all the species that have been planted and observed across the
+   * entire planting site. We can't limit the search to the specific subzone because subzone
+   * boundaries can change over time; a plant that was in subzone 1 in the past may be in subzone 2
+   * now due to a subsequent map edit.
+   */
+  fun fetchSiteSpeciesByPlantingSubzoneId(
       plantingSubzoneId: PlantingSubzoneId
   ): List<ExistingSpeciesModel> {
     requirePermissions { readPlantingSubzone(plantingSubzoneId) }
@@ -184,7 +192,9 @@ class SpeciesStore(
             SPECIES.ID.`in`(
                 DSL.select(PLANTINGS.SPECIES_ID)
                     .from(PLANTINGS)
-                    .where(PLANTINGS.PLANTING_SUBZONE_ID.eq(plantingSubzoneId))
+                    .join(PLANTING_SUBZONES)
+                    .on(PLANTINGS.PLANTING_SITE_ID.eq(PLANTING_SUBZONES.PLANTING_SITE_ID))
+                    .where(PLANTING_SUBZONES.ID.eq(plantingSubzoneId))
                     .union(
                         DSL.select(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID)
                             .from(OBSERVED_SITE_SPECIES_TOTALS)

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
@@ -23,17 +24,20 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @TrackingEndpoint
 class PlantingSubzonesController(
+    private val parentStore: ParentStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val speciesStore: SpeciesStore,
 ) {
   @GetMapping("/{id}/species")
   @Operation(
-      summary = "Gets a list of the species that have been planted in a specific planting subzone.",
-      description = "The list is based on nursery withdrawals.")
+      summary = "Gets a list of the species that may have been planted in a planting subzone.",
+      description =
+          "The list is based on nursery withdrawals to the planting site as well as past " +
+              "observations.")
   fun listPlantingSubzoneSpecies(
       @PathVariable id: PlantingSubzoneId,
   ): ListPlantingSubzoneSpeciesResponsePayload {
-    val species = speciesStore.fetchSpeciesByPlantingSubzoneId(id)
+    val species = speciesStore.fetchSiteSpeciesByPlantingSubzoneId(id)
 
     return ListPlantingSubzoneSpeciesResponsePayload(
         species.map { PlantingSubzoneSpeciesPayload(it) })


### PR DESCRIPTION
Currently, the mobile app's observation UI has a menu of known species, which is
based on the plants that are reported to have been planted in the monitoring
plot's subzone as well as plants that were previously observed at the site.

Now that subzone boundaries can be changed even after plants are planted, limiting
the menu to species in the plot's subzone no longer works, because the plot may be
in a different subzone now than it used to be.

Update the API endpoint that lists species in a subzone to include all species
planted at the site.