### PR TITLE
SW-6242 Don't differentiate trees and trunks in CSV

### DIFF
--- a/src/main/resources/i18n/Enums_en.properties
+++ b/src/main/resources/i18n/Enums_en.properties
@@ -364,4 +364,5 @@ tracking.PlantingType.ReassignmentTo=Reassignment To
 tracking.PlantingType.Undo=Undo
 tracking.TreeGrowthForm.Shrub=Shrub
 tracking.TreeGrowthForm.Tree=Tree
-tracking.TreeGrowthForm.Trunk=Trunk
+# This should use the word for "Tree", not for "Trunk" like the string's key implies.
+tracking.TreeGrowthForm.Trunk=Tree

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -197,6 +197,16 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         heightM = BigDecimal("13.1"),
         pointOfMeasurementM = BigDecimal("1.3"),
         treeGrowthForm = TreeGrowthForm.Tree,
+        treeNumber = 1,
+    )
+    insertRecordedTree(
+        description = "Trunk description",
+        diameterAtBreastHeightCm = BigDecimal("25.7"),
+        heightM = BigDecimal("10.2"),
+        pointOfMeasurementM = BigDecimal("1.3"),
+        treeGrowthForm = TreeGrowthForm.Trunk,
+        treeNumber = 1,
+        trunkNumber = 2,
     )
     insertObservationBiomassQuadratSpecies(
         abundancePercent = 33,
@@ -347,7 +357,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                     "description" to "Biomass description",
                                                     "forestType" to "Mangrove",
                                                     "herbaceousCoverPercent" to "33",
-                                                    "numPlants" to "1",
+                                                    "numPlants" to "2",
                                                     "numSpecies" to "1",
                                                     "ph" to "0.8",
                                                     "salinity" to "15",
@@ -396,6 +406,16 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
                                                         "pointOfMeasurement" to "1.3",
                                                         "treeNumber" to "1",
                                                         "trunkNumber" to "1",
+                                                    ),
+                                                    mapOf(
+                                                        "description" to "Trunk description",
+                                                        "diameterAtBreastHeight" to "25.7",
+                                                        "growthForm" to "Tree",
+                                                        "height" to "10.2",
+                                                        "isDead" to "false",
+                                                        "pointOfMeasurement" to "1.3",
+                                                        "treeNumber" to "1",
+                                                        "trunkNumber" to "2",
                                                     ),
                                                 ),
                                         ),


### PR DESCRIPTION
The web app displays the same growth form (`Tree`) for both recorded trees and
recorded trunks. Update the localized strings for the enum so the CSV export
does the same thing.