### PR TITLE
Move StableId wrapper to common db package

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -242,8 +242,8 @@ class TerrawareGenerator : KotlinGenerator() {
                 .withUserType("java.util.Locale"),
             ForcedType()
                 .withIncludeExpression(".*stable_id")
-                .withConverter("com.terraformation.backend.documentproducer.db.StableIdConverter")
-                .withUserType("com.terraformation.backend.documentproducer.model.StableId"),
+                .withConverter("com.terraformation.backend.db.StableIdConverter")
+                .withUserType("com.terraformation.backend.db.StableId"),
             ForcedType().withIncludeTypes("VECTOR").withUserType("com.pgvector.PGvector"),
         )
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.DeliverableCategory
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.DeliverableType
@@ -13,7 +14,6 @@ import com.terraformation.backend.db.accelerator.tables.references.MODULES
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.documentproducer.db.VariableStore
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.importer.CsvImportFailedException
 import com.terraformation.backend.importer.processCsvFile

--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesService.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.accelerator.model.SustainableDevelopmentGoal
 import com.terraformation.backend.accelerator.model.startingDigitRegex
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
@@ -19,7 +20,6 @@ import com.terraformation.backend.documentproducer.model.ExistingValue
 import com.terraformation.backend.documentproducer.model.LinkVariable
 import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.documentproducer.model.TextVariable
 import com.terraformation.backend.documentproducer.model.ValueOperation

--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesService.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.accelerator.model.PreScreenProjectType
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.CountryNotFoundException
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.daos.CountriesDao
 import com.terraformation.backend.db.docprod.VariableId
@@ -13,7 +14,6 @@ import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.model.ExistingValue
 import com.terraformation.backend.documentproducer.model.SelectValue
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.documentproducer.model.TextVariable
 import com.terraformation.backend.documentproducer.model.Variable

--- a/src/main/kotlin/com/terraformation/backend/accelerator/variables/VariableValuesHelper.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/variables/VariableValuesHelper.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.variables
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableValueId
@@ -19,7 +20,6 @@ import com.terraformation.backend.documentproducer.model.NewSelectValue
 import com.terraformation.backend.documentproducer.model.NewTextValue
 import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TextVariable
 import com.terraformation.backend.documentproducer.model.UpdateValueOperation
 import com.terraformation.backend.documentproducer.model.ValueOperation

--- a/src/main/kotlin/com/terraformation/backend/db/StableId.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/StableId.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.db
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class StableId @JsonCreator constructor(@get:JsonValue val value: String) {
+  override fun toString() = value
+}

--- a/src/main/kotlin/com/terraformation/backend/db/StableIdConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/StableIdConverter.kt
@@ -1,6 +1,5 @@
-package com.terraformation.backend.documentproducer.db
+package com.terraformation.backend.db
 
