### PR TITLE
SW-7367 Send activity videos to Mux

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/event/VideoFileDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/VideoFileDeletedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.file.event
+
+import com.terraformation.backend.db.default_schema.FileId
+
+/**
+ * Published when a video file is deleted from the system. The file ID will still be valid when this
+ * is published.
+ */
+data class VideoFileDeletedEvent(val fileId: FileId)

--- a/src/main/kotlin/com/terraformation/backend/file/event/VideoFileUploadedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/VideoFileUploadedEvent.kt
@@ -1,0 +1,6 @@
+package com.terraformation.backend.file.event
+
+import com.terraformation.backend.db.default_schema.FileId
+
+/** Published when a video file is uploaded to the system. */
+data class VideoFileUploadedEvent(val fileId: FileId)

--- a/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
@@ -66,6 +66,7 @@ class MuxService(
   private val fileAccessEndpoint = "/api/v1/files/tokens"
 
   private val muxApiUrl = URI("https://api.mux.com")
+  private val muxAssetsEndpoint = "/video/v1/assets"
 
   private val log = perClassLogger()
 
@@ -109,7 +110,7 @@ class MuxService(
             test = config.mux.useTestAssets,
             url = baseUrl.resolve("$fileAccessEndpoint/$token"),
         )
-    val response = sendRequest<MuxCreateVideoAssetResponsePayload>("/video/v1/assets", request)
+    val response = sendRequest<MuxCreateVideoAssetResponsePayload>(muxAssetsEndpoint, request)
 
     if (response.data.status == MuxApiStatus.errored) {
       log.warn("File $fileId marked as errored at creation time: ${response.data.errorMessage}")
@@ -228,7 +229,7 @@ class MuxService(
   @Suppress("MemberVisibilityCanBePrivate") // Called by JobRunr
   fun deleteMuxAssetIfExists(assetId: String) {
     try {
-      sendRequest<Unit>("/video/v1/assets/$assetId", method = HttpMethod.Delete)
+      sendRequest<Unit>("$muxAssetsEndpoint/$assetId", method = HttpMethod.Delete)
     } catch (e: ClientRequestException) {
       // Ignore "not found" responses since this is a "delete if exists" operation.
       if (e.response.status != HttpStatusCode.NotFound) {

--- a/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
@@ -228,7 +228,7 @@ class MuxService(
   @Suppress("MemberVisibilityCanBePrivate") // Called by JobRunr
   fun deleteMuxAssetIfExists(assetId: String) {
     try {
-      sendRequest<Unit>("/video/v1/assets/$assetId")
+      sendRequest<Unit>("/video/v1/assets/$assetId", method = HttpMethod.Delete)
     } catch (e: ClientRequestException) {
       // Ignore "not found" responses since this is a "delete if exists" operation.
       if (e.response.status != HttpStatusCode.NotFound) {


### PR DESCRIPTION
When a video file is stored for an activity, also send it to Mux for processing.
This is done asynchronously to avoid making the upload endpoint block on the
API calls to Mux.

Similarly, when a video is deleted from an activity, also delete it from Mux.