### PR TITLE
SW-6716 Use historical maps in observation results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -847,7 +847,9 @@ data class ObservationPlantingSubzoneResultsPayload(
                 "of monitoring plots.")
     val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
-    val plantingSubzoneId: PlantingSubzoneId,
+    @Schema(
+        description = "ID of the subzone. Absent if the subzone was deleted after the observation.")
+    val plantingSubzoneId: PlantingSubzoneId?,
     val species: List<ObservationSpeciesResultsPayload>,
     @Schema(
         description =
@@ -907,7 +909,8 @@ data class ObservationPlantingZoneResultsPayload(
     val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
     val plantingSubzones: List<ObservationPlantingSubzoneResultsPayload>,
-    val plantingZoneId: PlantingZoneId,
+    @Schema(description = "ID of the zone. Absent if the zone was deleted after the observation.")
+    val plantingZoneId: PlantingZoneId?,
     val species: List<ObservationSpeciesResultsPayload>,
     @Schema(
         description =

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -169,7 +169,7 @@ data class ObservationPlantingSubzoneResultsModel(
     override val plantingCompleted: Boolean,
     override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
-    val plantingSubzoneId: PlantingSubzoneId,
+    val plantingSubzoneId: PlantingSubzoneId?,
     /** List of species result used for this rollup */
     val species: List<ObservationSpeciesResultsModel>,
     /**
@@ -196,7 +196,7 @@ data class ObservationPlantingZoneResultsModel(
     override val plantingDensity: Int,
     override val plantingDensityStdDev: Int?,
     val plantingSubzones: List<ObservationPlantingSubzoneResultsModel>,
-    val plantingZoneId: PlantingZoneId,
+    val plantingZoneId: PlantingZoneId?,
     val species: List<ObservationSpeciesResultsModel>,
     /**
      * Total number of plants recorded. Includes all plants, regardless of live/dead status or

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -2125,7 +2125,7 @@ abstract class DatabaseBackedTest {
     inserted.monitoringPlotIds.add(monitoringPlotId)
 
     if (insertHistory && inserted.plantingSiteHistoryIds.isNotEmpty()) {
-      insertMonitoringPlotHistory()
+      insertMonitoringPlotHistory(plantingSubzoneId = plantingSubzoneId)
     }
 
     return monitoringPlotId


### PR DESCRIPTION
A planting site map edit can cause existing monitoring plots to move between
planting zones or subzones. Previously, the observation results fetching code only
looked at the _current_ location of each monitoring plot, so users looking at
the results of past observations, who expected to see the site map as it existed
at the time of each observation, would see monitoring plots listed under the wrong
zones. Worse, a monitoring plot in a zone that was subsequently deleted from the
site wouldn't show up in the observation details at all.

Change the results fetching logic to use the zone/subzone/plot associations from
the map that was active at the time of the observation.

If a plot was in a subzone that no longer exists, it won't have a subzone ID any
more, but we'll still be able to fetch the name of the subzone (and zone) that
existed during the observation. In that case, the subzone and zone IDs will be
null in the API response; update the response payload definitions accordingly.