### PR TITLE
SW-7367 Allow temporary read access to files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminFilesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminFilesController.kt
@@ -1,0 +1,56 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.log.perClassLogger
+import java.time.Duration
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminFilesController(
+    private val config: TerrawareServerConfig,
+    private val fileService: FileService,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/fileAccessTokens")
+  fun getFileAccessTokens(model: Model): String {
+    return "/admin/fileAccessTokens"
+  }
+
+  @PostMapping("/createFileAccessToken")
+  fun createFileAccessToken(
+      @RequestParam fileId: FileId,
+      @RequestParam expiration: String,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      val duration = Duration.parse("PT$expiration")
+      val token = fileService.createToken(fileId, duration)
+      val fetchUrl = config.webAppUrl.resolve("/api/v1/files/tokens/$token")
+
+      redirectAttributes.successMessage = "Created token $token"
+      redirectAttributes.successDetails = listOf("URL to fetch: $fetchUrl")
+    } catch (e: Exception) {
+      log.error("Error creating token", e)
+      redirectAttributes.failureMessage = "Failed to create token: ${e.message}"
+    }
+
+    return redirectToFileAccessTokens()
+  }
+
+  private fun redirectToFileAccessTokens() = "redirect:/admin/fileAccessTokens"
+}

--- a/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/auth/SecurityConfig.kt
@@ -85,6 +85,9 @@ class SecurityConfig(
         // Allow unauthenticated users (such as load balancers) to access health checks.
         authorize("/actuator/health", permitAll)
 
+        // Allow unauthenticated users to fetch files using temporary access tokens.
+        authorize("/api/v1/files/tokens/**", permitAll)
+
         authorize("/api/**", fullyAuthenticated)
         authorize("/admin/**", fullyAuthenticated)
       }

--- a/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/Exceptions.kt
@@ -225,6 +225,9 @@ class TimeseriesNotFoundException(
   constructor(deviceId: DeviceId) : this(deviceId, null, "Timeseries not found on device $deviceId")
 }
 
+class TokenNotFoundException(val token: String) :
+    EntityNotFoundException("Token $token not found or expired")
+
 class UploadNotAwaitingActionException(val uploadId: UploadId) :
     MismatchedStateException("Upload $uploadId is not awaiting user action")
 

--- a/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
@@ -1,0 +1,31 @@
+package com.terraformation.backend.file.api
+
+import com.terraformation.backend.api.InternalEndpoint
+import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.file.FileService
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@InternalEndpoint
+@RequestMapping("/api/v1/files")
+@RestController
+class FilesController(
+    private val fileService: FileService,
+) {
+  @GetMapping("/tokens/{token}", produces = [MediaType.ALL_VALUE])
+  @Operation(
+      summary = "Gets the contents of the file associated with a file access token.",
+      description =
+          "This endpoint does not require authentication; it's intended to offer temporary file " +
+              "access for third-party services such as video transcoding.",
+  )
+  fun getFileForToken(@PathVariable token: String): ResponseEntity<InputStreamResource> {
+    return fileService.readFileForToken(token).toResponseEntity()
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -134,6 +134,7 @@ springdoc:
     - "com.terraformation.backend.documentproducer.api"
     - "com.terraformation.backend.customer.api"
     - "com.terraformation.backend.device.api"
+    - "com.terraformation.backend.file.api"
     - "com.terraformation.backend.funder.api"
     - "com.terraformation.backend.gis.api"
     - "com.terraformation.backend.i18n.api"

--- a/src/main/resources/db/migration/0400/V405__FileAccessTokens.sql
+++ b/src/main/resources/db/migration/0400/V405__FileAccessTokens.sql
@@ -1,0 +1,10 @@
+CREATE TABLE file_access_tokens (
+    token TEXT PRIMARY KEY,
+    file_id BIGINT NOT NULL REFERENCES files ON DELETE CASCADE,
+    created_by BIGINT NOT NULL REFERENCES users,
+    created_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    expires_time TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX ON file_access_tokens (expires_time);
+CREATE INDEX ON file_access_tokens (file_id);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -89,6 +89,8 @@ COMMENT ON TABLE facility_connection_states IS '(Enum) Progress of the configura
 
 COMMENT ON TABLE facility_types IS '(Enum) Types of facilities that can be represented in the data model.';
 
+COMMENT ON TABLE file_access_tokens IS 'Temporary tokens for unauthenticated access to files from the file store.';
+
 COMMENT ON TABLE files IS 'Generic information about individual files. Files are associated with application entities using linking tables such as `accession_photos`.';
 
 COMMENT ON TABLE flyway_schema_history IS 'Tracks which database migrations have already been applied. Used by the Flyway library, not by application.';

--- a/src/main/resources/templates/admin/fileAccessTokens.html
+++ b/src/main/resources/templates/admin/fileAccessTokens.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        form { padding-bottom: 1em; }
+    </style>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>File Access Tokens</h2>
+
+<h3>Create New Token</h3>
+
+<form method="POST" action="/admin/createFileAccessToken">
+    <label>
+        File ID
+        <input type="text" name="fileId"/>
+    </label>
+    <label>
+        Expiration time with unit suffix (e.g., 30s, 15m, 1h)
+        <input type="text" name="expiration"/>
+    </label>
+    <button type="submit">Create Token</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -103,6 +103,10 @@
     <summary>Test Utilities</summary>
 
     <p>
+        <a href="/admin/fileAccessTokens">File access tokens</a>
+    </p>
+
+    <p>
         <a href="/admin/testClock">Test clock adjustment</a>
     </p>
 </details>

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -279,6 +279,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "facilities" to setOf(ALL, CUSTOMER, DEVICE, SEEDBANK),
                   "facility_connection_states" to setOf(ALL, CUSTOMER, DEVICE),
                   "facility_types" to setOf(ALL, CUSTOMER),
+                  "file_access_tokens" to setOf(ALL),
                   "files" to setOf(ALL, CUSTOMER, NURSERY, SEEDBANK),
                   "gbif_distributions" to setOf(SPECIES),
                   "gbif_names" to setOf(SPECIES),


### PR DESCRIPTION
To allow a video streaming provider to convert user-uploaded videos to the correct
formats for streaming, the provider needs to be able to access the original file,
and of course it won't know how to authenticate to Terraware.

Add an endpoint that works similarly to features like S3's pre-signed URLs: we can
generate a URL that includes a token that allows unauthenticated access to a file
for a certain amount of time. For our purposes, there's no need for anything as
complex as signed keys; it's sufficient to just generate a hard-enough-to-guess
token and check it against our database.

The admin UI has a new page that super-admins can use to generate tokens for
testing.