### PR TITLE
SW-7278 Store t0 plot density for species in plot

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.tracking.db.T0PlotStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -43,5 +44,5 @@ class T0Controller(private val t0PlotStore: T0PlotStore) {
 
 data class AssignT0PlotSpeciesPayload(
     val speciesId: SpeciesId,
-    @Schema(description = "Plants per plot") val plotDensity: Int,
+    @Schema(description = "Plants per plot") val plotDensity: BigDecimal,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -7,7 +7,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.tracking.db.T0PlotStore
 import io.swagger.v3.oas.annotations.Operation
-import java.math.BigDecimal
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -29,16 +29,19 @@ class T0Controller(private val t0PlotStore: T0PlotStore) {
     return SimpleSuccessResponsePayload()
   }
 
-  @Operation(summary = "Assigns a species and estimated density as T0 for a monitoring plot.")
+  @Operation(summary = "Assigns a species and plot density as T0 for a monitoring plot.")
   @PostMapping("/{monitoringPlotId}/species")
   fun assignT0PlotSpeciesDensity(
       @PathVariable monitoringPlotId: MonitoringPlotId,
       @RequestBody payload: AssignT0PlotSpeciesPayload,
   ): SimpleSuccessResponsePayload {
-    t0PlotStore.assignT0PlotSpeciesDensity(monitoringPlotId, payload.speciesId, payload.density)
+    t0PlotStore.assignT0PlotSpeciesDensity(monitoringPlotId, payload.speciesId, payload.plotDensity)
 
     return SimpleSuccessResponsePayload()
   }
 }
 
-data class AssignT0PlotSpeciesPayload(val speciesId: SpeciesId, val density: BigDecimal)
+data class AssignT0PlotSpeciesPayload(
+    val speciesId: SpeciesId,
+    @Schema(description = "Plants per plot") val plotDensity: Int,
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -4,12 +4,14 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
-import com.terraformation.backend.db.tracking.tables.references.T0_PLOT
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATION
 import com.terraformation.backend.tracking.event.T0ObservationAssignedEvent
 import com.terraformation.backend.tracking.event.T0SpeciesDensityAssignedEvent
 import jakarta.inject.Named
-import java.math.BigDecimal
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.springframework.context.ApplicationEventPublisher
 
 @Named
@@ -20,15 +22,38 @@ class T0PlotStore(
   fun assignT0PlotObservation(monitoringPlotId: MonitoringPlotId, observationId: ObservationId) {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    with(T0_PLOT) {
+    with(PLOT_T0_OBSERVATION) {
       dslContext
           .insertInto(this)
           .set(MONITORING_PLOT_ID, monitoringPlotId)
           .set(OBSERVATION_ID, observationId)
-          .onConflict(MONITORING_PLOT_ID)
-          .where(OBSERVATION_ID.isNotNull())
-          .doUpdate()
+          .onDuplicateKeyUpdate()
           .set(OBSERVATION_ID, observationId)
+          .execute()
+    }
+
+    with(PLOT_T0_DENSITY) {
+      // ensure no leftover densities for species that are not in this observation
+      dslContext.deleteFrom(this).where(MONITORING_PLOT_ID.eq(monitoringPlotId)).execute()
+
+      dslContext
+          .insertInto(this, MONITORING_PLOT_ID, SPECIES_ID, PLOT_DENSITY)
+          .select(
+              DSL.select(
+                      OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID,
+                      OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID,
+                      OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_LIVE.plus(
+                          OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD
+                      ),
+                  )
+                  .from(OBSERVED_PLOT_SPECIES_TOTALS)
+                  .where(
+                      OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId)
+                          .and(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(monitoringPlotId))
+                  )
+          )
+          .onDuplicateKeyUpdate()
+          .set(PLOT_DENSITY, DSL.excluded(PLOT_DENSITY))
           .execute()
 
       eventPublisher.publishEvent(
@@ -43,11 +68,11 @@ class T0PlotStore(
   fun assignT0PlotSpeciesDensity(
       monitoringPlotId: MonitoringPlotId,
       speciesId: SpeciesId,
-      density: BigDecimal,
+      plotDensity: Int,
   ) {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    if (density <= BigDecimal.ZERO) {
+    if (plotDensity <= 0) {
       throw IllegalArgumentException("Density must be above zero")
     }
 
@@ -57,31 +82,31 @@ class T0PlotStore(
       )
     }
 
-    with(T0_PLOT) {
+    with(PLOT_T0_DENSITY) {
       dslContext
           .insertInto(this)
           .set(MONITORING_PLOT_ID, monitoringPlotId)
           .set(SPECIES_ID, speciesId)
-          .set(ESTIMATED_PLANTING_DENSITY, density)
+          .set(PLOT_DENSITY, plotDensity)
           .onDuplicateKeyUpdate()
-          .set(ESTIMATED_PLANTING_DENSITY, density)
+          .set(PLOT_DENSITY, plotDensity)
           .execute()
 
       eventPublisher.publishEvent(
           T0SpeciesDensityAssignedEvent(
               monitoringPlotId = monitoringPlotId,
               speciesId = speciesId,
-              density = density,
+              plotDensity = plotDensity,
           )
       )
     }
   }
 
   private fun plotHasObservationT0(monitoringPlotId: MonitoringPlotId) =
-      with(T0_PLOT) {
+      with(PLOT_T0_OBSERVATION) {
         dslContext.fetchExists(
             this,
-            MONITORING_PLOT_ID.eq(monitoringPlotId).and(OBSERVATION_ID.isNotNull),
+            MONITORING_PLOT_ID.eq(monitoringPlotId),
         )
       }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -10,8 +10,10 @@ import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVAT
 import com.terraformation.backend.tracking.event.T0ObservationAssignedEvent
 import com.terraformation.backend.tracking.event.T0SpeciesDensityAssignedEvent
 import jakarta.inject.Named
+import java.math.BigDecimal
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 import org.springframework.context.ApplicationEventPublisher
 
 @Named
@@ -43,8 +45,9 @@ class T0PlotStore(
                       OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID,
                       OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID,
                       OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_LIVE.plus(
-                          OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD
-                      ),
+                              OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD
+                          )
+                          .cast(SQLDataType.NUMERIC),
                   )
                   .from(OBSERVED_PLOT_SPECIES_TOTALS)
                   .where(
@@ -68,11 +71,11 @@ class T0PlotStore(
   fun assignT0PlotSpeciesDensity(
       monitoringPlotId: MonitoringPlotId,
       speciesId: SpeciesId,
-      plotDensity: Int,
+      plotDensity: BigDecimal,
   ) {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    if (plotDensity <= 0) {
+    if (plotDensity <= BigDecimal.ZERO) {
       throw IllegalArgumentException("Density must be above zero")
     }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -76,7 +76,7 @@ class T0PlotStore(
     requirePermissions { updateT0(monitoringPlotId) }
 
     if (plotDensity <= BigDecimal.ZERO) {
-      throw IllegalArgumentException("Density must be above zero")
+      throw IllegalArgumentException("Plot density must be positive")
     }
 
     if (plotHasObservationT0(monitoringPlotId)) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATION
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.tracking.event.T0ObservationAssignedEvent
 import com.terraformation.backend.tracking.event.T0SpeciesDensityAssignedEvent
 import jakarta.inject.Named
@@ -22,7 +22,7 @@ class T0PlotStore(
   fun assignT0PlotObservation(monitoringPlotId: MonitoringPlotId, observationId: ObservationId) {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    with(PLOT_T0_OBSERVATION) {
+    with(PLOT_T0_OBSERVATIONS) {
       dslContext
           .insertInto(this)
           .set(MONITORING_PLOT_ID, monitoringPlotId)
@@ -103,7 +103,7 @@ class T0PlotStore(
   }
 
   private fun plotHasObservationT0(monitoringPlotId: MonitoringPlotId) =
-      with(PLOT_T0_OBSERVATION) {
+      with(PLOT_T0_OBSERVATIONS) {
         dslContext.fetchExists(
             this,
             MONITORING_PLOT_ID.eq(monitoringPlotId),

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -10,6 +10,7 @@ import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
+import java.math.BigDecimal
 import java.time.LocalDate
 
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
@@ -117,7 +118,7 @@ data class PlantingSiteMapEditedEvent(
 )
 
 data class T0SpeciesDensityAssignedEvent(
-    val plotDensity: Int,
+    val plotDensity: BigDecimal,
     val monitoringPlotId: MonitoringPlotId,
     val speciesId: SpeciesId,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
-import java.math.BigDecimal
 import java.time.LocalDate
 
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
@@ -118,7 +117,7 @@ data class PlantingSiteMapEditedEvent(
 )
 
 data class T0SpeciesDensityAssignedEvent(
-    val density: BigDecimal,
+    val plotDensity: Int,
     val monitoringPlotId: MonitoringPlotId,
     val speciesId: SpeciesId,
 )

--- a/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
+++ b/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
@@ -4,7 +4,7 @@ CREATE TABLE tracking.plot_t0_density
 (
     monitoring_plot_id BIGINT  NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
     species_id         BIGINT  NOT NULL REFERENCES species ON DELETE CASCADE,
-    plot_density       INTEGER NOT NULL,
+    plot_density       NUMERIC NOT NULL,
     PRIMARY KEY (monitoring_plot_id, species_id)
 );
 

--- a/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
+++ b/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
@@ -8,7 +8,7 @@ CREATE TABLE tracking.plot_t0_density
     PRIMARY KEY (monitoring_plot_id, species_id)
 );
 
-CREATE TABLE tracking.plot_t0_observation
+CREATE TABLE tracking.plot_t0_observations
 (
     monitoring_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
     observation_id     BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,

--- a/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
+++ b/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
@@ -1,0 +1,16 @@
+DROP TABLE tracking.t0_plot;
+
+CREATE TABLE tracking.plot_t0_density
+(
+    monitoring_plot_id BIGINT  NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
+    species_id         BIGINT  NOT NULL REFERENCES species ON DELETE CASCADE,
+    plot_density       INTEGER NOT NULL,
+    PRIMARY KEY (monitoring_plot_id, species_id)
+);
+
+CREATE TABLE tracking.plot_t0_observation
+(
+    monitoring_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
+    observation_id     BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
+    PRIMARY KEY (monitoring_plot_id)
+);

--- a/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
+++ b/src/main/resources/db/migration/0400/V400__PlotT0Density.sql
@@ -12,5 +12,6 @@ CREATE TABLE tracking.plot_t0_observations
 (
     monitoring_plot_id BIGINT NOT NULL REFERENCES tracking.monitoring_plots ON DELETE CASCADE,
     observation_id     BIGINT NOT NULL REFERENCES tracking.observations ON DELETE CASCADE,
-    PRIMARY KEY (monitoring_plot_id)
+    PRIMARY KEY (monitoring_plot_id),
+    FOREIGN KEY (observation_id, monitoring_plot_id) REFERENCES tracking.observation_plots ON DELETE CASCADE
 );

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -534,7 +534,7 @@ COMMENT ON COLUMN tracking.plantings.planting_subzone_id IS 'Which plot this pla
 COMMENT ON COLUMN tracking.plantings.species_id IS 'Which species was planted.';
 
 COMMENT ON TABLE tracking.plot_t0_density IS 'Density for a plot per species, in plants per plot.';
-COMMENT ON TABLE tracking.plot_t0_observation IS 'Which observation to use to determine t0 plot density.';
+COMMENT ON TABLE tracking.plot_t0_observations IS 'Which observation to use to determine t0 plot density.';
 
 COMMENT ON TABLE tracking.recorded_plant_statuses IS '(Enum) Possible statuses of a plant recorded during observation of a monitoring plot.';
 

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -533,6 +533,9 @@ COMMENT ON COLUMN tracking.plantings.planting_type_id IS 'Whether this is the pl
 COMMENT ON COLUMN tracking.plantings.planting_subzone_id IS 'Which plot this planting affected, if any. Must be a plot at the planting site referenced by `planting_site_id`. Null if the planting site does not have plot information. For reassignments, this is the original plot if `num_plants` is negative, or the new plot if `num_plants` is positive.';
 COMMENT ON COLUMN tracking.plantings.species_id IS 'Which species was planted.';
 
+COMMENT ON TABLE tracking.plot_t0_density IS 'Density for a plot per species, in plants per plot.';
+COMMENT ON TABLE tracking.plot_t0_observation IS 'Which observation to use to determine t0 plot density.';
+
 COMMENT ON TABLE tracking.recorded_plant_statuses IS '(Enum) Possible statuses of a plant recorded during observation of a monitoring plot.';
 
 COMMENT ON TABLE tracking.recorded_plants IS 'Information about individual plants observed in monitoring plots.';
@@ -544,8 +547,6 @@ COMMENT ON COLUMN tracking.recorded_trees.tree_number IS 'A unique incremental n
 COMMENT ON COLUMN tracking.recorded_trees.tree_number IS 'A unique incremental number starting at 1 for accounting trunks at a biomass observation. Defaults to 1 for Trees/Shrubs.';
 
 COMMENT ON TABLE tracking.recorded_species_certainties IS '(Enum) Levels of certainty about the identity of a species recorded in a monitoring plot observation.';
-
-COMMENT ON TABLE tracking.t0_plot IS 'For a given plot, which observation to use as T0 data, or the estimated density for a specific species.';
 
 COMMENT ON TABLE tracking.tree_growth_forms IS '(Enum) Growth form of each species in a biomass observation.';
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -448,7 +448,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonePopulatio
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensityRow
-import com.terraformation.backend.db.tracking.tables.pojos.PlotT0ObservationRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlotT0ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedTreesRow
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
@@ -458,7 +458,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SP
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATION
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.documentproducer.model.StableIds
 import com.terraformation.backend.point
@@ -3268,11 +3268,11 @@ abstract class DatabaseBackedTest {
   }
 
   fun insertPlotT0Observation(
-      row: PlotT0ObservationRow = PlotT0ObservationRow(),
+      row: PlotT0ObservationsRow = PlotT0ObservationsRow(),
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
   ) {
-    with(PLOT_T0_OBSERVATION) {
+    with(PLOT_T0_OBSERVATIONS) {
       dslContext
           .insertInto(this)
           .set(MONITORING_PLOT_ID, monitoringPlotId)

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3255,7 +3255,7 @@ abstract class DatabaseBackedTest {
       row: PlotT0DensityRow = PlotT0DensityRow(),
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
-      plotDensity: Int = row.plotDensity ?: 10,
+      plotDensity: BigDecimal = row.plotDensity ?: BigDecimal.valueOf(10),
   ) {
     with(PLOT_T0_DENSITY) {
       dslContext

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -403,11 +403,12 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "planting_subzone_populations" to setOf(ALL, TRACKING),
                   "planting_subzones" to setOf(ALL, TRACKING),
                   "plantings" to setOf(ALL, TRACKING),
+                  "plot_t0_density" to setOf(ALL, TRACKING),
+                  "plot_t0_observations" to setOf(ALL, TRACKING),
                   "recorded_plant_statuses" to setOf(ALL, TRACKING),
                   "recorded_plants" to setOf(ALL, TRACKING),
                   "recorded_species_certainties" to setOf(ALL, TRACKING),
                   "recorded_trees" to setOf(ALL, TRACKING),
-                  "t0_plot" to setOf(ALL, TRACKING),
                   "tree_growth_forms" to setOf(ALL, TRACKING),
               ),
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -15,7 +15,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.records.PlotT0DensityRecord
-import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationRecord
+import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.event.T0ObservationAssignedEvent
@@ -80,7 +80,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(
           listOf(
-              PlotT0ObservationRecord(
+              PlotT0ObservationsRecord(
                   monitoringPlotId = monitoringPlotId,
                   observationId = observationId,
               )
@@ -122,7 +122,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(
           listOf(
-              PlotT0ObservationRecord(
+              PlotT0ObservationsRecord(
                   monitoringPlotId = monitoringPlotId,
                   observationId = secondObservationId,
               )
@@ -173,7 +173,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(
           listOf(
-              PlotT0ObservationRecord(
+              PlotT0ObservationsRecord(
                   monitoringPlotId = monitoringPlotId,
                   observationId = observationId,
               ),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -57,6 +57,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     plantingSubzoneId = insertPlantingSubzone()
     monitoringPlotId = insertMonitoringPlot()
     observationId = insertObservation()
+    insertObservationPlot()
     speciesId1 = insertSpecies()
     speciesId2 = insertSpecies()
   }
@@ -116,6 +117,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `updates existing T0 plot record when monitoring plot already exists`() {
       insertObservedPlotSpeciesTotals(totalLive = 1, totalDead = 1)
       val secondObservationId = insertObservation(plantingSiteId = plantingSiteId)
+      insertObservationPlot()
       insertObservedPlotSpeciesTotals(totalLive = 2, totalDead = 2)
 
       store.assignT0PlotObservation(monitoringPlotId, observationId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.event.T0ObservationAssignedEvent
 import com.terraformation.backend.tracking.event.T0SpeciesDensityAssignedEvent
+import java.math.BigDecimal
 import kotlin.lazy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -92,12 +93,12 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotT0DensityRecord(
                   monitoringPlotId = monitoringPlotId,
                   speciesId = speciesId1,
-                  plotDensity = 3,
+                  plotDensity = BigDecimal.valueOf(3),
               ),
               PlotT0DensityRecord(
                   monitoringPlotId = monitoringPlotId,
                   speciesId = speciesId2,
-                  plotDensity = 7,
+                  plotDensity = BigDecimal.valueOf(7),
               ),
           ),
           "Should insert species densities",
@@ -134,7 +135,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotT0DensityRecord(
                   monitoringPlotId = monitoringPlotId,
                   speciesId = speciesId2,
-                  plotDensity = 4,
+                  plotDensity = BigDecimal.valueOf(4),
               ),
           ),
           "Should use final species density",
@@ -157,7 +158,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `observation overrides previous density`() {
       insertObservedPlotSpeciesTotals(totalLive = 1, totalDead = 1)
-      insertPlotT0Density(plotDensity = 1)
+      insertPlotT0Density(plotDensity = BigDecimal.ONE)
       store.assignT0PlotObservation(monitoringPlotId, observationId)
 
       assertTableEquals(
@@ -165,7 +166,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotT0DensityRecord(
                   monitoringPlotId = monitoringPlotId,
                   speciesId = speciesId2,
-                  plotDensity = 2,
+                  plotDensity = BigDecimal.TWO,
               ),
           ),
           "Should use observation for density",
@@ -194,8 +195,8 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `removes species densities not in observation`() {
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 1)
-      insertPlotT0Density(speciesId = speciesId1, plotDensity = 10)
-      insertPlotT0Density(speciesId = speciesId2, plotDensity = 20)
+      insertPlotT0Density(speciesId = speciesId1, plotDensity = BigDecimal.TEN)
+      insertPlotT0Density(speciesId = speciesId2, plotDensity = BigDecimal.valueOf(20))
       store.assignT0PlotObservation(monitoringPlotId, observationId)
 
       assertTableEquals(
@@ -203,7 +204,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               PlotT0DensityRecord(
                   monitoringPlotId = monitoringPlotId,
                   speciesId = speciesId1,
-                  plotDensity = 2,
+                  plotDensity = BigDecimal.TWO,
               )
           ),
           "Should have deleted density for species not in observation",
@@ -219,13 +220,13 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertOrganizationUser(role = Role.Contributor)
 
       assertThrows<AccessDeniedException> {
-        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, 10)
+        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, BigDecimal.TEN)
       }
     }
 
     @Test
     fun `inserts new T0 plot record with species and density`() {
-      val density = 12
+      val density = BigDecimal.valueOf(12)
 
       store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, density)
 
@@ -251,8 +252,8 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `updates existing T0 plot record when monitoring plot and species already exist`() {
-      val initialDensity = 10
-      val updatedDensity = 15
+      val initialDensity = BigDecimal.TEN
+      val updatedDensity = BigDecimal.valueOf(15)
 
       store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, initialDensity)
       store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, updatedDensity)
@@ -286,8 +287,8 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `allows multiple species for same monitoring plot`() {
-      val density1 = 10
-      val density2 = 20
+      val density1 = BigDecimal.TEN
+      val density2 = BigDecimal.valueOf(20)
 
       store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, density1)
       store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId2, density2)
@@ -327,14 +328,14 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exception for zero density values`() {
       assertThrows<IllegalArgumentException> {
-        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, 0)
+        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, BigDecimal.ZERO)
       }
     }
 
     @Test
     fun `throws exception for negative density values`() {
       assertThrows<IllegalArgumentException> {
-        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, -1)
+        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, BigDecimal.valueOf(-1))
       }
     }
 
@@ -342,7 +343,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `does not allow species density to be set after observation is assigned to plot`() {
       insertPlotT0Observation()
       assertThrows<IllegalStateException> {
-        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, 200)
+        store.assignT0PlotSpeciesDensity(monitoringPlotId, speciesId1, BigDecimal.valueOf(200))
       }
     }
   }


### PR DESCRIPTION
Instead of storing either an observation or multiple species' densities, store a species density always. Use a separate table for storing observations use for t0 data. Calculate density when observations are used by using the total live plus total dead from that observation.

Set plot density to numeric because it will likely be specified in plants per hectare and we want to store in plants per plot.