### PR TITLE
SW-7255 Update tf contacts retrieval to return all

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
@@ -61,8 +61,12 @@ class AcceleratorOrganizationsController(
 
     return ListAcceleratorOrganizationsResponsePayload(
         organizations.map { (organization, projects) ->
+          val contacts = userStore.getTerraformationContactUsers(organization.id)
           AcceleratorOrganizationPayload(
-              organization, projects, userStore.getTerraformationContactUser(organization.id))
+              organization,
+              projects,
+              contacts,
+          )
         })
   }
 
@@ -104,17 +108,19 @@ data class AcceleratorOrganizationPayload(
     val id: OrganizationId,
     val name: String,
     val projects: List<AcceleratorProjectPayload>,
-    val tfContactUser: TerraformationContactUserPayload?,
+    val tfContactUser: TerraformationContactUserPayload?, // for backwards compatibility
+    val tfContactUsers: List<TerraformationContactUserPayload> = emptyList(),
 ) {
   constructor(
       model: OrganizationModel,
       projects: List<ExistingProjectModel>,
-      tfContactUser: IndividualUser? = null,
+      tfContactUsers: List<IndividualUser> = emptyList(),
   ) : this(
       model.id,
       model.name,
       projects.map { AcceleratorProjectPayload(it) },
-      tfContactUser?.let { TerraformationContactUserPayload(it) },
+      tfContactUsers.firstOrNull()?.let { TerraformationContactUserPayload(it) },
+      tfContactUsers.map { TerraformationContactUserPayload(it) },
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/AcceleratorOrganizationsController.kt
@@ -62,11 +62,7 @@ class AcceleratorOrganizationsController(
     return ListAcceleratorOrganizationsResponsePayload(
         organizations.map { (organization, projects) ->
           val contacts = userStore.getTerraformationContactUsers(organization.id)
-          AcceleratorOrganizationPayload(
-              organization,
-              projects,
-              contacts,
-          )
+          AcceleratorOrganizationPayload(organization, projects, contacts)
         })
   }
 

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
@@ -48,11 +48,8 @@ class AdminOrganizationsController(
     val facilities = facilityStore.fetchByOrganizationId(organizationId)
     val plantingSites = plantingSiteStore.fetchSitesByOrganizationId(organizationId)
     val reports = seedFundReportStore.fetchMetadataByOrganization(organizationId)
-    val tfContactUserId = organizationStore.fetchTerraformationContact(organizationId)
-    val tfContact = if (tfContactUserId != null) userStore.fetchOneById(tfContactUserId) else null
     val isSuperAdmin = GlobalRole.SuperAdmin in currentUser().globalRoles
 
-    model.addAttribute("canAssignTerraformationContact", isSuperAdmin)
     model.addAttribute("canCreateFacility", currentUser().canCreateFacility(organization.id))
     model.addAttribute(
         "canCreatePlantingSite", currentUser().canCreatePlantingSite(organization.id))
@@ -65,7 +62,6 @@ class AdminOrganizationsController(
     model.addAttribute("organization", organization)
     model.addAttribute("plantingSites", plantingSites)
     model.addAttribute("reports", reports)
-    model.addAttribute("terraformationContact", tfContact)
 
     return "/admin/organization"
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -647,11 +647,8 @@ class AppNotificationService(
               .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
               .toMutableSet()
 
-      val tfContact = userStore.getTerraformationContactUser(organizationId)
-
-      if (tfContact != null) {
-        recipients.add(tfContact)
-      }
+      val tfContacts = userStore.getTerraformationContactUsers(organizationId)
+      tfContacts.forEach { recipients.add(it) }
 
       dslContext.transaction { _ ->
         recipients.forEach { user ->

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -527,8 +527,8 @@ class OrganizationStore(
     return Role.entries.associateWith { countByRoleId[it] ?: 0 }
   }
 
-  /** Fetches the Terraformation Contact role user in an organization, if one exists. */
-  fun fetchTerraformationContact(organizationId: OrganizationId): UserId? {
+  /** Fetches the Terraformation Contact role users in an organization, if one exists. */
+  fun fetchTerraformationContacts(organizationId: OrganizationId): List<UserId> {
     requirePermissions { listOrganizationUsers(organizationId) }
     return dslContext
         .select(ORGANIZATION_USERS.USER_ID)
@@ -536,8 +536,8 @@ class OrganizationStore(
         .where(ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId))
         .and(ORGANIZATION_USERS.ROLE_ID.eq(Role.TerraformationContact))
         .orderBy(ORGANIZATION_USERS.USER_ID)
-        .limit(1)
-        .fetchOne(ORGANIZATION_USERS.USER_ID)
+        .fetch(ORGANIZATION_USERS.USER_ID)
+        .filterNotNull()
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationStore.kt
@@ -536,8 +536,7 @@ class OrganizationStore(
         .where(ORGANIZATION_USERS.ORGANIZATION_ID.eq(organizationId))
         .and(ORGANIZATION_USERS.ROLE_ID.eq(Role.TerraformationContact))
         .orderBy(ORGANIZATION_USERS.USER_ID)
-        .fetch(ORGANIZATION_USERS.USER_ID)
-        .filterNotNull()
+        .fetch(ORGANIZATION_USERS.USER_ID.asNonNullable())
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -308,6 +308,10 @@ class UserStore(
         ?: throw UserNotFoundException(userId)
   }
 
+  fun fetchManyById(userIds: Collection<UserId>): List<TerrawareUser> {
+    return usersDao.fetchById(*userIds.toTypedArray()).map { rowToModel(it) }
+  }
+
   /** Returns the details for the user with a given user ID, if they have permission to do so. */
   fun fetchOneByIdAccelerator(userId: UserId): TerrawareUser {
     requirePermissions { readUser(userId) }
@@ -728,11 +732,13 @@ class UserStore(
     }
   }
 
-  /** Returns TF contact for an organization */
-  fun getTerraformationContactUser(organizationId: OrganizationId): IndividualUser? {
-    val tfContactId = organizationStore.fetchTerraformationContact(organizationId) ?: return null
-    return fetchOneById(tfContactId) as? IndividualUser
-        ?: throw IllegalArgumentException("Terraformation Contact user must be an individual user")
+  /** Returns TF contacts for an organization */
+  fun getTerraformationContactUsers(organizationId: OrganizationId): List<IndividualUser> {
+    val tfContactIds = organizationStore.fetchTerraformationContacts(organizationId)
+    return fetchManyById(tfContactIds).map { user ->
+      user as? IndividualUser
+          ?: throw IllegalArgumentException("Terraformation Contact users must be individual users")
+    }
   }
 
   private fun rowToIndividualUser(usersRow: UsersRow): IndividualUser {

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -848,9 +848,9 @@ class EmailNotificationService(
       model: EmailTemplateModel,
       fallBackToSupport: Boolean = true,
   ) {
-    val user = userStore.getTerraformationContactUser(organization.id)
-    if (user != null) {
-      emailService.sendUserNotification(user, model, false)
+    val users = userStore.getTerraformationContactUsers(organization.id)
+    if (users.isNotEmpty()) {
+      users.forEach { emailService.sendUserNotification(it, model, false) }
     } else if (fallBackToSupport && InternalTagIds.Accelerator in organization.internalTags) {
       emailService.sendSupportNotification(model)
       emailService.sendSupportNotification(
@@ -880,14 +880,12 @@ class EmailNotificationService(
               .fetchWithGlobalRoles(setOf(GlobalRole.TFExpert), internalInterestCondition)
               .toMutableSet()
 
-      val tfContact = userStore.getTerraformationContactUser(organizationId)
+      val tfContacts = userStore.getTerraformationContactUsers(organizationId)
 
-      // The TF contact will not have access to the accelerator console, this email notification
-      // gives the contact an opportunity to acquire global roles. Ideally we won't be sending
+      // The TF contacts will not have access to the accelerator console, this email notification
+      // gives the contacts an opportunity to acquire global roles. Ideally we won't be sending
       // these emails.
-      if (tfContact != null) {
-        recipients.add(tfContact)
-      }
+      tfContacts.forEach { recipients.add(it) }
 
       recipients.forEach { user -> emailService.sendUserNotification(user, model, false) }
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.InvalidTerraformationContactEmail
 import com.terraformation.backend.db.OrganizationHasOtherUsersException
 import com.terraformation.backend.db.UserNotFoundForEmailException
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationUsersRow
 import com.terraformation.backend.db.default_schema.tables.pojos.OrganizationsRow
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationUsersRecord
@@ -303,8 +304,8 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     val organizationId = insertOrganization()
 
     assertEquals(
-        0,
-        organizationStore.fetchTerraformationContacts(organizationId).size,
+        emptyList<UserId>(),
+        organizationStore.fetchTerraformationContacts(organizationId),
         "Should not find Terraformation Contacts")
 
     every { user.canAddTerraformationContact(organizationId) } returns true

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -41,7 +41,6 @@ import org.jobrunr.scheduling.JobScheduler
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -303,17 +302,18 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
     insertUser(email = "tfcontact@terraformation.com")
     val organizationId = insertOrganization()
 
-    assertNull(
-        organizationStore.fetchTerraformationContact(organizationId),
-        "Should not find a Terraformation Contact")
+    assertEquals(
+        0,
+        organizationStore.fetchTerraformationContacts(organizationId).size,
+        "Should not find Terraformation Contacts")
 
     every { user.canAddTerraformationContact(organizationId) } returns true
 
     val result = service.assignTerraformationContact("tfcontact@terraformation.com", organizationId)
     assertNotNull(result, "Should have a valid result")
     assertEquals(
-        organizationStore.fetchTerraformationContact(organizationId),
-        result,
+        organizationStore.fetchTerraformationContacts(organizationId),
+        listOf(result),
         "Should find a matching Terraformation Contact")
   }
 
@@ -332,13 +332,16 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
         service.assignTerraformationContact("tfcontactnew@terraformation.com", organizationId)
     assertNotNull(newContactId, "Should have a valid new result")
     assertEquals(
-        organizationStore.fetchTerraformationContact(organizationId),
-        initialContactId,
-        "Should find a matching Terraformation Contact")
+        organizationStore.fetchTerraformationContacts(organizationId),
+        listOf(initialContactId, newContactId),
+        "Should find all matching Terraformation Contacts")
 
     val contact = organizationStore.fetchUser(organizationId, newContactId)
     assertEquals(
         Role.TerraformationContact, contact.role, "Should have Terraformation Contact role")
+    val newContact = organizationStore.fetchUser(organizationId, newContactId)
+    assertEquals(
+        Role.TerraformationContact, newContact.role, "Should have Terraformation Contact role")
   }
 
   @Test
@@ -359,12 +362,15 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
         service.assignTerraformationContact("admin@terraformation.com", organizationId)
     assertEquals(adminUserId, reassignedUserId, "Should reassign role on existing user")
     assertEquals(
-        organizationStore.fetchTerraformationContact(organizationId),
-        initialContactId,
-        "Should find a matching Terraformation Contact")
+        organizationStore.fetchTerraformationContacts(organizationId),
+        listOf(initialContactId, reassignedUserId),
+        "Should find all matching Terraformation Contacts")
 
     val contact = organizationStore.fetchUser(organizationId, initialContactId)
     assertEquals(
         Role.TerraformationContact, contact.role, "Should have Terraformation Contact role")
+    val reassigned = organizationStore.fetchUser(organizationId, reassignedUserId)
+    assertEquals(
+        Role.TerraformationContact, reassigned.role, "Should have Terraformation Contact role")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -592,25 +592,25 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  fun `fetchTerraformationContact returns the user id of Terraformation Contact`() {
+  fun `fetchTerraformationContacts returns the user id of Terraformation Contact`() {
     assertEquals(
-        null,
-        store.fetchTerraformationContact(organizationId),
+        0,
+        store.fetchTerraformationContacts(organizationId).size,
         "Should not find a Terraformation Contact")
 
     val tfContact = configureUser(organizationUserModel(role = Role.TerraformationContact))
 
     assertEquals(
-        tfContact.userId,
-        store.fetchTerraformationContact(organizationId),
-        "Should find a Terraformation Contact")
+        listOf(tfContact.userId),
+        store.fetchTerraformationContacts(organizationId),
+        "Should find the Terraformation Contact")
   }
 
   @Test
-  fun `fetchTerraformationContact throws exception if no permission to list organization users`() {
+  fun `fetchTerraformationContacts throws exception if no permission to list organization users`() {
     every { user.canListOrganizationUsers(organizationId) } returns false
 
-    assertThrows<AccessDeniedException> { store.fetchTerraformationContact(organizationId) }
+    assertThrows<AccessDeniedException> { store.fetchTerraformationContacts(organizationId) }
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -594,8 +594,8 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `fetchTerraformationContacts returns the user id of Terraformation Contact`() {
     assertEquals(
-        0,
-        store.fetchTerraformationContacts(organizationId).size,
+        emptyList<UserId>(),
+        store.fetchTerraformationContacts(organizationId),
         "Should not find a Terraformation Contact")
 
     val tfContact = configureUser(organizationUserModel(role = Role.TerraformationContact))

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -907,22 +907,29 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns terraformation contact user if one exists`() {
+    fun `returns terraformation contact users if any exists`() {
       every { user.canListOrganizationUsers(any()) } returns true
 
-      val tfContact =
-          insertUser(email = "tfcontact@terraformation.com", emailNotificationsEnabled = true)
+      val tfContact1 =
+          insertUser(email = "tfcontact1@terraformation.com", emailNotificationsEnabled = true)
+      val tfContact2 =
+          insertUser(email = "tfcontact2@terraformation.com", emailNotificationsEnabled = true)
 
-      insertOrganizationUser(tfContact, role = Role.TerraformationContact)
+      insertOrganizationUser(tfContact1, role = Role.TerraformationContact)
+      insertOrganizationUser(tfContact2, role = Role.TerraformationContact)
+
       assertEquals(
-          userStore.getTerraformationContactUser(organizationId)?.email,
-          "tfcontact@terraformation.com")
+          userStore.getTerraformationContactUsers(organizationId).map { it.email },
+          listOf("tfcontact1@terraformation.com", "tfcontact2@terraformation.com"))
     }
 
     @Test
-    fun `returns no terraformation contact user if one does not exist`() {
+    fun `returns no terraformation contact users if one does not exist`() {
       every { user.canListOrganizationUsers(any()) } returns true
-      assertNull(userStore.getTerraformationContactUser(organizationId))
+      assertEquals(
+          userStore.getTerraformationContactUsers(organizationId).size,
+          0,
+          "Should be no Terraformation Contact users")
     }
   }
 


### PR DESCRIPTION
Change `getTerraformationContactUser` to `getTerraformationContactUsers`.
Change `fetchTerraformationContact` to `fetchTerraformationContacts`.
Update usages and tests.

Return `tfContactUsers` list in `AcceleratorOrganizationPayload`.

Remove TF contact attributes from Admin Org controller since no longer used.
