### PR TITLE
SW-7472 Generalize two-stage thumbnail generation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/JpegConverter.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/JpegConverter.kt
@@ -1,0 +1,13 @@
+package com.terraformation.backend.file
+
+import com.terraformation.backend.db.default_schema.FileId
+
+interface JpegConverter {
+  /**
+   * Returns true if this converter can produce a JPEG version of a file with the given MIME type.
+   */
+  fun canConvertToJpeg(mimeType: String): Boolean
+
+  /** Converts the specified file to JPEG and returns the JPEG contents. */
+  fun convertToJpeg(fileId: FileId): ByteArray
+}

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -73,6 +73,9 @@ class ThumbnailStore(
    */
   private val thumbnailTimeoutSecs: Long = 60
 
+  /** Which image MIME types we can scale natively. */
+  private val supportedMimeTypes = ImageIO.getReaderMIMETypes().toSet()
+
   /**
    * Returns the contents of a thumbnail image for a photo. This may return a cached copy of a
    * thumbnail if one exists, or it may scale the original image down on demand.
@@ -224,6 +227,11 @@ class ThumbnailStore(
               ?.id
         }
     log.info("Created file $fileId thumbnail $thumbnailId dimensions $width x $height bytes $size")
+  }
+
+  /** Returns true if we can generate thumbnails directly from a given media type. */
+  fun canGenerateThumbnails(mimeType: String): Boolean {
+    return mimeType.substringBefore(';') in supportedMimeTypes
   }
 
   private fun generateThumbnail(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -69,7 +69,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     )
   }
   private val thumbnailService: ThumbnailService by lazy {
-    ThumbnailService(dslContext, fileService, muxService, thumbnailStore)
+    ThumbnailService(dslContext, fileService, listOf(muxService), thumbnailStore)
   }
   private val service: ActivityMediaService by lazy {
     ActivityMediaService(
@@ -276,7 +276,8 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val maxWidth = 100
       val maxHeight = 100
 
-      every { thumbnailService.readFile(fileId, maxWidth, maxHeight) } returns
+      every { thumbnailStore.canGenerateThumbnails("image/png") } returns true
+      every { thumbnailStore.getThumbnailData(fileId, maxWidth, maxHeight) } returns
           SizedInputStream(thumbnailContent.inputStream(), 25L)
 
       val inputStream = service.readMedia(activityId, fileId, maxWidth, maxHeight)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -25,7 +25,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.io.ByteArrayInputStream
 import java.time.ZoneOffset
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -48,7 +48,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         reportStore,
         publishedReportPhotosDao,
         SystemUser(usersDao),
-        ThumbnailService(dslContext, fileService, mockk(), mockk()),
+        ThumbnailService(dslContext, fileService, listOf(mockk()), mockk()),
     )
   }
 

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -36,6 +36,7 @@ import javax.imageio.stream.MemoryCacheImageInputStream
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -109,6 +110,30 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
         }
 
     return thumbnailsRow
+  }
+
+  @Nested
+  inner class CanGenerateThumbnails {
+    @Test
+    fun `returns true for common image types but not video types`() {
+      val expected =
+          mapOf(
+              "application/octet-stream" to false,
+              "image/jpeg" to true,
+              "image/png" to true,
+              "image/tiff" to true,
+              "video/mp4" to false,
+              "video/quicktime" to false,
+          )
+      val actual = expected.keys.associateWith { store.canGenerateThumbnails(it) }
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ignores MIME type suffixes`() {
+      assertTrue(store.canGenerateThumbnails("image/jpeg; foo=bar"))
+    }
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -191,6 +191,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     repository.storePhoto(accessionId, onePixelPng.inputStream(), metadata)
     val fileId = filesDao.findAll().first().id!!
 
+    every { thumbnailStore.canGenerateThumbnails(metadata.contentType) } returns true
     every { thumbnailStore.getThumbnailData(fileId, any(), any()) } returns thumbnailStream
 
     val stream = repository.readPhoto(accessionId, filename, width, height)


### PR DESCRIPTION
For video files, we use a two-step process for generating thumbnails: first
generate a full-sized JPEG still image from the video, then scale that image to
the requested size.

We'll want to use a similar process for image file formats that aren't supported
by the Java ImageIO library, which we use for thumbnail generation.

Update the code so that the two-step process isn't specific to videos, and make
the one-step process work for all image formats we can handle natively.