### PR TITLE
SW-7022 Suppress warning about sun.misc.Unsafe

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,4 +17,9 @@ COPY --chown=$USER_ID application/ ./
 EXPOSE 8080
 
 USER $USER_ID
-CMD ["java", "-Djava.locale.providers=SPI,CLDR", "org.springframework.boot.loader.launch.JarLauncher"]
+CMD [ \
+    "java", \
+        "-Djava.locale.providers=SPI,CLDR", \
+        "--sun-misc-unsafe-memory-access=allow", \
+        "org.springframework.boot.loader.launch.JarLauncher" \
+]


### PR DESCRIPTION
A couple of libraries we use are calling sun.misc.Unsafe.invokeCleaner to release
memory-mapped files. That method was deprecated in Java 23, and in Java 24 the
default is to log a warning message, which actually gets logged at ERROR level
and clutters our error logs.

The deprecation is documented here: https://openjdk.org/jeps/498

There's not much we can do to eliminate the use of that function (short of doing
our own surgery on the libraries' memory management code) so for now, just turn
off the warning message. The function will continue to work until at least
Java 27, which should give the libraries' maintainers plenty of time to switch
to non-deprecated APIs for their mapped-file management.