### PR TITLE
SW-6912 Fixed duplicated report bugs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -550,7 +550,7 @@ class ReportStore(
   private fun updateReportRows(
       config: ExistingProjectReportConfigModel,
   ) {
-    val existingReports = reportsDao.fetchByConfigId(config.id)
+    val existingReports = reportsDao.fetchByConfigId(config.id).sortedBy { it.startDate }
     val newReportRows = createReportRows(config)
 
     if (existingReports.isEmpty()) {

--- a/src/main/resources/db/migration/0350/V379__DeleteDuplicatedReports.sql
+++ b/src/main/resources/db/migration/0350/V379__DeleteDuplicatedReports.sql
@@ -1,0 +1,11 @@
+DELETE FROM accelerator.reports
+WHERE id IN (
+    SELECT id
+    FROM accelerator.reports
+    WHERE (config_id, start_date, end_date) IN (
+        SELECT config_id, start_date, end_date
+        FROM accelerator.reports
+        GROUP BY config_id, start_date, end_date
+        HAVING COUNT(*) > 1
+    ))
+AND status_id = 5;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -2765,17 +2765,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               reportingEndDate = LocalDate.of(2024, Month.JULY, 9),
           )
 
-      // This one remains unchanged, but will help catch any looping issues
-      val year0ReportId =
-          insertReport(
-              configId = configId,
-              projectId = projectId,
-              quarter = null,
-              frequency = ReportFrequency.Annual,
-              status = ReportStatus.NotNeeded,
-              startDate = LocalDate.of(2020, Month.MARCH, 13),
-              endDate = LocalDate.of(2020, Month.MAY, 31),
-          )
+      // Reports are added in random order
 
       val year1ReportId =
           insertReport(
@@ -2789,17 +2779,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               upcomingNotificationSentTime = Instant.EPOCH,
           )
 
-      // year 2 is missing, which can happen if report dates were changed before
-      val year3ReportId =
+      // This one remains unchanged, but will help catch any looping issues
+      val year0ReportId =
           insertReport(
               configId = configId,
               projectId = projectId,
               quarter = null,
               frequency = ReportFrequency.Annual,
-              status = ReportStatus.Approved,
-              startDate = LocalDate.of(2023, Month.JANUARY, 1),
-              endDate = LocalDate.of(2023, Month.DECEMBER, 31),
-              upcomingNotificationSentTime = Instant.EPOCH,
+              status = ReportStatus.NotNeeded,
+              startDate = LocalDate.of(2020, Month.MARCH, 13),
+              endDate = LocalDate.of(2020, Month.MAY, 31),
           )
 
       val year4ReportId =
@@ -2813,6 +2802,20 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               endDate = LocalDate.of(2024, Month.JULY, 9),
               upcomingNotificationSentTime = Instant.EPOCH,
           )
+
+      val year3ReportId =
+          insertReport(
+              configId = configId,
+              projectId = projectId,
+              quarter = null,
+              frequency = ReportFrequency.Annual,
+              status = ReportStatus.Approved,
+              startDate = LocalDate.of(2023, Month.JANUARY, 1),
+              endDate = LocalDate.of(2023, Month.DECEMBER, 31),
+              upcomingNotificationSentTime = Instant.EPOCH,
+          )
+
+      // year 2 is missing, which can happen if report dates were changed before
 
       clock.instant = Instant.ofEpochSecond(9000)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -2815,7 +2815,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               upcomingNotificationSentTime = Instant.EPOCH,
           )
 
-      // year 2 is missing, which can happen if report dates were changed before
+      // year 2 is missing, which can happen if report dates were changed previously
 
       clock.instant = Instant.ofEpochSecond(9000)
 


### PR DESCRIPTION
This fixes an issue when updating report config dates, that multiple reports of the same dates get created. This was due to an incorrect assumption that reports are inserted/returned in order by the DAO.

This fixes it by sorting the results returned by the DAO, as well as removing all duplicated reports marked as "Not Needed".