### PR TITLE
Pass correct query param after admin UI Mux upload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
@@ -115,11 +115,11 @@ class AdminMuxController(
       redirectAttributes.failureMessage = "Failed to create asset: ${e.message}"
     }
 
-    return redirectToMuxHome(playbackId)
+    return redirectToMuxHome(fileId)
   }
 
-  private fun redirectToMuxHome(muxPlaybackId: String? = null): String {
-    val suffix = muxPlaybackId?.let { "?muxPlaybackId=$it" } ?: ""
+  private fun redirectToMuxHome(fileId: FileId? = null): String {
+    val suffix = fileId?.let { "?fileId=$it" } ?: ""
     return "redirect:/admin/mux$suffix"
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
@@ -103,7 +103,7 @@ class AdminMuxController(
       @RequestParam fileId: FileId,
       redirectAttributes: RedirectAttributes,
   ): String {
-    var playbackId: String? = null
+    val playbackId: String
 
     try {
       playbackId = muxService.sendFileToMux(fileId)


### PR DESCRIPTION
In the admin UI, after you upload a video to Mux, we want to show the video in the
UI. But we were passing the Mux playback ID, not the file ID, on the query string.