### PR TITLE
SW-6766 Improve zone replacement/rename handling

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/edit/PlantingSiteEditCalculator.kt
@@ -60,13 +60,15 @@ class PlantingSiteEditCalculator(
     val deleteEdits =
         existingSite.plantingZones.toSet().minus(existingZonesInUse).map { existingZone ->
           val plantingSubzoneEdits =
-              existingZone.plantingSubzones.map { existingSubzone ->
-                PlantingSubzoneEdit.Delete(
-                    existingSubzone,
-                    existingSubzone.monitoringPlots
-                        .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
-                        .map { MonitoringPlotEdit.Eject(it.id) })
-              }
+              existingZone.plantingSubzones
+                  .filter { it !in desiredSubzonesByExistingSubzone }
+                  .map { existingSubzone ->
+                    PlantingSubzoneEdit.Delete(
+                        existingSubzone,
+                        existingSubzone.monitoringPlots
+                            .filter { desiredSubzonesByMonitoringPlotId[it.id] == null }
+                            .map { MonitoringPlotEdit.Eject(it.id) })
+                  }
 
           PlantingZoneEdit.Delete(
               existingModel = existingZone,
@@ -120,7 +122,7 @@ class PlantingSiteEditCalculator(
               }
             }
 
-    return deleteEdits + updateEdits + createEdits
+    return createEdits + updateEdits + deleteEdits
   }
 
   private fun calculateMonitoringPlotEdits(
@@ -287,7 +289,7 @@ class PlantingSiteEditCalculator(
               }
             }
 
-    return deleteEdits + createEdits + updateEdits
+    return createEdits + updateEdits + deleteEdits
   }
 
   private fun calculateAreaHaDifference(existing: Geometry?, desired: Geometry): BigDecimal {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -438,6 +438,26 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
           "Monitoring plot in moved subzone")
     }
 
+    @Test
+    fun `moves subzone from deleted zone to new one, perhaps because the zone was renamed`() {
+      val initial = newSite {
+        zone(name = "A", numPermanent = 1) { subzone(name = "Subzone") { cluster() } }
+      }
+
+      val desired = newSite { zone(name = "B", numPermanent = 1) { subzone(name = "Subzone") } }
+
+      val (edited, existing) = runScenario(initial = initial, desired = desired)
+
+      val existingSubzone = existing.plantingZones[0].plantingSubzones[0]
+      val editedSubzone = edited.plantingZones[0].plantingSubzones[0]
+
+      assertEquals(existingSubzone.id, editedSubzone.id, "ID of moved subzone")
+      assertEquals(
+          existingSubzone.monitoringPlots[0].copy(permanentCluster = 1),
+          editedSubzone.monitoringPlots[0],
+          "Monitoring plot in moved subzone")
+    }
+
     private fun createSite(initial: NewPlantingSiteModel): ExistingPlantingSiteModel {
       clock.instant = Instant.EPOCH
 


### PR DESCRIPTION
The flexible site editing code had support for zone boundaries changing such that
a subzone moved from one zone to another. However, it wasn't handling cases where
the original zone was completely deleted. Since we match the existing and new
zones using their names when a new shapefile is uploaded, this meant that we
weren't handling cases where a planting zone is renamed.

Update the edit calculator to properly move subzones to the new zones in that
case, and don't delete the subzones as part of the deletion of their old zones.