### PR TITLE
SW-7192 Change criteria in search service to be a map of prefix to SearchNode

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -75,7 +75,7 @@ class SearchController(
         searchService.search(
             rootPrefix,
             payload.fields.map { rootPrefix.resolve(it) },
-            payload.toSearchNode(rootPrefix),
+            mapOf(rootPrefix to payload.toSearchNode(rootPrefix)),
             payload.getSearchSortFields(rootPrefix),
             payload.cursor,
             count))
@@ -100,7 +100,7 @@ class SearchController(
         searchService.search(
             rootPrefix,
             fields,
-            payload.toSearchNode(rootPrefix),
+            mapOf(rootPrefix to payload.toSearchNode(rootPrefix)),
             payload.getSearchSortFields(rootPrefix),
             payload.cursor,
             count)
@@ -143,7 +143,7 @@ class SearchController(
                   searchService.fetchValues(
                       rootPrefix,
                       searchField,
-                      payload.toSearchNode(rootPrefix),
+                      mapOf(rootPrefix to payload.toSearchNode(rootPrefix)),
                       payload.cursor,
                       count)
               FieldValuesPayload(fetchResult, fetchResult.size > count)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/AccessionService.kt
@@ -180,7 +180,8 @@ class AccessionService(
     @Suppress("UNCHECKED_CAST")
     val query =
         searchService
-            .buildQuery(accessionsPrefix, listOf(accessionIdField), criteria)
+            .buildQuery(
+                accessionsPrefix, listOf(accessionIdField), mapOf(accessionsPrefix to criteria))
             .toSelectQuery() as Select<Record1<AccessionId?>>
 
     return accessionStore.getSummaryStatistics(query)

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/ValuesController.kt
@@ -47,7 +47,10 @@ class ValuesController(
         fields.mapValues { (_, searchField) ->
           val values =
               searchService.fetchValues(
-                  rootPrefix, searchField, payload.toSearchNode(rootPrefix), limit = limit)
+                  rootPrefix,
+                  searchField,
+                  mapOf(rootPrefix to payload.toSearchNode(rootPrefix)),
+                  limit = limit)
           val partial = values.size > limit
           FieldValuesPayload(values.take(limit), partial)
         }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -138,7 +138,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                         ),
                 )))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -162,7 +163,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf("name" to "Organization 2"),
             ))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -180,7 +182,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     val expected = SearchResults(listOf(mapOf("name" to "Organization 1")))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -197,7 +200,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     val expected = SearchResults(listOf(mapOf("name" to "Project 1")))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -216,7 +220,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     val expected = SearchResults(listOf(mapOf("name" to "Project 1")))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -235,7 +240,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     val expected = SearchResults(listOf(mapOf("name" to "Organization 1")))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, condition))
+    assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to condition)))
   }
 
   @Test
@@ -263,7 +268,8 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                     "name" to "Project 1",
                 )))
 
-    assertJsonEquals(expected, searchService.search(prefix, fields, NoConditionNode()))
+    assertJsonEquals(
+        expected, searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())))
   }
 
   @Test
@@ -287,7 +293,10 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                     "landUseModelTypes_landUseModelType" to "Monoculture".toGibberish(),
                 )))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -338,7 +347,9 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
         searchService.search(
             prefix,
             fields,
-            FieldNode(prefix.resolve("cohortModules.cohort_id"), listOf("$cohortId1")))
+            mapOf(
+                prefix to
+                    FieldNode(prefix.resolve("cohortModules.cohort_id"), listOf("$cohortId1"))))
 
     assertJsonEquals(expected, actual)
   }
@@ -404,7 +415,9 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
 
     val actual =
         searchService.search(
-            prefix, fields, FieldNode(prefix.resolve("name"), listOf("Cohort 1 $suffix")))
+            prefix,
+            fields,
+            mapOf(prefix to FieldNode(prefix.resolve("name"), listOf("Cohort 1 $suffix"))))
 
     assertJsonEquals(expected, actual)
   }
@@ -451,7 +464,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
                         ),
                 )))
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleEventSearchTest.kt
@@ -87,7 +87,10 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
                     "recordingUrl" to "https://recording.google.com",
                 )))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -110,7 +113,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -132,7 +135,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf("id" to "$otherEvent", "module" to mapOf("id" to "$otherModule"))),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -180,7 +183,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -224,7 +227,9 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
 
     val actual =
         searchService.search(
-            prefix, fields, FieldNode(prefix.resolve("projects.id"), listOf("$project1")))
+            prefix,
+            fields,
+            mapOf(prefix to FieldNode(prefix.resolve("projects.id"), listOf("$project1"))))
 
     assertJsonEquals(expected, actual)
   }
@@ -264,7 +269,7 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -311,7 +316,9 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
                             mapOf("id" to "$event2"),
                             mapOf("id" to "$event3")),
                 )))
