### PR TITLE
SW-7416 Add temp plots to observations results for zones

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -492,8 +492,8 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
    *     9. Total live in permanent plots (non-nullable)
    *     10. Survival Rate (nullable)
    *     11. T0 Density (nullable)
-   *     12. Latest Live across multiple observations if needed (non-nullable) This one is only used
-   *         by zones and sites.
+   *     12. Latest Live from latest observation (or across multiple observations if not all
+   *         subzones are in the latest observation) (non-nullable)
    */
   private fun speciesMultiset(
       query:

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -55,6 +55,12 @@ data class ObservationSpeciesResultsModel(
      */
     val cumulativeDead: Int,
     /**
+     * Number of live plants observed in monitoring plots in the latest observations, including past
+     * observations if latest observation doesn't include all sub-areas. This only applies to Zones
+     * and Sites since subzones are fully observed in a single observation.
+     */
+    val latestLive: Int,
+    /**
      * Percentage of plants in permanent monitoring plots that are dead. If there are no permanent
      * monitoring plots (or if this is a plot-level result for a temporary monitoring plot) this
      * will be null. The mortality rate is calculated using [cumulativeDead] and [permanentLive].
@@ -533,7 +539,7 @@ fun List<ObservationSpeciesResultsModel>.calculateSurvivalRate(
 ): Int? {
   val sumDensity = this.mapNotNull { it.t0Density }.sumOf { it }
   val numKnownLive =
-      if (includeTempPlots) this.sumOf { it.totalLive } else this.sumOf { it.permanentLive }
+      if (includeTempPlots) this.sumOf { it.latestLive } else this.sumOf { it.permanentLive }
 
   val numerator = (numKnownLive * 100.0).toBigDecimal()
   val denominator = sumDensity.times(HECTARES_PER_PLOT.toBigDecimal())
@@ -587,6 +593,7 @@ fun List<ObservationSpeciesResultsModel>.unionSpecies(
         ObservationSpeciesResultsModel(
             certainty = key.first,
             cumulativeDead = cumulativeDead,
+            latestLive = groupedSpecies.sumOf { it.latestLive },
             mortalityRate = mortalityRate,
             permanentLive = permanentLive,
             speciesId = key.second,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -55,9 +55,9 @@ data class ObservationSpeciesResultsModel(
      */
     val cumulativeDead: Int,
     /**
-     * Number of live plants observed in monitoring plots in the latest observations, including past
-     * observations if latest observation doesn't include all sub-areas. This only applies to Zones
-     * and Sites since subzones are fully observed in a single observation.
+     * Number of live plants observed in monitoring plots in the latest observations. If this is for
+     * a zone or site, it may also include past observations (excluding ad-hoc) if the latest
+     * observation doesn't include all subareas.
      */
     val latestLive: Int,
     /**

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -1138,6 +1138,17 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
             }
             .flatten()
 
+    with(OBSERVATION_REQUESTED_SUBZONES) {
+      dslContext
+          .insertInto(OBSERVATION_REQUESTED_SUBZONES, OBSERVATION_ID, PLANTING_SUBZONE_ID)
+          .select(
+              DSL.selectDistinct(DSL.value(observationId), MONITORING_PLOTS.PLANTING_SUBZONE_ID)
+                  .from(MONITORING_PLOTS)
+                  .where(MONITORING_PLOTS.PLOT_NUMBER.`in`(observedPlotNames.map { it.toLong() }))
+          )
+          .execute()
+    }
+
     // This would normally happen in ObservationService.startObservation after plot selection;
     // do it explicitly since we're specifying our own plots in the test data.
     observationStore.populateCumulativeDead(observationId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -367,7 +367,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         listOf(
             mapOf(tempPlot1 to plot1SurvivalRates),
             mapOf(subzone1 to plot1SurvivalRates),
-            mapOf(zoneId to plot1SurvivalRates.filterKeys { it != null }),
+            mapOf(zoneId to plot1SurvivalRates),
             mapOf(plantingSiteId to plot1SurvivalRates.filterKeys { it != null }),
         ),
         "Temp plot 1 survival rates",
@@ -405,7 +405,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             mapOf(
                 subzone2 to plot2SurvivalRates,
             ),
-            mapOf(zoneId to survivalRates1And2.filterKeys { it != null }),
+            mapOf(zoneId to survivalRates1And2),
             mapOf(plantingSiteId to survivalRates1And2.filterKeys { it != null }),
         ),
         "Plots 1 and 2 survival rates",

--- a/src/test/resources/tracking/observation/SurvivalRateSiteTempData/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteTempData/ZoneRates.csv
@@ -1,4 +1,4 @@
 Zone Name,Zone Survival Rate,Species 0 Survival Rate,Species 1 Survival Rate,Species 2 Survival Rate
-Zone1,106%,213%,68%,233%
-Zone2,156%,224%,74%,79%
-Zone3,162%,209%,117%,108%
+Zone1,143%,213%,68%,233%
+Zone2,110%,224%,74%,79%
+Zone3,135%,209%,117%,108%

--- a/src/test/resources/tracking/observation/SurvivalRateT0ZoneDensityChange/AfterUpdate/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0ZoneDensityChange/AfterUpdate/ZoneRates.csv
@@ -1,3 +1,3 @@
 Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Zone1,,98%,37%
-Zone2,100%,68%,63%
+Zone1,49%,98%,37%
+Zone2,66%,68%,63%

--- a/src/test/resources/tracking/observation/SurvivalRateT0ZoneDensityChange/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0ZoneDensityChange/ZoneRates.csv
@@ -1,3 +1,3 @@
 Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Zone1,,49%,37%
-Zone2,100%,68%,63%
+Zone1,41%,49%,37%
+Zone2,66%,68%,63%


### PR DESCRIPTION
Add temp plots to survival rate calculations in observation results for zones.

Sites are handled in https://github.com/terraware/terraware-server/pull/3504 and plots/subzones are handled in https://github.com/terraware/terraware-server/pull/3497; this was broken up to keep the changes easier to review.