### PR TITLE
Run JUnit tests in headless mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -194,7 +194,12 @@ testing {
           targets {
             all {
               testTask.configure {
-                jvmArgs("-Dfile.encoding=UTF-8", "-Duser.country=US", "-Xmx5120m")
+                jvmArgs(
+                    "-Dfile.encoding=UTF-8",
+                    "-Djava.awt.headless=true",
+                    "-Duser.country=US",
+                    "-Xmx5120m",
+                )
                 systemProperty("java.locale.providers", "SPI,CLDR")
                 testLogging { exceptionFormat = TestExceptionFormat.FULL }
               }


### PR DESCRIPTION
This stops the test suite from stealing input focus on OS X.