### PR TITLE
SW-6826 Add planting zone renaming to admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -532,6 +532,7 @@ class AdminPlantingSitesController(
   fun updatePlantingZone(
       @RequestParam plantingSiteId: PlantingSiteId,
       @RequestParam plantingZoneId: PlantingZoneId,
+      @RequestParam name: String,
       @RequestParam variance: BigDecimal,
       @RequestParam errorMargin: BigDecimal,
       @RequestParam studentsT: BigDecimal,
@@ -544,6 +545,7 @@ class AdminPlantingSitesController(
       plantingSiteStore.updatePlantingZone(plantingZoneId) { row ->
         row.copy(
             errorMargin = errorMargin,
+            name = name,
             numPermanentPlots = numPermanent,
             numTemporaryPlots = numTemporary,
             studentsT = studentsT,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1044,6 +1044,7 @@ class PlantingSiteStore(
           .set(ERROR_MARGIN, edited.errorMargin)
           .set(MODIFIED_BY, currentUser().userId)
           .set(MODIFIED_TIME, clock.instant())
+          .set(NAME, edited.name)
           .set(NUM_PERMANENT_PLOTS, edited.numPermanentPlots)
           .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
           .set(STUDENTS_T, edited.studentsT)
@@ -1051,6 +1052,18 @@ class PlantingSiteStore(
           .set(VARIANCE, edited.variance)
           .where(ID.eq(plantingZoneId))
           .execute()
+    }
+
+    if (initial.name != edited.name) {
+      with(PLANTING_SUBZONES) {
+        dslContext
+            .update(PLANTING_SUBZONES)
+            .set(FULL_NAME, DSL.concat("${edited.name}-", NAME))
+            .set(MODIFIED_BY, currentUser().userId)
+            .set(MODIFIED_TIME, clock.instant())
+            .where(PLANTING_ZONE_ID.eq(plantingZoneId))
+            .execute()
+      }
     }
   }
 

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -19,7 +19,7 @@
             display: block;
         }
 
-        table#plotCounts input {
+        table#plotCounts input[type="number"] {
             text-align: right;
         }
 
@@ -243,7 +243,9 @@
 
             <tr th:each="zone : ${site.plantingZones}">
                 <td th:text="${zone.id}">1</td>
-                <td th:text="${zone.name}">XYZ</td>
+                <td>
+                    <input required name="name" th:value="${zone.name}" th:form="|zone-${zone.id}|"/>
+                </td>
                 <td>
                     <input type="number" required min="1" name="targetPlantingDensity" size="8"
                            th:value="${zone.targetPlantingDensity}" th:form="|zone-${zone.id}|"/>

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateZoneTest.kt
@@ -45,6 +45,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
       plantingZonesDao.insert(initialRow)
       val plantingZoneId = initialRow.id!!
 
+      val newName = "renamed"
       val newErrorMargin = BigDecimal(10)
       val newStudentsT = BigDecimal(11)
       val newVariance = BigDecimal(12)
@@ -57,6 +58,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
               errorMargin = newErrorMargin,
               modifiedBy = user.userId,
               modifiedTime = clock.instant(),
+              name = newName,
               numPermanentPlots = newPermanent,
               numTemporaryPlots = newTemporary,
               studentsT = newStudentsT,
@@ -68,6 +70,7 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
         it.copy(
             // Editable
             errorMargin = newErrorMargin,
+            name = newName,
             numPermanentPlots = newPermanent,
             numTemporaryPlots = newTemporary,
             studentsT = newStudentsT,
@@ -80,11 +83,29 @@ internal class PlantingSiteStoreUpdateZoneTest : BasePlantingSiteStoreTest() {
             createdTime = Instant.ofEpochSecond(5000),
             modifiedBy = createdBy,
             modifiedTime = Instant.ofEpochSecond(5000),
-            name = "bogus",
         )
       }
 
       assertEquals(expected, plantingZonesDao.fetchOneById(plantingZoneId))
+    }
+
+    @Test
+    fun `updates full names of subzones if zone is renamed`() {
+      insertPlantingSite()
+      val zoneId1 = insertPlantingZone(name = "initial 1")
+      val subzoneId1 = insertPlantingSubzone(name = "sub 1")
+      val subzoneId2 = insertPlantingSubzone(name = "sub 2")
+      insertPlantingZone(name = "initial 2")
+      val subzoneId3 = insertPlantingSubzone(name = "sub 3")
+
+      store.updatePlantingZone(zoneId1) { it.copy(name = "renamed") }
+
+      assertEquals(
+          mapOf(
+              subzoneId1 to "renamed-sub 1",
+              subzoneId2 to "renamed-sub 2",
+              subzoneId3 to "initial 2-sub 3"),
+          plantingSubzonesDao.findAll().associate { it.id to it.fullName })
     }
 
     @Test


### PR DESCRIPTION
Allow admins to rename planting zones without having to upload new shapefiles.

This updates the zones in place, rather than creating a new planting site
history entry; to make renames visible in the site's map history, admins can
upload new shapefiles as before.