### PR TITLE
SW-7138 Add Permission Grants for Read Only Users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -413,8 +413,9 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun isProjectInAccelerator(projectId: ProjectId?): Boolean =
       projectId != null &&
-          dslContext.fetchExists(
-              PROJECT_ACCELERATOR_DETAILS, PROJECT_ACCELERATOR_DETAILS.PROJECT_ID.eq(projectId))
+          (dslContext.fetchExists(
+              PROJECT_ACCELERATOR_DETAILS, PROJECT_ACCELERATOR_DETAILS.PROJECT_ID.eq(projectId)) ||
+              dslContext.fetchExists(PROJECTS, PROJECTS.participants.COHORT_ID.isNotNull))
 
   /**
    * Looks up a database row by an ID and returns the value of one of the columns, or null if no row

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -201,8 +201,9 @@ internal class PermissionTest : DatabaseTest() {
 
   private inline fun <reified T> List<T>.forOrg1() = filterStartsWith("1")
 
-  private inline fun <reified T> List<T>.forOrg4() =
-      filterStartsWith("4") // accelerator organization
+  private inline fun <reified T> List<T>.forOrgs(orgIds: List<Int>) = filterToArray { item ->
+    orgIds.any { orgId -> item.toString().startsWith(orgId.toString()) }
+  }
 
   private inline fun <reified T> List<T>.forFacility1000() = filterStartsWith("1000")
 
@@ -2680,22 +2681,22 @@ internal class PermissionTest : DatabaseTest() {
 
     // accelerator project/org details
     permissions.expect(
-        *accessionIds.forOrg4(),
+        *accessionIds.forOrgs(listOf(3, 4)),
         readAccession = true,
     )
 
     permissions.expect(
-        *batchIds.forOrg4(),
+        *batchIds.forOrgs(listOf(3, 4)),
         readBatch = true,
     )
 
     permissions.expect(
-        *deliveryIds.forOrg4(),
+        *deliveryIds.forOrgs(listOf(3, 4)),
         readDelivery = true,
     )
 
     permissions.expect(
-        *draftPlantingSiteIds.forOrg4(),
+        *draftPlantingSiteIds.forOrgs(listOf(1, 3, 4)),
         readDraftPlantingSite = true,
     )
 
@@ -2705,52 +2706,52 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *facilityIds.forOrg4(),
+        *facilityIds.forOrgs(listOf(3, 4)),
         readFacility = true,
     )
 
     permissions.expect(
-        *monitoringPlotIds.forOrg4(),
+        *monitoringPlotIds.forOrgs(listOf(3, 4)),
         readMonitoringPlot = true,
     )
 
     permissions.expect(
-        *observationIds.forOrg4(),
+        *observationIds.forOrgs(listOf(3, 4)),
         readObservation = true,
     )
 
     permissions.expect(
-        *plantingIds.forOrg4(),
+        *plantingIds.forOrgs(listOf(3, 4)),
         readPlanting = true,
     )
 
     permissions.expect(
-        *plantingSiteIds.forOrg4(),
+        *plantingSiteIds.forOrgs(listOf(3, 4)),
         readPlantingSite = true,
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg4(),
+        *plantingSubzoneIds.forOrgs(listOf(3, 4)),
         readPlantingSubzone = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg4(),
+        *plantingZoneIds.forOrgs(listOf(3, 4)),
         readPlantingZone = true,
     )
 
     permissions.expect(
-        *subLocationIds.forOrg4(),
+        *subLocationIds.forOrgs(listOf(3, 4)),
         readSubLocation = true,
     )
 
     permissions.expect(
-        *viabilityTestIds.forOrg4(),
+        *viabilityTestIds.forOrgs(listOf(3, 4)),
         readViabilityTest = true,
     )
 
     permissions.expect(
-        *withdrawalIds.forOrg4(),
+        *withdrawalIds.forOrgs(listOf(3, 4)),
         readWithdrawal = true,
     )
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1775,6 +1775,7 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       number: String? = row.number ?: "${nextAccessionNumber++}",
+      projectId: ProjectId? = row.projectId,
       receivedDate: LocalDate? = row.receivedDate,
       speciesId: SpeciesId? = row.speciesId,
       stateId: AccessionState = row.stateId ?: AccessionState.Processing,
@@ -1793,6 +1794,7 @@ abstract class DatabaseBackedTest {
             speciesId = speciesId,
             stateId = stateId,
             treesCollectedFrom = treesCollectedFrom,
+            projectId = projectId,
         )
 
     accessionsDao.insert(rowWithDefaults)


### PR DESCRIPTION
As a part of the effort to expand the functionality of the Terraformation Contact role in Terraware, we decided we are also going to make it such that all users with Global Roles have permission to read all accelerator project data.

Update the permissions of the Read Only role so they can read all accelerator related projects and orgs.