### PR TITLE
Allow internal users to read published reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -472,7 +472,7 @@ data class IndividualUser(
 
   override fun canReadProjectVotes(projectId: ProjectId) = isReadOnlyOrHigher()
 
-  override fun canReadPublishedReports(projectId: ProjectId) = false
+  override fun canReadPublishedReports(projectId: ProjectId) = isReadOnlyOrHigher()
 
   override fun canReadReport(reportId: ReportId) =
       isReadOnlyOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(reportId))

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1712,6 +1712,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateDefaultVoters = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
@@ -1750,6 +1751,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateDefaultVoters = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
@@ -1965,6 +1967,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateDefaultVoters = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
@@ -2011,6 +2014,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateDefaultVoters = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
@@ -2230,6 +2234,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
@@ -2268,6 +2273,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
         updateInternalVariableWorkflowDetails = true,
         updateProject = true,
         updateProjectAcceleratorDetails = true,
@@ -2486,6 +2492,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
     )
 
     // Not an admin of this org but can still access accelerator-related functions.
@@ -2500,6 +2507,7 @@ internal class PermissionTest : DatabaseTest() {
         readProjectModules = true,
         readProjectScores = true,
         readProjectVotes = true,
+        readPublishedReports = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
Internal users need to be able to see what projects look like to funders, which
means they need permission to read the published reports that are shown to
funders.