### PR TITLE
SW-7402 Allow TF Expert users to manage activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -67,7 +67,7 @@ class ActivitiesAdminController(
 
   @Operation(summary = "Creates a new activity including accelerator-admin-only details.")
   @PostMapping
-  @RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+  @RequireGlobalRole([GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
   fun adminCreateActivity(
       @RequestBody payload: AdminCreateActivityRequestPayload
   ): AdminGetActivityResponsePayload {
@@ -78,7 +78,7 @@ class ActivitiesAdminController(
 
   @Operation(summary = "Updates an activity including its accelerator-admin-only details.")
   @PutMapping("/{id}")
-  @RequireGlobalRole([GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+  @RequireGlobalRole([GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
   fun adminUpdateActivity(
       @PathVariable("id") id: ActivityId,
       @RequestBody payload: AdminUpdateActivityRequestPayload,


### PR DESCRIPTION
Commit 6edd2d76 updated the permission system to allow TF Expert users to perform
write operations on activities, but the API endpoints were still configured to
refuse access.