-    val projectActual = searchService.search(projectPrefix, projectFields, NoConditionNode())
+    val projectActual =
+        searchService.search(
+            projectPrefix, projectFields, mapOf(projectPrefix to NoConditionNode()))
 
     val eventPrefix = SearchFieldPrefix(searchTables.events)
     val eventFields = listOf("id").map { eventPrefix.resolve(it) }
@@ -319,7 +326,8 @@ class ModuleEventSearchTest : DatabaseTest(), RunsAsUser {
         SearchResults(
             listOf(mapOf("id" to "$event1"), mapOf("id" to "$event2"), mapOf("id" to "$event3")),
             null)
-    val eventActual = searchService.search(eventPrefix, eventFields, NoConditionNode())
+    val eventActual =
+        searchService.search(eventPrefix, eventFields, mapOf(eventPrefix to NoConditionNode()))
 
     assertJsonEquals(projectExpected, projectActual, "search for events by project prefix")
     assertJsonEquals(eventExpected, eventActual, "search for events by event prefix")

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -82,7 +82,10 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
                     "workshopDescription" to "Workshop ideas",
                 )))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
     assertJsonEquals(expected, actual)
   }
 
@@ -178,7 +181,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
     assertJsonEquals(expected, actual)
   }
 
@@ -223,7 +226,7 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
     assertJsonEquals(expected, actual)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectDeliverableSearchTest.kt
@@ -135,7 +135,10 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -158,7 +161,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
                     "module_id" to "${inserted.moduleId}",
                 )))
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -204,7 +207,9 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
 
     val actual =
         searchService.search(
-            prefix, fields, FieldNode(prefix.resolve("project.id"), listOf("$projectId")))
+            prefix,
+            fields,
+            mapOf(prefix to FieldNode(prefix.resolve("project.id"), listOf("$projectId"))))
 
     assertJsonEquals(expected, actual)
   }
@@ -231,7 +236,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
                             mapOf("id" to "$deliverableWithoutSubmissions"),
                         ))))
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -249,7 +254,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             listOf(
                 mapOf("id" to "$deliverableId", "dueDate" to "$moduleEndDate"),
             )),
-        searchService.search(prefix, fields, NoConditionNode()),
+        searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())),
         "Search project deliverables with module end date")
 
     val cohortDueDate = moduleEndDate.plusDays(5)
@@ -259,7 +264,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             listOf(
                 mapOf("id" to "$deliverableId", "dueDate" to "$cohortDueDate"),
             )),
-        searchService.search(prefix, fields, NoConditionNode()),
+        searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())),
         "Search project deliverables with cohort due date override")
 
     val projectDueDate = moduleEndDate.plusDays(5)
@@ -269,7 +274,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             listOf(
                 mapOf("id" to "$deliverableId", "dueDate" to "$projectDueDate"),
             )),
-        searchService.search(prefix, fields, NoConditionNode()),
+        searchService.search(prefix, fields, mapOf(prefix to NoConditionNode())),
         "Search project deliverables with project due date override")
   }
 
@@ -321,7 +326,7 @@ class ProjectDeliverableSearchTest : DatabaseTest(), RunsAsUser {
             ),
             null)
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
@@ -106,7 +106,10 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
             ),
             cursor = null)
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -137,7 +140,10 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
                             ),
                         ))))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -169,7 +175,10 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
                                 "variableId" to "$variableId1",
                             )))))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -239,7 +248,8 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
                 FieldNode(prefix.resolve("id"), listOf(projectId1.toString())),
                 FieldNode(prefix.resolve("variables.stableId"), listOf(stableId1, stableId3)),
             ))
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, search) }
+    val actual =
+        Locales.GIBBERISH.use { searchService.search(prefix, fields, mapOf(prefix to search)) }
 
     assertJsonEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
@@ -275,7 +275,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
                     "textValue" to "OtherValue",
                 ),
             ))
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableValueSearchTest.kt
@@ -183,7 +183,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
             cursor = null,
         )
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -219,7 +219,10 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
                             ),
                         ))))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -247,7 +250,7 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
                     "stableId" to referenceStableId,
                 )),
             cursor = null)
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -308,7 +311,10 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
                                 "values" to listOf(mapOf("variableValueId" to "$valueId1")),
                             )))))
 
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode()) }
+    val actual =
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
+        }
 
     assertJsonEquals(expected, actual)
   }
@@ -378,7 +384,8 @@ class ProjectVariableValueSearchTest : DatabaseTest(), RunsAsUser {
                 FieldNode(prefix.resolve("id"), listOf(projectId1.toString())),
                 FieldNode(prefix.resolve("variables.stableId"), listOf(stableId1, stableId3)),
             ))
