### PR TITLE
SW-7001 Improve Jira attachment failure error logging

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClient.kt
@@ -1,8 +1,10 @@
 package com.terraformation.backend.support.atlassian
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.support.atlassian.model.JiraServiceRequestFieldsModel
 import com.terraformation.backend.support.atlassian.model.ServiceDeskProjectModel
 import com.terraformation.backend.support.atlassian.model.SupportRequestType
@@ -16,15 +18,20 @@ import com.terraformation.backend.support.atlassian.request.ListServiceDesksHttp
 import com.terraformation.backend.support.atlassian.request.ListServiceRequestTypesHttpRequest
 import com.terraformation.backend.support.atlassian.request.PostServiceDeskRequestResponse
 import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
 import io.ktor.client.engine.java.Java
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.auth.*
-import io.ktor.client.plugins.auth.providers.*
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
+import io.ktor.client.plugins.auth.providers.basic
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.accept
 import io.ktor.client.request.request
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.jackson.JacksonConverter
 import jakarta.inject.Named
@@ -33,10 +40,20 @@ import kotlinx.coroutines.runBlocking
 /** Submits API requests to interact with Atlassian services. */
 @Named
 class AtlassianHttpClient(private val config: TerrawareServerConfig) {
+  private val log = perClassLogger()
   private val httpClient: HttpClient by lazy { createHttpClient() }
   private val serviceDesk: ServiceDeskProjectModel by lazy { findServiceDesk() }
 
   val requestTypeIds: Map<SupportRequestType, Int> by lazy { getJiraServiceRequestTypes() }
+
+  /**
+   * i18n error key that's returned when attempting to attach a file to a service request when the
+   * file's temporary ID isn't found. Temporary IDs expire after 1 hour (hence the mention of
+   * timeouts in the error key) but they also disappear when the files are attached to work items.
+   * If a client sends us two "create issue" requests with the same temporary ID, we'll get this
+   * error when we're handling the second request since the file will have already been used.
+   */
+  private val attachmentTimeoutErrorKey = "sd.attachment.temporary.session.time.out.ids"
 
   fun deleteIssue(issueId: String) {
     requirePermissions { deleteSupportIssue() }
@@ -87,12 +104,29 @@ class AtlassianHttpClient(private val config: TerrawareServerConfig) {
   ) {
     // No required permissions
 
-    makeRequest(
-        CreateAttachmentsHttpRequest(
-            issueId = issueId,
-            attachmentIds = attachmentIds,
-            comment = comment,
-        ))
+    try {
+      makeRequest(
+          CreateAttachmentsHttpRequest(
+              issueId = issueId,
+              attachmentIds = attachmentIds,
+              comment = comment,
+          ))
+    } catch (e: ClientRequestException) {
+      if (e.response.status == HttpStatusCode.BadRequest) {
+        try {
+          val errorResponse = runBlocking { e.response.body<AtlassianErrorResponse>() }
+          if (errorResponse.i18nErrorMessage?.i18nKey == attachmentTimeoutErrorKey) {
+            log.error(
+                "Jira attachment temporary ID(s) not found. This may be due to a duplicate API " +
+                    "request from the web app.")
+          }
+        } catch (e2: NoTransformationFoundException) {
+          log.warn("Unable to parse Atlassian API error response", e2)
+        }
+      }
+
+      throw e
+    }
   }
 
   private fun getJiraServiceRequestTypes(): Map<SupportRequestType, Int> =
@@ -144,4 +178,13 @@ class AtlassianHttpClient(private val config: TerrawareServerConfig) {
       }
     }
   }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  data class AtlassianI18nErrorMessage(val i18nKey: String?, val parameters: List<String>?)
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  data class AtlassianErrorResponse(
+      val errorMessage: String?,
+      val i18nErrorMessage: AtlassianI18nErrorMessage?
+  )
 }


### PR DESCRIPTION
If the client sends two "create issue" API requests with the same attachment IDs,
the second request fails because the attachments have already been consumed by the
first request. But in our error logs, this shows up as a generic "request failed"
error message, which makes the problem harder to troubleshoot.

Parse the Atlassian HTTP response and log a more specific error message for this
particular failure.