### PR TITLE
SW-6240 Remove Shrub or Tree from CSV templates

### DIFF
--- a/src/main/resources/csv/species-template.csv
+++ b/src/main/resources/csv/species-template.csv
@@ -34,7 +34,6 @@ Please choose from the following list or an error will occur during upload:
 - Moss
 - Multiple Forms
 - Shrub
-- Shrub or Tree
 - Subshrub
 - Tree
 - Vine

--- a/src/main/resources/csv/species-template_es.csv
+++ b/src/main/resources/csv/species-template_es.csv
@@ -25,7 +25,6 @@ Elija de la siguiente lista o se producirá un error durante la carga:
 
 - Árbol
 - Arbusto
-- Arbusto o árbol
 - Enredadera
 - Graminoide
 - Hierba

--- a/src/main/resources/csv/species-template_fr.csv
+++ b/src/main/resources/csv/species-template_fr.csv
@@ -25,7 +25,6 @@ Veuillez choisir parmi la liste suivante ou une erreur se produira lors du t√©l√
 
 - Arbre
 - Arbuste
-- Arbuste ou arbre
 - Champignons
 - Forb
 - Formes multiples

--- a/src/main/resources/csv/species-template_gx.csv
+++ b/src/main/resources/csv/species-template_gx.csv
@@ -34,7 +34,6 @@ dXBsb2FkOg ZHVyaW5n b2NjdXI d2lsbA ZXJyb3I YW4 b3I bGlzdA Zm9sbG93aW5n dGhl ZnJv
 - TW9zcw
 - Rm9ybXM TXVsdGlwbGU
 - U2hydWI
-- VHJlZQ b3I U2hydWI
 - U3Vic2hydWI
 - VHJlZQ
 - VmluZQ","QmVoYXZpb3I U3RvcmFnZQ U2VlZA


### PR DESCRIPTION
The "Shrub or Tree" option was still listed as one of the valid choices in the
species upload CSV templates; remove it.