### PR TITLE
Make notReadyQuantityWithdrawn optional in BatchWithdrawalPayload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -205,7 +205,7 @@ data class BatchWithdrawalPayload(
       )
 
   val notReadyQuantityWithdrawn:
-      Int? // for backwards compatibility in response payloads. Make it optional so that request
+      Int? // for backwards compatibility in response payloads. This is optional so that request
     // payloads don't require it
     get() = activeGrowthQuantityWithdrawn
 }

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -204,7 +204,9 @@ data class BatchWithdrawalPayload(
           readyQuantityWithdrawn = readyQuantityWithdrawn,
       )
 
-  val notReadyQuantityWithdrawn: Int // for backwards compatibility in response payloads
+  val notReadyQuantityWithdrawn:
+      Int? // for backwards compatibility in response payloads. Make it optional so that request
+    // payloads don't require it
     get() = activeGrowthQuantityWithdrawn
 }
 


### PR DESCRIPTION
`BatchWithdrawalPayload` has a getter for `notReadyQuantityWithdrawn` to support backwards compatibility in response payloads (and `JsonAlias` for request payloads). Unfortunately, the `generated-schema.ts` file doesn't know that the getter is only going to be on the response, and the property is not required for the request.

Make the property optional so that `generated-schema.ts` correctly shows it as optional, allowing the renaming of the property to get completed.

(Note that this temporary getter will need to stay in place for backwards compatibility for a few months in order for mobile to update and get all users on the latest version.)