### PR TITLE
SW-6327 Support multiple growth forms in species CSV

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidator.kt
@@ -118,7 +118,8 @@ class SpeciesCsvValidator(
   }
 
   private fun validateGrowthForm(value: String?, field: String) {
-    if (!value.isNullOrBlank() && value !in validGrowthForms) {
+    if (!value.isNullOrBlank() &&
+        value.split(MULTIPLE_VALUE_DELIMITER).any { it !in validGrowthForms }) {
       addError(
           UploadProblemType.UnrecognizedValue, field, value, messages.speciesCsvGrowthFormInvalid())
     }

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesImporter.kt
@@ -135,7 +135,10 @@ class SpeciesImporter(
                         ?.toSet() ?: emptySet(),
                 familyName = values[2],
                 growthForms =
-                    values[5]?.let { setOf(GrowthForm.forDisplayName(it, locale)) } ?: emptySet(),
+                    values[5]
+                        ?.split(SpeciesCsvValidator.MULTIPLE_VALUE_DELIMITER)
+                        ?.map { GrowthForm.forDisplayName(it, locale) }
+                        ?.toSet() ?: emptySet(),
                 localUsesKnown = values[11],
                 nativeEcosystem = values[8],
                 organizationId = organizationId,

--- a/src/main/resources/csv/species-template.csv
+++ b/src/main/resources/csv/species-template.csv
@@ -37,7 +37,9 @@ Please choose from the following list or an error will occur during upload:
 - Shrub or Tree
 - Subshrub
 - Tree
-- Vine","Seed Storage Behavior
+- Vine
+
+You can add multiple growth forms if they are separated with line breaks.","Seed Storage Behavior
 
 Please choose from the following list or an error will occur during upload:
 

--- a/src/main/resources/csv/species-template_es.csv
+++ b/src/main/resources/csv/species-template_es.csv
@@ -36,7 +36,9 @@ Elija de la siguiente lista o se producirá un error durante la carga:
 - Múltiples formas
 - Musgo
 - Para germinación
-- Subarbusto","Comportamiento de almacenamiento
+- Subarbusto
+
+Puede agregar varios formas de crecimiento si están separados por saltos de línea.","Comportamiento de almacenamiento
 
 Elija de la siguiente lista o se producirá un error durante la carga:
 

--- a/src/main/resources/csv/species-template_fr.csv
+++ b/src/main/resources/csv/species-template_fr.csv
@@ -37,7 +37,9 @@ Veuillez choisir parmi la liste suivante ou une erreur se produira lors du tél�
 - Mangrove
 - Mousse
 - Sous-arbuste
-- Vigne","Comportement de stockage des graines
+- Vigne
+
+Vous pouvez ajouter plusieurs formes de croissance en les séparant par des sauts de ligne.","Comportement de stockage des graines
 
 Veuillez choisir parmi la liste suivante ou une erreur se produira lors du téléchargement :
 

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesCsvValidatorTest.kt
@@ -371,6 +371,13 @@ internal class SpeciesCsvValidatorTest {
   }
 
   @Test
+  fun `accepts multiple values for growth forms`() {
+    val csv = "$header\nSci name,Common,,,,\"Vine\nMoss\n\",,,,,,,,"
+
+    assertValidationResults(csv)
+  }
+
+  @Test
   fun `accepts both UNIX-style and Windows-style line separators`() {
     val csv = "$header\nScientific a,,,,,,,,,,,,,\r\nScientific b,,,,,,,,,,,,,\r\n"
     assertValidationResults(csv)

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesImporterTest.kt
@@ -312,7 +312,7 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     every { fileStore.read(storageUrl) } returns
         sizedInputStream(
             "$header\nNew—name a–b," + // note the dash types in the scientific name
-                "Common,Family,NT,false,Shrub,Recalcitrant,\"Tundra \r\n Mangroves \r\n\"," +
+                "Common,Family,NT,false,\"Shrub\nHerb\",Recalcitrant,\"Tundra \r\n Mangroves \r\n\"," +
                 "Native,\"Pioneer\nMature\",Eco role,Local uses,\"Wildling harvest\nOther\",Facts\n")
     val uploadId =
         insertUpload(
@@ -359,10 +359,12 @@ internal class SpeciesImporterTest : DatabaseTest(), RunsAsUser {
     assertTableEquals(
         setOf(
             SpeciesEcosystemTypesRecord(newSpeciesId, EcosystemType.Tundra),
-            SpeciesEcosystemTypesRecord(newSpeciesId, EcosystemType.Mangroves)),
-    )
+            SpeciesEcosystemTypesRecord(newSpeciesId, EcosystemType.Mangroves)))
 
-    assertTableEquals(SpeciesGrowthFormsRecord(newSpeciesId, GrowthForm.Shrub))
+    assertTableEquals(
+        setOf(
+            SpeciesGrowthFormsRecord(newSpeciesId, GrowthForm.Herb),
+            SpeciesGrowthFormsRecord(newSpeciesId, GrowthForm.Shrub)))
 
     assertTableEquals(
         setOf(


### PR DESCRIPTION
Species can have multiple growth forms, and we support that in the species editor
in the web app, but the species CSV importer was only accepting single values.