### PR TITLE
SW-7365 Remove t0 observation if changing to manual species data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -104,10 +104,10 @@ class T0PlotStore(
   ) {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    if (plotHasObservationT0(monitoringPlotId)) {
-      throw IllegalStateException(
-          "Cannot assign species density to plot $monitoringPlotId which already has observation assigned"
-      )
+    with(PLOT_T0_OBSERVATIONS) {
+      // delete t0 observations associated with this plot so that retrieval doesn't return incorrect
+      // data
+      dslContext.deleteFrom(this).where(MONITORING_PLOT_ID.eq(monitoringPlotId)).execute()
     }
 
     with(PLOT_T0_DENSITY) {


### PR DESCRIPTION
If a user decides to change from an observation as the t0 source of truth to manual species values, the endpoint throws an exception. Update the endpoint to delete the existing t0 observation instead of throwing an exception.