### PR TITLE
SW-7102 Set GitHub environment in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ concurrency:
 
 jobs:
   build:
+    environment:
+      name: ${{ (github.ref == 'refs/heads/main' && 'staging') || (startsWith(github.ref, 'refs/tags/v2') && 'prod') || null }}
+      url: ${{ (github.ref == 'refs/heads/main' && 'https://staging.terraware.io/') || (startsWith(github.ref, 'refs/tags/v2') && 'https://terraware.io/') || null }}
+
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Make the CI workflow set the deployment environment to "prod" or "staging"
based on the branch or tag name, which should allow GitHub to track which
changes have been deployed where.