### PR TITLE
SW-7584 Exclude multisets to simplify search count queries

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/NestedQueryBuilder.kt
@@ -620,9 +620,10 @@ class NestedQueryBuilder(
   fun addSelectFields(
       fields: Collection<SearchFieldPath>,
       criteria: Map<SearchFieldPrefix, SearchNode>,
+      excludeMultisets: Boolean = false,
   ) {
     assertNotRendered()
-    fields.forEach { addSelectField(it, criteria) }
+    fields.forEach { addSelectField(it, criteria, excludeMultisets) }
   }
 
   /**
@@ -777,6 +778,7 @@ class NestedQueryBuilder(
   private fun addSelectField(
       fieldPath: SearchFieldPath,
       criteria: Map<SearchFieldPrefix, SearchNode>,
+      excludeMultisets: Boolean = false,
   ) {
     val relativeField = fieldPath.relativeTo(prefix)
 
@@ -795,6 +797,9 @@ class NestedQueryBuilder(
         nextSelectFieldPosition += searchField.selectFields.size
       }
     } else if (relativeField.isNested) {
+      if (excludeMultisets) {
+        return
+      }
       // Prefix = a.b, fieldName = a.b.c.d => make a sublist "c" to hold field "d"
       val sublistName = getSublistName(relativeField)
       val sublistQuery =

--- a/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/search/SearchServiceTest.kt
@@ -12,6 +12,7 @@ import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class SearchServiceTest : DatabaseTest(), RunsAsUser {
   override val user = mockUser()
@@ -200,6 +201,20 @@ class SearchServiceTest : DatabaseTest(), RunsAsUser {
           )
 
       assertJsonEquals(expected, searchService.search(prefix, fields, mapOf(prefix to conditions)))
+    }
+  }
+
+  @Nested
+  inner class BuildQuery {
+    @Test
+    fun `buildQuery throws exception`() {
+      val prefix = SearchFieldPrefix(searchTables.species)
+      val fields =
+          listOf("nurseryProjects.project.id", "organization.id").map { prefix.resolve(it) }
+
+      assertThrows<IllegalArgumentException> {
+        searchService.buildQuery(prefix, fields, emptyMap(), excludeMultisets = true)
+      }
     }
   }
 }


### PR DESCRIPTION
In order to simplify the queries used for getting search counts, exclude nested fields.

I wasn't sure if other things could be excluded, and/or if this is the best way to exclude multisets. Open to ideas here