### PR TITLE
Cleanup n+1 query to fetchMany

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminVotersController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminVotersController.kt
@@ -51,9 +51,10 @@ class AdminVotersController(
 
     val defaultVoters = defaultVoterStore.findAll()
     val users =
-        defaultVoters
-            .union(projectVoters.values.reduce { acc, userIds -> acc.union(userIds) })
-            .map { userStore.fetchOneById(it) }
+        userStore
+            .fetchManyById(
+                defaultVoters.union(
+                    projectVoters.values.reduce { acc, userIds -> acc.union(userIds) }))
             .associateBy { it.userId }
 
     model.addAttribute("selectedEmail", email)


### PR DESCRIPTION
The previous PR added `UserStore.fetchManyById`. In most usages of `UserStore.fetchOneById` we are only retrieving one user, but the AdminVotersController was retrieving a user per userId in a set. 
Clean this up by using the new `fetchManyById`.