### PR TITLE
Remove unnecessary JDBC configuration

### DIFF
--- a/src/main/resources/application-aws.yaml
+++ b/src/main/resources/application-aws.yaml
@@ -2,7 +2,6 @@
 
 spring:
   datasource:
-    driver-class-name: "software.amazon.jdbc.Driver"
     hikari:
       data-source-properties:
         wrapperPlugins: "iam,failover,efm2"

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,7 +1,6 @@
 spring:
   datasource:
     url: jdbc:tc:aws-wrapper:postgresql:15:///terraware
-    driver-class-name: software.amazon.jdbc.Driver
     hikari:
       data-source-properties:
         wrapperPlugins: dev


### PR DESCRIPTION
Now that we've upgraded to Spring Boot 3.5, we no longer need to specify that
we want to use the AWS JDBC wrapper; Spring Boot 3.5 automatically uses it if
the database's JDBC URL includes an `aws-wrapper` component.