-    val actual = Locales.GIBBERISH.use { searchService.search(prefix, fields, search) }
+    val actual =
+        Locales.GIBBERISH.use { searchService.search(prefix, fields, mapOf(prefix to search)) }
 
     assertJsonEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -165,7 +165,9 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("facilityInventories.readyQuantity"),
                   prefix.resolve("facilityInventories.totalQuantity"),
               ),
-              FieldNode(prefix.resolve("organization_id"), listOf("$organizationId")),
+              mapOf(
+                  prefix to
+                      FieldNode(prefix.resolve("organization_id"), listOf("$organizationId"))),
               listOf(
                   SearchSortField(prefix.resolve("species_id")),
                   SearchSortField(prefix.resolve("facilityInventories.facility_id")),
@@ -240,7 +242,9 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("totalQuantity"),
                   prefix.resolve("totalSpecies"),
               ),
-              FieldNode(prefix.resolve("organization_id"), listOf("$organizationId")),
+              mapOf(
+                  prefix to
+                      FieldNode(prefix.resolve("organization_id"), listOf("$organizationId"))),
               listOf(SearchSortField(prefix.resolve("facility_id"))))
 
       assertEquals(
@@ -301,7 +305,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("readyQuantity"),
                   prefix.resolve("totalQuantity"),
               ),
-              FieldNode(prefix.resolve("facility_id"), listOf("$facilityId2")))
+              mapOf(prefix to FieldNode(prefix.resolve("facility_id"), listOf("$facilityId2"))))
 
       assertEquals(
           SearchResults(
@@ -368,7 +372,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("subLocations.subLocation_id"),
                   prefix.resolve("version"),
               ),
-              FieldNode(prefix.resolve("species_id"), listOf("$speciesId1")))
+              mapOf(prefix to FieldNode(prefix.resolve("species_id"), listOf("$speciesId1"))))
 
       assertEquals(
           SearchResults(
@@ -436,11 +440,14 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   prefix.resolve("id"),
                   prefix.resolve("project_name"),
               ),
-              AndNode(
-                  listOf(
-                      FieldNode(
-                          prefix.resolve("facility_organization_id"), listOf("$organizationId")),
-                      FieldNode(prefix.resolve("project_id"), listOf(null)))))
+              mapOf(
+                  prefix to
+                      AndNode(
+                          listOf(
+                              FieldNode(
+                                  prefix.resolve("facility_organization_id"),
+                                  listOf("$organizationId")),
+                              FieldNode(prefix.resolve("project_id"), listOf(null))))))
 
       assertEquals(
           SearchResults(
@@ -611,7 +618,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                   ),
               ))
 
-      val actual = searchService.search(prefix, fields, NoConditionNode(), orderBy)
+      val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), orderBy)
 
       assertJsonEquals(expected, actual)
     }
@@ -661,7 +668,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                       "undoesWithdrawalId" to "$withdrawalId",
                   )))
 
-      val actual = searchService.search(prefix, fields, NoConditionNode(), orderBy)
+      val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), orderBy)
 
       assertJsonEquals(expected, actual)
     }
@@ -699,7 +706,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           searchService.search(
               prefix,
               fields,
-              FieldNode(prefix.resolve("species_id"), listOf("$speciesId1")),
+              mapOf(prefix to FieldNode(prefix.resolve("species_id"), listOf("$speciesId1"))),
               orderBy)
 
       assertJsonEquals(expected, actual)
@@ -727,7 +734,9 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
           searchService.search(
               prefix,
               fields,
-              FieldNode(prefix.resolve("organization_id"), listOf("$organizationId")),
+              mapOf(
+                  prefix to
+                      FieldNode(prefix.resolve("organization_id"), listOf("$organizationId"))),
               orderBy)
 
       assertJsonEquals(expected, actual)

--- a/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
@@ -61,7 +61,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koa"), SearchFilterType.Exact)
 
-      assertJsonEquals(expected, searchService.search(prefix, fields, conditions))
+      assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to conditions)))
     }
 
     @Test
@@ -95,7 +95,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koaa"), SearchFilterType.Fuzzy)
 
-      assertJsonEquals(expected, searchService.search(prefix, fields, conditions))
+      assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to conditions)))
     }
 
     @Test
@@ -112,7 +112,9 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf(""), SearchFilterType.PhraseMatch)
 
-      assertJsonEquals(SearchResults(emptyList()), searchService.search(prefix, fields, conditions))
+      assertJsonEquals(
+          SearchResults(emptyList()),
+          searchService.search(prefix, fields, mapOf(prefix to conditions)))
     }
 
     @Test
@@ -142,7 +144,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
       val conditions =
           FieldNode(prefix.resolve("scientificName"), listOf("Koa"), SearchFilterType.PhraseMatch)
 
-      assertJsonEquals(expected, searchService.search(prefix, fields, conditions))
+      assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to conditions)))
     }
 
     @Test
@@ -189,7 +191,7 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           FieldNode(
               prefix.resolve("scientificName"), listOf("Apple Tree"), SearchFilterType.PhraseMatch)
 
