### PR TITLE
Use higher-performance embedding for Ask Terraware

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,12 @@ terraware:
     api-client-id: "api"
 
 spring:
+  ai:
+    openai:
+      embedding:
+        options:
+          model: "text-embedding-3-large"
+
   autoconfigure:
     exclude:
       - org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration

--- a/src/main/resources/db/migration/0350/V376__VectorStoreLargerEmbedding.sql
+++ b/src/main/resources/db/migration/0350/V376__VectorStoreLargerEmbedding.sql
@@ -1,0 +1,5 @@
+TRUNCATE vector_store;
+
+ALTER TABLE vector_store DROP COLUMN embedding;
+ALTER TABLE vector_store ADD COLUMN embedding halfvec(3072) NOT NULL;
+CREATE INDEX vector_store_embedding_idx ON vector_store USING HNSW (embedding halfvec_cosine_ops);


### PR DESCRIPTION
Switch from Spring AI's default OpenAI embedding (text-embedding-ada-002) to
the embedding that currently has the best recall performance
(text-embedding-3-large).

This embedding doubles the number of dimensions from 1536 to 3072.
Unfortunately, pgvector's `vector` type currently has a limit of 2000
dimensions due to the block size in PostgreSQL's storage engine. Switch the
`vector_store` table to use the `halfvec` type, which uses a 16-bit floating
point representation of each dimension rather than a 32-bit one. 16-bit floats
will likely sacrifice a small amount of recall performance but the end result
should still be considerably better than the original embedding.

Switching embeddings will require rerunning the "prepare" operation on all the
projects that are currently prepared.