### PR TITLE
SW-7505 Methods to read published activity media files

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
@@ -3,14 +3,44 @@ package com.terraformation.backend.funder
 import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
+import com.terraformation.backend.file.mux.MuxService
+import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.funder.db.PublishedActivityStore
 import jakarta.inject.Named
 import org.springframework.context.event.EventListener
 
 @Named
 class PublishedActivityService(
+    private val muxService: MuxService,
     private val publishedActivityStore: PublishedActivityStore,
+    private val thumbnailService: ThumbnailService,
 ) {
+  fun readMedia(
+      activityId: ActivityId,
+      fileId: FileId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null,
+  ): SizedInputStream {
+    requirePermissions { readPublishedActivity(activityId) }
+
+    publishedActivityStore.ensureFileExists(activityId, fileId)
+
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
+  }
+
+  fun getMuxStreamInfo(activityId: ActivityId, fileId: FileId): MuxStreamModel {
+    requirePermissions { readPublishedActivity(activityId) }
+
+    publishedActivityStore.ensureFileExists(activityId, fileId)
+
+    return muxService.getMuxStream(fileId)
+  }
+
   /**
    * Deletes the published version of an activity, including its media files, when the original
    * activity is deleted.

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -3,11 +3,13 @@ package com.terraformation.backend.funder.db
 import com.terraformation.backend.accelerator.db.ActivityNotFoundException
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITIES
 import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDIA_FILES
 import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
@@ -35,6 +37,18 @@ class PublishedActivityStore(
       publishActivityDetails(activityId)
       publishMediaFileDeletions(activityId)
       publishCurrentMediaFiles(activityId)
+    }
+  }
+
+  fun ensureFileExists(activityId: ActivityId, fileId: FileId) {
+    val fileExists =
+        dslContext.fetchExists(
+            PUBLISHED_ACTIVITY_MEDIA_FILES,
+            PUBLISHED_ACTIVITY_MEDIA_FILES.ACTIVITY_ID.eq(activityId),
+            PUBLISHED_ACTIVITY_MEDIA_FILES.FILE_ID.eq(fileId),
+        )
+    if (!fileExists) {
+      throw FileNotFoundException(fileId)
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.funder
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.accelerator.db.ActivityNotFoundException
 import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.assertSetEquals
@@ -10,30 +11,46 @@ import com.terraformation.backend.customer.event.OrganizationDeletionStartedEven
 import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.FileNotFoundException
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.file.ThumbnailService
+import com.terraformation.backend.file.VideoStreamNotFoundException
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.file.mux.MuxService
+import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.funder.db.PublishedActivityStore
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.random.Random
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
 
 class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
+  private val muxService: MuxService = mockk()
   private val publishedActivityStore: PublishedActivityStore by lazy {
     PublishedActivityStore(clock, dslContext, eventPublisher)
   }
+  private val thumbnailService: ThumbnailService = mockk()
   private val service: PublishedActivityService by lazy {
-    PublishedActivityService(publishedActivityStore)
+    PublishedActivityService(muxService, publishedActivityStore, thumbnailService)
   }
 
   private lateinit var activityId: ActivityId
@@ -173,5 +190,127 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertSetEquals(expected, actual, "Remaining file IDs")
     }
+  }
+
+  @Nested
+  inner class GetMuxStreamInfo {
+    @Test
+    fun `returns stream info`() {
+      switchToFunderUser()
+      insertFundingEntityProject()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      val muxStream = MuxStreamModel(fileId, "playback", "token")
+      every { muxService.getMuxStream(fileId, any()) } returns muxStream
+
+      assertEquals(muxStream, service.getMuxStreamInfo(activityId, fileId))
+    }
+
+    @Test
+    fun `throws exception if file has no Mux stream`() {
+      switchToFunderUser()
+      insertFundingEntityProject()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      every { muxService.getMuxStream(fileId, any()) } throws VideoStreamNotFoundException(fileId)
+
+      assertThrows<VideoStreamNotFoundException> { service.getMuxStreamInfo(activityId, fileId) }
+    }
+
+    @Test
+    fun `throws exception if no permission to read activity`() {
+      switchToFunderUser()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<ActivityNotFoundException> { service.getMuxStreamInfo(activityId, fileId) }
+    }
+  }
+
+  @Nested
+  inner class ReadMedia {
+    @Test
+    fun `returns media data for correct activity`() {
+      switchToFunderUser()
+      insertFundingEntityProject()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      val testContent = Random.nextBytes(10)
+      every { thumbnailService.readFile(fileId) } answers
+          {
+            SizedInputStream(testContent.inputStream(), 10, MediaType.IMAGE_JPEG)
+          }
+
+      val inputStream = service.readMedia(activityId, fileId)
+      assertArrayEquals(testContent, inputStream.readAllBytes(), "File content")
+    }
+
+    @Test
+    fun `returns thumbnail data when dimensions specified`() {
+      switchToFunderUser()
+      insertFundingEntityProject()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      val thumbnailContent = Random.nextBytes(25)
+      val maxWidth = 100
+      val maxHeight = 100
+
+      every { thumbnailService.readFile(fileId, maxWidth, maxHeight) } answers
+          {
+            SizedInputStream(thumbnailContent.inputStream(), 25, MediaType.IMAGE_JPEG)
+          }
+
+      val inputStream = service.readMedia(activityId, fileId, maxWidth, maxHeight)
+      assertArrayEquals(thumbnailContent, inputStream.readAllBytes(), "Thumbnail content")
+    }
+
+    @Test
+    fun `throws exception if file not associated with activity`() {
+      switchToFunderUser()
+      insertFundingEntityProject()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      val otherActivityId = insertActivity()
+
+      assertThrows<FileNotFoundException> { service.readMedia(otherActivityId, fileId) }
+    }
+
+    @Test
+    fun `throws exception if no permission to read project`() {
+      switchToFunderUser()
+
+      val fileId = insertFile()
+      insertPublishedActivity()
+      insertPublishedActivityMediaFile()
+
+      assertThrows<ActivityNotFoundException> { service.readMedia(activityId, fileId) }
+    }
+  }
+
+  private fun switchToFunderUser() {
+    dslContext.update(USERS).set(USERS.USER_TYPE_ID, UserType.Funder).execute()
+    switchToUser(user.userId)
+    insertFundingEntity()
+    insertFundingEntityUser()
   }
 }


### PR DESCRIPTION
Implement the internal logic for reading published activities' media files.

This differs from the similar logic for activity media files in that it requires
a different permission (which means it'll be available to funder users) and
doesn't provide a way to read original raw files, since they might contain
sensitive information.