-      assertJsonEquals(expected, searchService.search(prefix, fields, conditions))
+      assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to conditions)))
     }
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/search/table/VariableSelectOptionsTableTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/table/VariableSelectOptionsTableTest.kt
@@ -117,7 +117,7 @@ class VariableSelectOptionsTableTest : DatabaseTest(), RunsAsUser {
                             ))),
             ))
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -135,12 +135,12 @@ class VariableSelectOptionsTableTest : DatabaseTest(), RunsAsUser {
 
     val prefix1 = SearchFieldPrefix(searchTables.projectVariableValues)
     val fields1 = listOf("options.id", "options.name").map { prefix1.resolve(it) }
-    val actual1 = searchService.search(prefix1, fields1, NoConditionNode())
+    val actual1 = searchService.search(prefix1, fields1, mapOf(prefix1 to NoConditionNode()))
     assertJsonEquals(expected, actual1)
 
     val prefix2 = SearchFieldPrefix(searchTables.variableSelectOptions)
     val fields2 = listOf("id", "name").map { prefix2.resolve(it) }
-    val actual2 = searchService.search(prefix2, fields2, NoConditionNode())
+    val actual2 = searchService.search(prefix2, fields2, mapOf(prefix2 to NoConditionNode()))
     assertJsonEquals(expected, actual2)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceAgeFieldTest.kt
@@ -61,7 +61,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         searchService.search(
             rootPrefix,
             listOf(idField, ageMonthsField, ageYearsField, collectedDateField),
-            searchNode,
+            mapOf(rootPrefix to searchNode),
             listOf(sortField))
 
     assertEquals(expected, actual)
@@ -86,7 +86,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         searchService.search(
             rootPrefix,
             listOf(idField, ageMonthsField, collectedDateField),
-            searchNode,
+            mapOf(rootPrefix to searchNode),
             listOf(sortField))
 
     assertEquals(expected, actual)
@@ -111,7 +111,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
         searchService.search(
             rootPrefix,
             listOf(idField, ageYearsField, collectedDateField),
-            searchNode,
+            mapOf(rootPrefix to searchNode),
             listOf(sortField))
 
     assertEquals(expected, actual)
@@ -124,7 +124,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageMonthsField, listOf(null))
 
     val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
-    val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
+    val actual = searchService.search(rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode))
 
     assertEquals(expected, actual)
   }
@@ -136,7 +136,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageMonthsField, listOf("0"))
 
     val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
-    val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
+    val actual = searchService.search(rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode))
 
     assertEquals(expected, actual)
   }
@@ -155,7 +155,9 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
 
     val expected =
         SearchResults(listOf(mapOf("id" to "$accessionId2"), mapOf("id" to "$accessionId1")))
-    val actual = searchService.search(rootPrefix, listOf(idField), searchNode, listOf(sortField))
+    val actual =
+        searchService.search(
+            rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode), listOf(sortField))
 
     assertEquals(expected, actual)
   }
@@ -168,7 +170,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageMonthsField, listOf(null, "2"), SearchFilterType.Range)
 
     val expected = SearchResults(listOf(mapOf("id" to "$accessionId2")))
-    val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
+    val actual = searchService.search(rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode))
 
     assertEquals(expected, actual)
   }
@@ -181,7 +183,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageMonthsField, listOf("3", null), SearchFilterType.Range)
 
     val expected = SearchResults(listOf(mapOf("id" to "$accessionId1")))
-    val actual = searchService.search(rootPrefix, listOf(idField), searchNode)
+    val actual = searchService.search(rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode))
 
     assertEquals(expected, actual)
   }
