### PR TITLE
SW-7420 Rename plot_t0_density to be plural

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -67,7 +67,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SP
 import com.terraformation.backend.db.tracking.tables.references.PLANTINGS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import jakarta.inject.Named
 import java.math.BigDecimal
 import java.net.URI
@@ -1465,20 +1465,20 @@ class ReportStore(
       DSL.exists(
           DSL.selectOne()
               .from(OBSERVATION_PLOTS)
-              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITY.MONITORING_PLOT_ID))
+              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITIES.MONITORING_PLOT_ID))
               .and(OBSERVATION_PLOTS.OBSERVATION_ID.`in`(observationsInReportPeriod))
               .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(true))
               .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull)
       )
 
   private val survivalRateDenominatorField =
-      with(PLOT_T0_DENSITY) {
+      with(PLOT_T0_DENSITIES) {
         DSL.sum(
             DSL.field(
                 DSL.select(DSL.sum(PLOT_DENSITY))
                     .from(this)
                     .where(
-                        PLOT_T0_DENSITY.monitoringPlots.PLANTING_SITE_ID.`in`(
+                        PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SITE_ID.`in`(
                             OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_ID
                         )
                     )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -38,7 +38,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_HISTORIES
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
@@ -453,7 +453,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
       DSL.exists(
           DSL.selectOne()
               .from(OBSERVATION_PLOTS)
-              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITY.MONITORING_PLOT_ID))
+              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITIES.MONITORING_PLOT_ID))
               .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(true))
               .and(OBSERVATION_PLOTS.COMPLETED_TIME.isNotNull)
       )
@@ -574,7 +574,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         .else_(null as Int?),
                     DSL.coalesce(
                         SPECIES_ID,
-                        PLOT_T0_DENSITY.SPECIES_ID,
+                        PLOT_T0_DENSITIES.SPECIES_ID,
                     ),
                     SPECIES_NAME,
                     DSL.coalesce(TOTAL_LIVE, 0),
@@ -585,21 +585,21 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                     DSL.coalesce(
                         SURVIVAL_RATE,
                         DSL.`when`(
-                            PLOT_T0_DENSITY.PLOT_DENSITY.isNotNull,
+                            PLOT_T0_DENSITIES.PLOT_DENSITY.isNotNull,
                             DSL.inline(BigDecimal.ZERO),
                         ),
                     ),
-                    PLOT_T0_DENSITY.PLOT_DENSITY,
+                    PLOT_T0_DENSITIES.PLOT_DENSITY,
                 )
                 .from(OBSERVED_PLOT_SPECIES_TOTALS)
-                .fullOuterJoin(PLOT_T0_DENSITY)
+                .fullOuterJoin(PLOT_T0_DENSITIES)
                 .on(
-                    PLOT_T0_DENSITY.MONITORING_PLOT_ID.eq(MONITORING_PLOT_ID)
-                        .and(PLOT_T0_DENSITY.SPECIES_ID.eq(SPECIES_ID))
+                    PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(MONITORING_PLOT_ID)
+                        .and(PLOT_T0_DENSITIES.SPECIES_ID.eq(SPECIES_ID))
                 )
                 .where(
                     MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID)
