### PR TITLE
Assert that t0 data can only be assigned to permanent plots

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
@@ -60,10 +60,10 @@ internal class T0ServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertPlantingSiteHistory()
     plantingZoneId1 = insertPlantingZone()
     insertPlantingSubzone()
-    monitoringPlotId1 = insertMonitoringPlot()
+    monitoringPlotId1 = insertMonitoringPlot(permanentIndex = 1)
     observationId = insertObservation()
     insertObservationPlot()
-    monitoringPlotId2 = insertMonitoringPlot()
+    monitoringPlotId2 = insertMonitoringPlot(permanentIndex = 2)
     plantingZoneId2 = insertPlantingZone()
     speciesId1 = insertSpecies()
     speciesId2 = insertSpecies()
@@ -78,7 +78,7 @@ internal class T0ServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSite()
       insertPlantingZone()
       insertPlantingSubzone()
-      val otherSitePlotId = insertMonitoringPlot()
+      val otherSitePlotId = insertMonitoringPlot(permanentIndex = 3)
 
       assertThrows<IllegalArgumentException> {
         service.assignT0PlotsData(
@@ -98,7 +98,7 @@ internal class T0ServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSite()
       insertPlantingZone()
       insertPlantingSubzone()
-      val otherSitePlotId = insertMonitoringPlot()
+      val otherSitePlotId = insertMonitoringPlot(permanentIndex = 4)
 
       assertThrows<IllegalArgumentException> {
         service.assignT0PlotsData(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -31,6 +31,7 @@ import com.terraformation.backend.tracking.model.ZoneT0TempDataModel
 import com.terraformation.backend.tracking.model.ZoneT0TempDensityChangedModel
 import com.terraformation.backend.util.toPlantsPerHectare
 import java.math.BigDecimal
+import kotlin.IllegalArgumentException
 import kotlin.lazy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -64,7 +65,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     insertPlantingSiteHistory()
     plantingZoneId = insertPlantingZone(name = "Zone 2")
     insertPlantingSubzone()
-    monitoringPlotId = insertMonitoringPlot(plotNumber = 2)
+    monitoringPlotId = insertMonitoringPlot(plotNumber = 2, permanentIndex = 2)
     observationId = insertObservation()
     insertObservationPlot()
     speciesId1 = insertSpecies()
@@ -173,6 +174,15 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertThrows<AccessDeniedException> {
         store.assignT0PlotObservation(monitoringPlotId, observationId)
+      }
+    }
+
+    @Test
+    fun `throws exception when plot is not permanent`() {
+      val tempPlot = insertMonitoringPlot(plotNumber = 1)
+
+      assertThrows<IllegalArgumentException> {
+        store.assignT0PlotObservation(tempPlot, observationId)
       }
     }
 
@@ -440,6 +450,18 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       assertThrows<AccessDeniedException> {
         store.assignT0PlotSpeciesDensities(
             monitoringPlotId,
+            listOf(SpeciesDensityModel(speciesId1, BigDecimal.TEN)),
+        )
+      }
+    }
+
+    @Test
+    fun `throws exception when plot is not permanent`() {
+      val tempPlot = insertMonitoringPlot(plotNumber = 1)
+
+      assertThrows<IllegalArgumentException> {
+        store.assignT0PlotSpeciesDensities(
+            tempPlot,
             listOf(SpeciesDensityModel(speciesId1, BigDecimal.TEN)),
         )
       }


### PR DESCRIPTION
We discovered that any plot that had ever been permanent in an observation were being included in the Survival Rate settings page. This was causing the FE to assign t0 data to permanent plots which isn't supposed to be allowed. The data was being rolled back when the `T0PlotDataAssignedEvent` occurred and the survival rates were being recalculated. Instead of relying on a different method to assert permanence, add a permanence check to the `assign` methods. 