### PR TITLE
SW-7087 Support stdout Logstash logging

### DIFF
--- a/src/main/resources/logback-access-spring.xml
+++ b/src/main/resources/logback-access-spring.xml
@@ -1,4 +1,51 @@
+<!-- See logback-spring.xml for information about how the profiles work. -->
+
 <configuration>
+  <springProfile name="logstash">
+    <appender name="LOGSTASH" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
+        <providers>
+          <timestamp/>
+          <version/>
+
+          <!-- Standard access log fields -->
+          <contentLength/>
+          <elapsedTime/>
+          <method/>
+          <protocol/>
+          <remoteHost/>
+          <remoteUser/>
+          <requestedUri/>
+          <requestedUrl/>
+          <statusCode/>
+
+          <requestHeaders>
+            <fieldName>headers</fieldName>
+            <lowerCaseHeaderNames>true</lowerCaseHeaderNames>
+            <filter>
+              <include>Referer</include>
+              <include>User-Agent</include>
+            </filter>
+          </requestHeaders>
+
+          <pattern>
+            <omitEmptyFields>true</omitEmptyFields>
+            <pattern>
+              {
+              "authId": "#nullNA{%u}",
+              "email": "#nullNA{%reqAttribute{terrawareEmail}}",
+              "log_type": "access",
+              "message": "%h - %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\"",
+              "requestId": "#nullNA{%reqAttribute{terrawareRequestId}}"
+              }
+            </pattern>
+          </pattern>
+        </providers>
+      </encoder>
+    </appender>
+    <appender-ref ref="LOGSTASH"/>
+  </springProfile>
+
   <springProfile name="jsonlog">
     <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
@@ -52,7 +99,7 @@
     <appender-ref ref="JSONFILE"/>
   </springProfile>
 
-  <springProfile name="!jsonlog">
+  <springProfile name="!jsonlog &amp; !logstash">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <encoder>
         <pattern>combined</pattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,39 @@
-<!-- Logging configuration. -->
+<!--
+Logging configuration. This uses Spring profiles to control the logging behavior. There
+are two profiles you can use:
+
+logstash - Formats logs as JSON and writes them to stdout. This is suitable when running in
+           ECS or other managed container environments. Application and access logs will be
+           distinguished by the "log_type" field.
+
+jsonlog - Formats logs as JSON and writes them to rolling logfiles, as defined by the LOG_FILE
+          and ACCESS_LOG_FILE environment variables. This is suitable when running on a host
+          where something like the Datadog agent can consume multiple logfiles.
+
+The default behavior, if neither of those profiles is active, is to format log messages as
+human-readable text (for application log messages) and as Apache-style access log lines (for
+access logs) and write them to stdout. This is suitable for dev environments.
+
+Access logging is configured in logback-access-spring.xml; it uses the same profile setup as
+this file.
+-->
+
 <configuration>
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <springProfile name="logstash">
+    <appender name="LOGSTASH" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <customFields>
+          {"log_type": "application"}
+        </customFields>
+      </encoder>
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="LOGSTASH"/>
+    </root>
+  </springProfile>
 
   <springProfile name="jsonlog">
     <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -14,19 +47,17 @@
         <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}</maxHistory>
       </rollingPolicy>
     </appender>
-  </springProfile>
 
-  <!-- If we aren't logging to a JSON logfile, log to the console, but don't do both. -->
-  <springProfile name="!jsonlog">
-    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
     <root level="INFO">
-      <appender-ref ref="CONSOLE"/>
+      <appender-ref ref="JSONFILE"/>
     </root>
   </springProfile>
 
-  <springProfile name="jsonlog">
+  <!-- If we aren't logging JSON, log text to the console, but don't do both. -->
+  <springProfile name="!jsonlog &amp; !logstash">
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
     <root level="INFO">
-      <appender-ref ref="JSONFILE"/>
+      <appender-ref ref="CONSOLE"/>
     </root>
   </springProfile>
 </configuration>


### PR DESCRIPTION
Currently, in production and staging, we run with the `jsonlog` Spring profile
which causes the server to write Logstash (JSON) formatted logs to logfiles on
the host filesystem. The Datadog agent then forwards the logs to Datadog.

When we run in ECS, we'll want to let CloudWatch collect logs and forward them
to Datadog. But we'll still want them in Logstash format so we can log structured
information.

Update the logging configuration to support a new Spring profile `logstash` which
uses Logstash format but writes the logs to stdout instead of to files. Since the
access and application logs will both go to stdout, this adds a new `log_type`
custom field we can filter on as needed.