### PR TITLE
Added events for when plots are created

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -57,6 +57,7 @@ import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.PlantingSubzoneEdit
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
+import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonEndedEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
@@ -1504,6 +1505,7 @@ class PlantingSiteStore(
     monitoringPlotsDao.insert(monitoringPlotsRow)
 
     insertMonitoringPlotHistory(monitoringPlotsRow)
+    eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
     return monitoringPlotsRow.id!!
   }
@@ -1578,6 +1580,7 @@ class PlantingSiteStore(
         monitoringPlotsDao.insert(monitoringPlotsRow)
 
         insertMonitoringPlotHistory(monitoringPlotsRow)
+        eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
         monitoringPlotsRow.id!!
       }
@@ -1628,6 +1631,7 @@ class PlantingSiteStore(
         monitoringPlotsDao.insert(monitoringPlotsRow)
 
         insertMonitoringPlotHistory(monitoringPlotsRow)
+        eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
         monitoringPlotsRow.id!!
       }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -10,6 +10,11 @@ import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
 import java.time.LocalDate
 
+/** Published when a monitoring plot is created. */
+data class MonitoringPlotCreatedEvent(
+    val monitoringPlotId: MonitoringPlotId,
+)
+
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
 data class ObservationPlotReplacedEvent(
     val duration: ReplacementDuration,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculator
 import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorTest
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
+import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
@@ -235,6 +236,10 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               results.edited,
               results.plantingSiteEdit,
               ReplacementResult(monitoringPlotIds, emptySet())))
+
+      eventPublisher.assertEventsPublished(
+          monitoringPlotIds.map { MonitoringPlotCreatedEvent(it) }
+      )
     }
 
     @Test
@@ -244,6 +249,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           desired = newSite { zone(numPermanent = 1) })
 
       eventPublisher.assertEventNotPublished<PlantingSiteMapEditedEvent>()
+      eventPublisher.assertEventNotPublished<MonitoringPlotCreatedEvent>()
     }
 
     @Test
@@ -309,6 +315,11 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               3 to existingArea,
               4 to newArea,
           ))
+
+      val plots = monitoringPlotsDao.findAll()
+      val newPlots = plots.filter { it.plotNumber == 2L || it.plotNumber == 4L }
+
+      eventPublisher.assertEventsPublished(newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test
@@ -371,6 +382,8 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
 
       runScenario(initial = initial, desired = desired)
 
+      val plots = monitoringPlotsDao.findAll()
+
       assertEquals(
           mapOf(
               16L to 1,
@@ -386,8 +399,11 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               29L to 11, // Newly-created plot
               27L to null,
           ),
-          monitoringPlotsDao.findAll().associate { it.plotNumber to it.permanentCluster },
+          plots.associate { it.plotNumber to it.permanentCluster },
           "Permanent cluster numbers for each plot number")
+
+      val newPlots = plots.filter { it.plotNumber == 29L }
+      eventPublisher.assertEventsPublished(newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -237,9 +237,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               results.plantingSiteEdit,
               ReplacementResult(monitoringPlotIds, emptySet())))
 
-      eventPublisher.assertEventsPublished(
-          monitoringPlotIds.map { MonitoringPlotCreatedEvent(it) }
-      )
+      eventPublisher.assertEventsPublished(monitoringPlotIds.map { MonitoringPlotCreatedEvent(it) })
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.util.Turtle
 import org.junit.jupiter.api.Assertions.*
@@ -80,6 +81,7 @@ class PlantingSiteStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(expected, actual.copy(boundary = null))
       assertGeometryEquals(plotBoundary, actual.boundary)
+      eventPublisher.assertEventPublished(MonitoringPlotCreatedEvent(monitoringPlotId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
+import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.util.Turtle
 import io.mockk.every
@@ -66,6 +67,8 @@ internal class PlantingSiteStoreCreateTemporaryTest : BasePlantingSiteStoreTest(
                   plantingSubzoneHistoryId = plantingSubzoneHistoryId,
                   plantingSubzoneId = plantingSubzoneId,
               )))
+
+      eventPublisher.assertEventPublished(MonitoringPlotCreatedEvent(newPlotId))
     }
 
     @Test


### PR DESCRIPTION
Fire an event when a monitoring plot is created. This will be handled later to calculate elevation data for a plot. 