### PR TITLE
SW-6825 Add zone/subzone stable IDs (1/2)

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -42,12 +43,14 @@ data class PlantingZoneHistoryModel(
     val plantingSubzones: List<PlantingSubzoneHistoryModel>,
     /** ID of planting zone if it currently exists. Null if the zone has been deleted. */
     val plantingZoneId: PlantingZoneId?,
+    val stableId: StableId,
 ) {
   fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
     return other is PlantingZoneHistoryModel &&
         id == other.id &&
         name == other.name &&
         plantingZoneId == other.plantingZoneId &&
+        stableId == other.stableId &&
         boundary.equalsExact(other.boundary, tolerance) &&
         plantingSubzones.size == other.plantingSubzones.size &&
         plantingSubzones.zip(other.plantingSubzones).all { it.first.equals(it.second, tolerance) }
@@ -62,6 +65,7 @@ data class PlantingSubzoneHistoryModel(
     val name: String,
     /** ID of planting subzone if it currently exists. Null if the zone has been deleted. */
     val plantingSubzoneId: PlantingSubzoneId?,
+    val stableId: StableId,
 ) {
   fun equals(other: Any?, tolerance: Double = 0.00001): Boolean {
     return other is PlantingSubzoneHistoryModel &&
@@ -69,6 +73,7 @@ data class PlantingSubzoneHistoryModel(
         id == other.id &&
         name == other.name &&
         plantingSubzoneId == other.plantingSubzoneId &&
+        stableId == other.stableId &&
         boundary.equalsExact(other.boundary, tolerance) &&
         monitoringPlots.size == other.monitoringPlots.size &&
         monitoringPlots.zip(other.monitoringPlots).all { it.first.equals(it.second, tolerance) }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSubzoneModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.util.calculateAreaHectares
@@ -14,10 +15,11 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
     val boundary: MultiPolygon,
     val id: PSZID,
     val fullName: String,
+    val monitoringPlots: List<MonitoringPlotModel> = emptyList(),
     val name: String,
     val observedTime: Instant? = null,
     val plantingCompletedTime: Instant? = null,
-    val monitoringPlots: List<MonitoringPlotModel> = emptyList(),
+    val stableId: StableId,
 ) {
   fun findMonitoringPlot(monitoringPlotId: MonitoringPlotId): MonitoringPlotModel? =
       monitoringPlots.find { it.id == monitoringPlotId }
@@ -40,10 +42,11 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
           boundary = boundary,
           id = null,
           fullName = fullName,
+          monitoringPlots = monitoringPlots,
           name = name,
           observedTime = null,
           plantingCompletedTime = plantingCompletedTime,
-          monitoringPlots = monitoringPlots,
+          stableId = stableId,
       )
 
   companion object {
@@ -54,6 +57,7 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
         exclusion: MultiPolygon? = null,
         plantingCompletedTime: Instant? = null,
         monitoringPlots: List<MonitoringPlotModel> = emptyList(),
+        stableId: StableId = StableId(fullName),
     ): NewPlantingSubzoneModel {
       val areaHa: BigDecimal = boundary.differenceNullable(exclusion).calculateAreaHectares()
 
@@ -65,6 +69,7 @@ data class PlantingSubzoneModel<PSZID : PlantingSubzoneId?>(
           monitoringPlots = monitoringPlots,
           name = name,
           plantingCompletedTime = plantingCompletedTime,
+          stableId = stableId,
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -31,6 +32,7 @@ data class PlantingZoneModel<
     val numPermanentPlots: Int = DEFAULT_NUM_PERMANENT_PLOTS,
     val numTemporaryPlots: Int = DEFAULT_NUM_TEMPORARY_PLOTS,
     val plantingSubzones: List<PlantingSubzoneModel<PSZID>>,
+    val stableId: StableId,
     val studentsT: BigDecimal = DEFAULT_STUDENTS_T,
     val targetPlantingDensity: BigDecimal = DEFAULT_TARGET_PLANTING_DENSITY,
     val variance: BigDecimal = DEFAULT_VARIANCE,
@@ -392,6 +394,7 @@ data class PlantingZoneModel<
           numPermanentPlots = numPermanentPlots,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = plantingSubzones.map { it.toNew() },
+          stableId = stableId,
           studentsT = studentsT,
           targetPlantingDensity = targetPlantingDensity,
           variance = variance,
@@ -420,6 +423,7 @@ data class PlantingZoneModel<
         errorMargin: BigDecimal = DEFAULT_ERROR_MARGIN,
         numPermanentPlots: Int? = null,
         numTemporaryPlots: Int? = null,
+        stableId: StableId = StableId(name),
         studentsT: BigDecimal = DEFAULT_STUDENTS_T,
         targetPlantingDensity: BigDecimal = DEFAULT_TARGET_PLANTING_DENSITY,
         variance: BigDecimal = DEFAULT_VARIANCE,
@@ -442,6 +446,7 @@ data class PlantingZoneModel<
           numPermanentPlots = numPermanentPlots ?: defaultPermanentPlots,
           numTemporaryPlots = numTemporaryPlots ?: defaultTemporaryPlots,
           plantingSubzones = plantingSubzones,
+          stableId = stableId,
           studentsT = studentsT,
           targetPlantingDensity = targetPlantingDensity,
           variance = variance,

--- a/src/main/resources/db/migration/0350/V375__TrackingStableId.sql
+++ b/src/main/resources/db/migration/0350/V375__TrackingStableId.sql
@@ -1,0 +1,17 @@
+ALTER TABLE tracking.planting_zones ADD COLUMN stable_id TEXT;
+ALTER TABLE tracking.planting_subzones ADD COLUMN stable_id TEXT;
+ALTER TABLE tracking.planting_zone_histories ADD COLUMN stable_id TEXT;
+ALTER TABLE tracking.planting_subzone_histories ADD COLUMN stable_id TEXT;
+
+UPDATE tracking.planting_zones SET stable_id = name;
+UPDATE tracking.planting_subzones SET stable_id = full_name;
+UPDATE tracking.planting_zone_histories SET stable_id = name;
+UPDATE tracking.planting_subzone_histories SET stable_id = full_name;
+
+ALTER TABLE tracking.planting_zones ALTER COLUMN stable_id SET NOT NULL;
+ALTER TABLE tracking.planting_subzones ALTER COLUMN stable_id SET NOT NULL;
+ALTER TABLE tracking.planting_zone_histories ALTER COLUMN stable_id SET NOT NULL;
+ALTER TABLE tracking.planting_subzone_histories ALTER COLUMN stable_id SET NOT NULL;
+
+ALTER TABLE tracking.planting_zones ADD UNIQUE (planting_site_id, stable_id);
+ALTER TABLE tracking.planting_subzones ADD UNIQUE (planting_site_id, stable_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -486,6 +486,7 @@ COMMENT ON COLUMN tracking.planting_subzones.name IS 'Short name of this plantin
 COMMENT ON COLUMN tracking.planting_subzones.observed_time IS 'When an observation of a monitoring plot in the subzone was most recently completed.';
 COMMENT ON COLUMN tracking.planting_subzones.planting_site_id IS 'Which planting site this subzone is part of. This is the same as the planting site ID of this subzone''s planting zone, but is duplicated here so it can be used as the target of a foreign key constraint.';
 COMMENT ON COLUMN tracking.planting_subzones.planting_zone_id IS 'Which planting zone this subzone is part of.';
+COMMENT ON COLUMN tracking.planting_subzones.stable_id IS 'Subzone identifier that doesn''t change even if the subzone is renamed or edited. Defaults to the full name.';
 
 COMMENT ON TABLE tracking.planting_zone_histories IS 'Versions of planting zone maps over time. Each time a planting site map changes, its zones'' maps are inserted into this table.';
 
@@ -502,6 +503,7 @@ COMMENT ON COLUMN tracking.planting_zones.modified_time IS 'When the planting zo
 COMMENT ON COLUMN tracking.planting_zones.name IS 'Short name of this planting zone. This is often just a single letter. Must be unique within a planting site.';
 COMMENT ON COLUMN tracking.planting_zones.num_permanent_plots IS 'Number of permanent plots to assign to the next observation. This is typically derived from a statistical formula.';
 COMMENT ON COLUMN tracking.planting_zones.planting_site_id IS 'Which planting site this zone is part of.';
+COMMENT ON COLUMN tracking.planting_zones.stable_id IS 'Zone identifier that doesn''t change even if the zone is renamed or edited. Defaults to the zone name.';
 
 COMMENT ON TABLE tracking.plantings IS 'Details about plants that were planted or reassigned as part of a delivery. There is one plantings row per species in a delivery.';
 COMMENT ON COLUMN tracking.plantings.created_by IS 'Which user created the planting.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1902,6 +1902,7 @@ abstract class DatabaseBackedTest {
           row.numPermanentPlots ?: PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
       numTemporaryPlots: Int =
           row.numTemporaryPlots ?: PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
+      stableId: Any = row.name ?: name,
       studentsT: BigDecimal = row.studentsT ?: PlantingZoneModel.DEFAULT_STUDENTS_T,
       targetPlantingDensity: BigDecimal? = row.targetPlantingDensity,
       variance: BigDecimal = row.variance ?: PlantingZoneModel.DEFAULT_VARIANCE,
@@ -1924,6 +1925,7 @@ abstract class DatabaseBackedTest {
             numPermanentPlots = numPermanentPlots,
             numTemporaryPlots = numTemporaryPlots,
             plantingSiteId = plantingSiteId,
+            stableId = StableId("$stableId"),
             studentsT = studentsT,
             targetPlantingDensity = targetPlantingDensity,
             variance = variance,
@@ -1948,6 +1950,7 @@ abstract class DatabaseBackedTest {
       name: String = lastPlantingZonesRow.name!!,
       plantingSiteHistoryId: PlantingSiteHistoryId = inserted.plantingSiteHistoryId,
       plantingZoneId: PlantingZoneId = inserted.plantingZoneId,
+      stableId: Any = lastPlantingZonesRow.stableId!!,
   ): PlantingZoneHistoryId {
     val row =
         PlantingZoneHistoriesRow(
@@ -1956,6 +1959,7 @@ abstract class DatabaseBackedTest {
             name = name,
             plantingSiteHistoryId = plantingSiteHistoryId,
             plantingZoneId = plantingZoneId,
+            stableId = StableId("$stableId"),
         )
 
     plantingZoneHistoriesDao.insert(row)
@@ -1990,6 +1994,7 @@ abstract class DatabaseBackedTest {
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       name: String = row.name ?: "${nextPlantingSubzoneNumber++}",
       fullName: String = "Z1-$name",
+      stableId: Any = row.fullName ?: fullName,
       insertHistory: Boolean = true,
   ): PlantingSubzoneId {
     val rowWithDefaults =
@@ -2006,6 +2011,7 @@ abstract class DatabaseBackedTest {
             plantingCompletedTime = plantingCompletedTime,
             plantingSiteId = plantingSiteId,
             plantingZoneId = plantingZoneId,
+            stableId = StableId("$stableId"),
         )
 
     plantingSubzonesDao.insert(rowWithDefaults)
@@ -2028,6 +2034,7 @@ abstract class DatabaseBackedTest {
       name: String = lastPlantingSubzonesRow.name!!,
       plantingSubzoneId: PlantingSubzoneId? = inserted.plantingSubzoneId,
       plantingZoneHistoryId: PlantingZoneHistoryId = inserted.plantingZoneHistoryId,
+      stableId: Any = lastPlantingSubzonesRow.stableId!!,
   ): PlantingSubzoneHistoryId {
     val row =
         PlantingSubzoneHistoriesRow(
@@ -2037,6 +2044,7 @@ abstract class DatabaseBackedTest {
             name = name,
             plantingZoneHistoryId = plantingZoneHistoryId,
             plantingSubzoneId = plantingSubzoneId,
+            stableId = StableId("$stableId"),
         )
 
     plantingSubzoneHistoriesDao.insert(row)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreApplyEditTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.db.NumericIdentifierType
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
@@ -423,7 +424,9 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
 
       val desired = newSite {
         zone(name = "A", numPermanent = 1, width = 250) { subzone(name = "Subzone 1") }
-        zone(name = "B", numPermanent = 1, width = 250) { subzone(name = "Subzone 2") }
+        zone(name = "B", numPermanent = 1, width = 250) {
+          subzone(name = "Subzone 2", stableId = StableId("A-Subzone 2"))
+        }
       }
 
       val (edited, existing) = runScenario(initial = initial, desired = desired)
@@ -444,7 +447,11 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
         zone(name = "A", numPermanent = 1) { subzone(name = "Subzone") { permanent() } }
       }
 
-      val desired = newSite { zone(name = "B", numPermanent = 1) { subzone(name = "Subzone") } }
+      val desired = newSite {
+        zone(name = "B", numPermanent = 1) {
+          subzone(name = "Subzone", stableId = StableId("A-Subzone"))
+        }
+      }
 
       val (edited, existing) = runScenario(initial = initial, desired = desired)
 
@@ -638,6 +645,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                     name = zone.name,
                     plantingSiteHistoryId = editedSiteHistory.id,
                     plantingZoneId = zone.id,
+                    stableId = zone.stableId,
                 )
               }
               .toSet(),
@@ -660,6 +668,7 @@ internal class PlantingSiteStoreApplyEditTest : BasePlantingSiteStoreTest() {
                   name = subzone.name,
                   plantingSubzoneId = subzone.id,
                   plantingZoneHistoryId = plantingZoneHistoryId,
+                  stableId = subzone.stableId,
               )
             }
           },

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
@@ -235,6 +236,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   name = "Zone 1",
                   numPermanentPlots = 3,
                   numTemporaryPlots = 4,
+                  stableId = StableId("Zone 1"),
                   studentsT = BigDecimal(5),
                   targetPlantingDensity = BigDecimal(6),
                   variance = BigDecimal(7),
@@ -245,6 +247,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   name = "Zone 2",
                   numPermanentPlots = PlantingZoneModel.DEFAULT_NUM_PERMANENT_PLOTS,
                   numTemporaryPlots = PlantingZoneModel.DEFAULT_NUM_TEMPORARY_PLOTS,
+                  stableId = StableId("Zone 2"),
                   studentsT = PlantingZoneModel.DEFAULT_STUDENTS_T,
                   targetPlantingDensity = PlantingZoneModel.DEFAULT_TARGET_PLANTING_DENSITY,
                   variance = PlantingZoneModel.DEFAULT_VARIANCE,
@@ -287,21 +290,25 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   fullName = "Zone 1-Subzone 1",
                   name = "Subzone 1",
                   plantingZoneId = actualZones["Zone 1"]?.id,
+                  stableId = StableId("Zone 1-Subzone 1"),
               ),
               commonSubzonesRow.copy(
                   fullName = "Zone 1-Subzone 2",
                   name = "Subzone 2",
                   plantingZoneId = actualZones["Zone 1"]?.id,
+                  stableId = StableId("Zone 1-Subzone 2"),
               ),
               commonSubzonesRow.copy(
                   fullName = "Zone 2-Subzone 1",
                   name = "Subzone 1",
                   plantingZoneId = actualZones["Zone 2"]?.id,
+                  stableId = StableId("Zone 2-Subzone 1"),
               ),
               commonSubzonesRow.copy(
                   fullName = "Zone 2-Subzone 2",
                   name = "Subzone 2",
                   plantingZoneId = actualZones["Zone 2"]?.id,
+                  stableId = StableId("Zone 2-Subzone 2"),
               ),
           ),
           actualSubzones.map { it.copy(boundary = null) }.toSet(),
@@ -396,6 +403,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   name = "zone",
                   plantingSiteHistoryId = model.historyId,
                   plantingZoneId = model.plantingZones.first().id,
+                  stableId = StableId("zone"),
               ),
           ),
           zoneHistories.map { it.copy(id = null) },
@@ -410,6 +418,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
                   name = "subzone",
                   plantingSubzoneId = model.plantingZones.first().plantingSubzones.first().id,
                   plantingZoneHistoryId = zoneHistories.first().id,
+                  stableId = StableId("zone-subzone"),
               ),
           ),
           plantingSubzoneHistoriesDao.findAll().map { it.copy(id = null) },

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.multiPolygon
@@ -73,6 +74,7 @@ internal class PlantingSiteStoreFetchSiteHistoryTest : BasePlantingSiteStoreTest
                         id = plantingZoneHistoryId1,
                         name = "Zone 1",
                         plantingZoneId = plantingZoneId1,
+                        stableId = StableId("Zone 1"),
                         plantingSubzones =
                             listOf(
                                 PlantingSubzoneHistoryModel(
@@ -81,6 +83,7 @@ internal class PlantingSiteStoreFetchSiteHistoryTest : BasePlantingSiteStoreTest
                                     fullName = "Z1-Subzone 1",
                                     name = "Subzone 1",
                                     plantingSubzoneId = plantingSubzoneId1,
+                                    stableId = StableId("Z1-Subzone 1"),
                                     monitoringPlots =
                                         listOf(
                                             MonitoringPlotHistoryModel(
@@ -99,6 +102,7 @@ internal class PlantingSiteStoreFetchSiteHistoryTest : BasePlantingSiteStoreTest
                                     fullName = "Z1-Subzone 2",
                                     name = "Subzone 2",
                                     plantingSubzoneId = null,
+                                    stableId = StableId("Z1-Subzone 2"),
                                     monitoringPlots =
                                         listOf(
                                             MonitoringPlotHistoryModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.polygon
@@ -105,6 +106,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                           id = plantingZoneId,
                           name = "Z1",
                           plantingSubzones = emptyList(),
+                          stableId = StableId("Z1"),
                           targetPlantingDensity = BigDecimal.ONE,
                       ),
                   ))
@@ -123,6 +125,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                       fullName = "Z1-1",
                                       name = "1",
                                       plantingCompletedTime = null,
+                                      stableId = StableId("Z1-1"),
                                       monitoringPlots = emptyList(),
                                   )))),
           )
