### PR TITLE
SW-6788 Add variableValueIds for project photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ProjectAcceleratorDetailsController.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.db.docprod.VariableValueId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
@@ -110,8 +111,10 @@ data class ProjectAcceleratorDetailsPayload(
     val perHectareBudget: BigDecimal?,
     val pipeline: Pipeline?,
     val projectArea: BigDecimal?,
+    val projectHighlightPhotoValueId: VariableValueId?,
     val projectId: ProjectId,
     val projectLead: String?,
+    val projectZoneFigureValueId: VariableValueId?,
     val region: Region?,
     val riskTrackerLink: URI?,
     val sdgList: Set<SustainableDevelopmentGoal>,
@@ -160,8 +163,10 @@ data class ProjectAcceleratorDetailsPayload(
       perHectareBudget = model.perHectareBudget,
       pipeline = model.pipeline,
       projectArea = model.projectArea,
+      projectHighlightPhotoValueId = model.projectHighlightPhotoValueId,
       projectId = model.projectId,
       projectLead = model.projectLead,
+      projectZoneFigureValueId = model.projectZoneFigureValueId,
       region = model.region,
       riskTrackerLink = model.riskTrackerLink,
       sdgList = model.sdgList,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModel.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import com.terraformation.backend.db.docprod.VariableValueId
 import java.math.BigDecimal
 import java.net.URI
 import org.jooq.Record
@@ -55,8 +56,10 @@ data class ProjectAcceleratorDetailsModel(
     val perHectareBudget: BigDecimal? = null,
     val pipeline: Pipeline? = null,
     val projectArea: BigDecimal? = null,
+    val projectHighlightPhotoValueId: VariableValueId? = null,
     val projectId: ProjectId,
     val projectLead: String? = null,
+    val projectZoneFigureValueId: VariableValueId? = null,
     val region: Region? = null,
     val riskTrackerLink: URI? = null,
     val sdgList: Set<SustainableDevelopmentGoal> = emptySet(),
@@ -110,8 +113,10 @@ data class ProjectAcceleratorDetailsModel(
             perHectareBudget = variableValues.perHectareBudget,
             pipeline = record[PIPELINE_ID],
             projectArea = variableValues.projectArea,
+            projectHighlightPhotoValueId = variableValues.projectHighlightPhotoValueId,
             projectId = record[PROJECTS.ID]!!,
             projectLead = record[PROJECT_LEAD],
+            projectZoneFigureValueId = variableValues.projectZoneFigureValueId,
             region = variableValues.region,
             riskTrackerLink = variableValues.riskTrackerLink,
             sdgList = variableValues.sdgList,
@@ -151,7 +156,9 @@ data class ProjectAcceleratorDetailsModel(
           numNativeSpecies = numNativeSpecies,
           perHectareBudget = perHectareBudget,
           projectArea = projectArea,
+          projectHighlightPhotoValueId = projectHighlightPhotoValueId,
           projectId = projectId,
+          projectZoneFigureValueId = projectZoneFigureValueId,
           riskTrackerLink = riskTrackerLink,
           sdgList = sdgList,
           slackLink = slackLink,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorVariableValuesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorVariableValuesModel.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator.model
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.db.docprod.VariableValueId
 import java.math.BigDecimal
 import java.net.URI
 
@@ -30,7 +31,9 @@ data class ProjectAcceleratorVariableValuesModel(
     val numNativeSpecies: Int? = null,
     val perHectareBudget: BigDecimal? = null,
     val projectArea: BigDecimal? = null,
+    val projectHighlightPhotoValueId: VariableValueId? = null,
     val projectId: ProjectId,
+    val projectZoneFigureValueId: VariableValueId? = null,
     val riskTrackerLink: URI? = null,
     val sdgList: Set<SustainableDevelopmentGoal> = emptySet(),
     val slackLink: URI? = null,
@@ -67,7 +70,9 @@ data class ProjectAcceleratorVariableValuesModel(
           numNativeSpecies = numNativeSpecies,
           perHectareBudget = perHectareBudget,
           projectArea = projectArea,
+          projectHighlightPhotoValueId = projectHighlightPhotoValueId,
           projectId = projectId,
+          projectZoneFigureValueId = projectZoneFigureValueId,
           riskTrackerLink = riskTrackerLink,
           sdgList = sdgList,
           slackLink = slackLink,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
@@ -56,6 +56,8 @@ class AcceleratorProjectVariableValuesService(
             StableIds.numSpecies,
             StableIds.perHectareEstimatedBudget,
             StableIds.projectArea,
+            StableIds.projectHighlightPhoto,
+            StableIds.projectZoneFigure,
             StableIds.riskTrackerLink,
             StableIds.sdgList,
             StableIds.slackLink,
@@ -152,6 +154,8 @@ class AcceleratorProjectVariableValuesService(
     val numNativeSpecies = getNumberValue(valuesByStableId, StableIds.numSpecies)?.toInt()
     val perHectareBudget = getNumberValue(valuesByStableId, StableIds.perHectareEstimatedBudget)
     val projectArea = getNumberValue(valuesByStableId, StableIds.projectArea)
+    val projectHighlightPhotoValueId = getValueId(valuesByStableId, StableIds.projectHighlightPhoto)
+    val projectZoneFigureValueId = getValueId(valuesByStableId, StableIds.projectZoneFigure)
     val riskTrackerLink = getLinkValue(valuesByStableId, StableIds.riskTrackerLink)
     val sdgList =
         getMultiSelectValue(variablesById, valuesByStableId, StableIds.sdgList)
@@ -195,8 +199,10 @@ class AcceleratorProjectVariableValuesService(
         minProjectArea = minProjectArea,
         numNativeSpecies = numNativeSpecies,
         perHectareBudget = perHectareBudget,
-        projectId = projectId,
         projectArea = projectArea,
+        projectHighlightPhotoValueId = projectHighlightPhotoValueId,
+        projectId = projectId,
+        projectZoneFigureValueId = projectZoneFigureValueId,
         riskTrackerLink = riskTrackerLink,
         sdgList = sdgList,
         slackLink = slackLink,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/VariableValuesHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/VariableValuesHelper.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.variables
 
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId
+import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.documentproducer.model.AppendValueOperation
 import com.terraformation.backend.documentproducer.model.BaseVariableValueProperties
 import com.terraformation.backend.documentproducer.model.DeleteValueOperation
@@ -22,6 +23,13 @@ import com.terraformation.backend.documentproducer.model.ValueOperation
 import com.terraformation.backend.documentproducer.model.Variable
 import java.math.BigDecimal
 import java.net.URI
+
+fun getValueId(
+    valuesByStableId: Map<StableId, ExistingValue>,
+    stableId: StableId
+): VariableValueId? {
+  return (valuesByStableId[stableId])?.id
+}
 
 fun getNumberValue(
     valuesByStableId: Map<StableId, ExistingValue>,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableIds.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableIds.kt
@@ -38,6 +38,7 @@ object StableIds {
   val whatNeedsToBeTrue = StableId("439")
   val verraLink = StableId("471")
   val dealName = StableId("472")
+  val projectZoneFigure = StableId("525")
   val expectedMarketCredits = StableId("544")
   val minProjectArea = StableId("545")
   val sdgList = StableId("546")
@@ -45,6 +46,7 @@ object StableIds {
   val riskTrackerLink = StableId("548")
   val clickUpLink = StableId("549")
   val slackLink = StableId("550")
+  val projectHighlightPhoto = StableId("551")
 
   val landUseHectaresByLandUseModel =
       mapOf(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorDetailsModelTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.accelerator.Pipeline
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Region
+import com.terraformation.backend.db.docprod.VariableValueId
 import java.math.BigDecimal
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -48,8 +49,10 @@ class ProjectAcceleratorDetailsModelTest {
             perHectareBudget = BigDecimal(6),
             pipeline = Pipeline.AcceleratorProjects,
             projectArea = BigDecimal(23),
+            projectHighlightPhotoValueId = VariableValueId(123),
             projectId = ProjectId(1),
             projectLead = "lead",
+            projectZoneFigureValueId = VariableValueId(456),
             region = Region.LatinAmericaCaribbean,
             riskTrackerLink = URI("https://riskTrackerLink"),
             sdgList =
@@ -91,8 +94,10 @@ class ProjectAcceleratorDetailsModelTest {
             minProjectArea = BigDecimal(22),
             numNativeSpecies = 1,
             perHectareBudget = BigDecimal(6),
-            projectId = ProjectId(1),
             projectArea = BigDecimal(23),
+            projectHighlightPhotoValueId = VariableValueId(123),
+            projectId = ProjectId(1),
+            projectZoneFigureValueId = VariableValueId(456),
             region = Region.LatinAmericaCaribbean,
             riskTrackerLink = URI("https://riskTrackerLink"),
             sdgList =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorVariableValuesModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/ProjectAcceleratorVariableValuesModelTest.kt
@@ -2,12 +2,14 @@ package com.terraformation.backend.accelerator.model
 
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.docprod.VariableValueId
 import java.math.BigDecimal
 import java.net.URI
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class ProjectAcceleratorVariableValuesModelTest {
+
   @Test
   fun `can convert to ProjectAcceleratorDetailsModel, with null values for non-variable fields`() {
     val values =
@@ -36,7 +38,9 @@ class ProjectAcceleratorVariableValuesModelTest {
             numNativeSpecies = 1,
             perHectareBudget = BigDecimal(6),
             projectArea = BigDecimal(23),
+            projectHighlightPhotoValueId = VariableValueId(234),
             projectId = ProjectId(1),
+            projectZoneFigureValueId = VariableValueId(567),
             riskTrackerLink = URI("https://riskTrackerLink"),
             sdgList =
                 setOf(
@@ -83,7 +87,9 @@ class ProjectAcceleratorVariableValuesModelTest {
             perHectareBudget = BigDecimal(6),
             pipeline = null,
             projectArea = BigDecimal(23),
+            projectHighlightPhotoValueId = VariableValueId(234),
             projectId = ProjectId(1),
+            projectZoneFigureValueId = VariableValueId(567),
             riskTrackerLink = URI("https://riskTrackerLink"),
             sdgList =
                 setOf(

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -4144,7 +4144,9 @@ abstract class DatabaseBackedTest {
               failureRisk to VariableType.Text,
               whatNeedsToBeTrue to VariableType.Text,
               dealName to VariableType.Text,
-              slackLink to VariableType.Link)
+              slackLink to VariableType.Link,
+              projectHighlightPhoto to VariableType.Image,
+          )
         }
 
     return stableIds.mapValues { (stableId, type) -> insertStableVariable(stableId, type) }


### PR DESCRIPTION
Return the variableValueIds in the project details endpoint. This will be used to call the endpoint `/api/v1/document-producer/projects/{projectId}/images/{valueId}` with the projectId and valueId to retrieve each photo.

A future PR (under the same story) will add an endpoint to generate a mapbox image on demand using the project's boundaries (from `planting_sites`).
