### PR TITLE
Add missing index on monitoring_plots

### DIFF
--- a/src/main/resources/db/migration/0350/V380__MonitoringPlotsSubzoneIndex.sql
+++ b/src/main/resources/db/migration/0350/V380__MonitoringPlotsSubzoneIndex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX ON tracking.monitoring_plots (planting_subzone_id);


### PR DESCRIPTION
The query to fetch planting site data was joining the `planting_subzones` table
to the `monitoring_plots` table but there was no index on the planting subzone ID,
so the database was forced to do a seq scan which made the query very expensive.