### PR TITLE
Update Internal Users api to combine calls

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.db.UserStore
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
+import com.terraformation.backend.customer.model.ProjectInternalUserModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.accelerator.CohortId
 import com.terraformation.backend.db.accelerator.CohortPhase
@@ -149,26 +150,11 @@ class ProjectsController(
 
   @Operation(summary = "Assign a user with global roles with an internal role for a project.")
   @PutMapping("/{id}/internalUsers")
-  fun assignInternalUser(
+  fun updateInternalUser(
       @PathVariable id: ProjectId,
-      @RequestBody payload: AssignProjectInternalUserRequestPayload,
+      @RequestBody payload: UpdateProjectInternalUserRequestPayload,
   ): SimpleSuccessResponsePayload {
-    projectService.addInternalUserRole(id, payload.userId, payload.role, payload.roleName)
-
-    return SimpleSuccessResponsePayload()
-  }
-
-  @Operation(
-      summary = "Remove a user with global roles as an internal user for a project.",
-      description =
-          "Does not remove Terraformation Contact even if assigned role caused them to be added.",
-  )
-  @DeleteMapping("/{id}/internalUsers/{userId}")
-  fun removeInternalUser(
-      @PathVariable id: ProjectId,
-      @PathVariable userId: UserId,
-  ): SimpleSuccessResponsePayload {
-    projectStore.removeInternalUser(id, userId)
+    projectService.updateInternalUsers(id, payload.internalUsers.map { it.toModel() })
 
     return SimpleSuccessResponsePayload()
   }
@@ -212,11 +198,15 @@ data class AssignProjectRequestPayload(
     val plantingSiteIds: List<PlantingSiteId>?,
 )
 
-data class AssignProjectInternalUserRequestPayload(
+data class InternalUserPayload(
     val userId: UserId,
     val role: ProjectInternalRole? = null,
     val roleName: String? = null,
-)
+) {
+  fun toModel() = ProjectInternalUserModel(userId = userId, role = role, roleName = roleName)
+}
+
+data class UpdateProjectInternalUserRequestPayload(val internalUsers: List<InternalUserPayload>)
 
 data class CreateProjectRequestPayload(
     val description: String?,

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -9,14 +9,15 @@ import com.terraformation.backend.customer.event.ProjectInternalUserRemovedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
+import com.terraformation.backend.customer.model.ProjectInternalUserModel
 import com.terraformation.backend.customer.model.ProjectModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNameInUseException
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.ParticipantId
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.db.default_schema.ProjectInternalRole
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.daos.ProjectInternalUsersDao
 import com.terraformation.backend.db.default_schema.tables.daos.ProjectsDao
@@ -27,6 +28,7 @@ import com.terraformation.backend.db.default_schema.tables.references.PROJECT_IN
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.dao.DuplicateKeyException
 
@@ -117,12 +119,7 @@ class ProjectStore(
     }
   }
 
-  fun addInternalUser(
-      projectId: ProjectId,
-      userId: UserId,
-      role: ProjectInternalRole? = null,
-      roleName: String? = null,
-  ) {
+  fun addInternalUsers(projectId: ProjectId, users: Collection<ProjectInternalUserModel>) {
     requirePermissions { updateProjectInternalUsers(projectId) }
 
     val organizationId =
@@ -132,38 +129,45 @@ class ProjectStore(
       with(PROJECT_INTERNAL_USERS) {
         dslContext
             .insertInto(this)
-            .set(PROJECT_ID, projectId)
-            .set(USER_ID, userId)
-            .set(PROJECT_INTERNAL_ROLE_ID, role)
-            .set(ROLE_NAME, roleName)
+            .columns(PROJECT_ID, USER_ID, PROJECT_INTERNAL_ROLE_ID, ROLE_NAME)
+            .apply { users.forEach { values(projectId, it.userId, it.role, it.roleName) } }
             .onConflict(PROJECT_ID, USER_ID)
             .doUpdate()
-            .set(PROJECT_INTERNAL_ROLE_ID, role)
-            .set(ROLE_NAME, roleName)
+            .set(PROJECT_INTERNAL_ROLE_ID, DSL.excluded(PROJECT_INTERNAL_ROLE_ID))
+            .set(ROLE_NAME, DSL.excluded(ROLE_NAME))
             .execute()
 
-        eventPublisher.publishEvent(
-            ProjectInternalUserAddedEvent(projectId, organizationId, userId, role, roleName)
-        )
+        users.forEach { user ->
+          eventPublisher.publishEvent(
+              ProjectInternalUserAddedEvent(
+                  projectId,
+                  organizationId,
+                  user.userId,
+                  user.role,
+                  user.roleName,
+              )
+          )
+        }
       }
     }
   }
 
-  fun removeInternalUser(projectId: ProjectId, userId: UserId) {
+  fun removeInternalUsers(projectId: ProjectId, userIds: Collection<UserId>) {
     requirePermissions { updateProjectInternalUsers(projectId) }
 
     val organizationId =
         parentStore.getOrganizationId(projectId) ?: throw ProjectNotFoundException(projectId)
     dslContext.transaction { _ ->
       with(PROJECT_INTERNAL_USERS) {
-        val rowsDeleted =
+        val userIdsDeleted =
             dslContext
                 .deleteFrom(this)
                 .where(PROJECT_ID.eq(projectId))
-                .and(USER_ID.eq(userId))
-                .execute()
+                .and(USER_ID.`in`(userIds))
+                .returning(USER_ID)
+                .fetch(USER_ID.asNonNullable())
 
-        if (rowsDeleted > 0) {
+        userIdsDeleted.forEach { userId ->
           eventPublisher.publishEvent(
               ProjectInternalUserRemovedEvent(projectId, organizationId, userId)
           )

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -128,8 +128,7 @@ class ProjectStore(
     dslContext.transaction { _ ->
       with(PROJECT_INTERNAL_USERS) {
         dslContext
-            .insertInto(this)
-            .columns(PROJECT_ID, USER_ID, PROJECT_INTERNAL_ROLE_ID, ROLE_NAME)
+            .insertInto(this, PROJECT_ID, USER_ID, PROJECT_INTERNAL_ROLE_ID, ROLE_NAME)
             .apply { users.forEach { values(projectId, it.userId, it.role, it.roleName) } }
             .onConflict(PROJECT_ID, USER_ID)
             .doUpdate()

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectInternalUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectInternalUserModel.kt
@@ -7,4 +7,10 @@ class ProjectInternalUserModel(
     val userId: UserId,
     val role: ProjectInternalRole? = null,
     val roleName: String? = null,
-)
+) {
+  init {
+    if (role == null && roleName == null) {
+      throw IllegalArgumentException("Either role or roleName must be non-null")
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/model/ProjectInternalUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/ProjectInternalUserModel.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.model
+
+import com.terraformation.backend.db.default_schema.ProjectInternalRole
+import com.terraformation.backend.db.default_schema.UserId
+
+class ProjectInternalUserModel(
+    val userId: UserId,
+    val role: ProjectInternalRole? = null,
+    val roleName: String? = null,
+)

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -343,7 +343,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exception if neither role or roleName are specified`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
-      assertThrows<DataIntegrityViolationException> {
+      assertThrows<IllegalArgumentException> {
         store.addInternalUsers(projectId, listOf(ProjectInternalUserModel(user.userId, null, null)))
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.customer.event.ProjectInternalUserRemovedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
+import com.terraformation.backend.customer.model.ProjectInternalUserModel
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -25,6 +26,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.ProjectInternal
 import com.terraformation.backend.db.default_schema.tables.pojos.ProjectsRow
 import com.terraformation.backend.db.default_schema.tables.records.OrganizationUsersRecord
 import com.terraformation.backend.db.default_schema.tables.records.ProjectInternalUsersRecord
+import com.terraformation.backend.db.default_schema.tables.references.PROJECT_INTERNAL_USERS
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -303,22 +305,24 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class AddInternalUser {
+  inner class AddInternalUsers {
     @Test
     fun `throws exception if no permission`() {
       deleteOrganizationUser()
       assertThrows<ProjectNotFoundException> {
-        store.addInternalUser(projectId, user.userId, ProjectInternalRole.ProjectLead)
+        store.addInternalUsers(
+            projectId,
+            listOf(ProjectInternalUserModel(user.userId, ProjectInternalRole.ProjectLead)),
+        )
       }
     }
 
     @Test
     fun `throws exception if no project`() {
       assertThrows<ProjectNotFoundException> {
-        store.addInternalUser(
+        store.addInternalUsers(
             ProjectId(Long.MAX_VALUE),
-            user.userId,
-            ProjectInternalRole.ProjectLead,
+            listOf(ProjectInternalUserModel(user.userId, ProjectInternalRole.ProjectLead)),
         )
       }
     }
@@ -327,7 +331,12 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `throws exception if role and roleName are specified`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       assertThrows<DataIntegrityViolationException> {
-        store.addInternalUser(projectId, user.userId, ProjectInternalRole.ProjectLead, "SomeRole")
+        store.addInternalUsers(
+            projectId,
+            listOf(
+                ProjectInternalUserModel(user.userId, ProjectInternalRole.ProjectLead, "SomeRole")
+            ),
+        )
       }
     }
 
@@ -335,7 +344,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `throws exception if neither role or roleName are specified`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       assertThrows<DataIntegrityViolationException> {
-        store.addInternalUser(projectId, user.userId, null, null)
+        store.addInternalUsers(projectId, listOf(ProjectInternalUserModel(user.userId, null, null)))
       }
     }
 
@@ -344,7 +353,10 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       insertUser() // other user doesn't get added
 
-      store.addInternalUser(projectId, user.userId, ProjectInternalRole.ProjectLead)
+      store.addInternalUsers(
+          projectId,
+          listOf(ProjectInternalUserModel(user.userId, ProjectInternalRole.ProjectLead)),
+      )
 
       assertEquals(
           listOf(ProjectInternalUsersRow(projectId, user.userId, ProjectInternalRole.ProjectLead)),
@@ -363,33 +375,59 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `adds internal user with roleName`() {
+    fun `adds internal users with roleName`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      val userId2 = insertUser()
+      insertUserGlobalRole(role = GlobalRole.ReadOnly)
       insertUser() // other user doesn't get added
 
-      store.addInternalUser(projectId, user.userId, roleName = "TheBestRole")
+      store.addInternalUsers(
+          projectId,
+          listOf(
+              ProjectInternalUserModel(user.userId, roleName = "TheBestRole"),
+              ProjectInternalUserModel(userId2, roleName = "AnotherRole"),
+          ),
+      )
 
       assertEquals(
-          listOf(ProjectInternalUsersRow(projectId, user.userId, roleName = "TheBestRole")),
+          listOf(
+              ProjectInternalUsersRow(projectId, user.userId, roleName = "TheBestRole"),
+              ProjectInternalUsersRow(projectId, userId2, roleName = "AnotherRole"),
+          ),
           store.fetchInternalUsers(projectId),
           "Should have added user to internal users",
       )
-      eventPublisher.assertEventPublished(
-          ProjectInternalUserAddedEvent(
-              projectId,
-              organizationId,
-              user.userId,
-              roleName = "TheBestRole",
+      eventPublisher.assertEventsPublished(
+          listOf(
+              ProjectInternalUserAddedEvent(
+                  projectId,
+                  organizationId,
+                  user.userId,
+                  roleName = "TheBestRole",
+              ),
+              ProjectInternalUserAddedEvent(
+                  projectId,
+                  organizationId,
+                  userId2,
+                  roleName = "AnotherRole",
+              ),
           )
       )
     }
 
     @Test
-    fun `updates role if called more than once`() {
+    fun `updates role if called more than once for the same user`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
 
-      store.addInternalUser(projectId, user.userId, ProjectInternalRole.ProjectLead)
-      store.addInternalUser(projectId, user.userId, ProjectInternalRole.Consultant)
+      store.addInternalUsers(
+          projectId,
+          listOf(ProjectInternalUserModel(user.userId, ProjectInternalRole.ProjectLead)),
+      )
+      // diff role
+      store.addInternalUsers(
+          projectId,
+          listOf(ProjectInternalUserModel(user.userId, ProjectInternalRole.Consultant)),
+      )
 
       assertTableEquals(
           ProjectInternalUsersRecord(
@@ -399,7 +437,11 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       )
 
-      store.addInternalUser(projectId, user.userId, roleName = "A Different Role")
+      // roleName instead of role
+      store.addInternalUsers(
+          projectId,
+          listOf(ProjectInternalUserModel(user.userId, roleName = "A Different Role")),
+      )
 
       assertTableEquals(
           ProjectInternalUsersRecord(
@@ -436,37 +478,40 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
-  inner class RemoveInternalUser {
+  inner class RemoveInternalUsers {
     @Test
     fun `throws exception if no permission`() {
       deleteOrganizationUser()
-      assertThrows<ProjectNotFoundException> { store.removeInternalUser(projectId, user.userId) }
+      assertThrows<ProjectNotFoundException> {
+        store.removeInternalUsers(projectId, listOf(user.userId))
+      }
     }
 
     @Test
     fun `throws exception if no project`() {
       assertThrows<ProjectNotFoundException> {
-        store.removeInternalUser(ProjectId(Long.MAX_VALUE), user.userId)
+        store.removeInternalUsers(ProjectId(Long.MAX_VALUE), listOf(user.userId))
       }
     }
 
     @Test
-    fun `removes internal user with role, doesn't remove TF Contact`() {
+    fun `removes internal users with role, doesn't remove TF Contact`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       deleteOrganizationUser()
       insertOrganizationUser(role = Role.TerraformationContact)
       insertProjectInternalUser(projectId = projectId, role = ProjectInternalRole.ProjectLead)
+      val userId2 = insertUser()
+      insertProjectInternalUser(role = ProjectInternalRole.SocialLead)
 
-      store.removeInternalUser(projectId, user.userId)
+      store.removeInternalUsers(projectId, listOf(user.userId, userId2))
 
-      assertEquals(
-          emptyList<ProjectInternalUsersRow>(),
-          store.fetchInternalUsers(projectId),
-          "Should have no internal users",
-      )
+      assertTableEmpty(PROJECT_INTERNAL_USERS, "Should have no internal users")
 
-      eventPublisher.assertEventPublished(
-          ProjectInternalUserRemovedEvent(projectId, organizationId, user.userId)
+      eventPublisher.assertEventsPublished(
+          listOf(
+              ProjectInternalUserRemovedEvent(projectId, organizationId, user.userId),
+              ProjectInternalUserRemovedEvent(projectId, organizationId, userId2),
+          )
       )
 
       assertTableEquals(
@@ -483,19 +528,24 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `removes internal user with roleName`() {
+    fun `removes internal users with roleName`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
       insertProjectInternalUser(projectId = projectId, roleName = "TheBestRole")
+      val userId2 = insertUser()
+      insertProjectInternalUser(roleName = "AnotherRole")
 
-      store.removeInternalUser(projectId, user.userId)
+      store.removeInternalUsers(projectId, listOf(user.userId, userId2))
 
       assertEquals(
           emptyList<ProjectInternalUsersRow>(),
           store.fetchInternalUsers(projectId),
           "Should have no internal users",
       )
-      eventPublisher.assertEventPublished(
-          ProjectInternalUserRemovedEvent(projectId, organizationId, user.userId)
+      eventPublisher.assertEventsPublished(
+          listOf(
+              ProjectInternalUserRemovedEvent(projectId, organizationId, user.userId),
+              ProjectInternalUserRemovedEvent(projectId, organizationId, userId2),
+          )
       )
     }
 
@@ -503,7 +553,7 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `no event published if user wasn't already on project`() {
       insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
 
-      store.removeInternalUser(projectId, user.userId)
+      store.removeInternalUsers(projectId, listOf(user.userId))
 
       assertEquals(
           emptyList<ProjectInternalUsersRow>(),


### PR DESCRIPTION
As part of FE implementation, it was realized that it would be easier to update internal users with a single endpoint instead of one for adding a single one and removing a single one (especially since updating the role for a user required first calling the endpoint to remove it then calling the endpoint to add it with the new role).
Update the api to accept the full list of users and roles that will be Project Internal Users. Update the service to parse out existing users vs requested users in order to determine which to delete and which to add. For users that need to be updated, add them to both lists.