### PR TITLE
SW-7560 Log persistent events to console/Datadog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
   implementation("org.jooq:jooq:$jooqVersion")
   implementation("org.locationtech.jts:jts-core:$jtsVersion")
   implementation("org.locationtech.jts.io:jts-io-common:$jtsVersion")
+  implementation("net.logstash.logback:logstash-logback-encoder:8.1")
   implementation(kotlin("reflect"))
   implementation("org.postgresql:postgresql:$postgresJdbcVersion")
   implementation(platform("software.amazon.awssdk:bom:$awsSdkVersion"))
@@ -148,7 +149,6 @@ dependencies {
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springDocVersion")
 
-  runtimeOnly("net.logstash.logback:logstash-logback-encoder:8.1")
   runtimeOnly("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
   runtimeOnly("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
 

--- a/src/main/kotlin/com/terraformation/backend/eventlog/PersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/PersistentEvent.kt
@@ -1,4 +1,10 @@
 package com.terraformation.backend.eventlog
 
-/** Marker interface implemented by events that should be saved to the event log when published. */
-interface PersistentEvent
+/** Implemented by events that should be saved to the event log when published. */
+interface PersistentEvent {
+  /**
+   * Returns a human-readable version of this event suitable for logging to the console or Datadog.
+   * If this returns null, a generic message will be logged.
+   */
+  fun toMessage(): String? = null
+}

--- a/src/main/kotlin/com/terraformation/backend/log/LogstashDecorator.kt
+++ b/src/main/kotlin/com/terraformation/backend/log/LogstashDecorator.kt
@@ -1,0 +1,35 @@
+package com.terraformation.backend.log
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule
+import com.terraformation.backend.db.GeometryModule
+import net.logstash.logback.decorate.JsonFactoryDecorator
+
+/**
+ * Configures the Logstash encoder to serialize objects to JSON the same way the application does.
+ * This allows objects in the key/value list of a log message to be inspected in Datadog.
+ */
+class LogstashDecorator : JsonFactoryDecorator {
+  override fun decorate(factory: JsonFactory): JsonFactory {
+    val objectMapper = factory.codec as ObjectMapper
+
+    // Configure the ObjectMapper the same as the one that's used by the application, including
+    // default Spring Boot modules and serialization features.
+
+    objectMapper.registerModule(GeometryModule())
+    objectMapper.registerModule(JavaTimeModule())
+    objectMapper.registerModule(Jdk8Module())
+    objectMapper.registerModule(KotlinModule.Builder().build())
+    objectMapper.registerModule(ParameterNamesModule())
+
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    objectMapper.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+
+    return factory
+  }
+}

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -54,4 +54,4 @@ logging:
       %clr([%15.15t]){faint}
       %clr(%-40.40logger{39}){cyan}
       %clr(:){faint}
-      %m%clr(%replace( %X){'^ $',''}){cyan}%n%wEx
+      %m%clr(%replace( %X){'^ $',''}%replace( %kvp){'^ $',''}){cyan}%n%wEx

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,6 +24,7 @@ this file.
   <springProfile name="logstash">
     <appender name="LOGSTASH" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <jsonFactoryDecorator class="com.terraformation.backend.log.LogstashDecorator"/>
         <customFields>
           {"log_type": "application"}
         </customFields>


### PR DESCRIPTION
When a persistent event is published, in addition to storing it in the database,
log a message about it to the console (in dev environments) or Datadog (in staging
and production). The log message may be customized on a per-event basis.

The Datadog log message includes the event payload in JSON form, which will allow
ad-hoc searches on specific event fields.