### PR TITLE
SW-7263 Include Used Up in accession summary stats

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/AccessionStore.kt
@@ -899,21 +899,13 @@ class AccessionStore(
             .select(ACCESSIONS.STATE_ID, DSL.count())
             .from(ACCESSIONS)
             .where(condition)
-            .and(ACCESSIONS.STATE_ID.`in`(AccessionState.activeValues))
             .groupBy(ACCESSIONS.STATE_ID)
 
-    val sql = query.getSQL(ParamType.INLINED)
-
-    val totals =
-        log.debugWithTiming("Accession state summary query: $sql") {
-          query.fetchMap(ACCESSIONS.STATE_ID, DSL.count())
-        }
+    val totals = query.fetchMap(ACCESSIONS.STATE_ID, DSL.count())
 
     // The query results won't include states with no accessions, but we want to return the full
     // list with counts of 0.
-    return AccessionState.activeValues
-        .filter { it.isV2Compatible }
-        .associateWith { totals[it] ?: 0 }
+    return AccessionState.entries.filter { it.isV2Compatible }.associateWith { totals[it] ?: 0 }
   }
 
   fun getSummaryStatistics(facilityId: FacilityId): AccessionSummaryStatistics {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreSummaryTest.kt
@@ -52,6 +52,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
             AccessionState.Drying to 2,
             AccessionState.InStorage to 3,
             AccessionState.Processing to 0,
+            AccessionState.UsedUp to 2,
         ),
         store.countByState(facilityId),
         "Counts for single facility")
@@ -63,6 +64,7 @@ internal class AccessionStoreSummaryTest : AccessionStoreTest() {
             AccessionState.Drying to 2,
             AccessionState.InStorage to 3,
             AccessionState.Processing to 2,
+            AccessionState.UsedUp to 3,
         ),
         store.countByState(organizationId),
         "Counts for organization")


### PR DESCRIPTION
`GET /api/v1/seedbank/summary` previously only returned accession counts for
"active" statuses, but we want to start showing the total number of Used Up
accessions for a facility in the web app. Remove the filter on statuses.

We were logging the SQL and the query execution time for the counts-by-status
query; remove that logging since we can get that data from the database server
logs.