### PR TITLE
Use StableId wrapper in API endpoints

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -71,7 +71,7 @@ class ValuesController(
                   "specified more than once to return values for multiple variables. Ignored if " +
                   "variableId is specified.")
       @RequestParam
-      stableId: List<String>? = null,
+      stableId: List<StableId>? = null,
       @Parameter(
           description =
               "If specified, return the value of this variable. May be specified more than once " +
@@ -82,8 +82,7 @@ class ValuesController(
     val currentMax = variableValueStore.fetchMaxValueId(projectId) ?: VariableValueId(0)
     val nextValueId = VariableValueId(currentMax.value + 1)
 
-    val variableIds =
-        variableId ?: stableId?.mapNotNull { variableStore.fetchByStableId(StableId(it))?.id }
+    val variableIds = variableId ?: stableId?.mapNotNull { variableStore.fetchByStableId(it)?.id }
 
     // If the client didn't explicitly tell us otherwise, only return values whose IDs are less
     // than the nextValueId we'll be returning, in case new values are inserted by another user at

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -57,7 +57,7 @@ class VariablesController(
                   "May be specified more than once to return multiple variables. deliverableId " +
                   "and documentId are ignored if this is specified.")
       @RequestParam
-      stableId: List<String>?,
+      stableId: List<StableId>?,
       @Parameter(
           description =
               "If specified, return the definition of a specific variable. May be specified more " +
@@ -74,7 +74,7 @@ class VariablesController(
         if (!variableId.isNullOrEmpty()) {
           variableId.distinct().mapNotNull { variableStore.fetchVariableOrNull(it) }
         } else if (!stableId.isNullOrEmpty()) {
-          stableId.distinct().mapNotNull { variableStore.fetchByStableId(StableId(it)) }
+          stableId.distinct().mapNotNull { variableStore.fetchByStableId(it) }
         } else if (deliverableId != null) {
           variableStore.fetchDeliverableVariables(deliverableId)
         } else if (documentId != null) {
@@ -128,8 +128,8 @@ interface VariablePayload {
   val dependencyValue: String?
     get() = model.dependencyValue
 
-  val dependencyVariableStableId: String?
-    get() = model.dependencyVariableStableId?.value
+  val dependencyVariableStableId: StableId?
+    get() = model.dependencyVariableStableId
 
   val description: String?
     get() = model.description
@@ -158,8 +158,8 @@ interface VariablePayload {
         arraySchema = Schema(description = "IDs of sections that recommend this variable."))
     get() = model.recommendedBy.toSet()
 
-  val stableId: String
-    get() = model.stableId.value
+  val stableId: StableId
+    get() = model.stableId
 
   val type
     get() = model.type

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableId.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableId.kt
@@ -1,3 +1,6 @@
 package com.terraformation.backend.documentproducer.model
 
-data class StableId(val value: String)
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class StableId @JsonCreator constructor(@get:JsonValue val value: String)


### PR DESCRIPTION
Commit afe0ed6 updated the application code to use the `StableId` wrapper class in
more places. Use it in API payloads and request parameters as well.