### PR TITLE
SW-6891 Allow contributors to mark subzones completed

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -646,8 +646,8 @@ data class IndividualUser(
   override fun canUpdatePlantingSiteProject(plantingSiteId: PlantingSiteId) =
       isMember(parentStore.getOrganizationId(plantingSiteId))
 
-  override fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId) =
-      isAdminOrHigher(parentStore.getOrganizationId(plantingSubzoneId))
+  override fun canUpdatePlantingSubzoneCompleted(plantingSubzoneId: PlantingSubzoneId) =
+      isMember(parentStore.getOrganizationId(plantingSubzoneId))
 
   override fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId) =
       isAdminOrHigher(parentStore.getOrganizationId(plantingZoneId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -1661,9 +1661,9 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
-  fun updatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId) {
+  fun updatePlantingSubzoneCompleted(plantingSubzoneId: PlantingSubzoneId) {
     user.recordPermissionChecks {
-      if (!user.canUpdatePlantingSubzone(plantingSubzoneId)) {
+      if (!user.canUpdatePlantingSubzoneCompleted(plantingSubzoneId)) {
         readPlantingSubzone(plantingSubzoneId)
         throw AccessDeniedException("No permission to update planting subzone $plantingSubzoneId")
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -596,7 +596,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canUpdatePlantingSiteProject(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canUpdatePlantingSubzone(plantingSubzoneId: PlantingSubzoneId): Boolean = defaultPermission
+  fun canUpdatePlantingSubzoneCompleted(plantingSubzoneId: PlantingSubzoneId): Boolean =
+      defaultPermission
 
   fun canUpdatePlantingZone(plantingZoneId: PlantingZoneId): Boolean = defaultPermission
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
@@ -7,12 +7,10 @@ import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
-import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import io.swagger.v3.oas.annotations.Operation
-import java.time.Instant
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -43,13 +41,13 @@ class PlantingSubzonesController(
         species.map { PlantingSubzoneSpeciesPayload(it) })
   }
 
-  @Operation(summary = "Updates information about a planting subzone.")
+  @Operation(summary = "Updates the planting-completed state of a planting subzone.")
   @PutMapping("/{id}")
   fun updatePlantingSubzone(
       @PathVariable id: PlantingSubzoneId,
       @RequestBody payload: UpdatePlantingSubzoneRequestPayload
   ): SimpleSuccessResponsePayload {
-    plantingSiteStore.updatePlantingSubzone(id) { payload.applyTo(it) }
+    plantingSiteStore.updatePlantingSubzoneCompleted(id, payload.plantingCompleted)
 
     return SimpleSuccessResponsePayload()
   }
@@ -70,12 +68,4 @@ data class ListPlantingSubzoneSpeciesResponsePayload(
 
 data class UpdatePlantingSubzoneRequestPayload(
     val plantingCompleted: Boolean,
-) {
-  fun applyTo(row: PlantingSubzonesRow): PlantingSubzonesRow {
-    // Completed time is treated as a flag; the specific value doesn't matter, just whether it's
-    // null or non-null.
-    val plantingCompletedTime = if (plantingCompleted) Instant.EPOCH else null
-
-    return row.copy(plantingCompletedTime = plantingCompletedTime)
-  }
-}
+)

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -1077,10 +1077,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
-  fun updatePlantingSubzone() =
-      allow { updatePlantingSubzone(plantingSubzoneId) } ifUser
+  fun updatePlantingSubzoneCompleted() =
+      allow { updatePlantingSubzoneCompleted(plantingSubzoneId) } ifUser
           {
-            canUpdatePlantingSubzone(plantingSubzoneId)
+            canUpdatePlantingSubzoneCompleted(plantingSubzoneId)
           }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -559,7 +559,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSubzoneIds.forOrg1(),
         readPlantingSubzone = true,
-        updatePlantingSubzone = true,
+        updatePlantingSubzoneCompleted = true,
     )
 
     permissions.expect(
@@ -833,7 +833,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSubzoneIds.forOrg1(),
         readPlantingSubzone = true,
-        updatePlantingSubzone = true,
+        updatePlantingSubzoneCompleted = true,
     )
 
     permissions.expect(
@@ -1027,6 +1027,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSubzoneIds.forOrg1(),
         readPlantingSubzone = true,
+        updatePlantingSubzoneCompleted = true,
     )
 
     permissions.expect(
@@ -1194,6 +1195,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSubzoneIds.forOrg1(),
         readPlantingSubzone = true,
+        updatePlantingSubzoneCompleted = true,
     )
 
     permissions.expect(
@@ -1477,7 +1479,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingSubzoneIds.toTypedArray(),
         readPlantingSubzone = true,
-        updatePlantingSubzone = true,
+        updatePlantingSubzoneCompleted = true,
     )
 
     permissions.expect(
@@ -3310,7 +3312,7 @@ internal class PermissionTest : DatabaseTest() {
     fun expect(
         vararg plantingSubzoneIds: PlantingSubzoneId,
         readPlantingSubzone: Boolean = false,
-        updatePlantingSubzone: Boolean = false,
+        updatePlantingSubzoneCompleted: Boolean = false,
     ) {
       plantingSubzoneIds.forEach { plantingSubzoneId ->
         val idInDatabase = getDatabaseId(plantingSubzoneId)
@@ -3320,9 +3322,9 @@ internal class PermissionTest : DatabaseTest() {
             user.canReadPlantingSubzone(idInDatabase),
             "Can read planting subzone $plantingSubzoneId")
         assertEquals(
-            updatePlantingSubzone,
-            user.canUpdatePlantingSubzone(idInDatabase),
-            "Can update planting subzone $plantingSubzoneId")
+            updatePlantingSubzoneCompleted,
+            user.canUpdatePlantingSubzoneCompleted(idInDatabase),
+            "Can update planting completed for subzone $plantingSubzoneId")
 
         uncheckedPlantingSubzones.remove(plantingSubzoneId)
       }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
@@ -54,7 +54,7 @@ internal abstract class BasePlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canReadProject(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
     every { user.canUpdatePlantingSite(any()) } returns true
-    every { user.canUpdatePlantingSubzone(any()) } returns true
+    every { user.canUpdatePlantingSubzoneCompleted(any()) } returns true
     every { user.canUpdatePlantingZone(any()) } returns true
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSubzoneCompletedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSubzoneCompletedTest.kt
@@ -2,15 +2,15 @@ package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import io.mockk.every
 import java.time.Instant
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
-internal class PlantingSiteStoreUpdateSubzoneTest : BasePlantingSiteStoreTest() {
+internal class PlantingSiteStoreUpdateSubzoneCompletedTest : BasePlantingSiteStoreTest() {
   @Nested
-  inner class UpdatePlantingSubzone {
+  inner class UpdatePlantingSubzoneCompleted {
     @Test
     fun `sets completed time to current time if not set previously`() {
       insertPlantingSite()
@@ -22,9 +22,7 @@ internal class PlantingSiteStoreUpdateSubzoneTest : BasePlantingSiteStoreTest() 
       val now = Instant.ofEpochSecond(5000)
       clock.instant = now
 
-      store.updatePlantingSubzone(plantingSubzoneId) { row ->
-        row.copy(plantingCompletedTime = Instant.EPOCH)
-      }
+      store.updatePlantingSubzoneCompleted(plantingSubzoneId, true)
 
       val expected = initial.copy(plantingCompletedTime = now, modifiedTime = now)
       val actual = plantingSubzonesDao.fetchOneById(plantingSubzoneId)!!
@@ -46,15 +44,11 @@ internal class PlantingSiteStoreUpdateSubzoneTest : BasePlantingSiteStoreTest() 
       val now = Instant.ofEpochSecond(5000)
       clock.instant = now
 
-      store.updatePlantingSubzone(plantingSubzoneId) { row ->
-        row.copy(plantingCompletedTime = now)
-      }
+      store.updatePlantingSubzoneCompleted(plantingSubzoneId, true)
 
-      val expected =
-          initial.copy(plantingCompletedTime = initialPlantingCompletedTime, modifiedTime = now)
       val actual = plantingSubzonesDao.fetchOneById(plantingSubzoneId)!!
 
-      assertEquals(expected, actual)
+      assertEquals(initial, actual)
     }
 
     @Test
@@ -69,9 +63,7 @@ internal class PlantingSiteStoreUpdateSubzoneTest : BasePlantingSiteStoreTest() 
       val now = Instant.ofEpochSecond(5000)
       clock.instant = now
 
-      store.updatePlantingSubzone(plantingSubzoneId) { row ->
-        row.copy(plantingCompletedTime = null)
-      }
+      store.updatePlantingSubzoneCompleted(plantingSubzoneId, false)
 
       val expected = initial.copy(plantingCompletedTime = null, modifiedTime = now)
       val actual = plantingSubzonesDao.fetchOneById(plantingSubzoneId)!!
@@ -85,9 +77,11 @@ internal class PlantingSiteStoreUpdateSubzoneTest : BasePlantingSiteStoreTest() 
       insertPlantingZone()
       val plantingSubzoneId = insertPlantingSubzone()
 
-      every { user.canUpdatePlantingSubzone(any()) } returns false
+      every { user.canUpdatePlantingSubzoneCompleted(any()) } returns false
 
-      assertThrows<AccessDeniedException> { store.updatePlantingSubzone(plantingSubzoneId) { it } }
+      assertThrows<AccessDeniedException> {
+        store.updatePlantingSubzoneCompleted(plantingSubzoneId, true)
+      }
     }
   }
 }


### PR DESCRIPTION
Contributors and managers are supposed to be able to mark a subzone as "planting
completed" but the server was only letting admins and owners do it.

Internally, the completed flag was being set using an "update subzone" function,
but the function didn't actually allow editing any data other than planting
completion; the idea was that it could be extended to other edits later. But
that's likely to make permissions more complex since contributors probably won't
be allowed to edit other subzone data if/when we allow users to edit site maps.

Change the function and its associated permission to only refer to editing
subzones' completion status, and relax the permission to allow contributors and
managers to change the completion status.