### PR TITLE
SW-6817 Improve handling of OpenAI API errors

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminAskController.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.admin
 
 import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.ask.ChatRequestFailedException
 import com.terraformation.backend.ask.ChatService
 import com.terraformation.backend.ask.ConditionalOnSpringAi
 import com.terraformation.backend.ask.EmbeddingService
@@ -98,9 +99,11 @@ class AdminAskController(
       val htmlAnswer = HtmlRenderer.builder().build().render(markdownAnswer)
 
       model.addAttribute("answer", htmlAnswer)
+    } catch (e: ChatRequestFailedException) {
+      // Don't spam our error logs if the external service is having an outage.
+      log.warn("Request to chat service failed for conversation $conversationId", e)
     } catch (e: Exception) {
-      log.error("Failed to generate answer", e)
-      model.addAttribute("failureMessage", e.message)
+      log.error("Failed to generate answer for conversation $conversationId", e)
     }
 
     return "/admin/ask/exchange"

--- a/src/main/kotlin/com/terraformation/backend/ask/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/Exceptions.kt
@@ -1,0 +1,3 @@
+package com.terraformation.backend.ask
+
+class ChatRequestFailedException(cause: Throwable? = null) : RuntimeException(cause)

--- a/src/main/resources/templates/admin/ask/exchange.html
+++ b/src/main/resources/templates/admin/ask/exchange.html
@@ -1,13 +1,19 @@
-<div class="question" th:text="${query}" th:if="${query} != null" />
-<div class="answer" th:utext="${answer}" th:if="${answer} != null" />
-<div class="error" th:text="${failureMessage}" th:if="${failureMessage} != null" />
+<div class="question" th:text="${query}" th:if="${query != null}" />
+<div class="answer" th:utext="${answer}" th:if="${answer != null}" />
+<div class="error" th:if="${answer == null && query != null}">
+    <b>Unable to get an answer!</b> This may be a temporary problem; wait a moment and try again.
+    Conversation ID:
+    <th:block th:utext="${conversationId}" />
+</div>
 
 <form id="queryForm" th:hx-post="|/admin/ask/projects/${projectId}|" hx-swap="outerHTML"
       hx-disabled-elt="input, textarea">
     <label>
         Question (Enter to submit, Shift-Enter for line break):
         <br/>
-        <textarea id="query" rows=4 cols=80 name="query" autofocus></textarea>
+        <textarea id="query" rows=4 cols=80 name="query" autofocus th:if="${answer != null}"></textarea>
+        <textarea id="query" rows=4 cols=80 name="query" autofocus th:if="${answer == null}"
+                  th:text="${query}"></textarea>
     </label>
     <br/>
     <input type="hidden" name="projectId" th:value="${projectId}"/>


### PR DESCRIPTION
If the request to OpenAI's API fails during an Ask Terraware session, log it as a
warning rather than an error to avoid cluttering our error logs. Show a
user-friendly error message asking the user to try again, and prepopulate the
textarea with the user's question so they don't have to type it again or
copy-paste it.