### PR TITLE
Persistent events for org and project operations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationCreatedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+data class OrganizationCreatedEventV1(val organizationId: OrganizationId, val name: String) :
+    PersistentEvent
+
+typealias OrganizationCreatedEvent = OrganizationCreatedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+data class OrganizationDeletedEventV1(val organizationId: OrganizationId) : PersistentEvent
+
+typealias OrganizationDeletedEvent = OrganizationDeletedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+data class OrganizationRenamedEventV1(val organizationId: OrganizationId, val name: String) :
+    PersistentEvent
+
+typealias OrganizationRenamedEvent = OrganizationRenamedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
@@ -4,11 +4,10 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.PersistentEvent
 
-/** Published when a project's name is changed. */
-data class ProjectRenamedEventV1(
+data class ProjectCreatedEventV1(
     val name: String,
     val organizationId: OrganizationId,
     val projectId: ProjectId,
 ) : PersistentEvent
 
-typealias ProjectRenamedEvent = ProjectRenamedEventV1
+typealias ProjectCreatedEvent = ProjectCreatedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletedEvent.kt
@@ -4,11 +4,9 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.PersistentEvent
 
-/** Published when a project's name is changed. */
-data class ProjectRenamedEventV1(
-    val name: String,
+data class ProjectDeletedEventV1(
     val organizationId: OrganizationId,
     val projectId: ProjectId,
 ) : PersistentEvent
 
-typealias ProjectRenamedEvent = ProjectRenamedEventV1
+typealias ProjectDeletedEvent = ProjectDeletedEventV1

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -1,9 +1,17 @@
 package com.terraformation.backend.eventlog.db
 
+import com.terraformation.backend.eventlog.UpgradableEvent
 import jakarta.inject.Named
 import org.jooq.DSLContext
 
+/**
+ * Support functions for upgrading events. If a new version of an event adds data that wasn't
+ * included in the previous version, [UpgradableEvent.toNextVersion] needs to be able to pull the
+ * data from the database. An instance of this class is passed to that method to allow it to do so.
+ */
 @Named
 class EventUpgradeUtils(
     val dslContext: DSLContext,
-)
+) {
+  // Add any accessor functions needed by UpgradableEvent.toNextVersion implementations.
+}

--- a/src/main/kotlin/com/terraformation/backend/report/SeedFundReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/SeedFundReportService.kt
@@ -143,7 +143,7 @@ class SeedFundReportService(
 
   @EventListener
   fun on(event: ProjectRenamedEvent) {
-    seedFundReportStore.updateProjectName(event.projectId, event.newName)
+    seedFundReportStore.updateProjectName(event.projectId, event.name)
   }
 
   @EventListener

--- a/src/main/resources/db/migration/0400/V418__OrgProjectHistoricalEvents.sql
+++ b/src/main/resources/db/migration/0400/V418__OrgProjectHistoricalEvents.sql
@@ -1,0 +1,20 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    created_by,
+    created_time,
+    'com.terraformation.backend.customer.event.OrganizationCreatedEventV1',
+    ('{"organizationId":' || id ||
+        ', "name": ' || json_scalar(name) ||
+        ', "_historical": true}')::jsonb
+FROM organizations;
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    created_by,
+    created_time,
+    'com.terraformation.backend.customer.event.ProjectCreatedEventV1',
+    ('{"organizationId":' || organization_id ||
+     ', "projectId": ' || id ||
+     ', "name": ' || json_scalar(name) ||
+     ', "_historical": true}')::jsonb
+FROM projects;

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.accelerator.event.ParticipantProjectAddedEvent
 import com.terraformation.backend.accelerator.event.ParticipantProjectRemovedEvent
+import com.terraformation.backend.customer.event.ProjectCreatedEvent
+import com.terraformation.backend.customer.event.ProjectDeletedEvent
 import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserAddedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserRemovedEvent
@@ -94,6 +96,14 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val actual = projectsDao.fetchOneById(newProjectId)
 
       assertEquals(expected, actual)
+
+      eventPublisher.assertEventPublished(
+          ProjectCreatedEvent(
+              name = "Project name",
+              organizationId = organizationId,
+              projectId = newProjectId,
+          )
+      )
     }
 
     @Test
@@ -277,7 +287,13 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertEquals(expected, actual)
 
-      eventPublisher.assertEventPublished(ProjectRenamedEvent(projectId, before.name!!, "New name"))
+      eventPublisher.assertEventPublished(
+          ProjectRenamedEvent(
+              name = "New name",
+              organizationId = organizationId,
+              projectId = projectId,
+          )
+      )
     }
 
     @Test
@@ -654,12 +670,13 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   @Nested
   inner class Delete {
     @Test
-    fun `publishes ProjectDeletionStartedEvent`() {
+    fun `publishes events`() {
       val projectId = insertProject()
 
       store.delete(projectId)
 
       eventPublisher.assertEventPublished(ProjectDeletionStartedEvent(projectId))
+      eventPublisher.assertEventPublished(ProjectDeletedEvent(organizationId, projectId))
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -1010,7 +1010,7 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
           )
       val orgReportId = insertSeedFundReport(status = SeedFundReportStatus.New, year = 1994)
 
-      service.on(ProjectRenamedEvent(projectId, "Old Name", "New Name"))
+      service.on(ProjectRenamedEvent("New Name", organizationId, projectId))
 
       assertEquals(
           mapOf(

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -11,6 +11,19 @@
 # deserialization.
 #
 
+com.terraformation.backend.customer.event.OrganizationCreatedEventV1/name: String
+com.terraformation.backend.customer.event.OrganizationCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.OrganizationDeletedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.OrganizationRenamedEventV1/name: String
+com.terraformation.backend.customer.event.OrganizationRenamedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.ProjectCreatedEventV1/name: String
+com.terraformation.backend.customer.event.ProjectCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.ProjectCreatedEventV1/projectId: ProjectId
+com.terraformation.backend.customer.event.ProjectDeletedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.ProjectDeletedEventV1/projectId: ProjectId
+com.terraformation.backend.customer.event.ProjectRenamedEventV1/name: String
+com.terraformation.backend.customer.event.ProjectRenamedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.ProjectRenamedEventV1/projectId: ProjectId
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestCircularEventV3/organizationId: OrganizationId
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestOrganizationCreatedEventV1/name: String
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestOrganizationCreatedEventV1/organizationId: OrganizationId


### PR DESCRIPTION
Add an initial simple set of persistent events (create, delete, rename) for
organizations and projects. Historical creation events for existing organizations
and projects are inserted by a database migration.