### PR TITLE
SW-6707 Merge species in biomass observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1186,17 +1186,17 @@ class ObservationStore(
               ID, SCIENTIFIC_NAME.eq(otherSpeciesName).and(OBSERVATION_ID.eq(observationId)))
         }
 
-    val targetBiomassSpeciesId =
-        with(OBSERVATION_BIOMASS_SPECIES) {
-          dslContext.fetchValue(ID, SPECIES_ID.eq(speciesId).and(OBSERVATION_ID.eq(observationId)))
-        }
-
     if (otherBiomassSpeciesId == null) {
       log.warn(
           "Biomass observation $observationId does not contain species name $otherSpeciesName; " +
               "merge is a no-op")
       return
     }
+
+    val targetBiomassSpeciesId =
+        with(OBSERVATION_BIOMASS_SPECIES) {
+          dslContext.fetchValue(ID, SPECIES_ID.eq(speciesId).and(OBSERVATION_ID.eq(observationId)))
+        }
 
     if (targetBiomassSpeciesId == null) {
       // The target species wasn't present at all in the observation, so there's no need to merge

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -43,6 +43,7 @@ import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_REQUESTED_SUBZONES
@@ -59,6 +60,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
@@ -1162,118 +1164,248 @@ class ObservationStore(
     }
 
     withLockedObservation(observationId) { observation ->
-      val observationPlotDetails =
-          dslContext
-              .select(
-                  OBSERVATION_PLOTS.MONITORING_PLOT_ID,
-                  OBSERVATION_PLOTS.IS_PERMANENT,
-                  MONITORING_PLOTS.PLANTING_SUBZONE_ID,
-                  PLANTING_SUBZONES.PLANTING_ZONE_ID)
-              .from(OBSERVATION_PLOTS)
-              .join(MONITORING_PLOTS)
-              .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
-              .leftJoin(PLANTING_SUBZONES)
-              .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
-              .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
-              .fetch()
-              .associateBy { it[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!! }
+      when (observation.observationType) {
+        ObservationType.BiomassMeasurements ->
+            mergeOtherSpeciesForBiomass(observation, speciesId, otherSpeciesName)
+        ObservationType.Monitoring ->
+            mergeOtherSpeciesForMonitoring(observation, speciesId, otherSpeciesName)
+      }
+    }
+  }
 
-      // Make the raw data (individual recorded plants) refer to the target species. This has no
-      // impact on statistics; those are adjusted later.
-      with(RECORDED_PLANTS) {
+  private fun mergeOtherSpeciesForBiomass(
+      observation: ExistingObservationModel,
+      speciesId: SpeciesId,
+      otherSpeciesName: String
+  ) {
+    val observationId = observation.id
+
+    val otherBiomassSpeciesId =
+        with(OBSERVATION_BIOMASS_SPECIES) {
+          dslContext.fetchValue(
+              ID, SCIENTIFIC_NAME.eq(otherSpeciesName).and(OBSERVATION_ID.eq(observationId)))
+        }
+
+    val targetBiomassSpeciesId =
+        with(OBSERVATION_BIOMASS_SPECIES) {
+          dslContext.fetchValue(ID, SPECIES_ID.eq(speciesId).and(OBSERVATION_ID.eq(observationId)))
+        }
+
+    if (otherBiomassSpeciesId == null) {
+      log.warn(
+          "Biomass observation $observationId does not contain species name $otherSpeciesName; " +
+              "merge is a no-op")
+      return
+    }
+
+    if (targetBiomassSpeciesId == null) {
+      // The target species wasn't present at all in the observation, so there's no need to merge
+      // anything: we can just update the biomass species to point to the target species ID instead
+      // of using a name.
+      with(OBSERVATION_BIOMASS_SPECIES) {
         dslContext
-            .update(RECORDED_PLANTS)
-            .set(CERTAINTY_ID, RecordedSpeciesCertainty.Known)
+            .update(OBSERVATION_BIOMASS_SPECIES)
             .set(SPECIES_ID, speciesId)
-            .setNull(SPECIES_NAME)
-            .where(OBSERVATION_ID.eq(observationId))
-            .and(SPECIES_NAME.eq(otherSpeciesName))
-            .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+            .setNull(SCIENTIFIC_NAME)
+            .where(ID.eq(otherBiomassSpeciesId))
             .execute()
       }
 
-      // We need to adjust the plot-level summary statistics for all the sightings of the Other
-      // species in this observation. Updating the plot-level statistics will automatically also
-      // update the site- and zone-level ones.
-      val plotTotals: List<ObservedPlotSpeciesTotalsRecord> =
-          with(OBSERVED_PLOT_SPECIES_TOTALS) {
-            dslContext
-                .selectFrom(OBSERVED_PLOT_SPECIES_TOTALS)
-                .where(OBSERVATION_ID.eq(observationId))
-                .and(SPECIES_NAME.eq(otherSpeciesName))
-                .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
-                .fetch()
-          }
+      return
+    }
 
-      plotTotals.forEach { plotTotal ->
-        val monitoringPlotId = plotTotal.monitoringPlotId
-        val plotDetails =
-            observationPlotDetails[monitoringPlotId]
-                ?: throw IllegalStateException(
-                    "Monitoring plot $monitoringPlotId has species totals for $otherSpeciesName " +
-                        "in observation $observationId but is not in observation")
+    // Recorded trees are a simple replacement of the biomass species ID.
+    with(RECORDED_TREES) {
+      dslContext
+          .update(RECORDED_TREES)
+          .set(BIOMASS_SPECIES_ID, targetBiomassSpeciesId)
+          .where(BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId))
+          .execute()
+    }
 
-        // Subtract the plot-level live/dead/existing counts from the Other species and add them
-        // to the target species. This propagates the changes up to the zone and site totals.
-        // Once this has been done for all the plot-level totals, the end result will be that the
-        // plot, zone, and site totals for the Other species will all be zero.
-        //
-        // We have to cancel out the Other totals rather than just deleting them because the same
-        // Other species might appear in later observations, in which case the cumulative dead and
-        // mortality rate in those observations will need to change to the values they would have
-        // had if the Other species hadn't been recorded in this observation.
-        updateSpeciesTotals(
-            observationId,
-            observation.plantingSiteId,
-            plotDetails[PLANTING_SUBZONES.PLANTING_ZONE_ID],
-            plotDetails[MONITORING_PLOTS.PLANTING_SUBZONE_ID],
-            monitoringPlotId,
-            observation.isAdHoc,
-            plotDetails[OBSERVATION_PLOTS.IS_PERMANENT]!!,
-            mapOf(
-                RecordedSpeciesKey(RecordedSpeciesCertainty.Other, null, otherSpeciesName) to
-                    mapOf(
-                        RecordedPlantStatus.Live to -(plotTotal.totalLive ?: 0),
-                        RecordedPlantStatus.Dead to -(plotTotal.totalDead ?: 0),
-                        RecordedPlantStatus.Existing to -(plotTotal.totalExisting ?: 0),
-                    ),
-                RecordedSpeciesKey(RecordedSpeciesCertainty.Known, speciesId, null) to
-                    mapOf(
-                        RecordedPlantStatus.Live to (plotTotal.totalLive ?: 0),
-                        RecordedPlantStatus.Dead to (plotTotal.totalDead ?: 0),
-                        RecordedPlantStatus.Existing to (plotTotal.totalExisting ?: 0))))
-      }
+    // For quadrat species, we need to add the abundance percentages of the numbered species and the
+    // "Other" one if both exist in the quadrat. If only the "Other" one exists, then we can just
+    // switch its biomass species ID in place.
+    with(OBSERVATION_BIOMASS_QUADRAT_SPECIES) {
+      val quadratSpeciesTable2 = OBSERVATION_BIOMASS_QUADRAT_SPECIES.`as`("quadrat2")
 
-      // The plant counts for the Other species have been emptied out for this observation. We want
-      // the end result to be as if people had never recorded the Other species in the first place,
-      // so we need to delete its statistics or else the Other species will still be included by
-      // queries that list all the recorded species in an observation.
-      with(OBSERVED_PLOT_SPECIES_TOTALS) {
+      dslContext
+          .update(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
+          .set(BIOMASS_SPECIES_ID, targetBiomassSpeciesId)
+          .where(BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId))
+          .andNotExists(
+              DSL.selectOne()
+                  .from(quadratSpeciesTable2)
+                  .where(quadratSpeciesTable2.BIOMASS_SPECIES_ID.eq(targetBiomassSpeciesId))
+                  .and(quadratSpeciesTable2.POSITION_ID.eq(POSITION_ID)))
+          .execute()
+
+      dslContext
+          .update(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
+          .set(
+              ABUNDANCE_PERCENT,
+              ABUNDANCE_PERCENT.plus(
+                  DSL.field(
+                      DSL.select(quadratSpeciesTable2.ABUNDANCE_PERCENT)
+                          .from(quadratSpeciesTable2)
+                          .where(quadratSpeciesTable2.BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId))
+                          .and(quadratSpeciesTable2.POSITION_ID.eq(POSITION_ID)))))
+          .where(BIOMASS_SPECIES_ID.eq(targetBiomassSpeciesId))
+          .andExists(
+              DSL.selectOne()
+                  .from(quadratSpeciesTable2)
+                  .where(quadratSpeciesTable2.BIOMASS_SPECIES_ID.eq(otherBiomassSpeciesId))
+                  .and(quadratSpeciesTable2.POSITION_ID.eq(POSITION_ID)))
+          .execute()
+    }
+
+    // Invasive and threatened should be true if they're true on either version of the species.
+    with(OBSERVATION_BIOMASS_SPECIES) {
+      dslContext
+          .update(OBSERVATION_BIOMASS_SPECIES)
+          .set(
+              IS_INVASIVE,
+              DSL.select(DSL.boolOr(IS_INVASIVE))
+                  .from(OBSERVATION_BIOMASS_SPECIES)
+                  .where(ID.`in`(otherBiomassSpeciesId, targetBiomassSpeciesId)))
+          .set(
+              IS_THREATENED,
+              DSL.select(DSL.boolOr(IS_THREATENED))
+                  .from(OBSERVATION_BIOMASS_SPECIES)
+                  .where(ID.`in`(otherBiomassSpeciesId, targetBiomassSpeciesId)))
+          .where(ID.eq(targetBiomassSpeciesId))
+          .execute()
+    }
+
+    // ON DELETE CASCADE will remove the data for the "Other" species from all the biomass tables.
+    dslContext
+        .deleteFrom(OBSERVATION_BIOMASS_SPECIES)
+        .where(OBSERVATION_BIOMASS_SPECIES.ID.eq(otherBiomassSpeciesId))
+        .execute()
+  }
+
+  private fun mergeOtherSpeciesForMonitoring(
+      observation: ExistingObservationModel,
+      speciesId: SpeciesId,
+      otherSpeciesName: String
+  ) {
+    val observationId = observation.id
+    val observationPlotDetails =
         dslContext
-            .deleteFrom(OBSERVED_PLOT_SPECIES_TOTALS)
-            .where(OBSERVATION_ID.eq(observationId))
-            .and(SPECIES_NAME.eq(otherSpeciesName))
-            .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
-            .execute()
-      }
+            .select(
+                OBSERVATION_PLOTS.MONITORING_PLOT_ID,
+                OBSERVATION_PLOTS.IS_PERMANENT,
+                MONITORING_PLOTS.PLANTING_SUBZONE_ID,
+                PLANTING_SUBZONES.PLANTING_ZONE_ID,
+            )
+            .from(OBSERVATION_PLOTS)
+            .join(MONITORING_PLOTS)
+            .on(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+            .leftJoin(PLANTING_SUBZONES)
+            .on(MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+            .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
+            .fetch()
+            .associateBy { it[OBSERVATION_PLOTS.MONITORING_PLOT_ID]!! }
 
-      with(OBSERVED_ZONE_SPECIES_TOTALS) {
-        dslContext
-            .deleteFrom(OBSERVED_ZONE_SPECIES_TOTALS)
-            .where(OBSERVATION_ID.eq(observationId))
-            .and(SPECIES_NAME.eq(otherSpeciesName))
-            .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
-            .execute()
-      }
+    // Make the raw data (individual recorded plants) refer to the target species. This has no
+    // impact on statistics; those are adjusted later.
+    with(RECORDED_PLANTS) {
+      dslContext
+          .update(RECORDED_PLANTS)
+          .set(CERTAINTY_ID, RecordedSpeciesCertainty.Known)
+          .set(SPECIES_ID, speciesId)
+          .setNull(SPECIES_NAME)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(SPECIES_NAME.eq(otherSpeciesName))
+          .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+          .execute()
+    }
 
-      with(OBSERVED_SITE_SPECIES_TOTALS) {
-        dslContext
-            .deleteFrom(OBSERVED_SITE_SPECIES_TOTALS)
-            .where(OBSERVATION_ID.eq(observationId))
-            .and(SPECIES_NAME.eq(otherSpeciesName))
-            .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
-            .execute()
-      }
+    // We need to adjust the plot-level summary statistics for all the sightings of the Other
+    // species in this observation. Updating the plot-level statistics will automatically also
+    // update the site- and zone-level ones.
+    val plotTotals: List<ObservedPlotSpeciesTotalsRecord> =
+        with(OBSERVED_PLOT_SPECIES_TOTALS) {
+          dslContext
+              .selectFrom(OBSERVED_PLOT_SPECIES_TOTALS)
+              .where(OBSERVATION_ID.eq(observationId))
+              .and(SPECIES_NAME.eq(otherSpeciesName))
+              .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+              .fetch()
+        }
+
+    plotTotals.forEach { plotTotal ->
+      val monitoringPlotId = plotTotal.monitoringPlotId
+      val plotDetails =
+          observationPlotDetails[monitoringPlotId]
+              ?: throw IllegalStateException(
+                  "Monitoring plot $monitoringPlotId has species totals for $otherSpeciesName " +
+                      "in observation $observationId but is not in observation",
+              )
+
+      // Subtract the plot-level live/dead/existing counts from the Other species and add them
+      // to the target species. This propagates the changes up to the zone and site totals.
+      // Once this has been done for all the plot-level totals, the end result will be that the
+      // plot, zone, and site totals for the Other species will all be zero.
+      //
+      // We have to cancel out the Other totals rather than just deleting them because the same
+      // Other species might appear in later observations, in which case the cumulative dead and
+      // mortality rate in those observations will need to change to the values they would have
+      // had if the Other species hadn't been recorded in this observation.
+      updateSpeciesTotals(
+          observationId,
+          observation.plantingSiteId,
+          plotDetails[PLANTING_SUBZONES.PLANTING_ZONE_ID],
+          plotDetails[MONITORING_PLOTS.PLANTING_SUBZONE_ID],
+          monitoringPlotId,
+          observation.isAdHoc,
+          plotDetails[OBSERVATION_PLOTS.IS_PERMANENT]!!,
+          mapOf(
+              RecordedSpeciesKey(RecordedSpeciesCertainty.Other, null, otherSpeciesName) to
+                  mapOf(
+                      RecordedPlantStatus.Live to -(plotTotal.totalLive ?: 0),
+                      RecordedPlantStatus.Dead to -(plotTotal.totalDead ?: 0),
+                      RecordedPlantStatus.Existing to -(plotTotal.totalExisting ?: 0),
+                  ),
+              RecordedSpeciesKey(RecordedSpeciesCertainty.Known, speciesId, null) to
+                  mapOf(
+                      RecordedPlantStatus.Live to (plotTotal.totalLive ?: 0),
+                      RecordedPlantStatus.Dead to (plotTotal.totalDead ?: 0),
+                      RecordedPlantStatus.Existing to (plotTotal.totalExisting ?: 0),
+                  ),
+          ),
+      )
+    }
+
+    // The plant counts for the Other species have been emptied out for this observation. We want
+    // the end result to be as if people had never recorded the Other species in the first place,
+    // so we need to delete its statistics or else the Other species will still be included by
+    // queries that list all the recorded species in an observation.
+    with(OBSERVED_PLOT_SPECIES_TOTALS) {
+      dslContext
+          .deleteFrom(OBSERVED_PLOT_SPECIES_TOTALS)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(SPECIES_NAME.eq(otherSpeciesName))
+          .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+          .execute()
+    }
+
+    with(OBSERVED_ZONE_SPECIES_TOTALS) {
+      dslContext
+          .deleteFrom(OBSERVED_ZONE_SPECIES_TOTALS)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(SPECIES_NAME.eq(otherSpeciesName))
+          .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+          .execute()
+    }
+
+    with(OBSERVED_SITE_SPECIES_TOTALS) {
+      dslContext
+          .deleteFrom(OBSERVED_SITE_SPECIES_TOTALS)
+          .where(OBSERVATION_ID.eq(observationId))
+          .and(SPECIES_NAME.eq(otherSpeciesName))
+          .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
+          .execute()
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeOtherSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeOtherSpeciesTest.kt
@@ -1,20 +1,38 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.BiomassForestType
+import com.terraformation.backend.db.tracking.BiomassSpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedPlotSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedSiteSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedZoneSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecord
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.SpeciesInWrongOrganizationException
+import com.terraformation.backend.tracking.model.BiomassQuadratModel
+import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
+import com.terraformation.backend.tracking.model.BiomassSpeciesModel
+import com.terraformation.backend.tracking.model.NewBiomassDetailsModel
+import com.terraformation.backend.tracking.model.NewRecordedTreeModel
 import io.mockk.every
+import java.math.BigDecimal
 import java.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,6 +42,7 @@ import org.springframework.security.access.AccessDeniedException
 class ObservationStoreMergeOtherSpeciesTest : BaseObservationStoreTest() {
   private lateinit var plantingZoneId: PlantingZoneId
   private lateinit var monitoringPlotId: MonitoringPlotId
+  private lateinit var observationId: ObservationId
 
   @BeforeEach
   fun insertDetailedPlantingSite() {
@@ -314,6 +333,246 @@ class ObservationStoreMergeOtherSpeciesTest : BaseObservationStoreTest() {
   }
 
   @Test
+  fun `updates entities for biomass observation`() {
+    observationId =
+        insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
+    monitoringPlotId = insertMonitoringPlot(plantingSubzoneId = null, isAdHoc = true)
+    insertObservationPlot(claimedBy = user.userId, isPermanent = false)
+    val speciesId1 = insertSpecies()
+    val speciesId2 = insertSpecies()
+
+    store.insertBiomassDetails(
+        observationId,
+        monitoringPlotId,
+        NewBiomassDetailsModel(
+            forestType = BiomassForestType.Terrestrial,
+            observationId = null,
+            herbaceousCoverPercent = 30,
+            quadrats =
+                mapOf(
+                    ObservationPlotPosition.NortheastCorner to
+                        BiomassQuadratModel(
+                            species =
+                                setOf(
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 1, speciesId = speciesId1),
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 2, speciesId = speciesId2),
+                                    // This will be merged with the speciesId1 entry
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 4, speciesName = "Other 1"),
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 8, speciesName = "Other 2"),
+                                ),
+                        ),
+                    ObservationPlotPosition.NorthwestCorner to
+                        BiomassQuadratModel(
+                            species =
+                                setOf(
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 16, speciesId = speciesId1),
+                                    // This will be merged with the speciesId1 entry
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 32, speciesName = "Other 1"),
+                                ),
+                        ),
+                    ObservationPlotPosition.SoutheastCorner to
+                        BiomassQuadratModel(
+                            species =
+                                setOf(
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 51, speciesId = speciesId1),
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 52, speciesName = "Other 2"),
+                                ),
+                        ),
+                    ObservationPlotPosition.SouthwestCorner to
+                        BiomassQuadratModel(
+                            species =
+                                setOf(
+                                    // This should turn into a speciesId1 entry
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 53, speciesName = "Other 1"),
+                                ),
+                        ),
+                ),
+            smallTreeCountRange = 1 to 20,
+            soilAssessment = "Dirty",
+            species =
+                setOf(
+                    BiomassSpeciesModel(
+                        isInvasive = false, isThreatened = true, speciesId = speciesId1),
+                    BiomassSpeciesModel(
+                        isInvasive = false, isThreatened = true, speciesId = speciesId2),
+                    BiomassSpeciesModel(
+                        isInvasive = true, isThreatened = false, scientificName = "Other 1"),
+                    BiomassSpeciesModel(
+                        isInvasive = false, isThreatened = false, scientificName = "Other 2"),
+                ),
+            plotId = null,
+            trees =
+                listOf(
+                    NewRecordedTreeModel(
+                        diameterAtBreastHeightCm = BigDecimal(1),
+                        heightM = BigDecimal(10),
+                        id = null,
+                        isDead = false,
+                        pointOfMeasurementM = BigDecimal(1.3),
+                        speciesId = speciesId1,
+                        treeNumber = 1,
+                        trunkNumber = 1,
+                        treeGrowthForm = TreeGrowthForm.Tree,
+                    ),
+                    NewRecordedTreeModel(
+                        diameterAtBreastHeightCm = BigDecimal(1.5),
+                        heightM = BigDecimal(11),
+                        id = null,
+                        isDead = false,
+                        pointOfMeasurementM = BigDecimal(1.4),
+                        speciesName = "Other 1",
+                        treeNumber = 2,
+                        trunkNumber = 1,
+                        treeGrowthForm = TreeGrowthForm.Trunk,
+                    ),
+                    NewRecordedTreeModel(
+                        diameterAtBreastHeightCm = BigDecimal(1.9),
+                        id = null,
+                        isDead = false,
+                        pointOfMeasurementM = BigDecimal(1.2),
+                        speciesName = "Other 1",
+                        treeNumber = 2,
+                        trunkNumber = 2,
+                        treeGrowthForm = TreeGrowthForm.Trunk,
+                    ),
+                    NewRecordedTreeModel(
+                        diameterAtBreastHeightCm = BigDecimal(12),
+                        heightM = BigDecimal(30),
+                        id = null,
+                        isDead = false,
+                        pointOfMeasurementM = BigDecimal(1.2),
+                        speciesName = "Other 2",
+                        treeNumber = 3,
+                        trunkNumber = 1,
+                        treeGrowthForm = TreeGrowthForm.Tree,
+                    ),
+                ),
+        ))
+
+    val recordedTreesBeforeMerge = dslContext.fetch(RECORDED_TREES)
+
+    val observationSpeciesBeforeMerge = dslContext.fetch(OBSERVATION_BIOMASS_SPECIES)
+    val biomassSpeciesId1 = observationSpeciesBeforeMerge.first { it.speciesId == speciesId1 }.id!!
+    val biomassSpeciesId2 = observationSpeciesBeforeMerge.first { it.speciesId == speciesId2 }.id!!
+    val biomassOtherId1 =
+        observationSpeciesBeforeMerge.first { it.scientificName == "Other 1" }.id!!
+    val biomassOtherId2 =
+        observationSpeciesBeforeMerge.first { it.scientificName == "Other 2" }.id!!
+
+    store.mergeOtherSpecies(observationId, "Other 1", speciesId1)
+
+    assertTableEquals(
+        recordedTreesBeforeMerge.map { record ->
+          if (record.biomassSpeciesId == biomassOtherId1) {
+            record.with(RECORDED_TREES.BIOMASS_SPECIES_ID, biomassSpeciesId1)
+          } else {
+            record
+          }
+        })
+
+    assertTableEquals(
+        setOf(
+            // Abundance percent is 5 because we are combining the original speciesId1 entry's 1
+            // with the "Other 1" entry's 4.
+            quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassSpeciesId1, 5),
+            quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassSpeciesId2, 2),
+            quadratSpeciesRecord(ObservationPlotPosition.NortheastCorner, biomassOtherId2, 8),
+            // And this one combines entries with abundances of 16 and 32 (to test that we aren't
+            // combining the values from the wrong quadrats).
+            quadratSpeciesRecord(ObservationPlotPosition.NorthwestCorner, biomassSpeciesId1, 48),
+            // There's no "Other 1" in the southeast corner, so the abundance percent stays the same
+            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassSpeciesId1, 51),
+            quadratSpeciesRecord(ObservationPlotPosition.SoutheastCorner, biomassOtherId2, 52),
+            // This started out as an "Other 1" entry.
+            quadratSpeciesRecord(ObservationPlotPosition.SouthwestCorner, biomassSpeciesId1, 53),
+        ))
+
+    assertTableEquals(
+        setOf(
+            // In the original data, "Species 1" is invasive and "Other 1" is threatened.
+            observationSpeciesRecord(
+                biomassSpeciesId1, speciesId1, isInvasive = true, isThreatened = true),
+            observationSpeciesRecord(
+                biomassSpeciesId2, speciesId2, isInvasive = false, isThreatened = true),
+            observationSpeciesRecord(
+                biomassOtherId2,
+                speciesName = "Other 2",
+                isInvasive = false,
+                isThreatened = false)))
+  }
+
+  @Test
+  fun `makes biomass species refer to target species ID if target was not already in observation`() {
+    val observationId =
+        insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
+    monitoringPlotId = insertMonitoringPlot(plantingSubzoneId = null, isAdHoc = true)
+    insertObservationPlot(claimedBy = user.userId, isPermanent = false)
+    val speciesId = insertSpecies()
+
+    store.insertBiomassDetails(
+        observationId,
+        monitoringPlotId,
+        NewBiomassDetailsModel(
+            forestType = BiomassForestType.Terrestrial,
+            observationId = null,
+            herbaceousCoverPercent = 30,
+            quadrats =
+                mapOf(
+                    ObservationPlotPosition.NortheastCorner to
+                        BiomassQuadratModel(
+                            species =
+                                setOf(
+                                    BiomassQuadratSpeciesModel(
+                                        abundancePercent = 1, speciesName = "Other")))),
+            smallTreeCountRange = 1 to 20,
+            soilAssessment = "Dirty",
+            species =
+                setOf(
+                    BiomassSpeciesModel(
+                        isInvasive = true, isThreatened = false, scientificName = "Other")),
+            plotId = null,
+            trees =
+                listOf(
+                    NewRecordedTreeModel(
+                        diameterAtBreastHeightCm = BigDecimal(15),
+                        heightM = BigDecimal(11),
+                        id = null,
+                        isDead = false,
+                        pointOfMeasurementM = BigDecimal(1.3),
+                        speciesName = "Other",
+                        treeNumber = 1,
+                        trunkNumber = 1,
+                        treeGrowthForm = TreeGrowthForm.Tree))))
+
+    val quadratSpeciesBeforeMerge = dslContext.fetch(OBSERVATION_BIOMASS_QUADRAT_SPECIES)
+    val recordedTreesBeforeMerge = dslContext.fetch(RECORDED_TREES)
+
+    store.mergeOtherSpecies(observationId, "Other", speciesId)
+
+    assertTableEquals(
+        ObservationBiomassSpeciesRecord(
+            isInvasive = true,
+            isThreatened = false,
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            scientificName = null,
+            speciesId = speciesId))
+
+    // Other tables should be unmodified because we updated the biomass species in place.
+    assertTableEquals(quadratSpeciesBeforeMerge)
+    assertTableEquals(recordedTreesBeforeMerge)
+  }
+
+  @Test
   fun `throws exception if no permission to update observation`() {
     val observationId = insertObservation()
     val speciesId = insertSpecies()
@@ -380,4 +639,29 @@ class ObservationStoreMergeOtherSpeciesTest : BaseObservationStoreTest() {
           mortalityRate = mortalityRate,
           cumulativeDead = cumulativeDead,
           permanentLive = permanentLive)
+
+  private fun quadratSpeciesRecord(
+      position: ObservationPlotPosition,
+      biomassSpeciesId: BiomassSpeciesId,
+      abundancePercent: Int
+  ) =
+      ObservationBiomassQuadratSpeciesRecord(
+          observationId, monitoringPlotId, position, biomassSpeciesId, abundancePercent)
+
+  private fun observationSpeciesRecord(
+      id: BiomassSpeciesId,
+      speciesId: SpeciesId? = null,
+      speciesName: String? = null,
+      isInvasive: Boolean = false,
+      isThreatened: Boolean = false
+  ) =
+      ObservationBiomassSpeciesRecord(
+          id = id,
+          observationId = observationId,
+          monitoringPlotId = monitoringPlotId,
+          speciesId = speciesId,
+          scientificName = speciesName,
+          isInvasive = isInvasive,
+          isThreatened = isThreatened,
+      )
 }


### PR DESCRIPTION
The "merge 'other' species" logic (for replacing user-entered species names in
observations with references to species from the organization's species list)
was only updating data related to monitoring observations. Add support for
merging species in biomass observations as well.