### PR TITLE
SW-7412 Assign T0 data at zone-level for temp plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -746,6 +746,9 @@ data class IndividualUser(
   override fun canUpdateT0(monitoringPlotId: MonitoringPlotId) =
       isManagerOrHigher(parentStore.getOrganizationId(monitoringPlotId))
 
+  override fun canUpdateT0(plantingZoneId: PlantingZoneId) =
+      isManagerOrHigher(parentStore.getOrganizationId(plantingZoneId))
+
   override fun canUpdateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -1976,6 +1976,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateT0(plantingZoneId: PlantingZoneId) {
+    user.recordPermissionChecks {
+      if (!user.canUpdateT0(plantingZoneId)) {
+        readPlantingZone(plantingZoneId)
+        throw AccessDeniedException("No permission to update T0 for planting zone $plantingZoneId")
+      }
+    }
+  }
+
   fun updateTimeseries(deviceId: DeviceId) {
     user.recordPermissionChecks {
       if (!user.canUpdateTimeseries(deviceId)) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -659,6 +659,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canUpdateT0(monitoringPlotId: MonitoringPlotId): Boolean = defaultPermission
 
+  fun canUpdateT0(plantingZoneId: PlantingZoneId): Boolean = defaultPermission
+
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 
   fun canUpdateUpload(uploadId: UploadId): Boolean = defaultPermission

--- a/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0PlotService.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.tracking.model.PlotT0DataModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedModel
 import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
+import com.terraformation.backend.tracking.model.ZoneT0TempDataModel
 import jakarta.inject.Named
 import org.jooq.DSLContext
 
@@ -84,6 +85,16 @@ class T0PlotService(
                     .sortedBy { it.monitoringPlotNumber },
         )
     )
+  }
+
+  fun assignT0TempZoneData(zonesList: List<ZoneT0TempDataModel>) {
+    dslContext.transaction { _ ->
+      zonesList.forEach { model ->
+        t0PlotStore.assignT0TempZoneSpeciesDensities(model.plantingZoneId, model.densityData)
+      }
+    }
+
+    // future PR: publish rate-limited event here
   }
 
   private fun getPlotInfo(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -52,6 +52,16 @@ class T0Controller(
 
     return SimpleSuccessResponsePayload()
   }
+
+  @Operation(summary = "Assign T0 Data for a planting site, only applicable to temporary plots")
+  @PostMapping("/site/temp")
+  fun assignT0TempSiteData(
+      @RequestBody payload: AssignSiteT0TempDataRequestPayload
+  ): SimpleSuccessResponsePayload {
+    t0PlotService.assignT0TempZoneData(payload.zones.map { it.toModel() })
+
+    return SimpleSuccessResponsePayload()
+  }
 }
 
 data class SpeciesDensityPayload(
@@ -92,11 +102,6 @@ data class PlotT0DataPayload(
       )
 }
 
-data class AssignSiteT0DataRequestPayload(
-    val plantingSiteId: PlantingSiteId,
-    val plots: List<PlotT0DataPayload> = emptyList(),
-)
-
 data class ZoneT0DataPayload(
     val plantingZoneId: PlantingZoneId,
     val densityData: List<SpeciesDensityPayload> = emptyList(),
@@ -107,6 +112,12 @@ data class ZoneT0DataPayload(
       plantingZoneId = model.plantingZoneId,
       densityData = model.densityData.map { SpeciesDensityPayload(it) },
   )
+
+  fun toModel() =
+      ZoneT0TempDataModel(
+          plantingZoneId = plantingZoneId,
+          densityData = densityData.map { it.toModel() },
+      )
 }
 
 data class SiteT0DataResponsePayload(
@@ -127,3 +138,13 @@ data class SiteT0DataResponsePayload(
 
 data class GetSiteT0DataResponsePayload(val data: SiteT0DataResponsePayload) :
     SuccessResponsePayload
+
+data class AssignSiteT0DataRequestPayload(
+    val plantingSiteId: PlantingSiteId,
+    val plots: List<PlotT0DataPayload> = emptyList(),
+)
+
+data class AssignSiteT0TempDataRequestPayload(
+    val plantingSiteId: PlantingSiteId,
+    val zones: List<ZoneT0DataPayload> = emptyList(),
+)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0PlotStore.kt
@@ -265,7 +265,7 @@ class T0PlotStore(
 
         var insertQuery =
             dslContext.insertInto(
-                this,
+                PLANTING_ZONE_T0_TEMP_DENSITIES,
                 PLANTING_ZONE_ID,
                 SPECIES_ID,
                 ZONE_DENSITY,
@@ -275,28 +275,28 @@ class T0PlotStore(
                 MODIFIED_TIME,
             )
 
-        densities.forEach {
-          if (it.density < BigDecimal.ZERO) {
+        densities.forEach { model ->
+          if (model.density < BigDecimal.ZERO) {
             throw IllegalArgumentException("Zone density must not be negative")
           }
           insertQuery =
               insertQuery.values(
                   plantingZoneId,
-                  it.speciesId,
-                  it.density,
+                  model.speciesId,
+                  model.density,
                   currentUserId,
                   now,
                   currentUserId,
                   now,
               )
-
-          insertQuery
-              .onDuplicateKeyUpdate()
-              .set(ZONE_DENSITY, DSL.excluded(ZONE_DENSITY))
-              .set(MODIFIED_BY, currentUserId)
-              .set(MODIFIED_TIME, now)
-              .execute()
         }
+
+        insertQuery
+            .onDuplicateKeyUpdate()
+            .set(ZONE_DENSITY, DSL.excluded(ZONE_DENSITY))
+            .set(MODIFIED_BY, currentUserId)
+            .set(MODIFIED_TIME, now)
+            .execute()
       }
 
       // future PR: publish event here

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -1220,7 +1220,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
-  fun updateT0() = allow { updateT0(monitoringPlotId) } ifUser { canUpdateT0(monitoringPlotId) }
+  fun updateT0Plot() = allow { updateT0(monitoringPlotId) } ifUser { canUpdateT0(monitoringPlotId) }
+
+  @Test
+  fun updateT0Zone() = allow { updateT0(plantingZoneId) } ifUser { canUpdateT0(plantingZoneId) }
 
   @Test fun updateUpload() = allow { updateUpload(uploadId) } ifUser { canUpdateUpload(uploadId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -644,6 +644,7 @@ internal class PermissionTest : DatabaseTest() {
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
         updatePlantingZone = true,
+        updateT0 = true,
     )
 
     permissions.expect(
@@ -931,6 +932,7 @@ internal class PermissionTest : DatabaseTest() {
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
         updatePlantingZone = true,
+        updateT0 = true,
     )
 
     permissions.expect(*moduleEventIds.forOrg1(), readModuleEvent = true)
@@ -1136,6 +1138,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *plantingZoneIds.forOrg1(),
         readPlantingZone = true,
+        updateT0 = true,
     )
 
     permissions.expect(
@@ -1605,6 +1608,7 @@ internal class PermissionTest : DatabaseTest() {
         *plantingZoneIds.toTypedArray(),
         readPlantingZone = true,
         updatePlantingZone = true,
+        updateT0 = true,
     )
 
     permissions.expect(
@@ -3925,6 +3929,7 @@ internal class PermissionTest : DatabaseTest() {
         vararg plantingZoneIds: PlantingZoneId,
         readPlantingZone: Boolean = false,
         updatePlantingZone: Boolean = false,
+        updateT0: Boolean = false,
     ) {
       plantingZoneIds.forEach { plantingZoneId ->
         val idInDatabase = getDatabaseId(plantingZoneId)
@@ -3938,6 +3943,11 @@ internal class PermissionTest : DatabaseTest() {
             updatePlantingZone,
             user.canUpdatePlantingZone(idInDatabase),
             "Can update planting zone $plantingZoneId",
+        )
+        assertEquals(
+            updateT0,
+            user.canUpdateT0(idInDatabase),
+            "Can update T0 for planting zone $plantingZoneId",
         )
 
         uncheckedPlantingZones.remove(plantingZoneId)


### PR DESCRIPTION
Add ability to assign t0 data at zone-level. 

Remove test that was already being tested in other tests.