### PR TITLE
Drop batch_summaries view

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -306,7 +306,6 @@ val ID_WRAPPERS =
                     "BatchId",
                     listOf(
                         "batches\\.id",
-                        "batch_summaries\\.id",
                         "batch_withdrawals\\.destination_batch_id",
                         ".*\\.batch_id",
                         ".*\\.initial_batch_id")),

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchSubLocationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchSubLocationsTable.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.search.table
 
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_SUB_LOCATIONS
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
 import com.terraformation.backend.search.field.SearchField
@@ -18,8 +18,7 @@ class BatchSubLocationsTable(private val tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          batches.asSingleValueSublist(
-              "batch", BATCH_SUB_LOCATIONS.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
+          batches.asSingleValueSublist("batch", BATCH_SUB_LOCATIONS.BATCH_ID.eq(BATCHES.ID)),
           subLocations.asSingleValueSublist(
               "subLocation", BATCH_SUB_LOCATIONS.SUB_LOCATION_ID.eq(SUB_LOCATIONS.ID)),
       )
@@ -31,7 +30,7 @@ class BatchSubLocationsTable(private val tables: SearchTables) : SearchTable() {
   override val inheritsVisibilityFrom: SearchTable = tables.batches
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
-    return query.join(BATCH_SUMMARIES).on(BATCH_SUB_LOCATIONS.BATCH_ID.eq(BATCH_SUMMARIES.ID))
+    return query.join(BATCHES).on(BATCH_SUB_LOCATIONS.BATCH_ID.eq(BATCHES.ID))
   }
 
   override val defaultOrderFields: List<OrderField<*>> =

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchWithdrawalsTable.kt
@@ -1,6 +1,6 @@
 package com.terraformation.backend.search.table
 
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_WITHDRAWALS
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
 import com.terraformation.backend.search.SearchTable
@@ -18,10 +18,10 @@ class BatchWithdrawalsTable(private val tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          batches.asSingleValueSublist("batch", BATCH_WITHDRAWALS.BATCH_ID.eq(BATCH_SUMMARIES.ID)),
+          batches.asSingleValueSublist("batch", BATCH_WITHDRAWALS.BATCH_ID.eq(BATCHES.ID)),
           batches.asSingleValueSublist(
               "destinationBatch",
-              BATCH_WITHDRAWALS.DESTINATION_BATCH_ID.eq(BATCH_SUMMARIES.ID),
+              BATCH_WITHDRAWALS.DESTINATION_BATCH_ID.eq(BATCHES.ID),
               isRequired = false),
           nurseryWithdrawals.asSingleValueSublist(
               "withdrawal", BATCH_WITHDRAWALS.WITHDRAWAL_ID.eq(WITHDRAWAL_SUMMARIES.ID)),
@@ -41,7 +41,7 @@ class BatchWithdrawalsTable(private val tables: SearchTables) : SearchTable() {
   override val inheritsVisibilityFrom: SearchTable = tables.batches
 
   override fun <T : Record> joinForVisibility(query: SelectJoinStep<T>): SelectJoinStep<T> {
-    return query.join(BATCH_SUMMARIES).on(BATCH_WITHDRAWALS.BATCH_ID.eq(BATCH_SUMMARIES.ID))
+    return query.join(BATCHES).on(BATCH_WITHDRAWALS.BATCH_ID.eq(BATCHES.ID))
   }
 
   override val defaultOrderFields: List<OrderField<*>> =

--- a/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/BatchesTable.kt
@@ -5,8 +5,8 @@ import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.nursery.BatchId
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_SUB_LOCATIONS
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
 import com.terraformation.backend.db.nursery.tables.references.BATCH_WITHDRAWALS
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.search.SearchTable
@@ -16,58 +16,70 @@ import org.jooq.Condition
 import org.jooq.OrderField
 import org.jooq.Record
 import org.jooq.TableField
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 
 class BatchesTable(private val tables: SearchTables) : SearchTable() {
   override val primaryKey: TableField<out Record, out Any?>
-    get() = BATCH_SUMMARIES.ID
+    get() = BATCHES.ID
 
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
           accessions.asSingleValueSublist(
-              "accession", BATCH_SUMMARIES.ACCESSION_ID.eq(ACCESSIONS.ID), isRequired = false),
-          facilities.asSingleValueSublist(
-              "facility", BATCH_SUMMARIES.FACILITY_ID.eq(FACILITIES.ID)),
+              "accession", BATCHES.ACCESSION_ID.eq(ACCESSIONS.ID), isRequired = false),
+          facilities.asSingleValueSublist("facility", BATCHES.FACILITY_ID.eq(FACILITIES.ID)),
           projects.asSingleValueSublist(
-              "project", BATCH_SUMMARIES.PROJECT_ID.eq(PROJECTS.ID), isRequired = false),
-          species.asSingleValueSublist("species", BATCH_SUMMARIES.SPECIES_ID.eq(SPECIES.ID)),
+              "project", BATCHES.PROJECT_ID.eq(PROJECTS.ID), isRequired = false),
+          species.asSingleValueSublist("species", BATCHES.SPECIES_ID.eq(SPECIES.ID)),
           batchSubLocations.asMultiValueSublist(
-              "subLocations", BATCH_SUMMARIES.ID.eq(BATCH_SUB_LOCATIONS.BATCH_ID)),
+              "subLocations", BATCHES.ID.eq(BATCH_SUB_LOCATIONS.BATCH_ID)),
           batchWithdrawals.asMultiValueSublist(
-              "withdrawals", BATCH_SUMMARIES.ID.eq(BATCH_WITHDRAWALS.BATCH_ID)),
+              "withdrawals", BATCHES.ID.eq(BATCH_WITHDRAWALS.BATCH_ID)),
       )
     }
   }
 
