### PR TITLE
Add assertSetEquals to compare sets in tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/Helpers.kt
+++ b/src/test/kotlin/com/terraformation/backend/Helpers.kt
@@ -65,6 +65,24 @@ fun assertGeometryEquals(expected: Geometry?, actual: Geometry?, message: String
   }
 }
 
+/**
+ * Asserts that two sets are equal. If not, produces an assertion failure message with the items
+ * sorted by their string representations, each item on a separate line, to make it easier to spot
+ * differences.
+ */
+fun <T> assertSetEquals(expected: Set<T>, actual: Set<T>, message: String? = null) {
+  if (expected != actual) {
+    assertEquals(expected.toPrettyString(), actual.toPrettyString(), message)
+
+    // Should never get here unless the string representations of the items are incomplete.
+    assertEquals(
+        expected,
+        actual,
+        "Sets are not equal, but their items' string representations are the same",
+    )
+  }
+}
+
 fun point(x: Number, y: Number = x, z: Number? = null, srid: Int = SRID.LONG_LAT): Point {
   val geometryFactory = GeometryFactory(PrecisionModel(), srid)
   return geometryFactory.createPoint(
@@ -215,3 +233,10 @@ fun getEnvOrSkipTest(name: String): String {
   assumeNotNull(value, "$name not set; skipping test")
   return value
 }
+
+/**
+ * Returns a string representation of a Set with the items sorted and each item on its own indented
+ * line.
+ */
+private fun Set<*>.toPrettyString(): String =
+    sortedBy { it.toString() }.joinToString(",\n  ", "[\n  ", "\n]")

--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -72,7 +72,7 @@ class TestEventPublisher : ApplicationEventPublisher, RateLimitedEventPublisher 
       events: Set<Any>,
       message: String = "Expected events not published",
   ) {
-    assertEquals(events, publishedEvents.toSet(), message)
+    assertSetEquals(events, publishedEvents.toSet(), message)
   }
 
   /** Asserts that a particular event was published. */

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ApplicationStoreTest.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.accelerator.model.DeliverableSubmissionModel
 import com.terraformation.backend.accelerator.model.ExistingApplicationModel
 import com.terraformation.backend.accelerator.model.PreScreenProjectType
 import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.OrganizationNotFoundException
@@ -876,19 +877,19 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
                 status = SubmissionStatus.Completed,
             )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project1PrescreenModel, org1Project1ApplicationModel),
             store.fetchApplicationDeliverables(projectId = org1ProjectId1).toSet(),
             "Fetch application deliverables by projectId for org1 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project2PrescreenModel, org1Project2ApplicationModel),
             store.fetchApplicationDeliverables(projectId = org1ProjectId2).toSet(),
             "Fetch application deliverables by projectId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org2Project1PrescreenModel,
                 org2Project1ApplicationModel,
@@ -898,7 +899,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by org2 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project1PrescreenModel),
             store
                 .fetchApplicationDeliverables(
@@ -909,7 +910,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by projectId and deliverableId for org1 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project2PrescreenModel),
             store
                 .fetchApplicationDeliverables(
@@ -920,7 +921,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by projectId and deliverableId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org2Project1PrescreenModel),
             store
                 .fetchApplicationDeliverables(
@@ -931,19 +932,19 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by projectId and deliverableId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project1PrescreenModel, org1Project1ApplicationModel),
             store.fetchApplicationDeliverables(applicationId = org1Project1ApplicationId).toSet(),
             "Fetch application deliverables by applicationId for org1 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project2PrescreenModel, org1Project2ApplicationModel),
             store.fetchApplicationDeliverables(applicationId = org1Project2ApplicationId).toSet(),
             "Fetch application deliverables by applicationId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org2Project1PrescreenModel,
                 org2Project1ApplicationModel,
@@ -953,7 +954,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by applicationId for org2 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project1ApplicationModel),
             store
                 .fetchApplicationDeliverables(
@@ -964,7 +965,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by applicationId and deliverableId for org1 project1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org1Project2ApplicationModel),
             store
                 .fetchApplicationDeliverables(
@@ -975,7 +976,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by applicationId and deliverableId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(org2Project1ApplicationModel),
             store
                 .fetchApplicationDeliverables(
@@ -986,7 +987,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by applicationId and deliverableId for org1 project2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1PrescreenModel,
                 org1Project1ApplicationModel,
@@ -997,7 +998,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by organizationId 1",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org2Project1PrescreenModel,
                 org2Project1ApplicationModel,
@@ -1007,7 +1008,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by organizationId 2",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1PrescreenModel,
                 org1Project2PrescreenModel,
@@ -1017,7 +1018,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by pre-screen deliverableId",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1ApplicationModel,
                 org1Project2ApplicationModel,
@@ -1027,7 +1028,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by application deliverableId",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1PrescreenModel,
                 org1Project2PrescreenModel,
@@ -1037,7 +1038,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by pre-screen moduleId",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1ApplicationModel,
                 org1Project2ApplicationModel,
@@ -1047,7 +1048,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
             "Fetch application deliverables by application moduleId",
         )
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 org1Project1PrescreenModel,
                 org1Project1ApplicationModel,
@@ -1713,7 +1714,7 @@ class ApplicationStoreTest : DatabaseTest(), RunsAsUser {
 
       store.submit(applicationId, validVariables(boundary))
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               ApplicationModulesRow(
                   applicationId = applicationId,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverableDueDateStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.model.DeliverableDueDateModel
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableCohortDueDatesRow
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableProjectDueDatesRow
@@ -119,7 +120,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
               deliverableId = deliverableId4,
           )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               cohort1Deliverable1,
               cohort1Deliverable2,
@@ -132,7 +133,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           "Fetch with no filters",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               cohort1Deliverable1,
               cohort1Deliverable2,
@@ -143,13 +144,13 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           "Fetch with cohort filter",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(cohort1Deliverable3, cohort1Deliverable4, cohort2Deliverable3, cohort2Deliverable4),
           store.fetchDeliverableDueDates(moduleId = moduleId2).toSet(),
           "Fetch with module filter",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               cohort1Deliverable3,
               cohort1Deliverable4,
@@ -158,7 +159,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           "Fetch with cohort and module filter",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               cohort1Deliverable3,
               cohort2Deliverable3,
@@ -167,7 +168,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           "Fetch with deliverable filter",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               cohort1Deliverable3,
           ),
@@ -177,7 +178,7 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
           "Fetch with cohort and deliverable filter",
       )
 
