### PR TITLE
SW-7402 Allow TF Experts to manage activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -154,7 +154,7 @@ data class IndividualUser(
   override fun canCreateAccession(facilityId: FacilityId) = isMember(facilityId)
 
   override fun canCreateActivity(projectId: ProjectId) =
-      isAcceleratorAdmin() || isAdminOrHigher(parentStore.getOrganizationId(projectId))
+      isTFExpertOrHigher() || isAdminOrHigher(parentStore.getOrganizationId(projectId))
 
   override fun canCreateApiKey(organizationId: OrganizationId) = isAdminOrHigher(organizationId)
 
@@ -227,7 +227,7 @@ data class IndividualUser(
       isManagerOrHigher(parentStore.getFacilityId(accessionId))
 
   override fun canDeleteActivity(activityId: ActivityId) =
-      isAcceleratorAdmin() || isAdminOrHigher(parentStore.getOrganizationId(activityId))
+      isTFExpertOrHigher() || isAdminOrHigher(parentStore.getOrganizationId(activityId))
 
   override fun canDeleteAutomation(automationId: AutomationId) =
       isAdminOrHigher(parentStore.getFacilityId(automationId))
@@ -311,7 +311,7 @@ data class IndividualUser(
   override fun canListSeedFundReports(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
 
-  override fun canManageActivity(activityId: ActivityId) = isAcceleratorAdmin()
+  override fun canManageActivity(activityId: ActivityId) = isTFExpertOrHigher()
 
   override fun canManageDefaultProjectLeads() = isAcceleratorAdmin()
 
@@ -603,7 +603,7 @@ data class IndividualUser(
       isMember(parentStore.getFacilityId(accessionId))
 
   override fun canUpdateActivity(activityId: ActivityId) =
-      isAcceleratorAdmin() || isAdminOrHigher(parentStore.getOrganizationId(activityId))
+      isTFExpertOrHigher() || isAdminOrHigher(parentStore.getOrganizationId(activityId))
 
   override fun canUpdateApplicationBoundary(applicationId: ApplicationId) =
       isTFExpertOrHigher() || isAdminOrHigher(parentStore.getOrganizationId(applicationId))

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -406,7 +406,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exception if no permission to delete activity`() {
       insertOrganizationUser(role = Role.Manager)
-      insertUserGlobalRole(role = GlobalRole.TFExpert)
+      insertUserGlobalRole(role = GlobalRole.ReadOnly)
 
       val activityId = insertActivity(projectId = projectId)
 
@@ -553,7 +553,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exception if no permission to update activity`() {
       insertOrganizationUser(role = Role.Manager)
-      insertUserGlobalRole(role = GlobalRole.TFExpert)
+      insertUserGlobalRole(role = GlobalRole.ReadOnly)
 
       val activityId = insertActivity(projectId = projectId)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -2425,6 +2425,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *activityIds.forOrg1(),
         deleteActivity = true,
+        manageActivity = true,
         readActivity = true,
         updateActivity = true,
     )
@@ -2443,6 +2444,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         ProjectId(4000),
+        createActivity = true,
         createParticipantProjectSpecies = true,
         createSubmission = true,
         listActivities = true,
@@ -2533,7 +2535,10 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ActivityId(3),
         ActivityId(4),
+        deleteActivity = true,
+        manageActivity = true,
         readActivity = true,
+        updateActivity = true,
     )
 
     permissions.expect(


### PR DESCRIPTION
The requirements have been changed to say that users with the TF Expert global
role should be allowed to manage activities in accelerator projects.