### PR TITLE
SW-7569 Add wrapper for FileService callback file ID

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -110,7 +110,7 @@ class ActivityMediaService(
                     geolocation = exifMetadata?.extractGeolocation(),
                 )
               },
-          ) { fileId ->
+          ) { (fileId) ->
             val mimeType =
                 fileType?.mimeType
                     ?: throw UnsupportedMediaTypeException("Cannot determine file type")

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesService.kt
@@ -212,7 +212,7 @@ class ParticipantProjectSpeciesService(
       metadata: NewFileMetadata,
       submissionId: SubmissionId,
   ) =
-      fileService.storeFile("species-list-deliverable", inputStream, metadata) { fileId ->
+      fileService.storeFile("species-list-deliverable", inputStream, metadata) { (fileId) ->
         with(SUBMISSION_SNAPSHOTS) {
           dslContext
               .insertInto(SUBMISSION_SNAPSHOTS)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ReportService.kt
@@ -90,7 +90,7 @@ class ReportService(
     requirePermissions { updateReport(reportId) }
 
     val fileId =
-        fileService.storeFile("report", data, metadata) { fileId ->
+        fileService.storeFile("report", data, metadata) { (fileId) ->
           reportPhotosDao.insert(
               ReportPhotosRow(
                   fileId = fileId,

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/VariableFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/VariableFileService.kt
@@ -51,7 +51,7 @@ class VariableFileService(
   ): VariableValueId {
     lateinit var valueId: VariableValueId
 
-    fileService.storeFile("imageValue", data, metadata) { fileId ->
+    fileService.storeFile("imageValue", data, metadata) { (fileId) ->
       val effectiveBase =
           if (isAppend) {
             base.copy(

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -72,7 +72,7 @@ class FileService(
       data: InputStream,
       metadata: NewFileMetadata,
       populateMetadata: ((NewFileMetadata) -> NewFileMetadata)? = null,
-      insertChildRows: (FileId) -> Unit,
+      insertChildRows: (StoredFile) -> Unit,
   ): FileId {
     val storageUrl = fileStore.newUrl(clock.instant(), category, metadata.contentType)
 
@@ -105,7 +105,7 @@ class FileService(
 
       dslContext.transaction { _ ->
         filesDao.insert(filesRow)
-        insertChildRows(filesRow.id!!)
+        insertChildRows(StoredFile(filesRow.id!!))
       }
 
       return filesRow.id!!
@@ -234,4 +234,12 @@ class FileService(
       }
     }
   }
+
+  /**
+   * Information about a file that has just been stored in the file store. This is passed to the
+   * `insertChildRows` callback of [FileService.storeFile].
+   */
+  data class StoredFile(
+      val fileId: FileId, // This should be first so it's easily accessible via destructuring
+  )
 }

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/BatchPhotoService.kt
@@ -41,7 +41,7 @@ class BatchPhotoService(
     requirePermissions { updateBatch(batchId) }
 
     val fileId =
-        fileService.storeFile("batch", data, metadata) { fileId ->
+        fileService.storeFile("batch", data, metadata) { (fileId) ->
           batchPhotosDao.insert(
               BatchPhotosRow(
                   batchId = batchId,

--- a/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/db/WithdrawalPhotoService.kt
@@ -36,7 +36,7 @@ class WithdrawalPhotoService(
     requirePermissions { createWithdrawalPhoto(withdrawalId) }
 
     val fileId =
-        fileService.storeFile("withdrawal", data, metadata) { fileId ->
+        fileService.storeFile("withdrawal", data, metadata) { (fileId) ->
           withdrawalPhotosDao.insert(
               WithdrawalPhotosRow(fileId = fileId, withdrawalId = withdrawalId)
           )

--- a/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/SeedFundReportFileService.kt
@@ -179,7 +179,8 @@ class SeedFundReportFileService(
   ): FileId {
     requirePermissions { updateSeedFundReport(reportId) }
 
-    val fileId = fileService.storeFile("report", data, metadata, insertChildRows = insertChildRow)
+    val fileId =
+        fileService.storeFile("report", data, metadata) { (fileId) -> insertChildRow(fileId) }
 
     log.info("Stored ${metadata.contentType} file $fileId for report $reportId")
 

--- a/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
+++ b/src/main/kotlin/com/terraformation/backend/seedbank/db/PhotoRepository.kt
@@ -42,7 +42,7 @@ class PhotoRepository(
     requirePermissions { uploadPhoto(accessionId) }
 
     val fileId =
-        fileService.storeFile("accession", data, metadata) { fileId ->
+        fileService.storeFile("accession", data, metadata) { (fileId) ->
           accessionPhotosDao.insert(AccessionPhotosRow(accessionId = accessionId, fileId = fileId))
         }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -214,7 +214,7 @@ class ObservationService(
     }
 
     val fileId =
-        fileService.storeFile("observation", data, metadata) { fileId ->
+        fileService.storeFile("observation", data, metadata) { (fileId) ->
           observationPhotosDao.insert(
               ObservationPhotosRow(
                   fileId = fileId,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -11,7 +11,6 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.ReportNotFoundException
 import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.tables.records.ReportPhotosRecord
-import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.GlobalRole
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -77,9 +76,9 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     every { reportStore.publishReport(any()) } returns Unit
     every { fileService.storeFile(any(), any(), any(), any(), any()) } answers
         {
-          val func = arg<((fileId: FileId) -> Unit)?>(4)
+          val func = arg<((storedFile: FileService.StoredFile) -> Unit)?>(4)
           val fileId = insertFile()
-          func?.let { it(fileId) }
+          func?.let { it(FileService.StoredFile(fileId)) }
           fileId
         }
 

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -231,7 +231,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
       insertActivity()
       val fileId =
           fileService.storeFile("category", Random.nextBytes(1).inputStream(), metadata) {
-            insertActivityMediaFile(fileId = it)
+            insertActivityMediaFile(fileId = it.fileId)
           }
       val filesTableBefore = dslContext.fetch(FILES)
       val storageUrl = filesTableBefore.first().storageUrl!!


### PR DESCRIPTION
In preparation for automatically extracting metadata from files as they're written
to the file store, update `FileService.storeFile` so that the callback function
that inserts rows in child tables takes a new `StoredFile` object rather than just
a file ID. Currently, `StoredFile` only includes the file ID, but later it will
be extended with additional metadata that callers can use if they need to.