### PR TITLE
Reset variable caches when variables, modules, or deliverables are uploaded

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporter.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.db
 
+import com.terraformation.backend.accelerator.event.DeliverablesUploadedEvent
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.StableId
@@ -22,6 +23,7 @@ import java.io.InputStream
 import java.net.URI
 import java.time.InstantSource
 import org.jooq.DSLContext
+import org.springframework.context.ApplicationEventPublisher
 
 /** Imports the list of deliverables from a CSV file. */
 @Named
@@ -29,6 +31,7 @@ class DeliverablesImporter(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val variableStore: VariableStore,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
   companion object {
     private const val COLUMN_NAME = 0
@@ -252,5 +255,7 @@ class DeliverablesImporter(
             "Deleting deliverables isn't supported yet. Missing IDs: $leftOverNegativePositions")
       }
     }
+
+    eventPublisher.publishEvent(DeliverablesUploadedEvent())
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ModulesImporter.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.db
 
+import com.terraformation.backend.accelerator.event.ModulesUploadedEvent
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.accelerator.CohortPhase
@@ -10,12 +11,14 @@ import jakarta.inject.Named
 import java.io.InputStream
 import java.time.InstantSource
 import org.jooq.DSLContext
+import org.springframework.context.ApplicationEventPublisher
 
 /** Imports the list of modules from a CSV file. */
 @Named
 class ModulesImporter(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
   companion object {
     private const val COLUMN_NAME = 0
@@ -110,5 +113,7 @@ class ModulesImporter(
         }
       }
     }
+
+    eventPublisher.publishEvent(ModulesUploadedEvent())
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverablesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverablesUploadedEvent.kt
@@ -1,0 +1,3 @@
+package com.terraformation.backend.accelerator.event
+
+class DeliverablesUploadedEvent

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverablesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/DeliverablesUploadedEvent.kt
@@ -1,3 +1,6 @@
 package com.terraformation.backend.accelerator.event
 
-class DeliverablesUploadedEvent
+import com.terraformation.backend.documentproducer.event.VariableUpdatedSource
+import com.terraformation.backend.documentproducer.event.VariablesUpdatedEvent
+
+class DeliverablesUploadedEvent : VariablesUpdatedEvent(VariableUpdatedSource.DeliverablesUploaded)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ModulesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ModulesUploadedEvent.kt
@@ -1,0 +1,3 @@
+package com.terraformation.backend.accelerator.event
+
+class ModulesUploadedEvent

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ModulesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ModulesUploadedEvent.kt
@@ -1,3 +1,6 @@
 package com.terraformation.backend.accelerator.event
 
-class ModulesUploadedEvent
+import com.terraformation.backend.documentproducer.event.VariableUpdatedSource
+import com.terraformation.backend.documentproducer.event.VariablesUpdatedEvent
+
+class ModulesUploadedEvent : VariablesUpdatedEvent(VariableUpdatedSource.ModulesUploaded)

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableService.kt
@@ -1,12 +1,11 @@
 package com.terraformation.backend.documentproducer
 
-import com.terraformation.backend.accelerator.event.DeliverablesUploadedEvent
-import com.terraformation.backend.accelerator.event.ModulesUploadedEvent
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.documentproducer.db.VariableStore
 import com.terraformation.backend.documentproducer.db.VariableValueStore
 import com.terraformation.backend.documentproducer.db.variable.VariableImportResult
 import com.terraformation.backend.documentproducer.db.variable.VariableImporter
+import com.terraformation.backend.documentproducer.event.VariablesUpdatedEvent
 import com.terraformation.backend.documentproducer.event.VariablesUploadedEvent
 import com.terraformation.backend.documentproducer.model.TableVariable
 import com.terraformation.backend.log.perClassLogger
@@ -93,20 +92,8 @@ class VariableService(
   }
 
   @EventListener
