### PR TITLE
SW-7306 Add observationPlots to monitoringPlots search table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -55,6 +55,7 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
           coordinateField("northeastLongitude", MONITORING_PLOTS.BOUNDARY, NORTHEAST, LONGITUDE),
           coordinateField("northwestLatitude", MONITORING_PLOTS.BOUNDARY, NORTHWEST, LATITUDE),
           coordinateField("northwestLongitude", MONITORING_PLOTS.BOUNDARY, NORTHWEST, LONGITUDE),
+          integerField("permanentIndex", MONITORING_PLOTS.PERMANENT_INDEX),
           longField("plotNumber", MONITORING_PLOTS.PLOT_NUMBER),
           integerField("sizeMeters", MONITORING_PLOTS.SIZE_METERS),
           coordinateField("southeastLatitude", MONITORING_PLOTS.BOUNDARY, SOUTHEAST, LATITUDE),

--- a/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/MonitoringPlotsTable.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.search.table
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_SUMMARIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.search.SearchTable
@@ -28,6 +29,10 @@ class MonitoringPlotsTable(tables: SearchTables) : SearchTable() {
           plantingSubzones.asSingleValueSublist(
               "plantingSubzone",
               MONITORING_PLOTS.PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID),
+          ),
+          observationPlots.asMultiValueSublist(
+              "observationPlots",
+              MONITORING_PLOTS.ID.eq(OBSERVATION_PLOTS.MONITORING_PLOT_ID),
           ),
       )
     }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -118,7 +118,7 @@ manifestCsvTopLevelNameNotUnique=Top Level Variable Name must be unique
 manifestCsvVariableNameNotUniqueWithinParent=No two children of the same parent can have the same name
 manifestCsvVariableParentDoesNotExist=Parent for variable does not exist
 manifestCsvWrongDataTypeForChild=Only tables and sections may be listed as parents
-monitoringPlotDescription= Plot type: {0}&#10;Planting Zone Name: {1}&#10;Planting Subzone Name: {2}
+monitoringPlotDescription=Plot type: {0}&#10;Planting Zone Name: {1}&#10;Planting Subzone Name: {2}
 # {0} is plot name
 monitoringPlotNortheastCorner={0} NE
 # {0} is plot name
@@ -622,6 +622,7 @@ search.monitoringPlots.northeastLatitude=Northeast corner latitude
 search.monitoringPlots.northeastLongitude=Northeast corner longitude
 search.monitoringPlots.northwestLatitude=Northwest corner latitude
 search.monitoringPlots.northwestLongitude=Northwest corner longitude
+search.monitoringPlots.permanentIndex=Monitoring plot permanent index
 search.monitoringPlots.plotNumber=Monitoring plot number
 search.monitoringPlots.sizeMeters=Monitoring plot size (m)
 search.monitoringPlots.southeastLatitude=Southeast corner latitude

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1093,6 +1093,8 @@ search.monitoringPlots.northeastLongitude=Longitud del ángulo noreste
 search.monitoringPlots.northwestLatitude=Latitud del ángulo noroeste
 # 355e9d22
 search.monitoringPlots.northwestLongitude=Longitud del ángulo noroeste
+# 72cd5c18
+search.monitoringPlots.permanentIndex=Índice permanente de parcela de monitoreo
 # adc14d07
 search.monitoringPlots.plotNumber=Seguimiento del número de parcela
 # e3684bc3

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1093,6 +1093,8 @@ search.monitoringPlots.northeastLongitude=Longitude de l''angle nord-est
 search.monitoringPlots.northwestLatitude=Latitude de l''angle nord-ouest
 # 355e9d22
 search.monitoringPlots.northwestLongitude=Longitude de l''angle nord-ouest
+# 72cd5c18
+search.monitoringPlots.permanentIndex=Indice permanent de la parcelle de suivi
 # adc14d07
 search.monitoringPlots.plotNumber=Numéro de parcelle de surveillance
 # e3684bc3

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -905,6 +905,9 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     // refers to a child, not a parent. Include it explicitly.
     val usersFieldNames = tables.users.getAllFieldNames("members.user.")
 
+    // exclude monitoringPlots.observationPlots because it causes ambiguous column references in the
+    // generated sql, and observationPlots are already queried as a multiValueSublist from the
+    // ObservationsTable.
     val fields =
         (organizationFieldNames + usersFieldNames)
             .filter { !it.contains("monitoringPlots.observationPlots") }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceNestedFieldsTest.kt
@@ -905,7 +905,11 @@ internal class SearchServiceNestedFieldsTest : SearchServiceTest() {
     // refers to a child, not a parent. Include it explicitly.
     val usersFieldNames = tables.users.getAllFieldNames("members.user.")
 
-    val fields = (organizationFieldNames + usersFieldNames).sorted().map { prefix.resolve(it) }
+    val fields =
+        (organizationFieldNames + usersFieldNames)
+            .filter { !it.contains("monitoringPlots.observationPlots") }
+            .sorted()
+            .map { prefix.resolve(it) }
 
     // We're querying a mix of nested fields and the old-style fields that put nested values
     // at the top level and return a separate top-level query result for each combination of rows


### PR DESCRIPTION
Thought this was already done but didn't realize that monitoringPlots didn't have a connection to observations (via observationPlots); it only went the other direction.

Add a multi value sublist for `observationPlots` to `MonitoringPlotsTable`.