### PR TITLE
SW-7408 Fix observations payload NPE

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -732,7 +732,7 @@ data class RecordedPlantPayload(
     val certainty: RecordedSpeciesCertainty,
     @Schema(description = "GPS coordinates where plant was observed.") //
     val gpsCoordinates: Point,
-    val id: RecordedPlantId,
+    val id: RecordedPlantId?,
     @Schema(
         description = "Required if certainty is Known. Ignored if certainty is Other or Unknown."
     )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -497,7 +497,7 @@ data class ObservationRollupResultsModel(
 data class RecordedPlantModel(
     val certainty: RecordedSpeciesCertainty,
     val gpsCoordinates: Point,
-    val id: RecordedPlantId,
+    val id: RecordedPlantId?,
     val speciesId: SpeciesId?,
     val speciesName: String?,
     val status: RecordedPlantStatus,


### PR DESCRIPTION
Completing observations is broken with this error:
```
{"error":{"message":"Field value cannot be null: plants[0].id"},"status":"error"}
```
which is caused by a new required id field. The field was added for response payloads, but perhaps it wasn't realized this was used in request payloads as well (specifically the `completeObservation` endpoint).
Make this field optional.