### PR TITLE
SW-7172 Make null ids greater than non-null for same-date withdrawal sorting

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Withdrawal.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.db.seedbank.ViabilityTestId
 import com.terraformation.backend.db.seedbank.WithdrawalId
 import com.terraformation.backend.db.seedbank.WithdrawalPurpose
 import com.terraformation.backend.db.seedbank.tables.references.WITHDRAWALS
-import com.terraformation.backend.util.compareNullsFirst
+import com.terraformation.backend.util.compareNullsLast
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -94,7 +94,7 @@ data class WithdrawalModel(
     return if (dateComparison != 0) {
       dateComparison
     } else {
-      val idComparison = id?.value.compareNullsFirst(other.id?.value)
+      val idComparison = id?.value.compareNullsLast(other.id?.value)
       if (idComparison != 0) {
         idComparison
       } else {

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -46,12 +46,12 @@ fun BigDecimal?.equalsIgnoreScale(other: BigDecimal?) =
  */
 fun <T> Field<T>.eqOrIsNull(value: T) = if (value != null) eq(value) else isNull
 
-/** Compares two comparable values, treating null values as less than non-null ones. */
-fun <T : Comparable<T>> T?.compareNullsFirst(other: T?): Int {
+/** Compares two comparable values, treating null values as greater than non-null ones. */
+fun <T : Comparable<T>> T?.compareNullsLast(other: T?): Int {
   return when {
     this != null && other != null -> this.compareTo(other)
-    this != null && other == null -> 1
-    this == null && other != null -> -1
+    this != null && other == null -> -1
+    this == null && other != null -> 1
     else -> 0
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/Helpers.kt
@@ -24,6 +24,10 @@ inline fun <reified T> milligrams(quantity: Int): T {
   return quantity(quantity, SeedQuantityUnits.Milligrams)
 }
 
+inline fun <reified T> milligrams(quantity: BigDecimal): T {
+  return quantity(quantity, SeedQuantityUnits.Milligrams)
+}
+
 inline fun <reified T> kilograms(quantity: BigDecimal): T {
   return quantity(quantity, SeedQuantityUnits.Kilograms)
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -131,7 +131,7 @@ internal abstract class AccessionModelTest {
       purpose: WithdrawalPurpose =
           if (viabilityTestId != null) WithdrawalPurpose.ViabilityTesting
           else WithdrawalPurpose.Other,
-      createdTime: Instant = clock.instant(),
+      createdTime: Instant? = clock.instant(),
       id: WithdrawalId? = nextWithdrawalId(),
       withdrawnByUserId: UserId? = null,
       estimatedCount: Int? =


### PR DESCRIPTION
When creating a nursery transfer withdrawal for a date that already had a withdrawal, the server does not use the most recent withdrawal to check if it is a Withdraw-All operation. This throws the all-too-familiar server error: "Withdrawal quantity can't be more than remaining quantity".

Change the sorting to make null IDs greater than non-null IDs for same-date withdrawal comparison.