### PR TITLE
SW-7503 Delete published versions of deleted activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -203,6 +203,10 @@ class ActivityMediaService(
     deleteFiles(activityMediaStore.fetchByOrganizationId(event.organizationId))
   }
 
+  /**
+   * Deletes media files from the database. This publishes events that may also cause the files to
+   * be deleted from the file store.
+   */
   private fun deleteFiles(mediaFiles: List<ActivityMediaModel>) {
     mediaFiles.forEach { mediaFile ->
       activityMediaStore.deleteFromDatabase(mediaFile.activityId, mediaFile.fileId)

--- a/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
@@ -1,0 +1,32 @@
+package com.terraformation.backend.funder
+
+import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
+import com.terraformation.backend.funder.db.PublishedActivityStore
+import jakarta.inject.Named
+import org.springframework.context.event.EventListener
+
+@Named
+class PublishedActivityService(
+    private val publishedActivityStore: PublishedActivityStore,
+) {
+  /**
+   * Deletes the published version of an activity, including its media files, when the original
+   * activity is deleted.
+   */
+  @EventListener
+  fun on(event: ActivityDeletionStartedEvent) {
+    @Suppress("DEPRECATION") publishedActivityStore.deletePublishedActivity(event.activityId)
+  }
+
+  @EventListener
+  fun on(event: OrganizationDeletionStartedEvent) {
+    @Suppress("DEPRECATION") publishedActivityStore.deletePublishedActivities(event.organizationId)
+  }
+
+  @EventListener
+  fun on(event: ProjectDeletionStartedEvent) {
+    @Suppress("DEPRECATION") publishedActivityStore.deletePublishedActivities(event.projectId)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -8,6 +8,8 @@ import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
@@ -34,6 +36,42 @@ class PublishedActivityStore(
       publishMediaFileDeletions(activityId)
       publishCurrentMediaFiles(activityId)
     }
+  }
+
+  @Deprecated("Do not call this except when handling deletion of the underlying activity")
+  fun deletePublishedActivity(activityId: ActivityId) {
+    deletePublishedMediaFiles(PUBLISHED_ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId))
+
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.ACTIVITY_ID.eq(activityId))
+        .execute()
+  }
+
+  @Deprecated("Do not call this except when handling deletion of the organization")
+  fun deletePublishedActivities(organizationId: OrganizationId) {
+    deletePublishedMediaFiles(
+        PUBLISHED_ACTIVITY_MEDIA_FILES.publishedActivities.projects.ORGANIZATION_ID.eq(
+            organizationId
+        )
+    )
+
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.projects.ORGANIZATION_ID.eq(organizationId))
+        .execute()
+  }
+
+  @Deprecated("Do not call this except when handling deletion of the project")
+  fun deletePublishedActivities(projectId: ProjectId) {
+    deletePublishedMediaFiles(
+        PUBLISHED_ACTIVITY_MEDIA_FILES.publishedActivities.PROJECT_ID.eq(projectId)
+    )
+
+    dslContext
+        .deleteFrom(PUBLISHED_ACTIVITIES)
+        .where(PUBLISHED_ACTIVITIES.PROJECT_ID.eq(projectId))
+        .execute()
   }
 
   private fun publishActivityDetails(activityId: ActivityId) {

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -1,0 +1,177 @@
+package com.terraformation.backend.funder
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
+import com.terraformation.backend.assertIsEventListener
+import com.terraformation.backend.assertSetEquals
+import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
+import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.funder.db.PublishedActivityStore
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val eventPublisher = TestEventPublisher()
+  private val publishedActivityStore: PublishedActivityStore by lazy {
+    PublishedActivityStore(clock, dslContext, eventPublisher)
+  }
+  private val service: PublishedActivityService by lazy {
+    PublishedActivityService(publishedActivityStore)
+  }
+
+  private lateinit var activityId: ActivityId
+  private lateinit var organizationId: OrganizationId
+  private lateinit var projectId: ProjectId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+    val cohortId = insertCohort()
+    val participantId = insertParticipant(cohortId = cohortId)
+    projectId = insertProject(participantId = participantId)
+
+    activityId =
+        insertActivity(
+            verifiedBy = user.userId,
+            verifiedTime = clock.instant(),
+        )
+  }
+
+  @Nested
+  inner class DeletionEventHandlers {
+    private lateinit var activityFileId: FileId
+    private lateinit var otherActivityId: ActivityId
+    private lateinit var otherActivityFileId: FileId
+    private lateinit var otherProjectActivityId: ActivityId
+    private lateinit var otherProjectActivityFileId: FileId
+    private lateinit var otherOrganizationActivityId: ActivityId
+    private lateinit var otherOrganizationActivityFileId: FileId
+
+    @BeforeEach
+    fun setUp() {
+      activityFileId = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      otherActivityId = insertActivity()
+      otherActivityFileId = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      insertProject()
+      otherProjectActivityId = insertActivity()
+      otherProjectActivityFileId = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      insertOrganization()
+      insertOrganizationUser(role = Role.Admin)
+      insertProject()
+      otherOrganizationActivityId = insertActivity()
+      otherOrganizationActivityFileId = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+    }
+
+    @Test
+    fun activityDeletionStartedEvent() {
+      service.on(ActivityDeletionStartedEvent(activityId))
+
+      eventPublisher.assertEventPublished(FileReferenceDeletedEvent(activityFileId))
+
+      assertRemainingPublishedActivityIds(
+          setOf(otherActivityId, otherProjectActivityId, otherOrganizationActivityId)
+      )
+      assertRemainingFileIds(
+          setOf(otherActivityFileId, otherProjectActivityFileId, otherOrganizationActivityFileId)
+      )
+
+      assertIsEventListener<ActivityDeletionStartedEvent>(service)
+    }
+
+    @Test
+    fun `activityDeletionStartedEvent for unpublished activity`() {
+      val unpublishedActivityId = insertActivity()
+
+      val publishedActivitiesBefore = dslContext.fetch(PUBLISHED_ACTIVITIES)
+      val publishedActivityMediaBefore = dslContext.fetch(PUBLISHED_ACTIVITY_MEDIA_FILES)
+
+      service.on(ActivityDeletionStartedEvent(unpublishedActivityId))
+
+      eventPublisher.assertNoEventsPublished()
+
+      assertTableEquals(publishedActivitiesBefore)
+      assertTableEquals(publishedActivityMediaBefore)
+    }
+
+    @Test
+    fun projectDeletionStartedEvent() {
+      service.on(ProjectDeletionStartedEvent(projectId))
+
+      eventPublisher.assertEventsPublished(
+          setOf(
+              FileReferenceDeletedEvent(activityFileId),
+              FileReferenceDeletedEvent(otherActivityFileId),
+          )
+      )
+
+      assertRemainingPublishedActivityIds(
+          setOf(otherProjectActivityId, otherOrganizationActivityId)
+      )
+      assertRemainingFileIds(setOf(otherProjectActivityFileId, otherOrganizationActivityFileId))
+
+      assertIsEventListener<ProjectDeletionStartedEvent>(service)
+    }
+
+    @Test
+    fun organizationDeletionStartedEvent() {
+      service.on(OrganizationDeletionStartedEvent(organizationId))
+
+      eventPublisher.assertEventsPublished(
+          setOf(
+              FileReferenceDeletedEvent(activityFileId),
+              FileReferenceDeletedEvent(otherActivityFileId),
+              FileReferenceDeletedEvent(otherProjectActivityFileId),
+          )
+      )
+
+      assertRemainingPublishedActivityIds(setOf(otherOrganizationActivityId))
+      assertRemainingFileIds(setOf(otherOrganizationActivityFileId))
+
+      assertIsEventListener<OrganizationDeletionStartedEvent>(service)
+    }
+
+    private fun assertRemainingPublishedActivityIds(expected: Set<ActivityId>) {
+      val actual = publishedActivitiesDao.findAll().map { it.activityId!! }.toSet()
+
+      assertEquals(expected, actual, "Remaining activity IDs")
+    }
+
+    private fun assertRemainingFileIds(expected: Set<FileId>) {
+      val actual = publishedActivityMediaFilesDao.findAll().map { it.fileId!! }.toSet()
+
+      assertSetEquals(expected, actual, "Remaining file IDs")
+    }
+  }
+}


### PR DESCRIPTION
When an activity is deleted, either individually or as a result of its containing
project or organization being deleted, also delete its published version, if any.