### PR TITLE
Enable virtual threads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -24,7 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 class JobRunrRecoveryThread(
     private val backgroundJobServer: BackgroundJobServer,
     private val dataSource: DataSource,
-) : Thread() {
+) {
   companion object {
     /** How often to check whether JobRunr's background thread has stopped. */
     private val JOBRUNR_DOWN_POLL_INTERVAL = Duration.ofSeconds(1)!!
@@ -42,8 +42,7 @@ class JobRunrRecoveryThread(
 
   @PostConstruct
   fun startThread() {
-    isDaemon = true
-    start()
+    Thread.ofVirtual().name(javaClass.simpleName).start { run() }
   }
 
   @PreDestroy
@@ -51,7 +50,7 @@ class JobRunrRecoveryThread(
     shutdownLatch.countDown()
   }
 
-  override fun run() {
+  private fun run() {
     try {
       while (!shutdownLatch.await(JOBRUNR_DOWN_POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS)) {
         if (!backgroundJobServer.isRunning) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,6 +98,10 @@ spring:
   session:
     store-type: jdbc
 
+  threads:
+    virtual:
+      enabled: true
+
 server:
   tomcat:
     max-http-form-post-size: 200MB


### PR DESCRIPTION
Tell Spring to use virtual threads where possible, e.g., for the threads that
handle HTTP requests. This should slightly reduce server memory consumption.

We'd previously tried this in commit 1f7b30d1 but ran into platform thread
starvation issues; these may have been due to limitations in Java 23's virtual
threads implementation (specifically, the fact that `synchronized` blocks
caused thread pinning) which have been addressed in the Java 24 JVM.