### PR TITLE
SW-7005 Fix observation data for deleted species

### DIFF
--- a/src/main/resources/db/migration/0350/V381__FixDeletedObservedSpecies.sql
+++ b/src/main/resources/db/migration/0350/V381__FixDeletedObservedSpecies.sql
@@ -1,0 +1,35 @@
+UPDATE tracking.observed_plot_species_totals t
+SET species_id = NULL, species_name = s.scientific_name, certainty_id = 2
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;
+
+UPDATE tracking.observed_site_species_totals t
+SET species_id = NULL, species_name = s.scientific_name, certainty_id = 2
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;
+
+UPDATE tracking.observed_subzone_species_totals t
+SET species_id = NULL, species_name = s.scientific_name, certainty_id = 2
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;
+
+UPDATE tracking.observed_zone_species_totals t
+SET species_id = NULL, species_name = s.scientific_name, certainty_id = 2
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;
+
+UPDATE tracking.recorded_plants t
+SET species_id = NULL, species_name = s.scientific_name, certainty_id = 2
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;
+
+UPDATE tracking.observation_biomass_species t
+SET species_id = NULL, scientific_name = s.scientific_name
+FROM species s
+WHERE t.species_id = s.id
+AND s.deleted_time IS NOT NULL;


### PR DESCRIPTION
A couple of species were deleted in production despite having been recorded in
observations. This is causing some of the observation statistics to be calculated
incorrectly.

We'll disallow deleting observed species going forward, but fix up the existing
instances by converting their observations to the "Other" certainty type so they
no longer reference the deleted species IDs.