### PR TITLE
SW-7367 Support video in activity media API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
@@ -45,14 +45,15 @@ fun MultipartFile.getPlainContentType(): String? {
  * @param allowedTypes Only accept content types from this set; throw NotSupportedException for
  *   types that aren't listed.
  */
-fun MultipartFile.getPlainContentType(allowedTypes: Set<String>): String {
-  val contentType = this.getPlainContentType()
+fun MultipartFile.getPlainContentType(allowedTypes: Set<MediaType>): String {
+  val plainContentType = this.getPlainContentType()
+  val contentType = plainContentType?.let { MediaType.parseMediaType(it) }
 
-  if (contentType == null || contentType !in allowedTypes) {
+  if (contentType == null || allowedTypes.none { it.includes(contentType) }) {
     throw NotSupportedException("Content type must be one of: ${allowedTypes.sorted()}")
   }
 
-  return contentType
+  return plainContentType
 }
 
 /**

--- a/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
@@ -6,4 +6,6 @@ import org.springframework.http.MediaType
  * List of supported photo content types. We only support content types that are compatible with our
  * thumbnail generator.
  */
-val SUPPORTED_PHOTO_TYPES = setOf(MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE)
+val SUPPORTED_PHOTO_TYPES = setOf(MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG)
+
+val SUPPORTED_VIDEO_TYPES = setOf(MediaType.valueOf("video/*"))


### PR DESCRIPTION
Accept video MIME types on the activity media upload endpoint and add an endpoint
to get the Mux playback ID and playback token for an activity video file.