-      assertEquals(
+      assertSetEquals(
           emptySet<DeliverableDueDateModel>(),
           store
               .fetchDeliverableDueDates(deliverableId = deliverableId1, moduleId = moduleId2)
@@ -237,7 +238,10 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
               dueDate = LocalDate.of(2024, 7, 1),
           )
 
-      assertEquals(setOf(updatedRow, insertedRow), deliverableCohortDueDatesDao.findAll().toSet())
+      assertSetEquals(
+          setOf(updatedRow, insertedRow),
+          deliverableCohortDueDatesDao.findAll().toSet(),
+      )
     }
 
     @Test
@@ -299,7 +303,10 @@ class DeliverableDueDateStoreTest : DatabaseTest(), RunsAsUser {
               dueDate = LocalDate.of(2024, 7, 1),
           )
 
-      assertEquals(setOf(updatedRow, insertedRow), deliverableProjectDueDatesDao.findAll().toSet())
+      assertSetEquals(
+          setOf(updatedRow, insertedRow),
+          deliverableProjectDueDatesDao.findAll().toSet(),
+      )
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/DeliverablesImporterTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.DeliverablesUploadedEvent
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.DeliverableId
 import com.terraformation.backend.db.accelerator.tables.pojos.DeliverableVariablesRow
@@ -76,7 +77,7 @@ class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.importDeliverables(csv.byteInputStream())
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               DeliverableVariablesRow(deliverableId1, variableId1, 0),
               DeliverableVariablesRow(deliverableId1, variableId2, 1),
@@ -110,7 +111,7 @@ class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.importDeliverables(csv.byteInputStream())
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               DeliverableVariablesRow(deliverableId, tableVariableId, 0),
               DeliverableVariablesRow(deliverableId, columnVariableId1, 1),
@@ -168,7 +169,7 @@ class DeliverablesImporterTest : DatabaseTest(), RunsAsUser {
 
       importer.importDeliverables(csv.byteInputStream())
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               DeliverableVariablesRow(deliverableId, variableId3, 0),
               DeliverableVariablesRow(deliverableId, variableId1, 1),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ModuleEventStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.MODULE_EVENT_NOTIFICATION_LEAD_TIME
 import com.terraformation.backend.accelerator.event.ModuleEventScheduledEvent
 import com.terraformation.backend.accelerator.model.EventModel
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.EventNotFoundException
 import com.terraformation.backend.db.accelerator.CohortId
@@ -372,7 +373,7 @@ class ModuleEventStoreTest : DatabaseTest(), RunsAsUser {
 
       assertNotNull(eventsDao.fetchOneById(model.id))
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               EventProjectsRow(model.id, project1),
               EventProjectsRow(model.id, project2),

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.accelerator.event.ParticipantProjectFileNaming
 import com.terraformation.backend.accelerator.model.MetricProgressModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorDetailsModel
 import com.terraformation.backend.accelerator.model.ProjectAcceleratorVariableValuesModel
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.DealStage
@@ -214,7 +215,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
               dealName = "Project deal name",
           )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               ProjectAcceleratorDetailsModel(
                   projectId = otherProject,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.accelerator.model.ExistingProjectScoreModel
 import com.terraformation.backend.accelerator.model.NewProjectScoreModel
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.ScoreCategory
@@ -193,7 +194,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      assertEquals(expected, projectScoresDao.findAll().toSet())
+      assertSetEquals(expected, projectScoresDao.findAll().toSet())
     }
 
     @Test
@@ -243,7 +244,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      assertEquals(expected, projectScoresDao.findAll().toSet())
+      assertSetEquals(expected, projectScoresDao.findAll().toSet())
     }
 
     @Test

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.accelerator.model.ReportStandardMetricModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricEntryModel
 import com.terraformation.backend.accelerator.model.ReportSystemMetricModel
 import com.terraformation.backend.accelerator.model.StandardMetricModel
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -707,19 +708,19 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       clock.instant = LocalDate.of(2041, Month.JANUARY, 1).atStartOfDay().toInstant(ZoneOffset.UTC)
 