-  fun on(@Suppress("UNUSED_PARAMETER") event: VariablesUploadedEvent) {
-    log.info("Variables uploaded; clearing cache")
-    variableStore.clearCache()
-  }
-
-  @EventListener
-  fun on(@Suppress("UNUSED_PARAMETER") event: ModulesUploadedEvent) {
-    log.info("Modules uploaded; clearing cache")
-    variableStore.clearCache()
-  }
-
-  @EventListener
-  fun on(@Suppress("UNUSED_PARAMETER") event: DeliverablesUploadedEvent) {
-    log.info("Deliverables uploaded; clearing cache")
+  fun on(event: VariablesUpdatedEvent) {
+    log.info(event.message)
     variableStore.clearCache()
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/VariableStore.kt
@@ -384,7 +384,7 @@ class VariableStore(
     }
   }
 
-  /** Clears the variable cache. Used in tests. */
+  /** Clears the variable caches. */
   fun clearCache() {
     publicVariables.clear()
     replacements.clear()

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUpdatedEvent.kt
@@ -1,0 +1,11 @@
+package com.terraformation.backend.documentproducer.event
+
+enum class VariableUpdatedSource {
+  VariablesUploaded,
+  ModulesUploaded,
+  DeliverablesUploaded,
+}
+
+open class VariablesUpdatedEvent(val source: VariableUpdatedSource) {
+  val message = "Variables updated from source: $source"
+}

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUploadedEvent.kt
@@ -1,0 +1,3 @@
+package com.terraformation.backend.documentproducer.event
+
+class VariablesUploadedEvent

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/event/VariablesUploadedEvent.kt
@@ -1,3 +1,3 @@
 package com.terraformation.backend.documentproducer.event
 
-class VariablesUploadedEvent
+class VariablesUploadedEvent : VariablesUpdatedEvent(VariableUpdatedSource.VariablesUploaded)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.DeliverablesUploadedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableVariablesRow
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.assertThrows
 
 class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
+  private val eventPublisher = TestEventPublisher()
 
   private val importer: DeliverablesImporter by lazy {
     DeliverablesImporter(
@@ -36,7 +39,9 @@ class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
             variableSelectOptionsDao,
             variableTablesDao,
             variableTableColumnsDao,
-            variableTextsDao))
+            variableTextsDao),
+        eventPublisher,
+    )
   }
 
   private val stableIdSuffix = "${UUID.randomUUID()}"
@@ -79,6 +84,8 @@ class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
               DeliverableVariablesRow(deliverableId2, variableId3, 2),
           ),
           deliverableVariablesDao.findAll().toSet())
+
+      eventPublisher.assertEventPublished { event -> event is DeliverablesUploadedEvent }
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModulesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModulesImporterTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.ModulesUploadedEvent
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ModuleId
@@ -18,11 +20,13 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
 
   private val importer: ModulesImporter by lazy {
     ModulesImporter(
         clock,
         dslContext,
+        eventPublisher,
     )
   }
 
@@ -110,6 +114,8 @@ class ModulesImporterTest : DatabaseTest(), RunsAsUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
               )))
+
+      eventPublisher.assertEventPublished { event -> event is ModulesUploadedEvent }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/VariableServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/VariableServiceTest.kt
@@ -1,0 +1,77 @@
+package com.terraformation.backend.documentproducer
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.customer.model.SystemUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.documentproducer.db.VariableStore
+import com.terraformation.backend.documentproducer.db.VariableValueStore
+import com.terraformation.backend.documentproducer.db.variable.VariableImporter
+import com.terraformation.backend.documentproducer.event.VariablesUpdatedEvent
+import com.terraformation.backend.documentproducer.event.VariablesUploadedEvent
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.mockUser
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class VariableServiceTest : DatabaseTest(), RunsAsUser {
+  override val user = mockUser()
+  private val systemUser = SystemUser(mockk())
+  private val messages = Messages()
+  private val eventPublisher = TestEventPublisher()
+
+  private val variableStore: VariableStore by lazy {
+    VariableStore(
+        dslContext,
+        variableNumbersDao,
+        variablesDao,
+        variableSectionDefaultValuesDao,
+        variableSectionRecommendationsDao,
+        variableSectionsDao,
+        variableSelectsDao,
+        variableSelectOptionsDao,
+        variableTablesDao,
+        variableTableColumnsDao,
+        variableTextsDao)
+  }
+
+  private val variableImporter: VariableImporter by lazy {
+    VariableImporter(DeliverableStore(dslContext), dslContext, messages, variableStore)
+  }
+
+  private val service: VariableService by lazy {
+    VariableService(
+        dslContext,
+        systemUser,
+        variableImporter,
+        variableStore,
+        VariableValueStore(
+            TestClock(),
+            dslContext,
+            eventPublisher,
+            variableImageValuesDao,
+            variableLinkValuesDao,
+            variablesDao,
+            variableSectionValuesDao,
+            variableSelectOptionValuesDao,
+            variableValuesDao,
+            variableValueTableRowsDao),
+        eventPublisher,
+    )
+  }
+
+  @Test
+  fun `test event listener when variables are updated`() {
+    assertIsEventListener<VariablesUpdatedEvent>(service)
+  }
+
+  @Test
+  fun `test importAllVariables publishes event`() {
+    service.importAllVariables("".byteInputStream())
+
+    eventPublisher.assertEventPublished { event -> event is VariablesUploadedEvent }
+  }
+}


### PR DESCRIPTION
We use a few `ConcurrentHashMap` caches for variables in `VariableStore`, but don't ever clear the cache (just variables, not values). When Variables, Modules, or Deliverables get re-uploaded in admin or the accelerator, the caches were not getting reset, so things such as `deliverable_position` for variables within a deliverable were not getting set or reset. 

This change just publishes events for each of those and clears the cache on the events. We opted for lazy repopulation of the cache instead of immediate repopulation.