### PR TITLE
Use event-based flow to delete unreferenced files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -179,9 +179,7 @@ class ActivityMediaService(
   fun deleteMedia(activityId: ActivityId, fileId: FileId) {
     requirePermissions { updateActivity(activityId) }
 
-    activityMediaStore.ensureFileExists(activityId, fileId)
-
-    fileService.deleteFile(fileId) { activityMediaStore.deleteFromDatabase(activityId, fileId) }
+    activityMediaStore.deleteFromDatabase(activityId, fileId)
   }
 
   @EventListener
@@ -196,9 +194,7 @@ class ActivityMediaService(
 
   private fun deleteFiles(mediaFiles: List<ActivityMediaModel>) {
     mediaFiles.forEach { mediaFile ->
-      fileService.deleteFile(mediaFile.fileId) {
-        activityMediaStore.deleteFromDatabase(mediaFile.activityId, mediaFile.fileId)
-      }
+      activityMediaStore.deleteFromDatabase(mediaFile.activityId, mediaFile.fileId)
     }
   }
 

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -24,6 +24,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.species.event.SpeciesEditedEvent
@@ -232,9 +233,9 @@ class ParticipantProjectSpeciesService(
                 .fetchOne(FILE_ID)
 
         if (fileId != null) {
-          fileService.deleteFile(fileId) {
-            dslContext.deleteFrom(SUBMISSION_SNAPSHOTS).where(FILE_ID.eq(fileId)).execute()
-          }
+          dslContext.deleteFrom(SUBMISSION_SNAPSHOTS).where(FILE_ID.eq(fileId)).execute()
+
+          eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
         }
       }
 

--- a/src/main/kotlin/com/terraformation/backend/file/event/FileDeletionStartedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/FileDeletionStartedEvent.kt
@@ -6,4 +6,4 @@ import com.terraformation.backend.db.default_schema.FileId
  * Published when a file is about to be deleted. The file will still exist at the time the event is
  * published.
  */
-data class FileDeletionStartedEvent(val fileId: FileId)
+data class FileDeletionStartedEvent(val fileId: FileId, val contentType: String)

--- a/src/main/kotlin/com/terraformation/backend/file/event/FileReferenceDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/FileReferenceDeletedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.file.event
+
+import com.terraformation.backend.db.default_schema.FileId
+
+/**
+ * Published after a reference to a file has been deleted. This will cause the file to be deleted
+ * from the file store if there are no other references.
+ */
+data class FileReferenceDeletedEvent(val fileId: FileId)

--- a/src/main/kotlin/com/terraformation/backend/file/event/VideoFileDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/event/VideoFileDeletedEvent.kt
@@ -1,9 +1,0 @@
-package com.terraformation.backend.file.event
-
-import com.terraformation.backend.db.default_schema.FileId
-
-/**
- * Published when a video file is deleted from the system. The file ID will still be valid when this
- * is published.
- */
-data class VideoFileDeletedEvent(val fileId: FileId)

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PHOT
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
@@ -626,7 +627,8 @@ class ObservationService(
           .where(condition)
           .fetch(FILE_ID.asNonNullable())
           .forEach { fileId ->
-            fileService.deleteFile(fileId) { observationPhotosDao.deleteById(fileId) }
+            observationPhotosDao.deleteById(fileId)
+            eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))
           }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -23,15 +23,13 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserId
-import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.InMemoryFileStore
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.ThumbnailStore
 import com.terraformation.backend.file.VideoStreamNotFoundException
-import com.terraformation.backend.file.event.FileDeletionStartedEvent
-import com.terraformation.backend.file.event.VideoFileDeletedEvent
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.event.VideoFileUploadedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.file.mux.MuxService
@@ -326,16 +324,12 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @Nested
   inner class DeleteMedia {
     @Test
-    fun `deletes media file and removes from storage`() {
+    fun `deletes media file`() {
       val fileId = storeMedia("pixel.png", pngMetadata)
-      val storageUrl = filesDao.fetchOneById(fileId)!!.storageUrl!!
 
       service.deleteMedia(activityId, fileId)
 
-      assertTableEmpty(FILES)
-      assertEquals(emptyList<ActivityMediaFilesRow>(), activityMediaFilesDao.findAll())
-      fileStore.assertFileWasDeleted(storageUrl)
-      eventPublisher.assertEventNotPublished<VideoFileDeletedEvent>()
+      assertTableEmpty(ACTIVITY_MEDIA_FILES)
     }
 
     @Test
@@ -367,12 +361,12 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
-    fun `publishes video deleted event if file was a video`() {
+    fun `publishes reference deleted event`() {
       val fileId = storeMedia("videoAndroid.mp4", mp4Metadata)
 
       service.deleteMedia(activityId, fileId)
 
-      eventPublisher.assertEventPublished(VideoFileDeletedEvent(fileId))
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(fileId))
     }
 
     @Test
@@ -432,13 +426,12 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     val videoFileId = storeMedia("videoHeaderOnly.mp4", mp4Metadata)
 
     val activity2Id = insertActivity()
-    val activity2FileId = storeMedia("photoWithDate.jpg", jpegMetadata, activity2Id)
+    storeMedia("photoWithDate.jpg", jpegMetadata, activity2Id)
 
     eventPublisher.clear()
 
     service.on(ActivityDeletionStartedEvent(activityId))
 
-    assertEquals(listOf(activity2FileId), filesDao.findAll().map { it.id }, "Remaining file IDs")
     assertEquals(
         listOf(activity2Id),
         activityMediaFilesDao.findAll().map { it.activityId },
@@ -447,9 +440,8 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     eventPublisher.assertExactEventsPublished(
         setOf(
-            FileDeletionStartedEvent(imageFileId),
-            FileDeletionStartedEvent(videoFileId),
-            VideoFileDeletedEvent(videoFileId),
+            FileReferenceDeletedEvent(imageFileId),
+            FileReferenceDeletedEvent(videoFileId),
         )
     )
 
@@ -466,13 +458,19 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     val otherProjectId = insertProject(otherOrgId)
     val otherActivityId = insertActivity(projectId = otherProjectId)
 
-    storeMedia("pixel.png", pngMetadata)
-    storeMedia("photoWithDate.jpg", jpegMetadata, activity2Id)
-    val otherOrgFileId = storeMedia("photoWithGps.jpg", jpegMetadata, otherActivityId)
+    val fileId1 = storeMedia("pixel.png", pngMetadata)
+    val fileId2 = storeMedia("photoWithDate.jpg", jpegMetadata, activity2Id)
+    storeMedia("photoWithGps.jpg", jpegMetadata, otherActivityId)
 
     service.on(OrganizationDeletionStartedEvent(organizationId))
 
-    assertEquals(listOf(otherOrgFileId), filesDao.findAll().map { it.id }, "Remaining file IDs")
+    eventPublisher.assertExactEventsPublished(
+        setOf(
+            FileReferenceDeletedEvent(fileId1),
+            FileReferenceDeletedEvent(fileId2),
+        )
+    )
+
     assertEquals(
         listOf(otherActivityId),
         activityMediaFilesDao.findAll().map { it.activityId },

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
@@ -56,7 +56,7 @@ class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
 
       every { thumbnailStore.deleteThumbnails(fileId) } just Runs
 
-      service.on(FileDeletionStartedEvent(fileId))
+      service.on(FileDeletionStartedEvent(fileId, MediaType.IMAGE_JPEG_VALUE))
 
       verify { thumbnailStore.deleteThumbnails(fileId) }
       confirmVerified(thumbnailStore)


### PR DESCRIPTION
Previously, to delete a file from the file store, application code would call
`FileService.deleteFile` and pass it a function to remove the reference to the
file from the appropriate child tables.

That worked well enough for simple cases where there was a 1:1 relationship
between files and references to them. But we're starting to see more complex
1:N relationships, and in those cases, it's not always clear which code should
be responsible for calling `FileService.deleteFile`.

Improve the situation by moving to an event-based scheme. When application code
deletes a reference to a file, instead of doing

    fileService.deleteFile(fileId) {
        deleteRowsThatReferToFile(fileId)
    }

it should now do

    deleteRowsThatReferToFile(fileId)
    eventPublisher.publishEvent(FileReferenceDeletedEvent(fileId))

`FileService` listens for the event and takes care of deleting the file from
the file store if there are no other references to the file.

With this setup, in a 1:N situation, the event can be published as each reference
is deleted, without regard to whether or not there are other references. When the
last one is gone, the file will be deleted.

Since the files in question may be video files that are associated with Mux
assets, and we only want to delete those when the video is no longer
referenced, Mux asset deletion is now handled the same way as deletion of
thumbnail images: it's triggered by the `FileDeletionStartedEvent` that's
published by `FileService` before the file is actually removed from the file
store, rather than by a video-specific event from `ActivityMediaService`. That
way as we add video support to more places in the app, we won't have to
remember to publish the correct deletion event everywhere.

We use a "scan for references" approach rather than maintaining a reference count
because it's simpler to make robust: it's impossible to fail to increment or
decrement the reference count. We also have a relatively low rate of file
deletion, so scanning a bunch of tables for references should be less expensive
overall than keeping reference counts up to date.