### PR TITLE
SW-7360 Add Created/Modified fields to Project Internal Users

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/api/ProjectsController.kt
@@ -228,23 +228,27 @@ data class GetProjectResponsePayload(val project: ProjectPayload) : SuccessRespo
 data class ListProjectsResponsePayload(val projects: List<ProjectPayload>) : SuccessResponsePayload
 
 data class ProjectInternalUserResponsePayload(
-    val userId: UserId,
+    val createdTime: Instant,
     val email: String,
     val firstName: String?,
     val lastName: String?,
+    val modifiedTime: Instant,
     val role: ProjectInternalRole? = null,
     val roleName: String? = null,
+    val userId: UserId,
 ) {
   constructor(
       user: TerrawareUser,
       projectInternalUser: ProjectInternalUsersRow,
   ) : this(
-      userId = user.userId,
+      createdTime = projectInternalUser.createdTime!!,
       email = user.email,
       firstName = user.firstName,
       lastName = user.lastName,
+      modifiedTime = projectInternalUser.modifiedTime!!,
       role = projectInternalUser.projectInternalRoleId,
       roleName = projectInternalUser.roleName,
+      userId = user.userId,
   )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -127,13 +127,39 @@ class ProjectStore(
 
     dslContext.transaction { _ ->
       with(PROJECT_INTERNAL_USERS) {
+        val currentUserId = currentUser().userId
+        val now = clock.instant()
         dslContext
-            .insertInto(this, PROJECT_ID, USER_ID, PROJECT_INTERNAL_ROLE_ID, ROLE_NAME)
-            .apply { users.forEach { values(projectId, it.userId, it.role, it.roleName) } }
+            .insertInto(
+                this,
+                PROJECT_ID,
+                USER_ID,
+                PROJECT_INTERNAL_ROLE_ID,
+                ROLE_NAME,
+                CREATED_BY,
+                CREATED_TIME,
+                MODIFIED_BY,
+                MODIFIED_TIME,
+            )
+            .apply {
+              users.forEach {
+                values(
+                    projectId,
+                    it.userId,
+                    it.role,
+                    it.roleName,
+                    currentUserId,
+                    now,
+                    currentUserId,
+                    now,
+                )
+              }
+            }
             .onConflict(PROJECT_ID, USER_ID)
             .doUpdate()
             .set(PROJECT_INTERNAL_ROLE_ID, DSL.excluded(PROJECT_INTERNAL_ROLE_ID))
             .set(ROLE_NAME, DSL.excluded(ROLE_NAME))
+            .set(MODIFIED_BY, DSL.excluded(MODIFIED_BY))
             .execute()
 
         users.forEach { user ->

--- a/src/main/resources/db/migration/0400/V403__InternalUsersModified.sql
+++ b/src/main/resources/db/migration/0400/V403__InternalUsersModified.sql
@@ -1,0 +1,39 @@
+ALTER TABLE project_internal_users
+    ADD COLUMN created_time TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+ALTER TABLE project_internal_users
+    ADD COLUMN modified_time TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+ALTER TABLE project_internal_users
+    ADD COLUMN created_by BIGINT REFERENCES users;
+ALTER TABLE project_internal_users
+    ADD COLUMN modified_by BIGINT REFERENCES users;
+
+-- Most internal users have been Project Leads, which includes TF Contacts
+UPDATE project_internal_users piu
+SET (created_by, modified_by, created_time, modified_time) = (
+    SELECT ou.created_by, ou.modified_by, ou.created_time, ou.modified_time
+    FROM organization_users ou
+    WHERE ou.user_id = piu.user_id
+    AND ou.organization_id = (select organization_id from projects where id = piu.project_id)
+    AND ou.role_id = 5 -- TF CONTACT
+)
+WHERE piu.project_internal_role_id in (1, 2) -- only do this for users that became TF Contacts through internal roles
+;
+
+-- If any others remain, use system user
+UPDATE project_internal_users piu
+SET (created_by, modified_by, created_time, modified_time) = (
+    SELECT u.id, u.id, NOW(), NOW()
+    FROM users u
+    WHERE u.user_type_id = 4 -- system user
+)
+WHERE created_by IS NULL;
+
+ALTER TABLE project_internal_users
+    ALTER COLUMN created_by SET NOT NULL;
+ALTER TABLE project_internal_users
+    ALTER COLUMN modified_by SET NOT NULL;
+ALTER TABLE project_internal_users
+    ALTER COLUMN created_time SET NOT NULL;
+ALTER TABLE project_internal_users
+    ALTER COLUMN modified_time SET NOT NULL;

--- a/src/main/resources/db/migration/0400/V403__InternalUsersModified.sql
+++ b/src/main/resources/db/migration/0400/V403__InternalUsersModified.sql
@@ -1,11 +1,7 @@
 ALTER TABLE project_internal_users
-    ADD COLUMN created_time TIMESTAMP WITH TIME ZONE DEFAULT NOW();
-ALTER TABLE project_internal_users
-    ADD COLUMN modified_time TIMESTAMP WITH TIME ZONE DEFAULT NOW();
-
-ALTER TABLE project_internal_users
-    ADD COLUMN created_by BIGINT REFERENCES users;
-ALTER TABLE project_internal_users
+    ADD COLUMN created_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    ADD COLUMN modified_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    ADD COLUMN created_by BIGINT REFERENCES users,
     ADD COLUMN modified_by BIGINT REFERENCES users;
 
 -- Most internal users have been Project Leads, which includes TF Contacts
@@ -22,18 +18,13 @@ WHERE piu.project_internal_role_id in (1, 2) -- only do this for users that beca
 
 -- If any others remain, use system user
 UPDATE project_internal_users piu
-SET (created_by, modified_by, created_time, modified_time) = (
-    SELECT u.id, u.id, NOW(), NOW()
+SET (created_by, modified_by) = (
+    SELECT u.id, u.id
     FROM users u
     WHERE u.user_type_id = 4 -- system user
 )
 WHERE created_by IS NULL;
 
 ALTER TABLE project_internal_users
-    ALTER COLUMN created_by SET NOT NULL;
-ALTER TABLE project_internal_users
+    ALTER COLUMN created_by SET NOT NULL,
     ALTER COLUMN modified_by SET NOT NULL;
-ALTER TABLE project_internal_users
-    ALTER COLUMN created_time SET NOT NULL;
-ALTER TABLE project_internal_users
-    ALTER COLUMN modified_time SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -342,16 +342,28 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
                   projectId = projectId,
                   userId = userToAdd,
                   roleName = "A new role",
+                  createdBy = user.userId,
+                  createdTime = clock.instant,
+                  modifiedBy = user.userId,
+                  modifiedTime = clock.instant,
               ),
               ProjectInternalUsersRecord(
                   projectId = projectId,
                   userId = userToKeep,
                   projectInternalRoleId = ProjectInternalRole.ProjectFinanceLead,
+                  createdBy = user.userId,
+                  createdTime = clock.instant,
+                  modifiedBy = user.userId,
+                  modifiedTime = clock.instant,
               ),
               ProjectInternalUsersRecord(
                   projectId = projectId,
                   userId = userToChange,
                   projectInternalRoleId = ProjectInternalRole.LegalLead,
+                  createdBy = user.userId,
+                  createdTime = clock.instant,
+                  modifiedBy = user.userId,
+                  modifiedTime = clock.instant,
               ),
           )
       )

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -928,13 +928,21 @@ abstract class DatabaseBackedTest {
       userId: UserId = row.userId ?: inserted.userId,
       role: ProjectInternalRole? = row.projectInternalRoleId,
       roleName: String? = row.roleName,
+      createdBy: UserId = currentUser().userId,
+      createdTime: Instant = Instant.EPOCH,
+      modifiedBy: UserId = currentUser().userId,
+      modifiedTime: Instant = Instant.EPOCH,
   ): ProjectInternalUsersRow {
     val rowWithDefaults =
         ProjectInternalUsersRow(
+            createdBy = createdBy,
+            createdTime = createdTime,
+            modifiedBy = modifiedBy,
+            modifiedTime = modifiedTime,
             projectId = projectId,
-            userId = userId,
             projectInternalRoleId = role,
             roleName = roleName,
+            userId = userId,
         )
 
     projectInternalUsersDao.insert(rowWithDefaults)


### PR DESCRIPTION
We want to be able to sort a project’s internal users by modified time but project_internal_users table does not have this field. 

Add created/modified by/time fields. Default these to the timestamp and user they were added with if Project Leads or Restoration Leads. Use the current timestamp and system user for the rest. (All currently in prod are Project Leads).

Add created and modified time to the controller payload for retrieving project internal users.