### PR TITLE
SW-7265 Add Admin UI to Delete Org Users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -75,6 +75,8 @@ class AdminController(
     model.addAttribute(
         "canRecalculatePopulations", GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute(
+        "canRemoveOrganizationUser", GlobalRole.SuperAdmin in currentUser().globalRoles)
+    model.addAttribute(
         "canSendTestEmail",
         config.email.enabled && GlobalRole.SuperAdmin in currentUser().globalRoles)
     model.addAttribute("canSetTestClock", config.useTestClock && currentUser().canSetTestClock())

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
@@ -94,5 +94,26 @@ class AdminOrganizationsController(
     return redirectToAdminHome()
   }
 
+  @PostMapping("/removeOrganizationUser")
+  fun removeOrganizationUser(
+      @RequestParam organizationId: OrganizationId,
+      @NotBlank @RequestParam email: String,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      val user = userStore.fetchByEmail(email)
+      if (user != null) {
+        organizationStore.removeUser(organizationId, user.userId)
+      } else {
+        redirectAttributes.failureMessage = "User $email does not exist"
+      }
+    } catch (e: Exception) {
+      log.warn("Failed to remove user from organization", e)
+      redirectAttributes.failureMessage = "Removing user failed: ${e.message}"
+    }
+
+    return redirectToAdminHome()
+  }
+
   private fun redirectToAdminHome() = "redirect:/admin/"
 }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminOrganizationsController.kt
@@ -104,6 +104,8 @@ class AdminOrganizationsController(
       val user = userStore.fetchByEmail(email)
       if (user != null) {
         organizationStore.removeUser(organizationId, user.userId)
+        redirectAttributes.successMessage =
+            "User ${user.userId} removed from organization $organizationId"
       } else {
         redirectAttributes.failureMessage = "User $email does not exist"
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -543,7 +543,8 @@ data class IndividualUser(
   override fun canRegenerateAllDeviceManagerTokens() = isSuperAdmin()
 
   override fun canRemoveOrganizationUser(organizationId: OrganizationId, userId: UserId): Boolean {
-    return isMember(organizationId) && (userId == this.userId || isAdminOrHigher(organizationId))
+    return isSuperAdmin() ||
+        (isMember(organizationId) && (userId == this.userId || isAdminOrHigher(organizationId)))
   }
 
   override fun canRemoveTerraformationContact(organizationId: OrganizationId) = isTFExpertOrHigher()

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -149,6 +149,22 @@
         </form>
     </th:block>
 
+    <th:block th:if="${canRemoveOrganizationUser}">
+        <h2>Remove Organization User</h2>
+
+        <form method="POST" action="/admin/removeOrganizationUser">
+            <label for="removeOrgUserEmail">Email (user must already exist)</label>
+            <input id="removeOrgUserEmail" type="email" name="email" required/>
+            <label for="removeOrgUserOrganizationId">Organization</label>
+            <select id="removeOrgUserOrganizationId" name="organizationId">
+                <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
+                        th:text="|${organization.name} (${organization.id})|">
+                    My Org (123)
+                </option>
+            </select>
+            <input type="submit" value="Remove User from Org"/>
+        </form>
+    </th:block>
 
     <th:block th:if="${canDeleteUsers}">
         <h2>Delete User</h2>

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -1764,6 +1764,8 @@ internal class PermissionTest : DatabaseTest() {
         readOrganization = true,
         readOrganizationDeliverables = true,
         readOrganizationUser = true,
+        removeOrganizationSelf = true,
+        removeOrganizationUser = true,
         removeTerraformationContact = true,
     )
 


### PR DESCRIPTION
We've never had a way to delete users from organizations that they don't belong to. Now that orgs can have multiple TF Contacts, these can start to pile up in an org because adding a new one no longer replaces the old one.
Add a section to the Admin UI (and corresponding endpoint) to delete users from an organization, only for Super Admins.

Currently this does not allow deleting the user if it's the last user in an org, but this may be added if product prefers.