### PR TITLE
SW-7505 Funder API to read published activities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
@@ -35,14 +35,21 @@ class ThumbnailService(
    *
    * The returned image's dimensions will never be larger than the original file's.
    */
-  fun readFile(fileId: FileId, maxWidth: Int? = null, maxHeight: Int? = null): SizedInputStream {
+  fun readFile(
+      fileId: FileId,
+      maxWidth: Int? = null,
+      maxHeight: Int? = null,
+      forceThumbnail: Boolean = false,
+  ): SizedInputStream {
     val mimeType =
         dslContext.fetchValue(FILES.CONTENT_TYPE, FILES.ID.eq(fileId))
             ?: throw FileNotFoundException(fileId)
 
     // If the user is requesting a full-sized version of the image and the original's file type is
     // already acceptable, just give them the original file.
-    if (maxWidth == null && maxHeight == null && mimeType in acceptableMimeTypes) {
+    if (
+        maxWidth == null && maxHeight == null && mimeType in acceptableMimeTypes && !forceThumbnail
+    ) {
       return fileService.readFile(fileId)
     }
 

--- a/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/PublishedActivityService.kt
@@ -30,7 +30,7 @@ class PublishedActivityService(
 
     publishedActivityStore.ensureFileExists(activityId, fileId)
 
-    return thumbnailService.readFile(fileId, maxWidth, maxHeight)
+    return thumbnailService.readFile(fileId, maxWidth, maxHeight, forceThumbnail = true)
   }
 
   fun getMuxStreamInfo(activityId: ActivityId, fileId: FileId): MuxStreamModel {

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
@@ -1,0 +1,136 @@
+package com.terraformation.backend.funder.api
+
+import com.terraformation.backend.accelerator.api.GetActivityStreamResponsePayload
+import com.terraformation.backend.api.FunderEndpoint
+import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
+import com.terraformation.backend.api.PHOTO_OPERATION_DESCRIPTION
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityMediaType
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.funder.PublishedActivityService
+import com.terraformation.backend.funder.db.PublishedActivityStore
+import com.terraformation.backend.funder.model.PublishedActivityMediaModel
+import com.terraformation.backend.funder.model.PublishedActivityModel
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.ws.rs.QueryParam
+import java.time.LocalDate
+import org.locationtech.jts.geom.Point
+import org.springframework.core.io.InputStreamResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+
+@FunderEndpoint
+@RequestMapping("/api/v1/funder/activities")
+@RestController
+class FunderActivitiesController(
+    private val publishedActivityService: PublishedActivityService,
+    private val publishedActivityStore: PublishedActivityStore,
+) {
+  @GetMapping
+  @Operation(description = "Returns a list of published activities for a project.")
+  fun funderListActivities(
+      @RequestParam projectId: ProjectId,
+      @RequestParam(defaultValue = "true") includeMedia: Boolean = true,
+  ): FunderListActivitiesResponsePayload {
+    val activities = publishedActivityStore.fetchByProjectId(projectId, includeMedia)
+
+    return FunderListActivitiesResponsePayload(activities.map { FunderActivityPayload(it) })
+  }
+
+  @GetMapping("/{activityId}/media/{fileId}")
+  @Operation(
+      summary = "Gets a photo file for an activity.",
+      description = PHOTO_OPERATION_DESCRIPTION,
+  )
+  @ResponseBody
+  fun getActivityMedia(
+      @PathVariable activityId: ActivityId,
+      @PathVariable fileId: FileId,
+      @QueryParam("maxWidth")
+      @Schema(description = PHOTO_MAXWIDTH_DESCRIPTION)
+      maxWidth: Int? = null,
+      @QueryParam("maxHeight")
+      @Schema(description = PHOTO_MAXHEIGHT_DESCRIPTION)
+      maxHeight: Int? = null,
+  ): ResponseEntity<InputStreamResource> {
+    return publishedActivityService
+        .readMedia(activityId, fileId, maxWidth, maxHeight)
+        .toResponseEntity()
+  }
+
+  @GetMapping("/{activityId}/media/{fileId}/stream")
+  @Operation(
+      summary = "Gets streaming details for a video for an activity.",
+      description =
+          "This does not return the actual streaming data; it just returns the necessary " +
+              "information to stream video from Mux.",
+  )
+  @ResponseBody
+  fun getActivityMediaStream(
+      @PathVariable activityId: ActivityId,
+      @PathVariable fileId: FileId,
+  ): GetActivityStreamResponsePayload {
+    val stream = publishedActivityService.getMuxStreamInfo(activityId, fileId)
+
+    return GetActivityStreamResponsePayload(stream)
+  }
+}
+
+data class FunderActivityMediaFilePayload(
+    val caption: String?,
+    val capturedDate: LocalDate,
+    val fileId: FileId,
+    val geolocation: Point?,
+    val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
+    val type: ActivityMediaType,
+) {
+  constructor(
+      model: PublishedActivityMediaModel
+  ) : this(
+      caption = model.caption,
+      capturedDate = model.capturedDate,
+      fileId = model.fileId,
+      geolocation = model.geolocation,
+      isCoverPhoto = model.isCoverPhoto,
+      isHiddenOnMap = model.isHiddenOnMap,
+      listPosition = model.listPosition,
+      type = model.type,
+  )
+}
+
+data class FunderActivityPayload(
+    val date: LocalDate,
+    val description: String?,
+    val id: ActivityId,
+    val isHighlight: Boolean,
+    val media: List<FunderActivityMediaFilePayload>,
+    val type: ActivityType,
+) {
+  constructor(
+      model: PublishedActivityModel
+  ) : this(
+      date = model.activityDate,
+      description = model.description,
+      id = model.id,
+      isHighlight = model.isHighlight,
+      media = model.media.map { FunderActivityMediaFilePayload(it) },
+      type = model.activityType,
+  )
+}
+
+data class FunderListActivitiesResponsePayload(
+    val activities: List<FunderActivityPayload>,
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
@@ -1,0 +1,44 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityMediaType
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
+import java.time.LocalDate
+import org.jooq.Field
+import org.jooq.Record
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.Point
+
+data class PublishedActivityMediaModel(
+    val activityId: ActivityId,
+    val caption: String?,
+    val capturedDate: LocalDate,
+    val fileId: FileId,
+    val geolocation: Point?,
+    val isCoverPhoto: Boolean,
+    val isHiddenOnMap: Boolean,
+    val listPosition: Int,
+    val type: ActivityMediaType,
+) {
+  companion object {
+    fun of(
+        record: Record,
+        geolocationField: Field<Geometry?> = PUBLISHED_ACTIVITY_MEDIA_FILES.GEOLOCATION,
+    ): PublishedActivityMediaModel {
+      return with(PUBLISHED_ACTIVITY_MEDIA_FILES) {
+        PublishedActivityMediaModel(
+            activityId = record[ACTIVITY_ID]!!,
+            caption = record[CAPTION],
+            capturedDate = record[CAPTURED_DATE]!!,
+            fileId = record[FILE_ID]!!,
+            geolocation = record[geolocationField] as? Point,
+            isCoverPhoto = record[IS_COVER_PHOTO]!!,
+            isHiddenOnMap = record[IS_HIDDEN_ON_MAP]!!,
+            listPosition = record[LIST_POSITION]!!,
+            type = record[ACTIVITY_MEDIA_TYPE_ID]!!,
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityModel.kt
@@ -1,0 +1,44 @@
+package com.terraformation.backend.funder.model
+
+import com.terraformation.backend.db.accelerator.ActivityId
+import com.terraformation.backend.db.accelerator.ActivityType
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
+import java.time.Instant
+import java.time.LocalDate
+import org.jooq.Field
+import org.jooq.Record
+
+data class PublishedActivityModel(
+    val activityDate: LocalDate,
+    val activityType: ActivityType,
+    val description: String,
+    val id: ActivityId,
+    val isHighlight: Boolean,
+    val media: List<PublishedActivityMediaModel> = emptyList(),
+    val projectId: ProjectId,
+    val publishedBy: UserId? = null,
+    val publishedTime: Instant? = null,
+) {
+  companion object {
+    fun of(
+        record: Record,
+        mediaField: Field<List<PublishedActivityMediaModel>>?,
+    ): PublishedActivityModel {
+      return with(PUBLISHED_ACTIVITIES) {
+        PublishedActivityModel(
+            activityDate = record[ACTIVITY_DATE]!!,
+            activityType = record[ACTIVITY_TYPE_ID]!!,
+            description = record[DESCRIPTION]!!,
+            id = record[ACTIVITY_ID]!!,
+            isHighlight = record[IS_HIGHLIGHT]!!,
+            media = mediaField?.let { record[it] } ?: emptyList(),
+            projectId = record[PROJECT_ID]!!,
+            publishedBy = record[PUBLISHED_ACTIVITIES.PUBLISHED_BY],
+            publishedTime = record[PUBLISHED_ACTIVITIES.PUBLISHED_TIME],
+        )
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
@@ -97,6 +97,23 @@ class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
+    fun `returns thumbnail if forceThumbnail is true`() {
+      val photoData = Random.nextBytes(10)
+      val thumbnailData = Random.nextBytes(10)
+      val fileId = fileService.storeFile("category", photoData.inputStream(), metadata) {}
+
+      every { thumbnailStore.canGenerateThumbnails(metadata.contentType) } returns true
+      every { thumbnailStore.getThumbnailData(fileId, null, null) } answers
+          {
+            SizedInputStream(thumbnailData.inputStream(), 10, MediaType.IMAGE_JPEG)
+          }
+
+      val stream = service.readFile(fileId, forceThumbnail = true)
+
+      assertArrayEquals(thumbnailData, stream.readAllBytes())
+    }
+
+    @Test
     fun `returns photo thumbnail if photo dimensions are specified`() {
       val photoData = Random.nextBytes(10)
       val thumbnailData = Random.nextBytes(10)

--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -241,26 +241,7 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @Nested
   inner class ReadMedia {
     @Test
-    fun `returns media data for correct activity`() {
-      switchToFunderUser()
-      insertFundingEntityProject()
-
-      val fileId = insertFile()
-      insertPublishedActivity()
-      insertPublishedActivityMediaFile()
-
-      val testContent = Random.nextBytes(10)
-      every { thumbnailService.readFile(fileId) } answers
-          {
-            SizedInputStream(testContent.inputStream(), 10, MediaType.IMAGE_JPEG)
-          }
-
-      val inputStream = service.readMedia(activityId, fileId)
-      assertArrayEquals(testContent, inputStream.readAllBytes(), "File content")
-    }
-
-    @Test
-    fun `returns thumbnail data when dimensions specified`() {
+    fun `returns thumbnail data for specified dimensions`() {
       switchToFunderUser()
       insertFundingEntityProject()
 
@@ -272,10 +253,9 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val maxWidth = 100
       val maxHeight = 100
 
-      every { thumbnailService.readFile(fileId, maxWidth, maxHeight) } answers
-          {
-            SizedInputStream(thumbnailContent.inputStream(), 25, MediaType.IMAGE_JPEG)
-          }
+      every {
+        thumbnailService.readFile(fileId, maxWidth, maxHeight, forceThumbnail = true)
+      } answers { SizedInputStream(thumbnailContent.inputStream(), 25, MediaType.IMAGE_JPEG) }
 
       val inputStream = service.readMedia(activityId, fileId, maxWidth, maxHeight)
       assertArrayEquals(thumbnailContent, inputStream.readAllBytes(), "Thumbnail content")

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.db.ActivityNotFoundException
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityStatus
@@ -15,9 +16,13 @@ import com.terraformation.backend.db.accelerator.tables.references.ACTIVITY_MEDI
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.funder.tables.records.PublishedActivitiesRecord
 import com.terraformation.backend.db.funder.tables.records.PublishedActivityMediaFilesRecord
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
+import com.terraformation.backend.funder.model.PublishedActivityMediaModel
+import com.terraformation.backend.funder.model.PublishedActivityModel
 import com.terraformation.backend.point
 import java.time.Instant
 import java.time.LocalDate
@@ -56,6 +61,161 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
             verifiedBy = user.userId,
             verifiedTime = Instant.EPOCH,
         )
+  }
+
+  @Nested
+  inner class FetchByProjectId {
+    @Test
+    fun `lists published activities for funder user who has access to project`() {
+      dslContext.update(USERS).set(USERS.USER_TYPE_ID, UserType.Funder).execute()
+      switchToUser(user.userId)
+      insertFundingEntity()
+      insertFundingEntityUser()
+      insertFundingEntityProject()
+
+      val activityId1 = insertActivity(isHighlight = true, verifiedBy = user.userId)
+      insertPublishedActivity(
+          activityDate = LocalDate.of(2025, 1, 1),
+          activityType = ActivityType.SeedCollection,
+          description = "Activity 1",
+          isHighlight = true,
+      )
+      val activity1FileId1 = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivityMediaFile()
+      val activity1FileId2 = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivityMediaFile()
+      val activityId2 = insertActivity(verifiedBy = user.userId)
+      insertPublishedActivity(
+          activityDate = LocalDate.of(2025, 1, 2),
+          activityType = ActivityType.Monitoring,
+          description = "Activity 2",
+      )
+      val activity2FileId = insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivityMediaFile()
+
+      // Activities from other projects shouldn't be included.
+      insertProject()
+      insertFundingEntityProject()
+      insertActivity(verifiedBy = user.userId)
+      insertPublishedActivity()
+
+      assertEquals(
+          listOf(
+              PublishedActivityModel(
+                  activityDate = LocalDate.of(2025, 1, 1),
+                  activityType = ActivityType.SeedCollection,
+                  description = "Activity 1",
+                  id = activityId1,
+                  isHighlight = true,
+                  media =
+                      listOf(
+                          PublishedActivityMediaModel(
+                              activityId = activityId1,
+                              caption = null,
+                              capturedDate = LocalDate.EPOCH,
+                              fileId = activity1FileId1,
+                              geolocation = null,
+                              isCoverPhoto = false,
+                              isHiddenOnMap = false,
+                              listPosition = 1,
+                              type = ActivityMediaType.Photo,
+                          ),
+                          PublishedActivityMediaModel(
+                              activityId = activityId1,
+                              caption = null,
+                              capturedDate = LocalDate.EPOCH,
+                              fileId = activity1FileId2,
+                              geolocation = null,
+                              isCoverPhoto = false,
+                              isHiddenOnMap = false,
+                              listPosition = 2,
+                              type = ActivityMediaType.Photo,
+                          ),
+                      ),
+                  projectId = projectId,
+                  publishedBy = user.userId,
+                  publishedTime = Instant.EPOCH,
+              ),
+              PublishedActivityModel(
+                  activityDate = LocalDate.of(2025, 1, 2),
+                  activityType = ActivityType.Monitoring,
+                  description = "Activity 2",
+                  id = activityId2,
+                  isHighlight = false,
+                  media =
+                      listOf(
+                          PublishedActivityMediaModel(
+                              activityId = activityId2,
+                              caption = null,
+                              capturedDate = LocalDate.EPOCH,
+                              fileId = activity2FileId,
+                              geolocation = null,
+                              isCoverPhoto = false,
+                              isHiddenOnMap = false,
+                              listPosition = 1,
+                              type = ActivityMediaType.Photo,
+                          ),
+                      ),
+                  projectId = projectId,
+                  publishedBy = user.userId,
+                  publishedTime = Instant.EPOCH,
+              ),
+          ),
+          store.fetchByProjectId(projectId, includeMedia = true),
+      )
+    }
+
+    @Test
+    fun `does not include media if not requested`() {
+      dslContext.update(USERS).set(USERS.USER_TYPE_ID, UserType.Funder).execute()
+      switchToUser(user.userId)
+      insertFundingEntity()
+      insertFundingEntityUser()
+      insertFundingEntityProject()
+
+      val activityId1 = insertActivity(isHighlight = true, verifiedBy = user.userId)
+      insertPublishedActivity(
+          activityDate = LocalDate.of(2025, 1, 1),
+          activityType = ActivityType.SeedCollection,
+          description = "Activity 1",
+          isHighlight = true,
+      )
+      insertFile()
+      insertActivityMediaFile()
+      insertPublishedActivityMediaFile()
+
+      assertEquals(
+          listOf(
+              PublishedActivityModel(
+                  activityDate = LocalDate.of(2025, 1, 1),
+                  activityType = ActivityType.SeedCollection,
+                  description = "Activity 1",
+                  id = activityId1,
+                  isHighlight = true,
+                  media = emptyList(),
+                  projectId = projectId,
+                  publishedBy = user.userId,
+                  publishedTime = Instant.EPOCH,
+              ),
+          ),
+          store.fetchByProjectId(projectId, includeMedia = false),
+      )
+    }
+
+    @Test
+    fun `throws exception for funder user who does not have access to project`() {
+      dslContext.update(USERS).set(USERS.USER_TYPE_ID, UserType.Funder).execute()
+      switchToUser(user.userId)
+      insertFundingEntity()
+      insertFundingEntityUser()
+
+      assertThrows<ProjectNotFoundException> {
+        store.fetchByProjectId(projectId, includeMedia = false)
+      }
+    }
   }
 
   @Nested


### PR DESCRIPTION
Add some API endpoints for reading published activities for use in the funder
portal.

`GET /api/v1/funder/activities?projectId={id}` will list all the published
activities for the project if the user has permission to see it.  This omits
some details such as user IDs that aren't shown in the read-only activity view
in the funder portal.

`GET /api/v1/funder/activities/{activityId}/media/{fileId}` will return a JPEG
version of a media file, optionally with a maximum height and width. Unlike the
non-funder version of this endpoint, there is no way to retrieve an original
file, since it might contain sensitive information.

`GET /api/v1/funder/activities/{activityId}/media/{fileId}/stream` will return
Mux stream details for a video file.