### PR TITLE
SW-6826 Update history on zone rename

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1038,31 +1038,58 @@ class PlantingSiteStore(
             ?: throw PlantingZoneNotFoundException(plantingZoneId)
     val edited = editFunc(initial)
 
-    with(PLANTING_ZONES) {
-      dslContext
-          .update(PLANTING_ZONES)
-          .set(ERROR_MARGIN, edited.errorMargin)
-          .set(MODIFIED_BY, currentUser().userId)
-          .set(MODIFIED_TIME, clock.instant())
-          .set(NAME, edited.name)
-          .set(NUM_PERMANENT_PLOTS, edited.numPermanentPlots)
-          .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
-          .set(STUDENTS_T, edited.studentsT)
-          .set(TARGET_PLANTING_DENSITY, edited.targetPlantingDensity)
-          .set(VARIANCE, edited.variance)
-          .where(ID.eq(plantingZoneId))
-          .execute()
-    }
-
-    if (initial.name != edited.name) {
-      with(PLANTING_SUBZONES) {
+    dslContext.transaction { _ ->
+      with(PLANTING_ZONES) {
         dslContext
-            .update(PLANTING_SUBZONES)
-            .set(FULL_NAME, DSL.concat("${edited.name}-", NAME))
+            .update(PLANTING_ZONES)
+            .set(ERROR_MARGIN, edited.errorMargin)
             .set(MODIFIED_BY, currentUser().userId)
             .set(MODIFIED_TIME, clock.instant())
-            .where(PLANTING_ZONE_ID.eq(plantingZoneId))
+            .set(NAME, edited.name)
+            .set(NUM_PERMANENT_PLOTS, edited.numPermanentPlots)
+            .set(NUM_TEMPORARY_PLOTS, edited.numTemporaryPlots)
+            .set(STUDENTS_T, edited.studentsT)
+            .set(TARGET_PLANTING_DENSITY, edited.targetPlantingDensity)
+            .set(VARIANCE, edited.variance)
+            .where(ID.eq(plantingZoneId))
             .execute()
+      }
+
+      if (initial.name != edited.name) {
+        with(PLANTING_SUBZONES) {
+          dslContext
+              .update(PLANTING_SUBZONES)
+              .set(FULL_NAME, DSL.concat("${edited.name}-", NAME))
+              .set(MODIFIED_BY, currentUser().userId)
+              .set(MODIFIED_TIME, clock.instant())
+              .where(PLANTING_ZONE_ID.eq(plantingZoneId))
+              .execute()
+        }
+
+        with(PLANTING_ZONE_HISTORIES) {
+          val plantingZoneHistoryId =
+              dslContext
+                  .select(ID)
+                  .from(PLANTING_ZONE_HISTORIES)
+                  .where(PLANTING_ZONE_ID.eq(plantingZoneId))
+                  .orderBy(ID.desc())
+                  .limit(1)
+                  .fetchSingle(ID)
+
+          dslContext
+              .update(PLANTING_ZONE_HISTORIES)
+              .set(NAME, edited.name)
+              .where(ID.eq(plantingZoneHistoryId))
+              .execute()
+
+          with(PLANTING_SUBZONE_HISTORIES) {
+            dslContext
+                .update(PLANTING_SUBZONE_HISTORIES)
+                .set(FULL_NAME, DSL.concat("${edited.name}-", NAME))
+                .where(PLANTING_ZONE_HISTORY_ID.eq(plantingZoneHistoryId))
+                .execute()
+          }
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/PlantingSiteStore.kt
@@ -1038,7 +1038,7 @@ class PlantingSiteStore(
             ?: throw PlantingZoneNotFoundException(plantingZoneId)
     val edited = editFunc(initial)
 
-    dslContext.transaction { _ ->
+    withLockedPlantingSite(initial.plantingSiteId!!) {
       with(PLANTING_ZONES) {
         dslContext
             .update(PLANTING_ZONES)

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -243,8 +243,9 @@
 
             <tr th:each="zone : ${site.plantingZones}">
                 <td th:text="${zone.id}">1</td>
-                <td>
+                <td title="Zone name edits will not show up in the site's map history; they will be applied retroactively, as if they had been the names in the most recently uploaded shapefile. If you want the old names to appear in the map history, upload a new shapefile instead of renaming the zones here.">
                     <input required name="name" th:value="${zone.name}" th:form="|zone-${zone.id}|"/>
+                    &#9432;
                 </td>
                 <td>
                     <input type="number" required min="1" name="targetPlantingDensity" size="8"


### PR DESCRIPTION
We want a planting site's current zone names to match the names in the most recent
edit history entry for the zone; otherwise historical views of the planting site
will be inconsistent. Make admin-UI zone name edits apply retroactively, with a
tooltip to clarify the behavior.