### PR TITLE
SW-7346 Support listing and reading activity media

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
@@ -1,0 +1,42 @@
+package com.terraformation.backend.accelerator.model
+
+import com.terraformation.backend.db.accelerator.ActivityMediaType
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import java.time.Instant
+import java.time.LocalDate
+import org.jooq.Field
+import org.jooq.Record
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.Point
+
+data class ActivityMediaModel(
+    val caption: String?,
+    val createdBy: UserId,
+    val createdTime: Instant,
+    val capturedDate: LocalDate,
+    val fileId: FileId,
+    val geolocation: Point?,
+    val isCoverPhoto: Boolean,
+    val type: ActivityMediaType,
+) {
+  companion object {
+    fun of(
+        record: Record,
+        geolocationField: Field<Geometry?> = ACTIVITY_MEDIA_FILES.GEOLOCATION,
+    ): ActivityMediaModel {
+      return ActivityMediaModel(
+          caption = record[ACTIVITY_MEDIA_FILES.CAPTION],
+          createdBy = record[FILES.CREATED_BY]!!,
+          createdTime = record[FILES.CREATED_TIME]!!,
+          capturedDate = record[ACTIVITY_MEDIA_FILES.CAPTURED_DATE]!!,
+          fileId = record[ACTIVITY_MEDIA_FILES.FILE_ID]!!,
+          geolocation = record[geolocationField] as? Point,
+          isCoverPhoto = record[ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO]!!,
+          type = record[ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID]!!,
+      )
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
 import java.time.Instant
 import java.time.LocalDate
+import org.jooq.Field
 import org.jooq.Record
 
 data class ExistingActivityModel(
@@ -17,6 +18,7 @@ data class ExistingActivityModel(
     val description: String?,
     val id: ActivityId,
     val isHighlight: Boolean,
+    val media: List<ActivityMediaModel> = emptyList(),
     val modifiedBy: UserId,
     val modifiedTime: Instant,
     val projectId: ProjectId,
@@ -25,7 +27,10 @@ data class ExistingActivityModel(
     val isVerified: Boolean = verifiedBy != null,
 ) {
   companion object {
-    fun of(record: Record): ExistingActivityModel {
+    fun of(
+        record: Record,
+        mediaField: Field<List<ActivityMediaModel>>?,
+    ): ExistingActivityModel {
       return with(ACTIVITIES) {
         ExistingActivityModel(
             activityDate = record[ACTIVITY_DATE]!!,
@@ -35,6 +40,7 @@ data class ExistingActivityModel(
             description = record[DESCRIPTION],
             id = record[ID]!!,
             isHighlight = record[IS_HIGHLIGHT]!!,
+            media = mediaField?.let { record[it] } ?: emptyList(),
             modifiedBy = record[MODIFIED_BY]!!,
             modifiedTime = record[MODIFIED_TIME]!!,
             projectId = record[PROJECT_ID]!!,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.AutomationModel
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.accelerator.ApplicationHistoryId
 import com.terraformation.backend.db.accelerator.ApplicationId
@@ -90,6 +91,7 @@ import com.terraformation.backend.db.accelerator.tables.daos.SubmissionSnapshots
 import com.terraformation.backend.db.accelerator.tables.daos.SubmissionsDao
 import com.terraformation.backend.db.accelerator.tables.daos.UserInternalInterestsDao
 import com.terraformation.backend.db.accelerator.tables.pojos.ActivitiesRow
+import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFilesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationHistoriesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationModulesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.ApplicationsRow
@@ -3761,6 +3763,29 @@ abstract class DatabaseBackedTest {
     activitiesDao.insert(row)
 
     return row.id!!.also { inserted.activityIds.add(it) }
+  }
+
+  protected fun insertActivityMediaFile(
+      activityId: ActivityId = inserted.activityId,
+      caption: String? = null,
+      capturedDate: LocalDate = LocalDate.EPOCH,
+      fileId: FileId = inserted.fileId,
+      geolocation: Point? = null,
+      isCoverPhoto: Boolean = false,
+      type: ActivityMediaType = ActivityMediaType.Photo,
+  ) {
+    val row =
+        ActivityMediaFilesRow(
+            activityId = activityId,
+            activityMediaTypeId = type,
+            caption = caption,
+            capturedDate = capturedDate,
+            fileId = fileId,
+            geolocation = geolocation,
+            isCoverPhoto = isCoverPhoto,
+        )
+
+    activityMediaFilesDao.insert(row)
   }
 
   private var nextInternalTagNumber = 1


### PR DESCRIPTION
Include a list of media files as part of the activity data, and add an endpoint to
allow fetching the original files or thumbnails; this works the same as the photo
GET endpoints elsewhere in the API.