-import com.terraformation.backend.documentproducer.model.StableId
 import org.jooq.impl.AbstractConverter
 
 /**

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValuesController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.documentproducer.api
 import com.terraformation.backend.api.InternalEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId
@@ -13,7 +14,6 @@ import com.terraformation.backend.documentproducer.VariableValueService
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.db.VariableWorkflowStore
-import com.terraformation.backend.documentproducer.model.StableId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.terraformation.backend.api.InternalEndpoint
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.DocumentId
@@ -20,7 +21,6 @@ import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SectionVariable
 import com.terraformation.backend.documentproducer.model.SelectOption
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TableColumn
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.documentproducer.model.TextVariable

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.db
 
 import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_VARIABLES
 import com.terraformation.backend.db.asNonNullable
@@ -48,7 +49,6 @@ import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SectionVariable
 import com.terraformation.backend.documentproducer.model.SelectOption
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TableColumn
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.documentproducer.model.TextVariable

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/CsvSectionVariable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/CsvSectionVariable.kt
@@ -1,10 +1,10 @@
 package com.terraformation.backend.documentproducer.db.manifest
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.embeddables.pojos.VariableManifestEntryId
 import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
-import com.terraformation.backend.documentproducer.model.StableId
 
 // In the header order in the CSV
 data class CsvSectionVariable(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/CsvVariableNormalizer.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/CsvVariableNormalizer.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.documentproducer.db.manifest
 
 import com.opencsv.CSVReader
-import com.terraformation.backend.documentproducer.model.StableId
+import com.terraformation.backend.db.StableId
 import java.io.InputStreamReader
 
 class CsvVariableNormalizer {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.db.manifest
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.docprod.DocumentTemplateId
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableInjectionDisplayStyle
@@ -15,7 +16,6 @@ import com.terraformation.backend.documentproducer.db.VariableManifestStore
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.model.NewVariableManifestModel
 import com.terraformation.backend.documentproducer.model.SectionVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.Variable
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/AllVariableCsvVariable.kt
@@ -1,12 +1,12 @@
 package com.terraformation.backend.documentproducer.db.variable
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableTableStyle
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSelectOptionsRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariablesRow
-import com.terraformation.backend.documentproducer.model.StableId
 import java.math.BigDecimal
 
 private const val LOCALIZED_ERROR_KEY_UNKNOWN_DATA_TYPE = "variablesCsvDataTypeUnknown"

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/CsvVariableNormalizer.kt
@@ -1,11 +1,11 @@
 package com.terraformation.backend.documentproducer.db.variable
 
 import com.opencsv.CSVReader
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.VariableTableStyle
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.tables.pojos.VariableSelectOptionsRow
-import com.terraformation.backend.documentproducer.model.StableId
 import java.io.InputStreamReader
 import java.math.BigDecimal
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/variable/VariableImporter.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.db.variable
 
 import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLE_VARIABLES
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableTextType
@@ -20,7 +21,6 @@ import com.terraformation.backend.documentproducer.model.LinkVariable
 import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SectionVariable
 import com.terraformation.backend.documentproducer.model.SelectVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.documentproducer.model.TextVariable
 import com.terraformation.backend.documentproducer.model.Variable

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableId.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableId.kt
@@ -1,6 +1,0 @@
-package com.terraformation.backend.documentproducer.model
-
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonValue
-
-data class StableId @JsonCreator constructor(@get:JsonValue val value: String)

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableIds.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/StableIds.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.LandUseModelType
 
 object StableIds {

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.VariableId

--- a/src/test/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/variables/AcceleratorProjectVariableValuesServiceTest.kt
@@ -9,13 +9,13 @@ import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.Region
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableSelectOptionId
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.PathGenerator

--- a/src/test/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/variables/ApplicationVariableValuesServiceTest.kt
@@ -8,13 +8,13 @@ import com.terraformation.backend.accelerator.model.PreScreenProjectType
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableSelectOptionId
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.mockUser
 import io.mockk.every

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -419,7 +419,6 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SP
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.point
 import com.terraformation.backend.rectangle

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.documentproducer.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.tables.records.DeliverableVariablesRecord
 import com.terraformation.backend.db.docprod.DependencyCondition
 import com.terraformation.backend.db.docprod.VariableTableStyle
@@ -19,7 +20,6 @@ import com.terraformation.backend.db.docprod.tables.records.VariableTableColumns
 import com.terraformation.backend.db.docprod.tables.records.VariablesRecord
 import com.terraformation.backend.documentproducer.db.variable.VariableImportResult
 import com.terraformation.backend.documentproducer.db.variable.VariableImporter
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.mockUser

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableStoreTest.kt
@@ -2,13 +2,13 @@ package com.terraformation.backend.documentproducer.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.docprod.VariableTableStyle
 import com.terraformation.backend.db.docprod.VariableTextType
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.documentproducer.model.BaseVariableProperties
 import com.terraformation.backend.documentproducer.model.NumberVariable
 import com.terraformation.backend.documentproducer.model.SectionVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.documentproducer.model.TableColumn
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.documentproducer.model.TextVariable

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/model/VariableTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/model/VariableTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.documentproducer.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -40,6 +40,7 @@ import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.NotificationJobFinishedEvent
 import com.terraformation.backend.daily.NotificationJobSucceededEvent
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.ApplicationId
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
@@ -93,7 +94,6 @@ import com.terraformation.backend.documentproducer.event.CompletedSectionVariabl
 import com.terraformation.backend.documentproducer.model.BaseVariableProperties
 import com.terraformation.backend.documentproducer.model.ExistingDocumentModel
 import com.terraformation.backend.documentproducer.model.SectionVariable
-import com.terraformation.backend.documentproducer.model.StableId
 import com.terraformation.backend.dummyKeycloakInfo
 import com.terraformation.backend.email.model.ObservationNotScheduled
 import com.terraformation.backend.funder.db.FundingEntityStore


### PR DESCRIPTION
In preparation for adding stable IDs to entities that aren't related to the
document producer, move the `StableId` wrapper to `com.terraformation.backend.db`.