### PR TITLE
SW-7387 Allow zones to have 0 temporary plots

### DIFF
--- a/src/main/resources/db/migration/0400/V410__ZeroTemporaryPlots.sql
+++ b/src/main/resources/db/migration/0400/V410__ZeroTemporaryPlots.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tracking.planting_zones DROP CONSTRAINT must_have_temporary_plots;
+ALTER TABLE tracking.planting_zones ADD CONSTRAINT no_negative_temporary_plots
+    CHECK (num_temporary_plots >= 0);

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -268,7 +268,7 @@
                            th:value="${zone.numPermanentPlots}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>
-                    <input type="number" required min="1" name="numTemporary" th:id="|numTemporary-${zone.id}|"
+                    <input type="number" required min="0" name="numTemporary" th:id="|numTemporary-${zone.id}|"
                            th:value="${zone.numTemporaryPlots}" th:form="|zone-${zone.id}|"/>
                 </td>
                 <td>


### PR DESCRIPTION
For small planting zones, in some cases we want to do monitoring observations
where we're just surveying the permanent plots. Allow admins to set the number of
temporary plots to 0 in the admin UI.