### PR TITLE
Extract getEnvOrSkipTest from test classes

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.util.Turtle
 import com.terraformation.backend.util.equalsOrBothNull
 import com.terraformation.backend.util.toMultiPolygon
 import java.math.BigDecimal
+import org.junit.Assume.assumeNotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.CoordinateXY
@@ -197,4 +198,15 @@ fun <T : Any, FAKE_ID : Any, ACTUAL_ID : Any> mapTo1IndexedIds(
         fakeId to actualId
       }
       .toMap()
+}
+
+/**
+ * Gets the value of an environment variable. If the variable isn't set, skips the current test.
+ * This is typically used for tests that depend on external services, which we don't want to include
+ * in test runs by default since they can be slow and flaky.
+ */
+fun getEnvOrSkipTest(name: String): String {
+  val value = System.getenv(name)
+  assumeNotNull(value, "$name not set; skipping test")
+  return value
 }

--- a/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/device/balena/LiveBalenaClientExternalTest.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.default_schema.BalenaDeviceId
 import com.terraformation.backend.db.default_schema.FacilityId
+import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.HttpClientConfig
 import io.ktor.http.HttpMethod
@@ -13,7 +14,6 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Instant
 import kotlin.random.Random
-import org.junit.AssumptionViolatedException
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -71,8 +71,7 @@ internal class LiveBalenaClientExternalTest {
   @BeforeAll
   fun setUp() {
     // Skip all the tests if no API key is available.
-    val apiKey =
-        System.getenv("TEST_BALENA_API_KEY") ?: throw AssumptionViolatedException("No API key")
+    val apiKey = getEnvOrSkipTest("TEST_BALENA_API_KEY")
 
     // Need to bootstrap the client without a fleet ID to create the fleet to define the config
     // that includes the fleet ID.

--- a/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
@@ -1,9 +1,9 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.getEnvOrSkipTest
 import java.net.URI
 import java.util.UUID
-import org.junit.Assume.assumeNotNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -92,11 +92,5 @@ class DropboxWriterExternalTest {
     // file is shared repeatedly while a valid link still exists.
     assertNotNull(writer.shareFile("$scratchFolder/$name"))
     assertNotNull(writer.shareFile("$scratchFolder/$name"))
-  }
-
-  private fun getEnvOrSkipTest(name: String): String {
-    val value = System.getenv(name)
-    assumeNotNull(value, "$name not set; skipping test")
-    return value
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/file/S3FileStoreExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/S3FileStoreExternalTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.log.perClassLogger
 import io.mockk.every
 import io.mockk.mockk
@@ -8,7 +9,6 @@ import java.net.URI
 import java.nio.file.NoSuchFileException
 import kotlin.random.Random
 import org.junit.Assume.assumeNoException
-import org.junit.Assume.assumeNotNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import software.amazon.awssdk.core.sync.RequestBody
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
  * run.
  */
 internal class S3FileStoreExternalTest : FileStoreTest() {
-  private val bucketName = System.getenv("TEST_S3_BUCKET_NAME")
+  private val bucketName = getEnvOrSkipTest("TEST_S3_BUCKET_NAME")
 
   private val config: TerrawareServerConfig = mockk()
   private val log = perClassLogger()
@@ -43,8 +43,6 @@ internal class S3FileStoreExternalTest : FileStoreTest() {
 
   @BeforeEach
   fun setUp() {
-    assumeNotNull(bucketName, "TEST_S3_BUCKET_NAME not set; skipping test")
-
     try {
       s3Client = S3Client.create()
     } catch (e: Exception) {

--- a/src/test/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClientExternalTest.kt
@@ -4,12 +4,12 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.support.atlassian.model.SupportRequestType
 import io.ktor.client.plugins.ClientRequestException
 import io.mockk.every
 import java.net.URI
-import org.junit.Assume
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -120,11 +120,5 @@ class AtlassianHttpClientExternalTest : RunsAsUser {
   fun `throws exception if no permission to delete issue`() {
     every { user.canDeleteSupportIssue() } returns false
     assertThrows<AccessDeniedException> { client.deleteIssue("issue") }
-  }
-
-  private fun getEnvOrSkipTest(name: String): String {
-    val value = System.getenv(name)
-    Assume.assumeNotNull(value, "$name not set; skipping test")
-    return value
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/mapbox/MapboxServiceExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/mapbox/MapboxServiceExternalTest.kt
@@ -5,13 +5,13 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.util.HttpClientConfig
 import io.ktor.client.engine.java.Java
 import io.mockk.every
 import java.net.URI
 import kotlin.math.abs
-import org.junit.Assume.assumeNotNull
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
@@ -56,12 +56,6 @@ class MapboxServiceExternalTest : RunsAsUser {
     val actual = service.getElevation(elevationDataPoint.point)
     assertApproximatelyEqual(
         elevationDataPoint.elevation, actual, 0.5, "Fetching elevation for $elevationDataPoint")
-  }
-
-  private fun getEnvOrSkipTest(name: String): String {
-    val value = System.getenv(name)
-    assumeNotNull(value, "$name not set; skipping test")
-    return value
   }
 
   data class ElevationDataPoint(val name: String, val point: Point, val elevation: Double) {


### PR DESCRIPTION
Tests that depend on external services are skipped if they're not run with
appropriate environment variables set. Extract the skipping logic out into a
shared helper function rather than duplicating it in each test.