### PR TITLE
Rename T0Plot service and store to T0

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
@@ -7,7 +7,7 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
-import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.event.RateLimitedT0DataAssignedEvent
 import com.terraformation.backend.tracking.model.PlotT0DataModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
@@ -18,10 +18,10 @@ import jakarta.inject.Named
 import org.jooq.DSLContext
 
 @Named
-class T0PlotService(
+class T0Service(
     private val dslContext: DSLContext,
     private val rateLimitedEventPublisher: RateLimitedEventPublisher,
-    private val t0PlotStore: T0PlotStore,
+    private val t0Store: T0Store,
 ) {
   private data class PlotEventDetailsModel(
       val plotNumber: Long,
@@ -41,9 +41,9 @@ class T0PlotService(
       plotsList.forEach { model ->
         plotsChangeList.add(
             if (model.observationId == null) {
-              t0PlotStore.assignT0PlotSpeciesDensities(model.monitoringPlotId, model.densityData)
+              t0Store.assignT0PlotSpeciesDensities(model.monitoringPlotId, model.densityData)
             } else {
-              t0PlotStore.assignT0PlotObservation(model.monitoringPlotId, model.observationId)
+              t0Store.assignT0PlotObservation(model.monitoringPlotId, model.observationId)
             }
         )
       }
@@ -90,7 +90,7 @@ class T0PlotService(
   fun assignT0TempZoneData(zonesList: List<ZoneT0TempDataModel>) {
     dslContext.transaction { _ ->
       zonesList.forEach { model ->
-        t0PlotStore.assignT0TempZoneSpeciesDensities(model.plantingZoneId, model.densityData)
+        t0Store.assignT0TempZoneSpeciesDensities(model.plantingZoneId, model.densityData)
       }
     }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -9,8 +9,8 @@ import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
-import com.terraformation.backend.tracking.T0PlotService
-import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.T0Service
+import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.model.PlotT0DataModel
 import com.terraformation.backend.tracking.model.SiteT0DataModel
 import com.terraformation.backend.tracking.model.SpeciesDensityModel
@@ -28,13 +28,13 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @TrackingEndpoint
 class T0Controller(
-    private val t0PlotService: T0PlotService,
-    private val t0PlotStore: T0PlotStore,
+    private val t0Service: T0Service,
+    private val t0Store: T0Store,
 ) {
   @Operation(summary = "Get all saved T0 Data for a planting site")
   @GetMapping("/site/{plantingSiteId}")
   fun getT0SiteData(@PathVariable plantingSiteId: PlantingSiteId): GetSiteT0DataResponsePayload {
-    val siteData = t0PlotStore.fetchT0SiteData(plantingSiteId)
+    val siteData = t0Store.fetchT0SiteData(plantingSiteId)
 
     return GetSiteT0DataResponsePayload(data = SiteT0DataResponsePayload(siteData))
   }
@@ -48,7 +48,7 @@ class T0Controller(
   fun assignT0SiteData(
       @RequestBody payload: AssignSiteT0DataRequestPayload,
   ): SimpleSuccessResponsePayload {
-    t0PlotService.assignT0PlotsData(payload.plots.map { it.toModel() })
+    t0Service.assignT0PlotsData(payload.plots.map { it.toModel() })
 
     return SimpleSuccessResponsePayload()
   }
@@ -58,7 +58,7 @@ class T0Controller(
   fun assignT0TempSiteData(
       @RequestBody payload: AssignSiteT0TempDataRequestPayload
   ): SimpleSuccessResponsePayload {
-    t0PlotService.assignT0TempZoneData(payload.zones.map { it.toModel() })
+    t0Service.assignT0TempZoneData(payload.zones.map { it.toModel() })
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -31,7 +31,7 @@ import org.jooq.impl.DSL
 import org.springframework.context.ApplicationEventPublisher
 
 @Named
-class T0PlotStore(
+class T0Store(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,

--- a/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
@@ -15,7 +15,7 @@ import com.terraformation.backend.db.tracking.tables.records.PlotT0DensitiesReco
 import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
-import com.terraformation.backend.tracking.db.T0PlotStore
+import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.event.RateLimitedT0DataAssignedEvent
 import com.terraformation.backend.tracking.model.PlotT0DataModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
@@ -29,15 +29,15 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-internal class T0PlotServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+internal class T0ServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val rateLimitedEventPublisher = TestEventPublisher()
-  private val t0PlotStore: T0PlotStore by lazy { T0PlotStore(clock, dslContext, eventPublisher) }
-  private val service: T0PlotService by lazy {
-    T0PlotService(dslContext, rateLimitedEventPublisher, t0PlotStore)
+  private val t0Store: T0Store by lazy { T0Store(clock, dslContext, eventPublisher) }
+  private val service: T0Service by lazy {
+    T0Service(dslContext, rateLimitedEventPublisher, t0Store)
   }
 
   private lateinit var monitoringPlotId1: MonitoringPlotId

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -39,12 +39,12 @@ import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
-internal class T0PlotStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
-  private val store: T0PlotStore by lazy { T0PlotStore(clock, dslContext, eventPublisher) }
+  private val store: T0Store by lazy { T0Store(clock, dslContext, eventPublisher) }
 
   private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var plantingZoneId: PlantingZoneId


### PR DESCRIPTION
Now that they handle more than just t0 plot data (with the zone data for temp plots), rename "T0Plot" to just "T0" for the service and the store. 