### PR TITLE
SW-7584 Add searchCount endpoint to search service

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -12,6 +12,7 @@ import org.jooq.Record
 import org.jooq.Record1
 import org.jooq.RecordMapper
 import org.jooq.Select
+import org.jooq.SelectConditionStep
 import org.jooq.SelectJoinStep
 import org.jooq.SelectSeekStepN
 import org.jooq.SortField
@@ -694,7 +695,7 @@ class NestedQueryBuilder(
   }
 
   /** Returns a jOOQ count query object for the currently-configured query */
-  fun toSelectCountQuery(): SelectSeekStepN<Record1<Int>> {
+  fun toSelectCountQuery(): SelectConditionStep<Record1<Int>> {
     val select = dslContext.selectOne()
 
     val selectFrom = select.from(prefix.searchTable.fromTable)
@@ -707,7 +708,7 @@ class NestedQueryBuilder(
           selectWithConditions
         }
 
-    return selectWithVisibility.orderBy(getOrderBy(true))
+    return selectWithVisibility
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -9,6 +9,7 @@ import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.OrderField
 import org.jooq.Record
+import org.jooq.Record1
 import org.jooq.RecordMapper
 import org.jooq.Select
 import org.jooq.SelectJoinStep
@@ -690,6 +691,23 @@ class NestedQueryBuilder(
 
       selectWithVisibility.orderBy(getOrderBy(!distinct))
     }
+  }
+
+  /** Returns a jOOQ count query object for the currently-configured query */
+  fun toSelectCountQuery(): SelectSeekStepN<Record1<Int>> {
+    val select = dslContext.selectOne()
+
+    val selectFrom = select.from(prefix.searchTable.fromTable)
+    val selectWithConditions = selectFrom.where(conditions)
+    val conditionForVisibility = prefix.searchTable.conditionForVisibility()
+    val selectWithVisibility =
+        if (conditionForVisibility != null) {
+          selectWithConditions.and(conditionForVisibility)
+        } else {
+          selectWithConditions
+        }
+
+    return selectWithVisibility.orderBy(getOrderBy(true))
   }
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -185,12 +185,11 @@ class SearchService(private val dslContext: DSLContext) {
 
   fun searchCount(
       rootPrefix: SearchFieldPrefix,
-      fields: Collection<SearchFieldPath>,
       criteria: Map<SearchFieldPrefix, SearchNode>,
   ): Long {
     val exactCriteria = criteria.mapValues { it.value.toExactSearch() }
     if (exactCriteria != criteria) {
-      val exactResults = searchCount(rootPrefix, fields, exactCriteria)
+      val exactResults = searchCount(rootPrefix, exactCriteria)
       if (exactResults > 0) {
         return exactResults
       }

--- a/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/SearchService.kt
@@ -196,16 +196,15 @@ class SearchService(private val dslContext: DSLContext) {
       }
     }
 
-    return runQueryCount(rootPrefix, fields, criteria)
+    return runQueryCount(rootPrefix, criteria)
   }
 
   private fun runQueryCount(
       rootPrefix: SearchFieldPrefix,
-      fields: Collection<SearchFieldPath>,
       criteria: Map<SearchFieldPrefix, SearchNode>,
   ): Long {
-    val queryBuilder = buildQuery(rootPrefix, fields, criteria, emptyList())
-    val query = queryBuilder.toSelectQuery()
+    val queryBuilder = buildQuery(rootPrefix, emptyList(), criteria, emptyList())
+    val query = queryBuilder.toSelectCountQuery()
 
     val count =
         log.debugWithTiming("Retrieved count for search query") {

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -94,11 +94,7 @@ class SearchController(
     val rootPrefix = resolvePrefix(payload.prefix)
 
     return SearchCountResponsePayload(
-        searchService.searchCount(
-            rootPrefix,
-            payload.fields.map { rootPrefix.resolve(it) },
-            payload.toSearchCriteria(rootPrefix),
-        )
+        searchService.searchCount(rootPrefix, payload.toSearchCriteria(rootPrefix))
     )
   }
 

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -88,6 +88,20 @@ class SearchController(
     )
   }
 
+  @Operation(summary = "Get the total count of values matching a set of search criteria.")
+  @PostMapping("/count")
+  fun searchCount(@RequestBody payload: SearchRequestPayload): SearchCountResponsePayload {
+    val rootPrefix = resolvePrefix(payload.prefix)
+
+    return SearchCountResponsePayload(
+        searchService.searchCount(
+            rootPrefix,
+            payload.fields.map { rootPrefix.resolve(it) },
+            payload.toSearchCriteria(rootPrefix),
+        )
+    )
+  }
+
   @ApiResponse(
       responseCode = "200",
       content =

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -207,3 +207,5 @@ data class FieldValuesPayload(
 )
 
 data class SearchValuesResponsePayload(val results: Map<String, FieldValuesPayload>)
+
+data class SearchCountResponsePayload(val count: Long)

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
@@ -43,27 +43,22 @@ internal class SearchServiceCountTest : SearchServiceTest() {
 
   @Test
   fun `basic count`() {
-    val fields = listOf(bagNumberSublistField)
-
     assertEquals(
         2,
-        searchService.searchCount(rootPrefix, fields, mapOf(rootPrefix to NoConditionNode())),
+        searchService.searchCount(rootPrefix, mapOf(rootPrefix to NoConditionNode())),
     )
   }
 
   @Test
   fun `respects criteria`() {
-    val fields = listOf(bagNumberSublistField)
     val criteria = FieldNode(bagNumberSublistField, listOf("101"))
 
-    assertEquals(1, searchService.searchCount(rootPrefix, fields, mapOf(rootPrefix to criteria)))
+    assertEquals(1, searchService.searchCount(rootPrefix, mapOf(rootPrefix to criteria)))
   }
 
   @Test
   fun `sublist criteria doesn't affect count`() {
     val prefix = SearchFieldPrefix(root = tables.viabilityTests)
-    val fields =
-        listOf(prefix.resolve("id"), prefix.resolve("viabilityTestResults.seedsGerminated"))
     val germinatedPrefix = prefix.relativeSublistPrefix("viabilityTestResults")!!
     val sublistCriteria =
         FieldNode(
@@ -79,7 +74,6 @@ internal class SearchServiceCountTest : SearchServiceTest() {
         4,
         searchService.searchCount(
             prefix,
-            fields,
             mapOf(prefix to NoConditionNode(), germinatedPrefix to sublistCriteria),
         ),
     )

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
@@ -85,24 +85,6 @@ internal class SearchServiceCountTest : SearchServiceTest() {
     )
   }
 
-  @Test
-  fun `works for large quantities`() {
-    val prefix = SearchFieldPrefix(root = tables.viabilityTestResults)
-    val fields = listOf(prefix.resolve("seedsGerminated"))
-    val criteria =
-        FieldNode(
-            prefix.resolve("viabilityTest.id"),
-            listOf(testId1.toString(), testId2.toString(), testId3.toString()),
-        )
-
-    insertTestResults(testId1, 1000)
-    insertTestResults(testId2, 2000)
-    insertTestResults(testId3, 3000)
-    insertTestResults(testId4, 5) // excluded from criteria
-
-    assertEquals(6000, searchService.searchCount(prefix, fields, mapOf(prefix to criteria)))
-  }
-
   private fun insertTestResults(testId: ViabilityTestId, total: Int) {
     for (n in 1..total) {
       insertViabilityTestResult(

--- a/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/seedbank/search/SearchServiceCountTest.kt
@@ -1,0 +1,115 @@
+package com.terraformation.backend.seedbank.search
+
+import com.terraformation.backend.db.seedbank.ViabilityTestId
+import com.terraformation.backend.search.FieldNode
+import com.terraformation.backend.search.NoConditionNode
+import com.terraformation.backend.search.SearchFieldPrefix
+import com.terraformation.backend.search.SearchFilterType
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SearchServiceCountTest : SearchServiceTest() {
+  val epochPlusOne: LocalDate = LocalDate.EPOCH.plusDays(1)
+  val epochPlusTwo: LocalDate = LocalDate.EPOCH.plusDays(2)
+
+  private lateinit var testId1: ViabilityTestId
+  private lateinit var testId2: ViabilityTestId
+  private lateinit var testId3: ViabilityTestId
+  private lateinit var testId4: ViabilityTestId
+
+  @BeforeEach
+  fun setUp() {
+    insertBag(accessionId = accessionId1, bagNumber = "101")
+    insertBag(accessionId = accessionId1, bagNumber = "102")
+    insertBag(accessionId = accessionId1, bagNumber = "103")
+    insertBag(accessionId = accessionId2, bagNumber = "201")
+    insertBag(accessionId = accessionId2, bagNumber = "202")
+
+    testId1 = insertViabilityTest(accessionId = accessionId1, notes = "this is Viability Test 1")
+    testId2 =
+        insertViabilityTest(
+            accessionId = accessionId2,
+            notes = "This is Viability Test 2 extra stuff",
+        )
+    testId3 =
+        insertViabilityTest(
+            accessionId = accessionId1,
+            notes = "this IS Viability Test 3 EXTRA STUFF AND THINGS AND WORDS",
+        )
+    testId4 = insertViabilityTest(accessionId = accessionId2, notes = "THIS IS Viability Test 4")
+  }
+
+  @Test
+  fun `basic count`() {
+    val fields = listOf(bagNumberSublistField)
+
+    assertEquals(
+        2,
+        searchService.searchCount(rootPrefix, fields, mapOf(rootPrefix to NoConditionNode())),
+    )
+  }
+
+  @Test
+  fun `respects criteria`() {
+    val fields = listOf(bagNumberSublistField)
+    val criteria = FieldNode(bagNumberSublistField, listOf("101"))
+
+    assertEquals(1, searchService.searchCount(rootPrefix, fields, mapOf(rootPrefix to criteria)))
+  }
+
+  @Test
+  fun `sublist criteria doesn't affect count`() {
+    val prefix = SearchFieldPrefix(root = tables.viabilityTests)
+    val fields =
+        listOf(prefix.resolve("id"), prefix.resolve("viabilityTestResults.seedsGerminated"))
+    val germinatedPrefix = prefix.relativeSublistPrefix("viabilityTestResults")!!
+    val sublistCriteria =
+        FieldNode(
+            prefix.resolve("viabilityTestResults.seedsGerminated"),
+            listOf("1", "5"),
+            type = SearchFilterType.Range,
+        )
+
+    insertTestResults(testId1, 10)
+    insertTestResults(testId2, 10)
+
+    assertEquals(
+        4,
+        searchService.searchCount(
+            prefix,
+            fields,
+            mapOf(prefix to NoConditionNode(), germinatedPrefix to sublistCriteria),
+        ),
+    )
+  }
+
+  @Test
+  fun `works for large quantities`() {
+    val prefix = SearchFieldPrefix(root = tables.viabilityTestResults)
+    val fields = listOf(prefix.resolve("seedsGerminated"))
+    val criteria =
+        FieldNode(
+            prefix.resolve("viabilityTest.id"),
+            listOf(testId1.toString(), testId2.toString(), testId3.toString()),
+        )
+
+    insertTestResults(testId1, 1000)
+    insertTestResults(testId2, 2000)
+    insertTestResults(testId3, 3000)
+    insertTestResults(testId4, 5) // excluded from criteria
+
+    assertEquals(6000, searchService.searchCount(prefix, fields, mapOf(prefix to criteria)))
+  }
+
+  private fun insertTestResults(testId: ViabilityTestId, total: Int) {
+    for (n in 1..total) {
+      insertViabilityTestResult(
+          viabilityTestId = testId,
+          seedsGerminated = n,
+          recordingDate = epochPlusOne,
+      )
+    }
+  }
+}


### PR DESCRIPTION
In order to support BE pagination, we'll need to have a total row count to know how many pages and rows there are. Rather than adding this to the regular search api (and thus probably over-query this when it's not needed), add a separate endpoint to support this. 

The next PR will limit what is queried.