### PR TITLE
SW-7119 Add support for ECS deployment

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -22,6 +22,8 @@ fi
     echo "COMMIT_SHA=$commit_sha"
     echo "AWS_REGION_SECRET_NAME=${TIER}_AWS_REGION"
     echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
+    echo "ECS_CLUSTER_VAR_NAME=${TIER}_ECS_CLUSTER"
+    echo "ECS_SERVICE_VAR_NAME=${TIER}_ECS_SERVICE"
 
     if [[ "$IS_CD" == true ]]; then
         echo "DOCKER_TAGS=${docker_image}:$commit_sha,${docker_image}:${TIER}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,12 +166,22 @@ jobs:
         oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
         tags: tag:github
 
-    - name: Deploy
+    - name: Deploy to EC2
       if: env.IS_CD == 'true'
       env:
         SSH_KEY: ${{ secrets[env.SSH_KEY_SECRET_NAME] }}
         SSH_USER: ${{ secrets[env.SSH_USER_SECRET_NAME] }}
       run: ./.github/scripts/deploy.sh
+
+    - name: Deploy to ECS
+      if: vars[env.ECS_CLUSTER_VAR_NAME] != '' && vars[env.ECS_SERVICE_VAR_NAME] != ''
+      run: |
+        aws ecs update-service --cluster ${{ vars[env.ECS_CLUSTER_VAR_NAME] }} --service ${{ vars[env.ECS_SERVICE_VAR_NAME] }} --force-new-deployment
+
+    - name: Wait for ECS deployment to become stable
+      if: vars[env.ECS_CLUSTER_VAR_NAME] != '' && vars[env.ECS_SERVICE_VAR_NAME] != ''
+      run: |
+        aws ecs wait services-stable --cluster ${{ vars[env.ECS_CLUSTER_VAR_NAME] }} --service ${{ vars[env.ECS_SERVICE_VAR_NAME] }}
 
     - name: Log into Jira
       if: env.TIER == 'PROD'


### PR DESCRIPTION
For prod and staging deploys, if the repo has variables whose names are the
tier name followed by `_ECS_CLUSTER` and `_ECS_SERVICE` (for example,
`STAGING_ECS_CLUSTER`), deploy to that ECS cluster and service.

For now, we continue to deploy to the EC2 instances even if we also deploy to
ECS. This will let us test ECS deployment without disrupting the existing
prod/staging environments.