+  private val totalQuantityWithdrawnField =
+      DSL.coalesce(
+          DSL.field(
+                  DSL.select(
+                          DSL.sum(
+                              BATCH_WITHDRAWALS.READY_QUANTITY_WITHDRAWN.plus(
+                                  BATCH_WITHDRAWALS.NOT_READY_QUANTITY_WITHDRAWN)))
+                      .from(BATCH_WITHDRAWALS)
+                      .where(BATCH_WITHDRAWALS.BATCH_ID.eq(BATCHES.ID)))
+              .cast(SQLDataType.BIGINT),
+          DSL.value(0))
+
   // This needs to be lazy-initialized because aliasField() references the list of sublists
   override val fields: List<SearchField> by lazy {
     listOf(
-        dateField("addedDate", BATCH_SUMMARIES.ADDED_DATE),
-        upperCaseTextField("batchNumber", BATCH_SUMMARIES.BATCH_NUMBER),
-        integerField("germinatingQuantity", BATCH_SUMMARIES.GERMINATING_QUANTITY),
-        integerField("germinationRate", BATCH_SUMMARIES.GERMINATION_RATE),
-        idWrapperField("id", BATCH_SUMMARIES.ID, ::BatchId),
-        idWrapperField("initialBatchId", BATCH_SUMMARIES.INITIAL_BATCH_ID, ::BatchId),
-        integerField("lossRate", BATCH_SUMMARIES.LOSS_RATE),
-        textField("notes", BATCH_SUMMARIES.NOTES),
-        integerField("notReadyQuantity", BATCH_SUMMARIES.NOT_READY_QUANTITY),
-        dateField("readyByDate", BATCH_SUMMARIES.READY_BY_DATE),
-        integerField("readyQuantity", BATCH_SUMMARIES.READY_QUANTITY),
-        enumField("substrate", BATCH_SUMMARIES.SUBSTRATE_ID),
-        textField("substrateNotes", BATCH_SUMMARIES.SUBSTRATE_NOTES),
-        integerField("totalQuantity", BATCH_SUMMARIES.TOTAL_QUANTITY),
-        enumField("treatment", BATCH_SUMMARIES.TREATMENT_ID),
-        textField("treatmentNotes", BATCH_SUMMARIES.TREATMENT_NOTES),
-        longField(
-            "totalQuantityWithdrawn", BATCH_SUMMARIES.TOTAL_QUANTITY_WITHDRAWN, nullable = false),
-        integerField("version", BATCH_SUMMARIES.VERSION, localize = false),
+        dateField("addedDate", BATCHES.ADDED_DATE),
+        upperCaseTextField("batchNumber", BATCHES.BATCH_NUMBER),
+        integerField("germinatingQuantity", BATCHES.GERMINATING_QUANTITY),
+        integerField("germinationRate", BATCHES.GERMINATION_RATE),
+        idWrapperField("id", BATCHES.ID, ::BatchId),
+        idWrapperField("initialBatchId", BATCHES.INITIAL_BATCH_ID, ::BatchId),
+        integerField("lossRate", BATCHES.LOSS_RATE),
+        textField("notes", BATCHES.NOTES),
+        integerField("notReadyQuantity", BATCHES.NOT_READY_QUANTITY),
+        dateField("readyByDate", BATCHES.READY_BY_DATE),
+        integerField("readyQuantity", BATCHES.READY_QUANTITY),
+        enumField("substrate", BATCHES.SUBSTRATE_ID),
+        textField("substrateNotes", BATCHES.SUBSTRATE_NOTES),
+        integerField("totalQuantity", BATCHES.READY_QUANTITY.plus(BATCHES.NOT_READY_QUANTITY)),
+        enumField("treatment", BATCHES.TREATMENT_ID),
+        textField("treatmentNotes", BATCHES.TREATMENT_NOTES),
+        longField("totalQuantityWithdrawn", totalQuantityWithdrawnField, nullable = false),
+        integerField("version", BATCHES.VERSION, localize = false),
     )
   }
 
   override fun conditionForVisibility(): Condition {
-    return BATCH_SUMMARIES.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
+    return BATCHES.FACILITY_ID.`in`(currentUser().facilityRoles.keys)
   }
 
   override val defaultOrderFields: List<OrderField<*>>
