### PR TITLE
SW-7505 Funders can't access unpublished activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -54,16 +54,11 @@ data class FunderUser(
   override fun canDeleteFunder(userId: UserId) =
       permissionStore.fetchFundingEntity(userId) == fundingEntityId
 
-  override fun canListActivities(projectId: ProjectId) = projectId in projectIds
-
   override fun canListFundingEntityUsers(entityId: FundingEntityId) = fundingEntityId == entityId
 
   override fun canListNotifications(organizationId: OrganizationId?) = organizationId == null
 
-  override fun canReadActivity(activityId: ActivityId): Boolean {
-    val projectId = parentStore.getProjectId(activityId) ?: return false
-    return canReadProject(projectId)
-  }
+  override fun canListPublishedActivities(projectId: ProjectId) = projectId in projectIds
 
   override fun canReadCurrentDisclaimer(): Boolean = true
 
@@ -72,6 +67,9 @@ data class FunderUser(
   override fun canReadProject(projectId: ProjectId) = projectId in projectIds
 
   override fun canReadProjectFunderDetails(projectId: ProjectId) = projectId in projectIds
+
+  override fun canReadPublishedActivity(activityId: ActivityId) =
+      parentStore.getProjectId(activityId) in projectIds
 
   override fun canReadPublishedReport(reportId: ReportId) =
       parentStore.getProjectId(reportId) in projectIds

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -308,6 +308,9 @@ data class IndividualUser(
   override fun canListOrganizationUsers(organizationId: OrganizationId) =
       isMember(organizationId) || isGlobalReader(organizationId)
 
+  override fun canListPublishedActivities(projectId: ProjectId) =
+      isReadOnlyOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(projectId))
+
   override fun canListSeedFundReports(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
 
@@ -507,6 +510,10 @@ data class IndividualUser(
   override fun canReadProjectScores(projectId: ProjectId) = isReadOnlyOrHigher()
 
   override fun canReadProjectVotes(projectId: ProjectId) = isReadOnlyOrHigher()
+
+  override fun canReadPublishedActivity(activityId: ActivityId): Boolean {
+    return isReadOnlyOrHigher() || isManagerOrHigher(parentStore.getOrganizationId(activityId))
+  }
 
   override fun canReadPublishedProjects() = isReadOnlyOrHigher()
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -715,6 +715,17 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun listPublishedActivities(projectId: ProjectId) {
+    user.recordPermissionChecks {
+      if (!user.canListPublishedActivities(projectId)) {
+        readProject(projectId)
+        throw AccessDeniedException(
+            "No permission to list published activities in project $projectId"
+        )
+      }
+    }
+  }
+
   fun listSeedFundReports(organizationId: OrganizationId) {
     user.recordPermissionChecks {
       if (!user.canListSeedFundReports(organizationId)) {
@@ -1257,6 +1268,14 @@ class PermissionRequirements(private val user: TerrawareUser) {
       if (!user.canReadProjectVotes(projectId)) {
         readProject(projectId)
         throw AccessDeniedException("No permission to view votes for project $projectId")
+      }
+    }
+  }
+
+  fun readPublishedActivity(activityId: ActivityId) {
+    user.recordPermissionChecks {
+      if (!user.canReadPublishedActivity(activityId)) {
+        throw ActivityNotFoundException(activityId)
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -355,6 +355,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canListOrganizationUsers(organizationId: OrganizationId): Boolean = defaultPermission
 
+  fun canListPublishedActivities(projectId: ProjectId): Boolean = defaultPermission
+
   fun canListSeedFundReports(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canManageActivity(activityId: ActivityId): Boolean = defaultPermission
@@ -490,6 +492,8 @@ interface TerrawareUser : Principal, UserDetails {
   fun canReadProjectScores(projectId: ProjectId): Boolean = defaultPermission
 
   fun canReadProjectVotes(projectId: ProjectId): Boolean = defaultPermission
+
+  fun canReadPublishedActivity(activityId: ActivityId): Boolean = defaultPermission
 
   fun canReadPublishedProjects(): Boolean = defaultPermission
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -175,6 +175,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
       readableId(PlantingZoneNotFoundException::class) { canReadPlantingZone(it) }
   private val projectId: ProjectId by
       readableId(ProjectNotFoundException::class) { canReadProject(it) }
+  private val publishedActivityId: ActivityId by
+      readableId(ActivityNotFoundException::class) { canReadPublishedActivity(it) }
   private val reportId: ReportId by readableId(ReportNotFoundException::class) { canReadReport(it) }
   private val seedFundReportId: SeedFundReportId by
       readableId(SeedFundReportNotFoundException::class) { canReadSeedFundReport(it) }
@@ -593,6 +595,10 @@ internal class PermissionRequirementsTest : RunsAsUser {
           }
 
   @Test
+  fun listPublishedActivities() =
+      allow { listPublishedActivities(projectId) } ifUser { canListPublishedActivities(projectId) }
+
+  @Test
   fun listReports() =
       allow { listSeedFundReports(organizationId) } ifUser
           {
@@ -869,6 +875,8 @@ internal class PermissionRequirementsTest : RunsAsUser {
     grant { user.canReadProjectScores(projectId) }
     requirements.readProjectScores(projectId)
   }
+
+  @Test fun readPublishedActivity() = testRead { readPublishedActivity(publishedActivityId) }
 
   @Test
   fun readPublishedProjects() {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -712,6 +712,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readProject = true,
         readProjectDeliverables = true,
         readProjectModules = true,
@@ -742,6 +743,7 @@ internal class PermissionTest : DatabaseTest() {
         *activityIds.forOrg1(),
         deleteActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -994,6 +996,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readProject = true,
         readProjectDeliverables = true,
         readProjectModules = true,
@@ -1024,6 +1027,7 @@ internal class PermissionTest : DatabaseTest() {
         *activityIds.forOrg1(),
         deleteActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -1191,6 +1195,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         createParticipantProjectSpecies = true,
         listActivities = true,
+        listPublishedActivities = true,
         readProject = true,
         readProjectDeliverables = true,
         readProjectModules = true,
@@ -1210,6 +1215,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *activityIds.forOrg1(),
         readActivity = true,
+        readPublishedActivity = true,
     )
 
     permissions.expect(
@@ -1676,6 +1682,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -1741,6 +1748,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteActivity = true,
         manageActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -1842,6 +1850,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -1888,6 +1897,7 @@ internal class PermissionTest : DatabaseTest() {
         createParticipantProjectSpecies = true,
         createSubmission = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -1988,6 +1998,7 @@ internal class PermissionTest : DatabaseTest() {
         *activityIds.toTypedArray(),
         deleteActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         manageActivity = true,
         updateActivity = true,
     )
@@ -2115,6 +2126,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2168,6 +2180,7 @@ internal class PermissionTest : DatabaseTest() {
         createParticipantProjectSpecies = true,
         createSubmission = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2268,6 +2281,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteActivity = true,
         manageActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -2397,6 +2411,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission = true,
         deleteProject = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2428,6 +2443,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteActivity = true,
         manageActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -2449,6 +2465,7 @@ internal class PermissionTest : DatabaseTest() {
         createParticipantProjectSpecies = true,
         createSubmission = true,
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2539,6 +2556,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteActivity = true,
         manageActivity = true,
         readActivity = true,
+        readPublishedActivity = true,
         updateActivity = true,
     )
 
@@ -2683,6 +2701,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *projectIds.forOrg1(),
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2697,6 +2716,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(3000),
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2713,6 +2733,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         ProjectId(4000),
         listActivities = true,
+        listPublishedActivities = true,
         readDefaultVoters = true,
         readInternalVariableWorkflowDetails = true,
         readProject = true,
@@ -2750,6 +2771,7 @@ internal class PermissionTest : DatabaseTest() {
     permissions.expect(
         *activityIds.toTypedArray(),
         readActivity = true,
+        readPublishedActivity = true,
     )
 
     permissions.expect(
@@ -2974,7 +2996,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *projectIds.forOrg1(),
-        listActivities = true,
+        listPublishedActivities = true,
         readProjectFunderDetails = true,
         readPublishedReports = true,
         readProject = true,
@@ -2982,7 +3004,7 @@ internal class PermissionTest : DatabaseTest() {
 
     permissions.expect(
         *activityIds.forOrg1(),
-        readActivity = true,
+        readPublishedActivity = true,
     )
 
     permissions.expect(
@@ -4121,6 +4143,7 @@ internal class PermissionTest : DatabaseTest() {
         createSubmission: Boolean = false,
         deleteProject: Boolean = false,
         listActivities: Boolean = false,
+        listPublishedActivities: Boolean = false,
         readDefaultVoters: Boolean = false,
         readInternalVariableWorkflowDetails: Boolean = false,
         readProject: Boolean = false,
@@ -4174,6 +4197,11 @@ internal class PermissionTest : DatabaseTest() {
             listActivities,
             user.canListActivities(idInDatabase),
             "Can list activities for project $projectId",
+        )
+        assertEquals(
+            listPublishedActivities,
+            user.canListPublishedActivities(idInDatabase),
+            "Can list published activities for project $projectId",
         )
         assertEquals(readDefaultVoters, user.canReadDefaultVoters(), "Can read default voters")
         assertEquals(
@@ -4542,6 +4570,7 @@ internal class PermissionTest : DatabaseTest() {
         deleteActivity: Boolean = false,
         manageActivity: Boolean = false,
         readActivity: Boolean = false,
+        readPublishedActivity: Boolean = false,
         updateActivity: Boolean = false,
     ) {
       activityIds
@@ -4563,6 +4592,11 @@ internal class PermissionTest : DatabaseTest() {
                 readActivity,
                 user.canReadActivity(idInDatabase),
                 "Can read activity $entityId",
+            )
+            assertEquals(
+                readPublishedActivity,
+                user.canReadPublishedActivity(idInDatabase),
+                "Can read published activity $entityId",
             )
             assertEquals(
                 updateActivity,


### PR DESCRIPTION
Add a new permission for listing published activities; funders should only be able
to see activities once they're published.