-                        .or(PLOT_T0_DENSITY.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+                        .or(PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
                 )
                 .and(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
                 .orderBy(SPECIES_ID, SPECIES_NAME)
@@ -758,7 +758,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
   private fun plantingSubzoneSpeciesMultiset(): Field<List<ObservationSpeciesResultsModel>> {
     val subzoneT0 =
-        with(PLOT_T0_DENSITY) {
+        with(PLOT_T0_DENSITIES) {
           DSL.select(
                   MONITORING_PLOTS.PLANTING_SUBZONE_ID,
                   SPECIES_ID,
@@ -953,7 +953,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
   private fun plantingZoneSpeciesMultiset(): Field<List<ObservationSpeciesResultsModel>> {
     val zoneT0 =
-        with(PLOT_T0_DENSITY) {
+        with(PLOT_T0_DENSITIES) {
           DSL.select(
                   PLANTING_SUBZONES.PLANTING_ZONE_ID,
                   SPECIES_ID,
@@ -1173,7 +1173,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
 
   private fun plantingSiteSpeciesMultiset(): Field<List<ObservationSpeciesResultsModel>> {
     val siteT0 =
-        with(PLOT_T0_DENSITY) {
+        with(PLOT_T0_DENSITIES) {
           DSL.select(
                   MONITORING_PLOTS.PLANTING_SITE_ID,
                   SPECIES_ID,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -59,7 +59,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.log.perClassLogger
@@ -264,7 +264,7 @@ class ObservationStore(
       DSL.exists(
           DSL.selectOne()
               .from(OBSERVATION_PLOTS)
-              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITY.MONITORING_PLOT_ID))
+              .where(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(PLOT_T0_DENSITIES.MONITORING_PLOT_ID))
               .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(true))
               .and(
                   DSL.or(
@@ -1632,11 +1632,11 @@ class ObservationStore(
         with(OBSERVED_ZONE_SPECIES_TOTALS) {
           val survivalRateDenominator =
               getSurvivalRateDenominator(
-                  PLOT_T0_DENSITY.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(
+                  PLOT_T0_DENSITIES.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(
                           plantingZoneId
                       )
                       .and(plotHasCompletedPermanentObservations())
-                      .and(PLOT_T0_DENSITY.SPECIES_ID.eq(speciesKey.id))
+                      .and(PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id))
               )
           val survivalRate = DSL.value(totalLive).mul(100).div(survivalRateDenominator)
 
@@ -1683,9 +1683,9 @@ class ObservationStore(
       with(OBSERVED_SITE_SPECIES_TOTALS) {
         val survivalRateDenominator =
             getSurvivalRateDenominator(
-                PLOT_T0_DENSITY.monitoringPlots.PLANTING_SITE_ID.eq(plantingSiteId)
+                PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SITE_ID.eq(plantingSiteId)
                     .and(plotHasCompletedPermanentObservations())
-                    .and(PLOT_T0_DENSITY.SPECIES_ID.eq(speciesKey.id))
+                    .and(PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id))
             )
         val survivalRate = DSL.value(totalLive).mul(100).div(survivalRateDenominator)
 
@@ -1731,7 +1731,7 @@ class ObservationStore(
     recalculateSurvivalRate(
         OBSERVED_PLOT_SPECIES_TOTALS,
         OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(monitoringPlotId),
-        PLOT_T0_DENSITY.MONITORING_PLOT_ID.eq(monitoringPlotId),
+        PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(monitoringPlotId),
     )
 
     val subzoneSelect =
@@ -1742,7 +1742,7 @@ class ObservationStore(
     recalculateSurvivalRate(
         OBSERVED_SUBZONE_SPECIES_TOTALS,
         OBSERVED_SUBZONE_SPECIES_TOTALS.PLANTING_SUBZONE_ID.eq(subzoneSelect),
-        PLOT_T0_DENSITY.monitoringPlots.PLANTING_SUBZONE_ID.eq(subzoneSelect),
+        PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SUBZONE_ID.eq(subzoneSelect),
     )
 
     val zoneSelect =
@@ -1759,7 +1759,7 @@ class ObservationStore(
     recalculateSurvivalRate(
         OBSERVED_ZONE_SPECIES_TOTALS,
         OBSERVED_ZONE_SPECIES_TOTALS.PLANTING_ZONE_ID.eq(zoneSelect),
-        PLOT_T0_DENSITY.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(zoneSelect),
+        PLOT_T0_DENSITIES.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(zoneSelect),
     )
 
     val siteSelect =
@@ -1769,7 +1769,7 @@ class ObservationStore(
     recalculateSurvivalRate(
         OBSERVED_SITE_SPECIES_TOTALS,
         OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_ID.eq(siteSelect),
-        PLOT_T0_DENSITY.monitoringPlots.PLANTING_SITE_ID.eq(siteSelect),
+        PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SITE_ID.eq(siteSelect),
     )
   }
 
@@ -1784,7 +1784,7 @@ class ObservationStore(
         getSurvivalRateDenominator(
             survivalRateCondition
                 .and(plotHasCompletedPermanentObservations())
-                .and(PLOT_T0_DENSITY.SPECIES_ID.eq(speciesIdField))
+                .and(PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesIdField))
         )
     val survivalRateField = table.field("survival_rate", Int::class.java)!!
     val permanentLiveField = table.field("permanent_live", Int::class.java)!!
@@ -2126,7 +2126,7 @@ class ObservationStore(
             isPermanent,
             plantCountsBySpecies,
             false,
-            PLOT_T0_DENSITY.MONITORING_PLOT_ID.eq(monitoringPlotId)
+            PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(monitoringPlotId)
                 .and(completedOrCurrentObservationPlotsCondition),
         )
       }
@@ -2140,7 +2140,7 @@ class ObservationStore(
               isPermanent,
               plantCountsBySpecies,
               cumulativeDeadFromCurrentObservation,
-              PLOT_T0_DENSITY.monitoringPlots.PLANTING_SUBZONE_ID.eq(plantingSubzoneId)
+              PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SUBZONE_ID.eq(plantingSubzoneId)
                   .and(completedOrCurrentObservationPlotsCondition),
           )
         }
@@ -2153,7 +2153,7 @@ class ObservationStore(
               isPermanent,
               plantCountsBySpecies,
               cumulativeDeadFromCurrentObservation,
-              PLOT_T0_DENSITY.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(plantingZoneId)
+              PLOT_T0_DENSITIES.monitoringPlots.plantingSubzones.PLANTING_ZONE_ID.eq(plantingZoneId)
                   .and(completedOrCurrentObservationPlotsCondition),
           )
         }
@@ -2165,7 +2165,7 @@ class ObservationStore(
             isPermanent,
             plantCountsBySpecies,
             cumulativeDeadFromCurrentObservation,
-            PLOT_T0_DENSITY.monitoringPlots.PLANTING_SITE_ID.eq(plantingSiteId)
+            PLOT_T0_DENSITIES.monitoringPlots.PLANTING_SITE_ID.eq(plantingSiteId)
                 .and(completedOrCurrentObservationPlotsCondition),
         )
       }
@@ -2273,7 +2273,7 @@ class ObservationStore(
 
         val survivalRateDenominator =
             getSurvivalRateDenominator(
-                survivalRateDensityCondition.and(PLOT_T0_DENSITY.SPECIES_ID.eq(speciesKey.id))
+                survivalRateDensityCondition.and(PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesKey.id))
             )
         val survivalRate =
             if (isPermanent && speciesKey.id != null) {
@@ -2385,7 +2385,9 @@ class ObservationStore(
 
   private fun getSurvivalRateDenominator(condition: Condition): Field<BigDecimal> =
       DSL.field(
-          DSL.select(DSL.sum(PLOT_T0_DENSITY.PLOT_DENSITY)).from(PLOT_T0_DENSITY).where(condition)
+          DSL.select(DSL.sum(PLOT_T0_DENSITIES.PLOT_DENSITY))
+              .from(PLOT_T0_DENSITIES)
+              .where(condition)
       )
 
   private fun validateAdHocPlotInPlantingSite(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -8,7 +8,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.tracking.event.T0PlotDataAssignedEvent
 import com.terraformation.backend.tracking.model.PlotT0DataModel
@@ -32,7 +32,7 @@ class T0PlotStore(
   fun fetchT0SiteData(plantingSiteId: PlantingSiteId): List<PlotT0DataModel> {
     requirePermissions { readPlantingSite(plantingSiteId) }
 
-    return with(PLOT_T0_DENSITY) {
+    return with(PLOT_T0_DENSITIES) {
       dslContext
           .select(MONITORING_PLOT_ID, SPECIES_ID, PLOT_DENSITY, PLOT_T0_OBSERVATIONS.OBSERVATION_ID)
           .from(this)
@@ -100,7 +100,7 @@ class T0PlotStore(
             .execute()
       }
 
-      with(PLOT_T0_DENSITY) {
+      with(PLOT_T0_DENSITIES) {
         // ensure no leftover densities for species that are not in this observation
         dslContext
             .deleteFrom(this)
@@ -184,7 +184,7 @@ class T0PlotStore(
         dslContext.deleteFrom(this).where(MONITORING_PLOT_ID.eq(monitoringPlotId)).execute()
       }
 
-      with(PLOT_T0_DENSITY) {
+      with(PLOT_T0_DENSITIES) {
         // ensure no leftover densities for species that are not in this request
         dslContext
             .deleteFrom(this)
@@ -243,7 +243,7 @@ class T0PlotStore(
   private fun fetchExistingDensities(
       monitoringPlotId: MonitoringPlotId
   ): Map<SpeciesId, BigDecimal> =
-      with(PLOT_T0_DENSITY) {
+      with(PLOT_T0_DENSITIES) {
         dslContext
             .select(SPECIES_ID, PLOT_DENSITY)
             .from(this)

--- a/src/main/resources/db/migration/0400/V412__PlotT0DensityPlural.sql
+++ b/src/main/resources/db/migration/0400/V412__PlotT0DensityPlural.sql
@@ -1,0 +1,12 @@
+ALTER TABLE tracking.plot_t0_density RENAME TO plot_t0_densities;
+
+ALTER TABLE tracking.plot_t0_densities
+    RENAME CONSTRAINT plot_t0_density_pkey TO plot_t0_densities_pkey;
+ALTER TABLE tracking.plot_t0_densities
+    RENAME CONSTRAINT plot_t0_density_created_by_fkey TO plot_t0_densities_created_by_fkey;
+ALTER TABLE tracking.plot_t0_densities
+    RENAME CONSTRAINT plot_t0_density_modified_by_fkey TO plot_t0_densities_modified_by_fkey;
+ALTER TABLE tracking.plot_t0_densities
+    RENAME CONSTRAINT plot_t0_density_monitoring_plot_id_fkey TO plot_t0_densities_monitoring_plot_id_fkey;
+ALTER TABLE tracking.plot_t0_densities
+    RENAME CONSTRAINT plot_t0_density_species_id_fkey TO plot_t0_densities_species_id_fkey;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -550,7 +550,7 @@ COMMENT ON COLUMN tracking.plantings.planting_type_id IS 'Whether this is the pl
 COMMENT ON COLUMN tracking.plantings.planting_subzone_id IS 'Which plot this planting affected, if any. Must be a plot at the planting site referenced by `planting_site_id`. Null if the planting site does not have plot information. For reassignments, this is the original plot if `num_plants` is negative, or the new plot if `num_plants` is positive.';
 COMMENT ON COLUMN tracking.plantings.species_id IS 'Which species was planted.';
 
-COMMENT ON TABLE tracking.plot_t0_density IS 'Density for a plot per species, in plants per plot.';
+COMMENT ON TABLE tracking.plot_t0_densities IS 'Density for a plot per species, in plants per plot.';
 COMMENT ON TABLE tracking.plot_t0_observations IS 'Which observation to use to determine t0 plot density.';
 
 COMMENT ON TABLE tracking.recorded_plant_statuses IS '(Enum) Possible statuses of a plant recorded during observation of a monitoring plot.';

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -458,7 +458,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingZoneHistories
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonePopulationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
-import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensityRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensitiesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlotT0ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedTreesRow
@@ -468,7 +468,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.documentproducer.model.StableIds
@@ -3279,7 +3279,7 @@ abstract class DatabaseBackedTest {
   private val nextTrunkNumber = mutableMapOf<Pair<ObservationId, Int>, Int>()
 
   fun insertPlotT0Density(
-      row: PlotT0DensityRow = PlotT0DensityRow(),
+      row: PlotT0DensitiesRow = PlotT0DensitiesRow(),
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
       plotDensity: BigDecimal = row.plotDensity ?: BigDecimal.valueOf(10),
@@ -3288,7 +3288,7 @@ abstract class DatabaseBackedTest {
       modifiedBy: UserId = row.modifiedBy ?: inserted.userId,
       modifiedTime: Instant = row.modifiedTime ?: Instant.EPOCH,
   ) {
-    with(PLOT_T0_DENSITY) {
+    with(PLOT_T0_DENSITIES) {
       dslContext
           .insertInto(this)
           .set(MONITORING_PLOT_ID, monitoringPlotId)

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -413,7 +413,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "planting_zone_t0_temp_densities" to setOf(ALL, TRACKING),
                   "planting_zones" to setOf(ALL, TRACKING),
                   "plantings" to setOf(ALL, TRACKING),
-                  "plot_t0_density" to setOf(ALL, TRACKING),
+                  "plot_t0_densities" to setOf(ALL, TRACKING),
                   "plot_t0_observations" to setOf(ALL, TRACKING),
                   "recorded_plant_statuses" to setOf(ALL, TRACKING),
                   "recorded_plants" to setOf(ALL, TRACKING),

--- a/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0PlotServiceTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
-import com.terraformation.backend.db.tracking.tables.records.PlotT0DensityRecord
+import com.terraformation.backend.db.tracking.tables.records.PlotT0DensitiesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
@@ -214,7 +214,7 @@ internal class T0PlotServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   private fun densityRecord(plotId: MonitoringPlotId, speciesId: SpeciesId, density: BigDecimal) =
-      PlotT0DensityRecord(
+      PlotT0DensitiesRecord(
           monitoringPlotId = plotId,
           speciesId = speciesId,
           plotDensity = density,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0PlotStoreTest.kt
@@ -11,7 +11,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
-import com.terraformation.backend.db.tracking.tables.records.PlotT0DensityRecord
+import com.terraformation.backend.db.tracking.tables.records.PlotT0DensitiesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.multiPolygon
@@ -439,7 +439,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertTableEquals(
           listOf(
-              PlotT0DensityRecord(
+              PlotT0DensitiesRecord(
                   monitoringPlotId,
                   speciesId1,
                   updatedDensity,
@@ -448,7 +448,7 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   createdTime = clock.instant().minusSeconds(60),
                   modifiedTime = clock.instant(),
               ),
-              PlotT0DensityRecord(
+              PlotT0DensitiesRecord(
                   monitoringPlotId,
                   speciesId2,
                   initialDensity,
@@ -630,8 +630,8 @@ internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       plotId: MonitoringPlotId,
       speciesId: SpeciesId,
       density: BigDecimal,
-  ): PlotT0DensityRecord =
-      PlotT0DensityRecord(
+  ): PlotT0DensitiesRecord =
+      PlotT0DensitiesRecord(
           monitoringPlotId = plotId,
           speciesId = speciesId,
           plotDensity = density,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -9,7 +9,7 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
-import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITY
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationScenarioTest
@@ -273,7 +273,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val species1 = speciesIds["Species 0"]!!
     val plot1 = plotIds["111"]!!
 
-    with(PLOT_T0_DENSITY) {
+    with(PLOT_T0_DENSITIES) {
       dslContext
           .update(this)
           .set(PLOT_DENSITY, BigDecimal.valueOf(20.0))


### PR DESCRIPTION
It was realized in the discussion in https://github.com/terraware/terraware-server/pull/3427 that `plot_t0_density`​ should have been plural. 

Rename the table to be plural.