### PR TITLE
SW-6901 Admin UI for testing CQL filters

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -62,6 +62,13 @@ class AdminController(
     model.addAttribute("canManageParticipants", currentUser().canCreateParticipant())
     model.addAttribute(
         "canMigrateSimplePlantingSites", GlobalRole.SuperAdmin in currentUser().globalRoles)
+    model.addAttribute(
+        "canQueryGeoServer",
+        config.geoServer.wfsUrl != null &&
+            currentUser()
+                .globalRoles
+                .intersect(setOf(GlobalRole.SuperAdmin, GlobalRole.AcceleratorAdmin))
+                .isNotEmpty())
     model.addAttribute("canReadCohorts", currentUser().canReadCohorts())
     model.addAttribute(
         "canRecalculateMortalityRates", GlobalRole.SuperAdmin in currentUser().globalRoles)

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminGeoServerController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminGeoServerController.kt
@@ -1,0 +1,106 @@
+package com.terraformation.backend.admin
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.gis.geoserver.GeoServerClient
+import com.terraformation.backend.tracking.mapbox.MapboxService
+import java.io.ByteArrayOutputStream
+import org.geotools.geojson.GeoJSON
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin/geoServer")
+@RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+@Validated
+class AdminGeoServerController(
+    private val config: TerrawareServerConfig,
+    private val geoServerClient: GeoServerClient,
+    private val mapboxService: MapboxService,
+    private val objectMapper: ObjectMapper,
+) {
+  @GetMapping
+  fun getGeoServerHome(model: Model): String {
+    val enabled = config.geoServer.wfsUrl != null
+    model.addAttribute("enabled", enabled)
+    addAttributeIfAbsent(model, "filter", "")
+    addAttributeIfAbsent(model, "cqlProperties", "geom,area_ha,project_id,site,strata,substrata")
+    addAttributeIfAbsent(model, "forceLongLat", true)
+    addAttributeIfAbsent(model, "showMap", false)
+
+    if (enabled) {
+      model.addAttribute(
+          "availableProperties",
+          geoServerClient
+              .describeFeatureType("tf_accelerator:planting_sites")
+              .properties
+              .map { it.name }
+              .sorted()
+              .joinToString(", "))
+    }
+
+    return "/admin/geoServer"
+  }
+
+  @PostMapping("/cql")
+  fun postCqlQuery(
+      @RequestParam filter: String,
+      @RequestParam properties: String? = null,
+      @RequestParam forceLongLat: Boolean = false,
+      @RequestParam showMap: Boolean = false,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    // We always need the "fid" property if we're showing the map, since it's used by the
+    // highlighting logic.
+    val requestedProperties =
+        properties?.ifBlank { null }?.split(",")?.map { it.trim() } ?: emptyList()
+    val propertiesWithFid =
+        if (showMap) (requestedProperties + "fid").distinct() else requestedProperties
+
+    val features =
+        geoServerClient.getPlantingSiteFeatures(
+            filter,
+            propertiesWithFid,
+            forceLongLat,
+        )
+
+    if (!features.isEmpty) {
+      val outputStream = ByteArrayOutputStream()
+      GeoJSON.write(features, outputStream)
+      val jsonTree = objectMapper.readTree(outputStream.toByteArray())
+      val prettyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonTree)
+
+      if (showMap) {
+        redirectAttributes.addFlashAttribute("geoJsonResults", jsonTree)
+      } else {
+        redirectAttributes.addFlashAttribute("results", prettyJson)
+      }
+    } else {
+      redirectAttributes.failureMessage = "Query returned no results."
+    }
+
+    redirectAttributes.addFlashAttribute("filter", filter)
+    redirectAttributes.addFlashAttribute("forceLongLat", forceLongLat || showMap)
+    redirectAttributes.addFlashAttribute("cqlProperties", properties)
+    redirectAttributes.addFlashAttribute("showMap", showMap)
+    redirectAttributes.addFlashAttribute("mapboxToken", mapboxService.generateTemporaryToken())
+
+    return redirectToGeoServerHome()
+  }
+
+  private fun addAttributeIfAbsent(model: Model, name: String, value: Any) {
+    if (!model.containsAttribute(name)) {
+      model.addAttribute(name, value)
+    }
+  }
+
+  private fun redirectToGeoServerHome() = "redirect:/admin/geoServer"
+}

