### PR TITLE
SW-6717 Don't double-count dead plants in moved plots

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
@@ -78,7 +78,13 @@ class ObservationTestHelper(
             claimedBy = effectiveUserId,
             isPermanent = plot.isPermanent,
             monitoringPlotId = plot.plotId)
+      }
+    }
 
+    observationStore.populateCumulativeDead(test.inserted.observationId)
+
+    zones.forEach { zone ->
+      zone.plots.forEach { plot ->
         val recordedPlantsRows =
             plot.plants.flatMap { plant ->
               (List(plant.live) { RecordedPlantStatus.Live } +


### PR DESCRIPTION
If all the permanent monitoring plots from past observations are moved to a
different subzone by a map edit, we were counting their dead plants in both
their new subzone and the original one. Instead, we need to treat the original
subzone as if it's being observed for the first time and not try to carry the
cumulative dead plants total forward from past observations.