### PR TITLE
SW-7562 Reject invalid requests for file access

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/FilesController.kt
@@ -4,6 +4,8 @@ import com.terraformation.backend.api.InternalEndpoint
 import com.terraformation.backend.api.toResponseEntity
 import com.terraformation.backend.file.FileService
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
 import org.springframework.core.io.InputStreamResource
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -26,7 +28,10 @@ class FilesController(
           "This endpoint does not require authentication; it's intended to offer temporary file " +
               "access for third-party services such as video transcoding.",
   )
-  fun getFileForToken(@PathVariable token: String): ResponseEntity<InputStreamResource> {
+  @Valid
+  fun getFileForToken(
+      @PathVariable @Size(min = 8) token: String
+  ): ResponseEntity<InputStreamResource> {
     return fileService.readFileForToken(token).toResponseEntity()
   }
 }


### PR DESCRIPTION
There's a bot that sometimes tries fetching all the endpoints in our OpenAPI
schema. Most of them require authentication, so the requests fail. But the file
access endpoint, since it's used by Mux to fetch files for processing, needs to
be public. When the bot hits that endpoint, we try to look up the literal string
`{token}` as a token, and of course there's no such token, so we log an error
message. The error is useless noise.

Add a minimum size constraint to the token. Actual tokens are UUIDs and will
always be above the minimum size, but the string `{token}` is below the minimum.
This causes the bogus requests to be rejected with HTTP 400 by Spring, and no
error message is logged.