### PR TITLE
SW-6786 Move SDG enum outside of Seed Fund Reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
@@ -1,0 +1,42 @@
+package com.terraformation.backend.accelerator.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+val startingDigitRegex = Regex("^\\d+")
+
+enum class SustainableDevelopmentGoal(val displayName: String) {
+  NoPoverty("1. No Poverty"),
+  ZeroHunger("2. Zero Hunger"),
+  GoodHealth("3. Good Health and Well-Being"),
+  QualityEducation("4. Quality Education"),
+  GenderEquality("5. Gender Equality"),
+  CleanWater("6. Clean Water and Sanitation"),
+  AffordableEnergy("7. Affordable and Clean Energy"),
+  DecentWork("8. Decent Work and Economic Growth"),
+  Industry("9. Industry, Innovation, and Infrastructure"),
+  ReducedInequalities("10. Reduced Inequalities"),
+  SustainableCities("11. Sustainable Cities and Communities"),
+  ResponsibleConsumption("12. Responsible Consumption and Production"),
+  ClimateAction("13. Climate Action"),
+  LifeBelowWater("14. Life Below Water"),
+  LifeOnLand("15. Life on Land"),
+  Peace("16. Peace, Justice, and Strong Institutions"),
+  Partnerships("17. Partnerships for the Goals");
+
+  @get:JsonValue val sdgNumber: String = startingDigitRegex.find(displayName)?.value ?: ""
+
+  companion object {
+    private val bySdgNumber: Map<String, SustainableDevelopmentGoal> by lazy {
+      SustainableDevelopmentGoal.entries.associateBy { it.sdgNumber }
+    }
+
+    @JsonCreator
+    @JvmStatic
+    fun forJsonValue(value: String): SustainableDevelopmentGoal {
+      val sdgNumber = startingDigitRegex.find(value)?.value ?: ""
+      return SustainableDevelopmentGoal.bySdgNumber[sdgNumber]
+          ?: throw IllegalArgumentException("Unknown goal $value")
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
@@ -24,17 +24,17 @@ enum class SustainableDevelopmentGoal(val displayName: String) {
   Peace("16. Peace, Justice, and Strong Institutions"),
   Partnerships("17. Partnerships for the Goals");
 
-  @get:JsonValue val sdgNumber: String = startingDigitRegex.find(displayName)?.value ?: ""
+  @get:JsonValue val sdgNumber: Int = startingDigitRegex.find(displayName)?.value?.toInt()!!
 
   companion object {
-    private val bySdgNumber: Map<String, SustainableDevelopmentGoal> by lazy {
+    private val bySdgNumber: Map<Int, SustainableDevelopmentGoal> by lazy {
       SustainableDevelopmentGoal.entries.associateBy { it.sdgNumber }
     }
 
     @JsonCreator
     @JvmStatic
     fun forJsonValue(value: String): SustainableDevelopmentGoal {
-      val sdgNumber = startingDigitRegex.find(value)?.value ?: ""
+      val sdgNumber = startingDigitRegex.find(value)?.value?.toInt()
       return SustainableDevelopmentGoal.bySdgNumber[sdgNumber]
           ?: throw IllegalArgumentException("Unknown goal $value")
     }

--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadsV1.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.report.api
 
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedFundReportId
@@ -11,7 +12,6 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.report.model.LatestSeedFundReportBodyModel
 import com.terraformation.backend.report.model.SeedFundReportBodyModelV1
 import com.terraformation.backend.report.model.SeedFundReportMetadata
-import com.terraformation.backend.report.model.SustainableDevelopmentGoal
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant

--- a/src/main/kotlin/com/terraformation/backend/report/model/SeedFundReportBodyModelV1.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/SeedFundReportBodyModelV1.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.report.model
 
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.GrowthForm

--- a/src/main/kotlin/com/terraformation/backend/report/model/SeedFundReports.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/model/SeedFundReports.kt
@@ -108,24 +108,3 @@ sealed interface SeedFundReportBodyModel {
    */
   fun validate()
 }
-
-@Suppress("unused")
-enum class SustainableDevelopmentGoal(val displayName: String) {
-  NoPoverty("1. No Poverty"),
-  ZeroHunger("2. Zero Hunger"),
-  GoodHealth("3. Good Health and Well-Being"),
-  QualityEducation("4. Quality Education"),
-  GenderEquality("5. Gender Equality"),
-  CleanWater("6. Clean Water and Sanitation"),
-  AffordableEnergy("7. Affordable and Clean Energy"),
-  DecentWork("8. Decent Work and Economic Growth"),
-  Industry("9. Industry, Innovation, and Infrastructure"),
-  ReducedInequalities("10. Reduced Inequalities"),
-  SustainableCities("11. Sustainable Cities and Communities"),
-  ResponsibleConsumption("12. Responsible Consumption and Production"),
-  ClimateAction("13. Climate Action"),
-  LifeBelowWater("14. Life Below Water"),
-  LifeOnLand("15. Life on Land"),
-  Peace("16. Peace, Justice, and Strong Institutions"),
-  Partnerships("17. Partnerships for the Goals")
-}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
@@ -1,0 +1,27 @@
+package com.terraformation.backend.accelerator.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SustainableDevelopmentGoalTest {
+
+  @Test
+  fun `sdgNumber works correctly for single and double digits`() {
+    assertEquals("4", SustainableDevelopmentGoal.QualityEducation.sdgNumber)
+    assertEquals("15", SustainableDevelopmentGoal.LifeOnLand.sdgNumber)
+  }
+
+  @Test
+  fun `forJsonValue throws exception when not found`() {
+    assertThrows<IllegalArgumentException> { SustainableDevelopmentGoal.forJsonValue("1000") }
+  }
+
+  @Test
+  fun `forJsonValue works correctly for single and double digits`() {
+    assertEquals(SustainableDevelopmentGoal.NoPoverty, SustainableDevelopmentGoal.forJsonValue("1"))
+
+    assertEquals(
+        SustainableDevelopmentGoal.Partnerships, SustainableDevelopmentGoal.forJsonValue("17"))
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
@@ -8,8 +8,8 @@ class SustainableDevelopmentGoalTest {
 
   @Test
   fun `sdgNumber works correctly for single and double digits`() {
-    assertEquals("4", SustainableDevelopmentGoal.QualityEducation.sdgNumber)
-    assertEquals("15", SustainableDevelopmentGoal.LifeOnLand.sdgNumber)
+    assertEquals(4, SustainableDevelopmentGoal.QualityEducation.sdgNumber)
+    assertEquals(15, SustainableDevelopmentGoal.LifeOnLand.sdgNumber)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
+import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.assertJsonEquals
 import com.terraformation.backend.customer.db.FacilityStore
@@ -44,7 +45,6 @@ import com.terraformation.backend.report.db.SeedFundReportStore
 import com.terraformation.backend.report.model.SeedFundReportBodyModelV1
 import com.terraformation.backend.report.model.SeedFundReportMetadata
 import com.terraformation.backend.report.model.SeedFundReportModel
-import com.terraformation.backend.report.model.SustainableDevelopmentGoal
 import com.terraformation.backend.report.render.SeedFundReportRenderer
 import com.terraformation.backend.seedbank.db.AccessionStore
 import com.terraformation.backend.species.db.SpeciesStore

--- a/src/test/kotlin/com/terraformation/backend/report/model/SeedFundReportBodyModelV1Test.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/model/SeedFundReportBodyModelV1Test.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.report.model
 
+import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.GrowthForm
 import com.terraformation.backend.db.default_schema.SpeciesId


### PR DESCRIPTION
The SDG enum was in the Seed Fund Reports folders still. This will be used for the new Project Profile updates page, so was moved outside of that folder. Tests were added for new methods in preparation of profile changes upcoming.