### PR TITLE
SW-6896 Fix permission error on embedding update

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/EmbeddingService.kt
@@ -158,12 +158,14 @@ class EmbeddingService(
   @EventListener
   fun on(event: DeliverableDocumentUploadedEvent) {
     try {
-      // Only generate embeddings for projects whose other embeddings have already been generated.
-      if (hasEmbeddings(event.projectId)) {
-        // Do the embedding asynchronously to avoid blocking the document upload operation on an
-        // interaction with an external API.
-        jobScheduler.enqueue<EmbeddingService> {
-          embedDeliverableDocument(event.projectId, event.deliverableId, event.documentId)
+      systemUser.run {
+        // Only generate embeddings for projects whose other embeddings have already been generated.
+        if (hasEmbeddings(event.projectId)) {
+          // Do the embedding asynchronously to avoid blocking the document upload operation on an
+          // interaction with an external API.
+          jobScheduler.enqueue<EmbeddingService> {
+            embedDeliverableDocument(event.projectId, event.deliverableId, event.documentId)
+          }
         }
       }
     } catch (e: Exception) {
@@ -174,13 +176,15 @@ class EmbeddingService(
   @EventListener
   fun on(event: VariableValueUpdatedEvent) {
     try {
-      // Only update variable value embeddings for projects whose other embeddings have already
-      // been generated.
-      if (hasEmbeddings(event.projectId)) {
-        // Do the embedding asynchronously to avoid blocking the variable value write operation on
-        // an interaction with an external API.
-        jobScheduler.enqueue<EmbeddingService> {
-          embedVariableValue(event.projectId, event.variableId)
+      systemUser.run {
+        // Only update variable value embeddings for projects whose other embeddings have already
+        // been generated.
+        if (hasEmbeddings(event.projectId)) {
+          // Do the embedding asynchronously to avoid blocking the variable value write operation on
+          // an interaction with an external API.
+          jobScheduler.enqueue<EmbeddingService> {
+            embedVariableValue(event.projectId, event.variableId)
+          }
         }
       }
     } catch (e: Exception) {


### PR DESCRIPTION
When a user without permission to read accelerator details updated a variable
value or uploaded a deliverable document, the event handler that enqueues a job
to update the project's embeddings was unable to check whether or not the
project had already had its embeddings generated. This didn't cause the original
operation to fail, but the embeddings never got updated.