### PR TITLE
SW-7514 Fix issue where sublist filtering depends on order of search fields

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -779,7 +779,8 @@ class NestedQueryBuilder(
     } else if (relativeField.isNested) {
       // Prefix = a.b, fieldName = a.b.c.d => make a sublist "c" to hold field "d"
       val sublistName = getSublistName(relativeField)
-      val sublistQuery = getSublistQuery(relativeField, criteria[fieldPath.prefix])
+      val sublistQuery =
+          getSublistQuery(relativeField, criteria[prefix.relativeSublistPrefix(sublistName)])
       sublistQuery.addSelectField(fieldPath, criteria)
       selectFieldPositions.computeIfAbsent(sublistName) { nextSelectFieldPosition++ }
     } else {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectVariableSearchTest.kt
@@ -21,7 +21,6 @@ import io.mockk.every
 import java.math.BigDecimal
 import java.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
@@ -193,7 +192,6 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
   }
 
   @Test
-  @Disabled("Waiting on SW-7192")
   fun `filters by stable id when prefix starts at project`() {
     val projectId1 = insertProject(name = "Project 1")
     val projectId2 = insertProject(name = "Project 2")
@@ -220,7 +218,7 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
                 "variables.projectId",
                 "variables.stableId",
                 "variables.variableId",
-                "variables.variableValueId",
+                "variables.values_variableValueId",
             )
             .map { prefix.resolve(it) }
 
@@ -231,37 +229,30 @@ class ProjectVariableSearchTest : DatabaseTest(), RunsAsUser {
                     "id" to "$projectId1",
                     "name" to "Project 1",
                     "variables" to
-                        mapOf(
-                            "projectId" to "$projectId1",
-                            "stableId" to stableId1,
-                            "variableId" to "$variableId1",
-                            "variableValueId" to "$included1",
-                        ),
-                ),
-                mapOf(
-                    "id" to "$projectId1",
-                    "name" to "Project 1",
-                    "variables" to
-                        mapOf(
-                            "projectId" to "$projectId1",
-                            "stableId" to stableId3,
-                            "variableId" to "$variableId3",
-                            "variableValueId" to "$included3",
+                        listOf(
+                            mapOf(
+                                "projectId" to "$projectId1",
+                                "stableId" to stableId1,
+                                "variableId" to "$variableId1",
+                                "values_variableValueId" to "$included1",
+                            ),
+                            mapOf(
+                                "projectId" to "$projectId1",
+                                "stableId" to stableId3,
+                                "variableId" to "$variableId3",
+                                "values_variableValueId" to "$included3",
+                            ),
                         ),
                 ),
             ),
             cursor = null,
         )
 
-    val search =
-        AndNode(
-            listOf(
-                FieldNode(prefix.resolve("id"), listOf(projectId1.toString())),
-                FieldNode(prefix.resolve("variables.stableId"), listOf(stableId1, stableId3)),
-            )
-        )
+    val search = AndNode(listOf(FieldNode(prefix.resolve("id"), listOf(projectId1.toString()))))
+    val variablesPrefix = prefix.relativeSublistPrefix("variables")!!
+    val filters = FieldNode(prefix.resolve("variables.stableId"), listOf(stableId1, stableId3))
     val actual =
-        Locales.GIBBERISH.use { searchService.search(prefix, fields, mapOf(prefix to search)) }
+        searchService.search(prefix, fields, mapOf(prefix to search, variablesPrefix to filters))
 
     assertJsonEquals(expected, actual)
   }


### PR DESCRIPTION
Sublist Filtering was only working if there were no flattened fields in the sublists being filtered (or if a direct property on the sublist was being queried above).
Example:
```json
"prefix": "projects",
"fields": [
  "id",
  "internalUsers.user_firstName",
],
"filters": [{
  "prefix": "internalUsers",
  "search": {
    "operation": "field",
    "field": "role",
    "values": ["Project Lead"]
  }
}]
```
This would only work if the field `internalUsers.role` was added _above_ `internalUsers.user_firstName` because then it would get processed first and the sublist query would get built with the correct criteria. 

The problem was that `fieldPath.prefix` for `internalUsers.user_firstName` is `internalUsers.user_` which causes `criteria[fieldPath.prefix]` to be null when adding the `sublistQuery` object to `sublistQueryBuilders`. 

Change this to `criteria[prefix.relativeSublistPrefix(sublistName)]` which correctly returns `internalUsers`.

Uncomment related sublist-filtering test, and delete duplicate test.