### PR TITLE
Allow NotReady as previousPhase for changeStatus

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -515,7 +515,7 @@ class BatchStore(
       throw BatchInventoryInsufficientException(batch.id)
     }
 
-    quantities[previousPhase] = startingQuantity - quantityToChange
+    quantities[convertedPreviousPhase] = startingQuantity - quantityToChange
     quantities[convertedNewPhase] = quantities[convertedNewPhase]!! + quantityToChange
 
     return quantities

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -504,13 +504,17 @@ class BatchStore(
             NurseryBatchPhase.HardeningOff to batch.hardeningOffQuantity,
             NurseryBatchPhase.Ready to batch.readyQuantity)
 
-    val startingQuantity = quantities[previousPhase]!!
+    val convertedPreviousPhase =
+        if (previousPhase == NurseryBatchPhase.NotReady) NurseryBatchPhase.ActiveGrowth
+        else previousPhase
+    val convertedNewPhase =
+        if (newPhase == NurseryBatchPhase.NotReady) NurseryBatchPhase.ActiveGrowth else newPhase
+
+    val startingQuantity = quantities[convertedPreviousPhase]!!
     if (startingQuantity < quantityToChange) {
       throw BatchInventoryInsufficientException(batch.id)
     }
 
-    val convertedNewPhase =
-        if (newPhase == NurseryBatchPhase.NotReady) NurseryBatchPhase.ActiveGrowth else newPhase
     quantities[previousPhase] = startingQuantity - quantityToChange
     quantities[convertedNewPhase] = quantities[convertedNewPhase]!! + quantityToChange
 


### PR DESCRIPTION
Nursery status NotReady is being renamed to ActiveGrowth.
Until the FE is fully updated to use ActiveGrowth as the phases of the `/changeStatuses` request, allow NotReady for both the previousPhase and the newPhase.