### PR TITLE
SW-6587 Exclude outdated variable values from prompt

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
@@ -103,7 +103,10 @@ class EmbeddingService(
   fun embedProjectData(projectId: ProjectId) {
     val project = projectStore.fetchOneById(projectId)
     val organization = organizationStore.fetchOneById(project.organizationId)
-    val valuesByVariableId = variableValueStore.listValues(projectId).groupBy { it.variableId }
+    val valuesByVariableId =
+        variableValueStore.listValues(projectId, includeReplacedVariables = false).groupBy {
+          it.variableId
+        }
     val projectDetails =
         projectAcceleratorDetailsStore.fetchOneById(
             projectId, acceleratorProjectVariableValuesService.fetchValues(projectId))


### PR DESCRIPTION
Currently, the prompts generated by Ask Terraware can include values of variables
that have been replaced by newer versions. The newer versions are usually also
included, which eats up space in the context for no benefit.

Exclude the values of variables that have been replaced.