### PR TITLE
SW-7059 Fix divide-by-zero in observation summary

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -495,10 +495,15 @@ fun Collection<Int>.calculateStandardDeviation(): Int? {
 }
 
 /**
- * Calculate standard deviation from a pair of (data, weight). Weight must be the number of samples,
- * so we can correctly apply the (n-1) Bessel's correction.
+ * Calculate standard deviation from a collection of pairs of (data, weight). Weight must be the
+ * number of samples, so we can correctly apply the (n-1) Bessel's correction.
  */
 fun Collection<Pair<Int, Int>>.calculateWeightedStandardDeviation(): Int? {
+  if (this.size == 1) {
+    // If there's only one sample, then by definition there's no variance.
+    return 0
+  }
+
   val totalWeights = this.sumOf { it.second }
 
   if (totalWeights <= 0) {


### PR DESCRIPTION
If a monitoring plot only had one observation where we calculated a mortality
rate, we were trying to divide by zero when calculating the mortality rate's
standard deviation. The standard deviation of a single sample is zero by
definition, so we can skip the rest of the standard deviation calculation in that
case.