### PR TITLE
Implement InputStreamCopier to double-process streams

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
@@ -1,0 +1,391 @@
+package com.terraformation.backend.util
+
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.Condition
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Makes InputStream data available to multiple concurrent readers.
+ *
+ * This class allows the data from an [InputStream] to be consumed by more than one thread without
+ * needing to load the entire contents of the stream into memory at once.
+ *
+ * Typical usage pattern:
+ * 1. Instantiate this class with the source input stream.
+ * 2. Call [getCopy] as many times as needed, once for each consumer of the stream data.
+ * 3. Pass each copy to its own thread to consume.
+ * 4. Call [transfer].
+ * 5. Call [close] (or put steps 2-4 in a [use] block).
+ *
+ * Each copy is its own [InputStream] that can be read semi-independently of the other copies.
+ * "Semi-independently" means that all the consumers progress through the data at roughly the same
+ * pace: if one of them falls too far behind the others, the others will block until the slower
+ * reader catches up sufficiently or closes its stream.
+ *
+ * The motivating use case is to support large file uploads where we need to both store the data on
+ * a cloud file storage service and retrieve metadata from video or photo files. Each of those
+ * operations requires an [InputStream] it can read independently.
+ *
+ * You will almost always want to read each copy from its own thread. It's possible to use more than
+ * one copy on a single thread, but you'll have to be careful of deadlocks: read too much from one
+ * copy and it will block forever, waiting for one of the other copies to catch up.
+ */
+class InputStreamCopier(
+    private val source: InputStream,
+    /**
+     * The size of the internal buffer in bytes. This determines how much data can be buffered in
+     * memory at once, which is how far behind the slowest reader can get before the fastest one
+     * blocks to wait for it to catch up. Larger buffers allow more tolerance for speed differences
+     * between copies, and allow reading from the source stream in larger chunks, but use more
+     * memory. Must be larger than [minReadSize].
+     */
+    private val bufferSize: Int = 64 * 1024,
+    /**
+     * The minimum number of bytes to read from the source in each read operation. Reading in larger
+     * chunks is more efficient than many small reads. When buffer space is available,
+     * [InputStreamCopier] will try to read up to the remaining buffer space, but will wait for at
+     * least this much space before attempting any read.
+     */
+    private val minReadSize: Int = 8192,
+) : Closeable {
+  private val buffer = ByteArray(bufferSize)
+  private val copies = mutableListOf<CopyInputStream>()
+  private val sourceExhausted = AtomicBoolean(false)
+  private val sourceException = AtomicReference<Exception?>(null)
+
+  /** If true, this */
+  @Volatile private var copierClosed = false
+
+  /** If true, the [transfer] function has been called; no more calls to [getCopy] are allowed. */
+  @Volatile private var transferStarted = false
+
+  /** The total number of bytes that have been read from the source stream. */
+  private val totalBytesRead = AtomicLong(0)
+
+  /**
+   * The absolute position in the source stream that corresponds to the first byte in our buffer. As
+   * copies consume data and we reclaim buffer space, this position advances forward through the
+   * stream, effectively creating a sliding window over the source data. This is a logical stream
+   * position, not a buffer array index - use modulo arithmetic to find the actual buffer offset
+   * where this position's data is stored in the circular buffer.
+   *
+   * Example: if bufferStartPosition=5000 and bufferSize=1024, then the first valid byte is at
+   * buffer[(5000 % 1024)] = buffer[904].
+   */
+  private var bufferStartPosition = 0L
+
+  /**
+   * The number of bytes currently stored in the circular buffer that contain valid data from the
+   * source stream. This starts at 0 and grows as we read from the source, and shrinks as we reclaim
+   * buffer space when all copies have consumed earlier data. Note that this is a linear count of
+   * valid bytes, not a buffer offset - the actual data may wrap around the end of the buffer array
+   * back to the beginning.
+   */
+  private var validBytes = 0
+
+  private val lock = ReentrantLock()
+  private val dataAvailable: Condition = lock.newCondition()
+
+  /**
+   * Returns a stream that has a copy of the data from [source]. You can create copies at any time
+   * before calling [transfer]. Copies can start reading immediately - they will block until data
+   * becomes available when [transfer] is called.
+   */
+  fun getCopy(): InputStream {
+    return lock.withLock {
+      if (copierClosed) {
+        throw IllegalStateException(
+            "Cannot create new copies after InputStreamCopier has been closed"
+        )
+      }
+      if (transferStarted) {
+        throw IllegalStateException("Cannot create new copies after transfer() has started")
+      }
+
+      CopyInputStream().also { copies.add(it) }
+    }
+  }
+
+  /**
+   * Copies the source stream's data to all the copy streams. Blocks until the entire source stream
+   * has been read and all copies have either finished reading the data or have been closed.
+   *
+   * Does not close the source stream; use [close] for that.
+   */
+  fun transfer() {
+    lock.withLock {
+      if (copierClosed) {
+        throw IllegalStateException("InputStreamCopier has been closed")
+      }
+      if (transferStarted) {
+        throw IllegalStateException("transfer() has already been called")
+      }
+      transferStarted = true
+    }
+
+    try {
+      readSourceIntoBuffer()
+    } catch (e: Exception) {
+      sourceException.set(e)
+      throw e
+    } finally {
+      sourceExhausted.set(true)
+      lock.withLock { dataAvailable.signalAll() }
+    }
+
+    // Wait for all copies to finish
+    lock.withLock {
+      while (anyCopiesActive()) {
+        try {
+          dataAvailable.await()
+        } catch (e: InterruptedException) {
+          Thread.currentThread().interrupt()
+          break
+        }
+      }
+    }
+  }
+
+  /**
+   * Closes the source stream. You'll usually want to call this after [transfer] completes, either
+   * explicitly or via a try-with-resources or [use] call. Calling this before [transfer] has
+   * completed will cause exceptions to be thrown when reading from the copy streams.
+   */
+  override fun close() {
+    lock.withLock {
+      if (!copierClosed) {
+        copierClosed = true
+        dataAvailable.signalAll() // Wake up any waiting copies
+        source.close()
+      }
+    }
+  }
+
+  private fun anyCopiesActive() = copies.any { it.isOpen() && !it.isAtEnd() }
+
+  private fun readSourceIntoBuffer() {
+    while (!sourceExhausted.get() && anyCopiesActive()) {
+      lock.withLock {
+        waitForBufferSpace(minReadSize)
+        if (sourceExhausted.get() || !anyCopiesActive()) return
+
+        // Calculate where to read in the circular buffer
+        val bufferOffset = ((bufferStartPosition + validBytes) % bufferSize).toInt()
+        val availableSpace = bufferSize - validBytes
+
+        // Read directly into circular buffer, handling wraparound
+        val bytesRead =
+            if (bufferOffset + availableSpace <= bufferSize) {
+              // Simple case: no wraparound needed
+              source.read(buffer, bufferOffset, availableSpace)
+            } else {
+              // Wraparound case: read in two parts
+              val firstPartSize = bufferSize - bufferOffset
+              val firstPartRead = source.read(buffer, bufferOffset, firstPartSize)
+
+              if (firstPartRead == -1) {
+                -1
+              } else if (firstPartRead < firstPartSize) {
+                // Source ended before wraparound
+                firstPartRead
+              } else {
+                // Continue reading into the beginning of buffer
+                val secondPartSize = availableSpace - firstPartSize
+                val secondPartRead = source.read(buffer, 0, secondPartSize)
+
+                if (secondPartRead == -1) {
+                  firstPartRead // Return only the first part
+                } else {
+                  firstPartRead + secondPartRead
+                }
+              }
+            }
+        if (bytesRead == -1) {
+          return
+        }
+
+        validBytes += bytesRead
+        totalBytesRead.addAndGet(bytesRead.toLong())
+        dataAvailable.signalAll()
+      }
+    }
+  }
+
+  private fun waitForBufferSpace(bytesNeeded: Int) {
+    while (anyCopiesActive() && validBytes + bytesNeeded > bufferSize) {
+      reclaimBufferSpace()
+      if (validBytes + bytesNeeded > bufferSize) {
+        try {
+          dataAvailable.await()
+        } catch (e: InterruptedException) {
+          Thread.currentThread().interrupt()
+          return
+        }
+      }
+    }
+  }
+
+  private fun reclaimBufferSpace() {
+    if (copies.isEmpty()) return
+
+    val minPosition =
+        copies.filter { copy -> copy.isOpen() }.minOfOrNull { copy -> copy.position.get() }
+            ?: return
+
+    // How much can we advance the buffer start?
+    val bytesToReclaim = minPosition - bufferStartPosition
+    if (bytesToReclaim <= 0) return
+
+    // Advance buffer start and reduce used space
+    bufferStartPosition += bytesToReclaim
+    validBytes -= bytesToReclaim.toInt()
+    dataAvailable.signalAll()
+  }
+
+  private fun waitForData(position: Long): Boolean =
+      lock.withLock {
+        while (
+            totalBytesRead.get() <= position &&
+                !sourceExhausted.get() &&
+                anyCopiesActive() &&
+                sourceException.get() == null
+        ) {
+          try {
+            dataAvailable.await()
+          } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return false
+          }
+        }
+
+        sourceException.get()?.let { throw it }
+        return totalBytesRead.get() > position || sourceExhausted.get()
+      }
+
+  private fun checkEndOfStream(position: Long): Boolean {
+    return sourceExhausted.get() && position >= totalBytesRead.get()
+  }
+
+  private fun copyBytesToArray(dest: ByteArray, destOffset: Int, startPosition: Long, length: Int) {
+    val relativePosition = startPosition - bufferStartPosition
+
+    if (relativePosition < 0) {
+      throw IllegalStateException(
+          "Position $startPosition is before buffer start $bufferStartPosition"
+      )
+    }
+    if (relativePosition >= validBytes) {
+      val bufferEnd = bufferStartPosition + validBytes
+      throw IllegalStateException(
+          "Position $startPosition is beyond available data (buffer end: $bufferEnd)"
+      )
+    }
+
+    if (relativePosition + length > validBytes) {
+      throw IllegalStateException(
+          "Read request at position $startPosition with length $length would exceed valid data boundary. " +
+              "relativePosition=$relativePosition, validBytes=$validBytes, bufferStartPosition=$bufferStartPosition"
+      )
+    }
+
+    // Calculate buffer offset - this is where the potential bug might be
+    val actualStartOffset = (bufferStartPosition % bufferSize).toInt()
+    val bufferOffset = ((actualStartOffset + relativePosition.toInt()) % bufferSize)
+    val bytesToEnd = bufferSize - bufferOffset
+
+    if (length <= bytesToEnd) {
+      // Simple case: no wraparound needed
+      System.arraycopy(buffer, bufferOffset, dest, destOffset, length)
+    } else {
+      // Wraparound case: copy in two parts
+      System.arraycopy(buffer, bufferOffset, dest, destOffset, bytesToEnd)
+      val remainingBytes = length - bytesToEnd
+      System.arraycopy(buffer, 0, dest, destOffset + bytesToEnd, remainingBytes)
+    }
+  }
+
+  private inner class CopyInputStream : InputStream() {
+    /** The position in the source stream this copy has read up to. */
+    val position = AtomicLong(0)
+
+    @Volatile private var closed = false
+
+    fun isOpen(): Boolean = !closed
+
+    fun isAtEnd(): Boolean = checkEndOfStream(position.get())
+
+    override fun read(): Int {
+      val buffer = ByteArray(1)
+      val bytesRead = read(buffer, 0, 1)
+      return if (bytesRead == -1) -1 else buffer[0].toInt() and 0xFF
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+      if (closed) throw IOException("Stream closed")
+      if (copierClosed)
+          throw IOException("InputStreamCopier was closed before transfer() completed")
+      if (b.isEmpty() || len == 0) return 0
+      if (off < 0) {
+        throw IndexOutOfBoundsException("Offset cannot be negative: $off")
+      }
+      if (len < 0) {
+        throw IndexOutOfBoundsException("Length cannot be negative: $len")
+      }
+      if (off + len > b.size) {
+        throw IndexOutOfBoundsException(
+            "Offset + length ($off + $len = ${off + len}) exceeds buffer size (${b.size})"
+        )
+      }
+
+      val currentPosition = position.get()
+      if (!waitForData(currentPosition)) return -1
+      if (checkEndOfStream(currentPosition)) return -1
+
+      val available = (totalBytesRead.get() - currentPosition).toInt()
+      val bytesToRead = minOf(len, available)
+
+      lock.withLock { copyBytesToArray(b, off, currentPosition, bytesToRead) }
+
+      position.addAndGet(bytesToRead.toLong())
+      lock.withLock { dataAvailable.signalAll() }
+
+      return bytesToRead
+    }
+
+    override fun available(): Int {
+      if (closed) return 0
+      val currentPosition = position.get()
+      return (totalBytesRead.get() - currentPosition).coerceAtLeast(0).toInt()
+    }
+
+    override fun skip(n: Long): Long {
+      if (closed) throw IOException("Stream closed")
+      if (copierClosed)
+          throw IOException("InputStreamCopier was closed before transfer() completed")
+      if (n <= 0) return 0
+
+      val currentPosition = position.get()
+      if (!waitForData(currentPosition)) return 0
+      if (checkEndOfStream(currentPosition)) return 0
+
+      val available = (totalBytesRead.get() - currentPosition)
+      val bytesToSkip = minOf(n, available)
+
+      position.addAndGet(bytesToSkip)
+      lock.withLock { dataAvailable.signalAll() }
+
+      return bytesToSkip
+    }
+
+    override fun close() {
+      closed = true
+      lock.withLock { dataAvailable.signalAll() }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
@@ -251,7 +251,9 @@ class InputStreamCopier(
           dataAvailable.await()
         }
 
-        sourceException.get()?.let { throw it }
+        sourceException.get()?.let {
+          throw IOException("Unable to read from source input stream", it)
+        }
         return totalBytesRead.get() > position || sourceExhausted.get()
       }
 

--- a/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
@@ -253,7 +253,6 @@ class InputStreamCopier(
         while (
             totalBytesRead.get() <= position &&
                 !sourceExhausted.get() &&
-                anyCopiesActive() &&
                 sourceException.get() == null
         ) {
           try {
@@ -294,9 +293,7 @@ class InputStreamCopier(
       )
     }
 
-    // Calculate buffer offset - this is where the potential bug might be
-    val actualStartOffset = (bufferStartPosition % bufferSize).toInt()
-    val bufferOffset = ((actualStartOffset + relativePosition.toInt()) % bufferSize)
+    val bufferOffset = ((bufferStartPosition + relativePosition) % bufferSize).toInt()
     val bytesToEnd = bufferSize - bufferOffset
 
     if (length <= bytesToEnd) {

--- a/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
@@ -142,12 +142,7 @@ class InputStreamCopier(
     // Wait for all copies to finish
     lock.withLock {
       while (anyCopiesActive()) {
-        try {
-          dataAvailable.await()
-        } catch (e: InterruptedException) {
-          Thread.currentThread().interrupt()
-          break
-        }
+        dataAvailable.await()
       }
     }
   }
@@ -221,12 +216,7 @@ class InputStreamCopier(
     while (anyCopiesActive() && validBytes + bytesNeeded > bufferSize) {
       reclaimBufferSpace()
       if (validBytes + bytesNeeded > bufferSize) {
-        try {
-          dataAvailable.await()
-        } catch (e: InterruptedException) {
-          Thread.currentThread().interrupt()
-          return
-        }
+        dataAvailable.await()
       }
     }
   }
@@ -255,12 +245,7 @@ class InputStreamCopier(
                 !sourceExhausted.get() &&
                 sourceException.get() == null
         ) {
-          try {
-            dataAvailable.await()
-          } catch (e: InterruptedException) {
-            Thread.currentThread().interrupt()
-            return false
-          }
+          dataAvailable.await()
         }
 
         sourceException.get()?.let { throw it }

--- a/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/InputStreamCopier.kt
@@ -59,7 +59,10 @@ class InputStreamCopier(
   private val sourceExhausted = AtomicBoolean(false)
   private val sourceException = AtomicReference<Exception?>(null)
 
-  /** If true, this */
+  /**
+   * If true, this InputStreamCopier has been closed. No more copies can be produced and any
+   * existing copies will throw [IOException] next time a caller attempts to read from them.
+   */
   @Volatile private var copierClosed = false
 
   /** If true, the [transfer] function has been called; no more calls to [getCopy] are allowed. */

--- a/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertThrows
 
 class InputStreamCopierTest {
-
   @Test
   fun `single copy reads entire stream correctly`() {
     val testData = "Hello, World!".toByteArray()
@@ -435,6 +434,18 @@ class InputStreamCopierTest {
 
     copierClosedLatch.countDown()
     copyThread.join()
+  }
+
+  @Test
+  fun `throws exception if minimum read size is not less than buffer size`() {
+    val dummyStream = ByteArrayInputStream(ByteArray(1))
+
+    assertThrows<IllegalArgumentException>("bufferSize == minReadSize") {
+      InputStreamCopier(dummyStream, 100, 100)
+    }
+    assertThrows<IllegalArgumentException>("bufferSize < minReadSize") {
+      InputStreamCopier(dummyStream, 100, 101)
+    }
   }
 
   private fun generateTestData(size: Int): ByteArray {

--- a/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
@@ -1,0 +1,447 @@
+package com.terraformation.backend.util
+
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.assertThrows
+
+class InputStreamCopierTest {
+
+  @Test
+  fun `single copy reads entire stream correctly`() {
+    val testData = "Hello, World!".toByteArray()
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy = copier.getCopy()
+
+    var result: ByteArray? = null
+    val readerThread = thread { result = copy.readAllBytes() }
+
+    copier.transfer()
+    readerThread.join()
+
+    assertArrayEquals(testData, result)
+  }
+
+  @Test
+  fun `multiple copies read identical data`() {
+    val testData = "This is a test with multiple copies".toByteArray()
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+    val copy2 = copier.getCopy()
+    val copy3 = copier.getCopy()
+
+    val results = Array<ByteArray?>(3) { null }
+    val threads =
+        listOf(
+            thread { results[0] = copy1.readAllBytes() },
+            thread { results[1] = copy2.readAllBytes() },
+            thread { results[2] = copy3.readAllBytes() },
+        )
+
+    copier.transfer()
+    threads.forEach { it.join() }
+
+    assertArrayEquals(testData, results[0])
+    assertArrayEquals(testData, results[1])
+    assertArrayEquals(testData, results[2])
+  }
+
+  @Test
+  fun `empty source stream`() {
+    val source = ByteArrayInputStream(ByteArray(0))
+    val copier = InputStreamCopier(source)
+
+    val copy = copier.getCopy()
+
+    var result: ByteArray? = null
+    val readerThread = thread { result = copy.readAllBytes() }
+
+    copier.transfer()
+    readerThread.join()
+
+    assertEquals(0, result?.size)
+  }
+
+  @Test
+  fun `can create copies dynamically before transfer`() {
+    val testData = generateTestData(10000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+    var result1: ByteArray? = null
+
+    val reader1StartedLatch = CountDownLatch(1)
+    val reader1Thread = thread {
+      reader1StartedLatch.countDown()
+      result1 = copy1.readAllBytes()
+    }
+
+    reader1StartedLatch.await()
+    // Give it a little time to actually start reading; no good way to make this deterministic
+    Thread.sleep(5)
+
+    val copy2 = copier.getCopy()
+    var result2: ByteArray? = null
+    val reader2Thread = thread { result2 = copy2.readAllBytes() }
+
+    copier.transfer()
+    reader1Thread.join()
+    reader2Thread.join()
+
+    assertArrayEquals(testData, result1)
+    assertArrayEquals(testData, result2)
+  }
+
+  @Test
+  fun `multiple copies read concurrently with different speeds`() {
+    val testData = generateTestData(3000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source, bufferSize = 1000, minReadSize = 50)
+
+    val copy1 = copier.getCopy()
+    val copy2 = copier.getCopy()
+
+    var slowResult: ByteArray? = null
+    var fastResult: ByteArray? = null
+    val exceptions = ConcurrentLinkedQueue<Exception>()
+
+    // Fast reader
+    val fastReader = thread {
+      try {
+        fastResult = copy1.readAllBytes()
+      } catch (e: Exception) {
+        exceptions.add(e)
+      }
+    }
+
+    // Slow reader with artificial delays
+    val slowReader = thread {
+      try {
+        val buffer = mutableListOf<Byte>()
+        var byte: Int
+        while (copy2.read().also { byte = it } != -1) {
+          buffer.add(byte.toByte())
+          if (buffer.size % 100 == 0) {
+            Thread.sleep(1)
+          }
+        }
+        slowResult = buffer.toByteArray()
+      } catch (e: Exception) {
+        exceptions.add(e)
+      }
+    }
+
+    copier.transfer()
+
+    fastReader.join()
+    slowReader.join()
+
+    assertEquals(emptyList<Exception>(), exceptions.toList(), "Exceptions")
+
+    assertArrayEquals(testData, slowResult, "Result from slow reader")
+    assertArrayEquals(testData, fastResult, "Result from fast reader")
+  }
+
+  @Test
+  fun `source exception propagated to all copies`() {
+    val failingStream =
+        object : InputStream() {
+          override fun read(): Int {
+            throw IOException("Test exception")
+          }
+        }
+
+    val copier = InputStreamCopier(failingStream)
+    val copy1 = copier.getCopy()
+    val copy2 = copier.getCopy()
+
+    val exceptions = ConcurrentLinkedQueue<Exception>()
+    val latch = CountDownLatch(2)
+
+    val threads =
+        listOf(
+            thread {
+              try {
+                copy1.readAllBytes()
+              } catch (e: Exception) {
+                exceptions.add(e)
+              } finally {
+                latch.countDown()
+              }
+            },
+            thread {
+              try {
+                copy2.readAllBytes()
+              } catch (e: Exception) {
+                exceptions.add(e)
+              } finally {
+                latch.countDown()
+              }
+            },
+        )
+
+    assertThrows<IOException> { copier.transfer() }
+
+    assertTrue(latch.await(5000, TimeUnit.MILLISECONDS), "All readers should complete")
+    threads.forEach { it.join() }
+
+    assertEquals(2, exceptions.size, "Both copies should receive the exception")
+    exceptions.forEach { exception ->
+      assertInstanceOf<IOException>(exception)
+      assertEquals("Test exception", exception.message)
+    }
+  }
+
+  @Test
+  fun `read methods work correctly`() {
+    val testData = "Hello, World! This is a longer test string.".toByteArray()
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+    val copy = copier.getCopy()
+
+    var firstByte: Int = -1
+    var bytesRead: Int = -1
+    var bytesRead2: Int = -1
+    val buffer = ByteArray(5)
+    val buffer2 = ByteArray(10)
+    var remaining: ByteArray? = null
+    var endByte: Int = -1
+
+    val readerThread = thread {
+      // Single byte read
+      firstByte = copy.read()
+
+      // Whole array read
+      bytesRead = copy.read(buffer)
+
+      // Array read with offset and length
+      bytesRead2 = copy.read(buffer2, 2, 6)
+
+      // Read remaining data
+      remaining = copy.readAllBytes()
+
+      // Read when stream exhausted
+      endByte = copy.read()
+    }
+
+    copier.transfer()
+    readerThread.join()
+
+    assertEquals(testData[0].toInt() and 0xFF, firstByte, "First byte")
+    assertEquals(5, bytesRead, "First array read length")
+    assertArrayEquals(testData.sliceArray(1..5), buffer, "First array read")
+    assertEquals(6, bytesRead2, "Second array read length")
+    assertArrayEquals(testData.sliceArray(6..11), buffer2.sliceArray(2..7), "Second array read")
+    assertEquals(-1, endByte, "Remainder read length")
+    assertArrayEquals(testData.sliceArray(12 until testData.size), remaining, "Remainder read")
+  }
+
+  @Test
+  fun `closed copy stream throws exception on read`() {
+    val testData = "test".toByteArray()
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+    val copy = copier.getCopy()
+
+    copy.close()
+
+    assertThrows<IOException> { copy.read() }
+    assertThrows<IOException> { copy.read(ByteArray(10)) }
+    assertEquals(0, copy.available(), "Bytes available")
+  }
+
+  @Test
+  fun `skip method skips input`() {
+    val testData = generateTestData(1000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+    val copy = copier.getCopy()
+
+    var bytesSkipped = 0L
+    var remainingData: ByteArray? = null
+
+    val readerThread = thread {
+      // Skip the first 100 bytes
+      bytesSkipped = copy.skip(100)
+
+      // Read the remaining data
+      remainingData = copy.readAllBytes()
+    }
+
+    copier.transfer()
+    readerThread.join()
+
+    assertEquals(100, bytesSkipped, "Should skip exactly 100 bytes")
+    assertEquals(900, remainingData?.size, "Should have 900 bytes remaining")
+
+    val expectedRemaining = testData.sliceArray(100..<testData.size)
+    assertArrayEquals(
+        expectedRemaining,
+        remainingData,
+        "Should have read data after the skipped bytes",
+    )
+  }
+
+  @Test
+  fun `creating copies after transfer throws exception`() {
+    val source = ByteArrayInputStream(generateTestData(5))
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+
+    val readerThread = thread { copy1.readAllBytes() }
+
+    copier.transfer()
+
+    assertThrows<IllegalStateException> { copier.getCopy() }
+
+    readerThread.join()
+  }
+
+  @Test
+  fun `transfer waits for all copies to finish or close`() {
+    val testData = generateTestData(1000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+    val copy2 = copier.getCopy()
+    val copy3 = copier.getCopy()
+
+    var closingReaderCompleted = false
+    var slowReaderCompleted = false
+
+    val fastReader = thread { copy1.readAllBytes() }
+
+    val slowReader = thread {
+      Thread.sleep(100) // Small delay to ensure transfer() waits
+      copy2.readAllBytes()
+      slowReaderCompleted = true
+    }
+
+    val closingReader = thread {
+      copy3.close()
+      closingReaderCompleted = true
+    }
+
+    copier.transfer()
+
+    assertTrue(closingReaderCompleted, "Should have waited for closing reader to complete")
+    assertTrue(slowReaderCompleted, "Should have waited for slow reader to complete")
+
+    closingReader.join()
+    fastReader.join()
+    slowReader.join()
+  }
+
+  @Test
+  fun `close without transfer causes copy reads to throw exception`() {
+    val testData = generateTestData(1000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+    val copy2 = copier.getCopy()
+
+    // Close without calling transfer
+    copier.close()
+
+    assertThrows<IOException> { copy1.read() }
+    assertThrows<IOException> { copy2.readAllBytes() }
+  }
+
+  @Test
+  fun `available correctly counts wrapped buffer data`() {
+    val testData = generateTestData(2000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source, bufferSize = 800, minReadSize = 200)
+
+    var availableBeforeBufferReplenish: Int? = null
+    var availableAfterBufferReplenish: Int? = null
+
+    val fastCopy = copier.getCopy()
+    val slowCopy = copier.getCopy()
+
+    val testThread = thread {
+      // We'll read from both copies in one thread and close them both afterwards since we need to
+      // read from them in a precise sequence.
+      fastCopy.use {
+        slowCopy.use {
+          // Consume the entire circular buffer's worth of data; this will make it available to the
+          // slow copy too.
+          fastCopy.read(ByteArray(800))
+
+          // Consume most of the buffer's worth of data on the slow copy, meaning the first part of
+          // the buffer is available for further reads from the source stream.
+          slowCopy.read(ByteArray(500))
+
+          // At this point, the slow copy should have the rest of the buffer's worth of data
+          // available.
+          availableBeforeBufferReplenish = slowCopy.available()
+
+          // Consume more data from the fast copy, which will trigger another read from the source
+          // stream to fill up the first 500 bytes of the buffer (which are now unused because the
+          // slow copy has consumed them already).
+          fastCopy.read()
+
+          // Now the slow copy should see the additional available bytes.
+          availableAfterBufferReplenish = slowCopy.available()
+        }
+      }
+    }
+
+    copier.transfer()
+
+    testThread.join()
+
+    assertEquals(300, availableBeforeBufferReplenish, "Available before additional read")
+    assertEquals(800, availableAfterBufferReplenish, "Available after buffer replenished")
+  }
+
+  @Test
+  fun `close completes quickly without waiting`() {
+    val testData = generateTestData(1000)
+    val source = ByteArrayInputStream(testData)
+    val copier = InputStreamCopier(source)
+
+    val copy1 = copier.getCopy()
+
+    val copierClosedLatch = CountDownLatch(1)
+    var copyRunning = true
+
+    val copyThread = thread {
+      try {
+        // Wait for main thread to tell us it's done asserting that it didn't wait for us
+        copierClosedLatch.await(15, TimeUnit.SECONDS)
+        copy1.close()
+      } finally {
+        copyRunning = false
+      }
+    }
+
+    copier.close()
+
+    assertTrue(copyRunning, "Copy thread should still be running after close")
+
+    copierClosedLatch.countDown()
+    copyThread.join()
+  }
+
+  private fun generateTestData(size: Int): ByteArray {
+    return ByteArray(size) { (it % 256).toByte() }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
@@ -370,7 +370,6 @@ class InputStreamCopierTest {
     val source = ByteArrayInputStream(testData)
     val copier = InputStreamCopier(source, bufferSize = 800, minReadSize = 200)
 
-    var availableBeforeBufferReplenish: Int? = null
     var availableAfterBufferReplenish: Int? = null
 
     val fastCopy = copier.getCopy()
@@ -389,10 +388,6 @@ class InputStreamCopierTest {
           // the buffer is available for further reads from the source stream.
           slowCopy.read(ByteArray(500))
 
-          // At this point, the slow copy should have the rest of the buffer's worth of data
-          // available.
-          availableBeforeBufferReplenish = slowCopy.available()
-
           // Consume more data from the fast copy, which will trigger another read from the source
           // stream to fill up the first 500 bytes of the buffer (which are now unused because the
           // slow copy has consumed them already).
@@ -408,7 +403,6 @@ class InputStreamCopierTest {
 
     testThread.join()
 
-    assertEquals(300, availableBeforeBufferReplenish, "Available before additional read")
     assertEquals(800, availableAfterBufferReplenish, "Available after buffer replenished")
   }
 

--- a/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/InputStreamCopierTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.util
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
+import java.net.SocketTimeoutException
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -161,7 +162,7 @@ class InputStreamCopierTest {
     val failingStream =
         object : InputStream() {
           override fun read(): Int {
-            throw IOException("Test exception")
+            throw SocketTimeoutException("Test exception")
           }
         }
 
@@ -201,8 +202,9 @@ class InputStreamCopierTest {
 
     assertEquals(2, exceptions.size, "Both copies should receive the exception")
     exceptions.forEach { exception ->
-      assertInstanceOf<IOException>(exception)
-      assertEquals("Test exception", exception.message)
+      assertInstanceOf<IOException>(exception, "Top-level exception")
+      assertInstanceOf<SocketTimeoutException>(exception.cause, "Nested exception")
+      assertEquals("Test exception", exception.cause?.message)
     }
   }
 


### PR DESCRIPTION
For the upcoming changes to support photos and videos in activity log entries, we
are going to need to store uploaded files in S3 and also pull metadata from them
(GPS location, etc.) We get an `InputStream` with the uploaded data, but we can
only read it once unless we want to load the whole thing into memory, impractical
with large video file uploads. We could also read the file back from S3 after
saving it, but that would incur extra transfer fees and would take extra time.

Add a new utility class that duplicates an `InputStream` incrementally, allowing
it to be read by multiple consumers at once. The source stream is incrementally
loaded into a small temporary buffer on demand, with backpressure to prevent fast
readers from outpacing slow ones by more than the size of that buffer.

We'll be able to use this to feed one copy of the stream to the file store and
another copy (or copies) to Apache Tika for metadata extraction.