### PR TITLE
Add missing hardening-off status to payloads, cleanup

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesController.kt
@@ -327,12 +327,12 @@ data class CreateBatchRequestPayload(
   fun toModel() =
       NewBatchModel(
           addedDate = addedDate,
+          activeGrowthQuantity = activeGrowthQuantity,
           facilityId = facilityId,
           germinatingQuantity = germinatingQuantity,
           germinationStartedDate = germinationStartedDate,
           hardeningOffQuantity = hardeningOffQuantity,
           notes = notes,
-          activeGrowthQuantity = activeGrowthQuantity,
           projectId = projectId,
           readyByDate = readyByDate,
           readyQuantity = readyQuantity,

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
@@ -271,11 +271,11 @@ data class BatchHistoryQuantityEditedPayload(
   constructor(
       row: BatchQuantityHistoryRow
   ) : this(
+      activeGrowthQuantity = row.activeGrowthQuantity!!,
       createdBy = row.createdBy!!,
       createdTime = row.createdTime!!,
       germinatingQuantity = row.germinatingQuantity!!,
       hardeningOffQuantity = row.hardeningOffQuantity!!,
-      activeGrowthQuantity = row.activeGrowthQuantity!!,
       readyQuantity = row.readyQuantity!!,
       version = row.version!!,
   )

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/NurseryFacilitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/NurseryFacilitiesController.kt
@@ -45,6 +45,7 @@ data class NurserySummaryPayload(
     val activeGrowthQuantity: Long,
     val germinatingQuantity: Long,
     val germinationRate: Int?,
+    val hardeningOffQuantity: Long,
     @Schema(
         description = "Percentage of current and past inventory that was withdrawn due to death.",
         minimum = "0",
@@ -67,6 +68,7 @@ data class NurserySummaryPayload(
       activeGrowthQuantity = stats.totalActiveGrowth,
       germinatingQuantity = stats.totalGerminating,
       germinationRate = stats.germinationRate,
+      hardeningOffQuantity = stats.totalHardeningOff,
       lossRate = stats.lossRate,
       readyQuantity = stats.totalReady,
       species = species.map { NurserySummarySpeciesPayload(it) },

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/NurserySummaryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/NurserySummaryController.kt
@@ -35,6 +35,7 @@ data class OrganizationNurserySummaryPayload(
     val activeGrowthQuantity: Long,
     val germinatingQuantity: Long,
     val germinationRate: Int?,
+    val hardeningOffQuantity: Long,
     @Schema(
         description = "Percentage of current and past inventory that was withdrawn due to death.",
         minimum = "0",
@@ -54,6 +55,7 @@ data class OrganizationNurserySummaryPayload(
       activeGrowthQuantity = stats.totalActiveGrowth,
       germinatingQuantity = stats.totalGerminating,
       germinationRate = stats.germinationRate,
+      hardeningOffQuantity = stats.totalHardeningOff,
       lossRate = stats.lossRate,
       readyQuantity = stats.totalReady,
       totalDead = stats.totalWithdrawnByPurpose[WithdrawalPurpose.Dead] ?: 0L,

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/SpeciesController.kt
@@ -41,6 +41,7 @@ data class SpeciesSummaryPayload(
     val activeGrowthQuantity: Long,
     val germinatingQuantity: Long,
     val germinationRate: Int?,
+    val hardeningOffQuantity: Long,
     @Schema(
         description = "Percentage of current and past inventory that was withdrawn due to death.",
         minimum = "0",
@@ -63,6 +64,7 @@ data class SpeciesSummaryPayload(
       activeGrowthQuantity = summary.activeGrowthQuantity,
       germinatingQuantity = summary.germinatingQuantity,
       germinationRate = summary.germinationRate,
+      hardeningOffQuantity = summary.hardeningOffQuantity,
       lossRate = summary.lossRate,
       nurseries = summary.nurseries.map { SpeciesSummaryNurseryPayload(it) },
       readyQuantity = summary.readyQuantity,

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -176,20 +176,22 @@ class WithdrawalsController(
 }
 
 data class BatchWithdrawalPayload(
-    val batchId: BatchId,
-    @Schema(defaultValue = "0") @Min(0) val germinatingQuantityWithdrawn: Int? = null,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(0)
     @JsonAlias("notReadyQuantityWithdrawn")
     val activeGrowthQuantityWithdrawn: Int,
+    val batchId: BatchId,
+    @Schema(defaultValue = "0") @Min(0) val germinatingQuantityWithdrawn: Int? = null,
+    @Schema(defaultValue = "0") @Min(0) val hardeningOffQuantityWithdrawn: Int? = null,
     @JsonSetter(nulls = Nulls.FAIL) @Min(0) val readyQuantityWithdrawn: Int,
 ) {
   constructor(
       model: BatchWithdrawalModel
   ) : this(
+      activeGrowthQuantityWithdrawn = model.activeGrowthQuantityWithdrawn,
       batchId = model.batchId,
       germinatingQuantityWithdrawn = model.germinatingQuantityWithdrawn,
-      activeGrowthQuantityWithdrawn = model.activeGrowthQuantityWithdrawn,
+      hardeningOffQuantityWithdrawn = model.hardeningOffQuantityWithdrawn,
       readyQuantityWithdrawn = model.readyQuantityWithdrawn,
   )
 
@@ -198,6 +200,7 @@ data class BatchWithdrawalPayload(
           batchId = batchId,
           germinatingQuantityWithdrawn = germinatingQuantityWithdrawn ?: 0,
           activeGrowthQuantityWithdrawn = activeGrowthQuantityWithdrawn,
+          hardeningOffQuantityWithdrawn = hardeningOffQuantityWithdrawn ?: 0,
           readyQuantityWithdrawn = readyQuantityWithdrawn,
       )
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchImporter.kt
@@ -131,10 +131,10 @@ class BatchImporter(
     batchStore.create(
         NewBatchModel(
             addedDate = storedDate,
+            activeGrowthQuantity = seedlingQuantity,
             facilityId = facilityId,
             germinatingQuantity = germinatingQuantity,
             hardeningOffQuantity = 0,
-            activeGrowthQuantity = seedlingQuantity,
             readyQuantity = 0,
             speciesId = speciesId,
             subLocationIds = subLocationNames.mapNotNull { subLocationIds[it] }.toSet(),

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchStore.kt
@@ -240,11 +240,11 @@ class BatchStore(
       batchesDao.insert(rowWithDefaults)
 
       insertQuantityHistoryRow(
+          activeGrowthQuantity = rowWithDefaults.activeGrowthQuantity!!,
           batchId = rowWithDefaults.id!!,
           germinatingQuantity = rowWithDefaults.germinatingQuantity!!,
           hardeningOffQuantity = rowWithDefaults.hardeningOffQuantity!!,
           historyType = BatchQuantityHistoryType.Observed,
-          activeGrowthQuantity = rowWithDefaults.activeGrowthQuantity!!,
           readyQuantity = rowWithDefaults.readyQuantity!!,
           version = 1,
           withdrawalId = withdrawalId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/BatchModel.kt
@@ -41,6 +41,7 @@ data class NewBatchModel(
   fun toRow() =
       BatchesRow(
           accessionId = accessionId,
+          activeGrowthQuantity = activeGrowthQuantity,
           addedDate = addedDate,
           batchNumber = batchNumber,
           facilityId = facilityId,
@@ -53,7 +54,6 @@ data class NewBatchModel(
           latestObservedHardeningOffQuantity = hardeningOffQuantity,
           latestObservedReadyQuantity = readyQuantity,
           notes = notes,
-          activeGrowthQuantity = activeGrowthQuantity,
           projectId = projectId,
           readyByDate = readyByDate,
           readyQuantity = readyQuantity,
@@ -117,9 +117,9 @@ data class ExistingBatchModel(
       hardeningOffQuantity = row.hardeningOffQuantity!!,
       id = row.id!!,
       initialBatchId = row.initialBatchId,
+      latestObservedActiveGrowthQuantity = row.latestObservedActiveGrowthQuantity!!,
       latestObservedGerminatingQuantity = row.latestObservedGerminatingQuantity!!,
       latestObservedHardeningOffQuantity = row.latestObservedHardeningOffQuantity!!,
-      latestObservedActiveGrowthQuantity = row.latestObservedActiveGrowthQuantity!!,
       latestObservedReadyQuantity = row.latestObservedReadyQuantity!!,
       latestObservedTime = row.latestObservedTime!!,
       lossRate = row.lossRate,

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/WithdrawalModel.kt
@@ -17,8 +17,8 @@ data class BatchWithdrawalModel(
     val batchId: BatchId,
     val destinationBatchId: BatchId? = null,
     val germinatingQuantityWithdrawn: Int,
-    val hardeningOffQuantityWithdrawn: Int = 0,
     val activeGrowthQuantityWithdrawn: Int,
+    val hardeningOffQuantityWithdrawn: Int = 0,
     val readyQuantityWithdrawn: Int,
 ) {
   val totalWithdrawn: Int
@@ -72,8 +72,8 @@ fun BatchWithdrawalsRow.toModel(): BatchWithdrawalModel =
         batchId = batchId!!,
         destinationBatchId = destinationBatchId,
         germinatingQuantityWithdrawn = germinatingQuantityWithdrawn!!,
-        hardeningOffQuantityWithdrawn = hardeningOffQuantityWithdrawn!!,
         activeGrowthQuantityWithdrawn = activeGrowthQuantityWithdrawn!!,
+        hardeningOffQuantityWithdrawn = hardeningOffQuantityWithdrawn!!,
         readyQuantityWithdrawn = readyQuantityWithdrawn!!,
     )
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/api/TransfersController.kt
@@ -41,6 +41,10 @@ class TransfersController(
 }
 
 data class CreateNurseryTransferRequestPayload(
+    @JsonSetter(nulls = Nulls.FAIL)
+    @Min(0) //
+    @JsonAlias("notReadyQuantity")
+    val activeGrowthQuantity: Int,
     val date: LocalDate,
     val destinationFacilityId: FacilityId,
     @JsonSetter(nulls = Nulls.FAIL)
@@ -49,10 +53,6 @@ data class CreateNurseryTransferRequestPayload(
     @Min(0) //
     val hardeningOffQuantity: Int? = 0,
     val notes: String? = null,
-    @JsonSetter(nulls = Nulls.FAIL)
-    @Min(0) //
-    @JsonAlias("notReadyQuantity")
-    val activeGrowthQuantity: Int,
     val readyByDate: LocalDate? = null,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(0) //
@@ -67,10 +67,10 @@ data class CreateNurseryTransferRequestPayload(
   fun toNewBatchModel() =
       NewBatchModel(
           addedDate = date,
+          activeGrowthQuantity = activeGrowthQuantity,
           facilityId = destinationFacilityId,
           germinatingQuantity = germinatingQuantity,
           notes = notes,
-          activeGrowthQuantity = activeGrowthQuantity,
           readyByDate = readyByDate,
           readyQuantity = readyQuantity,
           hardeningOffQuantity = hardeningOffQuantity ?: 0,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -4288,6 +4288,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 addedDate = getRandomDate(reportStartDate, reportEndDate),
                 activeGrowthQuantity = 15,
                 germinatingQuantity = 7,
+                hardeningOffQuantity = 4,
                 readyQuantity = 3,
                 totalLost = 100,
                 speciesId = speciesId,
@@ -4301,6 +4302,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 addedDate = getRandomDate(reportStartDate, reportEndDate),
                 activeGrowthQuantity = 4,
                 germinatingQuantity = 3,
+                hardeningOffQuantity = 1,
                 readyQuantity = 2,
                 totalLost = 100,
                 speciesId = otherSpeciesId,
@@ -4315,6 +4317,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 addedDate = getRandomDate(reportStartDate, reportEndDate),
                 activeGrowthQuantity = 100,
                 germinatingQuantity = 100,
+                hardeningOffQuantity = 100,
                 readyQuantity = 100,
                 totalLost = 100,
                 speciesId = speciesId,
@@ -4329,6 +4332,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                 addedDate = reportStartDate.minusDays(1),
                 activeGrowthQuantity = 100,
                 germinatingQuantity = 100,
+                hardeningOffQuantity = 100,
                 readyQuantity = 100,
                 totalLost = 100,
                 speciesId = speciesId,
@@ -4391,12 +4395,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         withdrawalId = otherWithdrawalId,
         germinatingQuantityWithdrawn = 1,
         activeGrowthQuantityWithdrawn = 2,
+        hardeningOffQuantityWithdrawn = 3,
     )
     insertBatchWithdrawal(
         batchId = batchId2,
         withdrawalId = otherWithdrawalId,
         germinatingQuantityWithdrawn = 4,
         activeGrowthQuantityWithdrawn = 3,
+        hardeningOffQuantityWithdrawn = 2,
     )
 
     val deadWithdrawalId =
@@ -4425,6 +4431,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         readyQuantityWithdrawn = 100,
         germinatingQuantityWithdrawn = 100,
         activeGrowthQuantityWithdrawn = 100,
+        hardeningOffQuantityWithdrawn = 100,
     )
     insertBatchWithdrawal(
         batchId = batchId2,
@@ -4432,6 +4439,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         readyQuantityWithdrawn = 100,
         germinatingQuantityWithdrawn = 100,
         activeGrowthQuantityWithdrawn = 100,
+        hardeningOffQuantityWithdrawn = 100,
     )
 
     // These two will not be counted

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreFetchTest.kt
@@ -47,12 +47,14 @@ internal class BatchStoreFetchTest : BatchStoreTest() {
     insertBatchWithdrawal(
         germinatingQuantityWithdrawn = 1,
         activeGrowthQuantityWithdrawn = 2,
-        readyQuantityWithdrawn = 4)
+        readyQuantityWithdrawn = 4,
+        hardeningOffQuantityWithdrawn = 8)
     insertNurseryWithdrawal()
     insertBatchWithdrawal(
         germinatingQuantityWithdrawn = 8,
         activeGrowthQuantityWithdrawn = 16,
-        readyQuantityWithdrawn = 32)
+        readyQuantityWithdrawn = 32,
+        hardeningOffQuantityWithdrawn = 64)
 
     val expected =
         ExistingBatchModel(
@@ -83,7 +85,7 @@ internal class BatchStoreFetchTest : BatchStoreTest() {
             substrateNotes = "Substrate Notes",
             treatment = SeedTreatment.Chemical,
             treatmentNotes = "Treatment Notes",
-            totalWithdrawn = 63,
+            totalWithdrawn = 135,
             version = 1,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreGetActiveSpeciesTest.kt
@@ -13,12 +13,14 @@ internal class BatchStoreGetActiveSpeciesTest : BatchStoreTest() {
     val speciesId2 = insertSpecies()
     insertBatch(speciesId = speciesId2, activeGrowthQuantity = 1)
     val speciesId3 = insertSpecies()
-    insertBatch(speciesId = speciesId3, readyQuantity = 1)
+    insertBatch(speciesId = speciesId3, hardeningOffQuantity = 1)
+    val speciesId4 = insertSpecies()
+    insertBatch(speciesId = speciesId4, readyQuantity = 1)
 
     val expected = speciesDao.findAll().sortedBy { it.id }
 
-    val speciesId4 = insertSpecies()
-    insertBatch(speciesId = speciesId4)
+    val speciesId5 = insertSpecies()
+    insertBatch(speciesId = speciesId5)
 
     val actual = store.getActiveSpecies(facilityId)
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreSpeciesSummaryTest.kt
@@ -13,13 +13,14 @@ internal class BatchStoreSpeciesSummaryTest : BatchStoreTest() {
         batchId = batchId,
         germinatingQuantityWithdrawn = 1,
         activeGrowthQuantityWithdrawn = 2,
+        hardeningOffQuantityWithdrawn = 3,
         readyQuantityWithdrawn = 4,
         withdrawalId = withdrawalId,
     )
 
     val summary = store.getSpeciesSummary(speciesId)
 
-    assertEquals(6, summary.totalWithdrawn, "Total withdrawn")
+    assertEquals(9, summary.totalWithdrawn, "Total withdrawn")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -231,12 +231,13 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
                               buildStartedDateEditable = false,
                               capacity = 1000,
                               id = nurseryId,
-                              // 152 dead / (498 remaining + 200 total withdrawn) = 21.8%
-                              mortalityRate = 22,
+                              // 152 dead / (898 remaining + 242 total withdrawn) = 13.3%
+                              mortalityRate = 13,
                               name = "Nursery",
-                              // inventory (200 active-growth, 300 ready) +
-                              // outplanting withdrawals (20 active-growth, 30 ready)
-                              totalPlantsPropagated = 550,
+                              // inventory (200 active-growth, 300 ready, 400 hardening-off) +
+                              // outplanting withdrawals (20 active-growth, 30 ready, 40
+                              // hardening-off)
+                              totalPlantsPropagated = 990,
                           ),
                       ),
                   organizationName = "Organization 1",
@@ -380,16 +381,17 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
                               buildStartedDateEditable = false,
                               capacity = 1000,
                               id = projectNurseryId,
-                              // 152 dead / (498 remaining + 200 total withdrawn) = 21.8%
-                              mortalityRate = 22,
+                              // 152 dead / (898 remaining + 242 total withdrawn) = 13.3%
+                              mortalityRate = 13,
                               name = "Facility 1",
                               // Project-level total only counts one of the four samples:
-                              //   inventory (200 active-growth, 300 ready) +
-                              //   outplanting withdrawals (20 active-growth, 30 ready)
-                              totalPlantsPropagatedForProject = 550,
+                              //   inventory (200 active-growth, 300 ready, 400 hardening-off) +
+                              //   outplanting withdrawals (20 active-growth, 30 ready, 40
+                              // hardening-off)
+                              totalPlantsPropagatedForProject = 990,
                               // Org-level total counts all three samples for this nursery (same
                               // numbers as above for each sample).
-                              totalPlantsPropagated = 1650,
+                              totalPlantsPropagated = 2970,
                           ),
                       ),
                   organizationName = "Organization 1",
@@ -684,6 +686,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
           germinatingQuantity = 50,
           activeGrowthQuantity = 60,
           readyQuantity = 70,
+          hardeningOffQuantity = 80,
           speciesId = speciesId,
       )
       val withdrawalId = insertNurseryWithdrawal(facilityId = firstNursery)
@@ -805,13 +808,15 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
                               initialBody.nurseries[0].copy(
                                   buildCompletedDate = LocalDate.of(2023, 1, 15),
                                   buildCompletedDateEditable = false,
-                                  // 152 dead / (628 remaining + 200 total withdrawn) = 18.4%
-                                  mortalityRate = 18,
+                                  // 152 dead / (1088 remaining + 242 total withdrawn) = 11.3%
+                                  mortalityRate = 11,
                                   name = "Facility 2",
-                                  // initial batch (60 active-growth, 70 ready) +
-                                  // insertSampleWithdrawals batch (200 active-growth, 300 ready) +
-                                  // outplanting withdrawals (20 active-growth, 30 ready)
-                                  totalPlantsPropagated = 680,
+                                  // initial batch (60 active-growth, 70 ready, 80 hardening-off) +
+                                  // insertSampleWithdrawals batch (200 active-growth, 300 ready,
+                                  // 400 hardening-off) +
+                                  // outplanting withdrawals (20 active-growth, 30 ready, 40
+                                  // hardening-off)
+                                  totalPlantsPropagated = 1200,
                               ),
                               SeedFundReportBodyModelV1.Nursery(
                                   id = secondNursery,
@@ -998,6 +1003,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
         facilityId = nurseryId,
         germinatingQuantity = 100,
         activeGrowthQuantity = 200,
+        hardeningOffQuantity = 400,
         projectId = projectId,
         readyQuantity = 300,
         speciesId = speciesId,
@@ -1007,7 +1013,10 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
     insertBatchWithdrawal(readyQuantityWithdrawn = 100, activeGrowthQuantityWithdrawn = 52)
 
     insertNurseryWithdrawal(facilityId = nurseryId, purpose = WithdrawalPurpose.OutPlant)
-    insertBatchWithdrawal(readyQuantityWithdrawn = 20, activeGrowthQuantityWithdrawn = 30)
+    insertBatchWithdrawal(
+        readyQuantityWithdrawn = 20,
+        activeGrowthQuantityWithdrawn = 30,
+        hardeningOffQuantityWithdrawn = 40)
     insertDelivery(plantingSiteId = plantingSiteId)
     insertPlanting(plantingSiteId = plantingSiteId, speciesId = speciesId)
   }


### PR DESCRIPTION
HardeningOff quantities were missing from the following payloads:
- BatchWithdrawalPayload
- NurserySummaryPayload
- OrganizationNurserySummaryPayload
- SpeciesSummaryPayload

Add it to these.
Cleanup ordering of activeGrowth in other places.
Add hardeningOff to a few tests that were missing it.