### PR TITLE
SW-7403 Move thumbnail management to new service

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -25,6 +25,7 @@ import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDI
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.VideoFileDeletedEvent
 import com.terraformation.backend.file.event.VideoFileUploadedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
@@ -59,6 +60,7 @@ class ActivityMediaService(
     private val fileService: FileService,
     private val muxService: MuxService,
     private val parentStore: ParentStore,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
   private val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
@@ -163,7 +165,7 @@ class ActivityMediaService(
 
     checkFileExists(activityId, fileId)
 
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun getMuxStreamInfo(activityId: ActivityId, fileId: FileId): MuxStreamModel {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.db.funder.tables.daos.PublishedReportPhotosDao
 import com.terraformation.backend.db.funder.tables.pojos.PublishedReportPhotosRow
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import jakarta.inject.Named
@@ -28,6 +29,7 @@ class ReportService(
     private val reportStore: ReportStore,
     private val publishedReportPhotosDao: PublishedReportPhotosDao,
     private val systemUser: SystemUser,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -72,7 +74,7 @@ class ReportService(
   ): SizedInputStream {
     requirePermissions { readReport(reportId) }
     fetchReportPhotosRow(reportId, fileId)
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun storeReportPhoto(

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableFileService.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.documentproducer.model.ImageValueDetails
 import com.terraformation.backend.documentproducer.model.NewImageValue
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import jakarta.inject.Named
 import java.io.InputStream
@@ -20,6 +21,7 @@ import java.io.InputStream
 @Named
 class VariableFileService(
     private val fileService: FileService,
+    private val thumbnailService: ThumbnailService,
     private val variableValueStore: VariableValueStore,
 ) {
   fun readImageValue(
@@ -34,7 +36,7 @@ class VariableFileService(
     }
 
     if (existingValue is ExistingImageValue) {
-      return fileService.readFile(existingValue.value.fileId, maxWidth, maxHeight)
+      return thumbnailService.readFile(existingValue.value.fileId, maxWidth, maxHeight)
     } else {
       throw VariableValueTypeMismatchException(valueId, VariableType.Image)
     }

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
@@ -1,0 +1,55 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.file.event.FileDeletionStartedEvent
+import com.terraformation.backend.log.perClassLogger
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
+import org.springframework.web.reactive.function.UnsupportedMediaTypeException
+
+@Named
+class ThumbnailService(
+    private val dslContext: DSLContext,
+    private val fileService: FileService,
+    private val thumbnailStore: ThumbnailStore,
+) {
+  private val log = perClassLogger()
+
+  /**
+   * Reads a file or a thumbnail image representing the file. The original file is read if neither
+   * [maxWidth] nor [maxHeight] is specified; otherwise an image that is no larger than the maximum
+   * width and height is returned.
+   */
+  fun readFile(fileId: FileId, maxWidth: Int? = null, maxHeight: Int? = null): SizedInputStream {
+    return if (maxWidth == null && maxHeight == null) {
+      fileService.readFile(fileId)
+    } else {
+      getThumbnailData(fileId, maxWidth, maxHeight)
+    }
+  }
+
+  @EventListener
+  fun on(event: FileDeletionStartedEvent) {
+    try {
+      thumbnailStore.deleteThumbnails(event.fileId)
+    } catch (e: Exception) {
+      log.error("Unable to delete thumbnails for file ${event.fileId}", e)
+    }
+  }
+
+  private fun getThumbnailData(fileId: FileId, maxWidth: Int?, maxHeight: Int?): SizedInputStream {
+    val mediaType =
+        dslContext.fetchValue(FILES.CONTENT_TYPE, FILES.ID.eq(fileId))
+            ?: throw FileNotFoundException(fileId)
+
+    // For images, ThumbnailStore will handle scaling the original if needed.
+    if (mediaType.startsWith("image/")) {
+      return thumbnailStore.getThumbnailData(fileId, maxWidth, maxHeight)
+    }
+
+    throw UnsupportedMediaTypeException("Cannot generate thumbnails for files of type $mediaType")
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/file/event/FileDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/FileDeletionStartedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.file.event
+
+import com.terraformation.backend.db.default_schema.FileId
+
+/**
+ * Published when a file is about to be deleted. The file will still exist at the time the event is
+ * published.
+ */
+data class FileDeletionStartedEvent(val fileId: FileId)

--- a/src/main/kotlin/com/terraformation/backend/funder/PublishedReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/PublishedReportService.kt
@@ -5,14 +5,14 @@ import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.funder.tables.daos.PublishedReportPhotosDao
-import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import jakarta.inject.Named
 
 @Named
 class PublishedReportService(
-    private val fileService: FileService,
     private val publishedReportPhotosDao: PublishedReportPhotosDao,
+    private val thumbnailService: ThumbnailService,
 ) {
   fun readPhoto(
       reportId: ReportId,
@@ -25,6 +25,6 @@ class PublishedReportService(
     if (row?.reportId != reportId) {
       throw FileNotFoundException(fileId)
     }
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchPhotosRow
 import com.terraformation.backend.db.nursery.tables.references.BATCH_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.BatchDeletionStartedEvent
@@ -31,6 +32,7 @@ class BatchPhotoService(
     private val dslContext: DSLContext,
     private val fileService: FileService,
     private val imageUtils: ImageUtils,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -64,7 +66,7 @@ class BatchPhotoService(
 
     requirePermissions { readBatch(batchId) }
 
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun listPhotos(batchId: BatchId): List<BatchPhotosRow> {

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalPhotosRow
 import com.terraformation.backend.db.nursery.tables.references.WITHDRAWAL_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.util.ImageUtils
@@ -25,6 +26,7 @@ class WithdrawalPhotoService(
     private val dslContext: DSLContext,
     private val fileService: FileService,
     private val imageUtils: ImageUtils,
+    private val thumbnailService: ThumbnailService,
     private val withdrawalPhotosDao: WithdrawalPhotosDao,
 ) {
   private val log = perClassLogger()
@@ -62,7 +64,7 @@ class WithdrawalPhotoService(
 
     requirePermissions { readWithdrawal(withdrawalId) }
 
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun listPhotos(withdrawalId: WithdrawalId): List<FileId> {

--- a/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.tables.pojos.SeedFundReportF
 import com.terraformation.backend.db.default_schema.tables.pojos.SeedFundReportPhotosRow
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.report.db.SeedFundReportStore
@@ -28,6 +29,7 @@ class SeedFundReportFileService(
     private val seedFundReportStore: SeedFundReportStore,
     private val seedFundReportFilesDao: SeedFundReportFilesDao,
     private val seedFundReportPhotosDao: SeedFundReportPhotosDao,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -54,7 +56,7 @@ class SeedFundReportFileService(
     // Make sure the photo is owned by the report.
     fetchPhotosRow(reportId, fileId)
 
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun readFile(reportId: SeedFundReportId, fileId: FileId): SizedInputStream {

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.seedbank.tables.pojos.AccessionPhotosRow
 import com.terraformation.backend.db.seedbank.tables.references.ACCESSION_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.ExistingFileMetadata
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.file.model.NewFileMetadata
@@ -30,6 +31,7 @@ class PhotoRepository(
     private val dslContext: DSLContext,
     private val fileService: FileService,
     private val imageUtils: ImageUtils,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -68,7 +70,7 @@ class PhotoRepository(
     requirePermissions { readAccession(accessionId) }
 
     val row = fetchFilesRow(accessionId, filename)
-    return fileService.readFile(row.id!!, maxWidth, maxHeight).withContentType(row.contentType)
+    return thumbnailService.readFile(row.id!!, maxWidth, maxHeight).withContentType(row.contentType)
   }
 
   /** Returns a list of metadata for an accession's photos. */

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PHOTOS
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
@@ -79,6 +80,7 @@ class ObservationService(
     private val plantingSiteStore: PlantingSiteStore,
     private val parentStore: ParentStore,
     private val systemUser: SystemUser,
+    private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
 
@@ -186,7 +188,7 @@ class ObservationService(
       throw FileNotFoundException(fileId)
     }
 
-    return fileService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
 
   fun storePhoto(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -20,13 +20,10 @@ import com.terraformation.backend.db.accelerator.tables.references.SUBMISSION_SN
 import com.terraformation.backend.db.default_schema.SpeciesNativeCategory
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.InMemoryFileStore
-import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -34,7 +31,7 @@ import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -46,9 +43,8 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
   private val eventPublisher = TestEventPublisher()
 
   private val fileStore = InMemoryFileStore()
-  private val thumbnailStore: ThumbnailStore = mockk()
   private val fileService: FileService by lazy {
-    FileService(dslContext, clock, mockk(), filesDao, fileStore, thumbnailStore)
+    FileService(dslContext, clock, mockk(), eventPublisher, filesDao, fileStore)
   }
 
   private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore by lazy {
@@ -504,8 +500,6 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val fileIdOld = insertFile()
       val submissionSnapshotIdOld =
           insertSubmissionSnapshot(fileId = fileIdOld, submissionId = submissionId)
-
-      every { thumbnailStore.deleteThumbnails(any()) } just Runs
 
       service.on(
           DeliverableStatusUpdatedEvent(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.funder.tables.records.PublishedReportPhotosRecord
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.model.FileMetadata
 import io.mockk.every
 import io.mockk.mockk
@@ -47,6 +48,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         reportStore,
         publishedReportPhotosDao,
         SystemUser(usersDao),
+        ThumbnailService(dslContext, fileService, mockk()),
     )
   }
 
@@ -82,7 +84,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           fileId
         }
 
-    every { fileService.readFile(any(), any(), any()) } returns inputStream
+    every { fileService.readFile(any()) } returns inputStream
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
@@ -1,0 +1,95 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.file.event.FileDeletionStartedEvent
+import com.terraformation.backend.file.model.FileMetadata
+import com.terraformation.backend.mockUser
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.ByteArrayInputStream
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val clock = TestClock()
+  private val config: TerrawareServerConfig = mockk()
+  private val eventPublisher = TestEventPublisher()
+  private val fileStore = InMemoryFileStore()
+  private val thumbnailStore: ThumbnailStore = mockk()
+  private val fileService: FileService by lazy {
+    FileService(dslContext, clock, config, eventPublisher, filesDao, fileStore)
+  }
+  private val service: ThumbnailService by lazy {
+    ThumbnailService(dslContext, fileService, thumbnailStore)
+  }
+
+  private val contentType = MediaType.IMAGE_JPEG_VALUE
+  private val filename = "test-photo.jpg"
+  private val metadata = FileMetadata.of(contentType, filename, 1L)
+
+  @Nested
+  inner class OnFileDeletionStartedEvent {
+    @Test
+    fun `deletes thumbnails`() {
+      val fileId = FileId(1)
+
+      every { thumbnailStore.deleteThumbnails(fileId) } just Runs
+
+      service.on(FileDeletionStartedEvent(fileId))
+
+      verify { thumbnailStore.deleteThumbnails(fileId) }
+      confirmVerified(thumbnailStore)
+
+      assertIsEventListener<FileDeletionStartedEvent>(service)
+    }
+  }
+
+  @Nested
+  inner class ReadFile {
+    @Test
+    fun `returns original file if no dimensions are specified`() {
+      val photoData = Random.nextBytes(10)
+      val fileId = fileService.storeFile("category", photoData.inputStream(), metadata) {}
+
+      val stream = service.readFile(fileId)
+
+      assertArrayEquals(photoData, stream.readAllBytes())
+    }
+
+    @Test
+    fun `returns photo thumbnail if photo dimensions are specified`() {
+      val photoData = Random.nextBytes(10)
+      val thumbnailData = Random.nextBytes(10)
+      val thumbnailStream =
+          SizedInputStream(ByteArrayInputStream(thumbnailData), thumbnailData.size.toLong())
+      val width = 123
+      val height = 456
+
+      val fileId = fileService.storeFile("category", photoData.inputStream(), metadata) {}
+
+      every { thumbnailStore.getThumbnailData(any(), any(), any()) } returns thumbnailStream
+
+      val stream = service.readFile(fileId, width, height)
+
+      verify { thumbnailStore.getThumbnailData(fileId, width, height) }
+
+      assertArrayEquals(thumbnailData, stream.readAllBytes())
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedReportServiceTest.kt
@@ -9,14 +9,14 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserType
-import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import java.io.ByteArrayInputStream
 import java.time.ZoneOffset
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -26,12 +26,9 @@ import org.junit.jupiter.api.assertThrows
 class PublishedReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
-  private val fileService = mockk<FileService>()
+  private val thumbnailService = mockk<ThumbnailService>()
   private val service: PublishedReportService by lazy {
-    PublishedReportService(
-        fileService,
-        publishedReportPhotosDao,
-    )
+    PublishedReportService(publishedReportPhotosDao, thumbnailService)
   }
 
   private lateinit var organizationId: OrganizationId
@@ -52,7 +49,7 @@ class PublishedReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     reportId = insertReport()
     insertPublishedReport()
 
-    every { fileService.readFile(any(), any(), any()) } returns inputStream
+    every { thumbnailService.readFile(any(), any(), any()) } returns inputStream
   }
 
   @Nested
@@ -83,7 +80,7 @@ class PublishedReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPublishedReportPhoto()
 
       val inputStream = service.readPhoto(reportId, fileId)
-      verify(exactly = 1) { fileService.readFile(fileId) }
+      verify(exactly = 1) { thumbnailService.readFile(fileId) }
       assertArrayEquals(content, inputStream.readAllBytes(), "Photo data")
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -73,6 +73,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         plantingSiteStore,
         parentStore,
         SystemUser(usersDao),
+        mockk(),
     )
   }
 


### PR DESCRIPTION
In preparation for generating thumbnail images for videos, restructure the
internal APIs for fetching and deleting thumbnails.

Previously, the flow for generating a new thumbnail looked like

    caller
    -> FileService.readFile
    -> ThumbnailStore.getThumbnailData
    -> FileStore.readFile (to fetch original file)

Now `FileService` is only concerned with reading and writing files, not with
transforming them to different sizes. The flow now looks like

    caller
    -> ThumbnailService.readFile
    -> ThumbnailStore.getThumbnailData
    -> FileStore.readFile (to fetch original file)

In addition to having a cleaner separation of concerns, this avoids a problem
when video thumbnail support is added. For videos, we'll need to fetch
thumbnails from Mux, which will mean calling `MuxService`. `MuxService` depends
on `FileService`. If we called `MuxService` from `FileService`, there'd be a
circular dependency between the two services, which we try to avoid whenever
possible.  With this new structure, the call to `MuxService` can happen from
`ThumbnailService` instead.

Handling deletion of thumbnails for video files would have introduced a similar
circular dependency. To break that cycle, `FileService` now publishes an event
when it deletes a file, rather than explicitly calling `ThumbnailStore` to
delete thumbnails. The thumbnails are deleted by an event listener. This also
separates the concerns more cleanly.