### PR TITLE
SW-7030 Proxy WFS requests to GeoServer

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -326,6 +326,8 @@ data class IndividualUser(
 
   override fun canNotifyUpcomingReports(): Boolean = false
 
+  override fun canProxyGeoServerGetRequests(): Boolean = isReadOnlyOrHigher()
+
   override fun canPublishReports() = isAcceleratorAdmin()
 
   override fun canReadAccession(accessionId: AccessionId) =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -766,6 +766,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun proxyGeoServerGetRequests() {
+    user.recordPermissionChecks {
+      if (!user.canProxyGeoServerGetRequests()) {
+        throw AccessDeniedException("No permission to proxy GET requests to GeoServer")
+      }
+    }
+  }
+
   fun publishReports() {
     user.recordPermissionChecks {
       if (!user.canPublishReports()) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -372,6 +372,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canNotifyUpcomingReports(): Boolean = defaultPermission
 
+  fun canProxyGeoServerGetRequests(): Boolean = defaultPermission
+
   fun canPublishReports(): Boolean = defaultPermission
 
   fun canReadAccession(accessionId: AccessionId): Boolean = defaultPermission

--- a/src/main/kotlin/com/terraformation/backend/gis/api/GeoServerProxyController.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/api/GeoServerProxyController.kt
@@ -1,0 +1,43 @@
+package com.terraformation.backend.gis.api
+
+import com.terraformation.backend.api.InternalEndpoint
+import com.terraformation.backend.gis.geoserver.GeoServerClient
+import io.ktor.client.statement.bodyAsBytes
+import io.ktor.http.contentType
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletRequest
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@InternalEndpoint
+@RequestMapping("/api/v1/gis/wfs")
+@RestController
+class GeoServerProxyController(private val geoServerClient: GeoServerClient) {
+  @GetMapping
+  @Operation(
+      summary = "Forwards a WFS API request to GeoServer.",
+      description =
+          "Query string parameters are passed to GeoServer, but headers aren't. The response " +
+              "from GeoServer, if any, will be returned verbatim. Only available for internal " +
+              "users.")
+  fun proxyGetRequest(
+      request: HttpServletRequest,
+  ): ResponseEntity<ByteArray> {
+    return runBlocking {
+      val response = geoServerClient.proxyGetRequest(request.parameterMap)
+      val mediaType =
+          response.contentType()?.toString()?.let { MediaType.parseMediaType(it) }
+              ?: MediaType.APPLICATION_OCTET_STREAM
+      ResponseEntity.status(response.status.value)
+          .contentType(mediaType)
+          .header(
+              HttpHeaders.CONTENT_DISPOSITION, response.headers[HttpHeaders.CONTENT_DISPOSITION])
+          .body(response.bodyAsBytes())
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -612,6 +612,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun notifyUpcomingReports() =
       allow { notifyUpcomingReports() } ifUser { canNotifyUpcomingReports() }
 
+  @Test
+  fun proxyGeoServerGetRequests() =
+      allow { proxyGeoServerGetRequests() } ifUser { canProxyGeoServerGetRequests() }
+
   @Test fun publishReports() = allow { publishReports() } ifUser { canPublishReports() }
 
   @Test fun readAccession() = testRead { readAccession(accessionId) }

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1440,6 +1440,7 @@ internal class PermissionTest : DatabaseTest() {
         manageNotifications = true,
         manageProjectReportConfigs = true,
         notifyUpcomingReports = true,
+        proxyGeoServerGetRequests = true,
         publishReports = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
@@ -1856,6 +1857,7 @@ internal class PermissionTest : DatabaseTest() {
         manageModuleEvents = true,
         manageModules = true,
         manageProjectReportConfigs = true,
+        proxyGeoServerGetRequests = true,
         publishReports = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
@@ -2113,6 +2115,7 @@ internal class PermissionTest : DatabaseTest() {
         manageModuleEvents = true,
         manageModules = true,
         manageProjectReportConfigs = true,
+        proxyGeoServerGetRequests = true,
         publishReports = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
@@ -2354,6 +2357,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         importGlobalSpeciesData = false,
         manageInternalTags = false,
+        proxyGeoServerGetRequests = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
         readCohort = true,
@@ -2532,6 +2536,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteSelf = true,
         importGlobalSpeciesData = false,
         manageInternalTags = false,
+        proxyGeoServerGetRequests = true,
         readAllAcceleratorDetails = true,
         readAllDeliverables = true,
         readCohort = true,
@@ -3083,6 +3088,7 @@ internal class PermissionTest : DatabaseTest() {
         manageNotifications: Boolean = false,
         manageProjectReportConfigs: Boolean = false,
         notifyUpcomingReports: Boolean = false,
+        proxyGeoServerGetRequests: Boolean = false,
         publishReports: Boolean = false,
         readAllAcceleratorDetails: Boolean = false,
         readAllDeliverables: Boolean = false,
@@ -3160,6 +3166,10 @@ internal class PermissionTest : DatabaseTest() {
           "Can manage project report configs")
       assertEquals(
           notifyUpcomingReports, user.canNotifyUpcomingReports(), "Can notify upcoming reports")
+      assertEquals(
+          proxyGeoServerGetRequests,
+          user.canProxyGeoServerGetRequests(),
+          "Can proxy GeoServer GET requests")
       assertEquals(publishReports, user.canPublishReports(), "Can publish reports")
       assertEquals(
           readAllAcceleratorDetails,


### PR DESCRIPTION
To allow maps from our GeoServer instance to be browsed from the accelerator
console, add an API endpoint to allow authorized users to fetch data from
GeoServer. This is implemented using request proxying; clients will construct
valid WFS queries the same way they would if they were talking directly to
GeoServer.