### PR TITLE
Remove survival rate system metric until it's ready for release

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1618,7 +1618,7 @@ class ReportStore(
       DSL.coalesce(
           DSL.case_()
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.MortalityRate), mortalityRateField)
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SurvivalRate), survivalRateField)
+              // .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SurvivalRate), survivalRateField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.Seedlings), seedlingsField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SeedsCollected), seedsCollectedField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SpeciesPlanted), speciesPlantedField)

--- a/src/main/resources/db/migration/0400/V410__RemoveSurvivalRateSystemMetric.sql
+++ b/src/main/resources/db/migration/0400/V410__RemoveSurvivalRateSystemMetric.sql
@@ -1,0 +1,2 @@
+DELETE FROM accelerator.system_metrics
+WHERE id = 7;

--- a/src/main/resources/db/migration/0400/V410__RemoveSurvivalRateSystemMetric.sql
+++ b/src/main/resources/db/migration/0400/V410__RemoveSurvivalRateSystemMetric.sql
@@ -1,2 +1,8 @@
+DELETE FROM accelerator.report_system_metrics
+    WHERE system_metric_id = 7;
+
+DELETE FROM funder.published_report_system_metrics
+    WHERE system_metric_id = 7;
+
 DELETE FROM accelerator.system_metrics
 WHERE id = 7;

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -522,8 +522,7 @@ VALUES (1, 'Seeds Collected', 'Total seed count checked-into accessions.', 2, 2,
        (3, 'Trees Planted', 'Total trees (and plants) planted in the field.', 2, 2, '1.3', true),
        (4, 'Species Planted', 'Total species of the plants/trees planted.', 2, 2, '1.4', true),
        (5, 'Mortality Rate', 'Mortality rate of plantings.', 3, 2, '2', true),
-       (6, 'Hectares Planted', 'This is the hectares marked as “Planting Complete” within the Project Area.', 2, 2, '1.1.1.1', true),
-       (7, 'Survival Rate', 'Survival rate of plantings.', 3, 2, '2', true)
+       (6, 'Hectares Planted', 'This is the hectares marked as “Planting Complete” within the Project Area.', 2, 2, '1.1.1.1', true)
 ON CONFLICT (id) DO UPDATE
 SET name = excluded.name,
     description = excluded.description,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -70,7 +70,6 @@ import java.time.LocalDate
 import java.time.Month
 import java.time.ZoneId
 import java.time.ZoneOffset
-import kotlin.math.roundToInt
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -435,10 +434,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           systemValue = 0,
                       ),
               ),
-              ReportSystemMetricModel(
-                  metric = SystemMetric.SurvivalRate,
-                  entry = ReportSystemMetricEntryModel(systemValue = 0),
-              ),
+              //              ReportSystemMetricModel(
+              //                  metric = SystemMetric.SurvivalRate,
+              //                  entry = ReportSystemMetricEntryModel(systemValue = 0),
+              //              ),
           )
 
       val reportModel =
@@ -524,15 +523,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           systemValue = 40,
                       ),
               ),
-              ReportSystemMetricModel(
-                  metric = SystemMetric.SurvivalRate,
-                  entry =
-                      ReportSystemMetricEntryModel(
-                          systemValue =
-                              (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density))
-                                  .roundToInt()
-                      ),
-              ),
+              //    ReportSystemMetricModel(
+              //        metric = SystemMetric.SurvivalRate,
+              //        entry =
+              //            ReportSystemMetricEntryModel(
+              //                systemValue =
+              //                    (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density))
+              //                        .roundToInt()
+              //            ),
+              //    ),
           ),
           store.fetch(includeFuture = true, includeMetrics = true).first().systemMetrics,
       )
@@ -1082,10 +1081,10 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           systemValue = 0,
                       ),
               ),
-              ReportSystemMetricModel(
-                  metric = SystemMetric.SurvivalRate,
-                  entry = ReportSystemMetricEntryModel(systemValue = 0),
-              ),
+              //              ReportSystemMetricModel(
+              //                  metric = SystemMetric.SurvivalRate,
+              //                  entry = ReportSystemMetricEntryModel(systemValue = 0),
+              //              ),
           )
 
       val reportModel =
@@ -2992,16 +2991,16 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   modifiedBy = user.userId,
                   modifiedTime = clock.instant,
               ),
