### PR TITLE
SW-6617 Added permission tests for Funder User, and list funders endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/PermissionStore.kt
@@ -11,6 +11,8 @@ import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.default_schema.tables.references.USER_GLOBAL_ROLES
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
 import jakarta.inject.Named
 import org.jooq.DSLContext
 
@@ -38,6 +40,15 @@ class PermissionStore(private val dslContext: DSLContext) {
         .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(FACILITIES.ORGANIZATION_ID))
         .where(ORGANIZATION_USERS.USER_ID.eq(userId))
         .fetchMap(FACILITIES.ID.asNonNullable(), ORGANIZATION_USERS.ROLE_ID.asNonNullable())
+  }
+
+  /** Returns a user's funding entity */
+  fun fetchFundingEntity(userId: UserId): FundingEntityId? {
+    return dslContext
+        .select(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID)
+        .from(FUNDING_ENTITY_USERS)
+        .where(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
+        .fetchOne { it[FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID] }
   }
 
   /** Returns a user's global roles. These roles are not tied to organizations. */

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -790,7 +790,7 @@ class UserStore(
         usersRow.cookiesConsentedTime,
         usersRow.locale,
         usersRow.timeZone,
-    )
+        permissionStore)
   }
 
   private fun insertKeycloakUser(

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -25,8 +25,8 @@ data class FunderUser(
     override val timeZone: ZoneId? = null,
     private val permissionStore: PermissionStore,
 ) : TerrawareUser {
-  private val _fundingEntity = ResettableLazy { permissionStore.fetchFundingEntity(userId) }
-  override val fundingEntity: FundingEntityId? by _fundingEntity
+  private val _fundingEntityId = ResettableLazy { permissionStore.fetchFundingEntity(userId) }
+  override val fundingEntityId: FundingEntityId? by _fundingEntityId
 
   override val userType: UserType
     get() = UserType.Funder
@@ -38,9 +38,9 @@ data class FunderUser(
 
   override fun canListNotifications(organizationId: OrganizationId?) = organizationId == null
 
-  override fun canReadFundingEntity(entityId: FundingEntityId) = fundingEntity == entityId
+  override fun canReadFundingEntity(entityId: FundingEntityId) = fundingEntityId == entityId
 
   override fun canReadUser(userId: UserId) = userId == this.userId
 
-  override fun canListFundingEntityUsers(entityId: FundingEntityId) = fundingEntity == entityId
+  override fun canListFundingEntityUsers(entityId: FundingEntityId) = fundingEntityId == entityId
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -1,8 +1,11 @@
 package com.terraformation.backend.customer.model
 
+import com.terraformation.backend.customer.db.PermissionStore
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.funder.FundingEntityId
+import com.terraformation.backend.util.ResettableLazy
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Locale
@@ -20,7 +23,10 @@ data class FunderUser(
     override val cookiesConsentedTime: Instant? = null,
     override val locale: Locale? = null,
     override val timeZone: ZoneId? = null,
+    private val permissionStore: PermissionStore,
 ) : TerrawareUser {
+  private val _fundingEntity = ResettableLazy { permissionStore.fetchFundingEntity(userId) }
+  override val fundingEntity: FundingEntityId? by _fundingEntity
 
   override val userType: UserType
     get() = UserType.Funder
@@ -32,5 +38,9 @@ data class FunderUser(
 
   override fun canListNotifications(organizationId: OrganizationId?) = organizationId == null
 
+  override fun canReadFundingEntity(entityId: FundingEntityId) = fundingEntity == entityId
+
   override fun canReadUser(userId: UserId) = userId == this.userId
+
+  override fun canListFundingEntityUsers(entityId: FundingEntityId) = fundingEntity == entityId
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -289,6 +289,8 @@ data class IndividualUser(
 
   override fun canListFacilities(organizationId: OrganizationId) = isMember(organizationId)
 
+  override fun canListFundingEntityUsers(entityId: FundingEntityId) = isReadOnlyOrHigher()
+
   override fun canListNotifications(organizationId: OrganizationId?): Boolean {
     return if (organizationId == null) {
       // user can list global notifications relevant to user
@@ -374,6 +376,8 @@ data class IndividualUser(
       isManagerOrHigher(parentStore.getOrganizationId(draftPlantingSiteId))
 
   override fun canReadFacility(facilityId: FacilityId) = isMember(facilityId)
+
+  override fun canReadFundingEntity(entityId: FundingEntityId) = canReadFundingEntities()
 
   override fun canReadFundingEntities() = isReadOnlyOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -64,6 +64,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.documentproducer.db.DocumentNotFoundException
+import com.terraformation.backend.funder.db.FundingEntityNotFoundException
 import com.terraformation.backend.nursery.db.BatchNotFoundException
 import com.terraformation.backend.nursery.db.WithdrawalNotFoundException
 import com.terraformation.backend.tracking.db.DeliveryNotFoundException
@@ -637,6 +638,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun listFundingEntityUsers(entityId: FundingEntityId) {
+    user.recordPermissionChecks {
+      if (!user.canListFundingEntityUsers(entityId)) {
+        readFundingEntity(entityId)
+        throw AccessDeniedException("No permission to list funders in funding entity $entityId")
+      }
+    }
+  }
+
   fun listNotifications(organizationId: OrganizationId?) {
     user.recordPermissionChecks {
       if (!user.canListNotifications(organizationId)) {
@@ -882,6 +892,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     user.recordPermissionChecks {
       if (!user.canReadFundingEntities()) {
         throw AccessDeniedException("No permission to read funding entities")
+      }
+    }
+  }
+
+  fun readFundingEntity(entityId: FundingEntityId) {
+    user.recordPermissionChecks {
+      if (!user.canReadFundingEntity(entityId)) {
+        throw FundingEntityNotFoundException(entityId)
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -134,6 +134,10 @@ interface TerrawareUser : Principal, UserDetails {
   val facilityRoles: Map<FacilityId, Role>
     get() = emptyMap()
 
+  /** The user's funder entity. */
+  val fundingEntity: FundingEntityId?
+    get() = null
+
   /** The user's global roles. These are not tied to organizations. */
   val globalRoles: Set<GlobalRole>
     get() = emptySet()
@@ -337,6 +341,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canListFacilities(organizationId: OrganizationId): Boolean = defaultPermission
 
+  fun canListFundingEntityUsers(entityId: FundingEntityId): Boolean = defaultPermission
+
   fun canListNotifications(organizationId: OrganizationId?): Boolean = defaultPermission
 
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = defaultPermission
@@ -399,6 +405,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canReadFacility(facilityId: FacilityId): Boolean = defaultPermission
 
   fun canReadFundingEntities(): Boolean = defaultPermission
+
+  fun canReadFundingEntity(entityId: FundingEntityId): Boolean = defaultPermission
 
   fun canReadGlobalRoles(): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -135,7 +135,7 @@ interface TerrawareUser : Principal, UserDetails {
     get() = emptyMap()
 
   /** The user's funder entity. */
-  val fundingEntity: FundingEntityId?
+  val fundingEntityId: FundingEntityId?
     get() = null
 
   /** The user's global roles. These are not tied to organizations. */

--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityStore.kt
@@ -24,7 +24,7 @@ class FundingEntityStore(
   fun fetchOneById(
       fundingEntityId: FundingEntityId,
   ): FundingEntityModel {
-    requirePermissions { readFundingEntities() }
+    requirePermissions { readFundingEntity(fundingEntityId) }
 
     return fetchWithCondition(FUNDING_ENTITIES.ID.eq(fundingEntityId)).firstOrNull()
         ?: throw FundingEntityNotFoundException(fundingEntityId)

--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
+import com.terraformation.backend.funder.model.FunderUserModel
 import com.terraformation.backend.funder.model.FundingEntityModel
 import jakarta.inject.Named
 import org.jooq.DSLContext
@@ -20,6 +21,26 @@ class FundingEntityUserStore(private val dslContext: DSLContext) {
   fun fetchEntityByUserId(userId: UserId): FundingEntityModel? {
     requirePermissions { readUser(userId) }
     return findFundingEntityByUserId(userId) { record -> FundingEntityModel.of(record) }
+  }
+
+  fun fetchFundersForEntity(entityId: FundingEntityId): List<FunderUserModel> {
+    requirePermissions { listFundingEntityUsers(entityId) }
+
+    return with(FUNDING_ENTITY_USERS) {
+      dslContext
+          .select(
+              users.ID,
+              users.EMAIL,
+              users.FIRST_NAME,
+              users.LAST_NAME,
+              users.CREATED_TIME,
+              users.AUTH_ID.isNotNull)
+          .from(this)
+          .where(FUNDING_ENTITY_ID.eq(entityId))
+          .and(users.DELETED_TIME.isNull)
+          .orderBy(users.ID)
+          .fetch { FunderUserModel.of(it) }
+    }
   }
 
   private fun <T> findFundingEntityByUserId(userId: UserId, mapper: (Record) -> T): T? {

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FunderUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FunderUserModel.kt
@@ -1,0 +1,33 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
+import java.time.Instant
+import org.jooq.Record
+
+/**
+ * A funder user with external facing information only. This is similar to the FunderUser object,
+ * but without sensitive information such as Auth ID.
+ */
+data class FunderUserModel(
+    val userId: UserId,
+    val email: String,
+    val firstName: String?,
+    val lastName: String?,
+    val createdTime: Instant,
+    val accountCreated: Boolean,
+) {
+  companion object {
+    fun of(record: Record): FunderUserModel {
+      return with(FUNDING_ENTITY_USERS.users) {
+        FunderUserModel(
+            userId = record[ID]!!,
+            email = record[EMAIL]!!,
+            firstName = record[FIRST_NAME],
+            lastName = record[LAST_NAME],
+            createdTime = record[CREATED_TIME]!!,
+            accountCreated = record[AUTH_ID.isNotNull])
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/RunsAsDatabaseUser.kt
+++ b/src/test/kotlin/com/terraformation/backend/RunsAsDatabaseUser.kt
@@ -83,6 +83,7 @@ interface RunsAsDatabaseUser : RunsAsUser {
                     record.cookiesConsentedTime,
                     record.locale,
                     record.timeZone,
+                    PermissionStore(dslContext),
                 )
           }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -80,6 +80,15 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
         permissionStore.fetchGlobalRoles(user.userId))
   }
 
+  @Test
+  fun `fetchFundingEntity returns funding entity`() {
+    assertEquals(null, permissionStore.fetchFundingEntity(user.userId))
+    val fundingEntityId = insertFundingEntity()
+    insertFundingEntityUser(fundingEntityId, user.userId)
+
+    assertEquals(fundingEntityId, permissionStore.fetchFundingEntity(user.userId))
+  }
+
   /**
    * Inserts some test data to exercise the fetch methods. The data set:
    * ```

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -1016,7 +1016,13 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
       val funderUser = userStore.createFunderUser(email)
 
       assertEquals(
-          FunderUser(Instant.EPOCH, funderUser.userId, null, email.lowercase()), funderUser)
+          FunderUser(
+              Instant.EPOCH,
+              funderUser.userId,
+              null,
+              email.lowercase(),
+              permissionStore = permissionStore),
+          funderUser)
 
       assertEquals(UserType.Funder, funderUser.userType)
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -143,7 +143,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(FacilityNotFoundException::class) { canReadFacility(it) }
   private val funderId: UserId by readableId(AccessDeniedException::class) { canReadUser(it) }
   private val fundingEntityId: FundingEntityId by
-      readableId(FundingEntityNotFoundException::class) { canReadFundingEntities() }
+      readableId(FundingEntityNotFoundException::class) { canReadFundingEntity(it) }
   private val moduleId: ModuleId by readableId(ModuleNotFoundException::class) { canReadModule(it) }
   private val monitoringPlotId: MonitoringPlotId by
       readableId(PlotNotFoundException::class) { canReadMonitoringPlot(it) }
@@ -536,6 +536,19 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { listAutomations(facilityId) } ifUser { canListAutomations(facilityId) }
 
   @Test
+  fun listFundingEntityUsers() {
+    assertThrows<FundingEntityNotFoundException> {
+      requirements.listFundingEntityUsers(fundingEntityId)
+    }
+
+    grant { user.canReadFundingEntity(fundingEntityId) }
+    assertThrows<AccessDeniedException> { requirements.listFundingEntityUsers(fundingEntityId) }
+
+    grant { user.canListFundingEntityUsers(fundingEntityId) }
+    requirements.listFundingEntityUsers(fundingEntityId)
+  }
+
+  @Test
   fun listGlobalNotifications() =
       allow { listNotifications(null) } ifUser { canListNotifications(null) }
 
@@ -645,6 +658,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun readFundingEntities() = allow { readFundingEntities() } ifUser { canReadFundingEntities() }
+
+  @Test fun readFundingEntity() = testRead { readFundingEntity(fundingEntityId) }
 
   @Test fun readGlobalRoles() = allow { readGlobalRoles() } ifUser { canReadGlobalRoles() }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2543,8 +2543,8 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(userId, readUser = true)
-
     permissions.expect(deleteSelf = true)
+    permissions.andNothingElse()
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -44,7 +44,9 @@ import com.terraformation.backend.db.default_schema.tables.references.SEED_FUND_
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
 import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES
+import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.docprod.DocumentId
+import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
@@ -171,6 +173,10 @@ internal class PermissionTest : DatabaseTest() {
   private val deliveryIds = plantingSiteIds.map { DeliveryId(it.value) }
   private val plantingIds = plantingSiteIds.map { PlantingId(it.value) }
 
+  private val userFundingEntityId = FundingEntityId(1000)
+  private val otherFundingEntityId = FundingEntityId(2000)
+  private val fundingEntityIds = listOf(userFundingEntityId, otherFundingEntityId)
+
   private val deviceManagerIds = listOf(1000L, 1001L, 2000L).map { DeviceManagerId(it) }
   private val nonConnectedDeviceManagerIds = deviceManagerIds.filterToArray { it.value >= 2000 }
 
@@ -221,6 +227,10 @@ internal class PermissionTest : DatabaseTest() {
 
     userId = insertUser()
     sameOrgUserId = insertUser()
+
+    fundingEntityIds.forEach { entityId ->
+      putDatabaseId(entityId, insertFundingEntity(createdBy = userId, modifiedBy = userId))
+    }
 
     organizationIds.forEach { organizationId ->
       putDatabaseId(organizationId, insertOrganization(createdBy = userId))
@@ -1577,6 +1587,12 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *fundingEntityIds.toTypedArray(),
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
+    )
+
+    permissions.expect(
         *otherUserIds.values.toTypedArray(),
         createEntityWithOwner = true,
         readUser = true,
@@ -1793,6 +1809,12 @@ internal class PermissionTest : DatabaseTest() {
         readUser = true,
         readUserInternalInterests = true,
         updateUserInternalInterests = true,
+    )
+
+    permissions.expect(
+        *fundingEntityIds.toTypedArray(),
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
     )
 
     permissions.expect(
@@ -2044,6 +2066,12 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *fundingEntityIds.toTypedArray(),
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = false,
         addCohortParticipant = true,
         addParticipantProject = true,
@@ -2177,6 +2205,12 @@ internal class PermissionTest : DatabaseTest() {
         updateProjectScores = true,
         updateProjectVotes = true,
         updateSubmissionStatus = true,
+    )
+
+    permissions.expect(
+        *fundingEntityIds.toTypedArray(),
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
     )
 
     // Not an admin of this org but can still access accelerator-related functions.
@@ -2450,6 +2484,12 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
+        *fundingEntityIds.toTypedArray(),
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
+    )
+
+    permissions.expect(
         addAnyOrganizationUser = false,
         addCohortParticipant = false,
         addParticipantProject = false,
@@ -2489,6 +2529,22 @@ internal class PermissionTest : DatabaseTest() {
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.ReadOnly)))
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.SuperAdmin)))
     assertFalse(user.canUpdateSpecificGlobalRoles(setOf(GlobalRole.TFExpert)))
+  }
+
+  @Test
+  fun `funder user has correct privileges`() {
+    val permissions = PermissionsTracker()
+    givenFunder(userFundingEntityId)
+
+    permissions.expect(
+        userFundingEntityId,
+        readFundingEntity = true,
+        listFundingEntityUsers = true,
+    )
+
+    permissions.expect(userId, readUser = true)
+
+    permissions.expect(deleteSelf = true)
   }
 
   @Test
@@ -2549,6 +2605,16 @@ internal class PermissionTest : DatabaseTest() {
     }
   }
 
+  private fun givenFunder(fundingEntityId: FundingEntityId) {
+    dslContext
+        .update(USERS)
+        .set(USERS.USER_TYPE_ID, UserType.Funder)
+        .where(USERS.ID.eq(userId))
+        .execute()
+
+    insertFundingEntityUser(getDatabaseId(fundingEntityId), userId)
+  }
+
   private fun fetchUser(): TerrawareUser {
     val user = userStore.fetchOneById(userId)
     return if (user.userType == UserType.System) {
@@ -2601,6 +2667,7 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedDocuments = documentIds.toMutableSet()
     private val uncheckedDraftPlantingSites = draftPlantingSiteIds.toMutableSet()
     private val uncheckedFacilities = facilityIds.toMutableSet()
+    private val uncheckedFundingEntities = fundingEntityIds.toMutableSet()
     private val uncheckedModuleEvents = moduleEventIds.toMutableSet()
     private val uncheckedModules = moduleIds.toMutableSet()
     private val uncheckedMonitoringPlots = monitoringPlotIds.toMutableSet()
@@ -3669,6 +3736,29 @@ internal class PermissionTest : DatabaseTest() {
           }
     }
 
+    fun expect(
+        vararg fundingEntityIds: FundingEntityId,
+        readFundingEntity: Boolean = false,
+        listFundingEntityUsers: Boolean = false,
+    ) {
+      fundingEntityIds
+          .filter { it in uncheckedFundingEntities }
+          .forEach { entityId ->
+            val idInDatabase = getDatabaseId(entityId)
+
+            assertEquals(
+                readFundingEntity,
+                user.canReadFundingEntity(idInDatabase),
+                "Can read funding entity $entityId")
+            assertEquals(
+                listFundingEntityUsers,
+                user.canListFundingEntityUsers(idInDatabase),
+                "Can list users for funding entity $entityId")
+
+            uncheckedFundingEntities.remove(entityId)
+          }
+    }
+
     fun andNothingElse() {
       expect(*uncheckedAccessions.toTypedArray())
       expect(*uncheckedApplications.toTypedArray())
@@ -3680,6 +3770,7 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedDocuments.toTypedArray())
       expect(*uncheckedDraftPlantingSites.toTypedArray())
       expect(*uncheckedFacilities.toTypedArray())
+      expect(*uncheckedFundingEntities.toTypedArray())
       expect(*uncheckedModuleEvents.toTypedArray())
       expect(*uncheckedModules.toTypedArray())
       expect(*uncheckedMonitoringPlots.toTypedArray())

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1284,6 +1284,8 @@ abstract class DatabaseBackedTest {
       locale: Locale? = null,
       cookiesConsented: Boolean? = null,
       cookiesConsentedTime: Instant? = if (cookiesConsented != null) Instant.EPOCH else null,
+      createdTime: Instant = Instant.EPOCH,
+      deletedTime: Instant? = null,
   ): UserId {
     val insertedId =
         with(USERS) {
@@ -1292,13 +1294,14 @@ abstract class DatabaseBackedTest {
               .set(AUTH_ID, authId)
               .set(COOKIES_CONSENTED, cookiesConsented)
               .set(COOKIES_CONSENTED_TIME, cookiesConsentedTime)
-              .set(CREATED_TIME, Instant.EPOCH)
+              .set(CREATED_TIME, createdTime)
+              .set(DELETED_TIME, deletedTime)
               .set(EMAIL, email)
               .set(EMAIL_NOTIFICATIONS_ENABLED, emailNotificationsEnabled)
               .set(FIRST_NAME, firstName)
               .set(LAST_NAME, lastName)
               .set(LOCALE, locale)
-              .set(MODIFIED_TIME, Instant.EPOCH)
+              .set(MODIFIED_TIME, createdTime)
               .set(TIME_ZONE, timeZone)
               .set(USER_TYPE_ID, type)
               .returning(ID)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3919,8 +3919,8 @@ abstract class DatabaseBackedTest {
       name: String = "TestFundingEntity ${UUID.randomUUID()}",
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
-      modifiedBy: UserId = currentUser().userId,
-      modifiedTime: Instant = Instant.EPOCH,
+      modifiedBy: UserId = createdBy,
+      modifiedTime: Instant = createdTime,
   ): FundingEntityId {
     val row =
         FundingEntitiesRow(

--- a/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/FundingEntityServiceTest.kt
@@ -81,9 +81,11 @@ class FundingEntityServiceTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
 
+    every { user.canReadFundingEntity(any()) } returns true
     every { user.canReadFundingEntities() } returns true
     every { user.canCreateFundingEntities() } returns true
     every { user.canDeleteFundingEntities() } returns true
+    every { user.canListFundingEntityUsers(any()) } returns true
     every { user.canUpdateFundingEntities() } returns true
     every { user.canUpdateFundingEntityProjects() } returns true
     every { user.canDeleteFunder(any()) } returns true


### PR DESCRIPTION
Key changes:
1) New permissions for `readFundingEntity` and `listFundingEntityUsers`
2) New test methods for testing funders permissions
3) New method and models for `fetchFundersForFundingEntity`. New model is to expose only a subset of user data from `FunderUser` similar to `OrganizationUserModel`.
4) Permission store to look up the Funder Entity that a `FunderUser` belongs to.