### PR TITLE
SW-7418 Publish Zones in Rate Limited T0 Changed Event

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -885,9 +885,9 @@ class EmailNotificationService(
   fun on(event: RateLimitedT0DataAssignedEvent) {
     if (
         (event.monitoringPlots == null ||
-            event.monitoringPlots.flatMap { plot -> plot.speciesDensityChanges }.isEmpty()) &&
+            event.monitoringPlots.all { it.speciesDensityChanges.isEmpty() }) &&
             (event.plantingZones == null ||
-                event.plantingZones.flatMap { zone -> zone.speciesDensityChanges }.isEmpty())
+                event.plantingZones.all { it.speciesDensityChanges.isEmpty() })
     ) {
       // changes were reversed before the event was eventually refired
       return

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.i18n.FormattingResourceBundleModel
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
+import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
 import freemarker.core.HTMLOutputFormat
 import freemarker.ext.beans.ResourceBundleModel
 import freemarker.template.Configuration
@@ -536,9 +537,10 @@ class AcceleratorReportPublished(
     get() = "acceleratorReport/published"
 }
 
-class T0PlotDataSet(
+class T0DataSet(
     config: TerrawareServerConfig,
     val monitoringPlots: List<PlotT0DensityChangedEventModel>,
+    val plantingZones: List<ZoneT0DensityChangedEventModel>,
     val organizationName: String,
     val plantingSiteId: PlantingSiteId,
     val plantingSiteName: String,

--- a/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
@@ -43,7 +43,6 @@ class T0Service(
   fun assignT0PlotsData(plotsList: List<PlotT0DataModel>) {
     val plotIds = plotsList.map { it.monitoringPlotId }
     val plotMap = getPlotInfo(plotIds)
-    val orgList = plotMap.values.map { it.organizationId }.toSet()
     val plantingSiteIds = plotMap.values.map { it.plantingSiteId }.toSet()
     require(plantingSiteIds.size == 1) { "Cannot assign T0 data to plots from multiple sites." }
 
@@ -63,10 +62,11 @@ class T0Service(
     val speciesToFetch =
         plotsChangeList.flatMap { it.speciesDensityChanges.map { it.speciesId } }.toSet()
     val speciesNames = getSpeciesNames(speciesToFetch)
+    val orgIds = plotMap.values.map { it.organizationId }.toSet()
 
     rateLimitedEventPublisher.publishEvent(
         RateLimitedT0DataAssignedEvent(
-            organizationId = orgList.first(),
+            organizationId = orgIds.first(),
             plantingSiteId = plantingSiteIds.first(),
             monitoringPlots =
                 plotsChangeList
@@ -94,7 +94,6 @@ class T0Service(
   fun assignT0TempZoneData(zonesList: List<ZoneT0TempDataModel>) {
     val zoneIds = zonesList.map { it.plantingZoneId }
     val zoneMap = getZoneInfo(zoneIds)
-    val orgList = zoneMap.values.map { it.organizationId }.toSet()
     val plantingSiteIds = zoneMap.values.map { it.plantingSiteId }.toSet()
     require(plantingSiteIds.size == 1) { "Cannot assign T0 data to zones from multiple sites." }
 
@@ -110,10 +109,11 @@ class T0Service(
     val speciesToFetch =
         zonesChangeList.flatMap { it.speciesDensityChanges.map { it.speciesId } }.toSet()
     val speciesNames = getSpeciesNames(speciesToFetch)
+    val orgIds = zoneMap.values.map { it.organizationId }.toSet()
 
     rateLimitedEventPublisher.publishEvent(
         RateLimitedT0DataAssignedEvent(
-            organizationId = orgList.first(),
+            organizationId = orgIds.first(),
             plantingSiteId = plantingSiteIds.first(),
             plantingZones =
                 zonesChangeList

--- a/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/T0Service.kt
@@ -2,10 +2,13 @@ package com.terraformation.backend.tracking
 
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.ratelimit.RateLimitedEventPublisher
 import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.event.RateLimitedT0DataAssignedEvent
@@ -13,7 +16,9 @@ import com.terraformation.backend.tracking.model.PlotT0DataModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedModel
 import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
+import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.ZoneT0TempDataModel
+import com.terraformation.backend.tracking.model.ZoneT0TempDensityChangedModel
 import jakarta.inject.Named
 import org.jooq.DSLContext
 
@@ -25,6 +30,12 @@ class T0Service(
 ) {
   private data class PlotEventDetailsModel(
       val plotNumber: Long,
+      val organizationId: OrganizationId,
+      val plantingSiteId: PlantingSiteId,
+  )
+
+  private data class ZoneEventDetailsModel(
+      val zoneName: String,
       val organizationId: OrganizationId,
       val plantingSiteId: PlantingSiteId,
   )
@@ -51,14 +62,7 @@ class T0Service(
 
     val speciesToFetch =
         plotsChangeList.flatMap { it.speciesDensityChanges.map { it.speciesId } }.toSet()
-    val speciesNames =
-        with(SPECIES) {
-          dslContext
-              .select(ID, SCIENTIFIC_NAME)
-              .from(this)
-              .where(ID.`in`(speciesToFetch))
-              .fetchMap(ID.asNonNullable(), SCIENTIFIC_NAME.asNonNullable())
-        }
+    val speciesNames = getSpeciesNames(speciesToFetch)
 
     rateLimitedEventPublisher.publishEvent(
         RateLimitedT0DataAssignedEvent(
@@ -73,7 +77,7 @@ class T0Service(
                               plotMap[changedModel.monitoringPlotId]!!.plotNumber,
                           speciesDensityChanges =
                               changedModel.speciesDensityChanges
-                                  .map { it ->
+                                  .map {
                                     SpeciesDensityChangedEventModel.of(
                                         it,
                                         speciesNames[it.speciesId]!!,
@@ -88,33 +92,97 @@ class T0Service(
   }
 
   fun assignT0TempZoneData(zonesList: List<ZoneT0TempDataModel>) {
+    val zoneIds = zonesList.map { it.plantingZoneId }
+    val zoneMap = getZoneInfo(zoneIds)
+    val orgList = zoneMap.values.map { it.organizationId }.toSet()
+    val plantingSiteIds = zoneMap.values.map { it.plantingSiteId }.toSet()
+    require(plantingSiteIds.size == 1) { "Cannot assign T0 data to zones from multiple sites." }
+
+    val zonesChangeList = mutableListOf<ZoneT0TempDensityChangedModel>()
     dslContext.transaction { _ ->
       zonesList.forEach { model ->
-        t0Store.assignT0TempZoneSpeciesDensities(model.plantingZoneId, model.densityData)
+        zonesChangeList.add(
+            t0Store.assignT0TempZoneSpeciesDensities(model.plantingZoneId, model.densityData)
+        )
       }
     }
 
-    // future PR: publish rate-limited event here
+    val speciesToFetch =
+        zonesChangeList.flatMap { it.speciesDensityChanges.map { it.speciesId } }.toSet()
+    val speciesNames = getSpeciesNames(speciesToFetch)
+
+    rateLimitedEventPublisher.publishEvent(
+        RateLimitedT0DataAssignedEvent(
+            organizationId = orgList.first(),
+            plantingSiteId = plantingSiteIds.first(),
+            plantingZones =
+                zonesChangeList
+                    .map { changedModel ->
+                      ZoneT0DensityChangedEventModel(
+                          plantingZoneId = changedModel.plantingZoneId,
+                          zoneName = zoneMap[changedModel.plantingZoneId]!!.zoneName,
+                          speciesDensityChanges =
+                              changedModel.speciesDensityChanges
+                                  .map {
+                                    SpeciesDensityChangedEventModel.of(
+                                        it,
+                                        speciesNames[it.speciesId]!!,
+                                    )
+                                  }
+                                  .sortedBy { it.speciesScientificName },
+                      )
+                    }
+                    .sortedBy { it.zoneName },
+        )
+    )
   }
 
   private fun getPlotInfo(
       plotIds: Collection<MonitoringPlotId>
-  ): Map<MonitoringPlotId, PlotEventDetailsModel> {
-    return with(MONITORING_PLOTS) {
-      dslContext
-          .select(ID, PLOT_NUMBER, ORGANIZATION_ID, PLANTING_SITE_ID)
-          .from(this)
-          .where(ID.`in`(plotIds.toSet()))
-          .fetchMap(
-              ID.asNonNullable(),
-              { record ->
-                PlotEventDetailsModel(
-                    plotNumber = record[PLOT_NUMBER.asNonNullable()],
-                    organizationId = record[ORGANIZATION_ID.asNonNullable()],
-                    plantingSiteId = record[PLANTING_SITE_ID.asNonNullable()],
-                )
-              },
-          )
-    }
-  }
+  ): Map<MonitoringPlotId, PlotEventDetailsModel> =
+      with(MONITORING_PLOTS) {
+        dslContext
+            .select(ID, PLOT_NUMBER, ORGANIZATION_ID, PLANTING_SITE_ID)
+            .from(this)
+            .where(ID.`in`(plotIds.toSet()))
+            .fetchMap(
+                ID.asNonNullable(),
+                { record ->
+                  PlotEventDetailsModel(
+                      plotNumber = record[PLOT_NUMBER.asNonNullable()],
+                      organizationId = record[ORGANIZATION_ID.asNonNullable()],
+                      plantingSiteId = record[PLANTING_SITE_ID.asNonNullable()],
+                  )
+                },
+            )
+      }
+
+  private fun getZoneInfo(
+      zoneIds: Collection<PlantingZoneId>
+  ): Map<PlantingZoneId, ZoneEventDetailsModel> =
+      with(PLANTING_ZONES) {
+        dslContext
+            .select(ID, NAME, plantingSites.ORGANIZATION_ID, PLANTING_SITE_ID)
+            .from(this)
+            .where(ID.`in`(zoneIds.toSet()))
+            .fetchMap(
+                ID.asNonNullable(),
+                { record ->
+                  ZoneEventDetailsModel(
+                      zoneName = record[NAME.asNonNullable()],
+                      organizationId = record[plantingSites.ORGANIZATION_ID.asNonNullable()],
+                      plantingSiteId = record[PLANTING_SITE_ID.asNonNullable()],
+                  )
+                },
+            )
+      }
+
+  private fun getSpeciesNames(speciesToFetch: Collection<SpeciesId>): Map<SpeciesId, String> =
+      with(SPECIES) {
+        dslContext
+            .select(ID, SCIENTIFIC_NAME)
+            .from(this)
+            .where(ID.`in`(speciesToFetch))
+            .fetchMap(ID.asNonNullable(), SCIENTIFIC_NAME.asNonNullable())
+      }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
@@ -48,6 +48,12 @@ data class PlotT0DensityChangedModel(
     val speciesDensityChanges: Set<SpeciesDensityChangedModel>,
 )
 
+data class ZoneT0TempDensityChangedModel(
+    val plantingZoneId: PlantingZoneId,
+    val zoneName: String? = null,
+    val speciesDensityChanges: Set<SpeciesDensityChangedModel>,
+)
+
 data class SpeciesDensityChangedEventModel(
     val speciesId: SpeciesId,
     val speciesScientificName: String,
@@ -74,5 +80,11 @@ data class SpeciesDensityChangedEventModel(
 data class PlotT0DensityChangedEventModel(
     val monitoringPlotId: MonitoringPlotId,
     val monitoringPlotNumber: Long,
+    val speciesDensityChanges: List<SpeciesDensityChangedEventModel>,
+)
+
+data class ZoneT0DensityChangedEventModel(
+    val plantingZoneId: PlantingZoneId,
+    val zoneName: String,
     val speciesDensityChanges: List<SpeciesDensityChangedEventModel>,
 )

--- a/src/main/resources/templates/email/observation/t0Set/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/t0Set/body.ftlh.mjml
@@ -1,4 +1,4 @@
-<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0PlotDataSet" -->
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0DataSet" -->
 <!-- <#setting date_format="full"> -->
 <mjml>
     <mj-include path="../../head.ftlh.mjml"/>

--- a/src/main/resources/templates/email/observation/t0Set/body.txt.ftl
+++ b/src/main/resources/templates/email/observation/t0Set/body.txt.ftl
@@ -1,4 +1,4 @@
-<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0PlotDataSet" -->
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0DataSet" -->
 ${strings("notification.observation.t0Set.email.body", plantingSiteName)}
 
 <#list monitoringPlots as plot><#list plot.speciesDensityChanges as change>

--- a/src/main/resources/templates/email/observation/t0Set/subject.ftl
+++ b/src/main/resources/templates/email/observation/t0Set/subject.ftl
@@ -1,2 +1,2 @@
-<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0PlotDataSet" -->
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.T0DataSet" -->
 ${strings("notification.observation.t0Set.email.subject", organizationName, plantingSiteName)}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -139,6 +139,7 @@ import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
 import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
+import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
 import freemarker.template.Configuration
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -1433,23 +1434,64 @@ internal class EmailNotificationServiceTest {
   }
 
   @Test
-  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes`() {
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in plots`() {
     service.on(
         RateLimitedT0DataAssignedEvent(
-            organization.id,
-            plantingSite.id,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    monitoringPlot.id,
-                    monitoringPlotNumber = monitoringPlot.plotNumber,
-                    speciesDensityChanges = emptyList(),
+            organizationId = organization.id,
+            plantingSiteId = plantingSite.id,
+            monitoringPlots =
+                listOf(
+                    PlotT0DensityChangedEventModel(
+                        monitoringPlot.id,
+                        monitoringPlotNumber = monitoringPlot.plotNumber,
+                        speciesDensityChanges = emptyList(),
+                    ),
+                    PlotT0DensityChangedEventModel(
+                        MonitoringPlotId(2),
+                        monitoringPlotNumber = 2L,
+                        speciesDensityChanges = emptyList(),
+                    ),
                 ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    monitoringPlotNumber = 2L,
-                    speciesDensityChanges = emptyList(),
+        )
+    )
+
+    assertNoMessageSent()
+  }
+
+  @Test
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in zones`() {
+    service.on(
+        RateLimitedT0DataAssignedEvent(
+            organizationId = organization.id,
+            plantingSiteId = plantingSite.id,
+            monitoringPlots = emptyList(),
+            plantingZones =
+                listOf(
+                    ZoneT0DensityChangedEventModel(
+                        plantingZone.id,
+                        zoneName = plantingZone.name,
+                        speciesDensityChanges = emptyList(),
+                    ),
+                    ZoneT0DensityChangedEventModel(
+                        PlantingZoneId(2),
+                        zoneName = "Z2",
+                        speciesDensityChanges = emptyList(),
+                    ),
                 ),
-            ),
+        )
+    )
+
+    assertNoMessageSent()
+  }
+
+  @Test
+  fun `rateLimitedT0DataAssignedEvent doesn't send if no plots or zones`() {
+    service.on(
+        RateLimitedT0DataAssignedEvent(
+            organizationId = organization.id,
+            plantingSiteId = plantingSite.id,
+            monitoringPlots = emptyList(),
+            plantingZones = emptyList(),
         )
     )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
@@ -33,6 +33,7 @@ class RateLimitedT0DataAssignedEventTest {
               ),
           ),
           newEvent.combine(existingEvent),
+          "Should add different plot",
       )
     }
 
@@ -52,6 +53,7 @@ class RateLimitedT0DataAssignedEventTest {
               ),
           ),
           newEvent.combine(existingEvent),
+          "Should add different species",
       )
     }
 
@@ -64,6 +66,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 4))))),
           newEvent.combine(existingEvent),
+          "Should modify newDensity on species",
       )
     }
 
@@ -76,6 +79,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(listOf(plotChangeModel(1, emptyList()))),
           newEvent.combine(existingEvent),
+          "Should leave densities as empty list because change was reverted",
       )
     }
 
@@ -88,6 +92,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, null))))),
           newEvent.combine(existingEvent),
+          "Should show species as removed",
       )
     }
 
@@ -137,6 +142,7 @@ class RateLimitedT0DataAssignedEventTest {
               ),
           ),
           newEvent.combine(existingEvent),
