### PR TITLE
SW-7102 Comment on PR when staging deploy finishes

### DIFF
--- a/.github/scripts/set-environment.sh
+++ b/.github/scripts/set-environment.sh
@@ -17,6 +17,10 @@ else
     IS_CD=false
 fi
 
+# If this commit's title has a suffix like (#123), it's probably a merged PR.
+# Extract the PR number from its title.
+merged_pr_number=$(git log -1 --pretty=%s | sed -En 's/.*\(#([0-9]+)\)$/\1/p')
+
 (
     echo "IS_CD=$IS_CD"
     echo "COMMIT_SHA=$commit_sha"
@@ -24,6 +28,7 @@ fi
     echo "AWS_ROLE_SECRET_NAME=${TIER}_AWS_ROLE"
     echo "ECS_CLUSTER_VAR_NAME=${TIER}_ECS_CLUSTER"
     echo "ECS_SERVICE_VAR_NAME=${TIER}_ECS_SERVICE"
+    echo "MERGED_PR_NUMBER=$merged_pr_number"
 
     if [[ "$IS_CD" == true ]]; then
         echo "DOCKER_TAGS=${docker_image}:$commit_sha,${docker_image}:${TIER}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -204,3 +205,10 @@ jobs:
       with:
         issueList: ./docs/jiralist.txt
         transition: "Released to Production from Done"
+
+    - name: Notify that merged PR has been deployed to staging
+      if: env.MERGED_PR_NUMBER != '' && github.ref == 'refs/heads/main'
+      uses: thollander/actions-comment-pull-request@v3
+      with:
+        pr-number: ${{ env.MERGED_PR_NUMBER }}
+        message: Staging deployment complete.


### PR DESCRIPTION
To make it easier to see when changes are ready for QA on staging, post a comment
on the PR when a deployment from the `main` branch finishes. This relies on the
fact that we use squash merges, so there'll always be a suffix on the commit title
with the PR number.