### PR TITLE
SW-6895 Prune old timeseries values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/device/TimeseriesPruner.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/TimeseriesPruner.kt
@@ -1,0 +1,80 @@
+package com.terraformation.backend.device
+
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.TimeseriesId
+import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES
+import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES_VALUES
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import java.time.InstantSource
+import java.time.temporal.ChronoUnit
+import org.jobrunr.jobs.annotations.Recurring
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+@Named
+class TimeseriesPruner(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  /** Only delete this many old values at a time from each timeseries. */
+  var maxRowsToDelete: Int = 10000
+
+  private val log = perClassLogger()
+
+  /**
+   * Prunes data from the `timeseries_values` table based on per-timeseries retention settings. By
+   * default, a timeseries isn't pruned at all; an admin needs to set its `retention_days` column to
+   * the number of days of data to retain.
+   *
+   * To avoid slamming the database with a gigantic delete operation when a retention limit is first
+   * configured on a timeseries with a lot of existing values, this will only delete up to
+   * [maxRowsToDelete] rows per timeseries each time it runs. Since this job runs repeatedly, the
+   * deletion will gradually catch up to the desired number of retention days.
+   */
+  @Recurring(id = "pruneTimeseriesValues", cron = "8,23,38,53 * * * *")
+  fun pruneTimeseriesValues() {
+    var totalRowsDeleted = 0
+    val timeseriesIdsDeleted = mutableListOf<TimeseriesId>()
+
+    log.debug("Scanning for timeseries to prune")
+
+    try {
+      dslContext
+          .select(TIMESERIES.ID.asNonNullable(), TIMESERIES.RETENTION_DAYS.asNonNullable())
+          .from(TIMESERIES)
+          .where(TIMESERIES.RETENTION_DAYS.isNotNull)
+          .orderBy(TIMESERIES.ID)
+          .fetch()
+          .forEach { (timeseriesId, retentionDays) ->
+            val minimumCreatedTime = clock.instant().minus(retentionDays.toLong(), ChronoUnit.DAYS)
+            val rowsDeleted =
+                with(TIMESERIES_VALUES) {
+                  dslContext
+                      .deleteFrom(TIMESERIES_VALUES)
+                      .where(TIMESERIES_ID.eq(timeseriesId))
+                      .and(
+                          CREATED_TIME.`in`(
+                              DSL.select(CREATED_TIME)
+                                  .from(TIMESERIES_VALUES)
+                                  .where(TIMESERIES_ID.eq(timeseriesId))
+                                  .and(CREATED_TIME.lessThan(minimumCreatedTime))
+                                  .orderBy(CREATED_TIME)
+                                  .limit(maxRowsToDelete)))
+                      .execute()
+                }
+
+            if (rowsDeleted > 0) {
+              totalRowsDeleted += rowsDeleted
+              timeseriesIdsDeleted.add(timeseriesId)
+            }
+          }
+    } catch (e: Exception) {
+      log.error("Error while pruning timeseries values", e)
+    }
+
+    if (totalRowsDeleted > 0) {
+      log.info("Deleted $totalRowsDeleted values from timeseries $timeseriesIdsDeleted")
+    }
+  }
+}

--- a/src/main/resources/db/migration/0350/V378__TimeseriesRetention.sql
+++ b/src/main/resources/db/migration/0350/V378__TimeseriesRetention.sql
@@ -1,0 +1,1 @@
+ALTER TABLE timeseries ADD COLUMN retention_days INTEGER;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -207,6 +207,7 @@ COMMENT ON TABLE thumbnails IS 'Information about scaled-down versions of photos
 
 COMMENT ON TABLE timeseries IS 'Properties of a series of values collected from a device. Each device metric is represented as a timeseries.';
 COMMENT ON COLUMN timeseries.decimal_places IS 'For numeric timeseries, the number of digits after the decimal point to display.';
