### PR TITLE
SW-6998 Support fetching simple planting site history

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -290,7 +290,7 @@ class PlantingSiteStore(
               boundary = record[boundaryField] as MultiPolygon,
               createdTime = record[PLANTING_SITE_HISTORIES.CREATED_TIME]!!,
               exclusion = record[exclusionField] as? MultiPolygon,
-              gridOrigin = record[gridOriginField] as Point,
+              gridOrigin = record[gridOriginField] as? Point,
               id = record[PLANTING_SITE_HISTORIES.ID]!!,
               plantingSiteId = record[PLANTING_SITE_HISTORIES.PLANTING_SITE_ID]!!,
               plantingZones = zonesField?.let { record[it] } ?: emptyList(),

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteHistoryModel.kt
@@ -22,7 +22,7 @@ data class PlantingSiteHistoryModel(
     val boundary: MultiPolygon,
     val createdTime: Instant,
     val exclusion: MultiPolygon? = null,
-    val gridOrigin: Point,
+    val gridOrigin: Point?,
     val id: PlantingSiteHistoryId,
     val plantingSiteId: PlantingSiteId,
     val plantingZones: List<PlantingZoneHistoryModel>,
@@ -32,9 +32,10 @@ data class PlantingSiteHistoryModel(
         id == other.id &&
         plantingSiteId == other.plantingSiteId &&
         areaHa == other.areaHa &&
+        createdTime == other.createdTime &&
         boundary.equalsExact(other.boundary, tolerance) &&
         exclusion.equalsOrBothNull(other.exclusion, tolerance) &&
-        gridOrigin.equalsExact(other.gridOrigin, tolerance) &&
+        gridOrigin.equalsOrBothNull(other.gridOrigin, tolerance) &&
         plantingZones.size == other.plantingZones.size &&
         plantingZones.zip(other.plantingZones).all { it.first.equals(it.second, tolerance) }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryByIdTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreFetchSiteHistoryByIdTest.kt
@@ -178,6 +178,32 @@ internal class PlantingSiteStoreFetchSiteHistoryByIdTest : DatabaseTest(), RunsA
   }
 
   @Test
+  fun `fetches history for simple planting site`() {
+    val siteBoundary = multiPolygon(100)
+    val plantingSiteId =
+        insertPlantingSite(areaHa = BigDecimal(50), boundary = siteBoundary, name = "Site")
+    val plantingSiteHistoryId = inserted.plantingSiteHistoryId
+
+    val expected =
+        PlantingSiteHistoryModel(
+            areaHa = BigDecimal(50),
+            boundary = siteBoundary,
+            createdTime = Instant.EPOCH,
+            gridOrigin = null,
+            id = plantingSiteHistoryId,
+            plantingSiteId = plantingSiteId,
+            plantingZones = emptyList(),
+        )
+
+    val actual =
+        store.fetchSiteHistoryById(plantingSiteId, plantingSiteHistoryId, PlantingSiteDepth.Plot)
+
+    if (!expected.equals(actual, 0.00001)) {
+      assertEquals(expected, actual)
+    }
+  }
+
+  @Test
   fun `throws exception if history ID does not exist`() {
     val plantingSiteId = insertPlantingSite(boundary = multiPolygon(1), name = "Site 1")
     assertThrows<PlantingSiteHistoryNotFoundException> {


### PR DESCRIPTION
If you tried to fetch the history of a planting site that started out as a simple
planting site (even if it later turned into a detailed one) it would fail because
there's no "grid origin" value for simple planting sites and the history fetching
code was expecting one.

Update the fetching code to make grid origin values optional.

Grid origin isn't exposed in the history fetching API, so no client changes
should be needed.