### PR TITLE
SW-6587 Skip embeddings for missing Google Drive files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.log.perClassLogger
 import java.util.UUID
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
@@ -34,6 +35,8 @@ class AdminAskController(
     private val projectStore: ProjectStore,
     private val systemUser: SystemUser,
 ) {
+  private val log = perClassLogger()
+
   @GetMapping fun askIndexRedirect() = "redirect:/admin/ask/"
 
   @GetMapping("/")
@@ -110,6 +113,7 @@ class AdminAskController(
       redirectAttributes.successMessage = "Project $projectId processed."
       return askProjectRedirect(projectId)
     } catch (e: Exception) {
+      log.error("Error while preparing project $projectId", e)
       redirectAttributes.failureMessage = e.message
       return askIndexRedirect()
     }


### PR DESCRIPTION
A couple of projects have document submissions that refer to Google Drive files
that were deleted from Google Drive. Currently, this causes preparing those
projects (generating embeddings) to bomb out.

Make the system instead log an error message and continue generating embeddings
for the remaining document submissions.