+COMMENT ON COLUMN timeseries.retention_days IS 'If non-null, only retain values for this many days. If null, do not expire old timeseries values.';
 COMMENT ON COLUMN timeseries.units IS 'For numeric timeseries, the units represented by the values; unit names should be short (possibly abbreviations) and in the default language of the site.';
 
 COMMENT ON TABLE timeseries_types IS '(Enum) Data formats of the values of a timeseries.';

--- a/src/test/kotlin/com/terraformation/backend/device/TimeseriesPrunerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/TimeseriesPrunerTest.kt
@@ -1,0 +1,78 @@
+package com.terraformation.backend.device
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.tables.records.TimeseriesValuesRecord
+import com.terraformation.backend.db.default_schema.tables.references.TIMESERIES_VALUES
+import com.terraformation.backend.mockUser
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TimeseriesPrunerTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val pruner by lazy { TimeseriesPruner(clock, dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    insertUser()
+    insertOrganization()
+    insertFacility()
+    insertDevice()
+
+    clock.instant = daysSinceEpoch(1000)
+  }
+
+  @Test
+  fun `does not delete from timeseries with null retention days`() {
+    insertTimeseries(retentionDays = null)
+    insertTimeseriesValue()
+
+    val initialValues = dslContext.fetch(TIMESERIES_VALUES)
+
+    pruner.pruneTimeseriesValues()
+
+    assertTableEquals(initialValues)
+  }
+
+  @Test
+  fun `honors different retention days on different timeseries`() {
+    val timeseriesId1 = insertTimeseries(retentionDays = 10)
+    insertTimeseriesValue(createdTime = daysAgo(30), value = "30 days old")
+    insertTimeseriesValue(createdTime = daysAgo(11), value = "11 days old")
+    insertTimeseriesValue(createdTime = daysAgo(10), value = "10 days old")
+    val timeseriesId2 = insertTimeseries(retentionDays = 30)
+    insertTimeseriesValue(createdTime = daysAgo(31), value = "31 days old")
+    insertTimeseriesValue(createdTime = daysAgo(30), value = "30 days old")
+    insertTimeseriesValue(createdTime = daysAgo(10), value = "10 days old")
+
+    pruner.pruneTimeseriesValues()
+
+    assertTableEquals(
+        listOf(
+            TimeseriesValuesRecord(timeseriesId1, daysAgo(10), "10 days old"),
+            TimeseriesValuesRecord(timeseriesId2, daysAgo(30), "30 days old"),
+            TimeseriesValuesRecord(timeseriesId2, daysAgo(10), "10 days old"),
+        ))
+  }
+
+  @Test
+  fun `only deletes up to a certain number of rows from a timeseries`() {
+    val timeseriesId = insertTimeseries(retentionDays = 5)
+    List(10) { index -> insertTimeseriesValue(createdTime = daysAgo(index)) }
+
+    pruner.maxRowsToDelete = 3
+    pruner.pruneTimeseriesValues()
+
+    assertTableEquals(List(7) { TimeseriesValuesRecord(timeseriesId, daysAgo(it), "1") })
+  }
+
+  private fun daysSinceEpoch(days: Int) = Instant.EPOCH.plus(days.toLong(), ChronoUnit.DAYS)
+
+  private fun daysAgo(days: Int) = clock.instant().minus(days.toLong(), ChronoUnit.DAYS)
+}


### PR DESCRIPTION
The `timeseries_values` table is by far the largest one in the production
database, and most of its contents are of no interest. We only need recent history
for most of the timeseries. However, for certain timeseries, we want to retain
historical data forever, so we can't just apply a fixed retention period across
the board.

Add a column to the timeseries table to configure how many days' worth of values
to retain, and add a recurring job that deletes old values based on each
timeseries' retention setting. To avoid accidentally deleting values that we need
to retain indefinitely, this uses an opt-in model: the default is to not prune any
old values, and we'll set the retention days on the specific timeseries we want to
trim. The opt-in approach also lets us roll this out gradually, starting with just
a few timeseries to get a better understanding of the real-world performance
impact.