### PR TITLE
SW-7306 Add endpoint to fetch t0 data for a planting site

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -1,14 +1,18 @@
 package com.terraformation.backend.tracking.api
 
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.model.PlotT0DataModel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -19,8 +23,16 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @TrackingEndpoint
 class T0Controller(private val t0PlotStore: T0PlotStore) {
+  @Operation(summary = "Get all saved T0 Data for a planting site")
+  @GetMapping("/site/{plantingSiteId}")
+  fun getT0SiteData(@PathVariable plantingSiteId: PlantingSiteId): SiteT0DataPayload {
+    val plotData = t0PlotStore.fetchT0SiteData(plantingSiteId)
+
+    return SiteT0DataPayload(plantingSiteId, plotData.map { PlotT0DataPayload(it) })
+  }
+
   @Operation(summary = "Assigns an observation as T0 for a monitoring plot.")
-  @PostMapping("/{monitoringPlotId}/observation/{observationId}")
+  @PostMapping("/plot/{monitoringPlotId}/observation/{observationId}")
   fun assignT0PlotObservation(
       @PathVariable monitoringPlotId: MonitoringPlotId,
       @PathVariable observationId: ObservationId,
@@ -31,7 +43,7 @@ class T0Controller(private val t0PlotStore: T0PlotStore) {
   }
 
   @Operation(summary = "Assigns a species and plot density as T0 for a monitoring plot.")
-  @PostMapping("/{monitoringPlotId}/species")
+  @PostMapping("/plot/{monitoringPlotId}/species")
   fun assignT0PlotSpeciesDensity(
       @PathVariable monitoringPlotId: MonitoringPlotId,
       @RequestBody payload: AssignT0PlotSpeciesPayload,
@@ -41,6 +53,27 @@ class T0Controller(private val t0PlotStore: T0PlotStore) {
     return SimpleSuccessResponsePayload()
   }
 }
+
+data class PlotT0DataPayload(
+    val monitoringPlotId: MonitoringPlotId,
+    val speciesId: SpeciesId,
+    val plotDensity: BigDecimal,
+    val observationId: ObservationId? = null,
+) {
+  constructor(
+      model: PlotT0DataModel
+  ) : this(
+      monitoringPlotId = model.monitoringPlotId,
+      speciesId = model.speciesId,
+      plotDensity = model.plotDensity,
+      observationId = model.observationId,
+  )
+}
+
+data class SiteT0DataPayload(
+    val plantingSiteId: PlantingSiteId,
+    val plots: List<PlotT0DataPayload> = emptyList(),
+) : SuccessResponsePayload
 
 data class AssignT0PlotSpeciesPayload(
     val speciesId: SpeciesId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
@@ -1,0 +1,13 @@
+package com.terraformation.backend.tracking.model
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import java.math.BigDecimal
+
+data class PlotT0DataModel(
+    val monitoringPlotId: MonitoringPlotId,
+    val speciesId: SpeciesId,
+    val plotDensity: BigDecimal,
+    val observationId: ObservationId? = null,
+)


### PR DESCRIPTION
The survival rate settings page needs to display all monitoring plots in the site and their t0 data. Add an endpoint to retrieve all monitoring plots that have t0 data.