### PR TITLE
SW-6757 Improve Ask Terraware error handling

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
@@ -81,9 +81,12 @@ class AdminAskController(
       showVariables: String?,
       model: Model
   ): String {
-    try {
-      val project = projectStore.fetchOneById(projectId)
+    model.addAttribute("conversationId", conversationId)
+    model.addAttribute("projectId", projectId)
+    model.addAttribute("query", query)
+    model.addAttribute("showVariables", showVariables != null)
 
+    try {
       val answer =
           chatService.askQuestion(projectId, query, conversationId, showVariables != null)
               ?: "No answer received from chat service"
@@ -91,11 +94,8 @@ class AdminAskController(
       val htmlAnswer = HtmlRenderer.builder().build().render(markdownAnswer)
 
       model.addAttribute("answer", htmlAnswer)
-      model.addAttribute("conversationId", conversationId)
-      model.addAttribute("project", project)
-      model.addAttribute("query", query)
-      model.addAttribute("showVariables", showVariables != null)
     } catch (e: Exception) {
+      log.error("Failed to generate answer", e)
       model.addAttribute("failureMessage", e.message)
     }
 

--- a/src/main/resources/templates/admin/ask/chat.html
+++ b/src/main/resources/templates/admin/ask/chat.html
@@ -10,6 +10,10 @@
             color: blue;
             margin-left: 10em;
         }
+        .error {
+            color: red;
+            margin-left: 10em;
+        }
     </style>
 
     <th:block th:fragment="additionalScript">

--- a/src/main/resources/templates/admin/ask/exchange.html
+++ b/src/main/resources/templates/admin/ask/exchange.html
@@ -1,7 +1,8 @@
 <div class="question" th:text="${query}" th:if="${query} != null" />
 <div class="answer" th:utext="${answer}" th:if="${answer} != null" />
+<div class="error" th:text="${failureMessage}" th:if="${failureMessage} != null" />
 
-<form id="queryForm" th:hx-post="|/admin/ask/projects/${project.id}|" hx-swap="outerHTML"
+<form id="queryForm" th:hx-post="|/admin/ask/projects/${projectId}|" hx-swap="outerHTML"
       hx-disabled-elt="input, textarea">
     <label>
         Question (Enter to submit, Shift-Enter for line break):
@@ -9,7 +10,7 @@
         <textarea id="query" rows=4 cols=80 name="query" autofocus></textarea>
     </label>
     <br/>
-    <input type="hidden" name="projectId" th:value="${project.id}"/>
+    <input type="hidden" name="projectId" th:value="${projectId}"/>
     <input type="hidden" name="conversationId" th:value="${conversationId}"/>
     <input id="submitButton" type="submit" value="Submit"/>
     <br/>


### PR DESCRIPTION
If an exception was thrown while trying to generate a chat response, we weren't
logging the original error, and rendering of the response failed because one of
the expected values (`project`) wasn't being passed to the template.

Improve this in a few ways:

* Add logging of the original error.
* Always supply the template with the values that don't depend on a successful
  interaction with the chat service.
* Show the error message in the UI.