### PR TITLE
Remove "jsonlog" Spring profile

### DIFF
--- a/src/main/resources/logback-access-spring.xml
+++ b/src/main/resources/logback-access-spring.xml
@@ -46,60 +46,7 @@
     <appender-ref ref="LOGSTASH"/>
   </springProfile>
 
-  <springProfile name="jsonlog">
-    <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <encoder class="net.logstash.logback.encoder.AccessEventCompositeJsonEncoder">
-        <providers>
-          <timestamp/>
-          <version/>
-
-          <!-- Standard access log fields -->
-          <contentLength/>
-          <elapsedTime/>
-          <method/>
-          <protocol/>
-          <remoteHost/>
-          <remoteUser/>
-          <requestedUri/>
-          <requestedUrl/>
-          <statusCode/>
-
-          <requestHeaders>
-            <fieldName>headers</fieldName>
-            <lowerCaseHeaderNames>true</lowerCaseHeaderNames>
-            <filter>
-              <include>Referer</include>
-              <include>User-Agent</include>
-            </filter>
-          </requestHeaders>
-
-          <pattern>
-            <omitEmptyFields>true</omitEmptyFields>
-            <pattern>
-              {
-                "authId": "#nullNA{%u}",
-                "email": "#nullNA{%reqAttribute{terrawareEmail}}",
-                "message": "%h - %u [%t] \"%r\" %s %b \"%i{Referer}\" \"%i{User-Agent}\"",
-                "requestId": "#nullNA{%reqAttribute{terrawareRequestId}}"
-              }
-            </pattern>
-          </pattern>
-        </providers>
-      </encoder>
-
-      <file>${ACCESS_LOG_FILE}</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${ACCESS_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
-        <cleanHistoryOnStart>${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
-        <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}</maxFileSize>
-        <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}</totalSizeCap>
-        <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}</maxHistory>
-      </rollingPolicy>
-    </appender>
-    <appender-ref ref="JSONFILE"/>
-  </springProfile>
-
-  <springProfile name="!jsonlog &amp; !logstash">
+  <springProfile name="!logstash">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <encoder>
         <pattern>combined</pattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,14 +1,10 @@
 <!--
-Logging configuration. This uses Spring profiles to control the logging behavior. There
-are two profiles you can use:
+Logging configuration. This uses Spring profiles to control the logging behavior. There is
+currently one profile you can use:
 
 logstash - Formats logs as JSON and writes them to stdout. This is suitable when running in
            ECS or other managed container environments. Application and access logs will be
            distinguished by the "log_type" field.
-
-jsonlog - Formats logs as JSON and writes them to rolling logfiles, as defined by the LOG_FILE
-          and ACCESS_LOG_FILE environment variables. This is suitable when running on a host
-          where something like the Datadog agent can consume multiple logfiles.
 
 The default behavior, if neither of those profiles is active, is to format log messages as
 human-readable text (for application log messages) and as Apache-style access log lines (for
@@ -36,26 +32,8 @@ this file.
     </root>
   </springProfile>
 
-  <springProfile name="jsonlog">
-    <appender name="JSONFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-      <file>${LOG_FILE}</file>
-      <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-        <fileNamePattern>${LOGBACK_ROLLINGPOLICY_FILE_NAME_PATTERN:-${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz}</fileNamePattern>
-        <cleanHistoryOnStart>${LOGBACK_ROLLINGPOLICY_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
-        <maxFileSize>${LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE:-10MB}</maxFileSize>
-        <totalSizeCap>${LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP:-0}</totalSizeCap>
-        <maxHistory>${LOGBACK_ROLLINGPOLICY_MAX_HISTORY:-7}</maxHistory>
-      </rollingPolicy>
-    </appender>
-
-    <root level="INFO">
-      <appender-ref ref="JSONFILE"/>
-    </root>
-  </springProfile>
-
   <!-- If we aren't logging JSON, log text to the console, but don't do both. -->
-  <springProfile name="!jsonlog &amp; !logstash">
+  <springProfile name="!logstash">
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
When we were running terraware-server on EC2 instances with the Datadog agent, we
needed it to write its JSON-formatted logs to files that the agent would monitor.
But with our ECS deployment, we no longer need that, and it's not useful in dev
environments either. Remove support for it from the logging configuration.