### PR TITLE
Fix intermittent NurseryWithdrawalStoreTest failures

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
@@ -62,7 +62,7 @@ internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSubzonePopulation(plantingSubzoneId = subzone3, speciesId = species3, 600)
 
       val expected =
-          listOf(
+          setOf(
               PlotSpeciesModel(
                   monitoringPlotId = plot1,
                   species =
@@ -106,7 +106,7 @@ internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
           )
 
-      assertEquals(expected, store.fetchSiteSpeciesByPlot(plantingSiteId))
+      assertEquals(expected, store.fetchSiteSpeciesByPlot(plantingSiteId).toSet())
     }
   }
 


### PR DESCRIPTION
The test was assuming a database query without an `ORDER BY` would return results
in a specific order. Make it order-independent.