### PR TITLE
SW-7506 Non-admins cannot modify published activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/Exceptions.kt
@@ -20,6 +20,12 @@ class ActivityNotFoundException(id: ActivityId) : EntityNotFoundException("Activ
 class ApplicationNotFoundException(id: ApplicationId) :
     EntityNotFoundException("Application $id not found")
 
+class CannotDeletePublishedActivityException(activityId: ActivityId) :
+    MismatchedStateException("Activity $activityId has been published and cannot be deleted")
+
+class CannotUpdatePublishedActivityException(activityId: ActivityId) :
+    MismatchedStateException("Activity $activityId has been published and cannot be updated")
+
 class CohortNotFoundException(id: CohortId) : EntityNotFoundException("Cohort $id not found")
 
 class CohortHasParticipantsException(id: CohortId) :


### PR DESCRIPTION
Don't allow end users to update or delete published activities.

This adds a feature to `TestEventPublisher` to allow tests to register event
listeners; it's needed here because without code to handle the event that's
fired during activity deletion, deleting an activity that has a published
version would fail due to a foreign key constraint.