### PR TITLE
SW-7345 Add admin-only activity creation endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -62,6 +62,7 @@ class ActivitiesAdminController(
 
   @Operation(summary = "Creates a new activity including accelerator-admin-only details.")
   @PostMapping
+  @RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
   fun adminCreateActivity(
       @RequestBody payload: AdminCreateActivityRequestPayload
   ): AdminGetActivityResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.accelerator.api
 import com.terraformation.backend.accelerator.db.ActivityStore
 import com.terraformation.backend.accelerator.model.ActivityMediaModel
 import com.terraformation.backend.accelerator.model.ExistingActivityModel
+import com.terraformation.backend.accelerator.model.NewActivityModel
 import com.terraformation.backend.api.AcceleratorEndpoint
 import com.terraformation.backend.api.RequireGlobalRole
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
@@ -21,6 +22,7 @@ import java.time.LocalDate
 import org.locationtech.jts.geom.Point
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -54,6 +56,16 @@ class ActivitiesAdminController(
   )
   fun adminGetActivity(@PathVariable("id") id: ActivityId): AdminGetActivityResponsePayload {
     val activity = activityStore.fetchOneById(id)
+
+    return AdminGetActivityResponsePayload(AdminActivityPayload(activity))
+  }
+
+  @Operation(summary = "Creates a new activity including accelerator-admin-only details.")
+  @PostMapping
+  fun adminCreateActivity(
+      @RequestBody payload: AdminCreateActivityRequestPayload
+  ): AdminGetActivityResponsePayload {
+    val activity = activityStore.create(payload.toModel())
 
     return AdminGetActivityResponsePayload(AdminActivityPayload(activity))
   }
@@ -127,6 +139,26 @@ data class AdminActivityPayload(
       verifiedBy = model.verifiedBy,
       verifiedTime = model.verifiedTime,
   )
+}
+
+data class AdminCreateActivityRequestPayload(
+    val date: LocalDate,
+    val description: String?,
+    val isHighlight: Boolean,
+    val isVerified: Boolean,
+    val projectId: ProjectId,
+    val type: ActivityType,
+) {
+  fun toModel(): NewActivityModel {
+    return NewActivityModel(
+        activityDate = date,
+        activityType = type,
+        description = description,
+        isHighlight = isHighlight,
+        isVerified = isVerified,
+        projectId = projectId,
+    )
+  }
 }
 
 data class AdminUpdateActivityRequestPayload(

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -36,6 +36,8 @@ class ActivityStore(
 
     val now = clock.instant()
     val userId = currentUser().userId
+    val verifiedBy = if (model.isVerified) userId else null
+    val verifiedTime = if (model.isVerified) now else null
 
     val activityId =
         dslContext
@@ -45,10 +47,12 @@ class ActivityStore(
             .set(ACTIVITIES.CREATED_BY, userId)
             .set(ACTIVITIES.CREATED_TIME, now)
             .set(ACTIVITIES.DESCRIPTION, model.description)
-            .set(ACTIVITIES.IS_HIGHLIGHT, false)
+            .set(ACTIVITIES.IS_HIGHLIGHT, model.isHighlight)
             .set(ACTIVITIES.MODIFIED_BY, userId)
             .set(ACTIVITIES.MODIFIED_TIME, now)
             .set(ACTIVITIES.PROJECT_ID, model.projectId)
+            .set(ACTIVITIES.VERIFIED_BY, verifiedBy)
+            .set(ACTIVITIES.VERIFIED_TIME, verifiedTime)
             .returningResult(ACTIVITIES.ID)
             .fetchOne(ACTIVITIES.ID)!!
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityModel.kt
@@ -57,4 +57,6 @@ data class NewActivityModel(
     val activityType: ActivityType,
     val activityDate: LocalDate,
     val description: String? = null,
+    val isHighlight: Boolean = false,
+    val isVerified: Boolean = false,
 )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -62,6 +62,40 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   activityDate = LocalDate.of(2024, 1, 15),
                   activityType = ActivityType.SeedCollection,
                   description = "Test activity description",
+                  isHighlight = true,
+                  projectId = projectId,
+              )
+          )
+
+      assertTableEquals(
+          ActivitiesRecord(
+              activityDate = LocalDate.of(2024, 1, 15),
+              activityTypeId = ActivityType.SeedCollection,
+              createdBy = currentUser().userId,
+              createdTime = clock.instant(),
+              description = "Test activity description",
+              id = model.id,
+              isHighlight = true,
+              modifiedBy = currentUser().userId,
+              modifiedTime = clock.instant(),
+              projectId = projectId,
+              verifiedBy = null,
+              verifiedTime = null,
+          )
+      )
+    }
+
+    @Test
+    fun `populates verifiedBy and verifiedTime if creating a verified activity`() {
+      insertOrganizationUser(role = Role.Admin)
+
+      val model =
+          store.create(
+              NewActivityModel(
+                  activityDate = LocalDate.of(2024, 1, 15),
+                  activityType = ActivityType.SeedCollection,
+                  description = "Test activity description",
+                  isVerified = true,
                   projectId = projectId,
               )
           )
@@ -78,8 +112,8 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               modifiedBy = currentUser().userId,
               modifiedTime = clock.instant(),
               projectId = projectId,
-              verifiedBy = null,
-              verifiedTime = null,
+              verifiedBy = currentUser().userId,
+              verifiedTime = clock.instant(),
           )
       )
     }


### PR DESCRIPTION
Accelerator admins need to be able to create pre-verified activities and mark them
as highlights from the get-go. Add a creation endpoint to let admins do both.