### PR TITLE
SW-7345 Activity CRUD APIs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -1,0 +1,124 @@
+package com.terraformation.backend.accelerator.api
+
+import com.terraformation.backend.accelerator.db.ActivityStore
+import com.terraformation.backend.accelerator.model.ExistingActivityModel
+import com.terraformation.backend.api.AcceleratorEndpoint
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.ws.rs.QueryParam
+import java.time.Instant
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@AcceleratorEndpoint
+@RequestMapping("/api/v1/accelerator/activities/admin")
+@RestController
+class ActivitiesAdminController(
+    private val activityStore: ActivityStore,
+) {
+  @GetMapping
+  @Operation(summary = "Lists all of a project's activities with accelerator-admin-only details.")
+  @RequireGlobalRole(
+      [GlobalRole.ReadOnly, GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin]
+  )
+  fun adminListActivities(
+      @QueryParam("projectId") projectId: ProjectId
+  ): AdminListActivitiesResponsePayload {
+    val activities = activityStore.fetchByProjectId(projectId)
+
+    return AdminListActivitiesResponsePayload(activities.map { AdminActivityPayload(it) })
+  }
+
+  @GetMapping("/{id}")
+  @Operation(
+      summary = "Gets information about a single activity with accelerator-admin-only details."
+  )
+  @RequireGlobalRole(
+      [GlobalRole.ReadOnly, GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin]
+  )
+  fun adminGetActivity(@PathVariable("id") id: ActivityId): AdminGetActivityResponsePayload {
+    val activity = activityStore.fetchOneById(id)
+
+    return AdminGetActivityResponsePayload(AdminActivityPayload(activity))
+  }
+
+  @Operation(summary = "Updates an activity including its accelerator-admin-only details.")
+  @PutMapping("/{id}")
+  @RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+  fun adminUpdateActivity(
+      @PathVariable("id") id: ActivityId,
+      @RequestBody payload: AdminUpdateActivityRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    activityStore.update(id, payload::applyTo)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class AdminActivityPayload(
+    val createdBy: UserId,
+    val createdTime: Instant,
+    val date: LocalDate,
+    val description: String?,
+    val id: ActivityId,
+    val isHighlight: Boolean,
+    val isVerified: Boolean,
+    val modifiedBy: UserId,
+    val modifiedTime: Instant,
+    val type: ActivityType,
+    val verifiedBy: UserId? = null,
+    val verifiedTime: Instant? = null,
+) {
+  constructor(
+      model: ExistingActivityModel
+  ) : this(
+      createdBy = model.createdBy,
+      createdTime = model.createdTime,
+      date = model.activityDate,
+      description = model.description,
+      id = model.id,
+      isHighlight = model.isHighlight,
+      isVerified = model.verifiedBy != null,
+      modifiedBy = model.modifiedBy,
+      modifiedTime = model.modifiedTime,
+      type = model.activityType,
+      verifiedBy = model.verifiedBy,
+      verifiedTime = model.verifiedTime,
+  )
+}
+
+data class AdminUpdateActivityRequestPayload(
+    val date: LocalDate,
+    val description: String?,
+    val isHighlight: Boolean,
+    val isVerified: Boolean,
+    val type: ActivityType,
+) {
+  fun applyTo(model: ExistingActivityModel): ExistingActivityModel {
+    return model.copy(
+        activityDate = date,
+        activityType = type,
+        description = description,
+        isHighlight = isHighlight,
+        isVerified = isVerified,
+    )
+  }
+}
+
+data class AdminGetActivityResponsePayload(val activity: AdminActivityPayload) :
+    SuccessResponsePayload
+
+data class AdminListActivitiesResponsePayload(val activities: List<AdminActivityPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -1,0 +1,130 @@
+package com.terraformation.backend.accelerator.api
+
+import com.terraformation.backend.accelerator.db.ActivityStore
+import com.terraformation.backend.accelerator.model.ExistingActivityModel
+import com.terraformation.backend.accelerator.model.NewActivityModel
+import com.terraformation.backend.api.AcceleratorEndpoint
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.default_schema.ProjectId
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.ws.rs.QueryParam
+import java.time.LocalDate
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@AcceleratorEndpoint
+@RequestMapping("/api/v1/accelerator/activities")
+@RestController
+class ActivitiesController(
+    private val activityStore: ActivityStore,
+) {
+  @Operation(summary = "Lists all of a project's activities.")
+  @GetMapping
+  fun listActivities(@QueryParam("projectId") projectId: ProjectId): ListActivitiesResponsePayload {
+    val activities = activityStore.fetchByProjectId(projectId)
+
+    return ListActivitiesResponsePayload(activities.map { ActivityPayload(it) })
+  }
+
+  @Operation(summary = "Gets information about a single activity.")
+  @GetMapping("/{id}")
+  fun getActivity(@PathVariable("id") id: ActivityId): GetActivityResponsePayload {
+    val activity = activityStore.fetchOneById(id)
+
+    return GetActivityResponsePayload(ActivityPayload(activity))
+  }
+
+  @Operation(summary = "Creates a new activity.")
+  @PostMapping
+  fun createActivity(
+      @RequestBody payload: CreateActivityRequestPayload
+  ): GetActivityResponsePayload {
+    val activity = activityStore.create(payload.toModel())
+
+    return GetActivityResponsePayload(ActivityPayload(activity))
+  }
+
+  @DeleteMapping("/{id}")
+  @Operation(
+      summary = "Deletes an activity.",
+      description = "Only activities that have not been published may be deleted.",
+  )
+  fun deleteActivity(@PathVariable("id") id: ActivityId): SimpleSuccessResponsePayload {
+    activityStore.delete(id)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @Operation(summary = "Updates an activity.")
+  @PutMapping("/{id}")
+  fun updateActivity(
+      @PathVariable("id") id: ActivityId,
+      @RequestBody payload: UpdateActivityRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    activityStore.update(id, payload::applyTo)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class ActivityPayload(
+    val date: LocalDate,
+    val description: String?,
+    val id: ActivityId,
+    val isHighlight: Boolean,
+    val type: ActivityType,
+) {
+  constructor(
+      model: ExistingActivityModel
+  ) : this(
+      date = model.activityDate,
+      description = model.description,
+      id = model.id,
+      isHighlight = model.isHighlight,
+      type = model.activityType,
+  )
+}
+
+data class CreateActivityRequestPayload(
+    val date: LocalDate,
+    val description: String?,
+    val projectId: ProjectId,
+    val type: ActivityType,
+) {
+  fun toModel(): NewActivityModel {
+    return NewActivityModel(
+        activityDate = date,
+        activityType = type,
+        description = description,
+        projectId = projectId,
+    )
+  }
+}
+
+data class UpdateActivityRequestPayload(
+    val date: LocalDate,
+    val description: String?,
+    val type: ActivityType,
+) {
+  fun applyTo(model: ExistingActivityModel): ExistingActivityModel {
+    return model.copy(
+        activityDate = date,
+        activityType = type,
+        description = description,
+    )
+  }
+}
+
+data class GetActivityResponsePayload(val activity: ActivityPayload) : SuccessResponsePayload
+
+data class ListActivitiesResponsePayload(val activities: List<ActivityPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -1,0 +1,146 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.accelerator.model.ExistingActivityModel
+import com.terraformation.backend.accelerator.model.NewActivityModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.tables.Activities.Companion.ACTIVITIES
+import com.terraformation.backend.db.default_schema.ProjectId
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.Condition
+import org.jooq.DSLContext
+
+@Named
+class ActivityStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+    private val parentStore: ParentStore,
+) {
+  fun create(model: NewActivityModel): ExistingActivityModel {
+    requirePermissions { createActivity(model.projectId) }
+
+    if (!parentStore.isProjectInCohort(model.projectId)) {
+      throw ProjectNotInCohortException(model.projectId)
+    }
+
+    val now = clock.instant()
+    val userId = currentUser().userId
+
+    val activityId =
+        dslContext
+            .insertInto(ACTIVITIES)
+            .set(ACTIVITIES.ACTIVITY_DATE, model.activityDate)
+            .set(ACTIVITIES.ACTIVITY_TYPE_ID, model.activityType)
+            .set(ACTIVITIES.CREATED_BY, userId)
+            .set(ACTIVITIES.CREATED_TIME, now)
+            .set(ACTIVITIES.DESCRIPTION, model.description)
+            .set(ACTIVITIES.IS_HIGHLIGHT, false)
+            .set(ACTIVITIES.MODIFIED_BY, userId)
+            .set(ACTIVITIES.MODIFIED_TIME, now)
+            .set(ACTIVITIES.PROJECT_ID, model.projectId)
+            .returningResult(ACTIVITIES.ID)
+            .fetchOne(ACTIVITIES.ID)!!
+
+    return ExistingActivityModel(
+        activityDate = model.activityDate,
+        activityType = model.activityType,
+        createdBy = userId,
+        createdTime = now,
+        description = model.description,
+        id = activityId,
+        isHighlight = false,
+        modifiedBy = userId,
+        modifiedTime = now,
+        projectId = model.projectId,
+    )
+  }
+
+  fun delete(activityId: ActivityId) {
+    requirePermissions { deleteActivity(activityId) }
+
+    // TODO: Don't let end users delete published activities once publication is implemented
+
+    val rowsDeleted =
+        dslContext.deleteFrom(ACTIVITIES).where(ACTIVITIES.ID.eq(activityId)).execute()
+    if (rowsDeleted == 0) {
+      throw ActivityNotFoundException(activityId)
+    }
+  }
+
+  fun update(
+      activityId: ActivityId,
+      applyFunc: (ExistingActivityModel) -> ExistingActivityModel,
+  ) {
+    requirePermissions { updateActivity(activityId) }
+
+    val existingModel = fetchOneById(activityId)
+    val updatedModel = applyFunc(existingModel)
+    val now = clock.instant()
+
+    // TODO: Don't let end users edit published activities once publication is implemented
+
+    val activitiesRecord = dslContext.fetchSingle(ACTIVITIES, ACTIVITIES.ID.eq(activityId))
+
+    with(activitiesRecord) {
+      activityDate = updatedModel.activityDate
+      activityTypeId = updatedModel.activityType
+      description = updatedModel.description
+      modifiedBy = currentUser().userId
+      modifiedTime = now
+
+      if (currentUser().canManageActivity(activityId)) {
+        isHighlight = updatedModel.isHighlight
+
+        if (!existingModel.isVerified && updatedModel.isVerified) {
+          verifiedBy = currentUser().userId
+          verifiedTime = now
+        } else if (existingModel.isVerified && !updatedModel.isVerified) {
+          verifiedBy = null
+          verifiedTime = null
+        }
+      }
+
+      update()
+    }
+  }
+
+  fun fetchOneById(activityId: ActivityId): ExistingActivityModel {
+    requirePermissions { readActivity(activityId) }
+
+    return fetchByCondition(ACTIVITIES.ID.eq(activityId)).firstOrNull()
+        ?: throw ActivityNotFoundException(activityId)
+  }
+
+  fun fetchByProjectId(projectId: ProjectId): List<ExistingActivityModel> {
+    requirePermissions { listActivities(projectId) }
+
+    return fetchByCondition(ACTIVITIES.PROJECT_ID.eq(projectId))
+  }
+
+  private fun fetchByCondition(condition: Condition): List<ExistingActivityModel> {
+    return with(ACTIVITIES) {
+      dslContext
+          .select(
+              ACTIVITY_DATE,
+              ACTIVITY_TYPE_ID,
+              CREATED_BY,
+              CREATED_TIME,
+              DESCRIPTION,
+              ID,
+              IS_HIGHLIGHT,
+              MODIFIED_BY,
+              MODIFIED_TIME,
+              PROJECT_ID,
+              VERIFIED_BY,
+              VERIFIED_TIME,
+          )
+          .from(ACTIVITIES)
+          .where(condition)
+          .orderBy(ID)
+          .fetch { record -> ExistingActivityModel.of(record) }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
@@ -1,0 +1,54 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import java.time.Instant
+import java.time.LocalDate
+import org.jooq.Record
+
+data class ExistingActivityModel(
+    val activityDate: LocalDate,
+    val activityType: ActivityType,
+    val createdBy: UserId,
+    val createdTime: Instant,
+    val description: String?,
+    val id: ActivityId,
+    val isHighlight: Boolean,
+    val modifiedBy: UserId,
+    val modifiedTime: Instant,
+    val projectId: ProjectId,
+    val verifiedBy: UserId? = null,
+    val verifiedTime: Instant? = null,
+    val isVerified: Boolean = verifiedBy != null,
+) {
+  companion object {
+    fun of(record: Record): ExistingActivityModel {
+      return with(ACTIVITIES) {
+        ExistingActivityModel(
+            activityDate = record[ACTIVITY_DATE]!!,
+            activityType = record[ACTIVITY_TYPE_ID]!!,
+            createdBy = record[CREATED_BY]!!,
+            createdTime = record[CREATED_TIME]!!,
+            description = record[DESCRIPTION],
+            id = record[ID]!!,
+            isHighlight = record[IS_HIGHLIGHT]!!,
+            modifiedBy = record[MODIFIED_BY]!!,
+            modifiedTime = record[MODIFIED_TIME]!!,
+            projectId = record[PROJECT_ID]!!,
+            verifiedBy = record[VERIFIED_BY],
+            verifiedTime = record[VERIFIED_TIME],
+        )
+      }
+    }
+  }
+}
+
+data class NewActivityModel(
+    val projectId: ProjectId,
+    val activityType: ActivityType,
+    val activityDate: LocalDate,
+    val description: String? = null,
+)

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -453,6 +453,10 @@ class ParentStore(private val dslContext: DSLContext) {
               PROJECT_ACCELERATOR_DETAILS.PROJECT_ID.eq(projectId),
           ) || dslContext.fetchExists(PROJECTS, PROJECTS.participants.COHORT_ID.isNotNull))
 
+  fun isProjectInCohort(projectId: ProjectId?): Boolean =
+      projectId != null &&
+          dslContext.fetchExists(PROJECTS, PROJECTS.participants.COHORT_ID.isNotNull)
+
   /**
    * Looks up a database row by an ID and returns the value of one of the columns, or null if no row
    * had the given ID.

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -455,7 +455,11 @@ class ParentStore(private val dslContext: DSLContext) {
 
   fun isProjectInCohort(projectId: ProjectId?): Boolean =
       projectId != null &&
-          dslContext.fetchExists(PROJECTS, PROJECTS.participants.COHORT_ID.isNotNull)
+          dslContext.fetchExists(
+              PROJECTS,
+              PROJECTS.ID.eq(projectId),
+              PROJECTS.participants.COHORT_ID.isNotNull,
+          )
 
   /**
    * Looks up a database row by an ID and returns the value of one of the columns, or null if no row

--- a/src/main/resources/db/migration/0400/V402__Activities.sql
+++ b/src/main/resources/db/migration/0400/V402__Activities.sql
@@ -20,7 +20,9 @@ CREATE TABLE accelerator.activities (
     modified_by BIGINT NOT NULL REFERENCES users,
     modified_time TIMESTAMP WITH TIME ZONE NOT NULL,
     verified_by BIGINT REFERENCES users,
-    verified_time TIMESTAMP WITH TIME ZONE
+    verified_time TIMESTAMP WITH TIME ZONE,
+
+    CONSTRAINT verified_by_requires_time CHECK ((verified_by IS NULL) = (verified_time IS NULL))
 );
 
 CREATE INDEX ON accelerator.activities (project_id);

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -1,0 +1,421 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.accelerator.model.ExistingActivityModel
+import com.terraformation.backend.accelerator.model.NewActivityModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.ProjectNotFoundException
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.accelerator.tables.records.ActivitiesRecord
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import java.time.Instant
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val store: ActivityStore by lazy {
+    ActivityStore(clock, dslContext, ParentStore(dslContext))
+  }
+
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    val cohortId = insertCohort()
+    val participantId = insertParticipant(cohortId = cohortId)
+    projectId = insertProject(participantId = participantId)
+  }
+
+  @Nested
+  inner class Create {
+    @Test
+    fun `populates fields`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val model =
+          store.create(
+              NewActivityModel(
+                  activityDate = LocalDate.of(2024, 1, 15),
+                  activityType = ActivityType.SeedCollection,
+                  description = "Test activity description",
+                  projectId = projectId,
+              )
+          )
+
+      assertTableEquals(
+          ActivitiesRecord(
+              activityDate = LocalDate.of(2024, 1, 15),
+              activityTypeId = ActivityType.SeedCollection,
+              createdBy = currentUser().userId,
+              createdTime = clock.instant(),
+              description = "Test activity description",
+              id = model.id,
+              isHighlight = false,
+              modifiedBy = currentUser().userId,
+              modifiedTime = clock.instant(),
+              projectId = projectId,
+              verifiedBy = null,
+              verifiedTime = null,
+          )
+      )
+    }
+
+    @Test
+    fun `throws exception if no permission to create activity`() {
+      insertOrganizationUser(role = Role.Contributor)
+
+      val model =
+          NewActivityModel(
+              activityDate = LocalDate.EPOCH,
+              activityType = ActivityType.SeedCollection,
+              projectId = projectId,
+          )
+
+      assertThrows<AccessDeniedException> { store.create(model) }
+    }
+
+    @Test
+    fun `throws exception if project is not in a cohort`() {
+      insertOrganizationUser(role = Role.Admin)
+      dslContext.update(PROJECTS).setNull(PROJECTS.PARTICIPANT_ID).execute()
+
+      val model =
+          NewActivityModel(
+              activityDate = LocalDate.EPOCH,
+              activityType = ActivityType.SeedCollection,
+              projectId = projectId,
+          )
+
+      assertThrows<ProjectNotInCohortException> { store.create(model) }
+    }
+  }
+
+  @Nested
+  inner class FetchOneById {
+    @Test
+    fun `fetches existing activity`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val activityId =
+          insertActivity(
+              activityDate = LocalDate.of(2024, 2, 20),
+              activityType = ActivityType.Monitoring,
+              description = "Test monitoring activity",
+          )
+
+      val expected =
+          ExistingActivityModel(
+              activityDate = LocalDate.of(2024, 2, 20),
+              activityType = ActivityType.Monitoring,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              description = "Test monitoring activity",
+              id = activityId,
+              isHighlight = false,
+              modifiedBy = user.userId,
+              modifiedTime = Instant.EPOCH,
+              projectId = projectId,
+          )
+
+      assertEquals(expected, store.fetchOneById(activityId))
+    }
+
+    @Test
+    fun `throws ActivityNotFoundException if activity does not exist`() {
+      assertThrows<ActivityNotFoundException> { store.fetchOneById(ActivityId(0)) }
+    }
+
+    @Test
+    fun `throws ActivityNotFoundException if no read permission`() {
+      insertOrganizationUser(role = Role.Contributor)
+
+      val activityId = insertActivity(projectId = projectId)
+
+      assertThrows<ActivityNotFoundException> { store.fetchOneById(activityId) }
+    }
+  }
+
+  @Nested
+  inner class FetchByProjectId {
+    @Test
+    fun `fetches activities`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val activityId1 =
+          insertActivity(
+              activityDate = LocalDate.of(2024, 2, 20),
+              activityType = ActivityType.Monitoring,
+              description = "Test monitoring activity",
+          )
+      val activityId2 =
+          insertActivity(
+              activityDate = LocalDate.of(2024, 3, 21),
+              activityType = ActivityType.Planting,
+              createdTime = Instant.ofEpochSecond(1),
+              description = "Did some stuff",
+              isHighlight = true,
+              modifiedTime = Instant.ofEpochSecond(2),
+          )
+
+      // Activities for other projects shouldn't be included
+      insertProject()
+      insertActivity()
+
+      val expected =
+          listOf(
+              ExistingActivityModel(
+                  activityDate = LocalDate.of(2024, 2, 20),
+                  activityType = ActivityType.Monitoring,
+                  createdBy = user.userId,
+                  createdTime = Instant.EPOCH,
+                  description = "Test monitoring activity",
+                  id = activityId1,
+                  isHighlight = false,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.EPOCH,
+                  projectId = projectId,
+              ),
+              ExistingActivityModel(
+                  activityDate = LocalDate.of(2024, 3, 21),
+                  activityType = ActivityType.Planting,
+                  createdBy = user.userId,
+                  createdTime = Instant.ofEpochSecond(1),
+                  description = "Did some stuff",
+                  id = activityId2,
+                  isHighlight = true,
+                  modifiedBy = user.userId,
+                  modifiedTime = Instant.ofEpochSecond(2),
+                  projectId = projectId,
+              ),
+          )
+
+      assertEquals(expected, store.fetchByProjectId(projectId))
+    }
+
+    @Test
+    fun `throws ProjectNotFoundException if project does not exist`() {
+      assertThrows<ProjectNotFoundException> { store.fetchByProjectId(ProjectId(0)) }
+    }
+
+    @Test
+    fun `throws ProjectNotFoundException if no read permission on project`() {
+      assertThrows<ProjectNotFoundException> { store.fetchByProjectId(projectId) }
+    }
+
+    @Test
+    fun `throws AccessDeniedException if no read permission on activities`() {
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> { store.fetchByProjectId(projectId) }
+    }
+  }
+
+  @Nested
+  inner class Delete {
+    @Test
+    fun `org admin can delete activity`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val activityId = insertActivity(projectId = projectId)
+
+      store.delete(activityId)
+
+      assertTableEmpty(ACTIVITIES)
+    }
+
+    @Test
+    fun `accelerator admin can delete activity`() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+
+      val activityId = insertActivity(projectId = projectId)
+
+      store.delete(activityId)
+
+      assertTableEmpty(ACTIVITIES)
+    }
+
+    @Test
+    fun `throws ActivityNotFoundException if activity does not exist`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      assertThrows<ActivityNotFoundException> { store.delete(ActivityId(0)) }
+    }
+
+    @Test
+    fun `throws exception if no permission to delete activity`() {
+      insertOrganizationUser(role = Role.Manager)
+      insertUserGlobalRole(role = GlobalRole.TFExpert)
+
+      val activityId = insertActivity(projectId = projectId)
+
+      assertThrows<AccessDeniedException> { store.delete(activityId) }
+    }
+  }
+
+  @Nested
+  inner class Update {
+    @Test
+    fun `updates activity fields`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val activityId =
+          insertActivity(
+              activityDate = LocalDate.of(2024, 1, 1),
+              activityType = ActivityType.SeedCollection,
+              description = "Original description",
+              projectId = projectId,
+          )
+
+      val updateTime = Instant.ofEpochSecond(100)
+      clock.instant = updateTime
+
+      store.update(activityId) { existing ->
+        existing.copy(
+            activityType = ActivityType.Planting,
+            activityDate = LocalDate.of(2024, 2, 1),
+            description = "Updated description",
+            // Updates to admin-only fields should be ignored.
+            isHighlight = true,
+            isVerified = true,
+        )
+      }
+
+      assertTableEquals(
+          ActivitiesRecord(
+              activityDate = LocalDate.of(2024, 2, 1),
+              activityTypeId = ActivityType.Planting,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              description = "Updated description",
+              id = activityId,
+              isHighlight = false,
+              modifiedBy = user.userId,
+              modifiedTime = updateTime,
+              projectId = projectId,
+              verifiedBy = null,
+              verifiedTime = null,
+          )
+      )
+    }
+
+    @Test
+    fun `accelerator admin can update additional fields`() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+
+      val activityId =
+          insertActivity(
+              activityDate = LocalDate.of(2024, 1, 1),
+              activityType = ActivityType.SeedCollection,
+              description = "Original description",
+              projectId = projectId,
+          )
+
+      val updateTime = Instant.ofEpochSecond(100)
+      clock.instant = updateTime
+
+      store.update(activityId) { existing ->
+        existing.copy(
+            activityType = ActivityType.Planting,
+            activityDate = LocalDate.of(2024, 2, 1),
+            description = "Updated description",
+            isHighlight = true,
+            isVerified = true,
+        )
+      }
+
+      assertTableEquals(
+          ActivitiesRecord(
+              activityDate = LocalDate.of(2024, 2, 1),
+              activityTypeId = ActivityType.Planting,
+              createdBy = user.userId,
+              createdTime = Instant.EPOCH,
+              description = "Updated description",
+              id = activityId,
+              isHighlight = true,
+              modifiedBy = user.userId,
+              modifiedTime = updateTime,
+              projectId = projectId,
+              verifiedBy = user.userId,
+              verifiedTime = updateTime,
+          )
+      )
+    }
+
+    @Test
+    fun `clears verifiedBy and verifiedTime if isVerified goes from true to false`() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+
+      val activityId = insertActivity(verifiedBy = user.userId, verifiedTime = Instant.EPOCH)
+      val record = dslContext.fetchOne(ACTIVITIES)!!
+
+      val updateTime = Instant.ofEpochSecond(100)
+      clock.instant = updateTime
+
+      store.update(activityId) { model -> model.copy(isVerified = false) }
+
+      record.modifiedTime = updateTime
+      record.verifiedBy = null
+      record.verifiedTime = null
+
+      assertTableEquals(record)
+    }
+
+    @Test
+    fun `leaves verifiedBy and verifiedTime alone if isVerified remains true`() {
+      insertUserGlobalRole(role = GlobalRole.AcceleratorAdmin)
+      val otherUserId = insertUser()
+
+      val verifiedTime = Instant.ofEpochSecond(30)
+      val activityId = insertActivity(verifiedBy = otherUserId, verifiedTime = verifiedTime)
+      val record = dslContext.fetchOne(ACTIVITIES)!!
+
+      val updateTime = Instant.ofEpochSecond(100)
+      clock.instant = updateTime
+
+      store.update(activityId) { it }
+
+      record.modifiedTime = updateTime
+
+      assertTableEquals(record)
+    }
+
+    @Test
+    fun `throws ActivityNotFoundException if activity does not exist`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      assertThrows<ActivityNotFoundException> {
+        store.update(ActivityId(0)) { it.copy(description = "Updated") }
+      }
+    }
+
+    @Test
+    fun `throws exception if no permission to update activity`() {
+      insertOrganizationUser(role = Role.Manager)
+      insertUserGlobalRole(role = GlobalRole.TFExpert)
+
+      val activityId = insertActivity(projectId = projectId)
+
+      assertThrows<AccessDeniedException> {
+        store.update(activityId) { it.copy(description = "Updated") }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add new API endpoints for end-user and accelerator-admin-only CRUD operations
on accelerator project activities.

This does not include uploading or downloading activity photos or videos;
media support will come in a later change.