### PR TITLE
Reduce variable fetches

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
@@ -56,15 +56,16 @@ class AcceleratorProjectVariableValuesService(
   }
 
   private val variablesById: Map<VariableId, Variable> by lazy {
-    projectAcceleratorVariablesStableIds
-        .mapNotNull {
-          val variable = variableStore.fetchByStableId(it)
-          if (variable == null) {
-            log.warn("Variable with stableId=${it.value} not found")
-          }
-          variable
-        }
-        .associateBy { it.id }
+    val variables = variableStore.fetchListByStableIds(projectAcceleratorVariablesStableIds)
+
+    val fetchedStableIds = variables.map { it.stableId }.toSet()
+    val missingStableIds = projectAcceleratorVariablesStableIds.filter { it !in fetchedStableIds }
+
+    if (missingStableIds.isNotEmpty()) {
+      log.warn("Variables with stableIds in: $missingStableIds not found")
+    }
+
+    variables.associateBy { it.id }
   }
 
   private val variablesByStableId: Map<StableId, Variable> by lazy {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -132,7 +132,7 @@ class VariableStore(
       with(VARIABLES) {
         dslContext
             .select(ID)
-            .on(STABLE_ID)
+            .distinctOn(STABLE_ID)
             .from(VARIABLES)
             .where(STABLE_ID.`in`(stableIds))
             .orderBy(STABLE_ID, ID.desc())

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -128,6 +128,23 @@ class VariableStore(
             ?.let { fetchVariableOrNull(it) }
       }
 
+  fun fetchListByStableIds(stableIds: List<StableId>): List<Variable> =
+      with(VARIABLES) {
+        dslContext
+            .select(ID)
+            .from(VARIABLES)
+            .where(STABLE_ID.`in`(stableIds))
+            .and(
+                ID.notIn(
+                    dslContext
+                        .select(REPLACES_VARIABLE_ID)
+                        .from(VARIABLES)
+                        .where(REPLACES_VARIABLE_ID.isNotNull())))
+            .fetch(ID)
+            .filterNotNull()
+            .mapNotNull { fetchVariableOrNull(it) }
+      }
+
   fun fetchDeliverableVariables(deliverableId: DeliverableId): List<Variable> {
     val replacementVariables = VARIABLES.`as`("replacement_variables")
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -132,16 +132,11 @@ class VariableStore(
       with(VARIABLES) {
         dslContext
             .select(ID)
+            .on(STABLE_ID)
             .from(VARIABLES)
             .where(STABLE_ID.`in`(stableIds))
-            .and(
-                ID.notIn(
-                    dslContext
-                        .select(REPLACES_VARIABLE_ID)
-                        .from(VARIABLES)
-                        .where(REPLACES_VARIABLE_ID.isNotNull())))
-            .fetch(ID)
-            .filterNotNull()
+            .orderBy(STABLE_ID, ID.desc())
+            .fetch(ID.asNonNullable())
             .mapNotNull { fetchVariableOrNull(it) }
       }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -98,6 +98,107 @@ class VariableStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Nested
+  inner class FetchListByStableIds {
+    @Test
+    fun `fetches the correct variables for a given list of stable IDs`() {
+      val variableName1 = "Variable 1"
+      val variableName2 = "Variable 2"
+      val variableName3 = "Variable 3"
+      val stableId1 = "1"
+      val stableId2 = "2"
+      val stableId3 = "3"
+
+      val variableId1 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName1, stableId = stableId1, type = VariableType.Number))
+      val variableId2 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName1,
+                  stableId = stableId1,
+                  type = VariableType.Number,
+                  replacesVariableId = variableId1))
+      val variableId3 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName1,
+                  stableId = stableId1,
+                  type = VariableType.Number,
+                  replacesVariableId = variableId2))
+
+      val variableId4 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName2, stableId = stableId2, type = VariableType.Number))
+      val variableId5 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName2,
+                  stableId = stableId2,
+                  type = VariableType.Number,
+                  replacesVariableId = variableId4))
+
+      val variableId6 =
+          insertNumberVariable(
+              insertVariable(
+                  name = variableName3, stableId = stableId3, type = VariableType.Number))
+
+      val expected =
+          listOf(
+              NumberVariable(
+                  base =
+                      BaseVariableProperties(
+                          id = variableId3,
+                          isRequired = false,
+                          manifestId = null,
+                          name = variableName1,
+                          position = 0,
+                          replacesVariableId = variableId2,
+                          stableId = StableId(stableId1),
+                      ),
+                  decimalPlaces = null,
+                  minValue = null,
+                  maxValue = null),
+              NumberVariable(
+                  base =
+                      BaseVariableProperties(
+                          id = variableId5,
+                          isRequired = false,
+                          manifestId = null,
+                          name = variableName2,
+                          position = 0,
+                          replacesVariableId = variableId4,
+                          stableId = StableId(stableId2),
+                      ),
+                  decimalPlaces = null,
+                  minValue = null,
+                  maxValue = null),
+              NumberVariable(
+                  base =
+                      BaseVariableProperties(
+                          id = variableId6,
+                          isRequired = false,
+                          manifestId = null,
+                          name = variableName3,
+                          position = 0,
+                          replacesVariableId = null,
+                          stableId = StableId(stableId3),
+                      ),
+                  decimalPlaces = null,
+                  minValue = null,
+                  maxValue = null),
+          )
+
+      val actual =
+          store.fetchListByStableIds(
+              listOf(StableId(stableId1), StableId(stableId2), StableId(stableId3)))
+
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Nested
   inner class FetchVariable {
     @Test
     fun `fetches nested sections`() {


### PR DESCRIPTION
Reduce calls for each of `projectAcceleratorVariablesStableIds` to one call to the VariableStore for all of them together. 

Future eventual enhancement: update `fetchByStableId` and new `fetchListByStableIds`  to add variables to the cache immediately instead of passing the ID to another fetch method for every value returned.

This extra fetching was noticed as part of SW-6786, since many more stable Ids will be added for that story.