### PR TITLE
SW-7306 Fetch withdrawal densities per species per plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -22,20 +22,25 @@ import com.terraformation.backend.api.getPlainContentType
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.db.default_schema.FacilityId
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
 import com.terraformation.backend.db.nursery.WithdrawalId
 import com.terraformation.backend.db.nursery.WithdrawalPurpose
+import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.nursery.BatchService
 import com.terraformation.backend.nursery.db.BatchStore
+import com.terraformation.backend.nursery.db.NurseryWithdrawalStore
 import com.terraformation.backend.nursery.db.WithdrawalPhotoService
 import com.terraformation.backend.nursery.model.BatchWithdrawalModel
 import com.terraformation.backend.nursery.model.ExistingBatchModel
 import com.terraformation.backend.nursery.model.ExistingWithdrawalModel
 import com.terraformation.backend.nursery.model.NewWithdrawalModel
+import com.terraformation.backend.nursery.model.NurserySpeciesModel
+import com.terraformation.backend.nursery.model.PlotSpeciesModel
 import com.terraformation.backend.tracking.api.DeliveryPayload
 import com.terraformation.backend.tracking.db.DeliveryStore
 import com.terraformation.backend.tracking.model.DeliveryModel
@@ -45,6 +50,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.validation.constraints.Min
 import jakarta.ws.rs.QueryParam
+import java.math.BigDecimal
 import java.time.LocalDate
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.MediaType
@@ -66,6 +72,7 @@ class WithdrawalsController(
     val batchService: BatchService,
     val batchStore: BatchStore,
     val deliveryStore: DeliveryStore,
+    val nurseryWithdrawalStore: NurseryWithdrawalStore,
     val withdrawalPhotoService: WithdrawalPhotoService,
 ) {
   @GetMapping("/{withdrawalId}")
@@ -83,6 +90,16 @@ class WithdrawalsController(
         }
 
     return GetNurseryWithdrawalResponsePayload(batches, deliveryModel, withdrawal)
+  }
+
+  @GetMapping("/plantingSite/{plantingSiteId}/species")
+  @Operation(summary = "Lists all the species that have been withdrawn to a planting site.")
+  fun getSpeciesWithdrawnToPlantingSite(
+      @PathVariable("plantingSiteId") plantingSiteId: PlantingSiteId
+  ): GetSitePlotSpeciesResponsePayload {
+    val plots = nurseryWithdrawalStore.fetchSiteSpeciesByPlot(plantingSiteId)
+
+    return GetSitePlotSpeciesResponsePayload(plots.map { PlotSpeciesDensitiesPayload(it) })
   }
 
   @Operation(summary = "Withdraws seedlings from one or more seedling batches at a nursery.")
@@ -340,6 +357,33 @@ data class GetNurseryWithdrawalResponsePayload(
       NurseryWithdrawalPayload(withdrawal),
   )
 }
