### PR TITLE
SW-6694 Convert simple planting sites to detailed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -59,6 +59,8 @@ class AdminController(
         currentUser().canManageModules() || currentUser().canManageDeliverables())
     model.addAttribute("canManageInternalTags", currentUser().canManageInternalTags())
     model.addAttribute("canManageParticipants", currentUser().canCreateParticipant())
+    model.addAttribute(
+        "canMigrateSimplePlantingSites", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canReadCohorts", currentUser().canReadCohorts())
     model.addAttribute(
         "canRecalculateMortalityRates", GlobalRole.SuperAdmin in currentUser().globalRoles)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -735,14 +735,23 @@ class AdminPlantingSitesController(
   @PostMapping("/migrateSimplePlantingSites")
   @RequireGlobalRole([GlobalRole.SuperAdmin])
   fun migrateSimplePlantingSites(redirectAttributes: RedirectAttributes): String {
+    val successDetails = mutableListOf<String>()
+    val failureDetails = mutableListOf<String>()
+
     try {
       systemUser.run {
-        redirectAttributes.successDetails = plantingSiteStore.migrateSimplePlantingSites()
+        plantingSiteStore.migrateSimplePlantingSites(successDetails::add, failureDetails::add)
+        redirectAttributes.successMessage = "Successfully migrated planting sites"
+        redirectAttributes.successDetails = successDetails
       }
-      redirectAttributes.successMessage = "Successfully migrated simple planting sites"
+
+      if (failureDetails.isNotEmpty()) {
+        redirectAttributes.failureMessage = "Failed to migrate some planting sites"
+        redirectAttributes.failureDetails = failureDetails
+      }
     } catch (e: Exception) {
       log.error("Failed to migrate simple planting sites", e)
-      redirectAttributes.failureMessage = "Failed to migrate simple planting sites: ${e.message}"
+      redirectAttributes.failureMessage = "Failed to migrate planting sites: ${e.message}"
     }
 
     return redirectToAdminHome()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -89,8 +89,10 @@ import com.terraformation.backend.tracking.model.ReplacementResult
 import com.terraformation.backend.tracking.model.UpdatedPlantingSeasonModel
 import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.calculateAreaHectares
+import com.terraformation.backend.util.equalsIgnoreScale
 import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.toInstant
+import com.terraformation.backend.util.toMultiPolygon
 import jakarta.inject.Named
 import java.math.BigDecimal
 import java.time.Instant
@@ -1667,6 +1669,93 @@ class PlantingSiteStore(
         monitoringPlotsRow.id!!
       }
     }
+  }
+
+  fun migrateSimplePlantingSites(): List<String> {
+    // These are the names we use in terraware-web when creating a new planting site without
+    // specifying zones or subzones. They are not translated into the user's language.
+    val zoneName = "Zone 01"
+    val subzoneName = "Subzone A"
+
+    val messages = mutableListOf<String>()
+
+    dslContext.transaction { _ ->
+      val simplePlantingSiteIds =
+          dslContext
+              .select(PLANTING_SITES.ID)
+              .distinctOn(PLANTING_SITES.ID)
+              .from(PLANTING_SITES)
+              .where(PLANTING_SITES.BOUNDARY.isNotNull)
+              .andNotExists(
+                  DSL.selectOne()
+                      .from(PLANTING_ZONES)
+                      .where(PLANTING_ZONES.PLANTING_SITE_ID.eq(PLANTING_SITES.ID)))
+              .orderBy(PLANTING_SITES.ID)
+              .fetch(PLANTING_SITES.ID.asNonNullable())
+
+      for (siteId in simplePlantingSiteIds) {
+        try {
+          val now = clock.instant()
+
+          log.info("Migrating simple planting site $siteId to detailed")
+
+          val existingSite = fetchSiteById(siteId, PlantingSiteDepth.Site)
+          val boundary = existingSite.boundary!!.toMultiPolygon()
+
+          // This calculates the grid origin and area.
+          val newSite =
+              NewPlantingSiteModel.create(
+                  boundary,
+                  existingSite.description,
+                  name = existingSite.name,
+                  organizationId = existingSite.organizationId,
+              )
+
+          if (newSite.areaHa == null || newSite.areaHa.equalsIgnoreScale(BigDecimal.ZERO)) {
+            messages.add("Planting site $siteId (${existingSite.name}) area too small to convert")
+            continue
+          }
+
+          val zone =
+              NewPlantingZoneModel.create(
+                  boundary = boundary,
+                  name = zoneName,
+                  plantingSubzones = emptyList(),
+              )
+          val subzone =
+              NewPlantingSubzoneModel.create(
+                  boundary = boundary,
+                  fullName = "$zoneName-$subzoneName",
+                  name = subzoneName,
+              )
+
+          with(PLANTING_SITES) {
+            dslContext
+                .update(PLANTING_SITES)
+                .set(AREA_HA, newSite.areaHa)
+                .set(GRID_ORIGIN, newSite.gridOrigin)
+                .set(MODIFIED_BY, currentUser().userId)
+                .set(MODIFIED_TIME, now)
+                .where(ID.eq(siteId))
+                .execute()
+          }
+
+          val siteHistoryId = insertPlantingSiteHistory(newSite, newSite.gridOrigin!!, now, siteId)
+          val zoneId = createPlantingZone(zone, siteId)
+          val zoneHistoryId = insertPlantingZoneHistory(zone, siteHistoryId, zoneId)
+          val subzoneId = createPlantingSubzone(subzone, siteId, zoneId)
+          insertPlantingSubzoneHistory(subzone, zoneHistoryId, subzoneId)
+
+          messages.add("Migrated planting site $siteId (${existingSite.name})")
+        } catch (e: Exception) {
+          log.error("Unable to migrate planting site $siteId", e)
+          messages.add("Unable to migrate planting site $siteId: ${e.message}")
+          break
+        }
+      }
+    }
+
+    return messages
   }
 
   private val plantingSeasonsMultiset =

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -174,6 +174,21 @@
 <details id="migrations" class="section">
     <summary>Migrations</summary>
 
+    <th:block th:if="${canMigrateSimplePlantingSites}">
+        <h3>Migrate Simple Planting Sites</h3>
+
+        <p>
+            This adds a zone and a subzone to each planting site that has a site boundary but
+            doesn't have zones or subzones, converting it to a detailed planting site. Planting
+            sites that don't have site boundaries, or have boundaries of 0.05 hectares or less,
+            aren't affected by this migration.
+        </p>
+
+        <form method="POST" action="/admin/migrateSimplePlantingSites">
+            <input type="submit" value="Migrate Simple Planting Sites" />
+        </form>
+    </th:block>
+
     <th:block th:if="${canRecalculateMortalityRates}">
         <h3>Recalculate Mortality Rates</h3>
 


### PR DESCRIPTION
Add a manual migration to the admin UI to add zones and subzones to planting
sites that don't have them. This will allow users to schedule observations of
sites they created as simple planting sites.

There is still a way to create simple planting sites in the web app; we'll need
to run the migration again once that's removed, at which point the migration can
go away.