### PR TITLE
Fix withdrawal python script, add to readme

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,20 @@ To advance that server's clock by 3 days:
 ./clock.py -d 3
 ```
 
+## Creating batch withdrawals
+
+```
+./withdraw_to_subzones.py -b 306 -p 190
+```
+
+and a quick example of repeating this 500 times:
+
+```
+for i in {1..500}; do
+  ./withdraw_to_subzones.py -b 306 -p 190
+done
+```
+
 ## Generating fake timeseries data for a facility's devices
 
 If you have already created temperature/humidity sensor devices and PV system devices using

--- a/scripts/withdraw_to_subzones.py
+++ b/scripts/withdraw_to_subzones.py
@@ -62,7 +62,7 @@ def main():
             print(f"Withdrawing to subzone {planting_subzone['id']}")
             client.withdraw_seedling_batch(
                 generate_nursery_withdrawal(
-                    batch["facility_id"],
+                    batch["facilityId"],
                     args.batch,
                     args.planting_site,
                     planting_subzone["id"],


### PR DESCRIPTION
The `withdraw_to_subzone` python script had an incorrect case for a variable. Fix this and add another example to the readme.