### PR TITLE
SW-7072 Delete projects when org is deleted

### DIFF
--- a/src/main/resources/db/migration/0350/V386__ProjectOrganizationCascade.sql
+++ b/src/main/resources/db/migration/0350/V386__ProjectOrganizationCascade.sql
@@ -1,0 +1,2 @@
+ALTER TABLE projects DROP CONSTRAINT projects_organization_id_fkey;
+ALTER TABLE projects ADD FOREIGN KEY (organization_id) REFERENCES organizations ON DELETE CASCADE;


### PR DESCRIPTION
We were missing `ON DELETE CASCADE` on the foreign key constraint linking projects
to organizations, which made it impossible to delete an organization if it had
projects.

Deleting accelerator projects is still prevented by the intentional lack of
cascading deletes on the `project_accelerator_details` table.