### PR TITLE
SW-7419 Include temp-plots-included changes in T0 Set email

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -887,7 +887,8 @@ class EmailNotificationService(
         (event.monitoringPlots == null ||
             event.monitoringPlots.all { it.speciesDensityChanges.isEmpty() }) &&
             (event.plantingZones == null ||
-                event.plantingZones.all { it.speciesDensityChanges.isEmpty() })
+                event.plantingZones.all { it.speciesDensityChanges.isEmpty() }) &&
+            event.previousSiteTempSetting == event.newSiteTempSetting
     ) {
       // changes were reversed before the event was eventually refired
       return
@@ -902,10 +903,12 @@ class EmailNotificationService(
           T0DataSet(
               config,
               organizationName = organization.name,
+              monitoringPlots = event.monitoringPlots ?: emptyList(),
+              newSiteTempSetting = event.newSiteTempSetting,
               plantingSiteId = event.plantingSiteId,
               plantingSiteName = plantingSite.name,
-              monitoringPlots = event.monitoringPlots ?: emptyList(),
               plantingZones = event.plantingZones ?: emptyList(),
+              previousSiteTempSetting = event.previousSiteTempSetting,
           )
       emailService.sendOrganizationNotification(
           event.organizationId,

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -540,10 +540,12 @@ class AcceleratorReportPublished(
 class T0DataSet(
     config: TerrawareServerConfig,
     val monitoringPlots: List<PlotT0DensityChangedEventModel>,
-    val plantingZones: List<ZoneT0DensityChangedEventModel>,
+    val newSiteTempSetting: Boolean?,
     val organizationName: String,
     val plantingSiteId: PlantingSiteId,
     val plantingSiteName: String,
+    val plantingZones: List<ZoneT0DensityChangedEventModel>,
+    val previousSiteTempSetting: Boolean?,
 ) : EmailTemplateModel(config) {
   override val templateDir: String
     get() = "observation/t0Set"

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -216,8 +216,10 @@ data class RateLimitedT0DataAssignedEvent(
         plantingSiteId = plantingSiteId,
         previousSiteTempSetting = existing.previousSiteTempSetting ?: previousSiteTempSetting,
         newSiteTempSetting = newSiteTempSetting ?: existing.newSiteTempSetting,
-        monitoringPlots = plotsMap.values.toList(),
-        plantingZones = zonesMap.values.toList(),
+        monitoringPlots =
+            if (monitoringPlots != null) plotsMap.values.toList() else existing.monitoringPlots,
+        plantingZones =
+            if (plantingZones != null) zonesMap.values.toList() else existing.plantingZones,
     )
   }
 }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -77,6 +77,8 @@ csvScientificNameTooLong=Scientific name must be no more than 4 words
 csvScientificNameTooShort=Scientific name must be at least 2 words
 csvSubLocationNotFound=Sub-location does not exist
 csvWrongFieldCount=Expected row to have {0} fields, not {1}
+disabled=Disabled
+enabled=Enabled
 historyAccessionCreated=created accession
 historyAccessionQuantityUpdated=updated the quantity to {0}
 historyAccessionQuantityWithdrawn=withdrew {0}
@@ -942,6 +944,7 @@ speciesCsvSuccessionalGroupInvalid=Successional group must be one of: {0}
 support.requestType.bugReport=Bug Report
 support.requestType.contactUs=Contact Us
 support.requestType.featureRequest=Feature Request
+survivalRateTempSetting=Survival Rate Calculations Include Temporary Plot Data
 # Items in the time zones menu that have example cities, e.g., "Pacific - Los Angeles"
 timeZoneWithCity={0} - {1}
 variablesCsvColumnName.0=Name

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -131,6 +131,10 @@ csvScientificNameTooShort=El nombre científico debe tener 2 palabras por lo men
 csvSubLocationNotFound=La sublocalización no existe
 # 9d9b6e82
 csvWrongFieldCount=Se espera que la fila tenga {0} campos, no {1}.
+# e717e29b
+disabled=Deshabilitado
+# 0cbb9a69
+enabled=Habilitado
 # 11138bfd
 historyAccessionCreated=accesión creada
 # 8fe87f5b
@@ -1715,6 +1719,8 @@ support.requestType.bugReport=Informe de errores
 support.requestType.contactUs=Contáctenos
 # 21c9d75f
 support.requestType.featureRequest=Solicitud de funciones
+# 38bcc9ea
+survivalRateTempSetting=Los cálculos de la tasa de supervivencia incluyen datos temporales de parcelas
 # f8c5697d
 timeZoneWithCity={0} - {1}
 # e7c2678c

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -131,6 +131,10 @@ csvScientificNameTooShort=Le nom scientifique doit comporter au moins 2 mots
 csvSubLocationNotFound=La sous-localisation n''existe pas
 # 9d9b6e82
 csvWrongFieldCount=La ligne devait contenir {0} champs, pas {1}
+# e717e29b
+disabled=Désactivé
+# 0cbb9a69
+enabled=Activé
 # 11138bfd
 historyAccessionCreated=a créé une accession
 # 8fe87f5b
@@ -1715,6 +1719,8 @@ support.requestType.bugReport=Rapport de bug
 support.requestType.contactUs=Nous contacter
 # 21c9d75f
 support.requestType.featureRequest=Demande de fonctionnalité
+# 38bcc9ea
+survivalRateTempSetting=Les calculs du taux de survie incluent les données des parcelles temporaires
 # f8c5697d
 timeZoneWithCity={0} - {1}
 # e7c2678c

--- a/src/main/resources/templates/email/observation/t0Set/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/t0Set/body.ftlh.mjml
@@ -73,6 +73,25 @@
                 </#list>
             </mj-raw>
 
+            <mj-raw>
+                <#if (previousSiteTempSetting!) != (newSiteTempSetting!)>
+            </mj-raw>
+                    <mj-text mj-class="text-body01-regular" padding-top="4px">
+                        <strong>
+                            ${strings("survivalRateTempSetting")}:
+                        </strong>
+                        <mj-raw>
+                            <#if newSiteTempSetting>
+                                ${strings("disabled")} → ${strings("enabled")}
+                            <#else>
+                                ${strings("enabled")} → ${strings("disabled")}
+                            </#if>
+                        </mj-raw>
+                    </mj-text>
+            <mj-raw>
+                </#if>
+            </mj-raw>
+
                 <mj-text mj-class="text-body-footer" css-class="text-body-footer">
                 ${link("notification.observation.t0Set.html.footer", manageT0SettingsUrl)}
                 </mj-text>

--- a/src/main/resources/templates/email/observation/t0Set/body.txt.ftl
+++ b/src/main/resources/templates/email/observation/t0Set/body.txt.ftl
@@ -9,6 +9,10 @@ ${strings("notification.observation.t0Set.email.body", plantingSiteName)}
     ${zone.zoneName}: ${change.speciesScientificName} - <#if change.previousDensity??><#if change.newDensity??>${change.previousDensity} -> ${change.newDensity}<#else>${change.previousDensity} → Removed</#if><#else><#if change.newDensity??>New → ${change.newDensity}<#else>No change</#if></#if> ${strings("plants.per.hectare.parens")}
 </#list></#list>
 
+<#if (previousSiteTempSetting!) != (newSiteTempSetting!)>
+    ${strings("survivalRateTempSetting")}:<#if newSiteTempSetting>${strings("disabled")} → ${strings("enabled")}<#else>${strings("enabled")} → ${strings("disabled")}</#if>
+</#if>
+
 ------------------------------
 
 ${strings("notification.observation.t0Set.text.footer", manageT0SettingsUrl)}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -1455,6 +1455,29 @@ internal class EmailNotificationServiceTest {
   }
 
   @Test
+  fun `rateLimitedT0DataAssignedEvent sends correctly if only temp setting change`() {
+    service.on(
+        RateLimitedT0DataAssignedEvent(
+            organizationId = organization.id,
+            plantingSiteId = plantingSite.id,
+            monitoringPlots = emptyList(),
+            plantingZones = emptyList(),
+            previousSiteTempSetting = false,
+            newSiteTempSetting = true,
+        )
+    )
+
+    val message = sentMessageWithSubject("t0 planting density settings")
+    assertSubjectContains(organization.name, message = message)
+    assertSubjectContains(plantingSite.name, message = message)
+    assertBodyContains(plantingSite.name, message = message)
+    assertBodyContains("Survival Rate Calculations Include Temporary Plot Data:", message = message)
+    assertBodyContains("Disabled", message = message)
+    assertBodyContains("Enabled", message = message)
+    assertRecipientsEqual(setOf(tfContactEmail1, tfContactEmail2))
+  }
+
+  @Test
   fun `rateLimitedT0DataAssignedEvent doesn't send if no species changes in plots or zones`() {
     service.on(
         RateLimitedT0DataAssignedEvent(

--- a/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
@@ -341,6 +341,67 @@ class RateLimitedT0DataAssignedEventTest {
           "Shouldn't remove site temp settings when they are not included",
       )
     }
+
+    @Test
+    fun `alternating change types combines correctly when starting with temp setting`() {
+      val existingEvent = event(previousSiteTempSetting = true, newSiteTempSetting = false)
+      val finalEvent =
+          existingEvent
+              .combine(
+                  event(plots = listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+              )
+              .combine(event(previousSiteTempSetting = false, newSiteTempSetting = true))
+              .combine(
+                  event(plots = listOf(plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2)))))
+              )
+              .combine(event(previousSiteTempSetting = true, newSiteTempSetting = false))
+
+      assertEquals(
+          event(
+              plots =
+                  listOf(
+                      plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2))),
+                      plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2))),
+                  ),
+              previousSiteTempSetting = true,
+              newSiteTempSetting = false,
+          ),
+          finalEvent,
+          "Should combine correctly when alternating",
+      )
+    }
+
+    @Test
+    fun `alternating change types combines correctly when starting with plots`() {
+      val existingEvent =
+          event(plots = listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2)))))
+      val finalEvent =
+          existingEvent
+              .combine(event(previousSiteTempSetting = false, newSiteTempSetting = true))
+              .combine(
+                  event(plots = listOf(plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2)))))
+              )
+              .combine(event(previousSiteTempSetting = true, newSiteTempSetting = false))
+              .combine(
+                  event(plots = listOf(plotChangeModel(3, listOf(speciesChangeModel(1, 1, 2)))))
+              )
+              .combine(event(previousSiteTempSetting = false, newSiteTempSetting = true))
+
+      assertEquals(
+          event(
+              plots =
+                  listOf(
+                      plotChangeModel(3, listOf(speciesChangeModel(1, 1, 2))),
+                      plotChangeModel(2, listOf(speciesChangeModel(1, 1, 2))),
+                      plotChangeModel(1, listOf(speciesChangeModel(1, 1, 2))),
+                  ),
+              previousSiteTempSetting = false,
+              newSiteTempSetting = true,
+          ),
+          finalEvent,
+          "Should combine correctly when alternating",
+      )
+    }
   }
 
   @Test


### PR DESCRIPTION
A [previous PR](https://github.com/terraware/terraware-server/pull/3441) included changes to publish an event when a user changes whether or not temp plots are included in survival rate calculations. 
Update the T0 Set email to include this information.