### PR TITLE
Speed up ObservationResultsStoreTest

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -143,7 +143,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         observationPlotsDao,
         observationRequestedSubzonesDao,
         parentStore,
-        recordedPlantsDao,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -41,7 +41,6 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         observationPlotsDao,
         observationRequestedSubzonesDao,
         parentStore,
-        recordedPlantsDao,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -65,7 +65,6 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
         observationPlotsDao,
         observationRequestedSubzonesDao,
         ParentStore(dslContext),
-        recordedPlantsDao,
     )
   }
   protected val resultsStore by lazy { ObservationResultsStore(dslContext) }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
@@ -26,7 +26,6 @@ abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
         observationPlotsDao,
         observationRequestedSubzonesDao,
         ParentStore(dslContext),
-        recordedPlantsDao,
     )
   }
   protected val helper: ObservationTestHelper by lazy {


### PR DESCRIPTION
`ObservationResultsStoreTest` is one of the slower test classes in our test
suite.

Some of the observation scenarios involve recording a lot of plants. Profiling
showed that it was spending a lot of time in `ObservationStore.completePlot`,
specifically the call to `RecordedPlantsDao.insert` which was inserting the
plants rows one at a time because it needed to retrieve their
database-generated IDs.

We don't care about the IDs in that context, so we can do a batch insert
operation instead.

In rough benchmarking, this appears to speed the test up by around 30%, still
not lightning-fast but noticeably quicker.

Completing a monitoring plot will be faster for users too, but the data volumes
are low enough that it won't be noticeable.