### PR TITLE
SW-7060 Improve GeoServer query UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/gis/geoserver/GeoServerClient.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.SRID
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.java.Java
@@ -45,21 +44,21 @@ class GeoServerClient(
     return descriptions.featureTypes.first().copy(targetPrefix = descriptions.targetPrefix)
   }
 
-  fun getPlantingSiteFeatures(
+  fun getFeatures(
+      featureType: String,
       filter: String,
       properties: List<String>?,
-      forceLongLat: Boolean = false,
+      srsName: String? = null,
   ): FeatureCollection<*, *> {
     return FeatureJSON()
         .readFeatureCollection(
             sendGetRequest<String>(
                 "GetFeature",
                 listOfNotNull(
-                        if (forceLongLat) "srsName" to "EPSG:${SRID.LONG_LAT}" else null,
+                        srsName?.let { "srsName" to it },
                         "cql_filter" to filter,
-                        "typeNames" to "tf_accelerator:planting_sites",
-                        if (properties != null) "propertyName" to properties.joinToString(",")
-                        else null,
+                        "typeNames" to featureType,
+                        properties?.let { "properties" to it.joinToString(",") },
                     )
                     .toMap()))
   }

--- a/src/main/resources/templates/admin/geoServer.html
+++ b/src/main/resources/templates/admin/geoServer.html
@@ -43,33 +43,33 @@
 
     <a href="/admin/">Home</a>
 
-    <h2>GeoServer</h2>
+    <h2>Query GeoServer</h2>
 
     <th:block th:if="${enabled}">
         <form method="POST" action="/admin/geoServer/cql">
-            <h3>CQL Planting Sites Query</h3>
-
+            <label>
+                Feature Type
+                <select name="featureType">
+                    <option value="tf_accelerator:planting_sites"
+                            th:selected="${featureType == 'tf_accelerator:planting_sites'}"
+                        >Planting Sites</option>
+                    <option value="tf_accelerator:project_boundaries"
+                            th:selected="${featureType == 'tf_accelerator:project_boundaries'}"
+                        >Project Boundaries</option>
+                </select>
+            </label>
             <label>
                 Filter
                 <input type="text" size="40" name="filter" th:value="${filter}"/>
             </label>
-            <br/>
             <label>
-                Properties (comma-separated)
-                <input type="text" size="40" name="properties" th:value="${cqlProperties}"/>
-                <small th:text="${availableProperties}"></small>
+                View As
+                <select name="resultFormat">
+                    <option value="Map" th:selected="${resultFormat == 'Map'}">Map</option>
+                    <option value="GeoJsonLongLat" th:selected="${resultFormat == 'GeoJsonLongLat'}">GeoJSON (longitude/latitude)</option>
+                    <option value="GeoJsonOriginal" th:selected="${resultFormat == 'GeoJsonOriginal'}">GeoJSON (original coordinate system)</option>
+                </select>
             </label>
-            <br/>
-            <label>
-                Force long/lat coordinates
-                <input type="checkbox" name="forceLongLat" th:checked="${forceLongLat}"/>
-            </label>
-            <br/>
-            <label>
-                Show results on map
-                <input type="checkbox" name="showMap" th:checked="${showMap}"/>
-            </label>
-            <br/>
             <input type="submit" value="Query"/>
         </form>
 
@@ -250,7 +250,7 @@
 
                 const showPopup = (e, properties) => {
                     let popupContent = '<h4>Feature Properties</h4>';
-                    Object.keys(properties).forEach((key) => {
+                    Object.keys(properties).sort().forEach((key) => {
                         if (properties[key] !== null && properties[key] !== undefined) {
                             popupContent += `<strong>${key}:</strong> ${properties[key]}<br>`;
                         }


### PR DESCRIPTION
Improve the admin UI's GeoServer page in a few ways:

* Support querying both planting sites and project boundaries.

* Always fetch all properties so users don't have to edit the property list.

* Use a drop-down menu instead of checkboxes for setting the output format.

* Reduce vertical space usage to free up more window space for the map.

* Sort the list of properties in the feature popup.