### PR TITLE
SW-7117 Allow retrieval of multiple published funder project details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -58,6 +58,8 @@ data class FunderUser(
 
   override fun canReadFundingEntity(entityId: FundingEntityId) = fundingEntityId == entityId
 
+  override fun canReadProject(projectId: ProjectId) = projectId in projectIds
+
   override fun canReadProjectFunderDetails(projectId: ProjectId) = projectId in projectIds
 
   override fun canReadPublishedReports(projectId: ProjectId) = projectId in projectIds

--- a/src/main/kotlin/com/terraformation/backend/funder/FunderProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/FunderProjectService.kt
@@ -1,7 +1,6 @@
 package com.terraformation.backend.funder
 
 import com.terraformation.backend.customer.model.requirePermissions
-import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.funder.db.PublishedProjectDetailsStore
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
@@ -11,11 +10,14 @@ import jakarta.inject.Named
 class FunderProjectService(
     private val publishedProjectDetailsStore: PublishedProjectDetailsStore,
 ) {
-  fun fetchByProjectId(projectId: ProjectId): FunderProjectDetailsModel {
+  fun fetchByProjectId(projectId: ProjectId): FunderProjectDetailsModel? {
     requirePermissions { readProjectFunderDetails(projectId) }
 
     return publishedProjectDetailsStore.fetchOneById(projectId)
-        ?: throw ProjectNotFoundException(projectId)
+  }
+
+  fun fetchListByProjectIds(projectIds: Set<ProjectId>): List<FunderProjectDetailsModel> {
+    return projectIds.mapNotNull { fetchByProjectId(it) }
   }
 
   fun publishProjectProfile(model: FunderProjectDetailsModel) {

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
@@ -41,7 +41,8 @@ class FundingProjectsController(
       if (model == null) {
         throw ProjectNotFoundException(projectIds.toList()[0])
       }
-      return GetFundingProjectResponsePayload(details = FunderProjectDetailsPayload(model))
+      val payload = FunderProjectDetailsPayload(model)
+      return GetFundingProjectResponsePayload(details = payload, projects = listOf(payload))
     }
 
     val models = funderProjectService.fetchListByProjectIds(projectIds)

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.FunderEndpoint
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.LandUseModelType
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableValueId
@@ -30,11 +31,22 @@ class FundingProjectsController(
 ) {
 
   @ApiResponse200
-  @GetMapping("/{projectId}")
-  @Operation(summary = "Gets project detail information displayable to funders")
-  fun getProject(@PathVariable projectId: ProjectId): GetFundingProjectResponsePayload {
-    val model: FunderProjectDetailsModel = funderProjectService.fetchByProjectId(projectId)
-    return GetFundingProjectResponsePayload(FunderProjectDetailsPayload(model))
+  @GetMapping("/{projectIds}")
+  @Operation(summary = "Get published project details displayable to funders")
+  fun getProjects(@PathVariable projectIds: Set<ProjectId>): GetFundingProjectResponsePayload {
+    // Remove this section once FE is handling the list of projects returned
+    if (projectIds.size == 1) {
+      val model: FunderProjectDetailsModel? =
+          funderProjectService.fetchByProjectId(projectIds.toList()[0])
+      if (model == null) {
+        throw ProjectNotFoundException(projectIds.toList()[0])
+      }
+      return GetFundingProjectResponsePayload(details = FunderProjectDetailsPayload(model))
+    }
+
+    val models = funderProjectService.fetchListByProjectIds(projectIds)
+    return GetFundingProjectResponsePayload(
+        projects = models.map { FunderProjectDetailsPayload(it) })
   }
 
   @ApiResponse200
@@ -51,7 +63,9 @@ class FundingProjectsController(
 }
 
 data class GetFundingProjectResponsePayload(
-    val details: FunderProjectDetailsPayload,
+    val projects: List<FunderProjectDetailsPayload> = emptyList(),
+    val details: FunderProjectDetailsPayload? =
+        null, // Remove this property once FE is handling the list of projects returned
 ) : SuccessResponsePayload
 
 data class FunderProjectDetailsPayload(

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2607,6 +2607,7 @@ internal class PermissionTest : DatabaseTest() {
         *projectIds.forOrg1(),
         readProjectFunderDetails = true,
         readPublishedReports = true,
+        readProject = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
Previously the endpoint only allowed for one projectId to be retrieved at a time. Update the endpoint to receive a set of projectIds. Return this in a different property so that the FE doesn't break. 
Eventually the original code returning only one project's details should be removed once the FE is only using the list of project details returned.