### PR TITLE
Upgrade to JobRunr 8.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,7 +129,7 @@ dependencies {
   implementation("org.geotools:gt-xml:$geoToolsVersion")
   implementation("org.geotools.xsd:gt-xsd-core:$geoToolsVersion")
   implementation("org.geotools.xsd:gt-xsd-kml:$geoToolsVersion")
-  implementation("org.jobrunr:jobrunr-spring-boot-3-starter:7.5.3")
+  implementation("org.jobrunr:jobrunr-spring-boot-3-starter:8.0.0")
   implementation("org.jooq:jooq:$jooqVersion")
   implementation("org.locationtech.jts:jts-core:$jtsVersion")
   implementation("org.locationtech.jts.io:jts-io-common:$jtsVersion")

--- a/src/main/resources/application-apidoc.yaml
+++ b/src/main/resources/application-apidoc.yaml
@@ -49,14 +49,13 @@ terraware:
   keycloak:
     apiClientId: dummy
 
-org:
-  jobrunr:
-    background-job-server:
-      enabled: false
-    job-scheduler:
-      enabled: false
-    database:
-      skip-create: true
+jobrunr:
+  background-job-server:
+    enabled: false
+  job-scheduler:
+    enabled: false
+  database:
+    skip-create: true
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -152,11 +152,10 @@ springdoc:
     with-credentials: true
   writer-with-order-by-keys: true
 
-org:
-  jobrunr:
-    background-job-server:
-      # All terraware-server instances can run scheduled jobs.
-      enabled: true
+jobrunr:
+  background-job-server:
+    # All terraware-server instances can run scheduled jobs.
+    enabled: true
 
 logging:
   level:


### PR DESCRIPTION
This version has a backward-incompatible change to its Spring configuration,
moving the config namespace from `org.jobrunr` to just `jobrunr`.