### PR TITLE
Remove unnecessary left joins from sublist filtering

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceSublistSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceSublistSearchTest.kt
@@ -12,10 +12,8 @@ import com.terraformation.backend.search.SearchSortField
 import java.time.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-@Disabled("Disabled until aliases on subfilters works")
 internal class SearchServiceSublistSearchTest : SearchServiceTest() {
   val epochPlusOne: LocalDate = LocalDate.EPOCH.plusDays(1)
   val epochPlusTwo: LocalDate = LocalDate.EPOCH.plusDays(2)


### PR DESCRIPTION
When aliases were added to sublists in the search api, they can cause queries to take 2 orders of magnitude longer, which sometimes causes health checks to fail and connections to reset. Aliasing on sublist tables was removed in https://github.com/terraware/terraware-server/pull/3309 to fix this, but this causes sublist filtering to not be possible, thus breaking the Matrix View which is the first (and currently only) usage of sublist filtering. However sublist filtering actually only needed aliasing because of an extra left join on the same table that is being queried. 
Remove this unnecessary left join, only for sublist filtering.