### PR TITLE
Properly set memory limit for test suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -194,6 +194,7 @@ testing {
           targets {
             all {
               testTask.configure {
+                jvmArgs("-Dfile.encoding=UTF-8", "-Duser.country=US", "-Xmx5120m")
                 systemProperty("java.locale.providers", "SPI,CLDR")
                 testLogging { exceptionFormat = TestExceptionFormat.FULL }
               }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 #
-org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8 -Xmx5120m
+org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 #
 # Version numbers of dependencies that come in multiple related artifacts. This ensures we have


### PR DESCRIPTION
Previously, we were setting the memory limit for the Gradle worker process that
runs the test suite by adding it to Gradle's JVM arguments. That no longer works;
instead we need to include it in the configuration for the test-running task.
Otherwise Gradle will use the default limit of 512MB, which isn't enough to
run our tests in parallel without lots of memory pressure that causes frequent
GC pauses.

In a local dev environment, this change cuts test suite execution time in half.