### PR TITLE
Specify Yarn version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
     "mjml": "node scripts/mjml-with-plugins.js",
     "translate": "autotranslate",
     "translate:start": "autotranslate --watch"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
The Yarn Gradle plugin wants to use Yarn 1; specify that in `package.json` so
Corepack doesn't keep trying to edit the file.