### PR TITLE
SW-7083 Allow native access in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,5 +21,6 @@ CMD [ \
     "java", \
         "-Djava.locale.providers=SPI,CLDR", \
         "--sun-misc-unsafe-memory-access=allow", \
+        "--enable-native-access=ALL-UNNAMED", \
         "org.springframework.boot.loader.launch.JarLauncher" \
 ]


### PR DESCRIPTION
The Netty library uses a native-code component on Linux, which it needs to load
using JNI. In Java 24, this causes the JVM to output a warning that access to
native code will be denied by default in a future version. Add the command-line
argument to explicitly enable native code access.

This will stop the warning in Java 24, and will stop the application from breaking
in whatever future Java version changes the default behavior.