### PR TITLE
Ask Terraware: strip underscore from deal name

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/ask/ChatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/ask/ChatService.kt
@@ -192,9 +192,9 @@ class ChatService(
     val projectName =
         if (
             projectAcceleratorDetails.dealName != null &&
-                projectAcceleratorDetails.dealName.length > 3
+                projectAcceleratorDetails.dealName.length > 4
         ) {
-          projectAcceleratorDetails.dealName.substring(3)
+          projectAcceleratorDetails.dealName.substring(4)
         } else {
           project.name
         }


### PR DESCRIPTION
Deal names start with a three-letter country code and an underscore. When
we were extracting a project name from a deal name to feed to the LLM, we
were only stripping off the country code, not the underscore.