### PR TITLE
SW-6600 Regenerate embeddings for updated variables

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/model/Variable.kt
@@ -198,6 +198,9 @@ sealed interface Variable : BaseVariable {
       oldValue: VariableValue<*, *>,
       newRowValueId: VariableValueId?,
   ): NewValue?
+
+  /** Returns a sequence of this variable and its descendents, if any. */
+  fun walkTree(): Sequence<Variable> = sequenceOf(this)
 }
 
 /**
@@ -540,6 +543,11 @@ data class SectionVariable(
       null
     }
   }
+
+  override fun walkTree(): Sequence<Variable> = sequence {
+    yield(this@SectionVariable)
+    children.forEach { child -> yieldAll(child.walkTree()) }
+  }
 }
 
 data class TableColumn(
@@ -574,6 +582,11 @@ data class TableVariable(
     } else {
       null
     }
+  }
+
+  override fun walkTree(): Sequence<Variable> = sequence {
+    yield(this@TableVariable)
+    columns.forEach { column -> yieldAll(column.variable.walkTree()) }
   }
 }
 


### PR DESCRIPTION
When a variable value is updated for a project that has been prepared for
Ask Terraware, generate new embeddings for just that variable. This will
keep Ask Terraware's responses up to date as project data is filled in
without the user having to manually re-prepare the project.

This only affects variable values. A separate change will add similar logic
for newly-submitted deliverable documents.