### PR TITLE
Fix incorrect HTML tag closure in notification email

### DIFF
--- a/src/main/resources/templates/email/acceleratorReport/submitted/body.ftlh.mjml
+++ b/src/main/resources/templates/email/acceleratorReport/submitted/body.ftlh.mjml
@@ -5,7 +5,7 @@
         <mj-include path="../../logo.ftlh.mjml"/>
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
-                <mj-text mj-class="text-headline06-bold">
+                <mj-text mj-class="text-headline06-bold"
                          padding-right="0px">
                     ${strings("notification.acceleratorReport.submitted.email.body", projectDealName, reportPrefix)}
                 </mj-text>

--- a/src/main/resources/templates/email/acceleratorReport/upcoming/body.ftlh.mjml
+++ b/src/main/resources/templates/email/acceleratorReport/upcoming/body.ftlh.mjml
@@ -6,7 +6,7 @@
         <mj-include path="../../logo.ftlh.mjml"/>
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
-                <mj-text mj-class="text-headline06-bold">
+                <mj-text mj-class="text-headline06-bold"
                          padding-right="0px">
                     ${strings("notification.acceleratorReport.upcoming.email.body", reportPrefix)}
                 </mj-text>


### PR DESCRIPTION
Two of the HTML email notifications had double `>` characters in tags, which
caused the attribute after the first `>` to show up as human-readable text in the
email messages.