### PR TITLE
SW-6530 Rename PlantingSiteEditCalculatorV2

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -30,7 +30,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.ShapefilesInvalidException
 import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
-import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorV2
+import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculator
 import com.terraformation.backend.tracking.edit.PlantingSubzoneEdit
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
 import com.terraformation.backend.tracking.mapbox.MapboxService
@@ -471,7 +471,7 @@ class AdminPlantingSitesController(
                 existing.organizationId,
             )
 
-        val calculator = PlantingSiteEditCalculatorV2(existing, desired)
+        val calculator = PlantingSiteEditCalculator(existing, desired)
 
         val edit = calculator.calculateSiteEdit()
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -18,7 +18,7 @@ import kotlin.math.min
 import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.MultiPolygon
 
-class PlantingSiteEditCalculatorV2(
+class PlantingSiteEditCalculator(
     private val existingSite: ExistingPlantingSiteModel,
     private val desiredSite: AnyPlantingSiteModel,
 ) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -13,8 +13,8 @@ import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
 import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
-import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorV2
-import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorV2Test
+import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculator
+import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorTest
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
 import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
@@ -38,8 +38,8 @@ import org.springframework.security.access.AccessDeniedException
 
 /**
  * Tests for applying edit operations to planting sites. Most of these tests don't manually
- * construct [PlantingSiteEdit] objects, but instead use [PlantingSiteEditCalculatorV2] and rely on
- * the coverage in [PlantingSiteEditCalculatorV2Test] to verify that the calculated edits would be
+ * construct [PlantingSiteEdit] objects, but instead use [PlantingSiteEditCalculator] and rely on
+ * the coverage in [PlantingSiteEditCalculatorTest] to verify that the calculated edits would be
  * correct.
  */
 internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
@@ -559,7 +559,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
         existing: ExistingPlantingSiteModel,
         desired: AnyPlantingSiteModel,
     ): PlantingSiteEdit {
-      val calculator = PlantingSiteEditCalculatorV2(existing, desired)
+      val calculator = PlantingSiteEditCalculator(existing, desired)
       return calculator.calculateSiteEdit()
     }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
 
-class PlantingSiteEditCalculatorV2Test {
+class PlantingSiteEditCalculatorTest {
   @Test
   fun `returns create edits for newly added zone and subzone`() {
     val existing = existingSite(width = 500) { zone(numPermanent = 1) { subzone { cluster() } } }
@@ -955,7 +955,7 @@ class PlantingSiteEditCalculatorV2Test {
     @Test
     fun `throws exception if desired site has no boundary`() {
       assertThrows<IllegalArgumentException> {
-        PlantingSiteEditCalculatorV2(
+        PlantingSiteEditCalculator(
                 existingSite(),
                 newSite().copy(boundary = null),
             )
@@ -966,7 +966,7 @@ class PlantingSiteEditCalculatorV2Test {
     @Test
     fun `throws exception if a subzone move is ambiguous`() {
       assertThrows<IllegalArgumentException> {
-        PlantingSiteEditCalculatorV2(
+        PlantingSiteEditCalculator(
                 existingSite {
                   zone {
                     subzone(name = "A")
@@ -986,7 +986,7 @@ class PlantingSiteEditCalculatorV2Test {
   private fun calculateSiteEdit(
       existing: ExistingPlantingSiteModel,
       desired: AnyPlantingSiteModel,
-  ): PlantingSiteEdit = PlantingSiteEditCalculatorV2(existing, desired).calculateSiteEdit()
+  ): PlantingSiteEdit = PlantingSiteEditCalculator(existing, desired).calculateSiteEdit()
 
   private fun assertEditResult(
       expected: PlantingSiteEdit,


### PR DESCRIPTION
Since there are no longer multiple versions of the planting site edit calculator,
there's no need for a V2 suffix on its name.