--- a/src/main/kotlin/com/terraformation/backend/gis/geoserver/FeatureTypeDescription.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/geoserver/FeatureTypeDescription.kt
@@ -1,0 +1,25 @@
+package com.terraformation.backend.gis.geoserver
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class FeatureProperty(
+    val localType: String,
+    val maxOccurs: Int,
+    val minOccurs: Int,
+    val name: String,
+    val nillable: Boolean,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class FeatureTypeDescription(
+    val properties: List<FeatureProperty>,
+    val targetPrefix: String? = null,
+    val typeName: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class FeatureTypeDescriptions(
+    val featureTypes: List<FeatureTypeDescription>,
+    val targetPrefix: String,
+)

--- a/src/main/resources/templates/admin/geoServer.html
+++ b/src/main/resources/templates/admin/geoServer.html
@@ -1,0 +1,306 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<head>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css" rel="stylesheet">
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
+    <style>
+        /* Only apply full-height flexbox when map is shown */
+        .has-map {
+            height: 100vh;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .page-content {
+            flex-shrink: 0;
+        }
+
+        .has-map .page-content {
+            margin: 8px;
+        }
+
+        .map-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+
+        #map {
+            flex: 1;
+            width: 100%;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body th:class="${geoJsonResults != null ? 'has-map' : ''}">
+
+<div class="page-content">
+    <span th:replace="~{/admin/header :: top}"/>
+
+    <a href="/admin/">Home</a>
+
+    <h2>GeoServer</h2>
+
+    <th:block th:if="${enabled}">
+        <form method="POST" action="/admin/geoServer/cql">
+            <h3>CQL Planting Sites Query</h3>
+
+            <label>
+                Filter
+                <input type="text" size="40" name="filter" th:value="${filter}"/>
+            </label>
+            <br/>
+            <label>
+                Properties (comma-separated)
+                <input type="text" size="40" name="properties" th:value="${cqlProperties}"/>
+                <small th:text="${availableProperties}"></small>
+            </label>
+            <br/>
+            <label>
+                Force long/lat coordinates
+                <input type="checkbox" name="forceLongLat" th:checked="${forceLongLat}"/>
+            </label>
+            <br/>
+            <label>
+                Show results on map
+                <input type="checkbox" name="showMap" th:checked="${showMap}"/>
+            </label>
+            <br/>
+            <input type="submit" value="Query"/>
+        </form>
+
+        <th:block th:if="${results != null}">
+            <h3>Results</h3>
+
+            <textarea rows="20" cols="80" th:text="${results}"></textarea>
+        </th:block>
+</div>
+
+<th:block th:if="${geoJsonResults != null}">
+    <div class="map-container">
+        <div id="map"></div>
+    </div>
+
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        mapboxgl.accessToken = /*[[${mapboxToken}]]*/;
+        const geoJsonData = /*[[${geoJsonResults}]]*/;
+
+        const map = new mapboxgl.Map({
+            container: 'map',
+            style: 'mapbox://styles/mapbox/satellite-streets-v12',
+            center: [0, 0],
+            zoom: 2
+        });
+
+        map.on('load', () => {
+            if (geoJsonData && geoJsonData.features && geoJsonData.features.length > 0) {
+                map.addSource('query-results', {
+                    type: 'geojson',
+                    data: geoJsonData
+                });
+
+                // Feature interiors
+                map.addLayer({
+                    id: 'fill',
+                    type: 'fill',
+                    source: 'query-results',
+                    filter: ['==', ['geometry-type'], 'Polygon'],
+                    paint: {
+                        'fill-color': '#088',
+                        'fill-opacity': 0.6
+                    }
+                });
+
+                // Line layer for feature boundaries
+                map.addLayer({
+                    id: 'line',
+                    source: 'query-results',
+                    type: 'line',
+                    filter: ['in', ['geometry-type'], ['literal', ['Polygon', 'LineString']]],
+                    paint: {
+                        'line-color': '#099',
+                        'line-width': 2
+                    }
+                });
+
+                // Default filter expression (shows no features initially)
+                const emptyFilter = ['==', ['get', 'fid'], ''];
+
+                // Hover highlight layers
+                map.addLayer({
+                    id: 'fill-hover',
+                    type: 'fill',
+                    source: 'query-results',
+                    filter: emptyFilter,
+                    paint: {
+                        'fill-color': '#0bb',
+                        'fill-opacity': 0.3
+                    }
+                });
+
+                map.addLayer({
+                    id: 'line-hover',
+                    source: 'query-results',
+                    type: 'line',
+                    filter: emptyFilter,
+                    paint: {
+                        'line-color': '#0bb',
+                        'line-width': 3
+                    }
+                });
+
+                // Add highlighted layers for selected features
+                map.addLayer({
+                    id: 'fill-highlighted',
+                    type: 'fill',
+                    source: 'query-results',
+                    filter: emptyFilter,
+                    paint: {
+                        'fill-color': '#ff8800',
+                        'fill-opacity': 0.8
+                    }
+                });
+
+                map.addLayer({
+                    id: 'line-highlighted',
+                    source: 'query-results',
+                    type: 'line',
+                    filter: emptyFilter,
+                    paint: {
+                        'line-color': '#ff8800',
+                        'line-width': 4
+                    }
+                });
+
+                // Fit map to show all features
+                const bounds = new mapboxgl.LngLatBounds();
+                geoJsonData.features.forEach((feature) => {
+                    if (feature.geometry.type === 'Polygon') {
+                        feature.geometry.coordinates[0].forEach((coord) => {
+                            bounds.extend(coord);
+                        });
+                    } else if (feature.geometry.type === 'MultiPolygon') {
+                        feature.geometry.coordinates.forEach((polygon) => {
+                            polygon[0].forEach((coord) => {
+                                bounds.extend(coord);
+                            });
+                        });
+                    }
+                });
+
+                if (!bounds.isEmpty()) {
+                    map.fitBounds(bounds, {padding: 50});
+                }
+
+                let currentlyHighlightedId = null;
+                let currentlyHoveredId = null;
+
+                const clearHighlight = () => {
+                    if (currentlyHighlightedId !== null) {
+                        map.setFilter('fill-highlighted', emptyFilter);
+                        map.setFilter('line-highlighted', emptyFilter);
+                        currentlyHighlightedId = null;
+                    }
+                };
+
+                const clearHover = () => {
+                    if (currentlyHoveredId !== null) {
+                        map.setFilter('fill-hover', emptyFilter);
+                        map.setFilter('line-hover', emptyFilter);
+                        currentlyHoveredId = null;
+                    }
+                };
+
+                const setHighlight = (featureId) => {
+                    const filterExpression = ['==', ['get', 'fid'], featureId];
+                    map.setFilter('fill-highlighted', filterExpression);
+                    map.setFilter('line-highlighted', filterExpression);
+                    currentlyHighlightedId = featureId;
+                };
+
+                const setHover = (featureId) => {
+                    const filterExpression = ['==', ['get', 'fid'], featureId];
+                    map.setFilter('fill-hover', filterExpression);
+                    map.setFilter('line-hover', filterExpression);
+                    currentlyHoveredId = featureId;
+                };
+
+                map.on('mousemove', (e) => {
+                    const features = map.queryRenderedFeatures(e.point, {layers: ['fill', 'line']});
+
+                    if (features.length > 0) {
+                        map.getCanvas().style.cursor = 'pointer';
+                        const featureId = features[0].properties.fid;
+
+                        // Only update hover if this is a different feature and not currently highlighted
+                        if (featureId !== currentlyHighlightedId && featureId !== currentlyHoveredId) {
+                            clearHover();
+                            setHover(featureId);
+                        }
+                    } else {
+                        map.getCanvas().style.cursor = '';
+                        clearHover();
+                    }
+                });
+
+                const showPopup = (e, properties) => {
+                    let popupContent = '<h4>Feature Properties</h4>';
+                    Object.keys(properties).forEach((key) => {
+                        if (properties[key] !== null && properties[key] !== undefined) {
+                            popupContent += `<strong>${key}:</strong> ${properties[key]}<br>`;
+                        }
+                    });
+
+                    new mapboxgl.Popup()
+                            .setLngLat(e.lngLat)
+                            .setHTML(popupContent)
+                            .addTo(map);
+                };
+
+                const addPopupClickHandler = (layerId) => {
+                    map.on('click', layerId, (e) => {
+                        const properties = e.features[0].properties;
+                        const featureId = properties.fid;
+
+                        clearHighlight();
+                        clearHover();
+                        setHighlight(featureId);
+                        showPopup(e, properties);
+                    });
+                };
+
+                // Clear highlights when clicking on empty map area
+                map.on('click', (e) => {
+                    const features = map.queryRenderedFeatures(e.point, {layers: ['fill', 'line']});
+                    if (features.length === 0) {
+                        clearHighlight();
+                        clearHover();
+                    }
+                });
+
+                addPopupClickHandler('fill');
+                addPopupClickHandler('line');
+            }
+        });
+        /*]]>*/
+    </script>
+    </div>
+</th:block>
+
+<th:block th:unless="${enabled}">
+    <p>
+        GeoServer is not configured.
+    </p>
+</th:block>
+
+<th:block th:if="${geoJsonResults == null}">
+    </div>
+</th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/geoServer.html
+++ b/src/main/resources/templates/admin/geoServer.html
@@ -289,7 +289,6 @@
         });
         /*]]>*/
     </script>
-    </div>
 </th:block>
 
 <th:block th:unless="${enabled}">

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -101,6 +101,10 @@
     <p>
         <a href="/admin/testClock">Test clock adjustment</a>
     </p>
+
+    <p th:if="${canQueryGeoServer}">
+        <a href="/admin/geoServer">GeoServer</a>
+    </p>
 </details>
 
 <details id="organizationManagement" class="section">

--- a/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
@@ -7,11 +7,8 @@ import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.getEnvOrSkipTest
 import java.net.URI
 import org.assertj.core.api.Assertions.assertThat
-import org.geotools.api.feature.simple.SimpleFeature
-import org.geotools.geojson.feature.FeatureJSON
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNull
 
 class GeoServerClientExternalTest {
   private lateinit var client: GeoServerClient
@@ -38,17 +35,5 @@ class GeoServerClientExternalTest {
     assertThat(capabilities.operations)
         .extracting("name")
         .containsAll(listOf("DescribeFeatureType", "GetFeature"))
-  }
-
-  @Test
-  fun `can get features`() {
-    val features = client.getPlantingSiteFeatures("tf_accelerator:project_no=2", null)
-    val iter = features.features()
-    val fj = FeatureJSON()
-    while (iter.hasNext()) {
-      fj.writeFeature(iter.next() as SimpleFeature, System.out)
-      println()
-    }
-    assertNull(features.features())
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClientExternalTest.kt
@@ -7,8 +7,11 @@ import com.terraformation.backend.dummyTerrawareServerConfig
 import com.terraformation.backend.getEnvOrSkipTest
 import java.net.URI
 import org.assertj.core.api.Assertions.assertThat
+import org.geotools.api.feature.simple.SimpleFeature
+import org.geotools.geojson.feature.FeatureJSON
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 
 class GeoServerClientExternalTest {
   private lateinit var client: GeoServerClient
@@ -35,5 +38,17 @@ class GeoServerClientExternalTest {
     assertThat(capabilities.operations)
         .extracting("name")
         .containsAll(listOf("DescribeFeatureType", "GetFeature"))
+  }
+
+  @Test
+  fun `can get features`() {
+    val features = client.getPlantingSiteFeatures("tf_accelerator:project_no=2", null)
+    val iter = features.features()
+    val fj = FeatureJSON()
+    while (iter.hasNext()) {
+      fj.writeFeature(iter.next() as SimpleFeature, System.out)
+      println()
+    }
+    assertNull(features.features())
   }
 }


### PR DESCRIPTION
Add a GeoServer page to the admin UI where people can try out different CQL
filter expressions on planting site features and browse the results on a map
or as GeoJSON.