@@ -221,6 +224,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                           boundaryModifiedTime = Instant.EPOCH,
                           id = plantingZoneId,
                           name = "Z1",
+                          stableId = StableId("Z1"),
                           plantingSubzones =
                               listOf(
                                   PlantingSubzoneModel(
@@ -230,6 +234,7 @@ internal class PlantingSiteStoreFetchSiteTest : BasePlantingSiteStoreTest() {
                                       fullName = "Z1-1",
                                       name = "1",
                                       plantingCompletedTime = null,
+                                      stableId = StableId("Z1-1"),
                                       monitoringPlots =
                                           listOf(
                                               MonitoringPlotModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.multiPolygon
 import io.mockk.every
@@ -35,6 +36,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
               name = "initial",
               numPermanentPlots = 1,
               numTemporaryPlots = 2,
+              stableId = StableId("initial"),
               studentsT = BigDecimal.ONE,
               targetPlantingDensity = BigDecimal.ONE,
               variance = BigDecimal.ZERO,

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
@@ -674,6 +675,7 @@ class PlantingZoneModelTest {
           name = "name",
           plantingCompletedTime = null,
           monitoringPlots = plots,
+          stableId = StableId("name"),
       )
 
   private fun plantingSubzoneIds(vararg id: Int) = id.map { PlantingSubzoneId(it.toLong()) }.toSet()
@@ -709,6 +711,7 @@ class PlantingZoneModelTest {
           numPermanentPlots = numPermanentPlots,
           numTemporaryPlots = numTemporaryPlots,
           plantingSubzones = subzones,
+          stableId = StableId("name"),
           studentsT = BigDecimal.ONE,
           targetPlantingDensity = BigDecimal.ONE,
           variance = BigDecimal.ONE,


### PR DESCRIPTION
Currently, when a new shapefile is uploaded for an existing planting site, we
match the zone and subzone names in the shapefile with the names in the
database to determine whether a zone/subzone is being created, deleted, or
modified.

Unfortunately, this means that we can't support renames very well: changing the
name causes the name-matching code to think that the existing zone/subzone is
being deleted and a new one is being created.

Address this by adding "stable ID" values to zones and subzones. This will work
similarly to the stable IDs of variables: it'll be used to determine the
identity of a zone/subzone.

This change adds the stable ID to the data model and populates it
appropriately, but nothing uses it yet. A followup change will update the
planting site editing code to use it to determine zone/subzone identity.