### PR TITLE
SW-6242 Make biomass observation enums localizable

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -204,17 +204,12 @@ val ENUM_TABLES =
                     "biomass_forest_types", listOf("observation_biomass_details\\.forest_type_id")),
                 EnumTable("mangrove_tides", listOf("observation_biomass_details\\.tide_id")),
                 EnumTable(
-                    "observable_conditions",
-                    listOf("observation_plot_conditions\\.condition_id"),
-                    isLocalizable = false),
+                    "observable_conditions", listOf("observation_plot_conditions\\.condition_id")),
                 EnumTable(
                     "observation_photo_types",
                     listOf("observation_photos\\.type_id"),
                     isLocalizable = false),
-                EnumTable(
-                    "observation_plot_positions",
-                    listOf("tracking\\..*\\.position_id"),
-                    isLocalizable = false),
+                EnumTable("observation_plot_positions", listOf("tracking\\..*\\.position_id")),
                 EnumTable(
                     "observation_plot_statuses",
                     listOf("observation_plots\\.status_id"),

--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -345,6 +345,17 @@ tracking.BiomassForestType.Terrestrial=Terrestrial
 tracking.MangroveTide.High=High
 # As in "low tide"
 tracking.MangroveTide.Low=Low
+tracking.ObservableCondition.AnimalDamage=Animal Damage
+tracking.ObservableCondition.FastGrowth=Fast Growth
+tracking.ObservableCondition.FavorableWeather=Favorable Weather
+tracking.ObservableCondition.Fungus=Fungus
+tracking.ObservableCondition.Pests=Pests
+tracking.ObservableCondition.SeedProduction=Seed Production
+tracking.ObservableCondition.UnfavorableWeather=Unfavorable Weather
+tracking.ObservationPlotPosition.NortheastCorner=Northeast
+tracking.ObservationPlotPosition.NorthwestCorner=Northwest
+tracking.ObservationPlotPosition.SoutheastCorner=Southeast
+tracking.ObservationPlotPosition.SouthwestCorner=Southwest
 tracking.ObservationType.BiomassMeasurements=Biomass Measurements
 tracking.ObservationType.Monitoring=Monitoring
 tracking.PlantingType.Delivery=Delivery


### PR DESCRIPTION
In preparation for supporting CSV export of biomass observation data, make a
couple of the enums localizable so their human-readable values will appear in
the exported CSV files.