### PR TITLE
SW-7565 Fix site survival rate showing when no t0 data has been set

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1472,7 +1472,13 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               .on(permSiteCol.eq(PLANTING_SITE_ID).and(permSpeciesCol.eq(SPECIES_ID)))
               .fullOuterJoin(tempSiteT0)
               .on(tempSiteCol.eq(PLANTING_SITE_ID).and(tempSpeciesCol.eq(SPECIES_ID)))
-              .where(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
+              .where(
+                  PLANTING_SITE_ID.eq(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID)
+                      .or(permSiteCol.eq(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID))
+                      .or(tempSiteCol.eq(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID))
+              )
+              .and(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
+              //              .where(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
               .orderBy(SPECIES_ID, SPECIES_NAME)
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1478,7 +1478,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       .or(tempSiteCol.eq(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID))
               )
               .and(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
-              //              .where(OBSERVATION_ID.eq(OBSERVATIONS.ID).or(OBSERVATION_ID.isNull))
               .orderBy(SPECIES_ID, SPECIES_NAME)
       )
     }


### PR DESCRIPTION
The site survival rate was showing a value in the plants dashboard even if no t0 data had been set for the site. The query for the species was incorrectly retrieving t0 data for all planting sites instead of just the requested. Only retrieve t0 data for the requested planting site(s).