### PR TITLE
SW-7569 Move geolocation, capture time to files table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityMediaStore.kt
@@ -146,8 +146,6 @@ class ActivityMediaStore(
             .set(ACTIVITY_MEDIA_TYPE_ID, row.activityMediaTypeId)
             .set(IS_COVER_PHOTO, row.isCoverPhoto)
             .set(IS_HIDDEN_ON_MAP, row.isHiddenOnMap)
-            .set(CAPTURED_DATE, row.capturedDate)
-            .set(GEOLOCATION, row.geolocation)
             .set(LIST_POSITION, 0) // We'll overwrite this with the real position
             .execute()
       }
@@ -207,7 +205,13 @@ class ActivityMediaStore(
 
   private fun fetchByCondition(condition: Condition): List<ActivityMediaModel> {
     return dslContext
-        .select(ACTIVITY_MEDIA_FILES.asterisk(), FILES.CREATED_BY, FILES.CREATED_TIME)
+        .select(
+            ACTIVITY_MEDIA_FILES.asterisk(),
+            FILES.CAPTURED_LOCAL_TIME,
+            FILES.CREATED_BY,
+            FILES.CREATED_TIME,
+            FILES.GEOLOCATION,
+        )
         .from(ACTIVITY_MEDIA_FILES)
         .join(FILES)
         .on(ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ActivityStore.kt
@@ -158,7 +158,7 @@ class ActivityStore(
     return fetchByCondition(ACTIVITIES.PROJECT_ID.eq(projectId), includeMedia)
   }
 
-  private val geolocationField = ACTIVITY_MEDIA_FILES.GEOLOCATION.forMultiset()
+  private val geolocationField = FILES.GEOLOCATION.forMultiset()
 
   private val mediaMultiset =
       DSL.multiset(
@@ -166,11 +166,11 @@ class ActivityStore(
                       ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID,
                       ACTIVITY_MEDIA_FILES.ACTIVITY_ID,
                       ACTIVITY_MEDIA_FILES.CAPTION,
-                      ACTIVITY_MEDIA_FILES.CAPTURED_DATE,
                       ACTIVITY_MEDIA_FILES.FILE_ID,
                       ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO,
                       ACTIVITY_MEDIA_FILES.IS_HIDDEN_ON_MAP,
                       ACTIVITY_MEDIA_FILES.LIST_POSITION,
+                      FILES.CAPTURED_LOCAL_TIME,
                       FILES.CREATED_BY,
                       FILES.CREATED_TIME,
                       geolocationField,

--- a/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/model/ActivityMediaModel.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.jooq.Field
 import org.jooq.Record
 import org.locationtech.jts.geom.Geometry
@@ -16,9 +17,9 @@ import org.locationtech.jts.geom.Point
 data class ActivityMediaModel(
     val activityId: ActivityId,
     val caption: String?,
+    val capturedLocalTime: LocalDateTime,
     val createdBy: UserId,
     val createdTime: Instant,
-    val capturedDate: LocalDate,
     val fileId: FileId,
     val geolocation: Point?,
     val isCoverPhoto: Boolean,
@@ -26,17 +27,20 @@ data class ActivityMediaModel(
     val listPosition: Int,
     val type: ActivityMediaType,
 ) {
+  val capturedDate: LocalDate
+    get() = capturedLocalTime.toLocalDate()
+
   companion object {
     fun of(
         record: Record,
-        geolocationField: Field<Geometry?> = ACTIVITY_MEDIA_FILES.GEOLOCATION,
+        geolocationField: Field<Geometry?> = FILES.GEOLOCATION,
     ): ActivityMediaModel {
       return ActivityMediaModel(
           activityId = record[ACTIVITY_MEDIA_FILES.ACTIVITY_ID]!!,
           caption = record[ACTIVITY_MEDIA_FILES.CAPTION],
+          capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME]!!,
           createdBy = record[FILES.CREATED_BY]!!,
           createdTime = record[FILES.CREATED_TIME]!!,
-          capturedDate = record[ACTIVITY_MEDIA_FILES.CAPTURED_DATE]!!,
           fileId = record[ACTIVITY_MEDIA_FILES.FILE_ID]!!,
           geolocation = record[geolocationField] as? Point,
           isCoverPhoto = record[ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO]!!,

--- a/src/main/kotlin/com/terraformation/backend/file/model/FileMetadata.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/model/FileMetadata.kt
@@ -5,7 +5,9 @@ import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.tables.pojos.FilesRow
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import java.net.URI
+import java.time.LocalDateTime
 import org.jooq.Record
+import org.locationtech.jts.geom.Point
 import org.springframework.http.MediaType
 
 data class FileMetadata<I : FileId?, U : URI?>(
@@ -14,6 +16,8 @@ data class FileMetadata<I : FileId?, U : URI?>(
     val id: I,
     val size: Long,
     val storageUrl: U,
+    val capturedLocalTime: LocalDateTime? = null,
+    val geolocation: Point? = null,
 ) {
   /** The filename with any directory names stripped off. */
   val filenameWithoutPath: String
@@ -22,8 +26,10 @@ data class FileMetadata<I : FileId?, U : URI?>(
   companion object {
     fun of(row: FilesRow): ExistingFileMetadata =
         ExistingFileMetadata(
+            capturedLocalTime = row.capturedLocalTime,
             contentType = row.contentType ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
             filename = row.fileName!!,
+            geolocation = row.geolocation?.centroid,
             id = row.id!!,
             size = row.size!!,
             storageUrl = row.storageUrl!!,
@@ -31,17 +37,25 @@ data class FileMetadata<I : FileId?, U : URI?>(
 
     fun of(record: Record): ExistingFileMetadata =
         ExistingFileMetadata(
+            capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME],
             contentType = record[FILES.CONTENT_TYPE] ?: MediaType.APPLICATION_OCTET_STREAM_VALUE,
             filename = record[FILES.FILE_NAME.asNonNullable()],
+            geolocation = record[FILES.GEOLOCATION]?.centroid,
             id = record[FILES.ID.asNonNullable()],
             size = record[FILES.SIZE.asNonNullable()],
             storageUrl = record[FILES.STORAGE_URL.asNonNullable()],
         )
 
-    fun of(contentType: String, filename: String, size: Long): NewFileMetadata =
+    fun of(
+        contentType: String,
+        filename: String,
+        size: Long,
+        geolocation: Point? = null,
+    ): NewFileMetadata =
         NewFileMetadata(
             contentType = contentType,
             filename = filename,
+            geolocation = geolocation,
             id = null,
             size = size,
             storageUrl = null,

--- a/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/db/PublishedActivityStore.kt
@@ -12,6 +12,7 @@ import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITIES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
@@ -100,7 +101,7 @@ class PublishedActivityStore(
         .execute()
   }
 
-  private val geolocationField = PUBLISHED_ACTIVITY_MEDIA_FILES.GEOLOCATION.forMultiset()
+  private val geolocationField = FILES.GEOLOCATION.forMultiset()
 
   private val mediaMultiset =
       with(PUBLISHED_ACTIVITY_MEDIA_FILES) {
@@ -109,14 +110,16 @@ class PublishedActivityStore(
                         ACTIVITY_MEDIA_TYPE_ID,
                         ACTIVITY_ID,
                         CAPTION,
-                        CAPTURED_DATE,
                         FILE_ID,
                         IS_COVER_PHOTO,
                         IS_HIDDEN_ON_MAP,
                         LIST_POSITION,
                         geolocationField,
+                        FILES.CAPTURED_LOCAL_TIME,
                     )
                     .from(PUBLISHED_ACTIVITY_MEDIA_FILES)
+                    .join(FILES)
+                    .on(PUBLISHED_ACTIVITY_MEDIA_FILES.FILE_ID.eq(FILES.ID))
                     .where(ACTIVITY_ID.eq(PUBLISHED_ACTIVITIES.ACTIVITY_ID))
                     .orderBy(LIST_POSITION)
             )
@@ -211,9 +214,7 @@ class PublishedActivityStore(
               ACTIVITY_ID,
               ACTIVITY_MEDIA_TYPE_ID,
               CAPTION,
-              CAPTURED_DATE,
               FILE_ID,
-              GEOLOCATION,
               IS_COVER_PHOTO,
               IS_HIDDEN_ON_MAP,
               LIST_POSITION,
@@ -223,9 +224,7 @@ class PublishedActivityStore(
                       ACTIVITY_MEDIA_FILES.ACTIVITY_ID,
                       ACTIVITY_MEDIA_FILES.ACTIVITY_MEDIA_TYPE_ID,
                       ACTIVITY_MEDIA_FILES.CAPTION,
-                      ACTIVITY_MEDIA_FILES.CAPTURED_DATE,
                       ACTIVITY_MEDIA_FILES.FILE_ID,
-                      ACTIVITY_MEDIA_FILES.GEOLOCATION,
                       ACTIVITY_MEDIA_FILES.IS_COVER_PHOTO,
                       ACTIVITY_MEDIA_FILES.IS_HIDDEN_ON_MAP,
                       ACTIVITY_MEDIA_FILES.LIST_POSITION,
@@ -237,8 +236,6 @@ class PublishedActivityStore(
           .doUpdate()
           .set(ACTIVITY_MEDIA_TYPE_ID, DSL.excluded(ACTIVITY_MEDIA_TYPE_ID))
           .set(CAPTION, DSL.excluded(CAPTION))
-          .set(CAPTURED_DATE, DSL.excluded(CAPTURED_DATE))
-          .set(GEOLOCATION, DSL.excluded(GEOLOCATION))
           .set(IS_COVER_PHOTO, DSL.excluded(IS_COVER_PHOTO))
           .set(IS_HIDDEN_ON_MAP, DSL.excluded(IS_HIDDEN_ON_MAP))
           .set(LIST_POSITION, DSL.excluded(LIST_POSITION))

--- a/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/model/PublishedActivityMediaModel.kt
@@ -3,8 +3,10 @@ package com.terraformation.backend.funder.model
 import com.terraformation.backend.db.accelerator.ActivityId
 import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.funder.tables.references.PUBLISHED_ACTIVITY_MEDIA_FILES
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.jooq.Field
 import org.jooq.Record
 import org.locationtech.jts.geom.Geometry
@@ -13,7 +15,7 @@ import org.locationtech.jts.geom.Point
 data class PublishedActivityMediaModel(
     val activityId: ActivityId,
     val caption: String?,
-    val capturedDate: LocalDate,
+    val capturedLocalTime: LocalDateTime,
     val fileId: FileId,
     val geolocation: Point?,
     val isCoverPhoto: Boolean,
@@ -21,16 +23,19 @@ data class PublishedActivityMediaModel(
     val listPosition: Int,
     val type: ActivityMediaType,
 ) {
+  val capturedDate: LocalDate
+    get() = capturedLocalTime.toLocalDate()
+
   companion object {
     fun of(
         record: Record,
-        geolocationField: Field<Geometry?> = PUBLISHED_ACTIVITY_MEDIA_FILES.GEOLOCATION,
+        geolocationField: Field<Geometry?> = FILES.GEOLOCATION,
     ): PublishedActivityMediaModel {
       return with(PUBLISHED_ACTIVITY_MEDIA_FILES) {
         PublishedActivityMediaModel(
             activityId = record[ACTIVITY_ID]!!,
             caption = record[CAPTION],
-            capturedDate = record[CAPTURED_DATE]!!,
+            capturedLocalTime = record[FILES.CAPTURED_LOCAL_TIME]!!,
             fileId = record[FILE_ID]!!,
             geolocation = record[geolocationField] as? Point,
             isCoverPhoto = record[IS_COVER_PHOTO]!!,

--- a/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
@@ -179,7 +179,7 @@ class SeedFundReportFileService(
   ): FileId {
     requirePermissions { updateSeedFundReport(reportId) }
 
-    val fileId = fileService.storeFile("report", data, metadata, null, insertChildRow)
+    val fileId = fileService.storeFile("report", data, metadata, insertChildRows = insertChildRow)
 
     log.info("Stored ${metadata.contentType} file $fileId for report $reportId")
 

--- a/src/main/kotlin/com/terraformation/backend/report/db/SeedFundReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/db/SeedFundReportStore.kt
@@ -486,8 +486,10 @@ class SeedFundReportStore(
 
     return dslContext
         .select(
+            FILES.CAPTURED_LOCAL_TIME,
             FILES.CONTENT_TYPE,
             FILES.FILE_NAME,
+            FILES.GEOLOCATION,
             FILES.ID,
             FILES.SIZE,
             FILES.STORAGE_URL,
@@ -510,8 +512,10 @@ class SeedFundReportStore(
 
     return dslContext
         .select(
+            FILES.CAPTURED_LOCAL_TIME,
             FILES.CONTENT_TYPE,
             FILES.FILE_NAME,
+            FILES.GEOLOCATION,
             FILES.ID,
             FILES.SIZE,
             FILES.STORAGE_URL,
@@ -536,8 +540,10 @@ class SeedFundReportStore(
 
     return dslContext
         .select(
+            FILES.CAPTURED_LOCAL_TIME,
             FILES.CONTENT_TYPE,
             FILES.FILE_NAME,
+            FILES.GEOLOCATION,
             FILES.ID,
             FILES.SIZE,
             FILES.STORAGE_URL,

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -86,8 +86,10 @@ class PhotoRepository(
 
     return dslContext
         .select(
+            FILES.CAPTURED_LOCAL_TIME,
             FILES.CONTENT_TYPE,
             FILES.FILE_NAME,
+            FILES.GEOLOCATION,
             FILES.ID,
             FILES.SIZE,
             FILES.STORAGE_URL,

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -195,7 +195,6 @@ class ObservationService(
   fun storePhoto(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,
-      gpsCoordinates: Point,
       position: ObservationPlotPosition?,
       data: InputStream,
       metadata: NewFileMetadata,
@@ -203,6 +202,9 @@ class ObservationService(
   ): FileId {
     requirePermissions { updateObservation(observationId) }
 
+    if (metadata.geolocation == null) {
+      throw IllegalArgumentException("Geolocation is required for observation photos")
+    }
     if (type == ObservationPhotoType.Quadrat && position == null) {
       throw IllegalArgumentException("Position is required for a quadrat photo")
     }
@@ -216,7 +218,6 @@ class ObservationService(
           observationPhotosDao.insert(
               ObservationPhotosRow(
                   fileId = fileId,
-                  gpsCoordinates = gpsCoordinates,
                   monitoringPlotId = monitoringPlotId,
                   observationId = observationId,
                   positionId = position,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -412,12 +412,11 @@ class ObservationsController(
 
     val fileId =
         observationService.storePhoto(
-            data = file.inputStream,
-            gpsCoordinates = payload.gpsCoordinates,
-            metadata = FileMetadata.of(contentType, filename, file.size),
-            monitoringPlotId = plotId,
             observationId = observationId,
+            monitoringPlotId = plotId,
             position = payload.position,
+            data = file.inputStream,
+            metadata = FileMetadata.of(contentType, filename, file.size, payload.gpsCoordinates),
             type = payload.type ?: ObservationPhotoType.Plot,
         )
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesIdConverter
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.USERS
 import com.terraformation.backend.db.forMultiset
 import com.terraformation.backend.db.tracking.MonitoringPlotId
@@ -425,7 +426,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             }
           }
 
-  private val photosGpsField = OBSERVATION_PHOTOS.GPS_COORDINATES.forMultiset()
+  private val photosGpsField = FILES.GEOLOCATION.forMultiset()
 
   private val photosMultiset =
       DSL.multiset(
@@ -436,6 +437,8 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       OBSERVATION_PHOTOS.TYPE_ID,
                   )
                   .from(OBSERVATION_PHOTOS)
+                  .join(FILES)
+                  .on(OBSERVATION_PHOTOS.FILE_ID.eq(FILES.ID))
                   .where(OBSERVATION_PHOTOS.OBSERVATION_ID.eq(OBSERVATIONS.ID))
                   .and(OBSERVATION_PHOTOS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
                   .orderBy(OBSERVATION_PHOTOS.FILE_ID)

--- a/src/main/resources/db/migration/0400/V419__FilesMetadata.sql
+++ b/src/main/resources/db/migration/0400/V419__FilesMetadata.sql
@@ -1,0 +1,19 @@
+ALTER TABLE files ADD COLUMN captured_local_time TIMESTAMP;
+ALTER TABLE files ADD COLUMN geolocation GEOMETRY(Point);
+
+UPDATE files
+SET geolocation = amf.geolocation,
+    captured_local_time = amf.captured_date
+FROM accelerator.activity_media_files amf
+WHERE amf.file_id = files.id;
+
+UPDATE files
+SET geolocation = op.gps_coordinates
+FROM tracking.observation_photos op
+WHERE op.file_id = files.id;
+
+ALTER TABLE accelerator.activity_media_files DROP COLUMN captured_date;
+ALTER TABLE accelerator.activity_media_files DROP COLUMN geolocation;
+ALTER TABLE funder.published_activity_media_files DROP COLUMN captured_date;
+ALTER TABLE funder.published_activity_media_files DROP COLUMN geolocation;
+ALTER TABLE tracking.observation_photos DROP COLUMN gps_coordinates;

--- a/src/main/resources/db/migration/0400/V419__FilesMetadata.sql
+++ b/src/main/resources/db/migration/0400/V419__FilesMetadata.sql
@@ -2,6 +2,12 @@ ALTER TABLE files ADD COLUMN captured_local_time TIMESTAMP;
 ALTER TABLE files ADD COLUMN geolocation GEOMETRY(Point);
 
 UPDATE files
+SET geolocation = pamf.geolocation,
+    captured_local_time = pamf.captured_date
+FROM funder.published_activity_media_files pamf
+WHERE pamf.file_id = files.id;
+
+UPDATE files
 SET geolocation = amf.geolocation,
     captured_local_time = amf.captured_date
 FROM accelerator.activity_media_files amf

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -100,6 +100,8 @@ COMMENT ON TABLE facility_types IS '(Enum) Types of facilities that can be repre
 COMMENT ON TABLE file_access_tokens IS 'Temporary tokens for unauthenticated access to files from the file store.';
 
 COMMENT ON TABLE files IS 'Generic information about individual files. Files are associated with application entities using linking tables such as `accession_photos`.';
+COMMENT ON COLUMN files.captured_local_time IS 'If applicable, the date and time in the local time zone of wherever the file''s data was captured. For example, the time a photo was taken. This may differ from `created_time`, which represents when the file was stored in Terraware. This is typically extracted from the file itself, e.g., EXIF metadata.';
+COMMENT ON COLUMN files.geolocation IS 'If applicable, the location where the file was created. For photos, typically extracted from EXIF metadata.';
 
 COMMENT ON TABLE flyway_schema_history IS 'Tracks which database migrations have already been applied. Used by the Flyway library, not by application.';
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -263,19 +263,21 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           ActivityMediaFilesRow(
               activityId = activityId,
               activityMediaTypeId = type,
-              capturedDate = capturedDate,
               fileId = fileId,
               isCoverPhoto = false,
               isHiddenOnMap = false,
               listPosition = 1,
           ),
-          row.copy(geolocation = null),
+          row,
       )
 
+      val filesRow = filesDao.fetchOneById(fileId)!!
+      assertEquals(filesRow.capturedLocalTime?.toLocalDate(), capturedDate, "Captured date")
+
       if (geolocation != null) {
-        assertGeometryEquals(geolocation, row.geolocation)
+        assertGeometryEquals(geolocation, filesRow.geolocation)
       } else {
-        assertNull(row.geolocation, "Geolocation")
+        assertNull(filesRow.geolocation, "Geolocation")
       }
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -75,9 +75,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertPublishedReport()
 
     every { reportStore.publishReport(any()) } returns Unit
-    every { fileService.storeFile(any(), any(), any(), any(), any()) } answers
+    every { fileService.storeFile(any(), any(), any(), any(), any(), any()) } answers
         {
-          val func = arg<((fileId: FileId) -> Unit)?>(4)
+          val func = arg<((fileId: FileId) -> Unit)?>(5)
           val fileId = insertFile()
           func?.let { it(fileId) }
           fileId
@@ -270,7 +270,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               metadata = metadata,
               reportId = reportId,
           )
-      verify(exactly = 1) { fileService.storeFile(any(), inputStream, metadata, any(), any()) }
+      verify(exactly = 1) {
+        fileService.storeFile(any(), inputStream, metadata, any(), any(), any())
+      }
 
       assertTableEquals(
           listOf(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.point
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -202,17 +203,19 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               activityType = ActivityType.Monitoring,
               description = "Test monitoring activity",
           )
-      val fileId1 = insertFile()
+      val fileId1 = insertFile(capturedLocalTime = LocalDate.of(2024, 2, 19).atStartOfDay())
       insertActivityMediaFile(
           caption = "Caption 1",
-          capturedDate = LocalDate.of(2024, 2, 19),
           isCoverPhoto = true,
       )
-      val fileId2 = insertFile(createdTime = Instant.ofEpochSecond(1))
+      val fileId2 =
+          insertFile(
+              capturedLocalTime = LocalDate.of(2024, 2, 20).atStartOfDay(),
+              createdTime = Instant.ofEpochSecond(1),
+              geolocation = point(1),
+          )
       insertActivityMediaFile(
           caption = "Caption 2",
-          capturedDate = LocalDate.of(2024, 2, 20),
-          geolocation = point(1),
           isHiddenOnMap = true,
           type = ActivityMediaType.Video,
       )
@@ -236,9 +239,9 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ActivityMediaModel(
                           activityId = activityId,
                           caption = "Caption 1",
+                          capturedLocalTime = LocalDate.of(2024, 2, 19).atStartOfDay(),
                           createdBy = user.userId,
                           createdTime = Instant.EPOCH,
-                          capturedDate = LocalDate.of(2024, 2, 19),
                           fileId = fileId1,
                           geolocation = null,
                           isCoverPhoto = true,
@@ -249,9 +252,9 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ActivityMediaModel(
                           activityId = activityId,
                           caption = "Caption 2",
+                          capturedLocalTime = LocalDate.of(2024, 2, 20).atStartOfDay(),
                           createdBy = user.userId,
                           createdTime = Instant.ofEpochSecond(1),
-                          capturedDate = LocalDate.of(2024, 2, 20),
                           fileId = fileId2,
                           geolocation = point(1),
                           isCoverPhoto = false,
@@ -296,7 +299,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               description = "Test monitoring activity",
           )
 
-      val fileId1 = insertFile()
+      val fileId1 = insertFile(capturedLocalTime = LocalDateTime.of(2025, 5, 4, 3, 2, 1))
       insertActivityMediaFile(caption = "Caption", isHiddenOnMap = true)
 
       val activityId2 =
@@ -311,7 +314,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val publishedTime = Instant.ofEpochSecond(5858)
       insertPublishedActivity(publishedTime = publishedTime)
 
-      val fileId2 = insertFile()
+      val fileId2 = insertFile(capturedLocalTime = LocalDate.EPOCH.atStartOfDay())
       insertActivityMediaFile(isCoverPhoto = true)
 
       // Activities for other projects shouldn't be included
@@ -334,9 +337,9 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           ActivityMediaModel(
                               activityId = activityId1,
                               caption = "Caption",
+                              capturedLocalTime = LocalDateTime.of(2025, 5, 4, 3, 2, 1),
                               createdBy = user.userId,
                               createdTime = Instant.EPOCH,
-                              capturedDate = LocalDate.EPOCH,
                               fileId = fileId1,
                               geolocation = null,
                               isCoverPhoto = false,
@@ -363,9 +366,9 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                           ActivityMediaModel(
                               activityId = activityId2,
                               caption = null,
+                              capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
                               createdBy = user.userId,
                               createdTime = Instant.EPOCH,
-                              capturedDate = LocalDate.EPOCH,
                               fileId = fileId2,
                               geolocation = null,
                               isCoverPhoto = true,

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -489,6 +489,7 @@ import java.math.BigDecimal
 import java.net.URI
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.Locale
@@ -1739,18 +1740,22 @@ abstract class DatabaseBackedTest {
       fileName: String = row.fileName ?: "fileName",
       contentType: String = row.contentType ?: "image/jpeg",
       size: Long = row.size ?: 1,
+      capturedLocalTime: LocalDateTime? = row.capturedLocalTime,
       createdBy: UserId = row.createdBy ?: currentUser().userId,
       createdTime: Instant = row.createdTime ?: Instant.EPOCH,
+      geolocation: Point? = row.geolocation?.centroid,
       modifiedBy: UserId = row.modifiedBy ?: createdBy,
       modifiedTime: Instant = row.modifiedTime ?: createdTime,
       storageUrl: Any = row.storageUrl ?: "http://dummy/${nextStorageUrlNumber++}",
   ): FileId {
     val rowWithDefaults =
         row.copy(
+            capturedLocalTime = capturedLocalTime,
             contentType = contentType,
             createdBy = createdBy,
             createdTime = createdTime,
             fileName = fileName,
+            geolocation = geolocation,
             modifiedBy = modifiedBy,
             modifiedTime = modifiedTime,
             size = size,
@@ -3071,14 +3076,12 @@ abstract class DatabaseBackedTest {
       fileId: FileId = row.fileId ?: inserted.fileId,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
-      gpsCoordinates: Point = row.gpsCoordinates?.centroid ?: point(1),
       position: ObservationPlotPosition = row.positionId ?: ObservationPlotPosition.SouthwestCorner,
       type: ObservationPhotoType = row.typeId ?: ObservationPhotoType.Plot,
   ) {
     val rowWithDefaults =
         row.copy(
             fileId = fileId,
-            gpsCoordinates = gpsCoordinates,
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,
             positionId = position,
@@ -3814,9 +3817,7 @@ abstract class DatabaseBackedTest {
   protected fun insertActivityMediaFile(
       activityId: ActivityId = inserted.activityId,
       caption: String? = null,
-      capturedDate: LocalDate = LocalDate.EPOCH,
       fileId: FileId = inserted.fileId,
-      geolocation: Point? = null,
       isCoverPhoto: Boolean = false,
       isHiddenOnMap: Boolean = false,
       listPosition: Int =
@@ -3829,9 +3830,7 @@ abstract class DatabaseBackedTest {
             activityId = activityId,
             activityMediaTypeId = type,
             caption = caption,
-            capturedDate = capturedDate,
             fileId = fileId,
-            geolocation = geolocation,
             isCoverPhoto = isCoverPhoto,
             isHiddenOnMap = isHiddenOnMap,
             listPosition = listPosition,
@@ -3874,9 +3873,7 @@ abstract class DatabaseBackedTest {
   protected fun insertPublishedActivityMediaFile(
       activityId: ActivityId = inserted.activityId,
       caption: String? = null,
-      capturedDate: LocalDate = LocalDate.EPOCH,
       fileId: FileId = inserted.fileId,
-      geolocation: Point? = null,
       isCoverPhoto: Boolean = false,
       isHiddenOnMap: Boolean = false,
       listPosition: Int =
@@ -3890,9 +3887,7 @@ abstract class DatabaseBackedTest {
             activityId = activityId,
             activityMediaTypeId = type,
             caption = caption,
-            capturedDate = capturedDate,
             fileId = fileId,
-            geolocation = geolocation,
             isCoverPhoto = isCoverPhoto,
             isHiddenOnMap = isHiddenOnMap,
             listPosition = listPosition,

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -21,6 +21,7 @@ import com.terraformation.backend.file.event.FileDeletionStartedEvent
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.point
 import io.mockk.every
 import io.mockk.mockk
 import java.io.IOException
@@ -100,10 +101,15 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
   fun `storeFile writes file and database row`() {
     val photoData = Random(System.currentTimeMillis()).nextBytes(10)
     val size = photoData.size.toLong()
+    val geolocation = point(1)
     var insertedChildRow = false
 
     val fileId =
-        fileService.storeFile("category", photoData.inputStream(), metadata.copy(size = size)) {
+        fileService.storeFile(
+            "category",
+            photoData.inputStream(),
+            metadata.copy(geolocation = geolocation, size = size),
+        ) {
           insertedChildRow = true
         }
 
@@ -111,6 +117,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
         FilesRow(
             contentType = contentType,
             fileName = filename,
+            geolocation = geolocation,
             id = fileId,
             storageUrl = photoStorageUrl,
             size = size,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -19,6 +19,7 @@ import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.NotificationType
 import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.UserType
+import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
@@ -608,7 +609,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     private lateinit var observationId: ObservationId
     private lateinit var plotId: MonitoringPlotId
 
-    private val metadata = FileMetadata.of(MediaType.IMAGE_JPEG_VALUE, "filename", 1L)
+    private val metadata = FileMetadata.of(MediaType.IMAGE_JPEG_VALUE, "filename", 1L, point(1))
 
     @BeforeEach
     fun setUp() {
@@ -631,7 +632,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             service.storePhoto(
                 observationId,
                 plotId,
-                point(1),
                 ObservationPlotPosition.NortheastCorner,
                 content.inputStream(),
                 metadata,
@@ -698,7 +698,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             service.storePhoto(
                 observationId,
                 plotId,
-                point(1),
                 ObservationPlotPosition.NortheastCorner,
                 byteArrayOf(1).inputStream(),
                 metadata,
@@ -708,7 +707,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             service.storePhoto(
                 observationId,
                 plotId,
-                point(1),
                 null,
                 byteArrayOf(1).inputStream(),
                 metadata,
@@ -725,7 +723,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                     observationId,
                     plotId,
                     ObservationPlotPosition.NortheastCorner,
-                    point(1),
                     ObservationPhotoType.Plot,
                 ),
                 ObservationPhotosRecord(
@@ -733,10 +730,21 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                     observationId,
                     plotId,
                     null,
-                    point(1),
                     ObservationPhotoType.Soil,
                 ),
             )
+        )
+
+        val filesRecords = dslContext.fetch(FILES)
+        assertGeometryEquals(
+            point(1),
+            filesRecords.single { it.id == fileId1 }.geolocation,
+            "File 1",
+        )
+        assertGeometryEquals(
+            point(1),
+            filesRecords.single { it.id == fileId2 }.geolocation,
+            "File 2",
         )
       }
 
@@ -746,7 +754,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service.storePhoto(
               observationId,
               plotId,
-              point(1),
               null,
               byteArrayOf(1).inputStream(),
               metadata,
@@ -761,7 +768,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service.storePhoto(
               observationId,
               plotId,
-              point(1),
               ObservationPlotPosition.SoutheastCorner,
               byteArrayOf(1).inputStream(),
               metadata,
@@ -778,7 +784,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           service.storePhoto(
               observationId,
               plotId,
-              point(1),
               ObservationPlotPosition.NortheastCorner,
               byteArrayOf(1).inputStream(),
               metadata,
@@ -795,7 +800,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             service.storePhoto(
                 observationId,
                 plotId,
-                point(1),
                 ObservationPlotPosition.NortheastCorner,
                 onePixelPng.inputStream(),
                 metadata,
@@ -812,7 +816,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             service.storePhoto(
                 inserted.observationId,
                 inserted.monitoringPlotId,
-                point(1),
                 ObservationPlotPosition.SouthwestCorner,
                 onePixelPng.inputStream(),
                 metadata,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -110,8 +110,8 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
       insertMonitoringPlot()
       insertObservation(completedTime = Instant.EPOCH)
       insertObservationPlot(claimedBy = user.userId, completedBy = user.userId)
-      insertFile()
-      insertObservationPhoto(gpsCoordinates = gpsCoordinates, position = position)
+      insertFile(geolocation = gpsCoordinates)
+      insertObservationPhoto(position = position)
 
       val results = resultsStore.fetchByOrganizationId(organizationId)
 


### PR DESCRIPTION
We're going to be pulling GPS coordinates from photo and video files in additional
places in the app soon. Currently we only extract them from files that are
attached to activity log entries, and we store them in `activity_media_files`.
We also store GPS locations for observation photos, though those GPS coordinates
are sent separately in the photo upload API request rather than extracted from the
photo files.

Move the geolocation and captured date columns to the files table so they'll be
stored consistently across the app. "Captured date" turns into "Captured local
time" because we may want the time of day rather than just the date; the word
"local" is to clarify that the timestamp is not necessarily in UTC. But in this
initial change, we still only extract the date part of the EXIF timestamp for
activity media files.

For observation photos, the GPS coordinates continue to come from the API request
payload for now, such that there's no client-visible behavior change.