### PR TITLE
SW-7113 Fix Seed Fund Reports with SDGs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoal.kt
@@ -36,6 +36,7 @@ enum class SustainableDevelopmentGoal(val displayName: String) {
     fun forJsonValue(value: String): SustainableDevelopmentGoal {
       val sdgNumber = startingDigitRegex.find(value)?.value?.toInt()
       return SustainableDevelopmentGoal.bySdgNumber[sdgNumber]
+          ?: runCatching { SustainableDevelopmentGoal.valueOf(value) }.getOrNull()
           ?: throw IllegalArgumentException("Unknown goal $value")
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
@@ -24,4 +24,60 @@ class SustainableDevelopmentGoalTest {
     assertEquals(
         SustainableDevelopmentGoal.Partnerships, SustainableDevelopmentGoal.forJsonValue("17"))
   }
+
+  @Test
+  fun `forJsonValue works correctly for names`() {
+    assertEquals(
+        SustainableDevelopmentGoal.NoPoverty, SustainableDevelopmentGoal.forJsonValue("NoPoverty"))
+    assertEquals(
+        SustainableDevelopmentGoal.ZeroHunger,
+        SustainableDevelopmentGoal.forJsonValue("ZeroHunger"))
+    assertEquals(
+        SustainableDevelopmentGoal.GoodHealth,
+        SustainableDevelopmentGoal.forJsonValue("GoodHealth"))
+    assertEquals(
+        SustainableDevelopmentGoal.QualityEducation,
+        SustainableDevelopmentGoal.forJsonValue("QualityEducation"))
+    assertEquals(
+        SustainableDevelopmentGoal.GenderEquality,
+        SustainableDevelopmentGoal.forJsonValue("GenderEquality"))
+    assertEquals(
+        SustainableDevelopmentGoal.CleanWater,
+        SustainableDevelopmentGoal.forJsonValue("CleanWater"))
+    assertEquals(
+        SustainableDevelopmentGoal.AffordableEnergy,
+        SustainableDevelopmentGoal.forJsonValue("AffordableEnergy"))
+    assertEquals(
+        SustainableDevelopmentGoal.DecentWork,
+        SustainableDevelopmentGoal.forJsonValue("DecentWork"))
+    assertEquals(
+        SustainableDevelopmentGoal.Industry, SustainableDevelopmentGoal.forJsonValue("Industry"))
+    assertEquals(
+        SustainableDevelopmentGoal.ReducedInequalities,
+        SustainableDevelopmentGoal.forJsonValue("ReducedInequalities"))
+    assertEquals(
+        SustainableDevelopmentGoal.SustainableCities,
+        SustainableDevelopmentGoal.forJsonValue("SustainableCities"))
+    assertEquals(
+        SustainableDevelopmentGoal.ResponsibleConsumption,
+        SustainableDevelopmentGoal.forJsonValue("ResponsibleConsumption"))
+    assertEquals(
+        SustainableDevelopmentGoal.ClimateAction,
+        SustainableDevelopmentGoal.forJsonValue("ClimateAction"))
+    assertEquals(
+        SustainableDevelopmentGoal.LifeBelowWater,
+        SustainableDevelopmentGoal.forJsonValue("LifeBelowWater"))
+    assertEquals(
+        SustainableDevelopmentGoal.LifeOnLand,
+        SustainableDevelopmentGoal.forJsonValue("LifeOnLand"))
+    assertEquals(SustainableDevelopmentGoal.Peace, SustainableDevelopmentGoal.forJsonValue("Peace"))
+    assertEquals(
+        SustainableDevelopmentGoal.Partnerships,
+        SustainableDevelopmentGoal.forJsonValue("Partnerships"))
+  }
+
+  @Test
+  fun `forJsonValue throws when doesn't exist`() {
+    assertThrows<IllegalArgumentException> { SustainableDevelopmentGoal.forJsonValue("BadValue") }
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/model/SustainableDevelopmentGoalTest.kt
@@ -30,50 +30,8 @@ class SustainableDevelopmentGoalTest {
     assertEquals(
         SustainableDevelopmentGoal.NoPoverty, SustainableDevelopmentGoal.forJsonValue("NoPoverty"))
     assertEquals(
-        SustainableDevelopmentGoal.ZeroHunger,
-        SustainableDevelopmentGoal.forJsonValue("ZeroHunger"))
-    assertEquals(
-        SustainableDevelopmentGoal.GoodHealth,
-        SustainableDevelopmentGoal.forJsonValue("GoodHealth"))
-    assertEquals(
-        SustainableDevelopmentGoal.QualityEducation,
-        SustainableDevelopmentGoal.forJsonValue("QualityEducation"))
-    assertEquals(
-        SustainableDevelopmentGoal.GenderEquality,
-        SustainableDevelopmentGoal.forJsonValue("GenderEquality"))
-    assertEquals(
-        SustainableDevelopmentGoal.CleanWater,
-        SustainableDevelopmentGoal.forJsonValue("CleanWater"))
-    assertEquals(
-        SustainableDevelopmentGoal.AffordableEnergy,
-        SustainableDevelopmentGoal.forJsonValue("AffordableEnergy"))
-    assertEquals(
-        SustainableDevelopmentGoal.DecentWork,
-        SustainableDevelopmentGoal.forJsonValue("DecentWork"))
-    assertEquals(
-        SustainableDevelopmentGoal.Industry, SustainableDevelopmentGoal.forJsonValue("Industry"))
-    assertEquals(
-        SustainableDevelopmentGoal.ReducedInequalities,
-        SustainableDevelopmentGoal.forJsonValue("ReducedInequalities"))
-    assertEquals(
-        SustainableDevelopmentGoal.SustainableCities,
-        SustainableDevelopmentGoal.forJsonValue("SustainableCities"))
-    assertEquals(
         SustainableDevelopmentGoal.ResponsibleConsumption,
         SustainableDevelopmentGoal.forJsonValue("ResponsibleConsumption"))
-    assertEquals(
-        SustainableDevelopmentGoal.ClimateAction,
-        SustainableDevelopmentGoal.forJsonValue("ClimateAction"))
-    assertEquals(
-        SustainableDevelopmentGoal.LifeBelowWater,
-        SustainableDevelopmentGoal.forJsonValue("LifeBelowWater"))
-    assertEquals(
-        SustainableDevelopmentGoal.LifeOnLand,
-        SustainableDevelopmentGoal.forJsonValue("LifeOnLand"))
-    assertEquals(SustainableDevelopmentGoal.Peace, SustainableDevelopmentGoal.forJsonValue("Peace"))
-    assertEquals(
-        SustainableDevelopmentGoal.Partnerships,
-        SustainableDevelopmentGoal.forJsonValue("Partnerships"))
   }
 
   @Test


### PR DESCRIPTION
Seed Fund Reports previously saved and retrieved SDGs by their enum value, but this was changed to their UN number. Update `forJsonValue` to first retrieve by UN number and then by enum value.