### PR TITLE
SW-7581 Remove image file validation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -212,7 +212,7 @@ class ParticipantProjectSpeciesService(
       metadata: NewFileMetadata,
       submissionId: SubmissionId,
   ) =
-      fileService.storeFile("species-list-deliverable", inputStream, metadata, null) { fileId ->
+      fileService.storeFile("species-list-deliverable", inputStream, metadata) { fileId ->
         with(SUBMISSION_SNAPSHOTS) {
           dslContext
               .insertInto(SUBMISSION_SNAPSHOTS)

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -62,12 +62,6 @@ class TerrawareServerConfig(
      */
     val useTestClock: Boolean = false,
 
-    /**
-     * Retain uploaded files that fail file validation. This may be set in test environments so we
-     * can examine the files and see why they failed.
-     */
-    val keepInvalidUploads: Boolean = false,
-
     /** Configures execution of daily tasks. */
     val dailyTasks: DailyTasksConfig = DailyTasksConfig(),
 

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
@@ -17,7 +17,6 @@ import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.nursery.event.BatchDeletionStartedEvent
-import com.terraformation.backend.util.ImageUtils
 import jakarta.inject.Named
 import java.io.InputStream
 import java.time.InstantSource
@@ -34,7 +33,6 @@ class BatchPhotoService(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val fileService: FileService,
-    private val imageUtils: ImageUtils,
     private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
@@ -43,7 +41,7 @@ class BatchPhotoService(
     requirePermissions { updateBatch(batchId) }
 
     val fileId =
-        fileService.storeFile("batch", data, metadata, imageUtils::read) { fileId ->
+        fileService.storeFile("batch", data, metadata) { fileId ->
           batchPhotosDao.insert(
               BatchPhotosRow(
                   batchId = batchId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -15,7 +15,6 @@ import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.util.ImageUtils
 import jakarta.inject.Named
 import java.io.InputStream
 import org.jooq.Condition
@@ -28,7 +27,6 @@ class WithdrawalPhotoService(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val fileService: FileService,
-    private val imageUtils: ImageUtils,
     private val thumbnailService: ThumbnailService,
     private val withdrawalPhotosDao: WithdrawalPhotosDao,
 ) {
@@ -38,7 +36,7 @@ class WithdrawalPhotoService(
     requirePermissions { createWithdrawalPhoto(withdrawalId) }
 
     val fileId =
-        fileService.storeFile("withdrawal", data, metadata, imageUtils::read) { fileId ->
+        fileService.storeFile("withdrawal", data, metadata) { fileId ->
           withdrawalPhotosDao.insert(
               WithdrawalPhotosRow(fileId = fileId, withdrawalId = withdrawalId)
           )

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -18,7 +18,6 @@ import com.terraformation.backend.file.model.ExistingFileMetadata
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.util.ImageUtils
 import jakarta.inject.Named
 import java.io.IOException
 import java.io.InputStream
@@ -34,7 +33,6 @@ class PhotoRepository(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
     private val fileService: FileService,
-    private val imageUtils: ImageUtils,
     private val thumbnailService: ThumbnailService,
 ) {
   private val log = perClassLogger()
@@ -44,7 +42,7 @@ class PhotoRepository(
     requirePermissions { uploadPhoto(accessionId) }
 
     val fileId =
-        fileService.storeFile("accession", data, metadata, imageUtils::read) { fileId ->
+        fileService.storeFile("accession", data, metadata) { fileId ->
           accessionPhotosDao.insert(AccessionPhotosRow(accessionId = accessionId, fileId = fileId))
         }
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.assertGeometryEquals
 import com.terraformation.backend.assertIsEventListener
 import com.terraformation.backend.assertSetEquals
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
@@ -57,7 +56,6 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   override lateinit var user: TerrawareUser
 
   private val clock = TestClock()
-  private val config: TerrawareServerConfig = mockk()
   private val eventPublisher = TestEventPublisher()
   private val fileStore = InMemoryFileStore()
   private val muxService: MuxService = mockk()
@@ -66,7 +64,6 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     FileService(
         dslContext,
         clock,
-        config,
         eventPublisher,
         filesDao,
         fileStore,
@@ -104,8 +101,6 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     activityId = insertActivity(createdBy = createdBy, projectId = projectId)
 
     insertOrganizationUser(role = Role.Admin)
-
-    every { config.keepInvalidUploads } returns false
   }
 
   @Nested

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -24,7 +24,6 @@ import com.terraformation.backend.mockUser
 import com.terraformation.backend.species.event.SpeciesEditedEvent
 import com.terraformation.backend.species.model.ExistingSpeciesModel
 import io.mockk.every
-import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import java.net.URI
@@ -44,7 +43,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
 
   private val fileStore = InMemoryFileStore()
   private val fileService: FileService by lazy {
-    FileService(dslContext, clock, mockk(), eventPublisher, filesDao, fileStore)
+    FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
 
   private val participantProjectSpeciesStore: ParticipantProjectSpeciesStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -75,9 +75,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertPublishedReport()
 
     every { reportStore.publishReport(any()) } returns Unit
-    every { fileService.storeFile(any(), any(), any(), any(), any(), any()) } answers
+    every { fileService.storeFile(any(), any(), any(), any(), any()) } answers
         {
-          val func = arg<((fileId: FileId) -> Unit)?>(5)
+          val func = arg<((fileId: FileId) -> Unit)?>(4)
           val fileId = insertFile()
           func?.let { it(fileId) }
           fileId
@@ -270,9 +270,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               metadata = metadata,
               reportId = reportId,
           )
-      verify(exactly = 1) {
-        fileService.storeFile(any(), inputStream, metadata, any(), any(), any())
-      }
+      verify(exactly = 1) { fileService.storeFile(any(), inputStream, metadata, any(), any()) }
 
       assertTableEquals(
           listOf(

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.MediaType
-import org.springframework.web.reactive.function.UnsupportedMediaTypeException
 
 class FileServiceTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
@@ -78,7 +77,6 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
 
     clock.instant = uploadedTime
     every { config.photoDir } returns tempDir
-    every { config.keepInvalidUploads } returns false
 
     every { random.nextLong() } returns 0x0123456789abcdef
     pathGenerator = PathGenerator(random)
@@ -89,7 +87,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
     photoPath = tempDir.resolve(relativePath)
     photoStorageUrl = URI("file:///${relativePath.invariantSeparatorsPathString}")
 
-    fileService = FileService(dslContext, clock, config, eventPublisher, filesDao, fileStore)
+    fileService = FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
 
   @AfterEach
@@ -161,36 +159,6 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
     }
 
     assertFalse(Files.exists(photoPath), "File should not exist")
-  }
-
-  @Test
-  fun `storeFile deletes file if validation fails`() {
-    assertThrows<UnsupportedMediaTypeException> {
-      fileService.storeFile(
-          "category",
-          ByteArray(0).inputStream(),
-          metadata,
-          { throw UnsupportedMediaTypeException("validation failed") },
-      ) {}
-    }
-
-    assertFalse(Files.exists(photoPath), "File should not exist")
-  }
-
-  @Test
-  fun `storeFile keeps file if validation fails and keepInvalidUploads config is set`() {
-    every { config.keepInvalidUploads } returns true
-
-    assertThrows<UnsupportedMediaTypeException> {
-      fileService.storeFile(
-          "category",
-          ByteArray(0).inputStream(),
-          metadata,
-          { throw UnsupportedMediaTypeException("validation failed") },
-      ) {}
-    }
-
-    assertTrue(Files.exists(photoPath), "File should still exist")
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.assertIsEventListener
-import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.FileNotFoundException
@@ -31,14 +30,13 @@ class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
   override val user: TerrawareUser = mockUser()
 
   private val clock = TestClock()
-  private val config: TerrawareServerConfig = mockk()
   private val eventPublisher = TestEventPublisher()
   private val fileStore = InMemoryFileStore()
   private val converter1: JpegConverter = mockk()
   private val converter2: JpegConverter = mockk()
   private val thumbnailStore: ThumbnailStore = mockk()
   private val fileService: FileService by lazy {
-    FileService(dslContext, clock, config, eventPublisher, filesDao, fileStore)
+    FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
   private val service: ThumbnailService by lazy {
     ThumbnailService(dslContext, fileService, listOf(converter1, converter2), thumbnailStore)

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/BatchPhotoServiceTest.kt
@@ -21,7 +21,6 @@ import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.nursery.event.BatchDeletionStartedEvent
 import com.terraformation.backend.onePixelPng
-import com.terraformation.backend.util.ImageUtils
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -47,7 +46,6 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
     FileService(
         dslContext,
         Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
-        mockk(),
         eventPublisher,
         filesDao,
         fileStore,
@@ -61,7 +59,6 @@ internal class BatchPhotoServiceTest : DatabaseTest(), RunsAsUser {
         dslContext,
         eventPublisher,
         fileService,
-        ImageUtils(fileStore),
         thumbnailService,
     )
   }

--- a/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoServiceTest.kt
@@ -19,7 +19,6 @@ import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.onePixelPng
-import com.terraformation.backend.util.ImageUtils
 import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
@@ -42,7 +41,6 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
     FileService(
         dslContext,
         Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
-        mockk(),
         eventPublisher,
         filesDao,
         fileStore,
@@ -54,7 +52,6 @@ internal class WithdrawalPhotoServiceTest : DatabaseTest(), RunsAsUser {
         dslContext,
         eventPublisher,
         fileService,
-        ImageUtils(fileStore),
         thumbnailService,
         withdrawalPhotosDao,
     )

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportFileServiceTest.kt
@@ -50,7 +50,7 @@ class SeedFundReportFileServiceTest : DatabaseTest(), RunsAsUser {
   private val eventPublisher = TestEventPublisher()
   private val fileStore: FileStore = mockk()
   private val fileService: FileService by lazy {
-    FileService(dslContext, clock, mockk(), eventPublisher, filesDao, fileStore)
+    FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
   private val seedFundReportStore: SeedFundReportStore by lazy {
     SeedFundReportStore(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/db/PhotoRepositoryTest.kt
@@ -23,7 +23,6 @@ import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.onePixelPng
-import com.terraformation.backend.util.ImageUtils
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -102,7 +101,7 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
     every { user.canReadAccession(any()) } returns true
     every { user.canUploadPhoto(any()) } returns true
 
-    fileService = FileService(dslContext, clock, mockk(), eventPublisher, filesDao, fileStore)
+    fileService = FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
     thumbnailService = ThumbnailService(dslContext, fileService, mockk(), thumbnailStore)
     repository =
         PhotoRepository(
@@ -110,7 +109,6 @@ class PhotoRepositoryTest : DatabaseTest(), RunsAsUser {
             dslContext,
             eventPublisher,
             fileService,
-            ImageUtils(fileStore),
             thumbnailService,
         )
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -128,7 +128,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     FileService(
         dslContext,
         Clock.fixed(Instant.EPOCH, ZoneOffset.UTC),
-        mockk(),
         eventPublisher,
         filesDao,
         fileStore,


### PR DESCRIPTION
For most of the photo upload endpoints, we've been validating that the uploaded
files can be loaded using the Java ImageIO class and rejecting them if not.
That won't work for HEIC images, which we can't read directly, or for video files.
Remove the validation since it won't be useful protection against malformed files
once we start supporting those formats in more places in the app.