### PR TITLE
SW-6839 Disallow ad-hoc observations of simple sites

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
 import com.terraformation.backend.tracking.db.ObservationHasNoSubzonesException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
 import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteNotDetailedException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlotAlreadyCompletedException
 import com.terraformation.backend.tracking.db.PlotNotFoundException
@@ -430,6 +431,10 @@ class ObservationService(
 
     if (observedTime.isAfter(clock.instant().plusSeconds(CLOCK_TOLERANCE_SECONDS))) {
       throw IllegalArgumentException("Observed time is in the future")
+    }
+
+    if (!plantingSiteStore.isDetailed(plantingSiteId)) {
+      throw PlantingSiteNotDetailedException(plantingSiteId)
     }
 
     when (observationType) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -79,6 +79,9 @@ class PlantingSeasonNotFoundException(val plantingSeasonId: PlantingSeasonId) :
 class PlantingSiteHistoryNotFoundException(val plantingSiteHistoryId: PlantingSiteHistoryId) :
     EntityNotFoundException("Planting site history $plantingSiteHistoryId not found")
 
+class PlantingSiteNotDetailedException(val plantingSiteId: PlantingSiteId) :
+    MismatchedStateException("Planting site $plantingSiteId is not a detailed planting site")
+
 class PlantingSiteNotFoundException(val plantingSiteId: PlantingSiteId) :
     EntityNotFoundException("Planting site $plantingSiteId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1257,6 +1257,17 @@ class PlantingSiteStore(
     }
   }
 
+  /**
+   * Returns true if the ID refers to a detailed planting site, that is, a site with planting zones
+   * and subzones.
+   */
+  fun isDetailed(plantingSiteId: PlantingSiteId): Boolean {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    return dslContext.fetchExists(
+        PLANTING_SUBZONES, PLANTING_SUBZONES.PLANTING_SITE_ID.eq(plantingSiteId))
+  }
+
   fun hasSubzonePlantings(plantingSiteId: PlantingSiteId): Boolean {
     requirePermissions { readPlantingSite(plantingSiteId) }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -60,6 +60,7 @@ import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
+import com.terraformation.backend.tracking.db.PlantingSiteNotDetailedException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlotAlreadyCompletedException
@@ -1764,6 +1765,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     @BeforeEach
     fun setUp() {
       insertOrganizationUser(role = Role.Contributor)
+      insertPlantingZone()
+      insertPlantingSubzone()
     }
 
     @Test
@@ -2037,6 +2040,20 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             observedTime = clock.instant.minusSeconds(1),
             observationType = ObservationType.Monitoring,
             plantingSiteId = plantingSiteId,
+            swCorner = point(1),
+        )
+      }
+    }
+
+    @Test
+    fun `throws exception if planting site is not detailed`() {
+      val simplePlantingSiteId = insertPlantingSite()
+
+      assertThrows<PlantingSiteNotDetailedException> {
+        service.completeAdHocObservation(
+            observedTime = clock.instant.minusSeconds(1),
+            observationType = ObservationType.Monitoring,
+            plantingSiteId = simplePlantingSiteId,
             swCorner = point(1),
         )
       }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchAttributesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchAttributesTest.kt
@@ -1,0 +1,45 @@
+package com.terraformation.backend.tracking.db.plantingSiteStore
+
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import io.mockk.every
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class PlantingSiteStoreFetchAttributesTest : BasePlantingSiteStoreTest() {
+  @Nested
+  inner class IsDetailed {
+    @BeforeEach
+    fun setUp() {
+      every { user.canReadPlantingSite(any()) } returns true
+    }
+
+    @Test
+    fun `returns false when site has no subzones`() {
+      val plantingSiteId = insertPlantingSite()
+
+      assertFalse(store.isDetailed(plantingSiteId))
+    }
+
+    @Test
+    fun `returns true when site has a subzone`() {
+      val plantingSiteId = insertPlantingSite()
+      insertPlantingZone()
+      insertPlantingSubzone()
+
+      assertTrue(store.isDetailed(plantingSiteId))
+    }
+
+    @Test
+    fun `throws exception when no permission to read the planting site`() {
+      val plantingSiteId = insertPlantingSite()
+
+      every { user.canReadPlantingSite(plantingSiteId) } returns false
+
+      assertThrows<PlantingSiteNotFoundException> { store.isDetailed(plantingSiteId) }
+    }
+  }
+}


### PR DESCRIPTION
Creating an observation of a planting site without a map currently fails with
an internal error because there's no planting site history ID to use when
inserting the ad-hoc plot.

Add a sanity check to make ad-hoc observations fail for simple planting sites
generally, not just ones without maps; the desired product behavior is to only
allow observations of detailed sites, whether the observations are assigned or
ad-hoc.