-      assertEquals(
+      assertSetEquals(
           setOf(reportModel1, reportModel2, otherReportModel1, otherReportModel2),
           store.fetch().toSet(),
           "Fetches all",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(reportModel1, reportModel2),
           store.fetch(projectId = projectId).toSet(),
           "Fetches by projectId",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(reportModel2, otherReportModel1),
           store.fetch(year = 2035).toSet(),
           "Fetches by year",
@@ -792,14 +793,14 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertEquals(emptyList<ReportModel>(), store.fetch(), "Contributor cannot see the reports")
 
       insertOrganizationUser(organizationId = organizationId, role = Role.Manager)
-      assertEquals(
+      assertSetEquals(
           setOf(reportModel, secondReportModel),
           store.fetch().toSet(),
           "Manager can see project reports within the organization",
       )
 
       insertUserGlobalRole(role = GlobalRole.ReadOnly)
-      assertEquals(
+      assertSetEquals(
           setOf(reportModel, secondReportModel, otherReportModel),
           store.fetch().toSet(),
           "Read-only admin user can see all project reports",
@@ -3103,13 +3104,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               logframeUrl = URI("https://terraware.io/logframe"),
           )
 
-      assertEquals(
+      assertSetEquals(
           setOf(projectConfigModel1, projectConfigModel2),
           store.fetchProjectReportConfigs(projectId = projectId).toSet(),
           "fetches by projectId",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               projectConfigModel1,
               projectConfigModel2,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/UserInternalInterestsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/UserInternalInterestsStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.db.UserInternalInterestsStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
@@ -37,7 +38,7 @@ class UserInternalInterestsStoreTest : DatabaseTest(), RunsAsUser {
       val targetUserId = insertUser()
       expected.forEach { insertUserInternalInterest(it) }
 
-      assertEquals(
+      assertSetEquals(
           expected,
           store.fetchForUser(targetUserId),
           "Should be accessible via fetch method",
@@ -71,12 +72,12 @@ class UserInternalInterestsStoreTest : DatabaseTest(), RunsAsUser {
           setOf(InternalInterest.FinancialViability, InternalInterest.SupplementalFiles),
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(InternalInterest.FinancialViability, InternalInterest.SupplementalFiles),
           store.fetchForUser(targetUserId),
           "Should have updated categories of target user",
       )
-      assertEquals(
+      assertSetEquals(
           setOf(InternalInterest.CarbonEligibility),
           store.fetchForUser(otherUserId),
           "Should not have updated categories of other user",

--- a/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/OrganizationServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.InMemoryKeycloakAdminClient
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.OrganizationStore
@@ -197,7 +198,7 @@ internal class OrganizationServiceTest : DatabaseTest(), RunsAsUser {
             ),
         )
 
-    assertEquals(
+    assertSetEquals(
         expectedOrganizationUsers,
         organizationUsersDao.findAll().toSet(),
         "User should be removed from organizations, but other user should remain",

--- a/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/ProjectServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.InMemoryKeycloakAdminClient
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
@@ -186,7 +187,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
           listOf(plantingSiteId1, plantingSiteId2),
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               accessionId1 to projectId,
               accessionId2 to projectId,
@@ -196,7 +197,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
           "Accession projects",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               batchId1 to projectId,
               batchId2 to projectId,
@@ -206,7 +207,7 @@ class ProjectServiceTest : DatabaseTest(), RunsAsUser {
           "Batch projects",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               plantingSiteId1 to projectId,
               plantingSiteId2 to projectId,

--- a/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/api/InternalTagsControllerTest.kt
@@ -1,9 +1,9 @@
 package com.terraformation.backend.customer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.default_schema.GlobalRole
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.get
@@ -126,7 +126,7 @@ class InternalTagsControllerTest : ControllerIntegrationTest() {
           .put("/api/v1/internalTags/organizations/$organizationId") { content = payload }
           .andExpect { status { isOk() } }
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               organizationId to InternalTagIds.Reporter,
               organizationId to newTagId,

--- a/src/test/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTaskTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/daily/NotificationsCleanupTaskTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.daily
 
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
 import com.terraformation.backend.db.DatabaseTest
@@ -53,7 +54,7 @@ internal class NotificationsCleanupTaskTest : DatabaseTest() {
     val notificationId2 = insertNotification(UserId(1), createdTime = now.minus(Duration.ofDays(6)))
 
     val beforeCleanup = notificationsDao.findAll()
-    assertEquals(
+    assertSetEquals(
         setOf(notificationId1, notificationId2),
         beforeCleanup.map { it.id }.toSet(),
         "Expected notification IDs 1 and 2",

--- a/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/FacilityStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.customer.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.event.FacilityTimeZoneChangedEvent
 import com.terraformation.backend.customer.model.NewFacilityModel
@@ -300,7 +301,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
 
     store.withIdleFacilities { actual.addAll(it) }
 
-    assertEquals(setOf(facilityId), actual)
+    assertSetEquals(setOf(facilityId), actual)
   }
 
   @Test
@@ -342,7 +343,7 @@ internal class FacilityStoreTest : DatabaseTest(), RunsAsUser {
         )
     val subLocations = store.fetchSubLocations(model.id)
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             SubLocationsRow(
                 createdBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/InternalTagStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.OrganizationModel
 import com.terraformation.backend.db.DatabaseTest
@@ -189,7 +190,7 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
     insertOrganizationInternalTag(organizationId, InternalTagIds.Testing)
     insertOrganizationInternalTag(otherOrganizationId, InternalTagIds.Internal)
 
-    assertEquals(
+    assertSetEquals(
         setOf(InternalTagIds.Reporter, InternalTagIds.Testing),
         store.fetchTagsByOrganization(organizationId),
     )
@@ -218,7 +219,7 @@ class InternalTagStoreTest : DatabaseTest(), RunsAsUser {
         setOf(InternalTagIds.Reporter, InternalTagIds.Testing),
     )
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             OrganizationInternalTagsRow(
                 createdBy = user.userId,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/PermissionStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityId
@@ -65,7 +66,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
 
   @Test
   fun `fetchGlobalRoles returns empty set if user has no global roles`() {
-    assertEquals(emptySet<GlobalRole>(), permissionStore.fetchGlobalRoles(user.userId))
+    assertSetEquals(emptySet<GlobalRole>(), permissionStore.fetchGlobalRoles(user.userId))
   }
 
   @Test
@@ -75,7 +76,7 @@ internal class PermissionStoreTest : DatabaseTest(), RunsAsUser {
     insertUserGlobalRole(role = GlobalRole.ReadOnly)
     insertUserGlobalRole(role = GlobalRole.SuperAdmin)
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             GlobalRole.AcceleratorAdmin,
             GlobalRole.TFExpert,

--- a/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/UserStoreTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.CredentialRepresentation
 import com.terraformation.backend.auth.InMemoryKeycloakAdminClient
 import com.terraformation.backend.auth.UserRepresentation
@@ -347,7 +348,7 @@ internal class UserStoreTest : DatabaseTest(), RunsAsUser {
     insertUserGlobalRole(acceleratorAdminUser, GlobalRole.AcceleratorAdmin)
     insertUserGlobalRole(readOnlyUser, GlobalRole.ReadOnly)
 
-    assertEquals(
+    assertSetEquals(
         setOf(acceleratorAdminUser, readOnlyUser),
         userStore
             .fetchWithGlobalRoles(setOf(GlobalRole.AcceleratorAdmin, GlobalRole.ReadOnly))

--- a/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/daily/NotificationScannerTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.FacilityStore
@@ -156,7 +157,11 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
         facilitiesDao.fetchOneById(facilityId)?.lastNotificationDate,
         "Should have set last notification date based on facility time zone",
     )
-    assertEquals(emptySet<FacilityId>(), notifiedFacilities, "Should not have sent notifications")
+    assertSetEquals(
+        emptySet<FacilityId>(),
+        notifiedFacilities,
+        "Should not have sent notifications",
+    )
   }
 
   @Test
@@ -184,6 +189,6 @@ class NotificationScannerTest : DatabaseTest(), RunsAsUser {
 
     scanner.sendNotifications()
 
-    assertEquals(setOf(notifiedFacilityId, laterFacilityId), notifiedFacilities)
+    assertSetEquals(setOf(notifiedFacilityId, laterFacilityId), notifiedFacilities)
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/SRIDTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SRIDTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.db
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.default_schema.tables.references.SPATIAL_REF_SYS
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -36,6 +37,6 @@ class SRIDTest : DatabaseTest() {
             .toSortedSet()
     val mappingSrids = SRID.mapping.values.toSortedSet()
 
-    assertEquals(emptySet<Int>(), mappingSrids - postgisSrids, "Unrecognized SRIDs in mapping")
+    assertSetEquals(emptySet<Int>(), mappingSrids - postgisSrids, "Unrecognized SRIDs in mapping")
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.db
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.SchemaDocsGenerator.Slice.ACCELERATOR
 import com.terraformation.backend.db.SchemaDocsGenerator.Slice.ALL
 import com.terraformation.backend.db.SchemaDocsGenerator.Slice.CUSTOMER
@@ -528,12 +529,12 @@ class SchemaDocsGenerator : DatabaseTest() {
       // message is easier to read; assertEquals() would require hunting through a big list of
       // tables to spot the differences.
 
-      assertEquals(
+      assertSetEquals(
           emptySet<String>(),
           tablesFromDb - tables.keys,
           "Tables not listed in $schemaName schema doc configuration",
       )
-      assertEquals(
+      assertSetEquals(
           emptySet<String>(),
           tables.keys - tablesFromDb,
           "Nonexistent tables listed in $schemaName schema doc configuration",

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ImagesControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.docprod.VariableType
 import com.terraformation.backend.db.docprod.tables.pojos.VariableImageValuesRow
@@ -225,7 +226,7 @@ class ImagesControllerTest : ControllerIntegrationTest() {
               """
           }
 
-      assertEquals(
+      assertSetEquals(
           setOf(0, 1, 2),
           valuesRows.map { it.listPosition }.toSet(),
           "List positions of values",

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/ValuesControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.db.default_schema.GlobalRole
@@ -854,7 +855,7 @@ class ValuesControllerTest : ControllerIntegrationTest() {
 
       val imageValuesRows = variableImageValuesDao.findAll().toSet()
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariableImageValuesRow(
                   caption = "Old caption",

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/api/VariableOwnersControllerTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.documentproducer.api
 
 import com.terraformation.backend.api.ControllerIntegrationTest
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.docprod.VariableId
@@ -128,7 +129,7 @@ class VariableOwnersControllerTest : ControllerIntegrationTest() {
             .put(path()) { content = """{"ownedBy": $newOwnerId}""" }
             .andExpect { status { isOk() } }
 
-        assertEquals(
+        assertSetEquals(
             setOf(
                 VariableOwnersRow(inserted.projectId, sectionId, newOwnerId),
                 VariableOwnersRow(inserted.projectId, otherSectionId, user.userId),

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/ManifestImporterTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.documentproducer.db
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.docprod.VariableId
 import com.terraformation.backend.db.docprod.VariableInjectionDisplayStyle
@@ -599,7 +600,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
       assertNull(updatedTop.replacesVariableId, "Replaces ID for top")
       assertEquals(initialBottom.id, updatedBottom.replacesVariableId, "Replaces ID for bottom")
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariableSectionsRow(
                   renderHeading = true,
@@ -642,7 +643,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
       assertEquals(initialTop2.id, updatedTop2.replacesVariableId, "Replaces ID for second top")
       assertEquals(initialBottom.id, updatedBottom.replacesVariableId, "Replaces ID for bottom")
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariableSectionsRow(
                   renderHeading = true,
@@ -692,7 +693,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
       assertEquals(initialMiddle.id, updatedMiddle.replacesVariableId, "Replaces ID for middle")
       assertEquals(initialBottom.id, updatedBottom.replacesVariableId, "Replaces ID for bottom")
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariableSectionsRow(
                   renderHeading = true,
@@ -744,7 +745,7 @@ class ManifestImporterTest : DatabaseTest(), RunsAsUser {
       assertEquals(initialTop.id, updatedTop.replacesVariableId, "Replaces ID for top")
       assertEquals(initialMiddle.id, updatedMiddle.replacesVariableId, "Replaces ID for middle")
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariableSectionsRow(
                   renderHeading = true,

--- a/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/documentproducer/db/VariableImporterTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.documentproducer.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.accelerator.db.DeliverableStore
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.accelerator.tables.records.DeliverableVariablesRecord
@@ -488,12 +489,12 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           updateResult,
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf("Option 1", "Option 2", "Option 3"),
           variableSelectOptionsDao.fetchByVariableId(variablesRows[0].id!!).map { it.name }.toSet(),
           "Initial options",
       )
-      assertEquals(
+      assertSetEquals(
           setOf("Option 1", "Option 2"),
           variableSelectOptionsDao.fetchByVariableId(variablesRows[1].id!!).map { it.name }.toSet(),
           "Updated options",
@@ -524,7 +525,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           updateResult,
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariablesRow(
                   description = "Original description",
@@ -581,7 +582,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           "New variable should be marked as replacement of existing one",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariablesRow(
                   id = initialVariableId,
@@ -643,7 +644,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           updateResult,
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               VariablesRow(
                   id = initialVariables[0].id,
@@ -744,7 +745,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           updateResult,
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(updatedVariables[4].id, updatedVariables[5].id),
           variableTableColumnsDao
               .fetchByTableVariableId(newTableVariableId)
@@ -786,7 +787,7 @@ class VariableImporterTest : DatabaseTest(), RunsAsUser {
           updateResult,
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(updatedVariables[3].id, updatedVariables[4].id),
           variableTableColumnsDao
               .fetchByTableVariableId(newTableVariableId)

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.accelerator.model.ExistingCohortModel
 import com.terraformation.backend.accelerator.model.ExistingParticipantModel
 import com.terraformation.backend.accelerator.model.ReportModel
 import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.AutomationStore
 import com.terraformation.backend.customer.db.FacilityStore
@@ -1719,7 +1720,7 @@ internal class EmailNotificationServiceTest {
 
     service.on(NotificationJobSucceededEvent())
 
-    assertEquals(setOf("1@test.com", "2@test.com"), sentMessages.keys, "Recipients")
+    assertSetEquals(setOf("1@test.com", "2@test.com"), sentMessages.keys, "Recipients")
   }
 
   @Test
@@ -1734,7 +1735,7 @@ internal class EmailNotificationServiceTest {
     service.on(AccessionDryingEndEvent(accessionNumber, accessionId))
     service.on(NotificationJobSucceededEvent())
 
-    assertEquals(setOf("2@test.com"), sentMessages.keys, "Recipients")
+    assertSetEquals(setOf("2@test.com"), sentMessages.keys, "Recipients")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -310,7 +311,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
 
     fileService.on(DailyTaskTimeArrivedEvent())
 
-    assertEquals(
+    assertSetEquals(
         setOf(token3, token4),
         dslContext.fetch(FILE_ACCESS_TOKENS).map { it.token }.toSet(),
         "Remaining tokens",

--- a/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/gis/CountryDetectorTest.kt
@@ -1,10 +1,10 @@
 package com.terraformation.backend.gis
 
 import com.terraformation.backend.TestSingletons
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.point
 import com.terraformation.backend.util.Turtle
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class CountryDetectorTest {
@@ -14,21 +14,21 @@ class CountryDetectorTest {
   fun `detects a geometry that is in one country`() {
     val geometry = Turtle(point(0, 51)).makePolygon { rectangle(100, 100) }
 
-    assertEquals(setOf("GB"), detector.getCountries(geometry))
+    assertSetEquals(setOf("GB"), detector.getCountries(geometry))
   }
 
   @Test
   fun `detects a geometry that includes multiple countries`() {
     val geometry = Turtle(point(3.5, 50)).makePolygon { rectangle(150000, 100000) }
 
-    assertEquals(setOf("BE", "FR"), detector.getCountries(geometry))
+    assertSetEquals(setOf("BE", "FR"), detector.getCountries(geometry))
   }
 
   @Test
   fun `detects a geometry that is completely outside any country`() {
     val geometry = Turtle(point(0, 0)).makePolygon { rectangle(10, 10) }
 
-    assertEquals(emptySet<String>(), detector.getCountries(geometry))
+    assertSetEquals(emptySet<String>(), detector.getCountries(geometry))
   }
 
   @Test
@@ -42,6 +42,6 @@ class CountryDetectorTest {
         .isLessThan(CountryDetector.MIN_COVERAGE_PERCENT)
         .describedAs("Geometry intersects NL a little bit")
 
-    assertEquals(setOf("BE", "FR"), detector.getCountries(geometry))
+    assertSetEquals(setOf("BE", "FR"), detector.getCountries(geometry))
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/SearchFieldMetadataTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.i18n
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.field.SearchField
 import com.terraformation.backend.search.table.SearchTables
@@ -61,7 +62,7 @@ class SearchFieldMetadataTest {
             .filterValues { it > 1 }
             .keys
 
-    assertEquals(emptySet<String>(), duplicateFields, "Found duplicate field names")
+    assertSetEquals(emptySet<String>(), duplicateFields, "Found duplicate field names")
   }
 
   private fun <T> mapAllSearchFields(func: (SearchTable, SearchField) -> T?): List<T> {

--- a/src/test/kotlin/com/terraformation/backend/i18n/TimeZonesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/i18n/TimeZonesTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.i18n
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.terraformation.backend.assertSetEquals
 import java.time.ZoneId
 import java.util.Locale
 import java.util.stream.Stream
@@ -21,7 +22,7 @@ internal class TimeZonesTest {
     val timeZoneNames = timeZones.getTimeZoneNames(locale).values
     val duplicateNames = timeZoneNames.groupBy { it }.filterValues { it.size > 1 }.keys
 
-    assertEquals(emptySet<String>(), duplicateNames)
+    assertSetEquals(emptySet<String>(), duplicateNames)
   }
 
   @MethodSource("locales")
@@ -60,7 +61,7 @@ internal class TimeZonesTest {
             }
             .toSet()
 
-    assertEquals(emptySet<ZoneId>(), localizedTimeZonesWithoutTranslations)
+    assertSetEquals(emptySet<ZoneId>(), localizedTimeZonesWithoutTranslations)
   }
 
   @MethodSource("browsers")
@@ -81,7 +82,7 @@ internal class TimeZonesTest {
             .toSet()
             .minus(browserZones)
 
-    assertEquals(emptySet<String>(), unsupportedZones)
+    assertSetEquals(emptySet<String>(), unsupportedZones)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/NurseryWithdrawalStoreTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.nursery.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.Role
@@ -10,7 +11,6 @@ import com.terraformation.backend.nursery.model.NurserySpeciesModel
 import com.terraformation.backend.nursery.model.PlotSpeciesModel
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import java.math.BigDecimal
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -106,7 +106,7 @@ internal class NurseryWithdrawalStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
           )
 
-      assertEquals(expected, store.fetchSiteSpeciesByPlot(plantingSiteId).toSet())
+      assertSetEquals(expected, store.fetchSiteSpeciesByPlot(plantingSiteId).toSet())
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreUpdateDetailsTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SeedTreatment
@@ -88,7 +89,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
         after,
     )
 
-    assertEquals(
+    assertSetEquals(
         setOf(newSubLocationId1, newSubLocationId2),
         batchSubLocationsDao.findAll().map { it.subLocationId }.toSet(),
         "Should have replaced sub-locations list",
@@ -116,7 +117,7 @@ internal class BatchStoreUpdateDetailsTest : BatchStoreTest() {
         batchDetailsHistoryDao.findAll().map { it.copy(id = null) },
     )
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             BatchDetailsHistorySubLocationsRow(
                 subLocationId = newSubLocationId1,

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/batchStore/BatchStoreWithdrawTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.nursery.db.batchStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.default_schema.FacilityType
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.nursery.BatchId
@@ -1071,7 +1072,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
           )
         },
         {
-          assertEquals(
+          assertSetEquals(
               setOf(
                   BatchQuantityHistoryRow(
                       batchId = newBatch.id!!,
@@ -1127,7 +1128,7 @@ internal class BatchStoreWithdrawTest : BatchStoreTest() {
           )
         },
         {
-          assertEquals(
+          assertSetEquals(
               setOf(
                   WithdrawalsRow(
                       id = firstWithdrawal.id,

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/accessionStore/AccessionStoreBagTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.seedbank.db.accessionStore
 
+import com.terraformation.backend.assertSetEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -23,7 +24,7 @@ internal class AccessionStoreBagTest : AccessionStoreTest() {
     val accessionId = initial.id!!
     val initialBags = bagsDao.fetchByAccessionId(accessionId)
 
-    assertEquals(
+    assertSetEquals(
         setOf("bag 1", "bag 2"),
         initialBags.map { it.bagNumber }.toSet(),
         "Initial bag numbers",

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.TestSingletons
 import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
@@ -1248,7 +1249,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       val plantingSiteIdWithPlantings = helper.insertPlantedSite()
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               plantingSiteIdWithCompletedObservation,
               anotherPlantingSiteIdWithCompletedObservation,
@@ -1346,7 +1347,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       insertPlantingSiteNotification(type = NotificationType.ScheduleObservation)
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               plantingSiteIdWithCompletedObservation,
               anotherPlantingSiteIdWithCompletedObservation,
@@ -1449,7 +1450,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               plantingCreatedTime = Instant.EPOCH.minus(6 * 7, ChronoUnit.DAYS)
           )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               plantingSiteIdWithCompletedObservation,
               anotherPlantingSiteIdWithCompletedObservation,
@@ -1566,7 +1567,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           )
       insertPlantingSiteNotification(type = NotificationType.ObservationNotScheduledSupport)
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               plantingSiteIdWithCompletedObservation,
               anotherPlantingSiteIdWithCompletedObservation,
@@ -1803,7 +1804,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               ReplacementDuration.LongTerm,
           )
 
-      assertEquals(setOf(plotId1), result.removedMonitoringPlotIds, "Removed plot IDs")
+      assertSetEquals(setOf(plotId1), result.removedMonitoringPlotIds, "Removed plot IDs")
       assertEquals(1, result.addedMonitoringPlotIds.size, "Number of plot IDs added")
 
       val plots = monitoringPlotsDao.findAll().associateBy { it.id!! }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DeliveryStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.FacilityType
@@ -88,7 +89,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Deliveries",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingsRow(
                   createdBy = user.userId,
@@ -115,7 +116,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Plantings",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSitePopulationsRow(plantingSiteId, speciesId1, 21, 20),
               PlantingSitePopulationsRow(plantingSiteId, speciesId2, 20, 20),
@@ -124,7 +125,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting site populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingZonePopulationsRow(plantingZoneId, speciesId1, 19, 18),
               PlantingZonePopulationsRow(plantingZoneId, speciesId2, 20, 20),
@@ -133,7 +134,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting zone populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId1, 17, 16),
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId2, 20, 20),
@@ -270,7 +271,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
       assertEquals(user.userId, deliveriesRow.reassignedBy, "Reassigned user ID on delivery")
       assertEquals(clock.instant(), deliveriesRow.reassignedTime, "Reassigned time on delivery")
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSitePopulationsRow(plantingSiteId, speciesId1, 106, 105),
               PlantingSitePopulationsRow(plantingSiteId, speciesId2, 100, 100),
@@ -279,7 +280,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting site populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingZonePopulationsRow(plantingZoneId, speciesId1, 104, 103),
               PlantingZonePopulationsRow(plantingZoneId, speciesId2, 100, 100),
@@ -288,7 +289,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting zone populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId1, 101, 100),
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId2, 98, 98),
@@ -602,7 +603,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Plantings",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSitePopulationsRow(plantingSiteId, speciesId1, 5, 4),
               PlantingSitePopulationsRow(plantingSiteId, speciesId2, 7, 6),
@@ -611,7 +612,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting site populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingZonePopulationsRow(plantingZoneId, speciesId1, 3, 2),
               PlantingZonePopulationsRow(plantingZoneId, speciesId2, 4, 3),
@@ -620,7 +621,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Planting zone populations",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId1, 3, 2),
               PlantingSubzonePopulationsRow(plantingSubzoneId, speciesId2, 3, 2),
@@ -674,7 +675,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
           "Plantings",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSitePopulationsRow(plantingSiteId, speciesId1, 5, 4),
               PlantingSitePopulationsRow(plantingSiteId, speciesId2, 7, 6),
@@ -706,7 +707,7 @@ internal class DeliveryStoreTest : DatabaseTest(), RunsAsUser {
 
       store.undoDelivery(deliveryId, undoWithdrawalId)
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSitePopulationsRow(plantingSiteId, speciesId1, 95, 10),
               PlantingSitePopulationsRow(plantingSiteId, speciesId2, 88, 9),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/DraftPlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/DraftPlantingSiteStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.db
 
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
@@ -134,7 +135,7 @@ class DraftPlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
 
       store.delete(draftIdToDelete)
 
-      assertEquals(
+      assertSetEquals(
           setOf(otherDraftId1, otherDraftId2),
           draftPlantingSitesDao.findAll().map { it.id }.toSet(),
           "Remaining IDs after deletion",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.OrganizationNotFoundException
 import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.MangroveTide
@@ -374,7 +375,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
       assertEquals(inserted.monitoringPlotId, plotResults.monitoringPlotId, "Plot ID")
       assertFalse(plotResults.isAdHoc, "Plot Is Ad Hoc")
       assertEquals(2L, plotResults.monitoringPlotNumber, "Plot number")
-      assertEquals(
+      assertSetEquals(
           setOf(
               ObservableCondition.AnimalDamage,
               ObservableCondition.Fungus,
@@ -814,8 +815,16 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
       val results = resultsStore.fetchByPlantingSiteId(plantingSiteId)
       val plotResults = results[0].plantingZones[0].plantingSubzones[0].monitoringPlots[0]
 
-      assertEquals(setOf(oldPlotId1, oldPlotId2), plotResults.overlapsWithPlotIds, "Overlaps with")
-      assertEquals(setOf(newPlotId1, newPlotId2), plotResults.overlappedByPlotIds, "Overlapped by")
+      assertSetEquals(
+          setOf(oldPlotId1, oldPlotId2),
+          plotResults.overlapsWithPlotIds,
+          "Overlaps with",
+      )
+      assertSetEquals(
+          setOf(newPlotId1, newPlotId2),
+          plotResults.overlappedByPlotIds,
+          "Overlapped by",
+      )
     }
 
     @Test
@@ -1057,7 +1066,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
       )
 
       val summary = resultsStore.fetchSummariesForPlantingSite(inserted.plantingSiteId, 1).first()
-      assertEquals(
+      assertSetEquals(
           setOf(observation1Subzone1Result, observation1Subzone2Result, observation2Subzone3Result),
           summary.plantingZones.flatMap { it.plantingSubzones }.toSet(),
           "Planting subzones used for summary did not include the Incomplete subzone result",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreAbandonObservationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreAbandonObservationTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
@@ -81,7 +82,7 @@ class ObservationStoreAbandonObservationTest : BaseObservationStoreTest() {
 
     store.abandonObservation(observationId)
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             earlierCompletedRow,
             laterCompletedRow,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreCreateObservationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreCreateObservationTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
@@ -53,7 +54,7 @@ class ObservationStoreCreateObservationTest : BaseObservationStoreTest() {
 
     assertEquals(expected, actual)
 
-    assertEquals(
+    assertSetEquals(
         setOf(subzoneId1, subzoneId2),
         observationRequestedSubzonesDao.findAll().map { it.plantingSubzoneId }.toSet(),
         "Subzone IDs",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStorePopulateCumulativeDeadTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStorePopulateCumulativeDeadTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
@@ -123,7 +124,7 @@ class ObservationStorePopulateCumulativeDeadTest : BaseObservationStoreTest() {
 
     val totalsForThisObservation = helper.fetchAllTotals() - totalsFromPreviousObservation
 
-    assertEquals(
+    assertSetEquals(
         setOf(
             ObservedPlotSpeciesTotalsRow(
                 observationId = observationId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
 import com.terraformation.backend.assertGeometryEquals
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSeasonsRow
@@ -249,7 +250,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
 
       assertGeometryEquals(zone1Boundary, actualZones["Zone 1"]?.boundary, "Zone 1 boundary")
       assertGeometryEquals(zone2Boundary, actualZones["Zone 2"]?.boundary, "Zone 2 boundary")
-      assertEquals(
+      assertSetEquals(
           setOf(
               commonZonesRow.copy(
                   errorMargin = BigDecimal(1),
@@ -310,7 +311,7 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
           actualSubzones.single { it.fullName == "Zone 2-Subzone 2" }.boundary,
           "Z2S2 boundary",
       )
-      assertEquals(
+      assertSetEquals(
           setOf(
               commonSubzonesRow.copy(
                   fullName = "Zone 1-Subzone 1",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreEnsurePermanentTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.NumericIdentifierType
 import com.terraformation.backend.db.tracking.tables.records.MonitoringPlotHistoriesRecord
 import com.terraformation.backend.point
@@ -30,7 +31,11 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plots = monitoringPlotsDao.findAll()
 
       assertEquals(4, plots.size, "Number of monitoring plots created")
-      assertEquals(setOf(1, 2, 3, 4), plots.map { it.permanentIndex }.toSet(), "Permanent indexes")
+      assertSetEquals(
+          setOf(1, 2, 3, 4),
+          plots.map { it.permanentIndex }.toSet(),
+          "Permanent indexes",
+      )
       assertEquals(1L, plots.minOf { it.plotNumber!! }, "Smallest plot number")
       assertEquals(4L, plots.maxOf { it.plotNumber!! }, "Largest plot number")
 
@@ -66,7 +71,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plots = monitoringPlotsDao.findAll()
 
       assertEquals(2, plots.size, "Number of monitoring plots created")
-      assertEquals(setOf(1, 2), plots.map { it.permanentIndex }.toSet(), "Permanent indexes")
+      assertSetEquals(setOf(1, 2), plots.map { it.permanentIndex }.toSet(), "Permanent indexes")
       assertEquals(1L, plots.minOf { it.plotNumber!! }, "Smallest plot number")
       assertEquals(2L, plots.maxOf { it.plotNumber!! }, "Largest plot number")
     }
@@ -98,7 +103,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       val plots = monitoringPlotsDao.findAll()
 
       assertEquals(3, plots.size, "Number of monitoring plots including existing one")
-      assertEquals(setOf(1, 2, 3), plots.map { it.permanentIndex }.toSet(), "Permanent indexes")
+      assertSetEquals(setOf(1, 2, 3), plots.map { it.permanentIndex }.toSet(), "Permanent indexes")
 
       assertTableEquals(
           plots
@@ -188,7 +193,7 @@ internal class PlantingSiteStoreEnsurePermanentTest : BasePlantingSiteStoreTest(
       store.ensurePermanentPlotsExist(plantingSiteId)
 
       val plots = monitoringPlotsDao.findAll()
-      assertEquals(
+      assertSetEquals(
           setOf(1L, 6L),
           plots.map { it.plotNumber }.toSet(),
           "Plot numbers including existing plot",

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSiteTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.plantingSiteStore
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.customer.event.PlantingSiteTimeZoneChangedEvent
 import com.terraformation.backend.db.ProjectInDifferentOrganizationException
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSiteHistoriesRow
@@ -72,7 +73,7 @@ internal class PlantingSiteStoreUpdateSiteTest : BasePlantingSiteStoreTest() {
           "Planting sites",
       )
 
-      assertEquals(
+      assertSetEquals(
           setOf(
               PlantingSiteHistoriesRow(
                   areaHa = BigDecimal("1.0"),

--- a/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/model/PlantingZoneModelTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.assertSetEquals
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.StableId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -50,7 +51,7 @@ class PlantingZoneModelTest {
                   ),
           )
 
-      assertEquals(
+      assertSetEquals(
           setOf(MonitoringPlotId(3), MonitoringPlotId(4)),
           model.choosePermanentPlots(plantingSubzoneIds(2)),
       )


### PR DESCRIPTION
We use sets to compare unordered collections of items in a lot of our tests.
The default JUnit `assertEquals` will correctly detect when two sets aren't
equal, but the assertion failure message is hard to read, especially when
the two sets have the same items but in a different order.

Add a helper function to compare sets and produce a more human-friendly failure
message if they aren't equal. The items are sorted by their string representations
and are separated by newlines.