### PR TITLE
SW-7559 Search event log in admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminEventLogController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminEventLogController.kt
@@ -1,0 +1,211 @@
+package com.terraformation.backend.admin
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.customer.db.UserStore
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.eventlog.db.EventLogStore
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AssignableTypeFilter
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+class AdminEventLogController(
+    private val eventLogStore: EventLogStore,
+    private val objectMapper: ObjectMapper,
+    private val userStore: UserStore,
+) {
+  private val dateTimeFormatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC)
+
+  @GetMapping("/eventLog")
+  fun getEventLogHome(
+      @RequestParam selectedClasses: List<String>?,
+      @RequestParam idField: String?,
+      @RequestParam idValue: Long?,
+      model: Model,
+  ): String {
+    model.addAttribute("allEventClasses", allEventClassesJson)
+
+    if (selectedClasses?.isNotEmpty() == true && idField != null && idValue != null) {
+      addSearchResults(idField, idValue, selectedClasses, model)
+    }
+
+    return "/admin/eventLog"
+  }
+
+  private fun addSearchResults(
+      idField: String,
+      idValue: Long,
+      selectedClasses: List<String>,
+      model: Model,
+  ) {
+    model.addAttribute("idField", idField)
+    model.addAttribute("idValue", idValue)
+    model.addAttribute("selectedClasses", selectedClasses)
+
+    val selectedKClasses = selectedClasses.map { eventKClassesByQualifiedName[it]!! }
+    val events =
+        eventLogStore.fetchByIntegerField(
+            idField,
+            idValue,
+            selectedKClasses,
+        )
+
+    val usersById =
+        userStore.fetchManyById(events.map { it.createdBy }.distinct()).associateBy { it.userId }
+
+    val propertyColumns = listAllProperties(selectedKClasses)
+
+    val allColumns =
+        listOf(
+            TableColumn("ID"),
+            TableColumn("Time (UTC)"),
+            TableColumn("User"),
+            TableColumn("Class"),
+        ) + propertyColumns
+
+    model.addAttribute("tableColumns", allColumns)
+
+    val tableRows =
+        events.map { eventLogEntry ->
+          val user = usersById[eventLogEntry.createdBy]!!
+          val userTooltip = "${user.fullName}\n${user.email}"
+          val event = eventLogEntry.event
+          val eventClass = event.javaClass
+
+          val fixedCells =
+              listOf(
+                  TableCell("${eventLogEntry.id}"),
+                  TableCell(dateTimeFormatter.format(eventLogEntry.createdTime)),
+                  TableCell("${eventLogEntry.createdBy}", userTooltip),
+                  TableCell(eventClass.simpleName.substringBeforeLast('V'), eventClass.name),
+              )
+
+          val propertyCells =
+              propertyColumns.map { column -> TableCell(getPropertyValue(event, column.name)) }
+
+          fixedCells + propertyCells
+        }
+
+    model.addAttribute("tableRows", tableRows)
+  }
+
+  /**
+   * Metadata about the current versions of all the event classes in the code base. This is all the
+   * classes that implement [PersistentEvent] but don't implement [UpgradableEvent].
+   */
+  private val allEventClasses: List<EventClassInfo> by lazy {
+    val scanner = ClassPathScanningCandidateComponentProvider(false)
+    scanner.addExcludeFilter(AssignableTypeFilter(UpgradableEvent::class.java))
+    scanner.addIncludeFilter(AssignableTypeFilter(PersistentEvent::class.java))
+
+    scanner
+        .findCandidateComponents("com.terraformation.backend")
+        .asSequence()
+        .mapNotNull { it.beanClassName }
+        .map {
+          @Suppress("UNCHECKED_CAST")
+          Class.forName(it) as Class<out PersistentEvent>
+        }
+        .map { it.kotlin }
+        .map { kClass ->
+          val idProperties = kClass.memberProperties.map { it.name }.filter { it.endsWith("Id") }
+          val displayName = kClass.simpleName!!.substringBeforeLast('V')
+          EventClassInfo(
+              displayName = displayName,
+              idProperties = idProperties,
+              kClass = kClass,
+              qualifiedName = kClass.qualifiedName!!,
+          )
+        }
+        .sortedBy { it.displayName }
+        .toList()
+  }
+
+  /**
+   * Metadata about event classes in JSON form, suitable for including in a Freemarker template as
+   * inline JavaScript. This is [allEventClasses] minus the [KClass] references.
+   */
+  private val allEventClassesJson: JsonNode by lazy { objectMapper.valueToTree(allEventClasses) }
+
+  private val eventKClassesByQualifiedName: Map<String, KClass<out PersistentEvent>> by lazy {
+    allEventClasses.associate { it.qualifiedName to it.kClass }
+  }
+
+  /**
+   * Returns a list of table columns for all the properties of a collection of event classes. The
+   * list is sorted by the number of classes that have the property in question; properties that are
+   * common to all the events (e.g., `organizationId` if the events are all organization-related)
+   * come first, whereas properties that are unique to a single event class come last. Properties
+   * that occur in the same number of classes are sorted alphabetically.
+   *
+   * The idea is that we want as many property values as possible to show up toward the left side of
+   * the table where the user won't have to scroll to see them. The long tail of one-off properties
+   * can extend off the right side of the screen.
+   */
+  private fun listAllProperties(
+      selectedClasses: List<KClass<out PersistentEvent>>
+  ): List<TableColumn> {
+    val propertyCountMap = mutableMapOf<String, Int>()
+
+    for (eventClass in selectedClasses) {
+      val properties = eventClass.memberProperties
+      for (property in properties) {
+        propertyCountMap[property.name] = propertyCountMap.getOrDefault(property.name, 0) + 1
+      }
+    }
+
+    return propertyCountMap.entries
+        .map { (name, count) -> TableColumn(name, eventClassCount = count) }
+        .sortedWith(compareByDescending<TableColumn> { it.eventClassCount }.thenBy { it.name })
+  }
+
+  /**
+   * Returns the value of a property on an event as a string, or an empty string if the property
+   * doesn't exist on the event or is null.
+   */
+  private fun getPropertyValue(event: PersistentEvent, propertyName: String): String {
+    return try {
+      event::class
+          .memberProperties
+          .find { it.name == propertyName }
+          ?.getter
+          ?.call(event)
+          ?.toString() ?: ""
+    } catch (_: Exception) {
+      ""
+    }
+  }
+
+  data class TableColumn(
+      val name: String,
+      val eventClassCount: Int = 0,
+  )
+
+  data class TableCell(
+      val value: String,
+      val tooltip: String? = null,
+  )
+
+  data class EventClassInfo(
+      val displayName: String,
+      val idProperties: List<String>,
+      @get:JsonIgnore val kClass: KClass<out PersistentEvent>,
+      val qualifiedName: String,
+  )
+}

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventLogStore.kt
@@ -23,6 +23,7 @@ import org.jooq.Field
 import org.jooq.JSONB
 import org.jooq.Record
 import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 
 @Named
 class EventLogStore(
@@ -68,6 +69,14 @@ class EventLogStore(
       projectId: ProjectId
   ): List<EventLogEntry<T>> {
     return fetchByProjectId(projectId, listOf(T::class))
+  }
+
+  fun <T : PersistentEvent> fetchByIntegerField(
+      fieldName: String,
+      fieldValue: Long,
+      eventClasses: Collection<KClass<out T>>,
+  ): List<EventLogEntry<T>> {
+    return fetchByIdField(fieldValue, fieldName, SQLDataType.BIGINT, eventClasses)
   }
 
   private fun <I : Any, T : PersistentEvent> fetchByIdField(

--- a/src/main/resources/templates/admin/eventLog.html
+++ b/src/main/resources/templates/admin/eventLog.html
@@ -1,0 +1,229 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}">
+    <style th:fragment="additionalStyle">
+        .results, .results td, .results th {
+            border: 1px black solid;
+            border-collapse: collapse;
+        }
+
+        .results td, .results th {
+            padding: 3px;
+        }
+    </style>
+
+    <script th:fragment="additionalScript" th:inline="javascript">
+        /*<![CDATA[*/
+        const allEventClasses = /*[[${allEventClasses}]]*/ [];
+        const selectedIdFieldFromServer = /*[[${idField}]]*/ '';
+        const selectedClassesFromServer = /*[[${selectedClasses}]]*/ [];
+        const tableColumns = /*[[${tableColumns}]]*/ [];
+
+        const eventClassMap = allEventClasses.reduce((map, eventClass) => {
+            map[eventClass.qualifiedName] = eventClass;
+            return map;
+        }, {});
+
+        function populateEventClassesSelect() {
+            const selectedClassesFromServerMap =
+                    (selectedClassesFromServer || []).reduce((map, eventClass) => {
+                        map[eventClass] = true;
+                        return map;
+                    }, {});
+
+            const select = document.getElementById('selectedClasses');
+            select.innerHTML = '';
+
+            allEventClasses.forEach(eventClass => {
+                const option = document.createElement('option');
+                option.selected = selectedClassesFromServerMap[eventClass.qualifiedName] === true;
+                option.text = eventClass.displayName;
+                option.title = eventClass.qualifiedName;
+                option.value = eventClass.qualifiedName;
+                select.appendChild(option);
+            });
+        }
+
+        function updateIdFieldOptions() {
+            const selectedClassesSelect = document.getElementById('selectedClasses');
+            const idFieldSelect = document.getElementById('idField');
+            const selectedOptions = Array.from(selectedClassesSelect.selectedOptions);
+
+            if (selectedOptions.length === 0) {
+                idFieldSelect.innerHTML = '<option value="" disabled>Select event classes first</option>';
+                idFieldSelect.disabled = true;
+                enableSearchIfPropertySelected();
+                return;
+            }
+
+            const propertiesOfSelectedClasses =
+                    selectedOptions
+                            .map(option => {
+                                const eventClass = eventClassMap[option.value];
+                                return eventClass ? eventClass.idProperties : [];
+                            });
+
+            // Find properties that all selected classes have in common, if any.
+            let commonProperties = propertiesOfSelectedClasses[0] || [];
+            for (let i = 1; i < propertiesOfSelectedClasses.length; i++) {
+                commonProperties = commonProperties.filter(prop =>
+                        propertiesOfSelectedClasses[i].includes(prop)
+                );
+            }
+
+            if (commonProperties.length === 0) {
+                idFieldSelect.innerHTML = '<option value="" disabled>No common properties found</option>';
+                idFieldSelect.disabled = true;
+            } else {
+                idFieldSelect.innerHTML = '';
+
+                commonProperties.sort();
+
+                commonProperties.forEach(property => {
+                    const option = document.createElement('option');
+                    option.value = property;
+                    option.text = property;
+                    option.selected = property === selectedIdFieldFromServer;
+                    idFieldSelect.appendChild(option);
+                });
+
+                idFieldSelect.disabled = false;
+            }
+
+            enableSearchIfPropertySelected();
+        }
+
+        function enableSearchIfPropertySelected() {
+            const idFieldSelect = document.getElementById('idField');
+            const idValueInput = document.getElementById('idValue');
+            const searchButton = document.getElementById('searchButton');
+
+            const hasValidIdField = !idFieldSelect.disabled && idFieldSelect.value !== '';
+
+            idValueInput.disabled = !hasValidIdField;
+            searchButton.disabled = !hasValidIdField;
+        }
+
+        function getEventClassesWithProperty(propertyName) {
+            return allEventClasses.filter(eventClass =>
+                    eventClass.idProperties.includes(propertyName)
+            );
+        }
+
+        // When the user clicks on an ID value, update the search form so it searches for all
+        // events related to that ID.
+        function navigateToProperty(propertyName, value) {
+            if (!value || value.trim() === '') return;
+
+            const eventClassesWithProperty = getEventClassesWithProperty(propertyName);
+            if (eventClassesWithProperty.length === 0) return;
+
+            // Select all event classes that have this property
+            const selectedClassesSelect = document.getElementById('selectedClasses');
+            Array.from(selectedClassesSelect.options).forEach(option => {
+                option.selected = eventClassesWithProperty.some(eventClass =>
+                        eventClass.qualifiedName === option.value
+                );
+            });
+
+            updateIdFieldOptions();
+
+            document.getElementById('idField').value = propertyName;
+            document.getElementById('idValue').value = value;
+
+            enableSearchIfPropertySelected();
+        }
+
+        function makeIdValuesClickable() {
+            if (!tableColumns) {
+                return;
+            }
+
+            tableColumns.forEach((column, columnIndex) => {
+                if (column.name.endsWith('Id')) {
+                    const cells = document.querySelectorAll(`.js-cell-${columnIndex}`);
+                    cells.forEach(cell => {
+                        const value = cell.dataset.value;
+                        if (value) {
+                            cell.style.cursor = 'pointer';
+                            cell.style.textDecoration = 'underline';
+                            cell.style.color = 'blue';
+                            cell.addEventListener('click', () => {
+                                navigateToProperty(column.name, value);
+                            });
+                        }
+                    });
+                }
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            populateEventClassesSelect();
+            updateIdFieldOptions();
+            makeIdValuesClickable();
+
+            document.getElementById('selectedClasses').addEventListener('change', updateIdFieldOptions);
+            document.getElementById('idField').addEventListener('change', enableSearchIfPropertySelected);
+        });
+        /*]]>*/
+    </script>
+</head>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<p>
+    <a href="/admin/">Home</a>
+</p>
+
+<h2>Event Log</h2>
+
+<form method="GET" action="/admin/eventLog" id="eventLogForm">
+    <label>
+        Events
+        <select id="selectedClasses" name="selectedClasses" multiple="multiple" size="8">
+        </select>
+    </label>
+    <label>
+        with
+        <select id="idField" name="idField">
+            <option value="" disabled>Select event classes first</option>
+        </select>
+    </label>
+    <label>
+        =
+        <input id="idValue" type="number" name="idValue" th:value="${idValue}"/>
+    </label>
+    <input id="searchButton" type="submit" value="Search"/>
+</form>
+
+<th:block th:if="${tableRows != null}">
+    <h2>Search Results</h2>
+
+    <table class="results">
+        <thead>
+        <tr>
+            <th th:each="column : ${tableColumns}" th:text="${column.name}">Column</th>
+        </tr>
+        </thead>
+
+        <tbody>
+        <tr th:each="row : ${tableRows}" class="striped">
+            <td th:each="cell, cellStat : ${row}" th:title="${cell.tooltip}">
+                <span th:text="${cell.value}"
+                      th:class="|js-cell-${cellStat.index}|"
+                      th:data-column-index="${cellStat.index}"
+                      th:data-value="${cell.value}"></span>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+    <p>
+        Hover over the user ID or class for more details. Click an ID value to set the search form
+        to look for all events with that ID.
+    </p>
+</th:block>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -110,6 +110,10 @@
     <p>
         <a href="/admin/mux">Mux integration</a>
     </p>
+
+    <p>
+        <a href="/admin/eventLog">Event log</a>
+    </p>
 </details>
 
 <details id="organizationManagement" class="section">

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
@@ -31,6 +31,24 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   @Nested
+  inner class FetchByIntegerField {
+    @Test
+    fun `can fetch by organization id`() {
+      val event = TestOrganizationCreatedEventV1(OrganizationId(1), "One")
+      val eventLogId = store.insertEvent(event)
+
+      assertEquals(
+          listOf(EventLogEntry(user.userId, Instant.EPOCH, event, eventLogId)),
+          store.fetchByIntegerField(
+              "organizationId",
+              1,
+              listOf(TestOrganizationCreatedEventV1::class),
+          ),
+      )
+    }
+  }
+
+  @Nested
   inner class FetchByOrganizationId {
     @Test
     fun `can fetch single class by organization id`() {


### PR DESCRIPTION
Add an admin UI page that super-admin users can use to search the event log.

It shows a list of all known event classes and, depending on which ones are
selected, a filtered list of ID properties they share in common. In search
results, IDs can be clicked to set up a search for events related to that ID.