@@ -191,7 +193,7 @@ internal class SearchServiceAgeFieldTest : SearchServiceTest() {
     val searchNode = FieldNode(ageMonthsField, listOf("-1"))
 
     assertThrows<IllegalArgumentException> {
-      searchService.search(rootPrefix, listOf(idField), searchNode)
+      searchService.search(rootPrefix, listOf(idField), mapOf(rootPrefix to searchNode))
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBasicSearchTest.kt
@@ -148,11 +148,13 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
 
     val englishResult =
         Locale.ENGLISH.use {
-          searchService.search(prefix, listOf(field), NoConditionNode(), listOf(sortOrder))
+          searchService.search(
+              prefix, listOf(field), mapOf(prefix to NoConditionNode()), listOf(sortOrder))
         }
     val swedishResult =
         Locale.forLanguageTag("se").use {
-          searchService.search(prefix, listOf(field), NoConditionNode(), listOf(sortOrder))
+          searchService.search(
+              prefix, listOf(field), mapOf(prefix to NoConditionNode()), listOf(sortOrder))
         }
 
     assertEquals(englishExpected, englishResult, "English should put Å before K")
@@ -203,7 +205,9 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
     val result =
         Locales.GIBBERISH.use {
           searchService.search(
-              countryPrefix, listOf(countryCodeField, countryNameField), searchNode)
+              countryPrefix,
+              listOf(countryCodeField, countryNameField),
+              mapOf(countryPrefix to searchNode))
         }
 
     val expected = SearchResults(listOf(mapOf("code" to "US", "name" to gibberishValue)))
@@ -215,7 +219,9 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
   fun `exact search on localizable text fields is accent-insensitive`() {
     val searchNode = FieldNode(countryNameField, listOf("cote d’ivoire"), SearchFilterType.Exact)
 
-    val result = searchService.search(countryPrefix, listOf(countryNameField), searchNode)
+    val result =
+        searchService.search(
+            countryPrefix, listOf(countryNameField), mapOf(countryPrefix to searchNode))
 
     val expected = SearchResults(listOf(mapOf("name" to "Côte d’Ivoire")))
 
@@ -235,7 +241,10 @@ internal class SearchServiceBasicSearchTest : SearchServiceTest() {
     val result =
         Locales.GIBBERISH.use {
           searchService.search(
-              countryPrefix, listOf(countryNameField), searchNode, listOf(sortField))
+              countryPrefix,
+              listOf(countryNameField),
+              mapOf(countryPrefix to searchNode),
+              listOf(sortField))
         }
 
     val expected =

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceBooleanTest.kt
@@ -19,7 +19,9 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
     val sortOrder = fields.map { SearchSortField(it) }
 
     val result =
-        Locales.GIBBERISH.use { searchService.search(prefix, fields, NoConditionNode(), sortOrder) }
+        Locales.GIBBERISH.use {
+          searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), sortOrder)
+        }
 
     val expected =
         SearchResults(
@@ -36,7 +38,8 @@ internal class SearchServiceBooleanTest : SearchServiceTest() {
     val fields = listOf(prefix.resolve("id"))
     val criteria = FieldNode(prefix.resolve("rare"), listOf("true".toGibberish()))
 
-    val result = Locales.GIBBERISH.use { searchService.search(prefix, fields, criteria) }
+    val result =
+        Locales.GIBBERISH.use { searchService.search(prefix, fields, mapOf(prefix to criteria)) }
 
     val expected = SearchResults(listOf(mapOf("id" to "$speciesId2")))
 

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceFetchValuesTest.kt
@@ -13,14 +13,18 @@ import org.junit.jupiter.api.Test
 internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   @Test
   fun `no criteria for simple column value`() {
-    val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
+    val values =
+        searchService.fetchValues(
+            rootPrefix, speciesNameField, mapOf(rootPrefix to NoConditionNode()))
     assertEquals(listOf("Kousa Dogwood", "Other Dogwood"), values)
   }
 
   @Test
   fun `renders null values as null, not as a string`() {
     accessionsDao.update(accessionsDao.fetchOneById(accessionId1)!!.copy(speciesId = null))
-    val values = searchService.fetchValues(rootPrefix, speciesNameField, NoConditionNode())
+    val values =
+        searchService.fetchValues(
+            rootPrefix, speciesNameField, mapOf(rootPrefix to NoConditionNode()))
     assertEquals(listOf("Other Dogwood", null), values)
   }
 
@@ -30,7 +34,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             speciesNameField,
-            FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.Fuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.Fuzzy)))
     assertEquals(listOf("Kousa Dogwood"), values)
   }
 
@@ -40,7 +46,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             speciesNameField,
-            FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.ExactOrFuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(accessionNumberField, listOf("xyzz"), SearchFilterType.ExactOrFuzzy)))
     assertEquals(listOf("Kousa Dogwood"), values)
   }
 
@@ -58,7 +66,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             accessionNumberField,
-            FieldNode(accessionNumberField, listOf("abcd"), SearchFilterType.ExactOrFuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(accessionNumberField, listOf("abcd"), SearchFilterType.ExactOrFuzzy)))
     assertEquals(listOf("ABCD", "ZABCDY"), values)
   }
 
@@ -79,7 +89,12 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             collectionSiteNameField,
-            FieldNode(collectionSiteNameField, listOf("location 1"), SearchFilterType.ExactOrFuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(
+                        collectionSiteNameField,
+                        listOf("location 1"),
+                        SearchFilterType.ExactOrFuzzy)))
     assertEquals(listOf("Location 10", "Location 11"), values)
   }
 
@@ -89,7 +104,8 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             speciesNameField,
-            FieldNode(accessionNumberField, listOf("a"), SearchFilterType.Fuzzy))
+            mapOf(
+                rootPrefix to FieldNode(accessionNumberField, listOf("a"), SearchFilterType.Fuzzy)))
     assertEquals(listOf("Other Dogwood"), values)
   }
 
@@ -99,7 +115,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             speciesNameField,
-            FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy)))
     assertEquals(listOf("Kousa Dogwood", "Other Dogwood"), values)
   }
 
