### PR TITLE
SW-7313 Used up accessions should allow updates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -251,10 +251,13 @@ data class AccessionModel(
           // always measured in seeds), we can't rely on the seeds-to-weight calculation precisely
           // matching the remaining weight quantity because weights have limited precision. Force
           // the remaining quantity to zero in that case.
+          // Also force the remaining quantity to zero if the accession is currently used up and the
+          // new state is also used up
           if (
-              latestObservedQuantity.units != SeedQuantityUnits.Seeds &&
+              (latestObservedQuantity.units != SeedQuantityUnits.Seeds &&
                   mostRecentWithdrawal?.withdrawn?.units == SeedQuantityUnits.Seeds &&
-                  mostRecentWithdrawal.withdrawn.quantity.toInt() == existing.estimatedSeedCount
+                  (mostRecentWithdrawal.withdrawn.quantity.toInt() == existing.estimatedSeedCount ||
+                      (state == AccessionState.UsedUp && existing.state == AccessionState.UsedUp)))
           ) {
             SeedQuantityModel.of(BigDecimal.ZERO, latestObservedQuantity.units)
           } else {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -257,8 +257,7 @@ data class AccessionModel(
               (latestObservedQuantity.units != SeedQuantityUnits.Seeds &&
                   mostRecentWithdrawal?.withdrawn?.units == SeedQuantityUnits.Seeds &&
                   (mostRecentWithdrawal.withdrawn.quantity.toInt() == existing.estimatedSeedCount ||
-                      (state == AccessionState.UsedUp &&
-                          existing.remaining?.quantity == BigDecimal.ZERO)))
+                      (state == AccessionState.UsedUp && remaining?.quantity == BigDecimal.ZERO)))
           ) {
             SeedQuantityModel.of(BigDecimal.ZERO, latestObservedQuantity.units)
           } else {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/model/Accession.kt
@@ -257,7 +257,8 @@ data class AccessionModel(
               (latestObservedQuantity.units != SeedQuantityUnits.Seeds &&
                   mostRecentWithdrawal?.withdrawn?.units == SeedQuantityUnits.Seeds &&
                   (mostRecentWithdrawal.withdrawn.quantity.toInt() == existing.estimatedSeedCount ||
-                      (state == AccessionState.UsedUp && existing.state == AccessionState.UsedUp)))
+                      (state == AccessionState.UsedUp &&
+                          existing.remaining?.quantity == BigDecimal.ZERO)))
           ) {
             SeedQuantityModel.of(BigDecimal.ZERO, latestObservedQuantity.units)
           } else {

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -163,6 +163,24 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
     }
 
     @Test
+    fun `updating an accession after it's used up shouldn't break on calculation`() {
+      val accession =
+          accession(
+              estimatedSeedCount = 0,
+              latestObservedQuantity = milligrams(BigDecimal("1874.8")),
+              latestObservedTime = yesterdayInstant,
+              remaining = milligrams(BigDecimal.ZERO),
+              subsetWeight = milligrams(BigDecimal("5.84")),
+              subsetCount = 100,
+              state = AccessionState.UsedUp,
+              withdrawals = listOf(withdrawal(seeds(32103), date = today)),
+          )
+
+      val actual = accession.calculateRemaining(accession)
+      assertEquals(BigDecimal.ZERO, actual?.quantity)
+    }
+
+    @Test
     fun `total withdrawal count is null for weight-based withdrawals without subset info`() {
       val accession = accession(remaining = grams(10)).withCalculatedValues()
       val afterWithdrawal = accession.addWithdrawal(withdrawal(grams(1), id = null))

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelCalculationsTest.kt
@@ -450,6 +450,16 @@ internal class AccessionModelCalculationsTest : AccessionModelTest() {
               AccessionState.InStorage,
               "Change from Awaiting Check-In to In Storage",
           )
+          .copy(
+              latestObservedQuantity = milligrams(BigDecimal("1874.8")),
+              subsetWeightQuantity = milligrams(BigDecimal("5.84")),
+              subsetCount = 100,
+          )
+          .addStateTest(
+              { copy() },
+              AccessionState.InStorage,
+              "Accession in mg is no longer used up",
+          )
 
       return tests
     }

--- a/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/model/accession/AccessionModelTest.kt
@@ -41,6 +41,7 @@ internal abstract class AccessionModelTest {
   protected fun accession(
       viabilityTests: List<ViabilityTestModel> = emptyList(),
       dryingEndDate: LocalDate? = null,
+      estimatedSeedCount: Int? = null,
       latestObservedQuantity: SeedQuantityModel? = null,
       latestObservedTime: Instant? = null,
       remaining: SeedQuantityModel? = null,
@@ -56,6 +57,7 @@ internal abstract class AccessionModelTest {
         clock = clock,
         createdTime = clock.instant(),
         dryingEndDate = dryingEndDate,
+        estimatedSeedCount = estimatedSeedCount,
         latestObservedQuantity = latestObservedQuantity,
         latestObservedTime = latestObservedTime,
         remaining = remaining,


### PR DESCRIPTION
When an accession was last withdrawn by seed and the latest observed quantity was not seed, and the accession is currently used up, it throws an error during `calculateRemaining` if the estimated seed count wasn't an exact match of the remaining weight.

Fix the error and add tests.