### PR TITLE
SW-7472 Support thumbnail generation for HEIC images

### DIFF
--- a/docs/CONVERTAPI.md
+++ b/docs/CONVERTAPI.md
@@ -1,0 +1,48 @@
+# ConvertAPI for additional image format support
+
+We use [ConvertAPI](https://convertapi.com/) to support generating thumbnail images when the original image file is in a format the server can't read natively, e.g., HEIC.
+
+Setting up a local dev environment to interact with ConvertAPI requires some setup steps.
+
+**Note:** You only need to do this if you want to work with images of unsupported formats. If you do all your local testing with JPEG or PNG images, you don't need ConvertAPI.
+
+## Step 1: Log into ConvertAPI
+
+Either get an invitation to an existing ConvertAPI team or sign up for an account on your own. At the time of this writing, they had a free trial period that may suffice for your needs.
+
+Once you've logged in, you should see a dashboard with an overview of conversion activity.
+
+## Step 2: Create an API token
+
+While it's possible to share API tokens across environments, it's preferable to use a separate token for each developer.
+
+Click the "Authentication" item in the left navbar. You should see a list of the existing API tokens.
+
+Click the "Create New Token" button and, depending on your needs, choose an expiration date and/or a usage limit. The name is up to you but `<your username> dev` is a reasonable pattern.
+
+The new token should appear in the token list.
+
+## Step 3: Configure terraware-server
+
+You can tell Terraware about the API token via environment variables or by putting it in `src/main/resources/application-dev.yaml`:
+
+```yaml
+terraware:
+  convert-api:
+    enabled: true
+    api-token: "Your API token from step 2"
+```
+
+If you're running terraware-server in a Docker container, you can use environment variables, e.g., `TERRAWARE_CONVERTAPI_ENABLED=true`.
+
+## Step 4: Try it out
+
+You'll need an HEIC image file, e.g., a photo from an iPhone.
+
+Launch terraware-server and terraware-web.
+
+Log into [the ConvertAPI test page in the admin UI](https://localhost:3000/admin/convertApi) as a super-admin user. That page is also accessible from the admin UI main menu.
+
+Use the "Upload File and View Thumbnail" form to upload your HEIC file.
+
+You should see a file ID in the success message, and then, after a brief delay, you should see a thumbnail version of the file you uploaded.

--- a/docs/CONVERTAPI.md
+++ b/docs/CONVERTAPI.md
@@ -30,7 +30,7 @@ You can tell Terraware about the API token via environment variables or by putti
 terraware:
   convert-api:
     enabled: true
-    api-token: "Your API token from step 2"
+    api-key: "Your API token from step 2"
 ```
 
 If you're running terraware-server in a Docker container, you can use environment variables, e.g., `TERRAWARE_CONVERTAPI_ENABLED=true`.

--- a/docs/CONVERTAPI.md
+++ b/docs/CONVERTAPI.md
@@ -30,7 +30,7 @@ You can tell Terraware about the API token via environment variables or by putti
 terraware:
   convert-api:
     enabled: true
-    api-key: "Your API token from step 2"
+    api-token: "Your API token from step 2"
 ```
 
 If you're running terraware-server in a Docker container, you can use environment variables, e.g., `TERRAWARE_CONVERTAPI_ENABLED=true`.

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminConvertApiController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminConvertApiController.kt
@@ -1,0 +1,87 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.api.getPlainContentType
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.convertapi.ConvertApiService
+import com.terraformation.backend.file.model.NewFileMetadata
+import com.terraformation.backend.log.perClassLogger
+import javax.imageio.ImageIO
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminConvertApiController(
+    private val config: TerrawareServerConfig,
+    private val convertApiService: ConvertApiService,
+    private val fileService: FileService,
+) {
+  private val log = perClassLogger()
+
+  @GetMapping("/convertApi")
+  fun convertApiHome(@RequestParam fileId: FileId?, model: Model): String {
+    model.addAttribute("convertApiEnabled", config.convertApi.enabled)
+    model.addAttribute("fileId", fileId)
+    model.addAttribute("imageFormats", ImageIO.getReaderMIMETypes().sorted())
+
+    return "/admin/convertApi"
+  }
+
+  @PostMapping("/convertImage")
+  fun convertApiConvertFile(@RequestPart file: MultipartFile): ResponseEntity<ByteArrayResource> {
+    val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
+    val converted =
+        convertApiService.convertFile(
+            SizedInputStream(file.inputStream, file.size, MediaType.valueOf(contentType)),
+            MediaType.IMAGE_JPEG,
+        )
+
+    return ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG).body(ByteArrayResource(converted))
+  }
+
+  @PostMapping("/uploadFile")
+  fun uploadFile(@RequestPart file: MultipartFile, redirectAttributes: RedirectAttributes): String {
+    val fileId =
+        try {
+          val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
+
+          fileService.storeFile(
+              "convertApiAdmin",
+              file.inputStream,
+              NewFileMetadata.of(contentType, file.name, file.size),
+          ) {
+            redirectAttributes.successMessage = "Uploaded file with ID $it"
+          }
+        } catch (e: Exception) {
+          perClassLogger().error("Error storing file", e)
+          redirectAttributes.failureMessage = "Unable to upload file: ${e.message}"
+          null
+        }
+
+    return redirectToConvertApiHome(fileId)
+  }
+
+  private fun redirectToConvertApiHome(fileId: FileId? = null): String {
+    val suffix = fileId?.let { "?fileId=$it" } ?: ""
+    return "redirect:/admin/convertApi$suffix"
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminMuxController.kt
@@ -67,7 +67,12 @@ class AdminMuxController(
       @RequestParam width: Int?,
       @RequestParam height: Int?,
   ): ResponseEntity<InputStreamResource> {
-    return thumbnailService.readFile(fileId, width, height).toResponseEntity()
+    return try {
+      thumbnailService.readFile(fileId, width, height).toResponseEntity()
+    } catch (e: Exception) {
+      log.error("Unable to get thumbnail", e)
+      throw e
+    }
   }
 
   @PostMapping("/createFileAccessToken")

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -306,13 +306,13 @@ class TerrawareServerConfig(
   }
 
   class ConvertApiConfig(
-      val apiKey: String? = null,
+      val apiToken: String? = null,
       @DefaultValue("false") val enabled: Boolean = false,
   ) {
     init {
       if (enabled) {
-        if (apiKey == null) {
-          throw IllegalArgumentException("API key is required if ConvertAPI is enabled")
+        if (apiToken == null) {
+          throw IllegalArgumentException("API token is required if ConvertAPI is enabled")
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -96,6 +96,12 @@ class TerrawareServerConfig(
     /** Configures how the server interacts with the Balena cloud service to manage sensor kits. */
     val balena: BalenaConfig = BalenaConfig(),
 
+    /**
+     * Configures how the server interacts with the ConvertAPI cloud service to work with file
+     * formats we don't support natively.
+     */
+    val convertApi: ConvertApiConfig = ConvertApiConfig(),
+
     /** Configures how the server interacts with Dropbox. */
     val dropbox: DropboxConfig = DropboxConfig(),
 
@@ -296,6 +302,19 @@ class TerrawareServerConfig(
 
     companion object {
       const val BALENA_API_URL = "https://api.balena-cloud.com"
+    }
+  }
+
+  class ConvertApiConfig(
+      val apiKey: String? = null,
+      @DefaultValue("false") val enabled: Boolean = false,
+  ) {
+    init {
+      if (enabled) {
+        if (apiKey == null) {
+          throw IllegalArgumentException("API key is required if ConvertAPI is enabled")
+        }
+      }
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType
  * List of supported photo content types. We only support content types that are compatible with our
  * thumbnail generator.
  */
-val SUPPORTED_PHOTO_TYPES = setOf(MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG)
+val SUPPORTED_PHOTO_TYPES =
+    setOf(MediaType.valueOf("image/heic"), MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG)
 
 val SUPPORTED_VIDEO_TYPES = setOf(MediaType.valueOf("video/*"))

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
@@ -66,7 +66,7 @@ class ThumbnailService(
       return thumbnailFromExistingStillImage
     }
 
-    // For video or for image formats we don't support natively, Mux will generate a
+    // For video or for image formats we don't support natively, Mux or ConvertAPI will generate a
     // JPEG image, which we'll store at its original size the first time someone requests a
     // thumbnail. Then we'll scale that still image to the desired size.
     val converter =

--- a/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiPayloads.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.file.convertapi
+
+import com.fasterxml.jackson.annotation.JsonFormat
+
+@JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
+class ConvertApiFilePayload(
+    // File data is base64-encoded in the response; Jackson automatically decodes it.
+    val fileData: ByteArray,
+)
+
+@JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
+class ConvertApiSuccessResponse(
+    val files: List<ConvertApiFilePayload>,
+)
+
+@JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
+class ConvertApiErrorResponse(
+    val code: Int,
+    val message: String?,
+)

--- a/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiService.kt
@@ -1,0 +1,113 @@
+package com.terraformation.backend.file.convertapi
+
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.file.FileService
+import com.terraformation.backend.file.JpegConverter
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailNotReadyException
+import com.terraformation.backend.log.debugWithTiming
+import com.terraformation.backend.log.perClassLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import jakarta.inject.Named
+import java.net.URI
+import kotlinx.coroutines.runBlocking
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.UnsupportedMediaTypeException
+
+@Named
+class ConvertApiService(
+    private val config: TerrawareServerConfig,
+    private val fileService: FileService,
+    private val httpClient: HttpClient,
+) : JpegConverter {
+  private val formatNames: Map<MediaType, String> =
+      mapOf(
+          MediaType.valueOf("image/heic") to "heic",
+          MediaType.IMAGE_JPEG to "jpg",
+      )
+  private val supportedFormats = formatNames.keys.toList()
+
+  private val convertApiBaseUrl = URI("https://v2.convertapi.com/")
+  private val log = perClassLogger()
+
+  override fun canConvertToJpeg(mimeType: String): Boolean {
+    return MediaType.valueOf(mimeType) in supportedFormats
+  }
+
+  override fun convertToJpeg(fileId: FileId): ByteArray {
+    ensureEnabled()
+
+    val originalFile = fileService.readFile(fileId)
+    return try {
+      convertFile(originalFile, MediaType.IMAGE_JPEG)
+    } catch (_: ConvertApiServiceUnavailableException) {
+      // This is likely due to throttling, so treat it as a "thumbnail isn't ready yet" condition.
+      // Clients can choose to retry later.
+      log.info("ConvertAPI service unavailable")
+      throw ThumbnailNotReadyException(fileId)
+    }
+  }
+
+  fun convertFile(original: SizedInputStream, targetFormat: MediaType): ByteArray {
+    ensureEnabled()
+
+    val originalContentType =
+        original.contentType ?: throw IllegalArgumentException("Original content type unknown")
+    val originalFormatName = getFormatName(originalContentType)
+    val targetFormatName = getFormatName(targetFormat)
+    val url =
+        convertApiBaseUrl.resolve("/convert/$originalFormatName/to/$targetFormatName").toString()
+
+    return log.debugWithTiming("Converted ${original.contentType} to $targetFormatName") {
+      runBlocking {
+        val response =
+            httpClient.post(url) {
+              bearerAuth(config.convertApi.apiKey!!)
+              contentType(ContentType.Application.OctetStream)
+              header("Content-Disposition", "attachment; filename=file.$originalFormatName")
+              header("Content-Length", original.size)
+
+              setBody(original)
+
+              expectSuccess = false
+            }
+
+        if (response.status == HttpStatusCode.ServiceUnavailable) {
+          // Probably throttled; ConvertAPI limits the number of concurrent conversions.
+          throw ConvertApiServiceUnavailableException()
+        }
+
+        if (!response.status.isSuccess()) {
+          throw ConvertApiErrorException(response.body())
+        }
+
+        val responsePayload: ConvertApiSuccessResponse = response.body()
+        val convertedFile = responsePayload.files.first()
+
+        convertedFile.fileData
+      }
+    }
+  }
+
+  private fun getFormatName(mediaType: MediaType): String {
+    return formatNames[mediaType]
+        ?: throw UnsupportedMediaTypeException(mediaType, supportedFormats)
+  }
+
+  private fun ensureEnabled() {
+    if (!config.convertApi.enabled) {
+      throw IllegalStateException("ConvertAPI is disabled")
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/convertapi/ConvertApiService.kt
@@ -73,7 +73,7 @@ class ConvertApiService(
       runBlocking {
         val response =
             httpClient.post(url) {
-              bearerAuth(config.convertApi.apiKey!!)
+              bearerAuth(config.convertApi.apiToken!!)
               contentType(ContentType.Application.OctetStream)
               header("Content-Disposition", "attachment; filename=file.$originalFormatName")
               header("Content-Length", original.size)

--- a/src/main/kotlin/com/terraformation/backend/file/convertapi/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/convertapi/Exceptions.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.file.convertapi
+
+class ConvertApiErrorException(val errorResponse: ConvertApiErrorResponse) :
+    RuntimeException(
+        "ConvertAPI request failed with error code ${errorResponse.code}: ${errorResponse.message}"
+    )
+
+class ConvertApiServiceUnavailableException :
+    RuntimeException("ConvertAPI service temporarily unavailable or throttled")

--- a/src/main/resources/templates/admin/convertApi.html
+++ b/src/main/resources/templates/admin/convertApi.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        form { padding-bottom: 1em; }
+        mux-player { max-width: 640px; }
+    </style>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>ConvertAPI Integration</h2>
+
+<img th:if="${fileId != null}" height="100" th:src="|/admin/mux/thumbnail/${fileId}?height=100|" />
+
+<th:block th:if="${convertApiEnabled}">
+    <h3>Upload File and View Thumbnail</h3>
+
+    <p>
+    <details>
+        <summary>
+            If the file is of a type that isn't in this list (expand to view), it will first be sent
+            to ConvertAPI for conversion to JPEG.
+        </summary>
+        <ul>
+            <li th:each="format : ${imageFormats}" th:text="${format}"/>
+        </ul>
+    </details>
+    </p>
+
+    <form method="POST" action="/admin/uploadFile" enctype="multipart/form-data">
+        <label>
+            Image file
+            <input type="file" name="file" required/>
+        </label>
+        <button type="submit">Upload</button>
+    </form>
+
+    <h3>Convert Image to JPEG</h3>
+
+    <p>
+        This will send the file to ConvertAPI and open the JPEG file in a new window.
+    </p>
+
+    <form method="POST" action="/admin/convertImage" enctype="multipart/form-data" target="_blank">
+        <label>
+            Image file
+            <input type="file" name="file" required/>
+        </label>
+        <button type="submit">Convert</button>
+    </form>
+</th:block>
+
+<p th:if="!${convertApiEnabled}">
+    The ConvertAPI integration is disabled.
+</p>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -107,6 +107,10 @@
     </p>
 
     <p>
+        <a href="/admin/convertApi">ConvertAPI integration</a>
+    </p>
+
+    <p>
         <a href="/admin/mux">Mux integration</a>
     </p>
 </details>


### PR DESCRIPTION
Use the ConvertAPI service to turn HEIC images into JPEG ones, from which we can
then generate thumbnail images.