### PR TITLE
Add GCS_WGS_1984 coordinate system name

### DIFF
--- a/src/main/resources/gis/srid.properties
+++ b/src/main/resources/gis/srid.properties
@@ -1,5 +1,6 @@
 # Longitude and latitude as used by GPS. https://epsg.io/4326
 WGS\ 84=4326
+GCS_WGS_1984=4326
 
 # WGS 1984 Web Mercator or Spherical Mercator as used by mapping software. https://epsg.io/3857
 WGS_1984_Web_Mercator_Auxiliary_Sphere=3857


### PR DESCRIPTION
We got a shapefile from the GIS team that used a different alias for the WGS 1984
coordinate system. Add it to our list of coordinate system names.