### PR TITLE
SW-7413 Retrieve T0 data at zone-level for temp plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.api
 
+import com.fasterxml.jackson.annotation.JsonAlias
 import com.terraformation.backend.api.SimpleSuccessResponsePayload
 import com.terraformation.backend.api.SuccessResponsePayload
 import com.terraformation.backend.api.TrackingEndpoint
@@ -7,10 +8,13 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.tracking.T0PlotService
 import com.terraformation.backend.tracking.db.T0PlotStore
 import com.terraformation.backend.tracking.model.PlotT0DataModel
+import com.terraformation.backend.tracking.model.SiteT0DataModel
 import com.terraformation.backend.tracking.model.SpeciesDensityModel
+import com.terraformation.backend.tracking.model.ZoneT0TempDataModel
 import io.swagger.v3.oas.annotations.Operation
 import java.math.BigDecimal
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,11 +34,9 @@ class T0Controller(
   @Operation(summary = "Get all saved T0 Data for a planting site")
   @GetMapping("/site/{plantingSiteId}")
   fun getT0SiteData(@PathVariable plantingSiteId: PlantingSiteId): GetSiteT0DataResponsePayload {
-    val plotData = t0PlotStore.fetchT0SiteData(plantingSiteId)
+    val siteData = t0PlotStore.fetchT0SiteData(plantingSiteId)
 
-    return GetSiteT0DataResponsePayload(
-        data = SiteT0DataPayload(plantingSiteId, plotData.map { PlotT0DataPayload(it) })
-    )
+    return GetSiteT0DataResponsePayload(data = SiteT0DataResponsePayload(siteData))
   }
 
   @Operation(
@@ -44,7 +46,7 @@ class T0Controller(
   )
   @PostMapping("/site")
   fun assignT0SiteData(
-      @RequestBody payload: SiteT0DataPayload,
+      @RequestBody payload: AssignSiteT0DataRequestPayload,
   ): SimpleSuccessResponsePayload {
     t0PlotService.assignT0PlotsData(payload.plots.map { it.toModel() })
 
@@ -54,16 +56,19 @@ class T0Controller(
 
 data class SpeciesDensityPayload(
     val speciesId: SpeciesId,
-    val plotDensity: BigDecimal,
+    @JsonAlias("plotDensity") val density: BigDecimal,
 ) {
   constructor(
       model: SpeciesDensityModel
   ) : this(
       speciesId = model.speciesId,
-      plotDensity = model.plotDensity,
+      density = model.density,
   )
 
-  fun toModel() = SpeciesDensityModel(speciesId = speciesId, plotDensity = plotDensity)
+  val plotDensity: BigDecimal // for backwards compatibility in response payloads
+    get() = density
+
+  fun toModel() = SpeciesDensityModel(speciesId = speciesId, density = density)
 }
 
 data class PlotT0DataPayload(
@@ -87,9 +92,38 @@ data class PlotT0DataPayload(
       )
 }
 
-data class SiteT0DataPayload(
+data class AssignSiteT0DataRequestPayload(
     val plantingSiteId: PlantingSiteId,
     val plots: List<PlotT0DataPayload> = emptyList(),
 )
 
-data class GetSiteT0DataResponsePayload(val data: SiteT0DataPayload) : SuccessResponsePayload
+data class ZoneT0DataPayload(
+    val plantingZoneId: PlantingZoneId,
+    val densityData: List<SpeciesDensityPayload> = emptyList(),
+) {
+  constructor(
+      model: ZoneT0TempDataModel
+  ) : this(
+      plantingZoneId = model.plantingZoneId,
+      densityData = model.densityData.map { SpeciesDensityPayload(it) },
+  )
+}
+
+data class SiteT0DataResponsePayload(
+    val plantingSiteId: PlantingSiteId,
+    val survivalRatesIncludeTempPlots: Boolean = false,
+    val plots: List<PlotT0DataPayload> = emptyList(),
+    val zones: List<ZoneT0DataPayload> = emptyList(),
+) {
+  constructor(
+      model: SiteT0DataModel
+  ) : this(
+      plantingSiteId = model.plantingSiteId,
+      survivalRatesIncludeTempPlots = model.survivalRateIncludesTempPlots,
+      plots = model.plots.map { PlotT0DataPayload(it) },
+      zones = model.zones.map { ZoneT0DataPayload(it) },
+  )
+}
+
+data class GetSiteT0DataResponsePayload(val data: SiteT0DataResponsePayload) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -111,7 +111,7 @@ data class ZoneT0DataPayload(
 
 data class SiteT0DataResponsePayload(
     val plantingSiteId: PlantingSiteId,
-    val survivalRatesIncludeTempPlots: Boolean = false,
+    val survivalRateIncludesTempPlots: Boolean = false,
     val plots: List<PlotT0DataPayload> = emptyList(),
     val zones: List<ZoneT0DataPayload> = emptyList(),
 ) {
@@ -119,7 +119,7 @@ data class SiteT0DataResponsePayload(
       model: SiteT0DataModel
   ) : this(
       plantingSiteId = model.plantingSiteId,
-      survivalRatesIncludeTempPlots = model.survivalRateIncludesTempPlots,
+      survivalRateIncludesTempPlots = model.survivalRateIncludesTempPlots,
       plots = model.plots.map { PlotT0DataPayload(it) },
       zones = model.zones.map { ZoneT0DataPayload(it) },
   )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
@@ -3,16 +3,30 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import java.math.BigDecimal
 
 data class SpeciesDensityModel(
     val speciesId: SpeciesId,
-    val plotDensity: BigDecimal,
+    val density: BigDecimal,
+)
+
+data class SiteT0DataModel(
+    val plantingSiteId: PlantingSiteId,
+    val survivalRateIncludesTempPlots: Boolean,
+    val plots: List<PlotT0DataModel> = emptyList(),
+    val zones: List<ZoneT0TempDataModel> = emptyList(),
 )
 
 data class PlotT0DataModel(
     val monitoringPlotId: MonitoringPlotId,
     val observationId: ObservationId? = null,
+    val densityData: List<SpeciesDensityModel> = emptyList(),
+)
+
+data class ZoneT0TempDataModel(
+    val plantingZoneId: PlantingZoneId,
     val densityData: List<SpeciesDensityModel> = emptyList(),
 )
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -456,6 +456,7 @@ import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonePopula
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSubzonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZoneHistoriesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonePopulationsRow
+import com.terraformation.backend.db.tracking.tables.pojos.PlantingZoneT0TempDensitiesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingZonesRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlotT0DensitiesRow
@@ -468,6 +469,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_POPULATIONS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_T0_TEMP_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
@@ -3275,8 +3277,29 @@ abstract class DatabaseBackedTest {
     }
   }
 
-  private val nextTreeNumber = mutableMapOf<ObservationId, Int>()
-  private val nextTrunkNumber = mutableMapOf<Pair<ObservationId, Int>, Int>()
+  fun insertPlantingZoneT0TempDensity(
+      row: PlantingZoneT0TempDensitiesRow = PlantingZoneT0TempDensitiesRow(),
+      plantingZoneId: PlantingZoneId = row.plantingZoneId ?: inserted.plantingZoneId,
+      speciesId: SpeciesId = row.speciesId ?: inserted.speciesId,
+      zoneDensity: BigDecimal = row.zoneDensity ?: BigDecimal.valueOf(10),
+      createdBy: UserId = row.createdBy ?: inserted.userId,
+      createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      modifiedBy: UserId = row.modifiedBy ?: inserted.userId,
+      modifiedTime: Instant = row.modifiedTime ?: Instant.EPOCH,
+  ) {
+    with(PLANTING_ZONE_T0_TEMP_DENSITIES) {
+      dslContext
+          .insertInto(this)
+          .set(PLANTING_ZONE_ID, plantingZoneId)
+          .set(SPECIES_ID, speciesId)
+          .set(ZONE_DENSITY, zoneDensity)
+          .set(CREATED_BY, createdBy)
+          .set(CREATED_TIME, createdTime)
+          .set(MODIFIED_BY, modifiedBy)
+          .set(MODIFIED_TIME, modifiedTime)
+          .execute()
+    }
+  }
 
   fun insertPlotT0Density(
       row: PlotT0DensitiesRow = PlotT0DensitiesRow(),
@@ -3323,6 +3346,9 @@ abstract class DatabaseBackedTest {
           .execute()
     }
   }
+
+  private val nextTreeNumber = mutableMapOf<ObservationId, Int>()
+  private val nextTrunkNumber = mutableMapOf<Pair<ObservationId, Int>, Int>()
 
   fun insertRecordedTree(
       row: RecordedTreesRow = RecordedTreesRow(),


### PR DESCRIPTION
Add zone-level data to fetch site t0 payload (as well as `survivalRateIncludesTempPlots`). 

Refactor fetch to multisets.

Rename `plotDensity` to `density` in species payload (but add alias and getter for backwards compatibility).
