### PR TITLE
Simplified notification permissions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/NotificationStore.kt
@@ -105,11 +105,8 @@ class NotificationStore(
    *   notifications, the organization id in the notification model will be null, hence this
    *   additional organization id parameter to capture context.
    */
-  fun create(
-      notification: CreateNotificationModel,
-      targetOrganizationId: OrganizationId
-  ): NotificationId {
-    requirePermissions { createNotification(notification.userId, targetOrganizationId) }
+  fun create(notification: CreateNotificationModel): NotificationId {
+    requirePermissions { createNotification(notification.userId) }
     return with(NOTIFICATIONS) {
       with(notification) {
         dslContext

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -132,14 +132,4 @@ data class DeviceManagerUser(
   override fun canUpdateDevice(deviceId: DeviceId): Boolean = canAccessDevice(deviceId)
 
   override fun canUpdateTimeseries(deviceId: DeviceId): Boolean = canAccessDevice(deviceId)
-
-  // This one isn't a simple "is this the right organization" check because it depends on the
-  // target user's organization membership too.
-  override fun canCreateNotification(
-      targetUserId: UserId,
-      organizationId: OrganizationId
-  ): Boolean {
-    return canAccessOrganization(organizationId) &&
-        organizationId in permissionStore.fetchOrganizationRoles(targetUserId)
-  }
 }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -183,15 +183,7 @@ data class IndividualUser(
 
   override fun canCreateFundingEntities() = isAcceleratorAdmin()
 
-  override fun canCreateNotification(
-      targetUserId: UserId,
-      organizationId: OrganizationId
-  ): Boolean {
-    // for now, ensure user making the request and the target user for notification,
-    // are both members of the organization in context
-    return isMember(organizationId) &&
-        organizationId in permissionStore.fetchOrganizationRoles(targetUserId)
-  }
+  override fun canCreateNotification(targetUserId: UserId): Boolean = false
 
   override fun canCreateObservation(plantingSiteId: PlantingSiteId) =
       isSuperAdmin() || isManagerOrHigher(plantingSiteId)

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -309,9 +309,8 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun createNotification(userId: UserId, organizationId: OrganizationId) {
-    readOrganization(organizationId)
-    if (!user.canCreateNotification(userId, organizationId)) {
+  fun createNotification(userId: UserId) {
+    if (!user.canCreateNotification(userId)) {
       throw AccessDeniedException("No permission to create notification")
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -259,8 +259,7 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canCreateFundingEntities(): Boolean = defaultPermission
 
-  fun canCreateNotification(targetUserId: UserId, organizationId: OrganizationId): Boolean =
-      defaultPermission
+  fun canCreateNotification(targetUserId: UserId): Boolean = defaultPermission
 
   fun canCreateObservation(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -272,7 +272,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
 
     every { user.canCreateAccession(facilityId) } returns true
     every { user.canCreateAutomation(any()) } returns true
-    every { user.canCreateNotification(any(), organizationId) } returns true
+    every { user.canCreateNotification(any()) } returns true
     every { user.canListOrganizationUsers(any()) } returns true
     every { user.canReadAccession(any()) } returns true
     every { user.canReadAllDeliverables() } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -387,9 +387,9 @@ internal class PermissionRequirementsTest : RunsAsUser {
 
   @Test
   fun createNotification() =
-      allow { createNotification(notificationUserId, organizationId) } ifUser
+      allow { createNotification(notificationUserId) } ifUser
           {
-            canCreateNotification(notificationUserId, organizationId)
+            canCreateNotification(notificationUserId)
           }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1607,6 +1607,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *otherUserIds.values.toTypedArray(),
         createEntityWithOwner = true,
+        createNotifications = true,
         readUser = true,
         readUserInternalInterests = true,
         updateUserInternalInterests = true,
@@ -3702,6 +3703,7 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg userIds: UserId,
         createEntityWithOwner: Boolean = false,
+        createNotifications: Boolean = false,
         readUser: Boolean = false,
         readUserInternalInterests: Boolean = false,
         updateUserInternalInterests: Boolean = false,
@@ -3711,6 +3713,10 @@ internal class PermissionTest : DatabaseTest() {
             createEntityWithOwner,
             user.canCreateEntityWithOwner(userId),
             "Can create entity with owner $userId")
+        assertEquals(
+            createNotifications,
+            user.canCreateNotification(userId),
+            "Can create notifications for $userId")
         assertEquals(readUser, user.canReadUser(userId), "Can read user $userId")
         assertEquals(
             readUserInternalInterests,


### PR DESCRIPTION
This is to prepare for adding funding entity notifications, which no longer targets an organization user.