### PR TITLE
Fix inconsistent use of ThumbnailService stubs

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -53,9 +53,7 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
         fileStore,
     )
   }
-  private val thumbnailService: ThumbnailService by lazy {
-    ThumbnailService(dslContext, fileService, mockk(), mockk())
-  }
+  private val thumbnailService: ThumbnailService = mockk()
   private val service: BatchPhotoService by lazy {
     BatchPhotoService(
         batchPhotosDao,
@@ -117,6 +115,13 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `returns photo data`() {
       val fileId = storePhoto(content = onePixelPng)
+
+      every { thumbnailService.readFile(fileId) } returns
+          SizedInputStream(
+              onePixelPng.inputStream(),
+              onePixelPng.size.toLong(),
+              MediaType.IMAGE_PNG,
+          )
 
       val inputStream = service.readPhoto(batchId, fileId)
       assertArrayEquals(onePixelPng, inputStream.readAllBytes(), "File content")

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -47,9 +47,7 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
         fileStore,
     )
   }
-  private val thumbnailService: ThumbnailService by lazy {
-    ThumbnailService(dslContext, fileService, mockk(), mockk())
-  }
+  private val thumbnailService: ThumbnailService = mockk()
   private val service: WithdrawalPhotoService by lazy {
     WithdrawalPhotoService(
         dslContext,
@@ -84,6 +82,9 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
   @Test
   fun `readPhoto returns photo data`() {
     val fileId = storePhoto(content = onePixelPng)
+
+    every { thumbnailService.readFile(fileId) } returns
+        SizedInputStream(onePixelPng.inputStream(), onePixelPng.size.toLong())
 
     val inputStream = service.readPhoto(withdrawalId, fileId)
     assertArrayEquals(onePixelPng, inputStream.readAllBytes(), "File content")

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
@@ -65,9 +65,7 @@ class SeedFundReportFileServiceTest : DatabaseTest(), RunsAsUser {
         seedFundReportsDao,
     )
   }
-  private val thumbnailService: ThumbnailService by lazy {
-    ThumbnailService(dslContext, fileService, mockk(), mockk())
-  }
+  private val thumbnailService: ThumbnailService = mockk()
   private val service: SeedFundReportFileService by lazy {
     SeedFundReportFileService(
         filesDao,
@@ -242,10 +240,11 @@ class SeedFundReportFileServiceTest : DatabaseTest(), RunsAsUser {
   inner class ReadPhoto {
     @Test
     fun `returns photo data`() {
-      val content = Random.Default.nextBytes(10)
+      val content = Random.nextBytes(10)
       val fileId = storePhoto(content = content)
 
-      every { fileStore.read(URI("1")) } returns SizedInputStream(content.inputStream(), 10L)
+      every { thumbnailService.readFile(fileId) } returns
+          SizedInputStream(content.inputStream(), 10L)
 
       val inputStream = service.readPhoto(seedFundReportId, fileId)
       assertArrayEquals(content, inputStream.readAllBytes(), "File content")

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -195,7 +195,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
 
     val stream = repository.readPhoto(accessionId, filename, width, height)
 
-    verify { thumbnailService.readFile(fileId, width, height) }
+    verify { thumbnailStore.getThumbnailData(fileId, width, height) }
 
     assertArrayEquals(thumbnailData, stream.readAllBytes())
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -132,9 +132,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         fileStore,
     )
   }
-  private val thumbnailService: ThumbnailService by lazy {
-    ThumbnailService(dslContext, fileService, mockk(), mockk())
-  }
+  private val thumbnailService: ThumbnailService = mockk()
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
@@ -641,6 +639,9 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       @Test
       fun `returns photo data`() {
+        every { thumbnailService.readFile(fileId) } returns
+            SizedInputStream(content.inputStream(), content.size.toLong())
+
         val inputStream = service.readPhoto(observationId, plotId, fileId)
         assertArrayEquals(content, inputStream.readAllBytes())
       }


### PR DESCRIPTION
The restructuring of thumbnail generation left some tests in an inconsistent
state where some test methods expected `ThumbnailService` to be a MockK stub
and others expected it to be a real instance of the class.