### PR TITLE
SW-7164 Create FetchAll Published Projects Endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -477,6 +477,8 @@ data class IndividualUser(
 
   override fun canReadProjectVotes(projectId: ProjectId) = isReadOnlyOrHigher()
 
+  override fun canReadPublishedProjects() = isReadOnlyOrHigher()
+
   override fun canReadPublishedReports(projectId: ProjectId) = isReadOnlyOrHigher()
 
   override fun canReadReport(reportId: ReportId) =

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -1206,6 +1206,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun readPublishedProjects() {
+    user.recordPermissionChecks {
+      if (!user.canReadPublishedProjects()) {
+        throw AccessDeniedException("No permission to read published projects")
+      }
+    }
+  }
+
   fun readPublishedReports(projectId: ProjectId) {
     user.recordPermissionChecks {
       if (!user.canReadPublishedReports(projectId)) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -482,6 +482,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canReadProjectVotes(projectId: ProjectId): Boolean = defaultPermission
 
+  fun canReadPublishedProjects(): Boolean = defaultPermission
+
   fun canReadPublishedReports(projectId: ProjectId): Boolean = defaultPermission
 
   fun canReadReport(reportId: ReportId): Boolean = defaultPermission

--- a/src/main/kotlin/com/terraformation/backend/funder/FunderProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/FunderProjectService.kt
@@ -4,12 +4,20 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.funder.db.PublishedProjectDetailsStore
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
+import com.terraformation.backend.funder.model.PublishedProjectNameModel
 import jakarta.inject.Named
 
 @Named
 class FunderProjectService(
     private val publishedProjectDetailsStore: PublishedProjectDetailsStore,
 ) {
+
+  fun fetchAll(): List<PublishedProjectNameModel> {
+    requirePermissions { readPublishedProjects() }
+
+    return publishedProjectDetailsStore.fetchAll()
+  }
+
   fun fetchByProjectId(projectId: ProjectId): FunderProjectDetailsModel? {
     requirePermissions { readProjectFunderDetails(projectId) }
 

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FundingProjectsController.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.funder.FunderProjectService
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
+import com.terraformation.backend.funder.model.PublishedProjectNameModel
 import io.swagger.v3.oas.annotations.Operation
 import java.math.BigDecimal
 import java.net.URI
@@ -29,6 +30,14 @@ import org.springframework.web.bind.annotation.RestController
 class FundingProjectsController(
     private val funderProjectService: FunderProjectService,
 ) {
+
+  @ApiResponse200
+  @GetMapping
+  @Operation(summary = "Get a list of all published projects")
+  fun getAllProjects(): GetPublishedProjectResponsePayload {
+    val models = funderProjectService.fetchAll()
+    return GetPublishedProjectResponsePayload(projects = models.map { PublishedProjectPayload(it) })
+  }
 
   @ApiResponse200
   @GetMapping("/{projectIds}")
@@ -68,6 +77,22 @@ data class GetFundingProjectResponsePayload(
     val details: FunderProjectDetailsPayload? =
         null, // Remove this property once FE is handling the list of projects returned
 ) : SuccessResponsePayload
+
+data class GetPublishedProjectResponsePayload(
+    val projects: List<PublishedProjectPayload> = emptyList()
+) : SuccessResponsePayload
+
+data class PublishedProjectPayload(
+    val dealName: String?,
+    val projectId: ProjectId,
+) {
+  constructor(
+      model: PublishedProjectNameModel
+  ) : this(
+      dealName = model.dealName,
+      projectId = model.projectId,
+  )
+}
 
 data class FunderProjectDetailsPayload(
     val accumulationRate: BigDecimal?,

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.funder.tables.references.PUBLISHED_PROJECT_
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_PROJECT_SDG
 import com.terraformation.backend.funder.event.FunderProjectProfilePublishedEvent
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
+import com.terraformation.backend.funder.model.PublishedProjectNameModel
 import jakarta.inject.Named
 import java.math.BigDecimal
 import java.time.InstantSource
@@ -24,6 +25,13 @@ class PublishedProjectDetailsStore(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
+
+  fun fetchAll(): List<PublishedProjectNameModel> {
+    return with(PUBLISHED_PROJECT_DETAILS) {
+      dslContext.select(PROJECT_ID, DEAL_NAME).from(this).fetch { PublishedProjectNameModel.of(it) }
+    }
+  }
+
   fun fetchOneById(projectId: ProjectId): FunderProjectDetailsModel? {
     // convert the list to a set
     val sdgList =

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedProjectNameModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedProjectNameModel.kt
@@ -1,0 +1,19 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_PROJECT_DETAILS
+import org.jooq.Record
+
+data class PublishedProjectNameModel(
+    val dealName: String? = null,
+    val projectId: ProjectId,
+) {
+  companion object {
+    fun of(record: Record): PublishedProjectNameModel {
+      return PublishedProjectNameModel(
+          dealName = record[PUBLISHED_PROJECT_DETAILS.DEAL_NAME],
+          projectId = record[PUBLISHED_PROJECT_DETAILS.PROJECT_ID]!!,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -844,6 +844,14 @@ internal class PermissionRequirementsTest : RunsAsUser {
   }
 
   @Test
+  fun readPublishedProjects() {
+    assertThrows<AccessDeniedException> { requirements.readPublishedProjects() }
+
+    grant { user.canReadPublishedProjects() }
+    requirements.readPublishedProjects()
+  }
+
+  @Test
   fun readPublishedReports() {
     assertThrows<ProjectNotFoundException> { requirements.readPublishedReports(projectId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1457,6 +1457,7 @@ internal class PermissionTest : DatabaseTest() {
         readInternalTags = true,
         readParticipant = true,
         readProjectReportConfigs = true,
+        readPublishedProjects = true,
         readReportInternalComments = true,
         reviewReports = true,
         setTestClock = true,
@@ -1885,6 +1886,7 @@ internal class PermissionTest : DatabaseTest() {
         readModuleEventParticipants = true,
         readParticipant = true,
         readProjectReportConfigs = true,
+        readPublishedProjects = true,
         readReportInternalComments = true,
         regenerateAllDeviceManagerTokens = true,
         reviewReports = true,
@@ -2149,6 +2151,7 @@ internal class PermissionTest : DatabaseTest() {
         readModuleEventParticipants = true,
         readParticipant = true,
         readProjectReportConfigs = true,
+        readPublishedProjects = true,
         readReportInternalComments = true,
         regenerateAllDeviceManagerTokens = false,
         reviewReports = true,
@@ -2393,6 +2396,7 @@ internal class PermissionTest : DatabaseTest() {
         readInternalTags = true,
         readParticipant = true,
         readProjectReportConfigs = true,
+        readPublishedProjects = true,
         readReportInternalComments = true,
         regenerateAllDeviceManagerTokens = false,
         reviewReports = true,
@@ -2574,6 +2578,7 @@ internal class PermissionTest : DatabaseTest() {
         readInternalTags = true,
         readParticipant = true,
         readProjectReportConfigs = true,
+        readPublishedProjects = true,
         readReportInternalComments = true,
         regenerateAllDeviceManagerTokens = false,
         setTestClock = false,
@@ -3152,6 +3157,7 @@ internal class PermissionTest : DatabaseTest() {
         readModuleEventParticipants: Boolean = false,
         readParticipant: Boolean = false,
         readProjectReportConfigs: Boolean = false,
+        readPublishedProjects: Boolean = false,
         readReportInternalComments: Boolean = false,
         regenerateAllDeviceManagerTokens: Boolean = false,
         reviewReports: Boolean = false,
@@ -3256,6 +3262,8 @@ internal class PermissionTest : DatabaseTest() {
           readProjectReportConfigs,
           user.canReadProjectReportConfigs(),
           "Can read project report configs")
+      assertEquals(
+          readPublishedProjects, user.canReadPublishedProjects(), "Can read published projects")
       assertEquals(
           readReportInternalComments,
           user.canReadReportInternalComments(),

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.PathGenerator
 import com.terraformation.backend.funder.model.FunderProjectDetailsModel
+import com.terraformation.backend.funder.model.PublishedProjectNameModel
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.net.URI
@@ -46,6 +47,31 @@ class PublishedProjectDetailsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   fun setup() {
     insertOrganization(timeZone = ZoneOffset.UTC)
     projectId = insertProject()
+  }
+
+  @Nested
+  inner class FetchAll {
+    @Test
+    fun `can retrieve all projects`() {
+      val projectId1 = projectId
+      insertPublishedProjectDetails(dealName = "Published Details 1")
+      val projectId2 = insertProject(name = "Published 2")
+      insertPublishedProjectDetails(dealName = "Published Details 2")
+      insertProject(name = "Unpublished")
+
+      val expected =
+          listOf(
+              PublishedProjectNameModel(
+                  projectId = projectId1,
+                  dealName = "Published Details 1",
+              ),
+              PublishedProjectNameModel(
+                  projectId = projectId2,
+                  dealName = "Published Details 2",
+              ),
+          )
+      assertEquals(expected, store.fetchAll(), "Fetch ALl should return published projects from db")
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedProjectDetailsStoreTest.kt
@@ -70,7 +70,7 @@ class PublishedProjectDetailsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   dealName = "Published Details 2",
               ),
           )
-      assertEquals(expected, store.fetchAll(), "Fetch ALl should return published projects from db")
+      assertEquals(expected, store.fetchAll(), "Fetch All should return published projects from db")
     }
   }
 


### PR DESCRIPTION
Product wants Funding Entities to only be able to select projects that have been published. 

Add an endpoint to retrieve all published projects.

For now it only returns `dealName` and `projectId` for each since that is all that is required at the moment. Later this endpoint could fetch all details for each if needed.