### PR TITLE
SW-7037 Recalculate site populations from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -66,6 +66,8 @@ class AdminController(
     model.addAttribute(
         "canRecalculateMortalityRates", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute(
+        "canRecalculatePopulations", GlobalRole.SuperAdmin in currentUser().globalRoles)
+    model.addAttribute(
         "canSendTestEmail",
         config.email.enabled && GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -217,6 +217,23 @@
             <input type="submit" value="Recalculate"/>
         </form>
     </th:block>
+
+    <th:block th:if="${canRecalculatePopulations}">
+        <h3>Recalculate Planting Site Populations</h3>
+
+        <p>
+            This updates the reported plant counts for a planting site based on the total numbers of
+            plants from the withdrawal log.
+        </p>
+
+        <form method="POST" action="/admin/recalculatePopulations">
+            <label>
+                Planting Site ID:
+                <input type="text" name="plantingSiteId"/>
+            </label>
+            <input type="submit" value="Recalculate"/>
+        </form>
+    </th:block>
 </details>
 
 <details id="sendTestEmail" class="section" th:if="${canSendTestEmail}">


### PR DESCRIPTION
In cases where nursery batches have been deleted, there can be a discrepancy
between the outplanting withdrawal totals from the withdrawal log and the reported
plant populations that are tracked in `planting_site_populations` and its sibling
tables.

We're figuring out a more robust plan for this going forward, but until that's
in place, we need to be able to clear up the discrepancies in the numbers.

Add an admin UI function to reset the populations to the totals from the
withdrawal log.