@@ -109,7 +127,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         searchService.fetchValues(
             rootPrefix,
             stateField,
-            FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy))
+            mapOf(
+                rootPrefix to
+                    FieldNode(speciesNameField, listOf("dogwod"), SearchFilterType.Fuzzy)))
     assertEquals(listOf("In Storage", "Processing"), values)
   }
 
@@ -117,14 +137,17 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
   fun `exact search of integer column value`() {
     val values =
         searchService.fetchValues(
-            rootPrefix, plantsCollectedFromField, FieldNode(plantsCollectedFromField, listOf("1")))
+            rootPrefix,
+            plantsCollectedFromField,
+            mapOf(rootPrefix to FieldNode(plantsCollectedFromField, listOf("1"))))
 
     assertEquals(listOf("1"), values)
   }
 
   @Test
   fun `no criteria for computed column value`() {
-    val values = searchService.fetchValues(rootPrefix, activeField, NoConditionNode())
+    val values =
+        searchService.fetchValues(rootPrefix, activeField, mapOf(rootPrefix to NoConditionNode()))
     assertEquals(listOf("Active"), values)
   }
 
@@ -134,7 +157,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
         accessionsDao.fetchOneById(accessionId1)!!.copy(stateId = AccessionState.UsedUp))
     val values =
         searchService.fetchValues(
-            rootPrefix, activeField, FieldNode(activeField, listOf("Inactive")))
+            rootPrefix,
+            activeField,
+            mapOf(rootPrefix to FieldNode(activeField, listOf("Inactive"))))
     assertEquals(listOf("Inactive"), values)
   }
 
@@ -146,7 +171,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
     val expected = listOf("1", "2")
 
-    val actual = searchService.fetchValues(rootPrefix, plantsCollectedFromField, NoConditionNode())
+    val actual =
+        searchService.fetchValues(
+            rootPrefix, plantsCollectedFromField, mapOf(rootPrefix to NoConditionNode()))
 
     assertEquals(expected, actual)
   }
@@ -162,7 +189,9 @@ internal class SearchServiceFetchValuesTest : SearchServiceTest() {
 
     val expected = listOf("1", "2", "3")
 
-    val actual = searchService.fetchValues(rootPrefix, plantsCollectedFromField, NoConditionNode())
+    val actual =
+        searchService.fetchValues(
+            rootPrefix, plantsCollectedFromField, mapOf(rootPrefix to NoConditionNode()))
 
     assertEquals(expected, actual)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -69,7 +69,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     // Use searchService rather than accessionSearchService; we don't want to include the
     // accession ID/number fields because those would cause the results for accession 1001 to
     // no longer be empty.
-    val result = searchService.search(rootPrefix, listOf(seedsTestedField), NoConditionNode())
+    val result =
+        searchService.search(
+            rootPrefix, listOf(seedsTestedField), mapOf(rootPrefix to NoConditionNode()))
 
     val expected =
         SearchResults(listOf(mapOf("viabilityTests" to listOf(mapOf("seedsTested" to "15")))))
@@ -86,7 +88,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         searchService.search(
             orgPrefix,
             listOf(fullyQualifiedField),
-            FieldNode(fullyQualifiedField, listOf("5")),
+            mapOf(orgPrefix to FieldNode(fullyQualifiedField, listOf("5"))),
             listOf(SearchSortField(fullyQualifiedField)))
 
     // Bags from both accessions appear here even though we're filtering on bag number because the
@@ -122,7 +124,10 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val result =
         searchService.search(
-            prefix, listOf(field), NoConditionNode(), listOf(SearchSortField(field)))
+            prefix,
+            listOf(field),
+            mapOf(prefix to NoConditionNode()),
+            listOf(SearchSortField(field)))
 
     val expected =
         SearchResults(
@@ -147,7 +152,10 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val result =
         searchService.search(
-            prefix, listOf(idField), NoConditionNode(), listOf(SearchSortField(aliasField)))
+            prefix,
+            listOf(idField),
+            mapOf(prefix to NoConditionNode()),
+            listOf(SearchSortField(aliasField)))
 
     val expected =
         SearchResults(
@@ -179,7 +187,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         searchService.search(
             viabilityTestResultsPrefix,
             listOf(orgNameField, rootSeedsGerminatedField),
-            FieldNode(orgNameField, listOf(orgName)))
+            mapOf(viabilityTestResultsPrefix to FieldNode(orgNameField, listOf(orgName))))
 
     val sublistValues =
         mapOf("accession" to mapOf("facility" to mapOf("organization" to mapOf("name" to orgName))))
