### PR TITLE
SW-7503 Admin endpoint to publish an activity

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesAdminController.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.funder.db.PublishedActivityStore
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import jakarta.ws.rs.QueryParam
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class ActivitiesAdminController(
     private val activityStore: ActivityStore,
+    private val publishedActivityStore: PublishedActivityStore,
 ) {
   @GetMapping
   @Operation(summary = "Lists all of a project's activities with accelerator-admin-only details.")
@@ -85,6 +87,18 @@ class ActivitiesAdminController(
       @RequestBody payload: AdminUpdateActivityRequestPayload,
   ): SimpleSuccessResponsePayload {
     activityStore.update(id, payload::applyTo)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @Operation(
+      summary = "Publishes an activity.",
+      description = "Only verified activities may be published.",
+  )
+  @PostMapping("/{id}/publish")
+  @RequireGlobalRole([GlobalRole.TFExpert, GlobalRole.AcceleratorAdmin, GlobalRole.SuperAdmin])
+  fun adminPublishActivity(@PathVariable id: ActivityId): SimpleSuccessResponsePayload {
+    publishedActivityStore.publish(id)
 
     return SimpleSuccessResponsePayload()
   }


### PR DESCRIPTION
`POST /api/v1/accelerator/activities/admin/{activityId}/publish` (no payload)
will publish the activity in question. If the activity was already published,
its published copy is updated with any changes that have been made since
publication.