### PR TITLE
SW-6804 Added published metrics to report fetch

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ReportsMetricsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ReportsMetricsController.kt
@@ -62,7 +62,7 @@ class ReportsController(private val metricStore: ReportMetricStore) {
 
 data class SystemMetricPayload(
     val metric: SystemMetric,
-    val name: String = metric.name,
+    val name: String = metric.jsonValue,
     val description: String = metric.description,
     val component: MetricComponent = metric.componentId,
     val type: MetricType = metric.typeId,

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderReportsController.kt
@@ -4,12 +4,16 @@ import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.FunderEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.accelerator.MetricComponent
+import com.terraformation.backend.db.accelerator.MetricType
 import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
+import com.terraformation.backend.db.accelerator.ReportMetricStatus
 import com.terraformation.backend.db.accelerator.ReportQuarter
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.funder.db.PublishedReportsStore
+import com.terraformation.backend.funder.model.PublishedReportMetricModel
 import com.terraformation.backend.funder.model.PublishedReportModel
 import io.swagger.v3.oas.annotations.Operation
 import java.time.Instant
@@ -42,6 +46,32 @@ data class ReportChallengePayload(
     val mitigationPlan: String,
 )
 
+data class PublishedReportMetricPayload(
+    val component: MetricComponent,
+    val description: String?,
+    val name: String,
+    val reference: String,
+    val status: ReportMetricStatus?,
+    val target: Int?,
+    val type: MetricType,
+    val underperformanceJustification: String?,
+    val value: Int?,
+) {
+  constructor(
+      model: PublishedReportMetricModel<*>
+  ) : this(
+      component = model.component,
+      description = model.description,
+      name = model.name,
+      reference = model.reference,
+      status = model.status,
+      target = model.target,
+      type = model.type,
+      underperformanceJustification = model.underperformanceJustification,
+      value = model.value,
+  )
+}
+
 data class PublishedReportPayload(
     val achievements: List<String>,
     val challenges: List<ReportChallengePayload>,
@@ -49,12 +79,15 @@ data class PublishedReportPayload(
     val frequency: ReportFrequency,
     val highlights: String?,
     val projectId: ProjectId,
+    val projectMetrics: List<PublishedReportMetricPayload>,
     val projectName: String,
     val publishedBy: UserId,
     val publishedTime: Instant,
     val quarter: ReportQuarter?,
     val reportId: ReportId,
+    val standardMetrics: List<PublishedReportMetricPayload>,
     val startDate: LocalDate,
+    val systemMetrics: List<PublishedReportMetricPayload>,
 ) {
   constructor(
       model: PublishedReportModel
@@ -65,12 +98,15 @@ data class PublishedReportPayload(
       frequency = model.frequency,
       highlights = model.highlights,
       projectId = model.projectId,
+      projectMetrics = model.projectMetrics.map { PublishedReportMetricPayload(it) },
       projectName = model.projectName,
       publishedBy = model.publishedBy,
       publishedTime = model.publishedTime,
       quarter = model.quarter,
       reportId = model.reportId,
+      standardMetrics = model.standardMetrics.map { PublishedReportMetricPayload(it) },
       startDate = model.startDate,
+      systemMetrics = model.systemMetrics.map { PublishedReportMetricPayload(it) },
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportMetricModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportMetricModel.kt
@@ -1,0 +1,18 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.accelerator.MetricComponent
+import com.terraformation.backend.db.accelerator.MetricType
+import com.terraformation.backend.db.accelerator.ReportMetricStatus
+
+data class PublishedReportMetricModel<ID : Any>(
+    val component: MetricComponent,
+    val description: String?,
+    val metricId: ID,
+    val name: String,
+    val reference: String,
+    val status: ReportMetricStatus?,
+    val target: Int?,
+    val type: MetricType,
+    val underperformanceJustification: String?,
+    val value: Int?,
+)

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedReportModel.kt
@@ -1,9 +1,12 @@
 package com.terraformation.backend.funder.model
 
 import com.terraformation.backend.accelerator.model.ReportChallengeModel
+import com.terraformation.backend.db.accelerator.ProjectMetricId
 import com.terraformation.backend.db.accelerator.ReportFrequency
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.ReportQuarter
+import com.terraformation.backend.db.accelerator.StandardMetricId
+import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import java.time.Instant
@@ -17,10 +20,13 @@ data class PublishedReportModel(
     val frequency: ReportFrequency,
     val highlights: String?,
     val projectId: ProjectId,
+    val projectMetrics: List<PublishedReportMetricModel<ProjectMetricId>>,
     val projectName: String,
     val publishedBy: UserId,
     val publishedTime: Instant,
     val quarter: ReportQuarter?,
     val reportId: ReportId,
-    val startDate: LocalDate
+    val standardMetrics: List<PublishedReportMetricModel<StandardMetricId>>,
+    val startDate: LocalDate,
+    val systemMetrics: List<PublishedReportMetricModel<SystemMetric>>,
 )


### PR DESCRIPTION
Added published metrics to the funders API. This is quite a bit simpler than the accelerator side because it is read only, and omits non-readable data such as metric ID, and progress notes. 