@@ -205,7 +213,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         searchService.search(
             viabilityTestResultsPrefix,
             listOf(orgNameField, rootSeedsGerminatedField),
-            FieldNode(orgNameField, listOf(orgName)))
+            mapOf(viabilityTestResultsPrefix to FieldNode(orgNameField, listOf(orgName))))
 
     val expected =
         SearchResults(
@@ -226,7 +234,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         searchService.search(
             viabilityTestResultsPrefix,
             listOf(orgNameField),
-            FieldNode(orgNameField, listOf("Non-matching organization name")))
+            mapOf(
+                viabilityTestResultsPrefix to
+                    FieldNode(orgNameField, listOf("Non-matching organization name"))))
 
     val expected = SearchResults(emptyList())
 
@@ -568,7 +578,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             SearchSortField(accessionNumberField),
         )
 
-    val result = searchService.search(rootPrefix, selectFields, NoConditionNode(), sortOrder)
+    val result =
+        searchService.search(
+            rootPrefix, selectFields, mapOf(rootPrefix to NoConditionNode()), sortOrder)
 
     val expected =
         SearchResults(
@@ -749,7 +761,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     val activeField = prefix.resolve("facilities.accessions.active")
     val stateField = prefix.resolve("facilities.accessions.state")
 
-    val result = searchService.search(prefix, listOf(stateField, activeField), NoConditionNode())
+    val result =
+        searchService.search(
+            prefix, listOf(stateField, activeField), mapOf(prefix to NoConditionNode()))
 
     val expected =
         SearchResults(
@@ -978,7 +992,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
                 "timeZone" to orgTimeZone,
             ))
 
-    val result = searchService.search(prefix, fields, NoConditionNode())
+    val result = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertNull(result.cursor)
     assertJsonEquals(expected, result.results)
@@ -1004,7 +1018,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
             ))
 
     val result =
-        searchService.search(rootPrefix, fields, NoConditionNode(), sortFields).flattenForCsv()
+        searchService
+            .search(rootPrefix, fields, mapOf(rootPrefix to NoConditionNode()), sortFields)
+            .flattenForCsv()
 
     assertEquals(expected, result)
   }
@@ -1020,7 +1036,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
       val field = prefix.resolve(fieldName)
       val sortFields = listOf(SearchSortField(field))
       assertDoesNotThrow("Sort by $fieldName") {
-        val result = searchService.search(prefix, searchFields, NoConditionNode(), sortFields)
+        val result =
+            searchService.search(
+                prefix, searchFields, mapOf(prefix to NoConditionNode()), sortFields)
         assertEquals(expected, result.results, "Sort by $fieldName")
       }
     }
@@ -1038,7 +1056,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
         SearchResults(
             listOf(mapOf("number" to "5", "accession" to mapOf("accessionNumber" to "XYZ"))))
 
-    val result = searchService.search(prefix, fields, criteria)
+    val result = searchService.search(prefix, fields, mapOf(prefix to criteria))
 
     assertEquals(expected, result)
   }
@@ -1052,7 +1070,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val expected = SearchResults(listOf(mapOf("number" to "5")))
 
-    val result = searchService.search(prefix, fields, criteria)
+    val result = searchService.search(prefix, fields, mapOf(prefix to criteria))
 
     assertEquals(expected, result)
   }
@@ -1074,7 +1092,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val expected = SearchResults(listOf(mapOf("number" to "2"), mapOf("number" to "6")))
 
-    val result = searchService.search(prefix, fields, criteria, order)
+    val result = searchService.search(prefix, fields, mapOf(prefix to criteria), order)
 
     assertEquals(expected, result)
   }
@@ -1107,7 +1125,7 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
 
     val expected = SearchResults(listOf(mapOf("seedsGerminated" to "8")))
 
-    val result = searchService.search(prefix, fields, criteria, order)
+    val result = searchService.search(prefix, fields, mapOf(prefix to criteria), order)
 
     assertEquals(expected, result)
   }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceRawTest.kt
@@ -18,7 +18,7 @@ internal class SearchServiceRawTest : SearchServiceTest() {
         listOf(rootPrefix.resolve("estimatedCount"), rootPrefix.resolve("estimatedCount(raw)"))
     val criteria = FieldNode(accessionIdField, listOf("$accessionId1"))
 
-    val result = searchService.search(rootPrefix, fields, criteria)
+    val result = searchService.search(rootPrefix, fields, mapOf(rootPrefix to criteria))
 
     val expected =
         SearchResults(listOf(mapOf("estimatedCount" to "12,000", "estimatedCount(raw)" to "12000")))
@@ -56,7 +56,10 @@ internal class SearchServiceRawTest : SearchServiceTest() {
                 FieldNode(rawTotalWeightField, listOf("5000")),
             ))
 
