### PR TITLE
SW-7057 Set quantities to 0 on batch delete

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -13,7 +13,6 @@ import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.nursery.event.WithdrawalDeletionStartedEvent
 import com.terraformation.backend.util.ImageUtils
 import jakarta.inject.Named
 import java.io.InputStream
@@ -81,12 +80,6 @@ class WithdrawalPhotoService(
     deleteWhere(
         WITHDRAWAL_PHOTOS.withdrawals.withdrawalsFacilityIdFkey.ORGANIZATION_ID.eq(
             event.organizationId))
-  }
-
-  /** Deletes all the photos from a withdrawal when the withdrawal is deleted. */
-  @EventListener
-  fun on(event: WithdrawalDeletionStartedEvent) {
-    deleteWhere(WITHDRAWAL_PHOTOS.WITHDRAWAL_ID.eq(event.withdrawalId))
   }
 
   private fun deleteWhere(condition: Condition) {

--- a/src/main/kotlin/com/terraformation/backend/nursery/event/WithdrawalDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/event/WithdrawalDeletionStartedEvent.kt
@@ -1,6 +1,0 @@
-package com.terraformation.backend.nursery.event
-
-import com.terraformation.backend.db.nursery.WithdrawalId
-
-/** Published when a withdrawal is about to be deleted from the database. */
-data class WithdrawalDeletionStartedEvent(val withdrawalId: WithdrawalId)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
-import com.terraformation.backend.nursery.event.WithdrawalDeletionStartedEvent
 import com.terraformation.backend.onePixelPng
 import com.terraformation.backend.util.ImageUtils
 import io.mockk.Runs
@@ -152,27 +151,6 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
         "Remaining withdrawal photos")
 
     assertIsEventListener<OrganizationDeletionStartedEvent>(service)
-  }
-
-  @Test
-  fun `handler for WithdrawalDeletionStartedEvent deletes withdrawal photos`() {
-    val otherWithdrawalId = insertNurseryWithdrawal()
-
-    storePhoto()
-    storePhoto()
-    val otherWithdrawalfileId = storePhoto(otherWithdrawalId)
-
-    service.on(WithdrawalDeletionStartedEvent(withdrawalId))
-
-    assertEquals(
-        listOf(otherWithdrawalfileId), filesDao.findAll().map { it.id }, "Remaining photo IDs")
-    assertEquals(
-        listOf(
-            WithdrawalPhotosRow(fileId = otherWithdrawalfileId, withdrawalId = otherWithdrawalId)),
-        withdrawalPhotosDao.findAll(),
-        "Remaining withdrawal photos")
-
-    assertIsEventListener<WithdrawalDeletionStartedEvent>(service)
   }
 
   private fun storePhoto(


### PR DESCRIPTION
When the user deletes a batch that has had withdrawals, keep it around but set its
remaining quantities to zero. This will remove it from the list of active batches
in the web app, while preserving its entries in the withdrawal log.

The reasoning is that users are using the delete function just to clear irrelevant
batches out of their inventory, not to forget the fact that the batches ever
existed.

However, for batches that have had no withdrawals, we continue to delete them
outright. This will have no effect on the nursery's withdrawal log, but will
remove batches that were entered by mistake and never used for anything.