+
+data class SpeciesDensityPayload(
+    val speciesId: SpeciesId,
+    @Schema(description = "Species density in plants per hectare.") val density: BigDecimal,
+) {
+  constructor(
+      model: NurserySpeciesModel
+  ) : this(
+      speciesId = model.speciesId,
+      density = model.density,
+  )
+}
+
+data class PlotSpeciesDensitiesPayload(
+    val monitoringPlotId: MonitoringPlotId,
+    val species: List<SpeciesDensityPayload>,
+) {
+  constructor(
+      model: PlotSpeciesModel
+  ) : this(
+      monitoringPlotId = model.monitoringPlotId,
+      species = model.species.map { SpeciesDensityPayload(it) },
+  )
+}
+
+data class GetSitePlotSpeciesResponsePayload(val plots: List<PlotSpeciesDensitiesPayload>) :
+    SuccessResponsePayload
 
 data class CreateNurseryWithdrawalPhotoResponsePayload(val id: FileId) : SuccessResponsePayload
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStore.kt
@@ -1,0 +1,52 @@
+package com.terraformation.backend.nursery.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
+import com.terraformation.backend.nursery.model.NurserySpeciesModel
+import com.terraformation.backend.nursery.model.PlotSpeciesModel
+import jakarta.inject.Named
+import java.math.BigDecimal
+import org.jooq.DSLContext
+
+@Named
+class NurseryWithdrawalStore(
+    private val dslContext: DSLContext,
+) {
+  fun fetchSiteSpeciesByPlot(plantingSiteId: PlantingSiteId): List<PlotSpeciesModel> {
+    requirePermissions { readPlantingSite(plantingSiteId) }
+
+    with(MONITORING_PLOTS) {
+      return dslContext
+          .select(
+              ID,
+              PLANTING_SUBZONE_POPULATIONS.SPECIES_ID,
+              (PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS / PLANTING_SUBZONES.AREA_HA).`as`(
+                  "density_per_hectare"
+              ),
+          )
+          .from(this)
+          .join(PLANTING_SUBZONE_POPULATIONS)
+          .on(PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID))
+          .join(PLANTING_SUBZONES)
+          .on(PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
+          .where(PLANTING_SUBZONES.PLANTING_SITE_ID.eq(plantingSiteId))
+          .fetchGroups(ID.asNonNullable())
+          .map { (plotId, records) ->
+            PlotSpeciesModel(
+                monitoringPlotId = plotId,
+                species =
+                    records.map {
+                      NurserySpeciesModel(
+                          speciesId = it[PLANTING_SUBZONE_POPULATIONS.SPECIES_ID]!!,
+                          density = it.get("density_per_hectare", BigDecimal::class.java)!!,
+                      )
+                    },
+            )
+          }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/nursery/model/PlotSpeciesModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/model/PlotSpeciesModel.kt
@@ -1,0 +1,12 @@
+package com.terraformation.backend.nursery.model
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import java.math.BigDecimal
+
+data class NurserySpeciesModel(val speciesId: SpeciesId, val density: BigDecimal)
+
+data class PlotSpeciesModel(
+    val monitoringPlotId: MonitoringPlotId,
+    val species: List<NurserySpeciesModel> = emptyList(),
+)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
@@ -1,0 +1,118 @@
+package com.terraformation.backend.nursery.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.nursery.model.NurserySpeciesModel
+import com.terraformation.backend.nursery.model.PlotSpeciesModel
+import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val store: NurseryWithdrawalStore by lazy { NurseryWithdrawalStore(dslContext) }
+
+  private lateinit var plantingSiteId: PlantingSiteId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertOrganizationUser(role = Role.Manager)
+    plantingSiteId = insertPlantingSite()
+  }
+
+  @Nested
+  inner class FetchSiteSpeciesByPlot {
+    @Test
+    fun `throws exception when user lacks permission`() {
+      deleteOrganizationUser()
+
+      assertThrows<PlantingSiteNotFoundException> { store.fetchSiteSpeciesByPlot(plantingSiteId) }
+    }
+
+    @Test
+    fun `fetches site species by plot with densities`() {
+      val species1 = insertSpecies()
+      val species2 = insertSpecies()
+      val species3 = insertSpecies()
+      insertPlantingZone()
+      val subzone1 = insertPlantingSubzone(areaHa = BigDecimal.ONE)
+      val plot1 = insertMonitoringPlot()
+      val plot2 = insertMonitoringPlot()
+      val subzone2 = insertPlantingSubzone(areaHa = BigDecimal.TEN)
+      val plot3 = insertMonitoringPlot()
+      val plot4 = insertMonitoringPlot()
+      insertPlantingZone()
+      val subzone3 = insertPlantingSubzone(areaHa = BigDecimal.valueOf(5))
+      val plot5 = insertMonitoringPlot()
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone1, speciesId = species1, 100)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone1, speciesId = species2, 200)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species1, 300)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species2, 400)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species3, 500)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone3, speciesId = species3, 600)
+
+      val expected =
+          listOf(
+              PlotSpeciesModel(
+                  monitoringPlotId = plot1,
+                  species =
+                      createSpeciesDensityList(
+                          species1 to BigDecimal.valueOf(100),
+                          species2 to BigDecimal.valueOf(200),
+                      ),
+              ),
+              PlotSpeciesModel(
+                  monitoringPlotId = plot2,
+                  species =
+                      createSpeciesDensityList(
+                          species1 to BigDecimal.valueOf(100),
+                          species2 to BigDecimal.valueOf(200),
+                      ),
+              ),
+              PlotSpeciesModel(
+                  monitoringPlotId = plot3,
+                  species =
+                      createSpeciesDensityList(
+                          species1 to BigDecimal.valueOf(30),
+                          species2 to BigDecimal.valueOf(40),
+                          species3 to BigDecimal.valueOf(50),
+                      ),
+              ),
+              PlotSpeciesModel(
+                  monitoringPlotId = plot4,
+                  species =
+                      createSpeciesDensityList(
+                          species1 to BigDecimal.valueOf(30),
+                          species2 to BigDecimal.valueOf(40),
+                          species3 to BigDecimal.valueOf(50),
+                      ),
+              ),
+              PlotSpeciesModel(
+                  monitoringPlotId = plot5,
+                  species =
+                      createSpeciesDensityList(
+                          species3 to BigDecimal.valueOf(120),
+                      ),
+              ),
+          )
+
+      assertEquals(expected, store.fetchSiteSpeciesByPlot(plantingSiteId))
+    }
+  }
+
+  private fun createSpeciesDensityList(
+      vararg densities: Pair<SpeciesId, BigDecimal>
+  ): List<NurserySpeciesModel> {
+    return densities.map { NurserySpeciesModel(speciesId = it.first, density = it.second) }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
@@ -57,7 +57,7 @@ internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone1, speciesId = species1, 100)
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone1, speciesId = species2, 200)
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species1, 300)
-      insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species2, 400)
+      insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species2, 395)
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone2, speciesId = species3, 500)
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone3, speciesId = species3, 600)
 
@@ -84,7 +84,7 @@ internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   species =
                       createSpeciesDensityList(
                           species1 to BigDecimal.valueOf(30),
-                          species2 to BigDecimal.valueOf(40),
+                          species2 to BigDecimal.valueOf(40), // this confirms correct rounding
                           species3 to BigDecimal.valueOf(50),
                       ),
               ),


### PR DESCRIPTION
The survival rate settings page needs to display densities calculated from withdrawal data to allow the user to select these values.

Add an endpoint to fetch this data.

All names and locations of classes and the endpoint open to change suggestions.