-              ReportSystemMetricsRecord(
-                  reportId = reportId,
-                  target = 0,
-                  systemMetricId = SystemMetric.SurvivalRate,
-                  systemValue =
-                      (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density)).roundToInt(),
-                  systemTime = clock.instant,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              ),
+              //  ReportSystemMetricsRecord(
+              //      reportId = reportId,
+              //      target = 0,
+              //      systemMetricId = SystemMetric.SurvivalRate,
+              //      systemValue =
+              //          (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density)).roundToInt(),
+              //      systemTime = clock.instant,
+              //      modifiedBy = user.userId,
+              //      modifiedTime = clock.instant,
+              //  ),
           ),
           "Report system metrics",
       )
@@ -4323,13 +4322,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           target = 0,
           systemValue = 50,
       )
-      insertReportSystemMetric(
-          reportId = reportId,
-          metric = SystemMetric.SurvivalRate,
-          status = ReportMetricStatus.Unlikely,
-          target = 0,
-          systemValue = 50,
-      )
+      //      insertReportSystemMetric(
+      //          reportId = reportId,
+      //          metric = SystemMetric.SurvivalRate,
+      //          status = ReportMetricStatus.Unlikely,
+      //          target = 0,
+      //          systemValue = 50,
+      //      )
     }
 
     // Helper function to validate the report from setupReport() is in the published reports tables
@@ -4468,13 +4467,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   target = 0,
                   value = 50,
               ),
-              PublishedReportSystemMetricsRecord(
-                  reportId = reportId,
-                  systemMetricId = SystemMetric.SurvivalRate,
-                  statusId = ReportMetricStatus.Unlikely,
-                  target = 0,
-                  value = 50,
-              ),
+              //              PublishedReportSystemMetricsRecord(
+              //                  reportId = reportId,
+              //                  systemMetricId = SystemMetric.SurvivalRate,
+              //                  statusId = ReportMetricStatus.Unlikely,
+              //                  target = 0,
+              //                  value = 50,
+              //              ),
               PublishedReportSystemMetricsRecord(
                   reportId = reportId,
                   systemMetricId = SystemMetric.HectaresPlanted,

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -171,14 +171,14 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           projectsComments = "Some plants had died.",
           status = ReportMetricStatus.Unlikely,
       )
-      insertPublishedReportSystemMetric(
-          reportId = reportId1,
-          metric = SystemMetric.SurvivalRate,
-          target = 6,
-          value = 6,
-          projectsComments = null,
-          status = ReportMetricStatus.Achieved,
-      )
+      //      insertPublishedReportSystemMetric(
+      //          reportId = reportId1,
+      //          metric = SystemMetric.SurvivalRate,
+      //          target = 6,
+      //          value = 6,
+      //          projectsComments = null,
+      //          status = ReportMetricStatus.Achieved,
+      //      )
 
       val reportId2 =
           insertReport(
@@ -317,20 +317,20 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               value = 5,
                               unit = null,
                           ),
-                          PublishedReportMetricModel(
-                              component = SystemMetric.SurvivalRate.componentId,
-                              description = SystemMetric.SurvivalRate.description,
-                              metricId = SystemMetric.SurvivalRate,
-                              name = SystemMetric.SurvivalRate.jsonValue,
-                              reference = SystemMetric.SurvivalRate.reference,
-                              status = ReportMetricStatus.Achieved,
-                              target = 6,
-                              type = SystemMetric.SurvivalRate.typeId,
-                              progressNotes = null,
-                              projectsComments = null,
-                              value = 6,
-                              unit = null,
-                          ),
+                          // PublishedReportMetricModel(
+                          //    component = SystemMetric.SurvivalRate.componentId,
+                          //    description = SystemMetric.SurvivalRate.description,
+                          //    metricId = SystemMetric.SurvivalRate,
+                          //    name = SystemMetric.SurvivalRate.jsonValue,
+                          //    reference = SystemMetric.SurvivalRate.reference,
+                          //    status = ReportMetricStatus.Achieved,
+                          //    target = 6,
+                          //    type = SystemMetric.SurvivalRate.typeId,
+                          //    progressNotes = null,
+                          //    projectsComments = null,
+                          //    value = 6,
+                          //    unit = null,
+                          // ),
                       ),
               ),
           ),


### PR DESCRIPTION
The Survival Rate system metric showed up in prod because there's nothing that hides it. Remove this metric and comment out the relevant code until this is ready to be released.

Note that this will be released as soon as it's merged in order to remove it from prod.

Most likely being replaced with PRs https://github.com/terraware/terraware-web/pull/4471 and https://github.com/terraware/terraware-server/pull/3407