-    get() = listOf(BATCH_SUMMARIES.BATCH_NUMBER, BATCH_SUMMARIES.ID)
+    get() = listOf(BATCHES.BATCH_NUMBER, BATCHES.ID)
 }

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilitiesTable.kt
@@ -5,7 +5,7 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SUB_LOCATIONS
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORY_TOTALS
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
@@ -24,7 +24,7 @@ class FacilitiesTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           accessions.asMultiValueSublist("accessions", FACILITIES.ID.eq(ACCESSIONS.FACILITY_ID)),
-          batches.asMultiValueSublist("batches", FACILITIES.ID.eq(BATCH_SUMMARIES.FACILITY_ID)),
+          batches.asMultiValueSublist("batches", FACILITIES.ID.eq(BATCHES.FACILITY_ID)),
           facilityInventoryTotals.asMultiValueSublist(
               "facilityInventoryTotals", FACILITIES.ID.eq(FACILITY_INVENTORY_TOTALS.FACILITY_ID)),
           nurseryWithdrawals.asMultiValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/FacilityInventoriesTable.kt
@@ -4,7 +4,7 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.default_schema.tables.references.FACILITIES
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATIONS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -30,8 +30,8 @@ class FacilityInventoriesTable(private val tables: SearchTables) : SearchTable()
       listOf(
           batches.asMultiValueSublist(
               "batches",
-              FACILITY_INVENTORIES.FACILITY_ID.eq(BATCH_SUMMARIES.FACILITY_ID)
-                  .and(FACILITY_INVENTORIES.SPECIES_ID.eq(BATCH_SUMMARIES.SPECIES_ID))),
+              FACILITY_INVENTORIES.FACILITY_ID.eq(BATCHES.FACILITY_ID)
+                  .and(FACILITY_INVENTORIES.SPECIES_ID.eq(BATCHES.SPECIES_ID))),
           facilities.asSingleValueSublist(
               "facility", FACILITY_INVENTORIES.FACILITY_ID.eq(FACILITIES.ID)),
           species.asSingleValueSublist("species", FACILITY_INVENTORIES.SPECIES_ID.eq(SPECIES.ID)),

--- a/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/OrganizationsTable.kt
@@ -12,7 +12,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.SEED_FUND_REPORTS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
@@ -32,8 +32,7 @@ class OrganizationsTable(tables: SearchTables) : SearchTable() {
   override val sublists: List<SublistField> by lazy {
     with(tables) {
       listOf(
-          batches.asMultiValueSublist(
-              "batches", ORGANIZATIONS.ID.eq(BATCH_SUMMARIES.ORGANIZATION_ID)),
+          batches.asMultiValueSublist("batches", ORGANIZATIONS.ID.eq(BATCHES.ORGANIZATION_ID)),
           countries.asSingleValueSublist(
               "country", ORGANIZATIONS.COUNTRY_CODE.eq(COUNTRIES.CODE), isRequired = false),
           countrySubdivisions.asSingleValueSublist(

--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -15,7 +15,7 @@ import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATI
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECT_LAND_USE_MODEL_TYPES
 import com.terraformation.backend.db.docprod.tables.references.DOCUMENTS
-import com.terraformation.backend.db.nursery.tables.references.BATCH_SUMMARIES
+import com.terraformation.backend.db.nursery.tables.references.BATCHES
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSIONS
 import com.terraformation.backend.db.tracking.tables.references.DRAFT_PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
@@ -36,7 +36,7 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           accessions.asMultiValueSublist("accessions", PROJECTS.ID.eq(ACCESSIONS.PROJECT_ID)),
-          batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCH_SUMMARIES.PROJECT_ID)),
+          batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCHES.PROJECT_ID)),
           countries.asSingleValueSublist("country", PROJECTS.COUNTRY_CODE.eq(COUNTRIES.CODE)),
           documents.asMultiValueSublist("documents", PROJECTS.ID.eq(DOCUMENTS.PROJECT_ID)),
           draftPlantingSites.asMultiValueSublist(

--- a/src/main/resources/db/migration/0350/V388__DropBatchSummaries.sql
+++ b/src/main/resources/db/migration/0350/V388__DropBatchSummaries.sql
@@ -1,0 +1,1 @@
+DROP VIEW nursery.batch_summaries;


### PR DESCRIPTION
We had a view of the batches table that included a couple computed fields; the
view was used in the search API because earlier revisions of the search API
required that search fields map to table (or view) columns rather than to
arbitrary expressions. That restriction has been gone for a while, and the view
adds another bit of complexity when we want to change the batches table.

Drop the view and update the search code to use the batches table directly.