### PR TITLE
SW-7034 Remove observations that can't be started

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.event
 
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
@@ -56,6 +57,12 @@ data class ScheduleObservationReminderNotificationEvent(
 
 /** Published when a site has not had observations scheduled */
 data class ObservationNotScheduledNotificationEvent(
+    val plantingSiteId: PlantingSiteId,
+) : ObservationSchedulingNotificationEvent
+
+/** Published when we're unable to start a scheduled observation. */
+data class ObservationNotStartedEvent(
+    val observationId: ObservationId,
     val plantingSiteId: PlantingSiteId,
 ) : ObservationSchedulingNotificationEvent
 


### PR DESCRIPTION
If a planting zone is too small for the required number of permanent and temporary
plots for an observation, we currently log an error and try again later, which
means there's a neverending trickle of error messages in the logs as we repeatedly
try and fail to start the same observations. Worse, the observations still show up
for users, listed as "upcoming" even when their scheduled start dates are past.

Since we will never be able to start an observation of a site that's too small,
make the server delete observations when there isn't room for the required number
of monitoring plots.