### PR TITLE
Generate unique storage URLs in insertFile

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -140,13 +140,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           mitigationPlan = "Plan A",
       )
 
-      val fileId1 = insertFile(storageUrl = "https://file1")
+      val fileId1 = insertFile()
       insertReportPhoto(caption = "photo caption 1")
 
-      val fileId2 = insertFile(storageUrl = "https://file2")
+      val fileId2 = insertFile()
       insertReportPhoto(caption = "photo caption 2")
 
-      insertFile(storageUrl = "https://file3")
+      insertFile()
       insertReportPhoto(caption = "deleted", deleted = true)
 
       val reportModel =

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -1732,6 +1732,8 @@ abstract class DatabaseBackedTest {
     return insertedId.also { inserted.subLocationIds.add(it) }
   }
 
+  private var nextStorageUrlNumber = 1
+
   fun insertFile(
       row: FilesRow = FilesRow(),
       fileName: String = row.fileName ?: "fileName",
@@ -1741,7 +1743,7 @@ abstract class DatabaseBackedTest {
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
-      storageUrl: Any = row.storageUrl ?: "http://dummy",
+      storageUrl: Any = row.storageUrl ?: "http://dummy/${nextStorageUrlNumber++}",
   ): FileId {
     val rowWithDefaults =
         row.copy(

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
@@ -7,7 +7,8 @@ import com.terraformation.backend.db.docprod.tables.pojos.VariableImageValuesRow
 import com.terraformation.backend.db.docprod.tables.pojos.VariableValuesRow
 import com.terraformation.backend.file.InMemoryFileStore
 import java.net.URI
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -194,16 +195,8 @@ class ImagesControllerTest : ControllerIntegrationTest() {
     @Test
     fun `allocates next available list position if not specified`() {
       val imageVariableId = insertVariable(type = VariableType.Image, isList = true)
-      insertImageValue(
-          imageVariableId,
-          insertFile(storageUrl = URI("http://dummy1")),
-          listPosition = 0,
-      )
-      insertImageValue(
-          imageVariableId,
-          insertFile(storageUrl = URI("http://dummy2")),
-          listPosition = 1,
-      )
+      insertImageValue(imageVariableId, insertFile(), listPosition = 0)
+      insertImageValue(imageVariableId, insertFile(), listPosition = 1)
 
       val caption = "Image caption"
       val fileData = byteArrayOf(1, 2, 3, 4)

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportsStoreTest.kt
@@ -117,11 +117,11 @@ class PublishedReportsStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           position = 1,
       )
 
-      val fileId1 = insertFile(storageUrl = "https://file1")
+      val fileId1 = insertFile()
       insertReportPhoto(caption = "photo caption 1")
       insertPublishedReportPhoto(caption = "photo caption 1")
 
-      val fileId2 = insertFile(storageUrl = "https://file2")
+      val fileId2 = insertFile()
       insertReportPhoto(caption = "photo caption 2")
       insertPublishedReportPhoto(caption = "photo caption 2")
 


### PR DESCRIPTION
Don't require tests that insert rows into the `files` table to include their own
unique storage URLs just to avoid unique key constraint violations.