### PR TITLE
Add dummy TerrawareServerConfig helper function

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/DummyTerrawareServerConfig.kt
+++ b/src/test/kotlin/com/terraformation/backend/DummyTerrawareServerConfig.kt
@@ -1,0 +1,29 @@
+package com.terraformation.backend
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.config.TerrawareServerConfig.AtlassianConfig
+import com.terraformation.backend.config.TerrawareServerConfig.DropboxConfig
+import com.terraformation.backend.config.TerrawareServerConfig.GeoServerConfig
+import com.terraformation.backend.config.TerrawareServerConfig.KeycloakConfig
+import com.terraformation.backend.config.TerrawareServerConfig.MapboxConfig
+import java.net.URI
+
+fun dummyTerrawareServerConfig(
+    atlassian: AtlassianConfig = AtlassianConfig(),
+    dropbox: DropboxConfig = DropboxConfig(),
+    geoServer: GeoServerConfig = GeoServerConfig(),
+    keycloak: KeycloakConfig =
+        KeycloakConfig(
+            apiClientId = "dummy", apiClientGroupName = "dummy", apiClientUsernamePrefix = "dummy"),
+    mapbox: MapboxConfig = MapboxConfig(),
+    webAppUrl: URI = URI.create("https://terraware.io"),
+): TerrawareServerConfig {
+  return TerrawareServerConfig(
+      atlassian = atlassian,
+      dropbox = dropbox,
+      geoServer = geoServer,
+      keycloak = keycloak,
+      mapbox = mapbox,
+      webAppUrl = webAppUrl,
+  )
+}

--- a/src/test/kotlin/com/terraformation/backend/daily/MonitoringPlotElevationSchedulerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/MonitoringPlotElevationSchedulerTest.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.daily
 
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.polygon
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.mapbox.MapboxService
@@ -11,7 +11,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.math.BigDecimal
-import java.net.URI
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -21,16 +20,7 @@ class MonitoringPlotElevationSchedulerTest {
 
   val scheduler: MonitoringPlotElevationScheduler by lazy {
     MonitoringPlotElevationScheduler(
-        TerrawareServerConfig(
-            webAppUrl = URI("https://terraware.io"),
-            keycloak =
-                TerrawareServerConfig.KeycloakConfig(
-                    apiClientId = "test",
-                    apiClientGroupName = "test",
-                    apiClientUsernamePrefix = "test")),
-        mapboxService,
-        plantingSiteStore,
-        SystemUser(mockk()))
+        dummyTerrawareServerConfig(), mapboxService, plantingSiteStore, SystemUser(mockk()))
   }
 
   @BeforeEach

--- a/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/DropboxWriterExternalTest.kt
@@ -1,11 +1,13 @@
 package com.terraformation.backend.file
 
 import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.getEnvOrSkipTest
-import java.net.URI
 import java.util.UUID
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -30,20 +32,13 @@ class DropboxWriterExternalTest {
     val refreshToken = getEnvOrSkipTest("TERRAWARE_DROPBOX_REFRESHTOKEN")
 
     val config =
-        TerrawareServerConfig(
-            webAppUrl = URI("https://terraware.io"),
+        dummyTerrawareServerConfig(
             dropbox =
                 TerrawareServerConfig.DropboxConfig(
                     enabled = true,
                     appKey = appKey,
                     appSecret = appSecret,
-                    refreshToken = refreshToken,
-                ),
-            keycloak =
-                TerrawareServerConfig.KeycloakConfig(
-                    apiClientId = "test",
-                    apiClientGroupName = "test",
-                    apiClientUsernamePrefix = "test"))
+                    refreshToken = refreshToken))
 
     writer = DropboxWriter(config)
   }

--- a/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.gis.geoserver
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.db.GeometryModule
+import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.getEnvOrSkipTest
 import java.net.URI
 import org.assertj.core.api.Assertions.assertThat
@@ -19,20 +20,10 @@ class GeoServerClientExternalTest {
     val password = System.getenv("TERRAWARE_GEOSERVER_PASSWORD")
 
     val config =
-        TerrawareServerConfig(
+        dummyTerrawareServerConfig(
             geoServer =
                 TerrawareServerConfig.GeoServerConfig(
-                    password = password,
-                    username = username,
-                    wfsUrl = wfsUrl,
-                ),
-            keycloak =
-                TerrawareServerConfig.KeycloakConfig(
-                    apiClientId = "test",
-                    apiClientGroupName = "test",
-                    apiClientUsernamePrefix = "test"),
-            webAppUrl = URI("https://terraware.io"),
-        )
+                    password = password, username = username, wfsUrl = wfsUrl))
 
     client = GeoServerClient(config, jacksonObjectMapper().registerModule(GeometryModule()))
   }

--- a/src/test/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/support/atlassian/AtlassianHttpClientExternalTest.kt
@@ -3,13 +3,13 @@ package com.terraformation.backend.support.atlassian
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.support.atlassian.model.SupportRequestType
 import io.ktor.client.plugins.ClientRequestException
 import io.mockk.every
-import java.net.URI
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -39,20 +39,14 @@ class AtlassianHttpClientExternalTest : RunsAsUser {
     val serviceDeskKey = getEnvOrSkipTest("TERRAWARE_ATLASSIAN_SERVICEDESKKEY")
 
     val config =
-        TerrawareServerConfig(
-            webAppUrl = URI("https://terraware.io"),
+        dummyTerrawareServerConfig(
             atlassian =
                 TerrawareServerConfig.AtlassianConfig(
                     account = account,
                     apiHost = apiHostname,
                     apiToken = apiToken,
                     enabled = true,
-                    serviceDeskKey = serviceDeskKey),
-            keycloak =
-                TerrawareServerConfig.KeycloakConfig(
-                    apiClientId = "test",
-                    apiClientGroupName = "test",
-                    apiClientUsernamePrefix = "test"))
+                    serviceDeskKey = serviceDeskKey))
 
     client = AtlassianHttpClient(config)
     assertTrue(client.requestTypeIds.isNotEmpty())

--- a/src/test/kotlin/com/terraformation/backend/tracking/mapbox/MapboxServiceExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/mapbox/MapboxServiceExternalTest.kt
@@ -5,14 +5,14 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.getEnvOrSkipTest
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.util.HttpClientConfig
 import io.ktor.client.engine.java.Java
 import io.mockk.every
-import java.net.URI
 import kotlin.math.abs
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -33,18 +33,10 @@ class MapboxServiceExternalTest : RunsAsUser {
     val apiToken = getEnvOrSkipTest("TERRAWARE_MAPBOX_APITOKEN")
 
     val config =
-        TerrawareServerConfig(
-            webAppUrl = URI("https://terraware.io"),
-            keycloak =
-                TerrawareServerConfig.KeycloakConfig(
-                    apiClientId = "test",
-                    apiClientGroupName = "test",
-                    apiClientUsernamePrefix = "test"),
+        dummyTerrawareServerConfig(
             mapbox =
                 TerrawareServerConfig.MapboxConfig(
-                    apiToken = apiToken,
-                    temporaryTokenExpirationMinutes = 30L,
-                ))
+                    apiToken = apiToken, temporaryTokenExpirationMinutes = 30L))
 
     val httpClient = HttpClientConfig().httpClient(Java.create(), jacksonObjectMapper())
     service = MapboxService(config, httpClient)


### PR DESCRIPTION
TerrawareServerConfig has some required fields, so whenever we construct an
instance of it in a test, we need to supply values for them even though they
aren't relevant to the code under test.

Add a helper function that populates them with default dummy values.