### PR TITLE
Use Kotlin 2.2 library functions, language features

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import com.terraformation.gradle.VersionFileTask
 import com.terraformation.gradle.computeGitVersion
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.deprecation.DeprecatableConfiguration
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -285,8 +286,10 @@ tasks.withType<KotlinCompile> {
     // Kotlin and Java target compatibility must be the same.
     jvmTarget = JvmTarget.JVM_24
     allWarningsAsErrors = true
-
     extraWarnings = true
+
+    // No need to generate code that's binary-compatible with earlier Kotlin versions
+    jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
 
     // jOOQ generated code has redundant modifiers
     freeCompilerArgs.add("-Xwarning-level=REDUNDANT_MODALITY_MODIFIER:disabled")

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -2,7 +2,7 @@ package com.terraformation.backend.jooq
 
 import java.io.File
 import java.sql.Connection
-import java.util.Base64
+import kotlin.io.encoding.Base64
 import org.jooq.codegen.JavaWriter
 import org.jooq.codegen.KotlinGenerator
 import org.jooq.meta.SchemaDefinition
@@ -270,7 +270,7 @@ class TerrawareGenerator : KotlinGenerator() {
 
   fun excludes() =
       ENUM_TABLES.entries.joinToString("|") { (schemaName, tables) ->
-        tables.joinToString { "$schemaName\\.$it\$" }
+        tables.joinToString { "$schemaName\\.$it$" }
       }
 
   private fun schemaPackage(targetPackage: String, schemaName: String): String {
@@ -287,7 +287,7 @@ class TerrawareGenerator : KotlinGenerator() {
         word
       } else {
         val bytes = word.toByteArray()
-        Base64.getEncoder().encodeToString(bytes).trimEnd('=')
+        Base64.encode(bytes).trimEnd('=')
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminDevicesController.kt
@@ -22,7 +22,6 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.time.DatabaseBackedClock
 import java.util.UUID
 import kotlin.random.Random
-import org.apache.tomcat.util.buf.HexUtils
 import org.jooq.JSONB
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -274,7 +273,7 @@ class AdminDevicesController(
   ): String {
     try {
       repeat(count) {
-        val calculatedName = name ?: HexUtils.toHexString(Random.nextBytes(4)).uppercase()
+        val calculatedName = name ?: Random.nextBytes(4).toHexString(HexFormat.UpperCase)
         val calculatedAddress = address ?: calculatedName
 
         val devicesRow =

--- a/src/main/kotlin/com/terraformation/backend/config/Base64ToByteArrayConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/Base64ToByteArrayConverter.kt
@@ -1,7 +1,7 @@
 package com.terraformation.backend.config
 
 import jakarta.inject.Named
-import java.util.Base64
+import kotlin.io.encoding.Base64
 import org.springframework.boot.context.properties.ConfigurationPropertiesBinding
 import org.springframework.core.convert.converter.Converter
 
@@ -13,11 +13,9 @@ import org.springframework.core.convert.converter.Converter
 @ConfigurationPropertiesBinding
 @Named
 class Base64ToByteArrayConverter : Converter<String, ByteArray> {
-  private val decoder = Base64.getDecoder()!!
-
   override fun convert(obj: String): ByteArray {
     return try {
-      decoder.decode(obj)
+      Base64.decode(obj)
     } catch (e: Exception) {
       throw IllegalArgumentException(e)
     }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/UserStore.kt
@@ -42,8 +42,8 @@ import jakarta.inject.Named
 import jakarta.ws.rs.core.Response
 import java.time.Clock
 import java.time.Instant
-import java.util.Base64
 import java.util.Locale
+import kotlin.io.encoding.Base64
 import kotlin.random.Random
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.codec.binary.Base32
@@ -606,7 +606,7 @@ class UserStore(
     // offline token. There is no administrative Keycloak API to do that on behalf of a user.
     // When we're done, we will remove the password. Use a long random password so that even if
     // this process bombs out, an attacker won't be able to guess the password.
-    val randomPassword = Base64.getEncoder().encodeToString(Random.nextBytes(40))
+    val randomPassword = Base64.encode(Random.nextBytes(40))
 
     keycloakAdminClient.setPassword(authId, randomPassword)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionCheck.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionCheck.kt
@@ -70,10 +70,10 @@ abstract class PermissionCheck {
       className == IndividualUser::class.java.name ->
           !methodName.startsWith("recordPermissionCheck")
       className == PermissionCheck::class.java.name -> false
-      className == PermissionRequirements::class.java.name -> !methodName.contains("\$lambda\$")
+      className == PermissionRequirements::class.java.name -> !methodName.contains($$"$lambda$")
       // Kotlin wrapper method that populates default argument values; it will always be immediately
       // followed by a stack frame for the actual method.
-      methodName.endsWith("\$default") -> false
+      methodName.endsWith($$"$default") -> false
       else -> true
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
+++ b/src/main/kotlin/com/terraformation/backend/device/balena/LiveBalenaClient.kt
@@ -207,9 +207,9 @@ class LiveBalenaClient(
   ): String {
     val elements =
         listOfNotNull(
-            filter?.joinToString("+and+", prefix = "\$filter="),
-            expand?.joinToString(",", prefix = "\$expand="),
-            select?.joinToString(",", prefix = "\$select="),
+            filter?.joinToString("+and+", prefix = $$"$filter="),
+            expand?.joinToString(",", prefix = $$"$expand="),
+            select?.joinToString(",", prefix = $$"$select="),
         )
 
     return if (elements.isNotEmpty()) elements.joinToString("&", prefix = "?") else ""

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/db/manifest/ManifestImporter.kt
@@ -231,8 +231,7 @@ class ManifestImporter(
 
     private fun importDefaultSectionText(csvVariable: CsvSectionVariable) {
       if (csvVariable.defaultSectionText != null) {
-        val regex =
-            Regex("(.*?)(?:\\{\\{(?:[^}]*-\\s*)?([0-9]+)}}|\$)", RegexOption.DOT_MATCHES_ALL)
+        val regex = Regex("(.*?)(?:\\{\\{(?:[^}]*-\\s*)?([0-9]+)}}|$)", RegexOption.DOT_MATCHES_ALL)
         val textVariablePairs =
             regex.findAll(csvVariable.defaultSectionText).map { it.groupValues.drop(1) }
 

--- a/src/main/kotlin/com/terraformation/backend/file/api/MuxWebhookController.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/MuxWebhookController.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.log.withMDC
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.ws.rs.BadRequestException
 import jakarta.ws.rs.InternalServerErrorException
-import java.util.HexFormat
 import org.apache.commons.codec.digest.HmacAlgorithms
 import org.apache.commons.codec.digest.HmacUtils
 import org.springframework.web.bind.annotation.PostMapping
@@ -110,7 +109,7 @@ class MuxWebhookController(
     val hmac = HmacUtils.getInitializedMac(HmacAlgorithms.HMAC_SHA_256, webhookSecret)
     hmac.update(timestamp.toByteArray())
     hmac.update(PERIOD_BYTE)
-    val payloadHash = HexFormat.of().formatHex(hmac.doFinal(payload))
+    val payloadHash = hmac.doFinal(payload).toHexString()
 
     if (hashFromHeader != payloadHash) {
       log.debug("Hash mismatch: expected $payloadHash but header had $hashFromHeader")

--- a/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
@@ -37,8 +37,8 @@ import java.security.PrivateKey
 import java.security.spec.PKCS8EncodedKeySpec
 import java.time.Duration
 import java.time.InstantSource
-import java.util.Base64
 import java.util.Date
+import kotlin.io.encoding.Base64
 import kotlinx.coroutines.runBlocking
 import org.bouncycastle.openssl.PEMKeyPair
 import org.bouncycastle.openssl.PEMParser
@@ -308,8 +308,7 @@ class MuxService(
    * that decode to PEM-formatted RSA private keys.
    */
   private fun parseSigningKey(): PrivateKey {
-    val pemString =
-        Base64.getDecoder().decode(config.mux.signingKeyPrivate).toString(Charsets.US_ASCII)
+    val pemString = Base64.decode(config.mux.signingKeyPrivate!!).toString(Charsets.US_ASCII)
     val pemObj = PEMParser(StringReader(pemString)).readObject() as PEMKeyPair
     val keySpec = PKCS8EncodedKeySpec(pemObj.privateKeyInfo.encoded)
     return KeyFactory.getInstance("RSA").generatePrivate(keySpec)

--- a/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Gibberish.kt
@@ -2,8 +2,8 @@ package com.terraformation.backend.i18n
 
 import java.text.DecimalFormatSymbols
 import java.text.spi.DecimalFormatSymbolsProvider
-import java.util.Base64
 import java.util.Locale
+import kotlin.io.encoding.Base64
 
 /**
  * Converts an English string to gibberish for localization testing:
@@ -13,11 +13,9 @@ import java.util.Locale
  * Note that this function does not preserve placeholder tokens.
  */
 fun String.toGibberish(): String {
-  val encoder = Base64.getEncoder()
-
   return split('\n').joinToString("\n") { line ->
     line.split(' ').asReversed().joinToString(" ") { word ->
-      encoder.encodeToString(word.toByteArray()).trimEnd('=')
+      Base64.encode(word.toByteArray()).trimEnd('=')
     }
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/log/LoggingExtensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/log/LoggingExtensions.kt
@@ -42,7 +42,7 @@ inline fun <reified T : Any> T.perClassLogger(): Logger {
       }
 
   // Remove CGLIB suffixes from classes Spring decides to rewrite
-  val className = loggingClass.canonicalName.substringBefore("\$\$")
+  val className = loggingClass.canonicalName.substringBefore("$$")
 
   return LoggerFactory.getLogger(className)
 }

--- a/src/test/kotlin/com/terraformation/backend/auth/SpringSessionCompatibilityTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/auth/SpringSessionCompatibilityTest.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.auth
 
 import java.io.ByteArrayInputStream
 import java.io.ObjectInputStream
-import java.util.HexFormat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
@@ -31,7 +30,7 @@ class SpringSessionCompatibilityTest {
 
   @Test
   fun `can deserialize security context used by frontend test suite`() {
-    val binary = HexFormat.of().parseHex(hexEncodedSecurityContext)
+    val binary = hexEncodedSecurityContext.hexToByteArray()
 
     assertDoesNotThrow("Serialized session format has changed! See class docs for instructions.") {
       ObjectInputStream(ByteArrayInputStream(binary)).readObject()!!

--- a/src/test/kotlin/com/terraformation/backend/customer/FrontEndTestSessionGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/FrontEndTestSessionGenerator.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.customer
 import com.terraformation.backend.auth.SimplePrincipal
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
-import java.util.HexFormat
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.context.SecurityContextImpl
 
@@ -42,8 +41,7 @@ fun main(args: Array<String>) {
   ByteArrayOutputStream().use { byteStream ->
     ObjectOutputStream(byteStream).use { objectStream -> objectStream.writeObject(springContext) }
 
-    val bytes = byteStream.toByteArray()
-    val hex = HexFormat.of().formatHex(bytes)
+    val hex = byteStream.toByteArray().toHexString()
 
     println("Hex-encoded SPRING_SECURITY_CONTEXT for auth ID $authId:")
     println()


### PR DESCRIPTION
Kotlin 2.2 adds standard library functions for Base64 and hex conversion, and adds
a better way to declare string literals that contain dollar signs. Update the code
to use those new features, and tell the compiler not to produce JVM bytecode
that's compatible with earlier Kotlin versions.