### PR TITLE
SW-6643 Updated workflow service to not copy unchanged workflow row

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableValueService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableValueService.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer
 
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_VARIABLES
 import com.terraformation.backend.db.asNonNullable
@@ -23,9 +24,10 @@ import org.jooq.DSLContext
 @Named
 class VariableValueService(
     private val dslContext: DSLContext,
+    private val systemUser: SystemUser,
     private val variableStore: VariableStore,
     private val variableValueStore: VariableValueStore,
-    private val variableWorkflowStore: VariableWorkflowStore
+    private val variableWorkflowStore: VariableWorkflowStore,
 ) {
   /**
    * Service method to validate, write values, and update workflows.
@@ -37,7 +39,9 @@ class VariableValueService(
   fun updateValues(operations: List<ValueOperation>, triggerWorkflows: Boolean = true) {
     validate(operations)
     val values = variableValueStore.updateValues(operations, triggerWorkflows)
-    updateWorkflowHistory(values, triggerWorkflows)
+    if (triggerWorkflows) {
+      systemUser.run { updateWorkflowHistory(values) }
+    }
   }
 
   /**
@@ -46,7 +50,7 @@ class VariableValueService(
    * @param values list of updated values
    * @param updateStatus if set to true, will set status to In Review, and feedback to null
    */
-  private fun updateWorkflowHistory(values: List<ExistingValue>, updateStatus: Boolean = true) {
+  private fun updateWorkflowHistory(values: List<ExistingValue>) {
     val projectId = values.firstOrNull()?.projectId ?: return
 
     val variableIdsInDeliverables: Set<VariableId> =
@@ -62,25 +66,10 @@ class VariableValueService(
         values.filter { it.variableId in variableIdsInDeliverables }.groupBy { it.variableId }
 
     valuesByVariables.keys.forEach { variableId ->
-      variableWorkflowStore.update(
-          projectId,
-          variableId,
-      ) {
-        val status =
-            if (updateStatus) {
-              VariableWorkflowStatus.InReview
-            } else {
-              it.status
-            }
-        val feedback =
-            if (updateStatus) {
-              null
-            } else {
-              it.feedback
-            }
+      variableWorkflowStore.update(projectId, variableId) {
         it.copy(
-            status = status,
-            feedback = feedback,
+            status = VariableWorkflowStatus.InReview,
+            feedback = null,
         )
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableValueService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableValueService.kt
@@ -60,31 +60,29 @@ class VariableValueService(
 
     val valuesByVariables =
         values.filter { it.variableId in variableIdsInDeliverables }.groupBy { it.variableId }
-    val currentWorkflow = variableWorkflowStore.fetchCurrentForProject(projectId)
 
     valuesByVariables.keys.forEach { variableId ->
-      val existing = currentWorkflow[variableId]
-      val status =
-          if (updateStatus || existing == null) {
-            VariableWorkflowStatus.InReview
-          } else {
-            existing.status
-          }
-
-      val feedback =
-          if (updateStatus) {
-            null
-          } else {
-            existing?.feedback
-          }
-
       variableWorkflowStore.update(
           projectId,
           variableId,
-          status,
-          feedback,
-          existing?.internalComment,
-      )
+      ) {
+        val status =
+            if (updateStatus) {
+              VariableWorkflowStatus.InReview
+            } else {
+              it.status
+            }
+        val feedback =
+            if (updateStatus) {
+              null
+            } else {
+              it.feedback
+            }
+        it.copy(
+            status = status,
+            feedback = feedback,
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariableWorkflowController.kt
@@ -59,8 +59,13 @@ class VariableWorkflowController(
       @PathVariable variableId: VariableId,
       @RequestBody payload: UpdateVariableWorkflowDetailsRequestPayload
   ): SimpleSuccessResponsePayload {
-    variableWorkflowStore.update(
-        projectId, variableId, payload.status, payload.feedback, payload.internalComment)
+    variableWorkflowStore.update(projectId, variableId) {
+      it.copy(
+          status = payload.status,
+          feedback = payload.feedback,
+          internalComment = payload.internalComment,
+      )
+    }
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableWorkflowStore.kt
@@ -93,18 +93,6 @@ class VariableWorkflowStore(
     }
 
     return dslContext.transactionResult { _ ->
-      // Block all workflow rows regarding this project variables. This is to prevent overwriting
-      // with stale results when multiple updates are called.
-      with(VARIABLE_WORKFLOW_HISTORY) {
-        dslContext
-            .select(asterisk())
-            .from(this)
-            .where(PROJECT_ID.eq(projectId))
-            .and(VARIABLE_ID.eq(variableId))
-            .forUpdate()
-            .execute()
-      }
-
       val existing =
           with(VARIABLE_WORKFLOW_HISTORY) {
             fetchCurrentByCondition(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableWorkflowModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/VariableWorkflowModel.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.documentproducer.model
+
+import com.terraformation.backend.db.docprod.VariableWorkflowStatus
+
+data class VariableWorkflowModel(
+    val status: VariableWorkflowStatus,
+    val feedback: String?,
+    val internalComment: String?,
+)


### PR DESCRIPTION
This prevents a race condition from happening when a user updates the variable value as well as the variable workflow. This is common when reviewing documents/questionnaire deliverables when an accelerator admin may adjust a value but also change the status of the variable. This was causing an issue when the value update API call, takes the workflow row that is not the latest, and creates a new workflow history row with it. 

The result is something like this:
Newest:
Row 3, Old Status, New value ID (Created by the update value API call)
Row 2, New Status, Old value ID (Created by the update workflow API call)
Row 1, Old Status, Old value ID (Existing)

But we want a guarantee of this:
Row 3, New Status, New value ID

The update order doesn't actually matter that much.


Key changes:
~~1) Moved the fetch existing instead a transaction, and behind a select for update.~~
2) Change the update function to take an update function, instead of individual values. This is to simplify the call from `VariableValuesService` since it is also doing a fetch workflow there. 
3) The actual simplification part in the service class of step 2. 