### PR TITLE
Disable H2 console

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -61,6 +61,10 @@ spring:
       jsonColumnType: "JSONB"
       uuidColumnType: "UUID"
 
+  h2:
+    console:
+      enabled: false
+
   jackson:
     default-property-inclusion: non_absent
 


### PR DESCRIPTION
By default, Spring Boot supports an admin console for the embedded H2 database
engine. We don't directly use H2, but it's used by one of our dependencies, and
Spring detects its presence and sets up the console. The console isn't accessible
because there's no access control rule for it in our security configuration and
we have a deny-by-default security policy, so it's doing nothing but eating memory
and wasting time at application start. Turn it off.