### PR TITLE
SW-7566 Only include subzones with at least one permanent plot in zone check

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1319,8 +1319,15 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       }
                     }
                     .calculateWeightedStandardDeviation()
+            val survivalRateSubzones =
+                subzones.filter { subzone ->
+                  subzone.monitoringPlots.any { survivalRateIncludesTempPlots || it.isPermanent }
+                }
             val survivalRate =
-                if (subzones.isNotEmpty() && subzones.all { it.survivalRate != null }) {
+                if (
+                    survivalRateSubzones.isNotEmpty() &&
+                        survivalRateSubzones.all { it.survivalRate != null }
+                ) {
                   species.calculateSurvivalRate(survivalRateIncludesTempPlots)
                 } else {
                   null

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -362,8 +362,15 @@ data class ObservationPlantingZoneRollupResultsModel(
                 }
               }
               .calculateWeightedStandardDeviation()
+      val survivalRateSubzones =
+          nonNullSubzoneResults.filter { subzone ->
+            subzone.monitoringPlots.any { survivalRateIncludesTempPlots || it.isPermanent }
+          }
       val survivalRate =
-          if (nonNullSubzoneResults.all { it.survivalRate != null })
+          if (
+              survivalRateSubzones.isNotEmpty() &&
+                  survivalRateSubzones.all { it.survivalRate != null }
+          )
               species.calculateSurvivalRate(survivalRateIncludesTempPlots)
           else null
       val survivalRateStdDev =

--- a/src/test/resources/tracking/observation/TwoObservations/ZoneStats.csv
+++ b/src/test/resources/tracking/observation/TwoObservations/ZoneStats.csv
@@ -1,4 +1,4 @@
 Observation ->,1,1,1,1,1,1,2,2,2,2,2,2
 Zone,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Survival Rate,Est Plants,# Plants (excluding existing),Planting Density,# Live Species,Mortality Rate,Survival Rate,Est Plants
 Alpha,14,20,6,42%,,,16,24,7,44%,,36000
-Beta,12,17,2,22%,,16500,9,15,3,44%,63%,15400
+Beta,12,17,2,22%,88%,16500,9,15,3,44%,63%,15400


### PR DESCRIPTION
When calculating survival rate for Zones, only include zones that have at least one permanent plot if `survivalRateIncludesTempPlots` is false.