### PR TITLE
SW-6189 Rename numPermanentClusters to numPermanentPlots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -240,7 +240,7 @@ class AdminPlantingSitesController(
           "type" to "FeatureCollection",
           "features" to
               site.plantingZones.flatMap { zone ->
-                val numPermanent = zone.numPermanentClusters
+                val numPermanent = zone.numPermanentPlots
 
                 val temporaryPlotsAndIds: List<Pair<Polygon, MonitoringPlotId?>> =
                     zone
@@ -535,7 +535,7 @@ class AdminPlantingSitesController(
       plantingSiteStore.updatePlantingZone(plantingZoneId) { row ->
         row.copy(
             errorMargin = errorMargin,
-            numPermanentClusters = numPermanent,
+            numPermanentPlots = numPermanent,
             numTemporaryPlots = numTemporary,
             studentsT = studentsT,
             targetPlantingDensity = targetPlantingDensity,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -227,7 +227,7 @@ class PlantingSiteImporter(
               .mapNotNull { it.getProperty(studentsTProperties)?.toBigDecimalOrNull() }
               .find { it.signum() > 0 } ?: PlantingZoneModel.DEFAULT_STUDENTS_T
 
-      val numPermanentClusters =
+      val numPermanentPlots =
           subzoneFeatures.firstNotNullOfOrNull {
             it.getProperty(permanentClusterCountProperties)?.toIntOrNull()
           }
@@ -246,7 +246,7 @@ class PlantingSiteImporter(
             errorMargin = errorMargin,
             exclusion = exclusion,
             name = zoneName,
-            numPermanentClusters = numPermanentClusters,
+            numPermanentPlots = numPermanentPlots,
             numTemporaryPlots = numTemporaryPlots,
             plantingSubzones = subzoneModels,
             studentsT = studentsT,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -666,7 +666,7 @@ class PlantingSiteStore(
                   .set(MODIFIED_BY, currentUser().userId)
                   .set(MODIFIED_TIME, now)
                   .set(NAME, edit.desiredModel.name)
-                  .set(NUM_PERMANENT_CLUSTERS, edit.desiredModel.numPermanentClusters)
+                  .set(NUM_PERMANENT_PLOTS, edit.desiredModel.numPermanentPlots)
                   .set(STUDENTS_T, edit.desiredModel.studentsT)
                   .set(TARGET_PLANTING_DENSITY, edit.desiredModel.targetPlantingDensity)
                   .set(VARIANCE, edit.desiredModel.variance)
@@ -997,7 +997,7 @@ class PlantingSiteStore(
           .set(ERROR_MARGIN, edited.errorMargin)
           .set(MODIFIED_BY, currentUser().userId)
           .set(MODIFIED_TIME, clock.instant())
-          .set(NUM_PERMANENT_CLUSTERS, edited.numPermanentClusters)
+          .set(NUM_PERMANENT_PLOTS, edited.numPermanentPlots)
           .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
           .set(STUDENTS_T, edited.studentsT)
           .set(TARGET_PLANTING_DENSITY, edited.targetPlantingDensity)
@@ -1064,7 +1064,7 @@ class PlantingSiteStore(
             modifiedBy = userId,
             modifiedTime = now,
             name = zone.name,
-            numPermanentClusters = zone.numPermanentClusters,
+            numPermanentPlots = zone.numPermanentPlots,
             numTemporaryPlots = zone.numTemporaryPlots,
             plantingSiteId = plantingSiteId,
             studentsT = zone.studentsT,
@@ -1457,7 +1457,7 @@ class PlantingSiteStore(
 
       plantingSite.plantingZones.flatMap { plantingZone ->
         val missingClusterNumbers: List<Int> =
-            (1..plantingZone.numPermanentClusters).filterNot {
+            (1..plantingZone.numPermanentPlots).filterNot {
               plantingZone.permanentClusterExists(it)
             }
 
@@ -1893,7 +1893,7 @@ class PlantingSiteStore(
                     PLANTING_ZONES.ERROR_MARGIN,
                     PLANTING_ZONES.ID,
                     PLANTING_ZONES.NAME,
-                    PLANTING_ZONES.NUM_PERMANENT_CLUSTERS,
+                    PLANTING_ZONES.NUM_PERMANENT_PLOTS,
                     PLANTING_ZONES.NUM_TEMPORARY_PLOTS,
                     PLANTING_ZONES.STUDENTS_T,
                     PLANTING_ZONES.TARGET_PLANTING_DENSITY,
@@ -1912,7 +1912,7 @@ class PlantingSiteStore(
                 record[PLANTING_ZONES.ERROR_MARGIN]!!,
                 record[PLANTING_ZONES.ID]!!,
                 record[PLANTING_ZONES.NAME]!!,
-                record[PLANTING_ZONES.NUM_PERMANENT_CLUSTERS]!!,
+                record[PLANTING_ZONES.NUM_PERMANENT_PLOTS]!!,
                 record[PLANTING_ZONES.NUM_TEMPORARY_PLOTS]!!,
                 subzonesField?.let { record[it] } ?: emptyList(),
                 record[PLANTING_ZONES.STUDENTS_T]!!,

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -179,7 +179,7 @@ class PlantingSiteEditCalculator(
 
     val desiredPermanentClusterEdits =
         (zipProportionally(
-            desiredZone.numPermanentClusters,
+            desiredZone.numPermanentPlots,
             fractionOfDesiredAreaOverlappingWithExisting,
             nextPlotForArea(existingPlotsInOverlappingArea, overlappingBoundary),
             nextPlotForArea(existingPlotsInNewArea, nonOverlappingBoundary),

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -28,7 +28,7 @@ data class PlantingZoneModel<
     val errorMargin: BigDecimal = DEFAULT_ERROR_MARGIN,
     val id: PZID,
     val name: String,
-    val numPermanentClusters: Int = DEFAULT_NUM_PERMANENT_CLUSTERS,
+    val numPermanentPlots: Int = DEFAULT_NUM_PERMANENT_PLOTS,
     val numTemporaryPlots: Int = DEFAULT_NUM_TEMPORARY_PLOTS,
     val plantingSubzones: List<PlantingSubzoneModel<PSZID>>,
     val studentsT: BigDecimal = DEFAULT_STUDENTS_T,
@@ -37,7 +37,7 @@ data class PlantingZoneModel<
 ) {
   /**
    * Chooses a set of plots to act as permanent monitoring plots. The number of plots is determined
-   * by [numPermanentClusters].
+   * by [numPermanentPlots].
    *
    * Only plots in requested subzones are returned, meaning there may be fewer plots than
    * configured, or none at all.
@@ -52,7 +52,7 @@ data class PlantingZoneModel<
     val plotsInRequestedSubzones =
         requestedSubzones.flatMap { subzone ->
           subzone.monitoringPlots.filter { plot ->
-            plot.permanentCluster != null && plot.permanentCluster <= numPermanentClusters
+            plot.permanentCluster != null && plot.permanentCluster <= numPermanentPlots
           }
         }
 
@@ -117,7 +117,7 @@ data class PlantingZoneModel<
         .sortedWith(
             compareBy { subzone: PlantingSubzoneModel<PSZID> ->
                   subzone.monitoringPlots.count { plot ->
-                    plot.permanentCluster != null && plot.permanentCluster <= numPermanentClusters
+                    plot.permanentCluster != null && plot.permanentCluster <= numPermanentPlots
                   }
                 }
                 .thenBy { if (it.id != null && it.id in requestedSubzoneIds) 0 else 1 }
@@ -351,7 +351,7 @@ data class PlantingZoneModel<
               !plot.isAvailable ||
                   plot.id in excludePlotIds ||
                   plot.permanentCluster != null &&
-                      (includeAll || plot.permanentCluster <= numPermanentClusters)
+                      (includeAll || plot.permanentCluster <= numPermanentPlots)
             }
 
     if (relevantPlots.isEmpty()) {
@@ -370,7 +370,7 @@ data class PlantingZoneModel<
         id == other.id &&
         name == other.name &&
         boundaryModifiedTime == other.boundaryModifiedTime &&
-        numPermanentClusters == other.numPermanentClusters &&
+        numPermanentPlots == other.numPermanentPlots &&
         numTemporaryPlots == other.numTemporaryPlots &&
         areaHa.equalsIgnoreScale(other.areaHa) &&
         errorMargin.equalsIgnoreScale(other.errorMargin) &&
@@ -389,7 +389,7 @@ data class PlantingZoneModel<
           errorMargin = errorMargin,
           id = null,
           name = name,
-          numPermanentClusters = numPermanentClusters,
+          numPermanentPlots = numPermanentPlots,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = plantingSubzones.map { it.toNew() },
           studentsT = studentsT,
@@ -406,7 +406,7 @@ data class PlantingZoneModel<
     val DEFAULT_ERROR_MARGIN = BigDecimal(100)
     val DEFAULT_STUDENTS_T = BigDecimal("1.645")
     val DEFAULT_VARIANCE = BigDecimal(40000)
-    const val DEFAULT_NUM_PERMANENT_CLUSTERS = 8
+    const val DEFAULT_NUM_PERMANENT_PLOTS = 8
     const val DEFAULT_NUM_TEMPORARY_PLOTS = 3
 
     /** Target planting density to use if not included in zone properties. */
@@ -418,7 +418,7 @@ data class PlantingZoneModel<
         plantingSubzones: List<NewPlantingSubzoneModel>,
         exclusion: MultiPolygon? = null,
         errorMargin: BigDecimal = DEFAULT_ERROR_MARGIN,
-        numPermanentClusters: Int? = null,
+        numPermanentPlots: Int? = null,
         numTemporaryPlots: Int? = null,
         studentsT: BigDecimal = DEFAULT_STUDENTS_T,
         targetPlantingDensity: BigDecimal = DEFAULT_TARGET_PLANTING_DENSITY,
@@ -439,7 +439,7 @@ data class PlantingZoneModel<
           errorMargin = errorMargin,
           id = null,
           name = name,
-          numPermanentClusters = numPermanentClusters ?: defaultPermanentClusters,
+          numPermanentPlots = numPermanentPlots ?: defaultPermanentClusters,
           numTemporaryPlots = numTemporaryPlots ?: defaultTemporaryPlots,
           plantingSubzones = plantingSubzones,
           studentsT = studentsT,

--- a/src/main/resources/db/migration/0350/V372__NumPermanentPlots.sql
+++ b/src/main/resources/db/migration/0350/V372__NumPermanentPlots.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracking.planting_zones RENAME COLUMN num_permanent_clusters TO num_permanent_plots;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -500,7 +500,7 @@ COMMENT ON COLUMN tracking.planting_zones.created_time IS 'When the planting zon
 COMMENT ON COLUMN tracking.planting_zones.modified_by IS 'Which user most recently modified the planting zone.';
 COMMENT ON COLUMN tracking.planting_zones.modified_time IS 'When the planting zone was most recently modified.';
 COMMENT ON COLUMN tracking.planting_zones.name IS 'Short name of this planting zone. This is often just a single letter. Must be unique within a planting site.';
-COMMENT ON COLUMN tracking.planting_zones.num_permanent_clusters IS 'Number of permanent clusters to assign to the next observation. This is typically derived from a statistical formula.';
+COMMENT ON COLUMN tracking.planting_zones.num_permanent_plots IS 'Number of permanent plots to assign to the next observation. This is typically derived from a statistical formula.';
 COMMENT ON COLUMN tracking.planting_zones.planting_site_id IS 'Which planting site this zone is part of.';
 
 COMMENT ON TABLE tracking.plantings IS 'Details about plants that were planted or reassigned as part of a delivery. There is one plantings row per species in a delivery.';

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -262,7 +262,7 @@
                 </td>
                 <td>
                     <input type="number" required min="1" name="numPermanent" th:id="|numPermanent-${zone.id}|"
-                           th:value="${zone.numPermanentClusters}" th:form="|zone-${zone.id}|"/>
+                           th:value="${zone.numPermanentPlots}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
                     <input type="number" required min="1" name="numTemporary" th:id="|numTemporary-${zone.id}|"
@@ -270,7 +270,7 @@
                 </td>
                 <td>
                     <span th:id="|total-${zone.id}|"
-                          th:text="${zone.numPermanentClusters != null || zone.numTemporaryPlots != null ? (zone.numPermanentClusters ?: 0) + (zone.numTemporaryPlots ?: 0) : ''}">
+                          th:text="${zone.numPermanentPlots != null || zone.numTemporaryPlots != null ? (zone.numPermanentPlots ?: 0) + (zone.numTemporaryPlots ?: 0) : ''}">
                         123
                     </span>
                 </td>

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1899,8 +1899,8 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: "Z${nextPlantingZoneNumber++}",
-      numPermanentClusters: Int =
-          row.numPermanentClusters ?: PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      numPermanentPlots: Int =
+          row.numPermanentPlots ?: PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
       numTemporaryPlots: Int =
           row.numTemporaryPlots ?: PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
       studentsT: BigDecimal = row.studentsT ?: PlantingZoneModel.DEFAULT_STUDENTS_T,
@@ -1922,7 +1922,7 @@ abstract class DatabaseBackedTest {
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             name = name,
-            numPermanentClusters = numPermanentClusters,
+            numPermanentPlots = numPermanentPlots,
             numTemporaryPlots = numTemporaryPlots,
             plantingSiteId = plantingSiteId,
             studentsT = studentsT,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -218,8 +218,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertFacility(type = FacilityType.Nursery)
 
-      insertPlantingZone(
-          x = 0, width = 4, height = 1, numPermanentClusters = 2, numTemporaryPlots = 3)
+      insertPlantingZone(x = 0, width = 4, height = 1, numPermanentPlots = 2, numTemporaryPlots = 3)
       val subzone1Boundary =
           rectangle(width = 4 * MONITORING_PLOT_SIZE, height = MONITORING_PLOT_SIZE)
       val plantingSubzoneId1 = insertPlantingSubzone(boundary = subzone1Boundary)
@@ -233,8 +232,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertMonitoringPlot(x = 5, y = 0)
       insertMonitoringPlot(x = 6, y = 0)
 
-      insertPlantingZone(
-          x = 7, width = 3, height = 1, numPermanentClusters = 2, numTemporaryPlots = 2)
+      insertPlantingZone(x = 7, width = 3, height = 1, numPermanentPlots = 2, numTemporaryPlots = 2)
       insertPlantingSubzone(x = 7, width = 3, height = 1)
       insertCluster(1, x = 7, y = 0)
 
@@ -312,16 +310,14 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertFacility(type = FacilityType.Nursery)
       insertSpecies()
 
-      insertPlantingZone(
-          x = 0, width = 6, height = 2, numPermanentClusters = 2, numTemporaryPlots = 3)
+      insertPlantingZone(x = 0, width = 6, height = 2, numPermanentPlots = 2, numTemporaryPlots = 3)
       val subzone1Boundary =
           rectangle(width = 3 * MONITORING_PLOT_SIZE, height = 2 * MONITORING_PLOT_SIZE)
       val subzone1Id = insertPlantingSubzone(boundary = subzone1Boundary)
 
       val subzone2Id = insertPlantingSubzone(x = 3, width = 3, height = 2)
 
-      insertPlantingZone(
-          x = 6, width = 8, height = 2, numPermanentClusters = 2, numTemporaryPlots = 2)
+      insertPlantingZone(x = 6, width = 8, height = 2, numPermanentPlots = 2, numTemporaryPlots = 2)
       insertPlantingSubzone(x = 6, width = 8, height = 2)
 
       val observationId = insertObservation(state = ObservationState.Upcoming)
@@ -449,7 +445,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertSpecies()
 
       insertPlantingZone(
-          x = 0, width = 15, height = 2, numPermanentClusters = 8, numTemporaryPlots = 6)
+          x = 0, width = 15, height = 2, numPermanentPlots = 8, numTemporaryPlots = 6)
       val subzoneIds =
           listOf(PlantingSubzoneId(0)) +
               (0..4).map { index -> insertPlantingSubzone(x = 3 * index, width = 3) }
@@ -497,7 +493,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `sets planting site history ID`() {
       val boundary = rectangle(width = 4 * MONITORING_PLOT_SIZE, height = MONITORING_PLOT_SIZE)
 
-      insertPlantingZone(boundary = boundary, numPermanentClusters = 1, numTemporaryPlots = 1)
+      insertPlantingZone(boundary = boundary, numPermanentPlots = 1, numTemporaryPlots = 1)
       insertPlantingSubzone(boundary = boundary)
 
       val observationId = insertObservation(state = ObservationState.Upcoming)
@@ -852,7 +848,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val startDate = LocalDate.EPOCH
       val endDate = startDate.plusDays(1)
 
-      helper.insertPlantedSite(numPermanentClusters = 2, numTemporaryPlots = 3)
+      helper.insertPlantedSite(numPermanentPlots = 2, numTemporaryPlots = 3)
 
       val observationId =
           service.scheduleObservation(
@@ -990,7 +986,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         stateName: String
     ) {
       insertPlantingSite()
-      insertPlantingZone(numPermanentClusters = 1, numTemporaryPlots = 1)
+      insertPlantingZone(numPermanentPlots = 1, numTemporaryPlots = 1)
       insertPlantingSubzone()
       insertMonitoringPlot()
 
@@ -1016,7 +1012,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         stateName: String
     ) {
       insertPlantingSite(x = 0)
-      insertPlantingZone(numPermanentClusters = 1, numTemporaryPlots = 1)
+      insertPlantingZone(numPermanentPlots = 1, numTemporaryPlots = 1)
       insertPlantingSubzone()
       insertMonitoringPlot()
 
@@ -1531,7 +1527,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `replaces entire permanent cluster if this is the first observation and there are no completed plots`() {
-      insertPlantingZone(numPermanentClusters = 1, width = 2, height = 4)
+      insertPlantingZone(numPermanentPlots = 1, width = 2, height = 4)
       insertPlantingSubzone(width = 2, height = 4)
       insertObservationRequestedSubzone()
       val cluster1 = insertCluster(1, isPermanent = true)
@@ -1558,7 +1554,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `removes permanent cluster if replacement cluster is in an unrequested subzone`() {
-      insertPlantingZone(numPermanentClusters = 1, width = 1, height = 2)
+      insertPlantingZone(numPermanentPlots = 1, width = 1, height = 2)
       insertPlantingSubzone(width = 1, height = 1)
       insertObservationRequestedSubzone()
       val cluster1 = insertCluster(1, isPermanent = true)
@@ -2121,7 +2117,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `abandons in-progress observations in edited zones`() {
-      insertPlantingZone(numPermanentClusters = 1, numTemporaryPlots = 1, width = 2, height = 7)
+      insertPlantingZone(numPermanentPlots = 1, numTemporaryPlots = 1, width = 2, height = 7)
       insertPlantingSubzone()
       val plotInEditedZone = insertMonitoringPlot(permanentCluster = 1)
       insertPlantingZone()

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -146,10 +146,10 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     // go in either one of them depending on where the permanent plots ended up. Any temporary
     // plots that ended up in subzone 2 will be discarded because subzone 2 has no plants.
 
-    val numPermanentClusters = observationPlots.count { it.model.isPermanent }
+    val numPermanentPlots = observationPlots.count { it.model.isPermanent }
     val numTemporaryPlots = observationPlots.count { !it.model.isPermanent }
 
-    when (numPermanentClusters) {
+    when (numPermanentPlots) {
       0 -> {
         // Subzone 1 has no clusters, so it should get the extra plot; either subzone 2 has more
         // clusters or all the clusters were disqualified for being partially in an unrequested
@@ -171,7 +171,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         assertEquals(1, numTemporaryPlots, "Temporary plots with 2 clusters")
       }
       else -> {
-        assertEquals("between 0 and 2", "$numPermanentClusters", "Number of permanent clusters")
+        assertEquals("between 0 and 2", "$numPermanentPlots", "Number of permanent clusters")
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationTestHelper.kt
@@ -120,7 +120,7 @@ class ObservationTestHelper(
   fun insertPlantedSite(
       height: Int = 10,
       width: Int = 10,
-      numPermanentClusters: Int = 1,
+      numPermanentPlots: Int = 1,
       numTemporaryPlots: Int = 1,
       plantingCreatedTime: Instant = Instant.EPOCH,
       subzoneCompletedTime: Instant? = null,
@@ -143,7 +143,7 @@ class ObservationTestHelper(
         )
     test.insertPlantingZone(
         height = height,
-        numPermanentClusters = numPermanentClusters,
+        numPermanentPlots = numPermanentPlots,
         numTemporaryPlots = numTemporaryPlots,
         width = width,
     )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -101,7 +101,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.import("site", null, organizationId, listOf(Shapefile(listOf(subzoneFeature))))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(expectedPermanent, plantingZonesRow.numPermanentClusters, "Permanent clusters")
+      assertEquals(expectedPermanent, plantingZonesRow.numPermanentPlots, "Permanent clusters")
       assertEquals(expectedTemporary, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
 
@@ -130,7 +130,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.import("site", null, organizationId, listOf(Shapefile(subzoneFeatures)))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(32, plantingZonesRow.numPermanentClusters, "Permanent clusters")
+      assertEquals(32, plantingZonesRow.numPermanentPlots, "Permanent clusters")
       assertEquals(10, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
 
@@ -150,7 +150,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.import("site", null, organizationId, listOf(Shapefile(subzoneFeatures)))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(15, plantingZonesRow.numPermanentClusters, "Permanent clusters")
+      assertEquals(15, plantingZonesRow.numPermanentPlots, "Permanent clusters")
       assertEquals(4, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -158,7 +158,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                           boundary = zone1Boundary,
                           errorMargin = BigDecimal(1),
                           name = "Zone 1",
-                          numPermanentClusters = 3,
+                          numPermanentPlots = 3,
                           numTemporaryPlots = 4,
                           plantingSubzones =
                               listOf(
@@ -233,7 +233,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   errorMargin = BigDecimal(1),
                   id = actualZones["Zone 1"]?.id,
                   name = "Zone 1",
-                  numPermanentClusters = 3,
+                  numPermanentPlots = 3,
                   numTemporaryPlots = 4,
                   studentsT = BigDecimal(5),
                   targetPlantingDensity = BigDecimal(6),
@@ -243,7 +243,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   errorMargin = PlantingZoneModel.DEFAULT_ERROR_MARGIN,
                   id = actualZones["Zone 2"]?.id,
                   name = "Zone 2",
-                  numPermanentClusters = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+                  numPermanentPlots = PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
                   numTemporaryPlots = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
                   studentsT = PlantingZoneModel.DEFAULT_STUDENTS_T,
                   targetPlantingDensity = PlantingZoneModel.DEFAULT_TARGET_PLANTING_DENSITY,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
@@ -20,7 +20,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plantingSiteId =
           insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0), insertHistory = false)
       val plantingSiteHistoryId = insertPlantingSiteHistory()
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 4)
       val plantingSubzoneId = insertPlantingSubzone(boundary = siteBoundary, insertHistory = false)
       val plantingSubzoneHistoryId = insertPlantingSubzoneHistory()
 
@@ -56,7 +56,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
           }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = point(0))
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 4)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 4)
       insertPlantingSubzone(boundary = siteBoundary)
 
       // Zone is configured for 4 clusters, but there's only room for 2.
@@ -81,7 +81,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
           insertPlantingSite(
               boundary = siteBoundary, gridOrigin = gridOrigin, insertHistory = false)
       val plantingSiteHistoryId = insertPlantingSiteHistory()
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 3)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 3)
       val plantingSubzoneId = insertPlantingSubzone(boundary = siteBoundary, insertHistory = false)
       val plantingSubzoneHistoryId = insertPlantingSubzoneHistory()
       insertMonitoringPlot(
@@ -127,7 +127,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
           }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 2)
       insertPlantingSubzone(boundary = siteBoundary)
       val existingPlotId = insertMonitoringPlot(boundary = existingPlotBoundary)
 
@@ -147,7 +147,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 2)
       insertPlantingSubzone(boundary = siteBoundary)
       insertMonitoringPlot(boundary = plotBoundary, permanentCluster = 1)
       insertMonitoringPlot(boundary = plotBoundary, permanentCluster = 2)
@@ -173,7 +173,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       }
 
       val plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
-      insertPlantingZone(boundary = siteBoundary, numPermanentClusters = 2)
+      insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 2)
       insertPlantingSubzone(boundary = siteBoundary)
       insertMonitoringPlot(boundary = existingPlotBoundary, plotNumber = 1, permanentCluster = 1)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
@@ -33,7 +33,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
               modifiedBy = createdBy,
               modifiedTime = createdTime,
               name = "initial",
-              numPermanentClusters = 1,
+              numPermanentPlots = 1,
               numTemporaryPlots = 2,
               studentsT = BigDecimal.ONE,
               targetPlantingDensity = BigDecimal.ONE,
@@ -55,7 +55,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
               errorMargin = newErrorMargin,
               modifiedBy = user.userId,
               modifiedTime = clock.instant(),
-              numPermanentClusters = newPermanent,
+              numPermanentPlots = newPermanent,
               numTemporaryPlots = newTemporary,
               studentsT = newStudentsT,
               targetPlantingDensity = newTargetPlantingDensity,
@@ -66,7 +66,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
         it.copy(
             // Editable
             errorMargin = newErrorMargin,
-            numPermanentClusters = newPermanent,
+            numPermanentPlots = newPermanent,
             numTemporaryPlots = newTemporary,
             studentsT = newStudentsT,
             targetPlantingDensity = newTargetPlantingDensity,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -142,7 +142,7 @@ private constructor(
       width: Int = this.width - (x - this.x),
       height: Int = this.height - (y - this.y),
       name: String? = null,
-      numPermanent: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      numPermanent: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
       numTemporary: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
       func: ZoneBuilder.() -> Unit = {}
   ): ExistingPlantingZoneModel {
@@ -155,7 +155,7 @@ private constructor(
             width = width,
             height = height,
             name = name ?: "Z$currentZoneId",
-            numPermanentClusters = numPermanent,
+            numPermanentPlots = numPermanent,
             numTemporaryPlots = numTemporary,
         )
     builder.func()
@@ -200,7 +200,7 @@ private constructor(
       private val width: Int,
       private val height: Int,
       private val name: String,
-      private val numPermanentClusters: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_CLUSTERS,
+      private val numPermanentPlots: Int = PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
       private val numTemporaryPlots: Int = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
   ) {
     var errorMargin: BigDecimal = PlantingZoneModel.DEFAULT_ERROR_MARGIN
@@ -221,7 +221,7 @@ private constructor(
           errorMargin = errorMargin,
           id = PlantingZoneId(currentZoneId),
           name = name,
-          numPermanentClusters = numPermanentClusters,
+          numPermanentPlots = numPermanentPlots,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = plantingSubzones.ifEmpty { listOf(subzone()) },
           studentsT = studentsT,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -35,7 +35,7 @@ class PlantingZoneModelTest {
     fun `only chooses plots that lie in requested subzones`() {
       val model =
           plantingZoneModel(
-              numPermanentClusters = 4,
+              numPermanentPlots = 4,
               subzones =
                   listOf(
                       plantingSubzoneModel(
@@ -236,7 +236,7 @@ class PlantingZoneModelTest {
     fun `places excess plots in subzones with fewest permanent plots`() {
       val model =
           plantingZoneModel(
-              numPermanentClusters = 3,
+              numPermanentPlots = 3,
               numTemporaryPlots = 5,
               subzones =
                   listOf(
@@ -292,7 +292,7 @@ class PlantingZoneModelTest {
     fun `places excess plots in requested subzones if no difference in permanent plots`() {
       val model =
           plantingZoneModel(
-              numPermanentClusters = 3,
+              numPermanentPlots = 3,
               numTemporaryPlots = 5,
               subzones =
                   listOf(
@@ -701,7 +701,7 @@ class PlantingZoneModelTest {
 
   private fun plantingZoneModel(
       numTemporaryPlots: Int = 1,
-      numPermanentClusters: Int = 1,
+      numPermanentPlots: Int = 1,
       subzones: List<ExistingPlantingSubzoneModel>,
       boundary: MultiPolygon = plantingZoneBoundary(subzones),
   ) =
@@ -712,7 +712,7 @@ class PlantingZoneModelTest {
           errorMargin = BigDecimal.ONE,
           id = PlantingZoneId(1),
           name = "name",
-          numPermanentClusters = numPermanentClusters,
+          numPermanentPlots = numPermanentPlots,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = subzones,
           studentsT = BigDecimal.ONE,


### PR DESCRIPTION
Change the `numPermanentClusters` field on the planting zone model to
`numPermanentPlots` to reflect the fact that we no longer create multi-plot
clusters. Rename the corresponding database column as well.