### PR TITLE
SW-7210 Allow changeStatuses to accept all phases

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -527,7 +527,7 @@ class BatchStore(
       return
     }
 
-    if (previousPhase.value > newPhase.value) {
+    if (previousPhase > newPhase) {
       throw BatchPhaseReversalNotAllowedException(batchId)
     }
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -61,6 +61,7 @@ import com.terraformation.backend.nursery.model.ExistingBatchModel
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewBatchModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import com.terraformation.backend.nursery.model.NurseryBatchPhase
 import com.terraformation.backend.nursery.model.NurseryStats
 import com.terraformation.backend.nursery.model.SpeciesSummary
 import com.terraformation.backend.nursery.model.WithdrawalModel
@@ -490,30 +491,56 @@ class BatchStore(
     }
   }
 
+  private fun calculateNewQuantities(
+      batch: ExistingBatchModel,
+      previousPhase: NurseryBatchPhase,
+      newPhase: NurseryBatchPhase,
+      quantityToChange: Int,
+  ): Map<NurseryBatchPhase, Int> {
+    val quantities =
+        mutableMapOf(
+            NurseryBatchPhase.Germinating to batch.germinatingQuantity,
+            NurseryBatchPhase.NotReady to batch.notReadyQuantity,
+            NurseryBatchPhase.HardeningOff to batch.hardeningOffQuantity,
+            NurseryBatchPhase.Ready to batch.readyQuantity)
+
+    val startingQuantity = quantities[previousPhase]!!
+    if (startingQuantity < quantityToChange) {
+      throw BatchInventoryInsufficientException(batch.id)
+    }
+
+    quantities[previousPhase] = startingQuantity - quantityToChange
+    quantities[newPhase] = quantities[newPhase]!! + quantityToChange
+
+    return quantities
+  }
+
   fun changeStatuses(
       batchId: BatchId,
-      germinatingQuantityToChange: Int,
-      notReadyQuantityToChange: Int
+      previousPhase: NurseryBatchPhase,
+      newPhase: NurseryBatchPhase,
+      quantityToChange: Int
   ) {
     requirePermissions { updateBatch(batchId) }
 
-    if (germinatingQuantityToChange == 0 && notReadyQuantityToChange == 0) {
+    if (quantityToChange == 0 || previousPhase == newPhase) {
       return
     }
 
+    if (previousPhase.value > newPhase.value) {
+      throw BatchPhaseReversalNotAllowedException(batchId)
+    }
+
     retryVersionedBatchUpdate(batchId) { batch ->
-      if (batch.germinatingQuantity < germinatingQuantityToChange ||
-          batch.notReadyQuantity < notReadyQuantityToChange) {
-        throw BatchInventoryInsufficientException(batchId)
-      }
+      val newQuantities = calculateNewQuantities(batch, previousPhase, newPhase, quantityToChange)
 
       updateQuantities(
           batchId,
           batch.version,
-          batch.germinatingQuantity - germinatingQuantityToChange,
-          batch.notReadyQuantity - notReadyQuantityToChange + germinatingQuantityToChange,
-          0,
-          batch.readyQuantity + notReadyQuantityToChange,
+          newQuantities[NurseryBatchPhase.Germinating]!!,
+          newQuantities[NurseryBatchPhase.NotReady]!!,
+          newQuantities[NurseryBatchPhase.HardeningOff]!!,
+          newQuantities[NurseryBatchPhase.Ready]!!,
           BatchQuantityHistoryType.StatusChanged,
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/Exceptions.kt
@@ -7,14 +7,17 @@ import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 
+class BatchInventoryInsufficientException(val batchId: BatchId) :
+    IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")
+
 class BatchNotFoundException(val batchId: BatchId) :
     EntityNotFoundException("Seedling batch $batchId not found")
 
+class BatchPhaseReversalNotAllowedException(val batchId: BatchId) :
+    IllegalArgumentException("Cannot move quantity from further phase for batch $batchId")
+
 class BatchStaleException(val batchId: BatchId, val requestedVersion: Int) :
     EntityStaleException("Seedling batch $batchId version $requestedVersion out of date")
-
-class BatchInventoryInsufficientException(val batchId: BatchId) :
-    IllegalArgumentException("Withdrawal quantity can't be more than remaining quantity")
 
 class CrossOrganizationNurseryTransferNotAllowedException(
     val facilityId: FacilityId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryBatchPhase.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryBatchPhase.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.nursery.model
+
+enum class NurseryBatchPhase(val value: Int) {
+  Germinating(10),
+  NotReady(20),
+  HardeningOff(30),
+  Ready(40)
+}

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryBatchPhase.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/NurseryBatchPhase.kt
@@ -1,8 +1,8 @@
 package com.terraformation.backend.nursery.model
 
-enum class NurseryBatchPhase(val value: Int) {
-  Germinating(10),
-  NotReady(20),
-  HardeningOff(30),
-  Ready(40)
+enum class NurseryBatchPhase {
+  Germinating,
+  NotReady,
+  HardeningOff,
+  Ready
 }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreChangeStatusesTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.db.nursery.BatchQuantityHistoryType
 import com.terraformation.backend.db.nursery.tables.pojos.BatchQuantityHistoryRow
 import com.terraformation.backend.db.nursery.tables.references.BATCH_QUANTITY_HISTORY
 import com.terraformation.backend.nursery.db.BatchInventoryInsufficientException
+import com.terraformation.backend.nursery.db.BatchPhaseReversalNotAllowedException
+import com.terraformation.backend.nursery.model.NurseryBatchPhase
 import io.mockk.every
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,6 +27,7 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
             germinatingQuantity = 10,
             notReadyQuantity = 20,
             readyQuantity = 30,
+            hardeningOffQuantity = 40,
             speciesId = speciesId)
 
     clock.instant = updateTime
@@ -34,19 +37,80 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
   fun `updates quantities and creates history entry`() {
     val before = batchesDao.fetchOneById(batchId)!!
 
-    store.changeStatuses(batchId, 2, 7)
+    store.changeStatuses(batchId, NurseryBatchPhase.Germinating, NurseryBatchPhase.NotReady, 2)
+    store.changeStatuses(batchId, NurseryBatchPhase.NotReady, NurseryBatchPhase.HardeningOff, 7)
+    store.changeStatuses(batchId, NurseryBatchPhase.HardeningOff, NurseryBatchPhase.Ready, 5)
 
     val after = batchesDao.fetchOneById(batchId)!!
 
     assertEquals(
         before.copy(
             germinatingQuantity = 8,
-            hardeningOffQuantity = 0,
+            hardeningOffQuantity = 42,
             notReadyQuantity = 15,
-            readyQuantity = 37,
+            readyQuantity = 35,
             totalLost = 0,
             // moved 2 seeds from germinating to not-ready
-            totalLossCandidates = 52,
+            totalLossCandidates = 92,
+            modifiedTime = updateTime,
+            version = 4),
+        after)
+
+    assertEquals(
+        listOf(
+            BatchQuantityHistoryRow(
+                batchId = batchId,
+                historyTypeId = BatchQuantityHistoryType.StatusChanged,
+                createdBy = user.userId,
+                createdTime = updateTime,
+                germinatingQuantity = 8,
+                hardeningOffQuantity = 40,
+                notReadyQuantity = 22,
+                readyQuantity = 30,
+                version = 2,
+            ),
+            BatchQuantityHistoryRow(
+                batchId = batchId,
+                historyTypeId = BatchQuantityHistoryType.StatusChanged,
+                createdBy = user.userId,
+                createdTime = updateTime,
+                germinatingQuantity = 8,
+                hardeningOffQuantity = 47,
+                notReadyQuantity = 15,
+                readyQuantity = 30,
+                version = 3,
+            ),
+            BatchQuantityHistoryRow(
+                batchId = batchId,
+                historyTypeId = BatchQuantityHistoryType.StatusChanged,
+                createdBy = user.userId,
+                createdTime = updateTime,
+                germinatingQuantity = 8,
+                hardeningOffQuantity = 42,
+                notReadyQuantity = 15,
+                readyQuantity = 35,
+                version = 4,
+            ),
+        ),
+        batchQuantityHistoryDao.findAll().map { it.copy(id = null) })
+  }
+
+  @Test
+  fun `supports moves from any status to any later status`() {
+    val before = batchesDao.fetchOneById(batchId)!!
+
+    store.changeStatuses(batchId, NurseryBatchPhase.Germinating, NurseryBatchPhase.HardeningOff, 3)
+
+    val after = batchesDao.fetchOneById(batchId)!!
+
+    assertEquals(
+        before.copy(
+            germinatingQuantity = 7,
+            notReadyQuantity = 20,
+            hardeningOffQuantity = 43,
+            readyQuantity = 30,
+            totalLost = 0,
+            totalLossCandidates = 93,
             modifiedTime = updateTime,
             version = 2),
         after)
@@ -58,10 +122,10 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
                 historyTypeId = BatchQuantityHistoryType.StatusChanged,
                 createdBy = user.userId,
                 createdTime = updateTime,
-                germinatingQuantity = 8,
-                hardeningOffQuantity = 0,
-                notReadyQuantity = 15,
-                readyQuantity = 37,
+                germinatingQuantity = 7,
+                notReadyQuantity = 20,
+                hardeningOffQuantity = 43,
+                readyQuantity = 30,
                 version = 2,
             )),
         batchQuantityHistoryDao.findAll().map { it.copy(id = null) })
@@ -71,26 +135,55 @@ internal class BatchStoreChangeStatusesTest : BatchStoreTest() {
   fun `does not update quantities or create history entry if no statuses are changed`() {
     val before = batchesDao.fetchOneById(batchId)
 
-    store.changeStatuses(batchId, 0, 0)
+    store.changeStatuses(batchId, NurseryBatchPhase.Germinating, NurseryBatchPhase.NotReady, 0)
 
     assertEquals(before, batchesDao.fetchOneById(batchId))
     assertTableEmpty(BATCH_QUANTITY_HISTORY)
   }
 
   @Test
+  fun `does not update quantities or create history entry if phases are the same`() {
+    val before = batchesDao.fetchOneById(batchId)
+
+    store.changeStatuses(batchId, NurseryBatchPhase.NotReady, NurseryBatchPhase.NotReady, 10)
+
+    assertEquals(before, batchesDao.fetchOneById(batchId))
+    assertTableEmpty(BATCH_QUANTITY_HISTORY)
+  }
+
+  @Test
+  fun `throws exception if phases move in reverse`() {
+    assertThrows<BatchPhaseReversalNotAllowedException> {
+      store.changeStatuses(batchId, NurseryBatchPhase.Ready, NurseryBatchPhase.NotReady, 1)
+    }
+    assertThrows<BatchPhaseReversalNotAllowedException> {
+      store.changeStatuses(batchId, NurseryBatchPhase.Ready, NurseryBatchPhase.HardeningOff, 2)
+    }
+    assertThrows<BatchPhaseReversalNotAllowedException> {
+      store.changeStatuses(
+          batchId, NurseryBatchPhase.HardeningOff, NurseryBatchPhase.Germinating, 3)
+    }
+  }
+
+  @Test
   fun `throws exception if no permission to update batch`() {
     every { user.canUpdateBatch(any()) } returns false
 
-    assertThrows<AccessDeniedException> { store.changeStatuses(batchId, 1, 1) }
+    assertThrows<AccessDeniedException> {
+      store.changeStatuses(batchId, NurseryBatchPhase.Germinating, NurseryBatchPhase.NotReady, 1)
+    }
   }
 
   @Test
   fun `throws exception if not enough seedlings to satisfy request`() {
     assertThrows<BatchInventoryInsufficientException>("Germinating") {
-      store.changeStatuses(batchId, 50, 0)
+      store.changeStatuses(batchId, NurseryBatchPhase.Germinating, NurseryBatchPhase.NotReady, 50)
     }
     assertThrows<BatchInventoryInsufficientException>("Not Ready") {
-      store.changeStatuses(batchId, 0, 50)
+      store.changeStatuses(batchId, NurseryBatchPhase.NotReady, NurseryBatchPhase.Ready, 50)
+    }
+    assertThrows<BatchInventoryInsufficientException>("Not Ready") {
+      store.changeStatuses(batchId, NurseryBatchPhase.HardeningOff, NurseryBatchPhase.Ready, 50)
     }
   }
 }


### PR DESCRIPTION
Previously `changeStatuses` only worked for moving quantities from germinating to notReady, or from notReady to ready. We want to support a move from any status to any later status (but not any previous status). Add support for this. 