### PR TITLE
SW-7383 Do not include survival rate when not all sub areas have it

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -350,16 +350,20 @@ data class ObservationPlantingZoneRollupResultsModel(
                 }
               }
               .calculateWeightedStandardDeviation()
-      val survivalRate = species.calculateSurvivalRate()
+      val survivalRate =
+          if (nonNullSubzoneResults.all { it.survivalRate != null }) species.calculateSurvivalRate()
+          else null
       val survivalRateStdDev =
-          completedMonitoringPlots
-              .mapNotNull { plot ->
-                plot.survivalRate?.let { survivalRate ->
-                  val sumDensity = plot.species.mapNotNull { it.t0Density }.sumOf { it }
-                  survivalRate to sumDensity.toDouble()
-                }
-              }
-              .calculateWeightedStandardDeviation()
+          if (survivalRate != null)
+              completedMonitoringPlots
+                  .mapNotNull { plot ->
+                    plot.survivalRate?.let { survivalRate ->
+                      val sumDensity = plot.species.mapNotNull { it.t0Density }.sumOf { it }
+                      survivalRate to sumDensity.toDouble()
+                    }
+                  }
+                  .calculateWeightedStandardDeviation()
+          else null
 
       return ObservationPlantingZoneRollupResultsModel(
           areaHa = areaHa,
@@ -462,16 +466,20 @@ data class ObservationRollupResultsModel(
                 }
               }
               .calculateWeightedStandardDeviation()
-      val survivalRate = species.calculateSurvivalRate()
+      val survivalRate =
+          if (nonNullZoneResults.all { it.survivalRate != null }) species.calculateSurvivalRate()
+          else null
       val survivalRateStdDev =
-          monitoringPlots
-              .mapNotNull { plot ->
-                plot.survivalRate?.let { survivalRate ->
-                  val sumDensity = plot.species.mapNotNull { it.t0Density }.sumOf { it }
-                  survivalRate to sumDensity.toDouble()
-                }
-              }
-              .calculateWeightedStandardDeviation()
+          if (survivalRate != null)
+              monitoringPlots
+                  .mapNotNull { plot ->
+                    plot.survivalRate?.let { survivalRate ->
+                      val sumDensity = plot.species.mapNotNull { it.t0Density }.sumOf { it }
+                      survivalRate to sumDensity.toDouble()
+                    }
+                  }
+                  .calculateWeightedStandardDeviation()
+          else null
 
       return ObservationRollupResultsModel(
           earliestCompletedTime = nonNullZoneResults.minOf { it.earliestCompletedTime },

--- a/src/test/resources/tracking/observation/ObservationsSummary/SiteStatsSummary.csv
+++ b/src/test/resources/tracking/observation/ObservationsSummary/SiteStatsSummary.csv
@@ -1,3 +1,3 @@
 1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3
 Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev,Survival Rate,Survival Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev,Survival Rate,Survival Rate Std Dev,Planting Density,Planting Density Std Dev,Estimated # Plants,# Species,Mortality Rate,Mortality Rate Std Dev,Survival Rate,Survival Rate Std Dev
-762,309,,4,25%,10%,121%,16%,1053,496,2220000,4,22%,8%,301%,16%,1614,859,4571000,4,23%,6%,461%,173%
+762,309,,4,25%,10%,121%,16%,1053,496,2220000,4,22%,8%,,,1614,859,4571000,4,23%,6%,,


### PR DESCRIPTION
The PRD says this:
> If all of the observed subzones in a zone have a calculated survival rate then Terraware will calculate survival rate in addition to mortality rate for that zone.
> If all of the observed subzones in a planting site have a calculated survival rate then Terraware will calculate survival rate in addition to mortality rate for that site.

But after discussion we just care about not displaying it, and don't want the FE doing the work for determining if it should be displayed or not. 
Update the Results model to only calculate zone and site survival rate (and stddev) if their observed sub-areas have a survival rate. 