### PR TITLE
Make JobRunr recovery thread wait for initialization

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -52,6 +52,12 @@ class JobRunrRecoveryThread(
 
   private fun run() {
     try {
+      while (!backgroundJobServer.isRunning &&
+          !shutdownLatch.await(JOBRUNR_DOWN_POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS)) {
+        // Wait for the background thread to start up initially so we don't try to "recover"
+        // during application start.
+      }
+
       while (!shutdownLatch.await(JOBRUNR_DOWN_POLL_INTERVAL.toMillis(), TimeUnit.MILLISECONDS)) {
         if (!backgroundJobServer.isRunning) {
           log.warn("JobRunr background thread is not running! Waiting for database to come back")


### PR DESCRIPTION
We have a background thread that restarts JobRunr if the database connection goes
away temporarily. Currently, during application startup, it sometimes sees that
JobRunr isn't started yet and tries to recover. This is harmless, but it spits
out a warning log message which adds unnecessary noise after a restart.

Change it to wait for JobRunr to start up initially.