### PR TITLE
SW-6890 Don't log error if module event is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ModuleEventService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ModuleEventService.kt
@@ -52,7 +52,7 @@ class ModuleEventService(
         }
       } else {
         log.warn(
-            "Module event ${event.eventId} is starting before notificaiton lead time. " +
+            "Module event ${event.eventId} is starting before notification lead time. " +
                 "No notifications sent to users.")
       }
 
@@ -80,7 +80,7 @@ class ModuleEventService(
           try {
             eventStore.fetchOneById(event.eventId)
           } catch (e: EventNotFoundException) {
-            log.error("Module event ${event.eventId} not found.")
+            log.info("Module event ${event.eventId} not found; it may have been deleted.")
             return@run
           }
 
@@ -102,7 +102,7 @@ class ModuleEventService(
           log.info("Module event ${event.eventId} has been changed. Not updating status.")
         }
       } catch (e: EventNotFoundException) {
-        log.error("Module event ${event.eventId} not found.")
+        log.info("Module event ${event.eventId} not found; it may have been deleted.")
       } catch (e: Exception) {
         log.error("Update status for event ${event.eventId} failed.", e)
       }


### PR DESCRIPTION
If an admin deletes a module event, the expected behavior is that the scheduled
jobs for checking the event's status and sending notifications about it will see
that the event no longer exists and exit cleanly. We were logging error messages
in that case, even though it's not an error condition.

Update the log messages to "info" level and add an explanation of why they're
not errors.