### PR TITLE
SW-6755 Added funder report tables

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -50,7 +50,7 @@ val ENUM_TABLES =
                         "report_standard_metrics\\.status_id",
                         "report_system_metrics\\.status_id",
                     )),
-                EnumTable("report_quarters", listOf("reports\\.report_quarter_id")),
+                EnumTable("report_quarters"),
                 EnumTable("report_statuses", listOf("reports\\.status_id")),
                 EnumTable("score_categories", isLocalizable = false),
                 EnumTable("submission_statuses"),
@@ -252,7 +252,11 @@ val ID_WRAPPERS =
                     listOf("project_report_configs\\.id", ".*\\.config_id")),
                 IdWrapper(
                     "ReportId",
-                    listOf("accelerator\\.reports\\.id", "accelerator\\..*\\.report_id")),
+                    listOf(
+                        "accelerator\\.reports\\.id",
+                        "accelerator\\..*\\.report_id",
+                        "funder\\.funder_reports\\.id",
+                        "funder\\..*\\.report_id")),
                 IdWrapper(
                     "StandardMetricId", listOf("standard_metrics\\.id", ".*\\.standard_metric_id")),
                 IdWrapper("SubmissionDocumentId", listOf("submission_documents\\.id")),

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -255,7 +255,6 @@ val ID_WRAPPERS =
                     listOf(
                         "accelerator\\.reports\\.id",
                         "accelerator\\..*\\.report_id",
-                        "funder\\.funder_reports\\.id",
                         "funder\\..*\\.report_id")),
                 IdWrapper(
                     "StandardMetricId", listOf("standard_metrics\\.id", ".*\\.standard_metric_id")),

--- a/src/main/resources/db/migration/0350/V367__FunderReports.sql
+++ b/src/main/resources/db/migration/0350/V367__FunderReports.sql
@@ -6,10 +6,8 @@ CREATE TABLE funder.funder_reports (
     start_date DATE NOT NULL,
     end_date DATE NOT NULL CHECK (end_date > start_date),
     highlights TEXT,
-    created_by BIGINT NOT NULL REFERENCES users,
-    created_time TIMESTAMP WITH TIME ZONE NOT NULL,
-    modified_by BIGINT NOT NULL REFERENCES users,
-    modified_time TIMESTAMP WITH TIME ZONE NOT NULL
+    published_by BIGINT NOT NULL REFERENCES users,
+    published_time TIMESTAMP WITH TIME ZONE NOT NULL
 );
 CREATE INDEX ON funder.funder_reports(project_id);
 

--- a/src/main/resources/db/migration/0350/V367__FunderReports.sql
+++ b/src/main/resources/db/migration/0350/V367__FunderReports.sql
@@ -1,0 +1,59 @@
+CREATE TABLE funder.funder_reports (
+    report_id BIGINT PRIMARY KEY REFERENCES accelerator.reports,
+    project_id BIGINT NOT NULL REFERENCES projects ON DELETE CASCADE,
+    report_frequency_id INTEGER NOT NULL REFERENCES accelerator.report_frequencies,
+    report_quarter_id INTEGER REFERENCES accelerator.report_quarters,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL CHECK (end_date > start_date),
+    highlights TEXT,
+    created_by BIGINT NOT NULL REFERENCES users,
+    created_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    modified_by BIGINT NOT NULL REFERENCES users,
+    modified_time TIMESTAMP WITH TIME ZONE NOT NULL
+);
+CREATE INDEX ON funder.funder_reports(project_id);
+
+CREATE TABLE funder.funder_report_achievements(
+    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+    position INT NOT NULL CHECK (position >= 0),
+    achievement TEXT NOT NULL,
+    PRIMARY KEY (report_id, position)
+);
+
+CREATE TABLE funder.funder_report_challenges(
+    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+    position INT NOT NULL CHECK (position >= 0),
+    challenge TEXT NOT NULL,
+    mitigation_plan TEXT NOT NULL,
+    PRIMARY KEY (report_id, position)
+);
+
+CREATE TABLE funder.funder_report_project_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+    project_metric_id BIGINT NOT NULL REFERENCES accelerator.project_metrics,
+    target INTEGER,
+    value INTEGER,
+    underperformance_justification TEXT,
+
+    PRIMARY KEY (report_id, project_metric_id)
+);
+
+CREATE TABLE funder.funder_report_standard_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+    standard_metric_id BIGINT NOT NULL REFERENCES accelerator.standard_metrics,
+    target INTEGER,
+    value INTEGER,
+    underperformance_justification TEXT,
+
+    PRIMARY KEY (report_id, standard_metric_id)
+);
+
+CREATE TABLE funder.funder_report_system_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+    system_metric_id INTEGER NOT NULL REFERENCES accelerator.system_metrics,
+    target INTEGER,
+    value INTEGER,
+    underperformance_justification TEXT,
+
+    PRIMARY KEY (report_id, system_metric_id)
+);

