### PR TITLE
Return participant projects for species in order

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -165,6 +165,7 @@ class ParticipantProjectSpeciesStore(
             DELIVERABLES.DELIVERABLE_TYPE_ID.eq(DeliverableType.Species))
         .where(SPECIES.ID.eq(speciesId))
         .groupBy(PROJECTS.ID, PARTICIPANT_PROJECT_SPECIES.ID, SPECIES.ID)
+        .orderBy(PROJECTS.ID, PARTICIPANT_PROJECT_SPECIES.ID, SPECIES.ID)
         .fetch { record ->
           if (user.canReadProjectDeliverables(record[PROJECTS.ID]!!)) {
             ParticipantProjectsForSpecies.of(record)


### PR DESCRIPTION
`ParticipantProjectSpeciesStore.fetchParticipantProjectsForSpecies` was returning
results in an undefined order, but its tests were assuming they'd be in a specific
order. Usually that worked, but occasionally the tests would fail if the database
decided to order its query results differently.

Make the query return results in the order expected by the tests.