### PR TITLE
Delete activity media when project is deleted

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.accelerator.model.ActivityMediaModel
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.SRID
 import com.terraformation.backend.db.accelerator.ActivityId
@@ -190,6 +191,11 @@ class ActivityMediaService(
   @EventListener
   fun on(event: ActivityDeletionStartedEvent) {
     deleteFiles(activityMediaStore.fetchByActivityId(event.activityId))
+  }
+
+  @EventListener
+  fun on(event: ProjectDeletionStartedEvent) {
+    deleteFiles(activityMediaStore.fetchByProjectId(event.projectId))
   }
 
   @EventListener

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDI
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import jakarta.inject.Named
@@ -51,6 +52,15 @@ class ActivityMediaStore(
             ACTIVITY_MEDIA_FILES.activities.projects.ORGANIZATION_ID.eq(organizationId)
         )
         .filter { user.canReadActivity(it.activityId) }
+  }
+
+  fun fetchByProjectId(projectId: ProjectId): List<ActivityMediaModel> {
+    requirePermissions { readProject(projectId) }
+
+    val user = currentUser()
+    return fetchByCondition(ACTIVITY_MEDIA_FILES.activities.PROJECT_ID.eq(projectId)).filter {
+      user.canReadActivity(it.activityId)
+    }
   }
 
   fun updateMedia(


### PR DESCRIPTION
We were deleting activity media when an activity was deleted and when an
organization was deleted, but not when the activity's project was deleted.
Handle that case and add tests for the deletion event handlers.