--- a/src/main/resources/db/migration/0350/V367__FunderReports.sql
+++ b/src/main/resources/db/migration/0350/V367__FunderReports.sql
@@ -1,5 +1,5 @@
-CREATE TABLE funder.funder_reports (
-    report_id BIGINT PRIMARY KEY REFERENCES accelerator.reports,
+CREATE TABLE funder.published_reports (
+    report_id BIGINT PRIMARY KEY REFERENCES accelerator.reports ON DELETE CASCADE,
     project_id BIGINT NOT NULL REFERENCES projects ON DELETE CASCADE,
     report_frequency_id INTEGER NOT NULL REFERENCES accelerator.report_frequencies,
     report_quarter_id INTEGER REFERENCES accelerator.report_quarters,
@@ -9,25 +9,25 @@ CREATE TABLE funder.funder_reports (
     published_by BIGINT NOT NULL REFERENCES users,
     published_time TIMESTAMP WITH TIME ZONE NOT NULL
 );
-CREATE INDEX ON funder.funder_reports(project_id);
+CREATE INDEX ON funder.published_reports(project_id);
 
-CREATE TABLE funder.funder_report_achievements(
-    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+CREATE TABLE funder.published_report_achievements(
+    report_id BIGINT NOT NULL REFERENCES funder.published_reports ON DELETE CASCADE,
     position INT NOT NULL CHECK (position >= 0),
     achievement TEXT NOT NULL,
     PRIMARY KEY (report_id, position)
 );
 
-CREATE TABLE funder.funder_report_challenges(
-    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+CREATE TABLE funder.published_report_challenges(
+    report_id BIGINT NOT NULL REFERENCES funder.published_reports ON DELETE CASCADE,
     position INT NOT NULL CHECK (position >= 0),
     challenge TEXT NOT NULL,
     mitigation_plan TEXT NOT NULL,
     PRIMARY KEY (report_id, position)
 );
 
-CREATE TABLE funder.funder_report_project_metrics(
-    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+CREATE TABLE funder.published_report_project_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.published_reports ON DELETE CASCADE,
     project_metric_id BIGINT NOT NULL REFERENCES accelerator.project_metrics,
     target INTEGER,
     value INTEGER,
@@ -36,8 +36,8 @@ CREATE TABLE funder.funder_report_project_metrics(
     PRIMARY KEY (report_id, project_metric_id)
 );
 
-CREATE TABLE funder.funder_report_standard_metrics(
-    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+CREATE TABLE funder.published_report_standard_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.published_reports ON DELETE CASCADE,
     standard_metric_id BIGINT NOT NULL REFERENCES accelerator.standard_metrics,
     target INTEGER,
     value INTEGER,
@@ -46,8 +46,8 @@ CREATE TABLE funder.funder_report_standard_metrics(
     PRIMARY KEY (report_id, standard_metric_id)
 );
 
-CREATE TABLE funder.funder_report_system_metrics(
-    report_id BIGINT NOT NULL REFERENCES funder.funder_reports ON DELETE CASCADE,
+CREATE TABLE funder.published_report_system_metrics(
+    report_id BIGINT NOT NULL REFERENCES funder.published_reports ON DELETE CASCADE,
     system_metric_id INTEGER NOT NULL REFERENCES accelerator.system_metrics,
     target INTEGER,
     value INTEGER,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -740,4 +740,16 @@ COMMENT ON TABLE funder.funding_entities IS 'Top-level information about Funding
 COMMENT ON TABLE funder.funding_entity_projects IS 'Which funding entities are associated with which projects.';
 COMMENT ON TABLE funder.funding_entity_users IS 'Funding Entity membership.';
 
+COMMENT ON TABLE funder.published_report_achievements IS 'Achievements of published reports.';
+
+COMMENT ON TABLE funder.published_report_challenges IS 'Challenges and mitigation plans of published reports.';
+
+COMMENT ON TABLE funder.published_report_project_metrics IS 'Project-specific metrics of published reports.';
+
+COMMENT ON TABLE funder.published_report_standard_metrics IS 'Standard metrics of published reports.';
+
+COMMENT ON TABLE funder.published_report_system_metrics IS 'System metrics of published reports.';
+
+COMMENT ON TABLE funder.published_reports IS 'Published reports visible to funders.';
+
 -- When adding new tables, put them in alphabetical (ASCII) order.

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -228,6 +228,12 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "funding_entities" to setOf(ALL, FUNDER),
                   "funding_entity_users" to setOf(ALL, FUNDER),
                   "funding_entity_projects" to setOf(ALL, FUNDER),
+                  "published_reports" to setOf(ALL, FUNDER),
+                  "published_report_achievements" to setOf(ALL, FUNDER),
+                  "published_report_challenges" to setOf(ALL, FUNDER),
+                  "published_report_project_metrics" to setOf(ALL, FUNDER),
+                  "published_report_standard_metrics" to setOf(ALL, FUNDER),
+                  "published_report_system_metrics" to setOf(ALL, FUNDER),
               ),
           "nursery" to
               mapOf(

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -228,12 +228,12 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "funding_entities" to setOf(ALL, FUNDER),
                   "funding_entity_users" to setOf(ALL, FUNDER),
                   "funding_entity_projects" to setOf(ALL, FUNDER),
-                  "published_reports" to setOf(ALL, FUNDER),
                   "published_report_achievements" to setOf(ALL, FUNDER),
                   "published_report_challenges" to setOf(ALL, FUNDER),
                   "published_report_project_metrics" to setOf(ALL, FUNDER),
                   "published_report_standard_metrics" to setOf(ALL, FUNDER),
                   "published_report_system_metrics" to setOf(ALL, FUNDER),
+                  "published_reports" to setOf(ALL, FUNDER),
               ),
           "nursery" to
               mapOf(


### PR DESCRIPTION
These tables are mostly just copied over from the accelerator reports, with some minor changes:

1) Metric `progress_notes` are removed since they are internal only.
2) Report config details are removed
3) Report submission time is removed
4) For system metrics, only one `value` is shown, instead of having both system and override values. Only one gets published, with priority given to `overriden_value` first.

Some intended use cases of these columns:
1) `modified_time` can be used to check when the report was last published, if the accelerator report equivalent has a later `modified_time`, we can use that to determine that data may have been updated since it was last published. However, this does not account for whether the changes are external facing yet.
2) The same `report_id` gets reused and referenced. Since accelerator reports and published reports are strictly 1:1 for now, we don't need a separate ID. 