### PR TITLE
Remove warning suppression that's no longer needed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -280,9 +280,6 @@ tasks.withType<KotlinCompile> {
 
     extraWarnings = true
 
-    // https://youtrack.jetbrains.com/issue/KT-72040
-    freeCompilerArgs.add("-Xsuppress-warning=UNUSED_ANONYMOUS_PARAMETER")
-
     // jOOQ generated code has redundant modifiers
     freeCompilerArgs.add("-Xsuppress-warning=REDUNDANT_MODALITY_MODIFIER")
     freeCompilerArgs.add("-Xsuppress-warning=REDUNDANT_VISIBILITY_MODIFIER")


### PR DESCRIPTION
We had to add a warning suppression when we upgraded to Kotlin 2.1 because the
compiler was generating spurious warnings. The compiler bug was fixed in 2.1.20
so we no longer need the suppression.