### PR TITLE
SW-6587 Include project context in every prompt

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/ask/InjectMetadataAdvisor.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/InjectMetadataAdvisor.kt
@@ -13,6 +13,8 @@ class InjectMetadataAdvisor(private val order: Int = 1) : CallAroundAdvisor {
   private val ignoredKeys =
       setOf(
           "distance",
+          "organizationName",
+          "projectName",
       )
 
   override fun getOrder(): Int = order


### PR DESCRIPTION
Currently, the prompts generated by Ask Terraware include the project and
organization name as part of the "header" for each variable value and document
excerpt that's retrieved based on embedding similarity. Additional project
information is only included if its embedding is sufficiently similar to the
conversation. This causes seemingly simple queries like, "Where is the project
located?" to fail. It also makes the prompt bigger for no real benefit since
the information is repeated for each variable.

Change the prompt generation to exclude the project/org names from the variable
value details, and instead include them along with some other generic project
information as the first item in the context part of the prompt.