### PR TITLE
Allow table names as search prefixes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -31,10 +31,10 @@ import org.springframework.web.bind.annotation.RestController
 class SearchController(
     private val clock: Clock,
     private val messages: Messages,
-    tables: SearchTables,
-    private val searchService: SearchService
+    private val searchService: SearchService,
+    private val searchTables: SearchTables
 ) {
-  private val organizationsTable = tables.organizations
+  private val organizationsTable = searchTables.organizations
 
   @Operation(summary = "Searches for data matching a supplied set of search criteria.")
   @PostMapping
@@ -153,7 +153,7 @@ class SearchController(
   private fun resolvePrefix(prefix: String?): SearchFieldPrefix {
     val table =
         if (prefix != null) {
-          organizationsTable.resolveTable(prefix)
+          searchTables[prefix] ?: organizationsTable.resolveTable(prefix)
         } else {
           organizationsTable
         }
@@ -167,9 +167,10 @@ data class SearchRequestPayload(
         description =
             "Prefix for field names. This determines how field names are interpreted, and also " +
                 "how results are structured. Each element in the \"results\" array in the " +
-                "response will be an instance of whatever entity the prefix points to. Always " +
-                "evaluated starting from the \"organizations\" level. If not present, the search " +
-                "will return a list of organizations.",
+                "response will be an instance of whatever entity the prefix points to. This may " +
+                "be a dotted sublist name starting from the \"organizations\" level, or the name " +
+                "of a search table. If not present, the search will return a list of " +
+                "organizations.",
         example = "facilities.accessions")
     val prefix: String? = null,
     @NotEmpty

--- a/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.search.table.SearchTables
 import java.time.Clock
+import kotlin.reflect.KVisibility
 import kotlin.reflect.full.memberProperties
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -68,6 +69,7 @@ class SearchFieldMetadataTest {
 
     return SearchTables::class
         .memberProperties
+        .filter { it.visibility == KVisibility.PUBLIC }
         .mapNotNull { it.get(tables) as? SearchTable }
         .flatMap { table -> table.fields.mapNotNull { func(table, it) } }
   }

--- a/src/test/kotlin/com/terraformation/backend/search/table/SearchTablesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/table/SearchTablesTest.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.search.table
+
+import com.terraformation.backend.TestClock
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
+
+class SearchTablesTest {
+  private val searchTables = SearchTables(TestClock())
+
+  @Test
+  fun `can look up search table by name`() {
+    assertSame(searchTables.bags, searchTables["bags"])
+  }
+
+  @Test
+  fun `lookup returns null if table name is unknown`() {
+    assertNull(searchTables["someBogusTableNameThatDoesNotExist"])
+  }
+}


### PR DESCRIPTION
Previously, the root prefix in a search API call had to be specified as a sublist
path starting from the `organizations` search table. This could be annoying
when searching against tables several steps removed from organizations.

Update the search API such that you can specify the root prefix either as a
sublist path or as the name of a search table as defined in the `SearchTables`
class. This only applies to the root prefix; the relative prefixes in field names
still have to be paths starting from the root prefix.

We can update clients to use table names instead of paths, after which we can get
rid of path-based prefixes.