### PR TITLE
SW-7569 Move EXIF extraction to FileService

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -1,9 +1,5 @@
 package com.terraformation.backend.accelerator
 
-import com.drew.imaging.FileType
-import com.drew.imaging.FileTypeDetector
-import com.drew.imaging.ImageMetadataReader
-import com.drew.metadata.Metadata
 import com.terraformation.backend.accelerator.db.ActivityMediaStore
 import com.terraformation.backend.accelerator.event.ActivityDeletionStartedEvent
 import com.terraformation.backend.accelerator.model.ActivityMediaModel
@@ -19,15 +15,11 @@ import com.terraformation.backend.file.FileService
 import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.VideoFileUploadedEvent
-import com.terraformation.backend.file.extractCapturedDate
-import com.terraformation.backend.file.extractGeolocation
 import com.terraformation.backend.file.model.NewFileMetadata
 import com.terraformation.backend.file.mux.MuxService
 import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.log.perClassLogger
-import com.terraformation.backend.util.InputStreamCopier
 import jakarta.inject.Named
-import java.io.BufferedInputStream
 import java.io.InputStream
 import java.time.InstantSource
 import java.time.LocalDate
@@ -55,88 +47,46 @@ class ActivityMediaService(
   ): FileId {
     requirePermissions { updateActivity(activityId) }
 
-    val copier = InputStreamCopier(data)
-    val fileTypeStream = copier.getCopy()
-    val exifStream = copier.getCopy()
-    val storageStream = copier.getCopy()
-
-    // Use a child thread to transfer data to the copy streams and the current thread to save the
-    // file to the file store, rather than the other way around, so that the call to
-    // fileService.storeFile() will use this thread's active database transaction.
-    val currentThreadName = Thread.currentThread().name
-    Thread.ofVirtual().name("$currentThreadName-transfer").start { copier.transfer() }
-
-    var fileType: FileType? = null
-    var exifMetadata: Metadata? = null
     var mediaType: ActivityMediaType? = null
 
-    val exifThread =
-        Thread.ofVirtual().name("$currentThreadName-exif").start {
-          exifStream.use {
-            try {
-              // Wrap the input in a BufferedInputStream because detectFileType calls mark/reset on
-              // it. But that's only done to read a small amount of header data at the beginning of
-              // the file to determine the file type. (That's also why we can safely read both
-              // fileTypeStream and exifStream in the same thread.) After that, we throw the
-              // buffered wrapper away and close the copy stream; another copy stream is used to
-              // read the actual EXIF metadata to avoid BufferedInputStream copying bytes around
-              // needlessly.
-              fileType =
-                  fileTypeStream.use { FileTypeDetector.detectFileType(BufferedInputStream(it)) }
-
-              exifMetadata = ImageMetadataReader.readMetadata(exifStream, -1, fileType)
-            } catch (e: Exception) {
-              log.error("Failed to extract EXIF data from uploaded file", e)
-            }
-          }
-        }
-
     val fileId =
-        storageStream.use {
-          fileService.storeFile(
-              "activity",
-              storageStream,
-              newFileMetadata,
-              populateMetadata = { metadata ->
-                // Make sure we've finished extracting EXIF metadata from the stream before trying
-                // to pull values from it. At this point, storageStream has been completely consumed
-                // because the file has been copied to the file store.
-                exifThread.join()
+        fileService.storeFile(
+            "activity",
+            data,
+            newFileMetadata,
+            populateMetadata = { metadata: NewFileMetadata ->
+              if (metadata.capturedLocalTime != null) {
+                metadata
+              } else {
+                metadata.copy(capturedLocalTime = getCurrentDate(activityId).atStartOfDay())
+              }
+            },
+        ) { storedFile ->
+          val mimeType =
+              storedFile.fileType?.mimeType
+                  ?: throw UnsupportedMediaTypeException("Cannot determine file type")
 
-                val capturedDate = exifMetadata?.extractCapturedDate() ?: getCurrentDate(activityId)
-                metadata.copy(
-                    // TODO: Extract time of day from EXIF, not just date
-                    capturedLocalTime = capturedDate.atStartOfDay(),
-                    geolocation = exifMetadata?.extractGeolocation(),
-                )
-              },
-          ) { (fileId) ->
-            val mimeType =
-                fileType?.mimeType
-                    ?: throw UnsupportedMediaTypeException("Cannot determine file type")
+          mediaType =
+              when {
+                mimeType.startsWith("image/") -> ActivityMediaType.Photo
+                mimeType.startsWith("video/") -> ActivityMediaType.Video
+                else ->
+                    throw UnsupportedMediaTypeException(
+                        "${storedFile.fileType.longName} ($mimeType) is not a supported file type"
+                    )
+              }
 
-            mediaType =
-                when {
-                  mimeType.startsWith("image/") -> ActivityMediaType.Photo
-                  mimeType.startsWith("video/") -> ActivityMediaType.Video
-                  else ->
-                      throw UnsupportedMediaTypeException(
-                          "${fileType!!.longName} ($mimeType) is not a supported file type"
-                      )
-                }
+          val row =
+              ActivityMediaFilesRow(
+                  activityId = activityId,
+                  activityMediaTypeId = mediaType,
+                  fileId = storedFile.fileId,
+                  isCoverPhoto = false,
+                  isHiddenOnMap = false,
+                  listPosition = listPosition,
+              )
 
-            val row =
-                ActivityMediaFilesRow(
-                    activityId = activityId,
-                    activityMediaTypeId = mediaType,
-                    fileId = fileId,
-                    isCoverPhoto = false,
-                    isHiddenOnMap = false,
-                    listPosition = listPosition,
-                )
-
-            activityMediaStore.insertMediaFile(row)
-          }
+          activityMediaStore.insertMediaFile(row)
         }
 
     log.info("Stored file $fileId for activity $activityId")


### PR DESCRIPTION
Move the "extract EXIF metadata from a file and store it" logic from
ActivityMediaService to FileService so it can easily be reused for file uploads in
other parts of Terraware.

With this change, we'll start recording captured dates and geolocations for photos
uploaded to all parts of the app, though those values aren't accessible via the
API in any new places yet.