### PR TITLE
SW-7033 Send email when observation fails to start

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -65,6 +65,7 @@ import com.terraformation.backend.email.model.FunderAddedToFundingEntity
 import com.terraformation.backend.email.model.MissingContact
 import com.terraformation.backend.email.model.NurserySeedlingBatchReady
 import com.terraformation.backend.email.model.ObservationNotScheduled
+import com.terraformation.backend.email.model.ObservationNotStarted
 import com.terraformation.backend.email.model.ObservationPlotReplaced
 import com.terraformation.backend.email.model.ObservationRescheduled
 import com.terraformation.backend.email.model.ObservationScheduled
@@ -96,6 +97,7 @@ import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import com.terraformation.backend.species.db.SpeciesStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationNotScheduledNotificationEvent
+import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
@@ -435,6 +437,16 @@ class EmailNotificationService(
     val model = ObservationNotScheduled(config, organization.name, plantingSite.name)
 
     sendToOrganizationContact(organization, model)
+  }
+
+  @EventListener
+  fun on(event: ObservationNotStartedEvent) {
+    val plantingSite = plantingSiteStore.fetchSiteById(event.plantingSiteId, PlantingSiteDepth.Site)
+
+    emailService.sendOrganizationNotification(
+        plantingSite.organizationId,
+        ObservationNotStarted(config, plantingSite.name, webAppUrls.fullContactUs().toString()),
+        roles = setOf(Role.Admin, Role.Owner))
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/WebAppUrls.kt
@@ -285,6 +285,10 @@ class WebAppUrls(
     return UriBuilder.fromPath("/accelerator/documents/$documentId").build()
   }
 
+  fun fullContactUs(): URI {
+    return UriBuilder.fromUri(config.webAppUrl).path("/help-support/contact-us").build()
+  }
+
   /** URL of the mobile app's page in the App Store. */
   val appStore = URI("https://apps.apple.com/us/app/terraware/id1568369900")
 

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -312,6 +312,15 @@ class ObservationNotScheduled(
     get() = "observation/notScheduled"
 }
 
+class ObservationNotStarted(
+    config: TerrawareServerConfig,
+    val plantingSiteName: String,
+    val contactUsUrl: String,
+) : EmailTemplateModel(config) {
+  override val templateDir: String
+    get() = "observation/notStarted"
+}
+
 class ObservationPlotReplaced(
     config: TerrawareServerConfig,
     val organizationName: String,

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -254,6 +254,18 @@ notification.observation.notScheduledSupport.email.body.2=There is currently no 
 notification.observation.notScheduledSupport.email.body.3=Planting site {0} is ready to have its next observation scheduled, but the organization has not scheduled one.
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.notScheduledSupport.email.subject=Organization {0} has not scheduled an observation of planting site {1}
+# {0} is the name of a planting site.
+notification.observation.notStarted.email.body.1=Scheduled Observation for {0} Not Started
+# {0} is the name of a planting site.
+notification.observation.notStarted.email.body.2=You scheduled an Observation for {0}, but the Observation cannot be started because the monitoring plots cannot be assigned by Terraware. The Planting Site’s subzones does not meet the threshold for the number of monitoring plots to be assigned. Therefore, we have removed the Observation from your account.
+# {0} is the name of a planting site.
+notification.observation.notStarted.email.body.3=If you would like to conduct an Observation for {0}, you can use the Ad Hoc Plot Observations feature in the mobile app.
+# The square brackets indicate a link.
+notification.observation.notStarted.email.body.4=Learn more about [Ad Hoc Plot Observations in the Terraware Knowledge Base].
+# The square brackets indicate a link.
+notification.observation.notStarted.email.body.5=If you would like more information about the above, feel free to [Contact Us].
+# {0} is the name of a planting site.
+notification.observation.notStarted.email.subject=Scheduled Observation for {0} Not Started
 # {0} is the name of an organization. {1} is the name of a planting site.
 notification.observation.rescheduled.email.body.1=Organization {0} has rescheduled an observation of planting site {1}
 # {0} is the name of a planting site.

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -257,7 +257,7 @@ notification.observation.notScheduledSupport.email.subject=Organization {0} has 
 # {0} is the name of a planting site.
 notification.observation.notStarted.email.body.1=Scheduled Observation for {0} Not Started
 # {0} is the name of a planting site.
-notification.observation.notStarted.email.body.2=You scheduled an Observation for {0}, but the Observation cannot be started because the monitoring plots cannot be assigned by Terraware. The Planting Site’s subzones does not meet the threshold for the number of monitoring plots to be assigned. Therefore, we have removed the Observation from your account.
+notification.observation.notStarted.email.body.2=You scheduled an Observation for {0}, but the Observation cannot be started because the monitoring plots cannot be assigned by Terraware. The Planting Site’s subzones do not meet the threshold for the number of monitoring plots to be assigned. Therefore, we have removed the Observation from your account.
 # {0} is the name of a planting site.
 notification.observation.notStarted.email.body.3=If you would like to conduct an Observation for {0}, you can use the Ad Hoc Plot Observations feature in the mobile app.
 # The square brackets indicate a link.

--- a/src/main/resources/templates/email/observation/notStarted/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/notStarted/body.ftlh.mjml
@@ -1,0 +1,33 @@
+<!-- <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationNotStarted" --> -->
+<!-- <#setting date_format="full"> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-headline06-bold">
+                ${strings("notification.observation.notStarted.email.body.1", plantingSiteName)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.notStarted.email.body.2", plantingSiteName)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                ${strings("notification.observation.notStarted.email.body.3", plantingSiteName)}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                    ${link("notification.observation.notStarted.email.body.4",
+                        "https://knowledge.terraformation.com/hc/en-us/articles/36389038050708-Ad-Hoc-Plot-Observations")}
+                </mj-text>
+                <mj-text mj-class="text-body03">
+                    ${link("notification.observation.notStarted.email.body.5", contactUsUrl)}
+                </mj-text>
+                <mj-include path="../../manageSettings.ftlh.mjml"/>
+
+                <mj-include path="../../footer.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/observation/notStarted/subject.ftl
+++ b/src/main/resources/templates/email/observation/notStarted/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ObservationNotStarted" -->
+${strings("notification.observation.notStarted.email.subject", plantingSiteName)}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -110,6 +110,7 @@ import com.terraformation.backend.species.model.ExistingSpeciesModel
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.event.ObservationNotScheduledNotificationEvent
+import com.terraformation.backend.tracking.event.ObservationNotStartedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotReplacedEvent
 import com.terraformation.backend.tracking.event.ObservationRescheduledEvent
 import com.terraformation.backend.tracking.event.ObservationScheduledEvent
@@ -830,6 +831,20 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     assertNoMessageSent()
+  }
+
+  @Test
+  fun observationNotStarted() {
+    val event = ObservationNotStartedEvent(ObservationId(1), PlantingSiteId(1))
+
+    service.on(event)
+
+    assertSubjectContains("Not Started")
+    assertSubjectContains("My Site")
+    assertBodyContains("My Site", hasTextPlain = false)
+    assertBodyContains("Contact Us", hasTextPlain = false)
+
+    assertRecipientsEqual(organizationRecipients)
   }
 
   @Test


### PR DESCRIPTION
If we're unable to start an observation because a planting zone is too small for
the required number of monitoring plots, send email to the organization's admins
telling them about it.

There is no in-app notification for this situation, just email.