### PR TITLE
Fix t0 payload, fix observation assign endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -72,11 +72,10 @@ data class PlotT0DataPayload(
     val densityData: List<SpeciesDensityPayload>,
 ) {
   constructor(
-      model: PlotT0DataModel,
-      observationId: ObservationId? = null,
+      model: PlotT0DataModel
   ) : this(
       monitoringPlotId = model.monitoringPlotId,
-      observationId = observationId,
+      observationId = model.observationId,
       densityData = model.densityData.map { SpeciesDensityPayload(it) },
   )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -82,6 +82,7 @@ class T0PlotStore(
                   .where(
                       OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId)
                           .and(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(monitoringPlotId))
+                          .and(OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID.isNotNull)
                   )
           )
           .onDuplicateKeyUpdate()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -130,13 +130,13 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertObservedPlotSpeciesTotals(
           certainty = RecordedSpeciesCertainty.Other,
           speciesName = "Something else",
-          totalLive = 3,
-          totalDead = 4,
+          totalLive = 5,
+          totalDead = 6,
       )
       insertObservedPlotSpeciesTotals(
           certainty = RecordedSpeciesCertainty.Unknown,
-          totalLive = 3,
-          totalDead = 4,
+          totalLive = 7,
+          totalDead = 8,
       )
       store.assignT0PlotObservation(monitoringPlotId, observationId)
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.records.PlotT0DensityRecord
 import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
 import com.terraformation.backend.multiPolygon
@@ -126,6 +127,17 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores observation and all species densities`() {
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 2)
       insertObservedPlotSpeciesTotals(speciesId = speciesId2, totalLive = 3, totalDead = 4)
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Other,
+          speciesName = "Something else",
+          totalLive = 3,
+          totalDead = 4,
+      )
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Unknown,
+          totalLive = 3,
+          totalDead = 4,
+      )
       store.assignT0PlotObservation(monitoringPlotId, observationId)
 
       assertTableEquals(


### PR DESCRIPTION
The Fetch T0 Data endpoint was not correctly returning observation ids. Fix that.

The Assign T0 Data endpoint was incorrectly including `Unknown` and `Other` when trying to assign densities from an observation. Exclude those. 