### PR TITLE
Support disabling JobRunr background thread

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
+++ b/src/main/kotlin/com/terraformation/backend/daily/JobRunrRecoveryThread.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
 import org.jobrunr.server.BackgroundJobServer
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 /**
@@ -19,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
  * up when the database becomes available again. We want the server to recover from transient
  * database problems.
  */
+@ConditionalOnBean(BackgroundJobServer::class)
 @ConditionalOnProperty(TerrawareServerConfig.DAILY_TASKS_ENABLED_PROPERTY, matchIfMissing = true)
 @Named
 class JobRunrRecoveryThread(


### PR DESCRIPTION
When we launch a server instance (say, in a dev environment) that connects to the
staging database rather than a local database, we don't want that server instance
to do things like send out scheduled notifications. JobRunr has a way to disable
the background job server thread, but currently that causes terraware-server to
fail to start up because the Spring bean for our recovery thread depends on the
bean for the JobRunr background job server thread.

Add a Spring autoconfigure rule so our recovery thread bean only gets created if the
JobRunr one exists.