### PR TITLE
Fix intermittent PlantingZoneModelTest failures

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
 import java.time.Instant
 import kotlin.random.Random
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -509,7 +510,7 @@ class PlantingZoneModelTest {
       }
     }
 
-    @RepeatedTest(20)
+    @RepeatedTest(20, failureThreshold = 1)
     fun `does exhaustive search of sparse map`() {
       // The site is a series of small triangles spread over a large area, plus one square that's
       // big enough to hold a monitoring plot.
@@ -543,9 +544,11 @@ class PlantingZoneModelTest {
       val square = zone.findUnusedSquare(siteOrigin, 30)
       assertNotNull(square, "Unused square")
 
-      if (square!!.intersection(targetArea).area < square.area * 0.99999) {
-        assertEquals(targetArea, square, "Should be contained in hole")
-      }
+      assertThat(square!!.intersection(targetArea).area)
+          .describedAs(
+              "Area of the part of the square that is inside the only region the square should " +
+                  "fit inside")
+          .isGreaterThanOrEqualTo(square.area * 0.999)
     }
   }
 


### PR DESCRIPTION
The assertion that was checking whether a monitoring plot was inside a specific
part of a planting zone map was too strict. We allow plots to fall _slightly_
outside the map boundaries to account for inaccuracy in the geometry calculations.

The test was failing if 0.001% or more of the plot was outside the requested
area, which was stricter than the fuzz factor we allow when searching for plot
locations. Increase the tolerance to 0.1%.

Also change the assertion to produce a more informative error message.