### PR TITLE
SW-7428 Fix error when deleting a species density that was recently added

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -148,16 +148,12 @@ data class RateLimitedT0DataAssignedEvent(
       // Use previousDensity from existing and newDensity from current
       newSpecies.forEach { newChange ->
         val existingChange = combinedChanges[newChange.speciesId]
-        if (existingChange?.previousDensity == newChange.newDensity) {
-          combinedChanges.remove(newChange.speciesId)
-        } else {
-          combinedChanges[newChange.speciesId] =
-              if (existingChange == null) {
-                newChange
-              } else {
-                newChange.copy(previousDensity = existingChange.previousDensity)
-              }
-        }
+        combinedChanges[newChange.speciesId] =
+            if (existingChange == null) {
+              newChange
+            } else {
+              newChange.copy(previousDensity = existingChange.previousDensity)
+            }
       }
 
       return combinedChanges.values.filter { it.previousDensity != it.newDensity }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -148,12 +148,16 @@ data class RateLimitedT0DataAssignedEvent(
       // Use previousDensity from existing and newDensity from current
       newSpecies.forEach { newChange ->
         val existingChange = combinedChanges[newChange.speciesId]
-        combinedChanges[newChange.speciesId] =
-            if (existingChange == null) {
-              newChange
-            } else {
-              newChange.copy(previousDensity = existingChange.previousDensity)
-            }
+        if (existingChange?.previousDensity == newChange.newDensity) {
+          combinedChanges.remove(newChange.speciesId)
+        } else {
+          combinedChanges[newChange.speciesId] =
+              if (existingChange == null) {
+                newChange
+              } else {
+                newChange.copy(previousDensity = existingChange.previousDensity)
+              }
+        }
       }
 
       return combinedChanges.values.filter { it.previousDensity != it.newDensity }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlotT0DataModel.kt
@@ -60,12 +60,6 @@ data class SpeciesDensityChangedEventModel(
     val previousDensity: BigDecimal? = null,
     val newDensity: BigDecimal? = null,
 ) {
-  init {
-    require(previousDensity != null || newDensity != null) {
-      "Either previousDensity or newDensity must be non-null."
-    }
-  }
-
   companion object {
     fun of(speciesChangeModel: SpeciesDensityChangedModel, scientificName: String) =
         SpeciesDensityChangedEventModel(

--- a/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/event/RateLimitedT0DataAssignedEventTest.kt
@@ -97,6 +97,19 @@ class RateLimitedT0DataAssignedEventTest {
     }
 
     @Test
+    fun `combine with species that were deleted after adding`() {
+      val existingEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, null, 2)))))
+
+      val newEvent = event(listOf(plotChangeModel(1, listOf(speciesChangeModel(1, 2, null)))))
+
+      assertEquals(
+          event(listOf(plotChangeModel(1, emptyList()))),
+          newEvent.combine(existingEvent),
+          "Should have species were added then deleted",
+      )
+    }
+
+    @Test
     fun `combine with lots of data`() {
       val existingEvent =
           event(


### PR DESCRIPTION
When a species' density was recently added, the event has the following properties:
```
previousDensity = null,
newDensity = X,
```
When the same species is then deleted before an email is sent, it throws an error because the new event has these properties:
```
previousDensity = X,
newDensity = null,
```
resulting in a `combine` operation that sets previous and new Density to `null` which throws an error. 
When `previousDensity` and `newDensity` are equal, remove the species from the list of changed species in the `combine` method.