### PR TITLE
Make hardening off optional in api

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -130,7 +130,7 @@ class BatchesController(
         version = payload.version,
         germinating = payload.germinatingQuantity,
         notReady = payload.notReadyQuantity,
-        hardeningOff = payload.hardeningOffQuantity,
+        hardeningOff = payload.hardeningOffQuantity ?: 0,
         ready = payload.readyQuantity,
         historyType = BatchQuantityHistoryType.Observed)
 
@@ -370,7 +370,7 @@ data class UpdateBatchRequestPayload(
 
 data class UpdateBatchQuantitiesRequestPayload(
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val germinatingQuantity: Int,
-    @Min(0) val hardeningOffQuantity: Int = 0,
+    @Min(0) val hardeningOffQuantity: Int? = 0,
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val notReadyQuantity: Int,
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantity: Int,
     @JsonSetter(nulls = Nulls.FAIL) val version: Int,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -46,7 +46,7 @@ data class CreateNurseryTransferRequestPayload(
     @Min(0) //
     val germinatingQuantity: Int,
     @Min(0) //
-    val hardeningOffQuantity: Int = 0,
+    val hardeningOffQuantity: Int? = 0,
     val notes: String? = null,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(0) //
@@ -71,7 +71,7 @@ data class CreateNurseryTransferRequestPayload(
           notReadyQuantity = notReadyQuantity,
           readyByDate = readyByDate,
           readyQuantity = readyQuantity,
-          hardeningOffQuantity = hardeningOffQuantity,
+          hardeningOffQuantity = hardeningOffQuantity ?: 0,
           speciesId = null,
       )
 }


### PR DESCRIPTION
Hardening off was supposed to be an optional property in the api after it was added, but default values are not treated the same as optional values in open api. Fix this.

(this fixes the FE issue where these were missing)