### PR TITLE
SW-6703 Fixed archive report infinite loop

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -462,12 +462,13 @@ class ReportStore(
                       submittedBy = null,
                       submittedTime = null,
                   ))
-          if (existingReportIterator.hasNext()) {
-            existingReport = existingReportIterator.next()
-          } else {
-            reportRowsToAdd.add(desiredReportRow)
-            break
-          }
+        }
+
+        if (existingReportIterator.hasNext()) {
+          existingReport = existingReportIterator.next()
+        } else {
+          reportRowsToAdd.add(desiredReportRow)
+          break
         }
       } else if (desiredReportRow.endDate!!.isBefore(existingReport.startDate)) {
         // If the new report date is before the existing report date, this report needs to be added
@@ -491,7 +492,8 @@ class ReportStore(
         // If the report dates overlap, they point to the same reporting period. Update the
         // existing report dates to match the desired report dates, and un-archive
         if (existingReport.startDate != desiredReportRow.startDate!! ||
-            existingReport.endDate != desiredReportRow.endDate!!) {
+            existingReport.endDate != desiredReportRow.endDate!! ||
+            existingReport.status == ReportStatus.NotNeeded) {
           reportRowsToUpdate.add(
               existingReport
                   .toRow()

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -2357,6 +2357,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               reportingEndDate = LocalDate.of(2024, Month.JULY, 9),
           )
 
+      // This one remains unchanged, but will help catch any looping issues
+      val year0ReportId =
+          insertReport(
+              configId = configId,
+              projectId = projectId,
+              status = ReportStatus.NotNeeded,
+              startDate = LocalDate.of(2020, Month.MARCH, 13),
+              endDate = LocalDate.of(2020, Month.MAY, 31),
+          )
+
       val year1ReportId =
           insertReport(
               configId = configId,
@@ -2408,6 +2418,18 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(
           listOf(
+              ReportsRecord(
+                  id = year0ReportId,
+                  configId = configId,
+                  projectId = projectId,
+                  statusId = ReportStatus.NotNeeded,
+                  startDate = LocalDate.of(2020, Month.MARCH, 13),
+                  endDate = LocalDate.of(2020, Month.MAY, 31),
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+              ),
               ReportsRecord(
                   id = year1ReportId,
                   configId = configId,


### PR DESCRIPTION
There was a bug, where if an existing report was already marked as "Not Needed", the loop did not progress correctly. 