### PR TITLE
SW-6767 Don't allow asking about unprepared projects

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
@@ -60,6 +60,10 @@ class AdminAskController(
     try {
       val project = projectStore.fetchOneById(projectId)
 
+      if (!embeddingService.hasEmbeddings(projectId)) {
+        throw IllegalStateException("Project $projectId has not been prepared yet")
+      }
+
       model.addAttribute("answer", null)
       model.addAttribute("conversationId", UUID.randomUUID().toString())
       model.addAttribute("project", project)


### PR DESCRIPTION
If a project's embeddings haven't been generated yet, Ask Terraware will only be
able to base its answers on the handful of metadata fields like project name that
are included as part of every prompt. Add a sanity check to return an error
message in that case.