### PR TITLE
Allow ReadOnly users to access project_internal_users in search requests

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -65,6 +65,16 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
                     ),
                     DSL.exists(
                         DSL.selectOne()
+                            .from(PROJECT_INTERNAL_USERS)
+                            .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
+                            .and(
+                                currentUser().canReadAllAcceleratorDetails().let {
+                                  if (it) DSL.trueCondition() else DSL.falseCondition()
+                                }
+                            )
+                    ),
+                    DSL.exists(
+                        DSL.selectOne()
                             .from(PROJECTS)
                             .join(PROJECT_INTERNAL_USERS)
                             .on(PROJECTS.ID.eq(PROJECT_INTERNAL_USERS.PROJECT_ID))

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -63,25 +63,26 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
                                 )
                             )
                     ),
-                    if (currentUser().canReadAllAcceleratorDetails())
-                        DSL.exists(
-                            DSL.selectOne()
-                                .from(PROJECT_INTERNAL_USERS)
-                                .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
-                        )
-                    else
-                        DSL.exists(
-                            DSL.selectOne()
-                                .from(PROJECTS)
-                                .join(PROJECT_INTERNAL_USERS)
-                                .on(PROJECTS.ID.eq(PROJECT_INTERNAL_USERS.PROJECT_ID))
-                                .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
-                                .and(
-                                    PROJECTS.ORGANIZATION_ID.`in`(
-                                        currentUser().organizationRoles.keys
-                                    )
-                                )
-                        ),
+                    if (currentUser().canReadAllAcceleratorDetails()) {
+                      DSL.exists(
+                          DSL.selectOne()
+                              .from(PROJECT_INTERNAL_USERS)
+                              .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
+                      )
+                    } else {
+                      DSL.exists(
+                          DSL.selectOne()
+                              .from(PROJECTS)
+                              .join(PROJECT_INTERNAL_USERS)
+                              .on(PROJECTS.ID.eq(PROJECT_INTERNAL_USERS.PROJECT_ID))
+                              .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
+                              .and(
+                                  PROJECTS.ORGANIZATION_ID.`in`(
+                                      currentUser().organizationRoles.keys
+                                  )
+                              )
+                      )
+                    },
                 )
             )
         )

--- a/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/UsersTable.kt
@@ -63,26 +63,25 @@ class UsersTable(private val tables: SearchTables) : SearchTable() {
                                 )
                             )
                     ),
-                    DSL.exists(
-                        DSL.selectOne()
-                            .from(PROJECT_INTERNAL_USERS)
-                            .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
-                            .and(
-                                currentUser().canReadAllAcceleratorDetails().let {
-                                  if (it) DSL.trueCondition() else DSL.falseCondition()
-                                }
-                            )
-                    ),
-                    DSL.exists(
-                        DSL.selectOne()
-                            .from(PROJECTS)
-                            .join(PROJECT_INTERNAL_USERS)
-                            .on(PROJECTS.ID.eq(PROJECT_INTERNAL_USERS.PROJECT_ID))
-                            .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
-                            .and(
-                                PROJECTS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys)
-                            )
-                    ),
+                    if (currentUser().canReadAllAcceleratorDetails())
+                        DSL.exists(
+                            DSL.selectOne()
+                                .from(PROJECT_INTERNAL_USERS)
+                                .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
+                        )
+                    else
+                        DSL.exists(
+                            DSL.selectOne()
+                                .from(PROJECTS)
+                                .join(PROJECT_INTERNAL_USERS)
+                                .on(PROJECTS.ID.eq(PROJECT_INTERNAL_USERS.PROJECT_ID))
+                                .where(USERS.ID.eq(PROJECT_INTERNAL_USERS.USER_ID))
+                                .and(
+                                    PROJECTS.ORGANIZATION_ID.`in`(
+                                        currentUser().organizationRoles.keys
+                                    )
+                                )
+                        ),
                 )
             )
         )

--- a/src/test/kotlin/com/terraformation/backend/customer/search/ProjectInternalUsersSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/search/ProjectInternalUsersSearchTest.kt
@@ -41,13 +41,16 @@ class ProjectInternalUsersSearchTest : DatabaseTest(), RunsAsUser {
   fun `returns internal users`() {
     val projectId = insertProject()
     val projectLead = insertUser()
+    insertOrganizationUser()
     insertProjectInternalUser(role = ProjectInternalRole.ProjectLead)
     val other = insertUser()
+    insertOrganizationUser()
     insertProjectInternalUser(roleName = "Other")
     // other org internal users are excluded
     insertOrganization()
     insertProject()
     insertUser()
+    insertOrganizationUser()
     insertProjectInternalUser(role = ProjectInternalRole.RestorationLead)
 
     val prefix = SearchFieldPrefix(searchTables.projectInternalUsers)
@@ -86,7 +89,7 @@ class ProjectInternalUsersSearchTest : DatabaseTest(), RunsAsUser {
     insertProjectInternalUser(role = ProjectInternalRole.ProjectLead)
     val otherOrg = insertOrganization()
     val otherProject = insertProject()
-    insertUser()
+    val otherOrgUser = insertUser()
     insertProjectInternalUser(role = ProjectInternalRole.RestorationLead)
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
 
@@ -107,8 +110,8 @@ class ProjectInternalUsersSearchTest : DatabaseTest(), RunsAsUser {
                 mapOf(
                     "role" to "Restoration Lead",
                     "project_id" to "$otherProject",
+                    "user_id" to "$otherOrgUser",
                     "project_organization_id" to "$otherOrg",
-                    // can't see the user details because user and project are not in org
                 ),
             )
         )


### PR DESCRIPTION
The Matrix View now uses the search api to get project leads for projects, but users are currently only visible if they are in the same org as the current user (or if they're a `project_internal_user` and the project is in the same org as the current user. 

Update the `UsersTable` to allow ReadOnly+ users to see `project_internal_users`, even if not in the same org.