### PR TITLE
SW-6840 Add raw per-observation plant totals to results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -727,6 +727,14 @@ data class ObservationSpeciesResultsPayload(
             "If certainty is Other, the user-supplied name of the species. Null if certainty is " +
                 "Known or Unknown.")
     val speciesName: String?,
+    @Schema(description = "Number of dead plants observed in this observation.") //
+    val totalDead: Int,
+    @Schema(description = "Number of existing plants observed in this observation.")
+    val totalExisting: Int,
+    @Schema(
+        description =
+            "Number of live plants observed in this observation, not including existing plants.")
+    val totalLive: Int,
     @Schema(description = "Total number of live and existing plants of this species.")
     val totalPlants: Int,
 ) {
@@ -739,6 +747,9 @@ data class ObservationSpeciesResultsPayload(
       permanentLive = model.permanentLive,
       speciesId = model.speciesId,
       speciesName = model.speciesName,
+      totalDead = model.totalDead,
+      totalExisting = model.totalExisting,
+      totalLive = model.totalLive,
       totalPlants = model.totalPlants,
   )
 }


### PR DESCRIPTION
We need to be able to generate a report on the client side that includes the live,
dead, and existing plant counts on a per-plot, per-species basis for an
observation, regardless of whether the plot was permanent or temporary or there
were previous observations. Add fields to the per-species observation results
payload to make those values visible to the client.