+          "Combine works with lots of data",
       )
     }
   }
@@ -159,6 +165,7 @@ class RateLimitedT0DataAssignedEventTest {
                   )
           ),
           newEvent.combine(existingEvent),
+          "Should add different zone",
       )
     }
 
@@ -180,6 +187,7 @@ class RateLimitedT0DataAssignedEventTest {
                   ),
           ),
           newEvent.combine(existingEvent),
+          "Should add different species",
       )
     }
 
@@ -193,6 +201,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 4))))),
           newEvent.combine(existingEvent),
+          "Should modify newDensity on species",
       )
     }
 
@@ -206,6 +215,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(zones = listOf(zoneChangeModel(1, emptyList()))),
           newEvent.combine(existingEvent),
+          "Should leave densities as empty list because change was reverted",
       )
     }
 
@@ -220,6 +230,7 @@ class RateLimitedT0DataAssignedEventTest {
       assertEquals(
           event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, null))))),
           newEvent.combine(existingEvent),
+          "Should show species as removed",
       )
     }
 
@@ -272,8 +283,26 @@ class RateLimitedT0DataAssignedEventTest {
                   ),
           ),
           newEvent.combine(existingEvent),
+          "Combine works with lots of data",
       )
     }
+  }
+
+  @Test
+  fun `combines both plots and zones`() {
+    val existingEvent =
+        event(plots = listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+    val newEvent = event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 3, 4)))))
+
+    assertEquals(
+        event(
+            plots = listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))),
+            zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 3, 4)))),
+        ),
+        newEvent.combine(existingEvent),
+        "Should include both plots and zones after combine",
+    )
   }
 
   private fun event(

--- a/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
@@ -4,520 +4,312 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
 import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
+import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
 import java.math.BigDecimal
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class RateLimitedT0DataAssignedEventTest {
   private val organizationId = OrganizationId(1)
   private val plantingSiteId = PlantingSiteId(10)
 
-  @Test
-  fun `combine for different monitoring plots`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
+  @Nested
+  inner class CombinePlots {
+    @Test
+    fun `combine for different monitoring plots`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
 
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    2L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
+      val newEvent = event(listOf(plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2)))))
 
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    2L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
+      assertEquals(
+          event(
+              listOf(
+                  plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2))),
+                  plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2))),
+              ),
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine for same monitoring plot, diff species`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(2, 3, 4)))))
+
+      assertEquals(
+          event(
+              listOf(
+                  plotChangeModel(
+                      1,
+                      listOf(speciesChangeModel(1, 1, 2), speciesChangeModel(2, 3, 4)),
+                  ),
+              ),
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine for same monitoring plot, same species`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 3, 4)))))
+
+      assertEquals(
+          event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 4))))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with changes that are reverted`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 2, 1)))))
+
+      assertEquals(
+          event(listOf(plotChangeModel(1, emptyList()))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with species that were removed`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 2, null)))))
+
+      assertEquals(
+          event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, null))))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with lots of data`() {
+      val existingEvent =
+          event(
+              listOf(
+                  plotChangeModel(1, listOf(speciesChangeModel(1, 10, 20))),
+                  plotChangeModel(
+                      2,
+                      listOf(speciesChangeModel(1, 1, 2), speciesChangeModel(2, 3, 4)),
+                  ),
+              )
+          )
+
+      val newEvent =
+          event(
+              listOf(
+                  plotChangeModel(
+                      2,
+                      listOf(speciesChangeModel(2, 4, 5), speciesChangeModel(3, 6, 7)),
+                  ),
+                  plotChangeModel(
+                      3,
+                      listOf(speciesChangeModel(1, 8, 9), speciesChangeModel(4, 11, 12)),
+                  ),
+              )
+          )
+
+      assertEquals(
+          event(
+              listOf(
+                  plotChangeModel(1, listOf(speciesChangeModel(1, 10, 20))),
+                  plotChangeModel(
+                      2,
+                      listOf(
+                          speciesChangeModel(1, 1, 2),
+                          speciesChangeModel(2, 3, 5),
+                          speciesChangeModel(3, 6, 7),
+                      ),
+                  ),
+                  plotChangeModel(
+                      3,
+                      listOf(speciesChangeModel(1, 8, 9), speciesChangeModel(4, 11, 12)),
+                  ),
+              ),
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
   }
 
-  @Test
-  fun `combine for same monitoring plot, diff species`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
+  @Nested
+  inner class CombineZones {
+    @Test
+    fun `combine for different planting zones`() {
+      val existingEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
 
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(2),
-                                speciesScientificName = "Species 2",
-                                previousPlotDensity = BigDecimal.valueOf(3),
-                                newPlotDensity = BigDecimal.valueOf(4),
-                            )
-                        ),
-                ),
-            ),
-        )
+      val newEvent = event(zones = listOf(zoneChangeModel(2, listOf(speciesChangeModel(1, 1, 2)))))
 
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(2),
-                                speciesScientificName = "Species 2",
-                                previousPlotDensity = BigDecimal.valueOf(3),
-                                newPlotDensity = BigDecimal.valueOf(4),
-                            ),
-                        ),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
+      assertEquals(
+          event(
+              zones =
+                  listOf(
+                      zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2))),
+                      zoneChangeModel(2, listOf(speciesChangeModel(1, 1, 2))),
+                  )
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine for same zone, diff species`() {
+      val existingEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(2, 3, 4)))))
+
+      assertEquals(
+          event(
+              zones =
+                  listOf(
+                      zoneChangeModel(
+                          1,
+                          listOf(speciesChangeModel(1, 1, 2), speciesChangeModel(2, 3, 4)),
+                      ),
+                  ),
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine for same zone, same species`() {
+      val existingEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 3, 4)))))
+
+      assertEquals(
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 4))))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with changes that are reverted`() {
+      val existingEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent = event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 2, 1)))))
+
+      assertEquals(
+          event(zones = listOf(zoneChangeModel(1, emptyList()))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with species that were removed`() {
+      val existingEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+
+      val newEvent =
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 2, null)))))
+
+      assertEquals(
+          event(zones = listOf(zoneChangeModel(1, listOf(speciesChangeModel(1, 1, null))))),
+          newEvent.combine(existingEvent),
+      )
+    }
+
+    @Test
+    fun `combine with lots of data`() {
+      val existingEvent =
+          event(
+              zones =
+                  listOf(
+                      zoneChangeModel(1, listOf(speciesChangeModel(1, 10, 20))),
+                      zoneChangeModel(
+                          2,
+                          listOf(speciesChangeModel(1, 1, 2), speciesChangeModel(2, 3, 4)),
+                      ),
+                  )
+          )
+
+      val newEvent =
+          event(
+              zones =
+                  listOf(
+                      zoneChangeModel(
+                          2,
+                          listOf(speciesChangeModel(2, 4, 5), speciesChangeModel(3, 6, 7)),
+                      ),
+                      zoneChangeModel(
+                          3,
+                          listOf(speciesChangeModel(1, 8, 9), speciesChangeModel(4, 11, 12)),
+                      ),
+                  )
+          )
+
+      assertEquals(
+          event(
+              zones =
+                  listOf(
+                      zoneChangeModel(1, listOf(speciesChangeModel(1, 10, 20))),
+                      zoneChangeModel(
+                          2,
+                          listOf(
+                              speciesChangeModel(1, 1, 2),
+                              speciesChangeModel(2, 3, 5),
+                              speciesChangeModel(3, 6, 7),
+                          ),
+                      ),
+                      zoneChangeModel(
+                          3,
+                          listOf(speciesChangeModel(1, 8, 9), speciesChangeModel(4, 11, 12)),
+                      ),
+                  ),
+          ),
+          newEvent.combine(existingEvent),
+      )
+    }
   }
 
-  @Test
-  fun `combine for same monitoring plot, same species`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
+  private fun event(
+      plots: List<PlotT0DensityChangedEventModel> = emptyList(),
+      zones: List<ZoneT0DensityChangedEventModel> = emptyList(),
+  ): RateLimitedT0DataAssignedEvent =
+      RateLimitedT0DataAssignedEvent(
+          organizationId = organizationId,
+          plantingSiteId = plantingSiteId,
+          monitoringPlots = plots,
+          plantingZones = zones,
+      )
 
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(3),
-                                newPlotDensity = BigDecimal.valueOf(4),
-                            )
-                        ),
-                ),
-            ),
-        )
+  private fun plotChangeModel(plotId: Int, densities: List<SpeciesDensityChangedEventModel>) =
+      PlotT0DensityChangedEventModel(
+          monitoringPlotId = MonitoringPlotId(plotId.toLong()),
+          monitoringPlotNumber = plotId.toLong(),
+          speciesDensityChanges = densities,
+      )
 
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(4),
-                            ),
-                        ),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
-  }
+  private fun zoneChangeModel(zoneId: Int, densities: List<SpeciesDensityChangedEventModel>) =
+      ZoneT0DensityChangedEventModel(
+          plantingZoneId = PlantingZoneId(zoneId.toLong()),
+          zoneName = "Z$zoneId",
+          speciesDensityChanges = densities,
+      )
 
-  @Test
-  fun `combine with changes that are reverted`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
-
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(2),
-                                newPlotDensity = BigDecimal.valueOf(1),
-                            )
-                        ),
-                ),
-            ),
-        )
-
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges = emptyList(),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
-  }
-
-  @Test
-  fun `combine with species that were removed`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            )
-                        ),
-                ),
-            ),
-        )
-
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(2),
-                                newPlotDensity = null,
-                            )
-                        ),
-                ),
-            ),
-        )
-
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = null,
-                            ),
-                        ),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
-  }
-
-  @Test
-  fun `combine with lots of data`() {
-    val existingEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(10),
-                                newPlotDensity = BigDecimal.valueOf(20),
-                            ),
-                        ),
-                ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    2L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(2),
-                                speciesScientificName = "Species 2",
-                                previousPlotDensity = BigDecimal.valueOf(3),
-                                newPlotDensity = BigDecimal.valueOf(4),
-                            ),
-                        ),
-                ),
-            ),
-        )
-
-    val newEvent =
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    2L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(2),
-                                speciesScientificName = "Species 2",
-                                previousPlotDensity = BigDecimal.valueOf(4),
-                                newPlotDensity = BigDecimal.valueOf(5),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(3),
-                                speciesScientificName = "Species 3",
-                                previousPlotDensity = BigDecimal.valueOf(6),
-                                newPlotDensity = BigDecimal.valueOf(7),
-                            ),
-                        ),
-                ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(3),
-                    3L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(8),
-                                newPlotDensity = BigDecimal.valueOf(9),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(4),
-                                speciesScientificName = "Species 4",
-                                previousPlotDensity = BigDecimal.valueOf(11),
-                                newPlotDensity = BigDecimal.valueOf(12),
-                            ),
-                        ),
-                ),
-            ),
-        )
-
-    assertEquals(
-        RateLimitedT0DataAssignedEvent(
-            organizationId = organizationId,
-            plantingSiteId = plantingSiteId,
-            listOf(
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(1),
-                    1L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(10),
-                                newPlotDensity = BigDecimal.valueOf(20),
-                            ),
-                        ),
-                ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(2),
-                    2L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(1),
-                                newPlotDensity = BigDecimal.valueOf(2),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(2),
-                                speciesScientificName = "Species 2",
-                                previousPlotDensity = BigDecimal.valueOf(3),
-                                newPlotDensity = BigDecimal.valueOf(5),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(3),
-                                speciesScientificName = "Species 3",
-                                previousPlotDensity = BigDecimal.valueOf(6),
-                                newPlotDensity = BigDecimal.valueOf(7),
-                            ),
-                        ),
-                ),
-                PlotT0DensityChangedEventModel(
-                    MonitoringPlotId(3),
-                    3L,
-                    speciesDensityChanges =
-                        listOf(
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(1),
-                                speciesScientificName = "Species 1",
-                                previousPlotDensity = BigDecimal.valueOf(8),
-                                newPlotDensity = BigDecimal.valueOf(9),
-                            ),
-                            SpeciesDensityChangedEventModel(
-                                speciesId = SpeciesId(4),
-                                speciesScientificName = "Species 4",
-                                previousPlotDensity = BigDecimal.valueOf(11),
-                                newPlotDensity = BigDecimal.valueOf(12),
-                            ),
-                        ),
-                ),
-            ),
-        ),
-        newEvent.combine(existingEvent),
-    )
-  }
+  private fun speciesChangeModel(
+      speciesId: Int,
+      prevDensity: Int?,
+      newDensity: Int?,
+  ): SpeciesDensityChangedEventModel =
+      SpeciesDensityChangedEventModel(
+          speciesId = SpeciesId(speciesId.toLong()),
+          speciesScientificName = "Species $speciesId",
+          previousPlotDensity = prevDensity?.let { BigDecimal.valueOf(it.toLong()) },
+          newPlotDensity = newDensity?.let { BigDecimal.valueOf(it.toLong()) },
+      )
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
@@ -338,7 +338,7 @@ class RateLimitedT0DataAssignedEventTest {
       SpeciesDensityChangedEventModel(
           speciesId = SpeciesId(speciesId.toLong()),
           speciesScientificName = "Species $speciesId",
-          previousPlotDensity = prevDensity?.let { BigDecimal.valueOf(it.toLong()) },
-          newPlotDensity = newDensity?.let { BigDecimal.valueOf(it.toLong()) },
+          previousPlotDensity = prevDensity?.let { BigDecimal(it) },
+          newPlotDensity = newDensity?.let { BigDecimal(it) },
       )
 }


### PR DESCRIPTION
Return changed model from `T0Store`.

Add plantingZones to rate limited T0 changed event.

Update `combine` method to include plots and zones.

Refactor `RateLimitedT0DataAssignedEventTest` to significantly simplify the readability, and add zones to it.