### PR TITLE
SW-7570 Add endpoint for checking if all site t0 data has been set

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -39,6 +39,16 @@ class T0Controller(
     return GetSiteT0DataResponsePayload(data = SiteT0DataResponsePayload(siteData))
   }
 
+  @Operation(summary = "Get whether or not all T0 Data has been set for a planting site")
+  @GetMapping("/site/{plantingSiteId}/allSet")
+  fun getAllT0SiteDataSet(
+      @PathVariable plantingSiteId: PlantingSiteId
+  ): GetAllSiteT0DataSetResponsePayload {
+    val allSet = t0Store.fetchAllT0SiteDataSet(plantingSiteId)
+
+    return GetAllSiteT0DataSetResponsePayload(allSet = allSet)
+  }
+
   @Operation(
       summary = "Assign T0 Data for a planting site",
       description =
@@ -138,6 +148,8 @@ data class SiteT0DataResponsePayload(
 
 data class GetSiteT0DataResponsePayload(val data: SiteT0DataResponsePayload) :
     SuccessResponsePayload
+
+data class GetAllSiteT0DataSetResponsePayload(val allSet: Boolean) : SuccessResponsePayload
 
 data class AssignSiteT0DataRequestPayload(
     val plantingSiteId: PlantingSiteId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -39,6 +39,8 @@ import kotlin.IllegalArgumentException
 import kotlin.lazy
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -211,8 +213,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           .execute()
       insertPlantingSubzonePopulation(speciesId = speciesId1)
 
-      assertEquals(
-          false,
+      assertFalse(
           store.fetchAllT0SiteDataSet(plantingSiteId),
           "Requires all plots to have completed observations",
       )
@@ -222,8 +223,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `permanent plot has no t0 density set`() {
       insertPlantingSubzonePopulation(speciesId = speciesId1)
 
-      assertEquals(
-          false,
+      assertFalse(
           store.fetchAllT0SiteDataSet(plantingSiteId),
           "Requires all permanent plots to have t0 data set",
       )
@@ -234,8 +234,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSubzonePopulation(speciesId = speciesId1)
       insertPlotT0Density(speciesId = speciesId1)
 
-      assertEquals(
-          false,
+      assertFalse(
           store.fetchAllT0SiteDataSet(plantingSiteId),
           "Requires all temp plots to have t0 data set",
       )
@@ -247,8 +246,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlotT0Density(speciesId = speciesId1, monitoringPlotId = monitoringPlotId)
       insertPlantingSubzonePopulation(speciesId = speciesId2)
 
-      assertEquals(
-          false,
+      assertFalse(
           store.fetchAllT0SiteDataSet(plantingSiteId),
           "Requires all withdrawn species to have t0 data",
       )
@@ -263,8 +261,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlantingSubzonePopulation(speciesId = speciesId1)
       insertPlantingSubzonePopulation(speciesId = speciesId2)
 
-      assertEquals(
-          true,
+      assertTrue(
           store.fetchAllT0SiteDataSet(plantingSiteId),
           "All site data set",
       )

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -10,12 +10,15 @@ import com.terraformation.backend.db.default_schema.Role
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.records.PlantingZoneT0TempDensitiesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlotT0DensitiesRecord
 import com.terraformation.backend.db.tracking.tables.records.PlotT0ObservationsRecord
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVATIONS
 import com.terraformation.backend.multiPolygon
@@ -34,6 +37,7 @@ import com.terraformation.backend.util.toPlantsPerHectare
 import java.math.BigDecimal
 import kotlin.IllegalArgumentException
 import kotlin.lazy
+import org.jooq.impl.DSL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -52,6 +56,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
   private lateinit var plantingSiteId: PlantingSiteId
   private lateinit var plantingZoneId: PlantingZoneId
   private lateinit var monitoringPlotId: MonitoringPlotId
+  private lateinit var tempPlotId: MonitoringPlotId
   private lateinit var observationId: ObservationId
   private lateinit var speciesId1: SpeciesId
   private lateinit var speciesId2: SpeciesId
@@ -63,12 +68,27 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     val gridOrigin = point(1)
     val siteBoundary = multiPolygon(200)
     plantingSiteId = insertPlantingSite(boundary = siteBoundary, gridOrigin = gridOrigin)
-    insertPlantingSiteHistory()
     plantingZoneId = insertPlantingZone(name = "Zone 2")
     insertPlantingSubzone()
+    observationId = insertObservation(completedTime = clock.instant())
+
+    tempPlotId = insertMonitoringPlot(plotNumber = 10)
+    insertObservationPlot(
+        claimedTime = clock.instant(),
+        claimedBy = user.userId,
+        completedTime = clock.instant(),
+        completedBy = user.userId,
+        isPermanent = false,
+    )
+
     monitoringPlotId = insertMonitoringPlot(plotNumber = 2, permanentIndex = 2)
-    observationId = insertObservation()
-    insertObservationPlot()
+    insertObservationPlot(
+        claimedTime = clock.instant(),
+        claimedBy = user.userId,
+        completedTime = clock.instant(),
+        completedBy = user.userId,
+        isPermanent = true,
+    )
     speciesId1 = insertSpecies()
     speciesId2 = insertSpecies()
   }
@@ -163,6 +183,91 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           )
 
       assertEquals(expected, store.fetchT0SiteData(plantingSiteId))
+    }
+  }
+
+  @Nested
+  inner class FetchAllT0SiteDataSet {
+    @Test
+    fun `throws exception when user lacks permission`() {
+      deleteOrganizationUser()
+
+      assertThrows<PlantingSiteNotFoundException> { store.fetchAllT0SiteDataSet(plantingSiteId) }
+    }
+
+    @Test
+    fun `plots have no completed observations`() {
+      dslContext
+          .update(OBSERVATIONS)
+          .set(OBSERVATIONS.COMPLETED_TIME, DSL.castNull(OBSERVATIONS.COMPLETED_TIME))
+          .set(OBSERVATIONS.STATE_ID, ObservationState.InProgress)
+          .where(OBSERVATIONS.ID.eq(observationId))
+          .execute()
+      dslContext
+          .update(OBSERVATION_PLOTS)
+          .set(OBSERVATION_PLOTS.COMPLETED_TIME, DSL.castNull(OBSERVATION_PLOTS.COMPLETED_TIME))
+          .set(OBSERVATION_PLOTS.COMPLETED_BY, DSL.castNull(OBSERVATION_PLOTS.COMPLETED_BY))
+          .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
+          .execute()
+      insertPlantingSubzonePopulation(speciesId = speciesId1)
+
+      assertEquals(
+          false,
+          store.fetchAllT0SiteDataSet(plantingSiteId),
+          "Requires all plots to have completed observations",
+      )
+    }
+
+    @Test
+    fun `permanent plot has no t0 density set`() {
+      insertPlantingSubzonePopulation(speciesId = speciesId1)
+
+      assertEquals(
+          false,
+          store.fetchAllT0SiteDataSet(plantingSiteId),
+          "Requires all permanent plots to have t0 data set",
+      )
+    }
+
+    @Test
+    fun `temp plot has no zone t0 density set`() {
+      insertPlantingSubzonePopulation(speciesId = speciesId1)
+      insertPlotT0Density(speciesId = speciesId1)
+
+      assertEquals(
+          false,
+          store.fetchAllT0SiteDataSet(plantingSiteId),
+          "Requires all temp plots to have t0 data set",
+      )
+    }
+
+    @Test
+    fun `withdrawal data has other species than t0`() {
+      insertPlantingZoneT0TempDensity(speciesId = speciesId2)
+      insertPlotT0Density(speciesId = speciesId1, monitoringPlotId = monitoringPlotId)
+      insertPlantingSubzonePopulation(speciesId = speciesId2)
+
+      assertEquals(
+          false,
+          store.fetchAllT0SiteDataSet(plantingSiteId),
+          "Requires all withdrawn species to have t0 data",
+      )
+    }
+
+    @Test
+    fun `correctly checks all data`() {
+      insertPlantingZoneT0TempDensity(speciesId = speciesId1)
+      insertPlantingZoneT0TempDensity(speciesId = speciesId2)
+      insertPlotT0Density(speciesId = speciesId1, monitoringPlotId = monitoringPlotId)
+      insertPlotT0Density(speciesId = speciesId2, monitoringPlotId = monitoringPlotId)
+      insertPlantingSubzonePopulation(speciesId = speciesId1)
+      insertPlantingSubzonePopulation(speciesId = speciesId2)
+
+      assertEquals(
+          true,
+          store.fetchAllT0SiteDataSet(plantingSiteId),
+          "All site data set",
+      )
     }
   }
 


### PR DESCRIPTION
To determine whether all t0 data has been set, the FE currently has to query 3 endpoints and combine all the data, and then the data is never used again on the page.

Add an endpoint to do this determination on the BE since this is used on pages that only need to show an indication for whether or not all t0 data has been set.