### PR TITLE
SW-7346 Add activity media update/delete APIs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.accelerator.model.ActivityMediaModel
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import jakarta.inject.Named
+import java.time.InstantSource
+import org.jooq.Condition
+import org.jooq.DSLContext
+
+@Named
+class ActivityMediaStore(
+    private val clock: InstantSource,
+    private val dslContext: DSLContext,
+) {
+  fun fetchOne(activityId: ActivityId, fileId: FileId): ActivityMediaModel {
+    requirePermissions { readActivity(activityId) }
+
+    return fetchByCondition(
+            ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId)
+                .and(ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId))
+        )
+        .firstOrNull() ?: throw FileNotFoundException(fileId)
+  }
+
+  fun updateMedia(
+      activityId: ActivityId,
+      fileId: FileId,
+      applyFunc: (ActivityMediaModel) -> ActivityMediaModel,
+  ) {
+    requirePermissions { updateActivity(activityId) }
+
+    val existing = fetchOne(activityId, fileId)
+    val updated = applyFunc(existing)
+
+    dslContext.transaction { _ ->
+      with(ACTIVITY_MEDIA_FILES) {
+        if (!existing.isCoverPhoto && updated.isCoverPhoto) {
+          dslContext
+              .update(ACTIVITY_MEDIA_FILES)
+              .set(IS_COVER_PHOTO, false)
+              .where(ACTIVITY_ID.eq(activityId))
+              .execute()
+        }
+
+        dslContext
+            .update(ACTIVITY_MEDIA_FILES)
+            .set(CAPTION, updated.caption)
+            .set(IS_COVER_PHOTO, updated.isCoverPhoto)
+            .where(ACTIVITY_ID.eq(activityId))
+            .and(FILE_ID.eq(fileId))
+            .execute()
+      }
+
+      with(FILES) {
+        dslContext
+            .update(FILES)
+            .set(MODIFIED_BY, currentUser().userId)
+            .set(MODIFIED_TIME, clock.instant())
+            .where(ID.eq(fileId))
+            .execute()
+      }
+    }
+  }
+
+  private fun fetchByCondition(condition: Condition): List<ActivityMediaModel> {
+    return dslContext
+        .select(ACTIVITY_MEDIA_FILES.asterisk(), FILES.CREATED_BY, FILES.CREATED_TIME)
+        .from(ACTIVITY_MEDIA_FILES)
+        .join(FILES)
+        .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
+        .where(condition)
+        .orderBy(ACTIVITY_MEDIA_FILES.FILE_ID)
+        .fetch { ActivityMediaModel.of(it) }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/ActivityDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/ActivityDeletionStartedEvent.kt
@@ -1,0 +1,6 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.ActivityId
+
+/** Published in an open database transaction when an activity is about to be deleted. */
+data class ActivityDeletionStartedEvent(val activityId: ActivityId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
@@ -1,0 +1,111 @@
+package com.terraformation.backend.accelerator.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val store: ActivityMediaStore by lazy { ActivityMediaStore(clock, dslContext) }
+
+  private lateinit var activityId: ActivityId
+  private lateinit var organizationId: OrganizationId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+    val projectId = insertProject(organizationId)
+    activityId = insertActivity(projectId = projectId)
+
+    insertOrganizationUser(role = Role.Admin)
+  }
+
+  @Nested
+  inner class UpdateMedia {
+    @Test
+    fun `updates writable fields`() {
+      val otherUserId = insertUser()
+      val fileId = insertFile(createdBy = otherUserId)
+      insertActivityMediaFile()
+
+      val filesBefore = dslContext.selectFrom(FILES).fetch()
+      val activityMediaFilesBefore = dslContext.selectFrom(ACTIVITY_MEDIA_FILES).fetch()
+
+      val now = Instant.ofEpochSecond(30)
+      clock.instant = now
+
+      store.updateMedia(activityId, fileId) {
+        it.copy(caption = "New caption", isCoverPhoto = true)
+      }
+
+      assertTableEquals(
+          activityMediaFilesBefore.first().also { record ->
+            record.caption = "New caption"
+            record.isCoverPhoto = true
+          }
+      )
+      assertTableEquals(
+          filesBefore.first().also { record ->
+            record.modifiedBy = user.userId
+            record.modifiedTime = now
+          }
+      )
+    }
+
+    @Test
+    fun `clears isCoverPhoto on existing cover photo if it is set on updated file`() {
+      val fileId1 = insertFile()
+      insertActivityMediaFile(isCoverPhoto = true)
+      val fileId2 = insertFile()
+      insertActivityMediaFile(isCoverPhoto = false)
+
+      store.updateMedia(activityId, fileId2) { it.copy(isCoverPhoto = true) }
+
+      assertEquals(
+          mapOf(fileId1 to false, fileId2 to true),
+          activityMediaFilesDao.findAll().associate { it.fileId to it.isCoverPhoto },
+          "Cover photo flags",
+      )
+    }
+
+    @Test
+    fun `leaves isCoverPhoto alone on existing cover photo if it is not set on updated file`() {
+      val fileId1 = insertFile()
+      insertActivityMediaFile(isCoverPhoto = true)
+      val fileId2 = insertFile()
+      insertActivityMediaFile(isCoverPhoto = false)
+
+      store.updateMedia(activityId, fileId2) { it.copy(caption = "Edited") }
+
+      assertEquals(
+          mapOf(fileId1 to true, fileId2 to false),
+          activityMediaFilesDao.findAll().associate { it.fileId to it.isCoverPhoto },
+          "Cover photo flags",
+      )
+    }
+
+    @Test
+    fun `throws exception if no permission to update activity`() {
+      val fileId = insertFile()
+      insertActivityMediaFile()
+
+      deleteOrganizationUser()
+
+      assertThrows<ActivityNotFoundException> { store.updateMedia(activityId, fileId) { it } }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.accelerator.model.ActivityMediaModel
 import com.terraformation.backend.accelerator.model.ExistingActivityModel
 import com.terraformation.backend.accelerator.model.NewActivityModel
@@ -33,8 +35,9 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
   private val store: ActivityStore by lazy {
-    ActivityStore(clock, dslContext, ParentStore(dslContext))
+    ActivityStore(clock, dslContext, eventPublisher, ParentStore(dslContext))
   }
 
   private lateinit var projectId: ProjectId
@@ -344,6 +347,8 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       store.delete(activityId)
 
       assertTableEmpty(ACTIVITIES)
+
+      eventPublisher.assertEventPublished(ActivityDeletionStartedEvent(activityId))
     }
 
     @Test


### PR DESCRIPTION
Add PUT and DELETE endpoints for activity media files. Only a couple fields can be
edited using the PUT endpoint.