### PR TITLE
SW-7306 Fetch Data grouped by monitoring plots, assign multiple monitoring plots at once

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.model.PlotT0DataModel
+import jakarta.inject.Named
+
+@Named
+class T0PlotService(
+    private val t0PlotStore: T0PlotStore,
+) {
+  fun assignT0PlotsData(plotsList: List<PlotT0DataModel>) {
+    plotsList.forEach {
+      if (it.observationId == null) {
+        t0PlotStore.assignT0PlotSpeciesDensities(it.monitoringPlotId, it.densityData)
+      } else {
+        t0PlotStore.assignT0PlotObservation(it.monitoringPlotId, it.observationId)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
@@ -3,17 +3,21 @@ package com.terraformation.backend.tracking
 import com.terraformation.backend.tracking.db.T0PlotStore
 import com.terraformation.backend.tracking.model.PlotT0DataModel
 import jakarta.inject.Named
+import org.jooq.DSLContext
 
 @Named
 class T0PlotService(
+    private val dslContext: DSLContext,
     private val t0PlotStore: T0PlotStore,
 ) {
   fun assignT0PlotsData(plotsList: List<PlotT0DataModel>) {
-    plotsList.forEach { model ->
-      if (model.observationId == null) {
-        t0PlotStore.assignT0PlotSpeciesDensities(model.monitoringPlotId, model.densityData)
-      } else {
-        t0PlotStore.assignT0PlotObservation(model.monitoringPlotId, model.observationId)
+    dslContext.transaction { _ ->
+      plotsList.forEach { model ->
+        if (model.observationId == null) {
+          t0PlotStore.assignT0PlotSpeciesDensities(model.monitoringPlotId, model.densityData)
+        } else {
+          t0PlotStore.assignT0PlotObservation(model.monitoringPlotId, model.observationId)
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
@@ -9,11 +9,11 @@ class T0PlotService(
     private val t0PlotStore: T0PlotStore,
 ) {
   fun assignT0PlotsData(plotsList: List<PlotT0DataModel>) {
-    plotsList.forEach {
-      if (it.observationId == null) {
-        t0PlotStore.assignT0PlotSpeciesDensities(it.monitoringPlotId, it.densityData)
+    plotsList.forEach { model ->
+      if (model.observationId == null) {
+        t0PlotStore.assignT0PlotSpeciesDensities(model.monitoringPlotId, model.densityData)
       } else {
-        t0PlotStore.assignT0PlotObservation(it.monitoringPlotId, it.observationId)
+        t0PlotStore.assignT0PlotObservation(model.monitoringPlotId, model.observationId)
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -35,7 +35,11 @@ class T0Controller(
     return SiteT0DataPayload(plantingSiteId, plotData.map { PlotT0DataPayload(it) })
   }
 
-  @Operation
+  @Operation(
+      summary = "Assign T0 Data for a planting site",
+      description =
+          "Deletes existing densities in the same plot if they don't appear in the payload.",
+  )
   @PostMapping("/site")
   fun assignT0SiteData(
       @RequestBody payload: SiteT0DataPayload,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -7,10 +7,11 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.tracking.T0PlotService
 import com.terraformation.backend.tracking.db.T0PlotStore
 import com.terraformation.backend.tracking.model.PlotT0DataModel
+import com.terraformation.backend.tracking.model.SpeciesDensityModel
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,7 +23,10 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/tracking/t0")
 @RestController
 @TrackingEndpoint
-class T0Controller(private val t0PlotStore: T0PlotStore) {
+class T0Controller(
+    private val t0PlotService: T0PlotService,
+    private val t0PlotStore: T0PlotStore,
+) {
   @Operation(summary = "Get all saved T0 Data for a planting site")
   @GetMapping("/site/{plantingSiteId}")
   fun getT0SiteData(@PathVariable plantingSiteId: PlantingSiteId): SiteT0DataPayload {
@@ -31,51 +35,54 @@ class T0Controller(private val t0PlotStore: T0PlotStore) {
     return SiteT0DataPayload(plantingSiteId, plotData.map { PlotT0DataPayload(it) })
   }
 
-  @Operation(summary = "Assigns an observation as T0 for a monitoring plot.")
-  @PostMapping("/plot/{monitoringPlotId}/observation/{observationId}")
-  fun assignT0PlotObservation(
-      @PathVariable monitoringPlotId: MonitoringPlotId,
-      @PathVariable observationId: ObservationId,
+  @Operation
+  @PostMapping("/site")
+  fun assignT0SiteData(
+      @RequestBody payload: SiteT0DataPayload,
   ): SimpleSuccessResponsePayload {
-    t0PlotStore.assignT0PlotObservation(monitoringPlotId, observationId)
-
-    return SimpleSuccessResponsePayload()
-  }
-
-  @Operation(summary = "Assigns a species and plot density as T0 for a monitoring plot.")
-  @PostMapping("/plot/{monitoringPlotId}/species")
-  fun assignT0PlotSpeciesDensity(
-      @PathVariable monitoringPlotId: MonitoringPlotId,
-      @RequestBody payload: AssignT0PlotSpeciesPayload,
-  ): SimpleSuccessResponsePayload {
-    t0PlotStore.assignT0PlotSpeciesDensity(monitoringPlotId, payload.speciesId, payload.plotDensity)
+    t0PlotService.assignT0PlotsData(payload.plots.map { it.toModel() })
 
     return SimpleSuccessResponsePayload()
   }
 }
 
-data class PlotT0DataPayload(
-    val monitoringPlotId: MonitoringPlotId,
+data class SpeciesDensityPayload(
     val speciesId: SpeciesId,
     val plotDensity: BigDecimal,
-    val observationId: ObservationId? = null,
 ) {
   constructor(
-      model: PlotT0DataModel
+      model: SpeciesDensityModel
   ) : this(
-      monitoringPlotId = model.monitoringPlotId,
       speciesId = model.speciesId,
       plotDensity = model.plotDensity,
-      observationId = model.observationId,
   )
+
+  fun toModel() = SpeciesDensityModel(speciesId = speciesId, plotDensity = plotDensity)
+}
+
+data class PlotT0DataPayload(
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId? = null,
+    val densityData: List<SpeciesDensityPayload>,
+) {
+  constructor(
+      model: PlotT0DataModel,
+      observationId: ObservationId? = null,
+  ) : this(
+      monitoringPlotId = model.monitoringPlotId,
+      observationId = observationId,
+      densityData = model.densityData.map { SpeciesDensityPayload(it) },
+  )
+
+  fun toModel() =
+      PlotT0DataModel(
+          monitoringPlotId = monitoringPlotId,
+          observationId = observationId,
+          densityData = densityData.map { it.toModel() },
+      )
 }
 
 data class SiteT0DataPayload(
     val plantingSiteId: PlantingSiteId,
     val plots: List<PlotT0DataPayload> = emptyList(),
 ) : SuccessResponsePayload
-
-data class AssignT0PlotSpeciesPayload(
-    val speciesId: SpeciesId,
-    @Schema(description = "Plants per plot") val plotDensity: BigDecimal,
-)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -109,25 +109,23 @@ class T0PlotStore(
       )
     }
 
-    dslContext.transaction { _ ->
-      with(PLOT_T0_DENSITY) {
-        // ensure no leftover densities for species that are not in this request
-        dslContext.deleteFrom(this).where(MONITORING_PLOT_ID.eq(monitoringPlotId)).execute()
+    with(PLOT_T0_DENSITY) {
+      // ensure no leftover densities for species that are not in this request
+      dslContext.deleteFrom(this).where(MONITORING_PLOT_ID.eq(monitoringPlotId)).execute()
 
-        var insertQuery = dslContext.insertInto(this, MONITORING_PLOT_ID, SPECIES_ID, PLOT_DENSITY)
+      var insertQuery = dslContext.insertInto(this, MONITORING_PLOT_ID, SPECIES_ID, PLOT_DENSITY)
 
-        densities.forEach {
-          if (it.plotDensity < BigDecimal.ZERO) {
-            throw IllegalArgumentException("Plot density must not be negative")
-          }
-          insertQuery = insertQuery.values(monitoringPlotId, it.speciesId, it.plotDensity)
+      densities.forEach {
+        if (it.plotDensity < BigDecimal.ZERO) {
+          throw IllegalArgumentException("Plot density must not be negative")
         }
-
-        insertQuery.execute()
+        insertQuery = insertQuery.values(monitoringPlotId, it.speciesId, it.plotDensity)
       }
 
-      eventPublisher.publishEvent(T0PlotDataAssignedEvent(monitoringPlotId = monitoringPlotId))
+      insertQuery.execute()
     }
+
+    eventPublisher.publishEvent(T0PlotDataAssignedEvent(monitoringPlotId = monitoringPlotId))
   }
 
   private fun plotHasObservationT0(monitoringPlotId: MonitoringPlotId) =

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.tracking.event
 
-import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSeasonId
@@ -10,7 +9,6 @@ import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
-import java.math.BigDecimal
 import java.time.LocalDate
 
 /** Published when an organization requests that a monitoring plot be replaced in an observation. */
@@ -117,13 +115,7 @@ data class PlantingSiteMapEditedEvent(
     val monitoringPlotReplacements: ReplacementResult,
 )
 
-data class T0SpeciesDensityAssignedEvent(
-    val plotDensity: BigDecimal,
+data class T0PlotDataAssignedEvent(
     val monitoringPlotId: MonitoringPlotId,
-    val speciesId: SpeciesId,
-)
-
-data class T0ObservationAssignedEvent(
-    val monitoringPlotId: MonitoringPlotId,
-    val observationId: ObservationId,
+    val observationId: ObservationId? = null,
 )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
@@ -5,9 +5,13 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import java.math.BigDecimal
 
-data class PlotT0DataModel(
-    val monitoringPlotId: MonitoringPlotId,
+data class SpeciesDensityModel(
     val speciesId: SpeciesId,
     val plotDensity: BigDecimal,
+)
+
+data class PlotT0DataModel(
+    val monitoringPlotId: MonitoringPlotId,
     val observationId: ObservationId? = null,
+    val densityData: List<SpeciesDensityModel> = emptyList(),
 )

--- a/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
@@ -1,0 +1,109 @@
+package com.terraformation.backend.tracking
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.records.PlotT0DensityRecord
+import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
+import com.terraformation.backend.multiPolygon
+import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.model.PlotT0DataModel
+import com.terraformation.backend.tracking.model.SpeciesDensityModel
+import java.math.BigDecimal
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class T0PlotServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val eventPublisher = TestEventPublisher()
+  private val t0PlotStore: T0PlotStore by lazy { T0PlotStore(dslContext, eventPublisher) }
+  private val service: T0PlotService by lazy { T0PlotService(t0PlotStore) }
+
+  private lateinit var monitoringPlotId1: MonitoringPlotId
+  private lateinit var monitoringPlotId2: MonitoringPlotId
+  private lateinit var observationId: ObservationId
+  private lateinit var speciesId1: SpeciesId
+  private lateinit var speciesId2: SpeciesId
+  private lateinit var speciesId3: SpeciesId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertOrganizationUser(role = Role.Manager)
+    val gridOrigin = point(1)
+    val siteBoundary = multiPolygon(200)
+    insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
+    insertPlantingSiteHistory()
+    insertPlantingZone()
+    insertPlantingSubzone()
+    monitoringPlotId1 = insertMonitoringPlot()
+    observationId = insertObservation()
+    insertObservationPlot()
+    monitoringPlotId2 = insertMonitoringPlot()
+    speciesId1 = insertSpecies()
+    speciesId2 = insertSpecies()
+    speciesId3 = insertSpecies()
+  }
+
+  @Nested
+  inner class AssignT0PlotsData {
+    @Test
+    fun `assigns both observations and species densities in list`() {
+      insertObservedPlotSpeciesTotals(
+          monitoringPlotId = monitoringPlotId1,
+          speciesId = speciesId1,
+          totalLive = 1,
+          totalDead = 1,
+      )
+      insertObservedPlotSpeciesTotals(
+          monitoringPlotId = monitoringPlotId1,
+          speciesId = speciesId2,
+          totalLive = 3,
+          totalDead = 4,
+      )
+      insertObservedPlotSpeciesTotals(
+          monitoringPlotId = monitoringPlotId1,
+          speciesId = speciesId3,
+          totalLive = 5,
+          totalDead = 6,
+      )
+
+      service.assignT0PlotsData(
+          listOf(
+              PlotT0DataModel(monitoringPlotId1, observationId = observationId),
+              PlotT0DataModel(
+                  monitoringPlotId2,
+                  densityData =
+                      listOf(
+                          SpeciesDensityModel(speciesId1, BigDecimal.TEN),
+                          SpeciesDensityModel(speciesId2, BigDecimal.valueOf(20)),
+                      ),
+              ),
+          )
+      )
+
+      assertTableEquals(
+          listOf(PlotT0ObservationsRecord(monitoringPlotId1, observationId)),
+          "Should have inserted one observation",
+      )
+      assertTableEquals(
+          listOf(
+              PlotT0DensityRecord(monitoringPlotId1, speciesId1, BigDecimal.valueOf(2)),
+              PlotT0DensityRecord(monitoringPlotId1, speciesId2, BigDecimal.valueOf(7)),
+              PlotT0DensityRecord(monitoringPlotId1, speciesId3, BigDecimal.valueOf(11)),
+              PlotT0DensityRecord(monitoringPlotId2, speciesId1, BigDecimal.valueOf(10)),
+              PlotT0DensityRecord(monitoringPlotId2, speciesId2, BigDecimal.valueOf(20)),
+          ),
+          "Should have inserted species densities",
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
@@ -25,7 +25,7 @@ internal class T0PlotServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val eventPublisher = TestEventPublisher()
   private val t0PlotStore: T0PlotStore by lazy { T0PlotStore(dslContext, eventPublisher) }
-  private val service: T0PlotService by lazy { T0PlotService(t0PlotStore) }
+  private val service: T0PlotService by lazy { T0PlotService(dslContext, t0PlotStore) }
 
   private lateinit var monitoringPlotId1: MonitoringPlotId
   private lateinit var monitoringPlotId2: MonitoringPlotId


### PR DESCRIPTION
Previously there was discussion about only updating survival rate settings for one monitoring plot at a time, but that was replaced with a single save button for an entire planting site.

Group t0 data fetched for survival rate settings by monitoring plot.
Replace assign-t0-endpoints with single endpoint to assign multiple plots' data in one call, to match designs.