### PR TITLE
SW-7005 Treat observed species as in use

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1628,6 +1628,7 @@ abstract class DatabaseBackedTest {
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       number: String? = row.number ?: "${nextAccessionNumber++}",
       receivedDate: LocalDate? = row.receivedDate,
+      speciesId: SpeciesId? = row.speciesId,
       stateId: AccessionState = row.stateId ?: AccessionState.Processing,
       treesCollectedFrom: Int? = row.treesCollectedFrom,
   ): AccessionId {
@@ -1641,6 +1642,7 @@ abstract class DatabaseBackedTest {
             modifiedTime = modifiedTime,
             number = number,
             receivedDate = receivedDate,
+            speciesId = speciesId,
             stateId = stateId,
             treesCollectedFrom = treesCollectedFrom,
         )

--- a/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/SpeciesServiceTest.kt
@@ -19,7 +19,8 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -105,10 +106,33 @@ internal class SpeciesServiceTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `deleteSpecies throws exception if species is in use`() {
+  fun `deleteSpecies throws exception if species is in use in accession`() {
+    val speciesId = insertSpecies("species name")
+    insertFacility()
+    insertAccession(speciesId = speciesId)
+
+    assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
+  }
+
+  @Test
+  fun `deleteSpecies throws exception if species is in use in batch`() {
     val speciesId = insertSpecies("species name")
     insertFacility()
     insertBatch(speciesId = speciesId)
+
+    assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
+  }
+
+  @Test
+  fun `deleteSpecies throws exception if species is in use in observation`() {
+    val speciesId = insertSpecies("species name")
+    insertPlantingSite(x = 0)
+    insertPlantingZone()
+    insertPlantingSubzone()
+    insertMonitoringPlot()
+    insertObservation()
+    insertObservationPlot()
+    insertRecordedPlant(speciesId = speciesId)
 
     assertThrows<SpeciesInUseException> { service.deleteSpecies(speciesId) }
   }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -771,7 +771,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     // create an accession with 'other' species
     insertFacility()
-    insertAccession(row = AccessionsRow(speciesId = created))
+    insertAccession(speciesId = created)
 
     // create another org accession
     val otherOrgId = insertOrganization()
@@ -782,6 +782,27 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
     val expected = listOf(store.fetchSpeciesById(created))
     val actual = store.findAllSpecies(organizationId, true)
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `find all species in use returns species used in observations`() {
+    val inUseSpeciesId =
+        store.createSpecies(
+            NewSpeciesModel(organizationId = organizationId, scientificName = "observed"))
+    store.createSpecies(NewSpeciesModel(organizationId = organizationId, scientificName = "unused"))
+
+    insertPlantingSite(x = 0)
+    insertPlantingZone()
+    insertPlantingSubzone()
+    insertMonitoringPlot()
+    insertObservation()
+    insertObservationPlot()
+    insertRecordedPlant(speciesId = inUseSpeciesId)
+
+    val expected = listOf(store.fetchSpeciesById(inUseSpeciesId))
+    val actual = store.findAllSpecies(organizationId, inUse = true)
 
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
The web app and backend prevent you from deleting a species that's used by an
accession, nursery batch, or planting, but it doesn't check whether the species
was recorded in any observations. Add observations to the in-use criteria.