### PR TITLE
SW-7512 Allow download of raw activity media files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -160,12 +160,17 @@ class ActivityMediaService(
       fileId: FileId,
       maxWidth: Int? = null,
       maxHeight: Int? = null,
+      raw: Boolean = false,
   ): SizedInputStream {
     requirePermissions { readActivity(activityId) }
 
     activityMediaStore.ensureFileExists(activityId, fileId)
 
-    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
+    return if (raw) {
+      fileService.readFile(fileId)
+    } else {
+      thumbnailService.readFile(fileId, maxWidth, maxHeight)
+    }
   }
 
   fun getMuxStreamInfo(activityId: ActivityId, fileId: FileId): MuxStreamModel {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -156,9 +156,17 @@ class ActivitiesController(
       @QueryParam("maxHeight")
       @Schema(description = PHOTO_MAXHEIGHT_DESCRIPTION)
       maxHeight: Int? = null,
+      @QueryParam("raw")
+      @Schema(
+          description =
+              "If true, return the originally uploaded media file verbatim. maxWidth and " +
+                  "maxHeight are ignored when raw is true.",
+          defaultValue = "false",
+      )
+      raw: Boolean? = null,
   ): ResponseEntity<InputStreamResource> {
     return activityMediaService
-        .readMedia(activityId, fileId, maxWidth, maxHeight)
+        .readMedia(activityId, fileId, maxWidth, maxHeight, raw == true)
         .toResponseEntity()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -305,6 +305,16 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `returns raw file when requested`() {
+      val testContent =
+          javaClass.getResourceAsStream("/file/videoAndroid.mp4")!!.use { it.readAllBytes() }
+      val fileId = storeMediaBytes(testContent, mp4Metadata)
+
+      val inputStream = service.readMedia(activityId, fileId, raw = true)
+      assertArrayEquals(testContent, inputStream.readAllBytes(), "Raw content")
+    }
+
+    @Test
     fun `throws exception if file not associated with activity`() {
       val otherProjectId = insertProject()
       val otherActivityId = insertActivity(projectId = otherProjectId)


### PR DESCRIPTION
Add an optional query string parameter to the activity media fetching endpoint to
allow the originally-uploaded file to be retrieved verbatim, even if it is of a
format that's not supported by a user's browser.