### PR TITLE
Revert "Added events for when plots are created"

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -57,7 +57,6 @@ import com.terraformation.backend.tracking.edit.MonitoringPlotEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.PlantingSubzoneEdit
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
-import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonEndedEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonRescheduledEvent
 import com.terraformation.backend.tracking.event.PlantingSeasonScheduledEvent
@@ -1505,7 +1504,6 @@ class PlantingSiteStore(
     monitoringPlotsDao.insert(monitoringPlotsRow)
 
     insertMonitoringPlotHistory(monitoringPlotsRow)
-    eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
     return monitoringPlotsRow.id!!
   }
@@ -1580,7 +1578,6 @@ class PlantingSiteStore(
         monitoringPlotsDao.insert(monitoringPlotsRow)
 
         insertMonitoringPlotHistory(monitoringPlotsRow)
-        eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
         monitoringPlotsRow.id!!
       }
@@ -1631,7 +1628,6 @@ class PlantingSiteStore(
         monitoringPlotsDao.insert(monitoringPlotsRow)
 
         insertMonitoringPlotHistory(monitoringPlotsRow)
-        eventPublisher.publishEvent(MonitoringPlotCreatedEvent(monitoringPlotsRow.id!!))
 
         monitoringPlotsRow.id!!
       }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -10,11 +10,6 @@ import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
 import java.time.LocalDate
 
-/** Published when a monitoring plot is created. */
-data class MonitoringPlotCreatedEvent(
-    val monitoringPlotId: MonitoringPlotId,
-)
-
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
 data class ObservationPlotReplacedEvent(
     val duration: ReplacementDuration,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculator
 import com.terraformation.backend.tracking.edit.PlantingSiteEditCalculatorTest
 import com.terraformation.backend.tracking.edit.PlantingZoneEdit
-import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.event.PlantingSiteMapEditedEvent
 import com.terraformation.backend.tracking.model.AnyPlantingSiteModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
@@ -236,8 +235,6 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               results.edited,
               results.plantingSiteEdit,
               ReplacementResult(monitoringPlotIds, emptySet())))
-
-      eventPublisher.assertEventsPublished(monitoringPlotIds.map { MonitoringPlotCreatedEvent(it) })
     }
 
     @Test
@@ -247,7 +244,6 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           desired = newSite { zone(numPermanent = 1) })
 
       eventPublisher.assertEventNotPublished<PlantingSiteMapEditedEvent>()
-      eventPublisher.assertEventNotPublished<MonitoringPlotCreatedEvent>()
     }
 
     @Test
@@ -313,11 +309,6 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               3 to existingArea,
               4 to newArea,
           ))
-
-      val plots = monitoringPlotsDao.findAll()
-      val newPlots = plots.filter { it.plotNumber == 2L || it.plotNumber == 4L }
-
-      eventPublisher.assertEventsPublished(newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test
@@ -380,8 +371,6 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
 
       runScenario(initial = initial, desired = desired)
 
-      val plots = monitoringPlotsDao.findAll()
-
       assertEquals(
           mapOf(
               16L to 1,
@@ -397,11 +386,8 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
               29L to 11, // Newly-created plot
               27L to null,
           ),
-          plots.associate { it.plotNumber to it.permanentCluster },
+          monitoringPlotsDao.findAll().associate { it.plotNumber to it.permanentCluster },
           "Permanent cluster numbers for each plot number")
-
-      val newPlots = plots.filter { it.plotNumber == 29L }
-      eventPublisher.assertEventsPublished(newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateAdHocMonitoringPlotsTest.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
-import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.util.Turtle
 import org.junit.jupiter.api.Assertions.*
@@ -81,7 +80,6 @@ class PlantingSiteStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(expected, actual.copy(boundary = null))
       assertGeometryEquals(plotBoundary, actual.boundary)
-      eventPublisher.assertEventPublished(MonitoringPlotCreatedEvent(monitoringPlotId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateTemporaryTest.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.tracking.tables.pojos.MonitoringPlotsRow
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
-import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE_INT
 import com.terraformation.backend.util.Turtle
 import io.mockk.every
@@ -67,8 +66,6 @@ internal class PlantingSiteStoreCreateTemporaryTest : BasePlantingSiteStoreTest(
                   plantingSubzoneHistoryId = plantingSubzoneHistoryId,
                   plantingSubzoneId = plantingSubzoneId,
               )))
-
-      eventPublisher.assertEventPublished(MonitoringPlotCreatedEvent(newPlotId))
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
-import com.terraformation.backend.tracking.event.MonitoringPlotCreatedEvent
 import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
 import com.terraformation.backend.util.Turtle
 import java.time.Instant
@@ -47,8 +46,6 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
                 plantingSubzoneId = plantingSubzoneId,
             )
           })
-
-      eventPublisher.assertExactEventsPublished(plots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test
@@ -72,8 +69,6 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
           setOf(1, 2), plots.map { it.permanentCluster }.toSet(), "Permanent cluster numbers")
       assertEquals(1L, plots.minOf { it.plotNumber!! }, "Smallest plot number")
       assertEquals(2L, plots.maxOf { it.plotNumber!! }, "Largest plot number")
-
-      eventPublisher.assertExactEventsPublished(plots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test
@@ -100,23 +95,20 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       assertEquals(
           setOf(1, 2, 3), plots.map { it.permanentCluster }.toSet(), "Permanent cluster numbers")
 
-      val newPlots = plots.filter { it.permanentCluster != 2 }
-
       assertTableEquals(
-          newPlots.map { plot ->
-            MonitoringPlotHistoriesRecord(
-                createdBy = user.userId,
-                createdTime = Instant.EPOCH,
-                monitoringPlotId = plot.id,
-                plantingSiteHistoryId = plantingSiteHistoryId,
-                plantingSiteId = plantingSiteId,
-                plantingSubzoneHistoryId = plantingSubzoneHistoryId,
-                plantingSubzoneId = plantingSubzoneId,
-            )
-          })
-
-      eventPublisher.assertExactEventsPublished(
-          newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
+          plots
+              .filter { it.permanentCluster != 2 }
+              .map { plot ->
+                MonitoringPlotHistoriesRecord(
+                    createdBy = user.userId,
+                    createdTime = Instant.EPOCH,
+                    monitoringPlotId = plot.id,
+                    plantingSiteHistoryId = plantingSiteHistoryId,
+                    plantingSiteId = plantingSiteId,
+                    plantingSubzoneHistoryId = plantingSubzoneHistoryId,
+                    plantingSubzoneId = plantingSubzoneId,
+                )
+              })
     }
 
     @Test
@@ -143,13 +135,9 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
 
       val plots = monitoringPlotsDao.findAll()
       val existingPlot = plots.first { it.id == existingPlotId }
-      val newPlots = plots.filter { it.id != existingPlotId }
 
       assertEquals(2, plots.size, "Number of monitoring plots including existing one")
       assertNotNull(existingPlot.permanentCluster, "Cluster number of existing plot")
-
-      eventPublisher.assertExactEventsPublished(
-          newPlots.map { MonitoringPlotCreatedEvent(it.id!!) })
     }
 
     @Test
@@ -171,8 +159,6 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val after = monitoringPlotsDao.findAll().toSet()
 
       assertEquals(before, after, "Should not have created or modified any plots")
-
-      eventPublisher.assertNoEventsPublished()
     }
 
     @Test


### PR DESCRIPTION
Reverts terraware/terraware-server#3038

We are updating to use an interval job instead to fill elevation data.