### PR TITLE
Upgrade to Java 24 JVM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,7 +267,7 @@ sourceSets.main { java.srcDir("build/generated/kotlin") }
 sourceSets.test { java.srcDir("build/generated-test/kotlin") }
 
 java {
-  toolchain { languageVersion = JavaLanguageVersion.of(23) }
+  toolchain { languageVersion = JavaLanguageVersion.of(24) }
   targetCompatibility = JavaVersion.VERSION_23
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:23.0.2-al2023-headless
+FROM amazoncorretto:24.0.1-al2023-headless
 
 ARG USER_ID=1001
 


### PR DESCRIPTION
Use the Java 24 JVM to run and build the application. This should give us better
CPU and memory performance as well as more robust virtual threads support.

Continue to build Java 23-compatible class files because the Kotlin compiler
doesn't yet support targeting Java 24.