### PR TITLE
SW-6716 Add areas to site history tables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/HistoriesAreaMigration.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/HistoriesAreaMigration.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_HISTORIES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_HISTORIES
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.differenceNullable
+import jakarta.inject.Named
+import java.math.BigDecimal
+import org.jooq.DSLContext
+import org.jooq.TableField
+import org.locationtech.jts.geom.Geometry
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+
+@Named
+class HistoriesAreaMigration(private val dslContext: DSLContext) {
+  private val log = perClassLogger()
+
+  @EventListener
+  fun populatePlantingSiteHistoriesAreas(event: ApplicationStartedEvent) {
+    with(PLANTING_SITE_HISTORIES) { populateArea(ID, BOUNDARY, AREA_HA, EXCLUSION) }
+    with(PLANTING_ZONE_HISTORIES) {
+      populateArea(ID, BOUNDARY, AREA_HA, plantingSiteHistories.EXCLUSION)
+    }
+    with(PLANTING_SUBZONE_HISTORIES) {
+      populateArea(ID, BOUNDARY, AREA_HA, plantingZoneHistories.plantingSiteHistories.EXCLUSION)
+    }
+  }
+
+  private fun <ID : Any> populateArea(
+      idColumn: TableField<*, ID?>,
+      boundaryColumn: TableField<*, Geometry?>,
+      areaColumn: TableField<*, BigDecimal?>,
+      exclusionColumn: TableField<*, Geometry?>,
+  ) {
+    val tableName = idColumn.table!!.name
+
+    dslContext.transaction { _ ->
+      dslContext
+          .select(idColumn, boundaryColumn.asNonNullable(), exclusionColumn)
+          .from(idColumn.table)
+          .where(areaColumn.isNull)
+          .forUpdate()
+          .skipLocked()
+          .fetch()
+          .also { result ->
+            if (result.isNotEmpty) {
+              log.info("Populating areas for ${result.size} row(s) in $tableName")
+            }
+          }
+          .forEach { (id, boundary, exclusion) ->
+            try {
+              dslContext
+                  .update(idColumn.table)
+                  .set(areaColumn, boundary.differenceNullable(exclusion).calculateAreaHectares())
+                  .where(idColumn.eq(id))
+                  .execute()
+            } catch (e: Exception) {
+              log.error("Unable to populate areas for $tableName row $id", e)
+            }
+          }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/HistoriesAreaMigration.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/HistoriesAreaMigration.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db
 
+import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_HISTORIES
@@ -12,9 +13,11 @@ import java.math.BigDecimal
 import org.jooq.DSLContext
 import org.jooq.TableField
 import org.locationtech.jts.geom.Geometry
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.event.ApplicationStartedEvent
 import org.springframework.context.event.EventListener
 
+@ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
 @Named
 class HistoriesAreaMigration(private val dslContext: DSLContext) {
   private val log = perClassLogger()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -474,6 +474,7 @@ class PlantingSiteStore(
 
     val initialTimeZone = initial.timeZone ?: parentStore.getEffectiveTimeZone(plantingSiteId)
     val editedTimeZone = edited.timeZone ?: parentStore.getEffectiveTimeZone(plantingSiteId)
+    val editedArea = edited.boundary?.calculateAreaHectares()
 
     val now = clock.instant()
 
@@ -490,7 +491,7 @@ class PlantingSiteStore(
             .apply {
               // Boundaries can only be updated on simple planting sites.
               if (initial.plantingZones.isEmpty()) {
-                set(AREA_HA, edited.boundary?.calculateAreaHectares())
+                set(AREA_HA, editedArea)
                 set(BOUNDARY, edited.boundary)
               }
             }
@@ -510,6 +511,7 @@ class PlantingSiteStore(
           !edited.exclusion.equalsOrBothNull(initial.exclusion)) {
         val historiesRecord =
             PlantingSiteHistoriesRecord(
+                    areaHa = editedArea,
                     boundary = edited.boundary,
                     createdBy = currentUser().userId,
                     createdTime = now,
@@ -576,6 +578,7 @@ class PlantingSiteStore(
           with(PLANTING_SITE_HISTORIES) {
             dslContext
                 .insertInto(PLANTING_SITE_HISTORIES)
+                .set(AREA_HA, plantingSiteEdit.desiredModel.areaHa)
                 .set(BOUNDARY, plantingSiteEdit.desiredModel.boundary)
                 .set(CREATED_BY, userId)
                 .set(CREATED_TIME, now)
@@ -2187,6 +2190,7 @@ class PlantingSiteStore(
   ): PlantingSiteHistoryId {
     val historiesRecord =
         PlantingSiteHistoriesRecord(
+                areaHa = newModel.areaHa,
                 boundary = newModel.boundary,
                 createdBy = currentUser().userId,
                 createdTime = now,
@@ -2209,6 +2213,7 @@ class PlantingSiteStore(
   ): PlantingZoneHistoryId {
     val historiesRecord =
         PlantingZoneHistoriesRecord(
+                areaHa = model.areaHa,
                 boundary = model.boundary,
                 name = model.name,
                 plantingSiteHistoryId = plantingSiteHistoryId,
@@ -2229,6 +2234,7 @@ class PlantingSiteStore(
   ): PlantingSubzoneHistoryId {
     val historiesRecord =
         PlantingSubzoneHistoriesRecord(
+                areaHa = model.areaHa,
                 boundary = model.boundary,
                 fullName = model.fullName,
                 name = model.name,

--- a/src/main/resources/db/migration/0350/V364__HistoriesArea.sql
+++ b/src/main/resources/db/migration/0350/V364__HistoriesArea.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tracking.planting_site_histories ADD COLUMN area_ha NUMERIC;
+ALTER TABLE tracking.planting_zone_histories ADD COLUMN area_ha NUMERIC;
+ALTER TABLE tracking.planting_subzone_histories ADD COLUMN area_ha NUMERIC;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1787,6 +1787,7 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertPlantingSiteHistory(
+      areaHa: BigDecimal? = lastPlantingSitesRow.areaHa,
       boundary: Geometry = lastPlantingSitesRow.boundary!!,
       createdBy: UserId = lastPlantingSitesRow.createdBy!!,
       createdTime: Instant = lastPlantingSitesRow.createdTime!!,
@@ -1796,6 +1797,7 @@ abstract class DatabaseBackedTest {
   ): PlantingSiteHistoryId {
     val row =
         PlantingSiteHistoriesRow(
+            areaHa = areaHa,
             boundary = boundary,
             createdBy = createdBy,
             createdTime = createdTime,
@@ -1924,6 +1926,7 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertPlantingZoneHistory(
+      areaHa: BigDecimal? = null,
       boundary: Geometry? = null,
       name: String? = null,
       plantingSiteHistoryId: PlantingSiteHistoryId = inserted.plantingSiteHistoryId,
@@ -1931,6 +1934,7 @@ abstract class DatabaseBackedTest {
   ): PlantingZoneHistoryId {
     val row =
         PlantingZoneHistoriesRow(
+            areaHa = areaHa ?: lastPlantingZonesRow.areaHa,
             boundary = boundary ?: lastPlantingZonesRow.boundary,
             name = name ?: lastPlantingZonesRow.name,
             plantingSiteHistoryId = plantingSiteHistoryId,
@@ -2001,6 +2005,7 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertPlantingSubzoneHistory(
+      areaHa: BigDecimal? = null,
       boundary: Geometry? = null,
       fullName: String? = null,
       name: String? = null,
@@ -2009,6 +2014,7 @@ abstract class DatabaseBackedTest {
   ): PlantingSubzoneHistoryId {
     val row =
         PlantingSubzoneHistoriesRow(
+            areaHa = areaHa ?: lastPlantingSubzonesRow.areaHa,
             boundary = boundary ?: lastPlantingSubzonesRow.boundary,
             fullName = fullName ?: lastPlantingSubzonesRow.fullName,
             name = name ?: lastPlantingSubzonesRow.name,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -841,6 +841,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       assertEquals(2, siteHistories.size, "Number of site history entries")
       assertEquals(
           PlantingSiteHistoriesRow(
+              areaHa = existing.areaHa,
               boundary = existing.boundary,
               createdBy = user.userId,
               createdTime = Instant.EPOCH,
@@ -853,6 +854,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           "Existing site history")
       assertEquals(
           PlantingSiteHistoriesRow(
+              areaHa = edited.areaHa,
               boundary = edited.boundary,
               createdBy = user.userId,
               createdTime = editTime,
@@ -875,10 +877,11 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           edited.plantingZones
               .map { zone ->
                 PlantingZoneHistoriesRow(
+                    areaHa = zone.areaHa,
+                    boundary = zone.boundary,
+                    name = zone.name,
                     plantingSiteHistoryId = editedSiteHistory.id,
                     plantingZoneId = zone.id,
-                    name = zone.name,
-                    boundary = zone.boundary,
                 )
               }
               .toSet(),
@@ -895,11 +898,12 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                 editedZoneHistories.first { it.plantingZoneId == zone.id }.id
             zone.plantingSubzones.map { subzone ->
               PlantingSubzoneHistoriesRecord(
-                  plantingZoneHistoryId = plantingZoneHistoryId,
-                  plantingSubzoneId = subzone.id,
-                  name = subzone.name,
-                  fullName = subzone.fullName,
+                  areaHa = subzone.areaHa,
                   boundary = subzone.boundary,
+                  fullName = subzone.fullName,
+                  name = subzone.name,
+                  plantingSubzoneId = subzone.id,
+                  plantingZoneHistoryId = plantingZoneHistoryId,
               )
             }
           },

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -331,13 +331,14 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
-                  model.historyId,
-                  model.id,
-                  user.userId,
-                  clock.instant,
-                  boundary,
-                  gridOrigin,
-                  exclusion,
+                  areaHa = BigDecimal("2.2"),
+                  boundary = boundary,
+                  createdBy = user.userId,
+                  createdTime = clock.instant,
+                  exclusion = exclusion,
+                  gridOrigin = gridOrigin,
+                  id = model.historyId,
+                  plantingSiteId = model.id,
               ),
           ),
           plantingSiteHistoriesDao.findAll())
@@ -376,6 +377,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSiteHistoriesRow(
+                  areaHa = BigDecimal("4.0"),
                   boundary = siteBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
@@ -392,6 +394,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingZoneHistoriesRow(
+                  areaHa = BigDecimal("4.0"),
                   boundary = zoneBoundary,
                   name = "zone",
                   plantingSiteHistoryId = model.historyId,
@@ -404,6 +407,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           listOf(
               PlantingSubzoneHistoriesRow(
+                  areaHa = BigDecimal("4.0"),
                   boundary = subzoneBoundary,
                   fullName = "zone-subzone",
                   name = "subzone",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -70,18 +70,20 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
       assertEquals(
           setOf(
               PlantingSiteHistoriesRow(
-                  plantingSiteId = initialModel.id,
+                  areaHa = BigDecimal("1.0"),
+                  boundary = initialModel.boundary,
                   createdBy = user.userId,
                   createdTime = createdTime,
-                  boundary = initialModel.boundary,
                   gridOrigin = initialModel.gridOrigin,
+                  plantingSiteId = initialModel.id,
               ),
               PlantingSiteHistoriesRow(
-                  plantingSiteId = initialModel.id,
+                  areaHa = BigDecimal("4.0"),
+                  boundary = newBoundary,
                   createdBy = user.userId,
                   createdTime = clock.instant,
-                  boundary = newBoundary,
                   gridOrigin = initialModel.gridOrigin,
+                  plantingSiteId = initialModel.id,
               ),
           ),
           plantingSiteHistoriesDao.findAll().map { it.copy(id = null) }.toSet(),


### PR DESCRIPTION
Some observation statistics are based on the areas of the site, zones, and
subzones, so we include the area of each region in observation results API
responses. Currently, the areas are based on the current boundaries of the
regions, but for sites whose maps were edited after an observation, the current
areas might not be the same as the areas at the time of observation.

Rather than calculating the areas on the fly at read time, record them at edit
time; the area for a given history entry will never change.

Add a migration to populate the values for existing history rows.