### PR TITLE
SW-7439 Add support for recalculating survival rates for a zone

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1789,16 +1789,12 @@ class ObservationStore(
   fun recalculateSurvivalRates(plantingZoneId: PlantingZoneId) {
     val subzoneGroups: Map<PlantingSubzoneId, List<MonitoringPlotId>> =
         dslContext
-            .select(PLANTING_SUBZONES.ID.asNonNullable(), MONITORING_PLOTS.ID.asNonNullable())
+            .select(PLANTING_SUBZONES.ID, MONITORING_PLOTS.ID)
             .from(MONITORING_PLOTS)
             .join(PLANTING_SUBZONES)
             .on(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
             .where(PLANTING_SUBZONES.PLANTING_ZONE_ID.eq(plantingZoneId))
-            .fetch()
-            .groupBy(
-                { it[PLANTING_SUBZONES.ID.asNonNullable()] },
-                { it[MONITORING_PLOTS.ID.asNonNullable()] },
-            )
+            .fetchGroups(PLANTING_SUBZONES.ID.asNonNullable(), MONITORING_PLOTS.ID.asNonNullable())
 
     subzoneGroups.values.flatten().forEach { recalculateSurvivalRate(ObservationSpeciesPlot(it)) }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/util/ObservationSpeciesScope.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBZONE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_T0_TEMP_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import org.jooq.Condition
@@ -156,6 +157,14 @@ class ObservationSpeciesSite(
           .from(MONITORING_PLOTS)
           .where(MONITORING_PLOTS.ID.eq(plotId)),
       plotId,
+  )
+
+  constructor(
+      zoneId: PlantingZoneId
+  ) : this(
+      DSL.select(PLANTING_ZONES.PLANTING_SITE_ID)
+          .from(PLANTING_ZONES)
+          .where(PLANTING_ZONES.ID.eq(zoneId))
   )
 
   override val scopeId = siteSelect

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -488,8 +488,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           .and(SPECIES_ID.eq(species1))
           .execute()
     }
-    val plotsInUpdatedZone = listOf("111", "112")
-    plotsInUpdatedZone.forEach { observationStore.recalculateSurvivalRates(plotIds[it]!!) }
+    observationStore.recalculateSurvivalRates(zone1)
 
     val ratesAfterUpdate =
         loadExpectedSurvivalRates(


### PR DESCRIPTION
We need to recalculate survival rates when t0 data changes for temp plots, which is stored at a zone level. A future PR will include an event publishing when this happens, which will call this new method.
Add a zone level `recalculateSurvivalRates` method.