### PR TITLE
SW-7346 Add hidden, list position to activity media

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -92,6 +92,8 @@ data class AdminActivityMediaFilePayload(
     val fileId: FileId,
     val geolocation: Point?,
     val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -104,6 +106,8 @@ data class AdminActivityMediaFilePayload(
       fileId = model.fileId,
       geolocation = model.geolocation,
       isCoverPhoto = model.isCoverPhoto,
+      isHiddenOnMap = model.isHiddenOnMap,
+      listPosition = model.listPosition,
       type = model.type,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -115,6 +115,7 @@ class ActivitiesController(
   @RequestBodyPhotoFile
   fun uploadActivityMedia(
       @PathVariable activityId: ActivityId,
+      @RequestPart("listPosition", required = false) listPositionStr: String?,
       @RequestPart("file") file: MultipartFile,
   ): UploadActivityMediaResponsePayload {
     val contentType = file.getPlainContentType(supportedMediaTypes)
@@ -125,6 +126,7 @@ class ActivitiesController(
             activityId,
             file.inputStream,
             FileMetadata.of(contentType, filename, file.size),
+            listPositionStr?.toIntOrNull(),
         )
 
     return UploadActivityMediaResponsePayload(fileId)
@@ -198,6 +200,8 @@ data class ActivityMediaFilePayload(
     val fileId: FileId,
     val geolocation: Point?,
     val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
     val type: ActivityMediaType,
 ) {
   constructor(
@@ -208,6 +212,8 @@ data class ActivityMediaFilePayload(
       fileId = model.fileId,
       geolocation = model.geolocation,
       isCoverPhoto = model.isCoverPhoto,
+      isHiddenOnMap = model.isHiddenOnMap,
+      listPosition = model.listPosition,
       type = model.type,
   )
 }
@@ -251,9 +257,16 @@ data class CreateActivityRequestPayload(
 data class UpdateActivityMediaRequestPayload(
     val caption: String?,
     val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
 ) {
   fun applyTo(model: ActivityMediaModel): ActivityMediaModel {
-    return model.copy(caption = caption, isCoverPhoto = isCoverPhoto)
+    return model.copy(
+        caption = caption,
+        isCoverPhoto = isCoverPhoto,
+        isHiddenOnMap = isHiddenOnMap,
+        listPosition = listPosition,
+    )
   }
 }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -117,7 +117,7 @@ class ActivitiesController(
   fun uploadActivityMedia(
       @PathVariable activityId: ActivityId,
       @RequestPart("listPosition", required = false)
-      @Schema(type = "number", format = "int32")
+      @Schema(type = "integer", format = "int32")
       listPositionStr: String?,
       @RequestPart("file") file: MultipartFile,
   ): UploadActivityMediaResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -219,6 +219,13 @@ class ActivityMediaStore(
     }
   }
 
+  /**
+   * Sets the list positions of the files in an activity.
+   *
+   * @param fileIds The list of activity media file IDs in the desired order. The file whose ID is
+   *   the first element of this list will have its list position set to 1, then 2 for the second
+   *   element of this list, and so forth.
+   */
   private fun updateListPositions(activityId: ActivityId, fileIds: List<FileId>) {
     val positionsMap = fileIds.mapIndexed { index, fileId -> fileId to index + 1 }.toMap()
     with(ACTIVITY_MEDIA_FILES) {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -5,18 +5,27 @@ import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityMediaType
+import com.terraformation.backend.db.accelerator.tables.pojos.ActivityMediaFilesRow
+import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.file.event.VideoFileDeletedEvent
 import jakarta.inject.Named
 import java.time.InstantSource
 import org.jooq.Condition
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.springframework.context.ApplicationEventPublisher
 
 @Named
 class ActivityMediaStore(
     private val clock: InstantSource,
     private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
   fun fetchOne(activityId: ActivityId, fileId: FileId): ActivityMediaModel {
     requirePermissions { readActivity(activityId) }
@@ -26,6 +35,22 @@ class ActivityMediaStore(
                 .and(ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId))
         )
         .firstOrNull() ?: throw FileNotFoundException(fileId)
+  }
+
+  fun fetchByActivityId(activityId: ActivityId): List<ActivityMediaModel> {
+    requirePermissions { readActivity(activityId) }
+
+    return fetchByCondition(ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId))
+  }
+
+  fun fetchByOrganizationId(organizationId: OrganizationId): List<ActivityMediaModel> {
+    requirePermissions { readOrganization(organizationId) }
+
+    val user = currentUser()
+    return fetchByCondition(
+            ACTIVITY_MEDIA_FILES.activities.projects.ORGANIZATION_ID.eq(organizationId)
+        )
+        .filter { user.canReadActivity(it.activityId) }
   }
 
   fun updateMedia(
@@ -38,7 +63,11 @@ class ActivityMediaStore(
     val existing = fetchOne(activityId, fileId)
     val updated = applyFunc(existing)
 
-    dslContext.transaction { _ ->
+    if (updated.isCoverPhoto && existing.type != ActivityMediaType.Photo) {
+      throw IllegalArgumentException("Only photo files can be selected as cover photos")
+    }
+
+    withLockedActivity(activityId) {
       with(ACTIVITY_MEDIA_FILES) {
         if (!existing.isCoverPhoto && updated.isCoverPhoto) {
           dslContext
@@ -52,9 +81,21 @@ class ActivityMediaStore(
             .update(ACTIVITY_MEDIA_FILES)
             .set(CAPTION, updated.caption)
             .set(IS_COVER_PHOTO, updated.isCoverPhoto)
+            .set(IS_HIDDEN_ON_MAP, updated.isHiddenOnMap)
             .where(ACTIVITY_ID.eq(activityId))
             .and(FILE_ID.eq(fileId))
             .execute()
+      }
+
+      val fileIds = fetchFileIds(activityId).toMutableList()
+      val desiredIndex = (updated.listPosition - 1).coerceIn(0, fileIds.size - 1)
+      val currentIndex = fileIds.indexOf(fileId)
+
+      if (desiredIndex != currentIndex) {
+        fileIds.removeAt(currentIndex)
+        fileIds.add(desiredIndex, fileId)
+
+        updateListPositions(activityId, fileIds)
       }
 
       with(FILES) {
@@ -68,6 +109,92 @@ class ActivityMediaStore(
     }
   }
 
+  fun insertMediaFile(row: ActivityMediaFilesRow) {
+    val activityId = row.activityId!!
+    val fileId = row.fileId!!
+    val listPosition = row.listPosition
+
+    requirePermissions { updateActivity(activityId) }
+
+    withLockedActivity(activityId) {
+      val orderedFileIds = fetchFileIds(activityId).toMutableList()
+
+      if (listPosition != null) {
+        val newIndex = (listPosition - 1).coerceIn(0, orderedFileIds.size)
+        orderedFileIds.add(newIndex, fileId)
+      } else {
+        orderedFileIds.add(fileId)
+      }
+
+      with(ACTIVITY_MEDIA_FILES) {
+        dslContext
+            .insertInto(ACTIVITY_MEDIA_FILES)
+            .set(FILE_ID, fileId)
+            .set(ACTIVITY_ID, activityId)
+            .set(ACTIVITY_MEDIA_TYPE_ID, row.activityMediaTypeId)
+            .set(IS_COVER_PHOTO, row.isCoverPhoto)
+            .set(IS_HIDDEN_ON_MAP, row.isHiddenOnMap)
+            .set(CAPTURED_DATE, row.capturedDate)
+            .set(GEOLOCATION, row.geolocation)
+            .set(LIST_POSITION, 0) // We'll overwrite this with the real position
+            .execute()
+      }
+
+      updateListPositions(activityId, orderedFileIds)
+    }
+  }
+
+  /**
+   * Deletes an activity media file from the database. Does not delete it from the file store! You
+   * probably want `ActivityMediaService.deleteMedia`, not this.
+   */
+  fun deleteFromDatabase(activityId: ActivityId, fileId: FileId) {
+    requirePermissions { updateActivity(activityId) }
+
+    withLockedActivity(activityId) {
+      ensureFileExists(activityId, fileId)
+
+      with(ACTIVITY_MEDIA_FILES) {
+        val mediaType =
+            dslContext
+                .deleteFrom(ACTIVITY_MEDIA_FILES)
+                .where(FILE_ID.eq(fileId))
+                .returning(ACTIVITY_MEDIA_TYPE_ID)
+                .fetchOne(ACTIVITY_MEDIA_TYPE_ID)
+
+        if (mediaType == ActivityMediaType.Video) {
+          eventPublisher.publishEvent(VideoFileDeletedEvent(fileId))
+        }
+
+        updateListPositions(activityId, fetchFileIds(activityId))
+      }
+    }
+  }
+
+  fun ensureFileExists(activityId: ActivityId, fileId: FileId) {
+    val fileExists =
+        dslContext.fetchExists(
+            ACTIVITY_MEDIA_FILES,
+            ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId),
+            ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId),
+        )
+    if (!fileExists) {
+      throw FileNotFoundException(fileId)
+    }
+  }
+
+  /** Returns the file IDs for an activity in list position order. */
+  private fun fetchFileIds(activityId: ActivityId): List<FileId> {
+    return with(ACTIVITY_MEDIA_FILES) {
+      dslContext
+          .select(FILE_ID)
+          .from(ACTIVITY_MEDIA_FILES)
+          .where(ACTIVITY_ID.eq(activityId))
+          .orderBy(LIST_POSITION)
+          .fetch(FILE_ID.asNonNullable())
+    }
+  }
+
   private fun fetchByCondition(condition: Condition): List<ActivityMediaModel> {
     return dslContext
         .select(ACTIVITY_MEDIA_FILES.asterisk(), FILES.CREATED_BY, FILES.CREATED_TIME)
@@ -77,5 +204,30 @@ class ActivityMediaStore(
         .where(condition)
         .orderBy(ACTIVITY_MEDIA_FILES.FILE_ID)
         .fetch { ActivityMediaModel.of(it) }
+  }
+
+  private fun <T> withLockedActivity(activityId: ActivityId, func: () -> T): T {
+    return dslContext.transactionResult { _ ->
+      dslContext
+          .selectOne()
+          .from(ACTIVITIES)
+          .where(ACTIVITIES.ID.eq(activityId))
+          .forUpdate()
+          .fetchOne() ?: throw ActivityNotFoundException(activityId)
+
+      func()
+    }
+  }
+
+  private fun updateListPositions(activityId: ActivityId, fileIds: List<FileId>) {
+    val positionsMap = fileIds.mapIndexed { index, fileId -> fileId to index + 1 }.toMap()
+    with(ACTIVITY_MEDIA_FILES) {
+      dslContext
+          .update(ACTIVITY_MEDIA_FILES)
+          .set(LIST_POSITION, DSL.case_(FILE_ID.asNonNullable()).mapValues(positionsMap))
+          .where(FILE_ID.`in`(fileIds))
+          .and(ACTIVITY_ID.eq(activityId))
+          .execute()
+    }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -145,10 +145,13 @@ class ActivityStore(
       DSL.multiset(
               DSL.select(
                       ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID,
+                      ACTIVITY_MEDIA_FILES.ACTIVITY_ID,
                       ACTIVITY_MEDIA_FILES.CAPTION,
                       ACTIVITY_MEDIA_FILES.CAPTURED_DATE,
                       ACTIVITY_MEDIA_FILES.FILE_ID,
                       ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO,
+                      ACTIVITY_MEDIA_FILES.IS_HIDDEN_ON_MAP,
+                      ACTIVITY_MEDIA_FILES.LIST_POSITION,
                       FILES.CREATED_BY,
                       FILES.CREATED_TIME,
                       geolocationField,
@@ -157,7 +160,7 @@ class ActivityStore(
                   .join(FILES)
                   .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
                   .where(ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(ACTIVITIES.ID))
-                  .orderBy(ACTIVITY_MEDIA_FILES.FILE_ID)
+                  .orderBy(ACTIVITY_MEDIA_FILES.LIST_POSITION)
           )
           .convertFrom { result -> result.map { ActivityMediaModel.of(it, geolocationField) } }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.accelerator.model
 
+import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.db.default_schema.FileId
@@ -13,6 +14,7 @@ import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
 
 data class ActivityMediaModel(
+    val activityId: ActivityId,
     val caption: String?,
     val createdBy: UserId,
     val createdTime: Instant,
@@ -20,6 +22,8 @@ data class ActivityMediaModel(
     val fileId: FileId,
     val geolocation: Point?,
     val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
     val type: ActivityMediaType,
 ) {
   companion object {
@@ -28,6 +32,7 @@ data class ActivityMediaModel(
         geolocationField: Field<Geometry?> = ACTIVITY_MEDIA_FILES.GEOLOCATION,
     ): ActivityMediaModel {
       return ActivityMediaModel(
+          activityId = record[ACTIVITY_MEDIA_FILES.ACTIVITY_ID]!!,
           caption = record[ACTIVITY_MEDIA_FILES.CAPTION],
           createdBy = record[FILES.CREATED_BY]!!,
           createdTime = record[FILES.CREATED_TIME]!!,
@@ -35,6 +40,8 @@ data class ActivityMediaModel(
           fileId = record[ACTIVITY_MEDIA_FILES.FILE_ID]!!,
           geolocation = record[geolocationField] as? Point,
           isCoverPhoto = record[ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO]!!,
+          isHiddenOnMap = record[ACTIVITY_MEDIA_FILES.IS_HIDDEN_ON_MAP]!!,
+          listPosition = record[ACTIVITY_MEDIA_FILES.LIST_POSITION]!!,
           type = record[ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID]!!,
       )
     }

--- a/src/main/resources/db/migration/0400/V413__ActivityMediaDisplay.sql
+++ b/src/main/resources/db/migration/0400/V413__ActivityMediaDisplay.sql
@@ -1,0 +1,20 @@
+ALTER TABLE accelerator.activity_media_files
+    ADD COLUMN is_hidden_on_map BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN list_position INTEGER,
+    ADD CONSTRAINT unambiguous_list_order
+        UNIQUE (activity_id, list_position)
+            DEFERRABLE
+            INITIALLY DEFERRED;
+
+-- Put existing files in file ID order by default.
+WITH media_positions AS (
+    SELECT file_id, RANK() OVER (PARTITION BY activity_id ORDER BY file_id) AS list_position
+    FROM accelerator.activity_media_files
+)
+UPDATE accelerator.activity_media_files amf
+SET list_position = mp.list_position
+FROM media_positions mp
+WHERE amf.file_id = mp.file_id;
+
+ALTER TABLE accelerator.activity_media_files
+    ALTER COLUMN list_position SET NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStoreTest.kt
@@ -89,6 +89,20 @@ class ActivityMediaStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `maintains existing list position if requested`() {
+      val fileId1 = insertFile()
+      insertActivityMediaFile(listPosition = 1)
+      val fileId2 = insertFile()
+      insertActivityMediaFile(listPosition = 2)
+      val fileId3 = insertFile()
+      insertActivityMediaFile(listPosition = 3)
+
+      store.updateMedia(activityId, fileId2) { it.copy(caption = "New caption") }
+
+      assertListPositions(listOf(fileId1, fileId2, fileId3))
+    }
+
+    @Test
     fun `moves file later in list if requested`() {
       val fileId1 = insertFile()
       insertActivityMediaFile(listPosition = 1)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -200,6 +200,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           caption = "Caption 2",
           capturedDate = LocalDate.of(2024, 2, 20),
           geolocation = point(1),
+          isHiddenOnMap = true,
           type = ActivityMediaType.Video,
       )
 
@@ -219,6 +220,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               media =
                   listOf(
                       ActivityMediaModel(
+                          activityId = activityId,
                           caption = "Caption 1",
                           createdBy = user.userId,
                           createdTime = Instant.EPOCH,
@@ -226,9 +228,12 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           fileId = fileId1,
                           geolocation = null,
                           isCoverPhoto = true,
+                          isHiddenOnMap = false,
+                          listPosition = 1,
                           type = ActivityMediaType.Photo,
                       ),
                       ActivityMediaModel(
+                          activityId = activityId,
                           caption = "Caption 2",
                           createdBy = user.userId,
                           createdTime = Instant.ofEpochSecond(1),
@@ -236,6 +241,8 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           fileId = fileId2,
                           geolocation = point(1),
                           isCoverPhoto = false,
+                          isHiddenOnMap = true,
+                          listPosition = 2,
                           type = ActivityMediaType.Video,
                       ),
                   ),
@@ -276,7 +283,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           )
 
       val fileId1 = insertFile()
-      insertActivityMediaFile(caption = "Caption")
+      insertActivityMediaFile(caption = "Caption", isHiddenOnMap = true)
 
       val activityId2 =
           insertActivity(
@@ -308,6 +315,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   media =
                       listOf(
                           ActivityMediaModel(
+                              activityId = activityId1,
                               caption = "Caption",
                               createdBy = user.userId,
                               createdTime = Instant.EPOCH,
@@ -315,6 +323,8 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               fileId = fileId1,
                               geolocation = null,
                               isCoverPhoto = false,
+                              isHiddenOnMap = true,
+                              listPosition = 1,
                               type = ActivityMediaType.Photo,
                           ),
                       ),
@@ -333,6 +343,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   media =
                       listOf(
                           ActivityMediaModel(
+                              activityId = activityId2,
                               caption = null,
                               createdBy = user.userId,
                               createdTime = Instant.EPOCH,
@@ -340,6 +351,8 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                               fileId = fileId2,
                               geolocation = null,
                               isCoverPhoto = true,
+                              isHiddenOnMap = false,
+                              listPosition = 1,
                               type = ActivityMediaType.Photo,
                           ),
                       ),

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3809,6 +3809,9 @@ abstract class DatabaseBackedTest {
     return row.id!!.also { inserted.activityIds.add(it) }
   }
 
+  private var lastActivityMediaFileActivityId: ActivityId? = null
+  private var nextActivityMediaFileListPosition = 1
+
   protected fun insertActivityMediaFile(
       activityId: ActivityId = inserted.activityId,
       caption: String? = null,
@@ -3816,6 +3819,10 @@ abstract class DatabaseBackedTest {
       fileId: FileId = inserted.fileId,
       geolocation: Point? = null,
       isCoverPhoto: Boolean = false,
+      isHiddenOnMap: Boolean = false,
+      listPosition: Int =
+          if (activityId == lastActivityMediaFileActivityId) nextActivityMediaFileListPosition
+          else 1,
       type: ActivityMediaType = ActivityMediaType.Photo,
   ) {
     val row =
@@ -3827,9 +3834,14 @@ abstract class DatabaseBackedTest {
             fileId = fileId,
             geolocation = geolocation,
             isCoverPhoto = isCoverPhoto,
+            isHiddenOnMap = isHiddenOnMap,
+            listPosition = listPosition,
         )
 
     activityMediaFilesDao.insert(row)
+
+    lastActivityMediaFileActivityId = activityId
+    nextActivityMediaFileListPosition = listPosition + 1
   }
 
   private var nextInternalTagNumber = 1


### PR DESCRIPTION
Add a boolean field to indicate whether a media file should be hidden on the map.

Add an integer field to indicate the list position of each file. This can be
updated to rearrange the list.

Since maintaining the list position requires additional database operations, move
the media file deletion logic into `ActivityMediaStore`. `ActivityMediaService`
no longer directly interacts with the database.