### PR TITLE
Return projects list with funding entity details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/FundingEntityUserStore.kt
@@ -1,26 +1,71 @@
 package com.terraformation.backend.funder.db
 
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
+import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_PROJECTS
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITY_USERS
 import com.terraformation.backend.funder.model.FunderUserModel
 import com.terraformation.backend.funder.model.FundingEntityModel
+import com.terraformation.backend.funder.model.FundingProjectModel
 import jakarta.inject.Named
 import org.jooq.DSLContext
-import org.jooq.Record
+import org.jooq.impl.DSL
 
 @Named
 class FundingEntityUserStore(private val dslContext: DSLContext) {
   fun getFundingEntityId(userId: UserId): FundingEntityId? {
     requirePermissions { readUser(userId) }
-    return findFundingEntityByUserId(userId) { record -> record.get(FUNDING_ENTITIES.ID) }
+
+    return with(FUNDING_ENTITY_USERS) {
+      dslContext
+          .select(FUNDING_ENTITY_ID)
+          .from(FUNDING_ENTITY_USERS)
+          .where(USER_ID.eq(userId))
+          .fetchOne(FUNDING_ENTITY_ID)
+    }
   }
 
   fun fetchEntityByUserId(userId: UserId): FundingEntityModel? {
     requirePermissions { readUser(userId) }
-    return findFundingEntityByUserId(userId) { record -> FundingEntityModel.of(record) }
+
+    val projectsMultiset =
+        DSL.multiset(
+                DSL.select(
+                        FUNDING_ENTITY_PROJECTS.PROJECT_ID,
+                        PROJECT_ACCELERATOR_DETAILS.DEAL_NAME,
+                        PROJECTS.NAME)
+                    .from(FUNDING_ENTITY_PROJECTS)
+                    .join(PROJECTS)
+                    .on(FUNDING_ENTITY_PROJECTS.PROJECT_ID.eq(PROJECTS.ID))
+                    .leftJoin(PROJECT_ACCELERATOR_DETAILS)
+                    .on(
+                        FUNDING_ENTITY_PROJECTS.PROJECT_ID.eq(
+                            PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
+                    .where(
+                        FUNDING_ENTITY_PROJECTS.FUNDING_ENTITY_ID.eq(
+                            FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID))
+                    .orderBy(FUNDING_ENTITY_PROJECTS.PROJECT_ID))
+            .convertFrom { result ->
+              result.map { record ->
+                FundingProjectModel(
+                    dealName =
+                        record[PROJECT_ACCELERATOR_DETAILS.DEAL_NAME] ?: record[PROJECTS.NAME]!!,
+                    projectId = record[FUNDING_ENTITY_PROJECTS.PROJECT_ID]!!,
+                )
+              }
+            }
+
+    return dslContext
+        .select(FUNDING_ENTITIES.asterisk(), projectsMultiset)
+        .from(FUNDING_ENTITY_USERS)
+        .join(FUNDING_ENTITIES)
+        .on(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID.eq(FUNDING_ENTITIES.ID))
+        .where(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
+        .fetchOne { FundingEntityModel.of(it, projectsMultiset) }
   }
 
   fun fetchFundersForEntity(entityId: FundingEntityId): List<FunderUserModel> {
@@ -41,15 +86,5 @@ class FundingEntityUserStore(private val dslContext: DSLContext) {
           .orderBy(users.ID)
           .fetch { FunderUserModel.of(it) }
     }
-  }
-
-  private fun <T> findFundingEntityByUserId(userId: UserId, mapper: (Record) -> T): T? {
-    return dslContext
-        .select(FUNDING_ENTITIES.asterisk())
-        .from(FUNDING_ENTITIES)
-        .join(FUNDING_ENTITY_USERS)
-        .on(FUNDING_ENTITY_USERS.FUNDING_ENTITY_ID.eq(FUNDING_ENTITIES.ID))
-        .where(FUNDING_ENTITY_USERS.USER_ID.eq(userId))
-        .fetchOne(mapper)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/FundingEntityModel.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.funder.FundingEntityId
 import com.terraformation.backend.db.funder.tables.references.FUNDING_ENTITIES
 import java.time.Instant
+import org.jooq.Field
 import org.jooq.Record
 
 data class FundingEntityModel(
@@ -16,12 +17,14 @@ data class FundingEntityModel(
   companion object {
     fun of(
         record: Record,
+        projectsField: Field<List<FundingProjectModel>>? = null,
     ): FundingEntityModel {
       return FundingEntityModel(
           id = record[FUNDING_ENTITIES.ID]!!,
           name = record[FUNDING_ENTITIES.NAME]!!,
           createdTime = record[FUNDING_ENTITIES.CREATED_TIME]!!,
           modifiedTime = record[FUNDING_ENTITIES.MODIFIED_TIME]!!,
+          projects = projectsField?.let { record[it] } ?: emptyList(),
       )
     }
   }


### PR DESCRIPTION
The response payload for fetching funding entities included a list of projects,
but the projects were never actually being fetched from the database so the list
was always empty.