### PR TITLE
Fix incorrect include paths in activity created MJML

### DIFF
--- a/src/main/resources/templates/email/accelerator/activity/created/body.ftlh.mjml
+++ b/src/main/resources/templates/email/accelerator/activity/created/body.ftlh.mjml
@@ -1,8 +1,8 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ActivityCreated" -->
 <mjml>
-    <mj-include path="../../head.ftlh.mjml"/>
+    <mj-include path="../../../head.ftlh.mjml"/>
     <mj-body>
-        <mj-include path="../../logo.ftlh.mjml"/>
+        <mj-include path="../../../logo.ftlh.mjml"/>
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold"
@@ -14,9 +14,9 @@
                     ${strings("notification.accelerator.activity.created.email.buttonLabel")}
                 </mj-button>
 
-                <mj-include path="../../manageSettings.ftlh.mjml"/>
+                <mj-include path="../../../manageSettings.ftlh.mjml"/>
 
-                <mj-include path="../../footer.ftlh.mjml"/>
+                <mj-include path="../../../footer.ftlh.mjml"/>
             </mj-column>
         </mj-section>
     </mj-body>


### PR DESCRIPTION
This MJML file lives one level deeper in a directory hierarchy than the file that
was used as a starting point for it; adjust the include paths accordingly so the
notification emails will be properly styled.