-    val result = Locales.GIBBERISH.use { searchService.search(rootPrefix, fields, criteria) }
+    val result =
+        Locales.GIBBERISH.use {
+          searchService.search(rootPrefix, fields, mapOf(rootPrefix to criteria))
+        }
 
     val expected =
         SearchResults(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceTest.kt
@@ -179,6 +179,7 @@ internal abstract class SearchServiceTest : DatabaseTest(), RunsAsUser {
     val facilityIdCriterion = FieldNode(facilityIdField, listOf("$facilityId"))
     val fullCriteria = AndNode(listOf(criteria, facilityIdCriterion))
 
-    return searchService.search(rootPrefix, fullFieldList, fullCriteria, sortOrder, cursor, limit)
+    return searchService.search(
+        rootPrefix, fullFieldList, mapOf(rootPrefix to fullCriteria), sortOrder, cursor, limit)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUriFieldTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUriFieldTest.kt
@@ -40,7 +40,7 @@ internal class SearchServiceUriFieldTest : SearchServiceTest() {
     val fields = listOf(prefix.resolve("id"), prefix.resolve("meetingUrl"))
     val sortOrder = fields.map { SearchSortField(it) }
 
-    val result = searchService.search(prefix, fields, NoConditionNode(), sortOrder)
+    val result = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()), sortOrder)
     val expected = SearchResults(listOf(searchResult1, searchResult2, searchResult3), cursor = null)
 
     assertEquals(expected, result)
@@ -55,9 +55,9 @@ internal class SearchServiceUriFieldTest : SearchServiceTest() {
     val criteria2 = FieldNode(prefix.resolve("meetingUrl"), listOf("formation"))
     val criteria3 = FieldNode(prefix.resolve("meetingUrl"), listOf(null))
 
-    val result1 = searchService.search(prefix, fields, criteria1)
-    val result2 = searchService.search(prefix, fields, criteria2)
-    val result3 = searchService.search(prefix, fields, criteria3)
+    val result1 = searchService.search(prefix, fields, mapOf(prefix to criteria1))
+    val result2 = searchService.search(prefix, fields, mapOf(prefix to criteria2))
+    val result3 = searchService.search(prefix, fields, mapOf(prefix to criteria3))
 
     val expected1 = SearchResults(listOf(searchResult1, searchResult2), cursor = null)
     val expected2 = SearchResults(listOf(searchResult1))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceUserSearchTest.kt
@@ -80,7 +80,9 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                                                     "organization" to
                                                         mapOf("id" to "$organizationId")))))))))
 
-    val actual = searchService.search(organizationsPrefix, fields, NoConditionNode(), sortOrder)
+    val actual =
+        searchService.search(
+            organizationsPrefix, fields, mapOf(organizationsPrefix to NoConditionNode()), sortOrder)
 
     assertEquals(expected, actual)
   }
@@ -105,7 +107,9 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                     "organizationMemberships_organization_id" to "$organizationId",
                 )))
 
-    val actual = searchService.search(usersPrefix, fields, NoConditionNode(), sortOrder)
+    val actual =
+        searchService.search(
+            usersPrefix, fields, mapOf(usersPrefix to NoConditionNode()), sortOrder)
 
     assertEquals(expected, actual)
   }
@@ -119,7 +123,9 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
     val expected =
         SearchResults(listOf(mapOf("id" to "${user.userId}"), mapOf("id" to "$bothOrgsUserId")))
 
-    val actual = searchService.search(usersPrefix, fields, NoConditionNode(), sortOrder)
+    val actual =
+        searchService.search(
+            usersPrefix, fields, mapOf(usersPrefix to NoConditionNode()), sortOrder)
 
     assertEquals(expected, actual)
   }
@@ -153,7 +159,8 @@ internal class SearchServiceUserSearchTest : SearchServiceTest() {
                     "roleName" to Role.Admin.getDisplayName(Locale.ENGLISH),
                 )))
 
-    val actual = searchService.search(membersPrefix, fields, criteria, sortOrder)
+    val actual =
+        searchService.search(membersPrefix, fields, mapOf(membersPrefix to criteria), sortOrder)
     assertEquals(expected, actual)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -688,7 +688,7 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
             )
             .map { prefix.resolve(it) }
 
-    val actual = searchService.search(prefix, fields, NoConditionNode())
+    val actual = searchService.search(prefix, fields, mapOf(prefix to NoConditionNode()))
 
     assertJsonEquals(expected, actual)
   }
@@ -703,7 +703,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
     val prefix = SearchFieldPrefix(root = searchTables.plantingSubzones)
 
     val expected = SearchResults(emptyList())
-    val actual = searchService.search(prefix, listOf(prefix.resolve("id")), NoConditionNode())
+    val actual =
+        searchService.search(
+            prefix, listOf(prefix.resolve("id")), mapOf(prefix to NoConditionNode()))
 
     assertEquals(expected, actual)
   }


### PR DESCRIPTION
This is some pre-work for making sublist searching work in the search api, which has been accomplished in this PR stack by allowing `criteria` to be a map of prefix to SearchNode, and then applying a filter condition when adding each select field (if relevant) instead of only at the end of query building. See downstream PRs for more details.