### PR TITLE
SW-6189 Remove remaining references to clusters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -317,9 +317,8 @@ class ObservationsController(
   @Operation(
       summary = "Requests that a monitoring plot be replaced with a new one.",
       description =
-          "Additional monitoring plots may be replaced as well, e.g., if the requested plot is " +
-              "part of a permanent cluster. In some cases, the requested plot will be removed " +
-              "from the observation but not replaced with a different one.")
+          "In some cases, the requested plot will be removed from the observation but not " +
+              "replaced with a different one.")
   @PostMapping("/{observationId}/plots/{plotId}/replace")
   fun replaceObservationPlot(
       @PathVariable observationId: ObservationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporter.kt
@@ -37,7 +37,7 @@ class PlantingSiteImporter(
     val varianceProperties = setOf("variance")
 
     // Optional zone-level properties to set initial plot counts; mostly for testing
-    val permanentClusterCountProperties = setOf("permanent")
+    val permanentPlotCountProperties = setOf("permanent")
     val temporaryPlotCountProperties = setOf("temporary")
   }
 
@@ -229,7 +229,7 @@ class PlantingSiteImporter(
 
       val numPermanentPlots =
           subzoneFeatures.firstNotNullOfOrNull {
-            it.getProperty(permanentClusterCountProperties)?.toIntOrNull()
+            it.getProperty(permanentPlotCountProperties)?.toIntOrNull()
           }
       val numTemporaryPlots =
           subzoneFeatures.firstNotNullOfOrNull {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1332,7 +1332,7 @@ class PlantingSiteStore(
    *
    * The requested plot's "is available" flag is set to false, and its permanent index is cleared.
    * If the plot was permanent, a new one with the removed index will be created next time
-   * [ensurePermanentClustersExist] is called.
+   * [ensurePermanentPlotsExist] is called.
    *
    * @return The plots that were modified. This is always either an empty list (if the plot was
    *   already unavailable) or a removed plots list with just the requested plot (if the plot was
@@ -1449,7 +1449,7 @@ class PlantingSiteStore(
    *
    * @return The IDs of any newly-created monitoring plots.
    */
-  fun ensurePermanentClustersExist(plantingSiteId: PlantingSiteId): List<MonitoringPlotId> {
+  fun ensurePermanentPlotsExist(plantingSiteId: PlantingSiteId): List<MonitoringPlotId> {
     requirePermissions { updatePlantingSite(plantingSiteId) }
 
     return withLockedPlantingSite(plantingSiteId) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -191,12 +191,12 @@ class PlantingSiteEditCalculator(
     // permanent list by setting their permanent indexes to null so that any permanent plots we
     // create later will be randomly placed in the zone. We still want to adopt them into the
     // correct subzones, though.
-    val dropExcessExistingClusterEdits =
+    val dropExcessExistingPlotEdits =
         (existingPlotsInOverlappingArea + existingPlotsInNewArea + disqualifiedPlots).map {
           MonitoringPlotEdit.Adopt(it.id, permanentIndex = null)
         }
 
-    return desiredPermanentPlotEdits + dropExcessExistingClusterEdits
+    return desiredPermanentPlotEdits + dropExcessExistingPlotEdits
   }
 
   private fun calculateSubzoneEdits(

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -402,7 +402,7 @@ data class PlantingZoneModel<
     // required in each observation. The "Student's t" value is a constant based on a 90%
     // confidence level and should rarely need to change, but the other two will be adjusted by
     // admins based on the conditions at the planting site. These defaults mean that planting zones
-    // will have 11 permanent clusters and 14 temporary plots.
+    // will have 11 permanent plots and 14 temporary plots.
     val DEFAULT_ERROR_MARGIN = BigDecimal(100)
     val DEFAULT_STUDENTS_T = BigDecimal("1.645")
     val DEFAULT_VARIANCE = BigDecimal(40000)
@@ -429,8 +429,8 @@ data class PlantingZoneModel<
           (studentsT * studentsT * variance / errorMargin / errorMargin)
               .setScale(0, RoundingMode.UP)
               .toInt()
-      val defaultPermanentClusters = max((defaultTotalPlots * 0.75).roundToInt(), 1)
-      val defaultTemporaryPlots = max(defaultTotalPlots - defaultPermanentClusters, 1)
+      val defaultPermanentPlots = max((defaultTotalPlots * 0.75).roundToInt(), 1)
+      val defaultTemporaryPlots = max(defaultTotalPlots - defaultPermanentPlots, 1)
 
       return NewPlantingZoneModel(
           areaHa = areaHa,
@@ -439,7 +439,7 @@ data class PlantingZoneModel<
           errorMargin = errorMargin,
           id = null,
           name = name,
-          numPermanentPlots = numPermanentPlots ?: defaultPermanentClusters,
+          numPermanentPlots = numPermanentPlots ?: defaultPermanentPlots,
           numTemporaryPlots = numTemporaryPlots ?: defaultTemporaryPlots,
           plantingSubzones = plantingSubzones,
           studentsT = studentsT,

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -387,7 +387,7 @@ COMMENT ON TABLE tracking.observation_plot_positions IS '(Enum) Positions in a m
 
 COMMENT ON TABLE tracking.observation_plots IS 'Information about monitoring plots that are required to be surveyed as part of observations. This is not populated until the scheduled start time of the observation.';
 COMMENT ON COLUMN tracking.observation_plots.completed_time IS 'Server-generated completion date and time. This is the time the observation was submitted to the server, not the time it was performed in the field.';
-COMMENT ON COLUMN tracking.observation_plots.is_permanent IS 'If true, this plot was selected for observation as part of a permanent monitoring plot cluster. If false, this plot was selected as a temporary monitoring plot.';
+COMMENT ON COLUMN tracking.observation_plots.is_permanent IS 'If true, this plot was selected for observation as a permanent monitoring plot. If false, this plot was selected as a temporary monitoring plot.';
 COMMENT ON COLUMN tracking.observation_plots.observed_time IS 'Client-supplied observation date and time. This is the time the observation was performed in the field, not the time it was submitted to the server.';
 
 COMMENT ON TABLE tracking.observation_requested_subzones IS 'If an observation should only cover a specific set of subzones, the subzone IDs are stored here. If an observation is of the entire site (the default), there will be no rows for that observation in this table.';

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -40,7 +40,7 @@
         <script th:inline="javascript">
             function registerPlotCalculator(zoneId) {
                 const errorMarginField = document.getElementById(`errorMargin-${zoneId}`);
-                const permanentClustersField = document.getElementById(`numPermanent-${zoneId}`);
+                const permanentPlotsField = document.getElementById(`numPermanent-${zoneId}`);
                 const studentsTField = document.getElementById(`studentsT-${zoneId}`);
                 const temporaryPlotsField = document.getElementById(`numTemporary-${zoneId}`);
                 const totalPlotsField = document.getElementById(`total-${zoneId}`);
@@ -54,36 +54,36 @@
                 };
 
                 const recalculateTotalPlots = () => {
-                    const permanentClusters = Number.parseFloat(permanentClustersField.value) || 0;
+                    const permanentPlots = Number.parseFloat(permanentPlotsField.value) || 0;
                     const temporaryPlots = Number.parseFloat(temporaryPlotsField.value) || 0;
-                    const totalPlots = permanentClusters + temporaryPlots;
+                    const totalPlots = permanentPlots + temporaryPlots;
 
                     totalPlotsField.innerText = `${totalPlots}`;
                 };
 
                 const recalculateTemporaryPlots = () => {
                     const defaultTotalPlots = calculateDefaultTotalPlots();
-                    const permanentClusters = Number.parseFloat(permanentClustersField.value);
-                    const temporaryPlots = Math.max(1, defaultTotalPlots - permanentClusters);
+                    const permanentPlots = Number.parseFloat(permanentPlotsField.value);
+                    const temporaryPlots = Math.max(1, defaultTotalPlots - permanentPlots);
 
                     temporaryPlotsField.value = `${temporaryPlots}`;
 
                     recalculateTotalPlots();
                 };
 
-                const recalculatePermanentClusters = () => {
+                const recalculatePermanentPlots = () => {
                     const defaultTotalPlots = calculateDefaultTotalPlots();
-                    const permanentClusters = Math.round(defaultTotalPlots * 0.75);
+                    const permanentPlots = Math.round(defaultTotalPlots * 0.75);
 
-                    permanentClustersField.value = `${permanentClusters}`;
+                    permanentPlotsField.value = `${permanentPlots}`;
 
                     recalculateTemporaryPlots();
                 };
 
-                errorMarginField.addEventListener('change', recalculatePermanentClusters);
-                studentsTField.addEventListener('change', recalculatePermanentClusters);
-                varianceField.addEventListener('change', recalculatePermanentClusters);
-                permanentClustersField.addEventListener('change', recalculateTemporaryPlots);
+                errorMarginField.addEventListener('change', recalculatePermanentPlots);
+                studentsTField.addEventListener('change', recalculatePermanentPlots);
+                varianceField.addEventListener('change', recalculatePermanentPlots);
+                permanentPlotsField.addEventListener('change', recalculateTemporaryPlots);
                 temporaryPlotsField.addEventListener('change', recalculateTotalPlots);
             }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -75,7 +75,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     )
   }
 
-  private val gen = ShapefileGenerator(defaultPermanentClusters = 1, defaultTemporaryPlots = 2)
+  private val gen = ShapefileGenerator(defaultPermanentPlots = 1, defaultTemporaryPlots = 2)
 
   private lateinit var organizationId: OrganizationId
 
@@ -109,17 +109,16 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     //     |                    |                |             |
     //     +-------------------------------------|-------------+
     //     |   |   |   |   |   |   |   |   |   |   |   |   |   | (plot borders)
-    //     |       |       |       |       |       |       |     (cluster borders)
 
     val subzone1Boundary = gen.multiRectangle(0 to 0, 130 to 101)
     val subzone2Boundary = gen.multiRectangle(130 to 0, 230 to 101)
     val zone2Boundary = gen.multiRectangle(230 to 0, 326 to 101)
 
     val subzone1Feature =
-        gen.subzoneFeature(subzone1Boundary, zone = "Z1", permanentClusters = 2, temporaryPlots = 3)
+        gen.subzoneFeature(subzone1Boundary, zone = "Z1", permanentPlots = 2, temporaryPlots = 3)
     val subzone2Feature = gen.subzoneFeature(subzone2Boundary)
     val subzone3Feature =
-        gen.subzoneFeature(zone2Boundary, zone = "Z2", permanentClusters = 2, temporaryPlots = 3)
+        gen.subzoneFeature(zone2Boundary, zone = "Z2", permanentPlots = 2, temporaryPlots = 3)
 
     val plantingSite = importSite(listOf(subzone1Feature, subzone2Feature, subzone3Feature))
     val subzone1 =
@@ -151,27 +150,27 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
 
     when (numPermanentPlots) {
       0 -> {
-        // Subzone 1 has no clusters, so it should get the extra plot; either subzone 2 has more
-        // clusters or all the clusters were disqualified for being partially in an unrequested
-        // subzone, in which case subzone 1 gets the extra plot because it's requested.
-        assertEquals(2, numTemporaryPlots, "Temporary plots with 0 clusters")
+        // Subzone 1 has no permanent plots, so it should get the extra plot; either subzone 2 has
+        // more permanent plots or all of them were disqualified for being partially in an
+        // unrequested subzone, in which case subzone 1 gets the extra plot because it's requested.
+        assertEquals(2, numTemporaryPlots, "Temporary plots with 0 permanent")
       }
       1 -> {
-        // Subzone 1 has one cluster, but we can't tell if the other cluster would have been in
-        // subzone 2 (in which case the extra plot would go to subzone 1 since it's requested) or
-        // straddles the subzone boundary (in which case it'd be eliminated and the extra plot
-        // would go to subzone 2 for having fewer clusters).
+        // Subzone 1 has one permanent plot, but we can't tell if the other permanent plot would
+        // have been in subzone 2 (in which case the extra plot would go to subzone 1 since it's
+        // requested) or straddles the subzone boundary (in which case it'd be eliminated and the
+        // extra plot would go to subzone 2 for having fewer permanent plots).
         if (numTemporaryPlots < 1 || numTemporaryPlots > 2) {
           // This will always fail but will give a nice assertion failure message.
-          assertEquals("either 1 or 2", "$numTemporaryPlots", "Temporary plots with 1 cluster")
+          assertEquals("either 1 or 2", "$numTemporaryPlots", "Temporary plots with 1 permanent")
         }
       }
       2 -> {
-        // Subzone 1 has both clusters, so subzone 2 will get the extra plot.
-        assertEquals(1, numTemporaryPlots, "Temporary plots with 2 clusters")
+        // Subzone 1 has both permanent plots, so subzone 2 will get the extra plot.
+        assertEquals(1, numTemporaryPlots, "Temporary plots with 2 permanent")
       }
       else -> {
-        assertEquals("between 0 and 2", "$numPermanentPlots", "Number of permanent clusters")
+        assertEquals("between 0 and 2", "$numPermanentPlots", "Number of permanent plots")
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ShapefileGenerator.kt
@@ -17,10 +17,10 @@ class ShapefileGenerator(
     /** Coordinate system to use for polygons. */
     srid: Int = SRID.UTM_20S,
     /**
-     * Number of permanent clusters to specify in zone shapefile features by default. Null means
-     * ShapefileImporter will calculate the number of clusters.
+     * Number of permanent plots to specify in zone shapefile features by default. Null means
+     * ShapefileImporter will calculate the number of plots.
      */
-    private val defaultPermanentClusters: Int? = null,
+    private val defaultPermanentPlots: Int? = null,
     /**
      * Number of temporary plots to specify in zone shapefile features by default. Null means
      * ShapefileImporter will calculate the number of plots.
@@ -41,7 +41,7 @@ class ShapefileGenerator(
       errorMargin: BigDecimal? = PlantingZoneModel.DEFAULT_ERROR_MARGIN,
       studentsT: BigDecimal? = null,
       variance: BigDecimal? = PlantingZoneModel.DEFAULT_VARIANCE,
-      permanentClusters: Int? = defaultPermanentClusters,
+      permanentPlots: Int? = defaultPermanentPlots,
       temporaryPlots: Int? = defaultTemporaryPlots,
       targetPlantingDensity: BigDecimal? = null,
   ): ShapefileFeature {
@@ -56,7 +56,7 @@ class ShapefileGenerator(
                 errorMargin?.let { "error_marg" to "$it" },
                 studentsT?.let { "students_t" to "$it" },
                 variance?.let { "variance" to "$it" },
-                permanentClusters?.let { "permanent" to "$it" },
+                permanentPlots?.let { "permanent" to "$it" },
                 temporaryPlots?.let { "temporary" to "$it" },
                 targetPlantingDensity?.let { "density" to "$it" },
             )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/PlantingSiteImporterTest.kt
@@ -76,7 +76,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
 
   @Nested
   inner class PlotCounts {
-    // Error, Student's t, variance, permanent clusters, temporary plots
+    // Error, Student's t, variance, permanent plots, temporary plots
     @CsvSource(
         "defaults        ,100,1.645,40000, 8, 3",
         "no students t   ,100,     ,40000, 8, 3",
@@ -101,7 +101,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.import("site", null, organizationId, listOf(Shapefile(listOf(subzoneFeature))))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(expectedPermanent, plantingZonesRow.numPermanentPlots, "Permanent clusters")
+      assertEquals(expectedPermanent, plantingZonesRow.numPermanentPlots, "Permanent plots")
       assertEquals(expectedTemporary, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
 
@@ -130,7 +130,7 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
       importer.import("site", null, organizationId, listOf(Shapefile(subzoneFeatures)))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(32, plantingZonesRow.numPermanentPlots, "Permanent clusters")
+      assertEquals(32, plantingZonesRow.numPermanentPlots, "Permanent plots")
       assertEquals(10, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
 
@@ -144,13 +144,13 @@ internal class PlantingSiteImporterTest : DatabaseTest(), RunsAsUser {
                   errorMargin = BigDecimal(70),
                   studentsT = BigDecimal(1.7),
                   variance = BigDecimal(70000),
-                  permanentClusters = 15,
+                  permanentPlots = 15,
                   temporaryPlots = 4))
 
       importer.import("site", null, organizationId, listOf(Shapefile(subzoneFeatures)))
 
       val plantingZonesRow = plantingZonesDao.findAll().first()
-      assertEquals(15, plantingZonesRow.numPermanentPlots, "Permanent clusters")
+      assertEquals(15, plantingZonesRow.numPermanentPlots, "Permanent plots")
       assertEquals(4, plantingZonesRow.numTemporaryPlots, "Temporary plots")
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -172,7 +172,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                 zone(numPermanent = 1) {
                   subzone(width = 250) {
                     plantingCompletedTime = Instant.EPOCH
-                    cluster()
+                    permanent()
                   }
                   subzone(width = 250) { plantingCompletedTime = Instant.EPOCH }
                 }
@@ -240,7 +240,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     @Test
     fun `does not publish event if edit was a no-op`() {
       runScenario(
-          initial = newSite { zone(numPermanent = 1) { subzone { cluster() } } },
+          initial = newSite { zone(numPermanent = 1) { subzone { permanent() } } },
           desired = newSite { zone(numPermanent = 1) })
 
       eventPublisher.assertEventNotPublished<PlantingSiteMapEditedEvent>()
@@ -316,10 +316,10 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       val initial = newSite {
         zone {
           subzone {
-            cluster(x = 0)
-            cluster(x = 300)
-            cluster(x = 30)
-            cluster(x = 330)
+            permanent(x = 0)
+            permanent(x = 300)
+            permanent(x = 30)
+            permanent(x = 330)
           }
         }
       }
@@ -343,21 +343,21 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           newSite(x = 0, width = 1000) {
             zone(name = "A", x = 0, width = 500) {
               subzone {
-                cluster(plotNumber = 1, x = 300, y = 0)
-                cluster(plotNumber = 2, x = 300, y = 30)
-                cluster(plotNumber = 4, x = 300, y = 60)
-                cluster(plotNumber = 7, x = 300, y = 90)
+                permanent(plotNumber = 1, x = 300, y = 0)
+                permanent(plotNumber = 2, x = 300, y = 30)
+                permanent(plotNumber = 4, x = 300, y = 60)
+                permanent(plotNumber = 7, x = 300, y = 90)
               }
             }
             zone(name = "B", x = 500, width = 500) {
               subzone {
-                cluster(plotNumber = 16, x = 600, y = 0)
-                cluster(plotNumber = 18, x = 600, y = 30)
-                cluster(plotNumber = 19, x = 600, y = 60)
-                cluster(plotNumber = 23, x = 600, y = 90)
-                cluster(plotNumber = 25, x = 600, y = 120)
-                cluster(plotNumber = 26, x = 600, y = 150)
-                cluster(plotNumber = 27, x = 600, y = 180)
+                permanent(plotNumber = 16, x = 600, y = 0)
+                permanent(plotNumber = 18, x = 600, y = 30)
+                permanent(plotNumber = 19, x = 600, y = 60)
+                permanent(plotNumber = 23, x = 600, y = 90)
+                permanent(plotNumber = 25, x = 600, y = 120)
+                permanent(plotNumber = 26, x = 600, y = 150)
+                permanent(plotNumber = 27, x = 600, y = 180)
               }
             }
           }
@@ -395,8 +395,8 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
       val initial = newSite {
         zone(name = "A") {
           subzone {
-            cluster(plotNumber = 1, x = 100)
-            cluster(plotNumber = 2, x = 400)
+            permanent(plotNumber = 1, x = 100)
+            permanent(plotNumber = 2, x = 400)
           }
         }
       }
@@ -416,8 +416,8 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     fun `moves existing subzones between zones`() {
       val initial = newSite {
         zone(name = "A", numPermanent = 2) {
-          subzone(name = "Subzone 1", width = 250) { cluster() }
-          subzone(name = "Subzone 2", width = 250) { cluster() }
+          subzone(name = "Subzone 1", width = 250) { permanent() }
+          subzone(name = "Subzone 2", width = 250) { permanent() }
         }
       }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -441,7 +441,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
     @Test
     fun `moves subzone from deleted zone to new one, perhaps because the zone was renamed`() {
       val initial = newSite {
-        zone(name = "A", numPermanent = 1) { subzone(name = "Subzone") { cluster() } }
+        zone(name = "A", numPermanent = 1) { subzone(name = "Subzone") { permanent() } }
       }
 
       val desired = newSite { zone(name = "B", numPermanent = 1) { subzone(name = "Subzone") } }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
@@ -13,9 +13,9 @@ import org.junit.jupiter.api.Test
 
 internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest() {
   @Nested
-  inner class EnsurePermanentClustersExist {
+  inner class EnsurePermanentPlotsExist {
     @Test
-    fun `creates all clusters in empty planting site`() {
+    fun `creates all plots in empty planting site`() {
       val siteBoundary = Turtle(point(0)).makeMultiPolygon { square(101) }
 
       val plantingSiteId =
@@ -25,7 +25,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plantingSubzoneId = insertPlantingSubzone(boundary = siteBoundary, insertHistory = false)
       val plantingSubzoneHistoryId = insertPlantingSubzoneHistory()
 
-      store.ensurePermanentClustersExist(plantingSiteId)
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
 
@@ -49,7 +49,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
     }
 
     @Test
-    fun `creates as many clusters as there is room for`() {
+    fun `creates as many plots as there is room for`() {
       val siteBoundary =
           Turtle(point(0)).makeMultiPolygon {
             rectangle(MONITORING_PLOT_SIZE * 2 + 1, MONITORING_PLOT_SIZE + 1)
@@ -59,8 +59,8 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       insertPlantingZone(boundary = siteBoundary, numPermanentPlots = 4)
       insertPlantingSubzone(boundary = siteBoundary)
 
-      // Zone is configured for 4 clusters, but there's only room for 2.
-      store.ensurePermanentClustersExist(plantingSiteId)
+      // Zone is configured for 4 permanent plots, but there's only room for 2.
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
 
@@ -71,7 +71,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
     }
 
     @Test
-    fun `only creates nonexistent permanent clusters`() {
+    fun `only creates nonexistent permanent plots`() {
       val gridOrigin = point(0)
       val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { square(201) }
       val existingPlotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
@@ -86,7 +86,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       insertMonitoringPlot(
           boundary = existingPlotBoundary, permanentIndex = 2, insertHistory = false)
 
-      store.ensurePermanentClustersExist(plantingSiteId)
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
 
@@ -129,7 +129,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       insertPlantingSubzone(boundary = siteBoundary)
       val existingPlotId = insertMonitoringPlot(boundary = existingPlotBoundary)
 
-      store.ensurePermanentClustersExist(plantingSiteId)
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
       val existingPlot = plots.first { it.id == existingPlotId }
@@ -139,7 +139,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
     }
 
     @Test
-    fun `does nothing if required clusters already exist`() {
+    fun `does nothing if required permanent plots already exist`() {
       val gridOrigin = point(0)
       val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { square(201) }
       val plotBoundary = Turtle(gridOrigin).makePolygon { square(25) }
@@ -152,7 +152,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
 
       val before = monitoringPlotsDao.findAll().toSet()
 
-      store.ensurePermanentClustersExist(plantingSiteId)
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val after = monitoringPlotsDao.findAll().toSet()
 
@@ -175,7 +175,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       insertPlantingSubzone(boundary = siteBoundary)
       insertMonitoringPlot(boundary = existingPlotBoundary, plotNumber = 1, permanentIndex = 1)
 
-      store.ensurePermanentClustersExist(plantingSiteId)
+      store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
       assertEquals(

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.assertThrows
 class PlantingSiteEditCalculatorTest {
   @Test
   fun `returns create edits for newly added zone and subzone`() {
-    val existing = existingSite(width = 500) { zone(numPermanent = 1) { subzone { cluster() } } }
+    val existing = existingSite(width = 500) { zone(numPermanent = 1) { subzone { permanent() } } }
     val desired =
         newSite(width = 750) {
           zone(width = 500, numPermanent = 1)
@@ -53,8 +53,8 @@ class PlantingSiteEditCalculatorTest {
         existingSite(width = 500) {
           zone {
             subzone {
-              cluster()
-              cluster()
+              permanent()
+              permanent()
               plot(x = 600, isAdHoc = true)
             }
           }
@@ -122,7 +122,7 @@ class PlantingSiteEditCalculatorTest {
     val newTargetPlantingDensity = BigDecimal(1100)
     val newVariance = BigDecimal(40001)
 
-    val existing = existingSite { zone { subzone { repeat(8) { cluster() } } } }
+    val existing = existingSite { zone { subzone { repeat(8) { permanent() } } } }
     val desired = newSite {
       zone {
         errorMargin = newErrorMargin
@@ -190,8 +190,8 @@ class PlantingSiteEditCalculatorTest {
   fun `matches existing and new zones based on names, not locations`() {
     val existing =
         existingSite(width = 1000, height = 500) {
-          zone(name = "A", width = 800) { subzone(name = "A-1") { cluster() } }
-          zone(name = "B", width = 200) { subzone(name = "B-1") { cluster() } }
+          zone(name = "A", width = 800) { subzone(name = "A-1") { permanent() } }
+          zone(name = "B", width = 200) { subzone(name = "B-1") { permanent() } }
         }
     val desired =
         newSite(width = 1000, height = 500) {
@@ -253,7 +253,7 @@ class PlantingSiteEditCalculatorTest {
                                             // Plot 2 was in the area that overlapped with the old
                                             // area of the zone, which is smaller than the newly
                                             // added area, so it is removed from the permanent
-                                            // cluster list.
+                                            // plot list.
                                             MonitoringPlotEdit.Adopt(MonitoringPlotId(2), null),
                                         ),
                                     removedRegion = rectangle(x = 0, width = 500, height = 500),
@@ -270,8 +270,8 @@ class PlantingSiteEditCalculatorTest {
   fun `moves existing subzones to new zones`() {
     val existing = existingSite {
       zone(name = "A", numPermanent = 2) {
-        subzone(name = "Subzone 1", width = 250) { cluster() }
-        subzone(name = "Subzone 2", width = 250) { cluster() }
+        subzone(name = "Subzone 1", width = 250) { permanent() }
+        subzone(name = "Subzone 2", width = 250) { permanent() }
       }
     }
 
@@ -321,14 +321,14 @@ class PlantingSiteEditCalculatorTest {
     val existing =
         existingSite(width = 750) {
           zone(name = "A", width = 500, numPermanent = 3) {
-            subzone(name = "Subzone 1", width = 250) { cluster() }
+            subzone(name = "Subzone 1", width = 250) { permanent() }
             subzone(name = "Subzone 2", width = 250) {
-              cluster()
-              cluster()
+              permanent()
+              permanent()
             }
           }
           zone(name = "B", width = 250, numPermanent = 1) {
-            subzone(name = "Subzone 3", width = 250) { cluster() }
+            subzone(name = "Subzone 3", width = 250) { permanent() }
           }
         }
 
@@ -454,21 +454,21 @@ class PlantingSiteEditCalculatorTest {
         existingSite(x = 0, width = 1000) {
           zone(name = "A", x = 0, width = 500) {
             subzone {
-              cluster(plotNumber = 1, x = 300, y = 0)
-              cluster(plotNumber = 2, x = 300, y = 30)
-              cluster(plotNumber = 4, x = 300, y = 60)
-              cluster(plotNumber = 7, x = 300, y = 90)
+              permanent(plotNumber = 1, x = 300, y = 0)
+              permanent(plotNumber = 2, x = 300, y = 30)
+              permanent(plotNumber = 4, x = 300, y = 60)
+              permanent(plotNumber = 7, x = 300, y = 90)
             }
           }
           zone(name = "B", x = 500, width = 500) {
             subzone {
-              cluster(plotNumber = 16, x = 600, y = 0)
-              cluster(plotNumber = 18, x = 600, y = 30)
-              cluster(plotNumber = 19, x = 600, y = 60)
-              cluster(plotNumber = 23, x = 600, y = 90)
-              cluster(plotNumber = 25, x = 600, y = 120)
-              cluster(plotNumber = 26, x = 600, y = 150)
-              cluster(plotNumber = 27, x = 600, y = 180)
+              permanent(plotNumber = 16, x = 600, y = 0)
+              permanent(plotNumber = 18, x = 600, y = 30)
+              permanent(plotNumber = 19, x = 600, y = 60)
+              permanent(plotNumber = 23, x = 600, y = 90)
+              permanent(plotNumber = 25, x = 600, y = 120)
+              permanent(plotNumber = 26, x = 600, y = 150)
+              permanent(plotNumber = 27, x = 600, y = 180)
             }
           }
         }
@@ -687,12 +687,12 @@ class PlantingSiteEditCalculatorTest {
   }
 
   @Test
-  fun `increases number of permanent clusters even if geometry stayed the same`() {
+  fun `increases number of permanent plots even if geometry stayed the same`() {
     val existing = existingSite {
       zone(numPermanent = 2) {
         subzone {
-          cluster()
-          cluster()
+          permanent()
+          permanent()
         }
       }
     }
@@ -719,13 +719,13 @@ class PlantingSiteEditCalculatorTest {
   }
 
   @Test
-  fun `reduces number of permanent clusters even if geometry stayed the same`() {
+  fun `reduces number of permanent plots even if geometry stayed the same`() {
     val existing = existingSite {
       zone(numPermanent = 3) {
         subzone {
-          cluster()
-          cluster()
-          cluster()
+          permanent()
+          permanent()
+          permanent()
         }
       }
     }
@@ -764,8 +764,8 @@ class PlantingSiteEditCalculatorTest {
   fun `returns deletion of zone that no longer exists`() {
     val existing =
         existingSite(width = 1000) {
-          zone(width = 750, numPermanent = 1) { subzone { cluster() } }
-          zone(width = 250, numPermanent = 1) { subzone { cluster() } }
+          zone(width = 750, numPermanent = 1) { subzone { permanent() } }
+          zone(width = 250, numPermanent = 1) { subzone { permanent() } }
         }
     val desired = newSite(width = 750) { zone(numPermanent = 1) }
 
@@ -961,7 +961,7 @@ class PlantingSiteEditCalculatorTest {
 
   @Test
   fun `returns empty list of edits if nothing changed`() {
-    val existing = existingSite { zone(numPermanent = 1) { subzone { cluster() } } }
+    val existing = existingSite { zone(numPermanent = 1) { subzone { permanent() } } }
     val desired = existing.toNew()
 
     assertEditResult(

--- a/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculatorTest.kt
@@ -827,8 +827,8 @@ class PlantingSiteEditCalculatorTest {
   fun `updates existing subzone if original zone is deleted and new zone has a subzone with its name`() {
     val existing =
         existingSite(width = 1000) {
-          zone(name = "A", width = 500, numPermanent = 1) { subzone(name = "1") { cluster() } }
-          zone(name = "B", width = 500, numPermanent = 1) { subzone(name = "2") { cluster() } }
+          zone(name = "A", width = 500, numPermanent = 1) { subzone(name = "1") { permanent() } }
+          zone(name = "B", width = 500, numPermanent = 1) { subzone(name = "2") { permanent() } }
         }
     val desired =
         newSite(width = 1000) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingSiteBuilder.kt
@@ -41,7 +41,7 @@ import org.locationtech.jts.geom.PrecisionModel
  *     existingSite(width = 1000) {
  *       zone(width = 400) {
  *         subzone(width = 150) {
- *           cluster()
+ *           permanent()
  *           plot()
  *         }
  *         subzone()
@@ -309,7 +309,7 @@ private constructor(
         return plot
       }
 
-      fun cluster(
+      fun permanent(
           x: Int = nextMonitoringPlotX,
           y: Int = this.y,
           index: Int = nextPermanentIndex++,


### PR DESCRIPTION
Clean up the remaining references to "permanent clusters" in the code. This is a
mix of renaming functions and variables and of editing comments.

There are no behavioral changes here, just renames.