### PR TITLE
SW-7569 Extract EXIF captured time, not just date

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ActivityMediaService.kt
@@ -22,7 +22,7 @@ import com.terraformation.backend.log.perClassLogger
 import jakarta.inject.Named
 import java.io.InputStream
 import java.time.InstantSource
-import java.time.LocalDate
+import java.time.LocalDateTime
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.web.reactive.function.UnsupportedMediaTypeException
@@ -58,7 +58,7 @@ class ActivityMediaService(
               if (metadata.capturedLocalTime != null) {
                 metadata
               } else {
-                metadata.copy(capturedLocalTime = getCurrentDate(activityId).atStartOfDay())
+                metadata.copy(capturedLocalTime = getCurrentTime(activityId))
               }
             },
         ) { storedFile ->
@@ -156,6 +156,6 @@ class ActivityMediaService(
   }
 
   /** Returns the current date in the time zone of the organization associated with an activity. */
-  private fun getCurrentDate(activityId: ActivityId): LocalDate =
-      LocalDate.ofInstant(clock.instant(), parentStore.getEffectiveTimeZone(activityId))
+  private fun getCurrentTime(activityId: ActivityId): LocalDateTime =
+      LocalDateTime.ofInstant(clock.instant(), parentStore.getEffectiveTimeZone(activityId))
 }

--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -146,10 +146,8 @@ class FileService(
 
         val fileMetadataWithExifValues =
             newFileMetadata.copy(
-                // TODO: Extract time of day from EXIF, not just date
                 capturedLocalTime =
-                    newFileMetadata.capturedLocalTime
-                        ?: exifMetadata?.extractCapturedDate()?.atStartOfDay(),
+                    newFileMetadata.capturedLocalTime ?: exifMetadata?.extractCapturedTime(),
                 geolocation = newFileMetadata.geolocation ?: exifMetadata?.extractGeolocation(),
             )
 

--- a/src/main/kotlin/com/terraformation/backend/file/MetadataExtensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/MetadataExtensions.kt
@@ -11,9 +11,10 @@ import com.drew.metadata.mov.QuickTimeDirectory
 import com.drew.metadata.mov.metadata.QuickTimeMetadataDirectory
 import com.drew.metadata.mp4.Mp4Directory
 import com.terraformation.backend.db.SRID
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Date
 import kotlin.math.withSign
 import org.locationtech.jts.geom.Coordinate
@@ -26,9 +27,9 @@ private val log = LoggerFactory.getLogger(Metadata::class.java)
 private val geometryFactory = GeometryFactory(PrecisionModel(), SRID.LONG_LAT)
 
 /** Returns the date the file was originally captured, if available. */
-fun Metadata.extractCapturedDate(): LocalDate? {
+fun Metadata.extractCapturedTime(): LocalDateTime? {
   return try {
-    extractExifCapturedDate() ?: extractVideoCapturedDate()
+    extractExifCapturedTime() ?: extractVideoCapturedTime()
   } catch (e: Exception) {
     log.warn("Failed to extract captured date from media metadata", e)
     null
@@ -40,9 +41,29 @@ fun Metadata.extractGeolocation(): Point? {
   return extractExifGeolocation() ?: extractQuickTimeGeolocation() ?: extractMp4Geolocation()
 }
 
-/** Extracts the captured date, if any, from EXIF metadata. */
-@Suppress("ReplaceSubstringWithIndexingOperation") // Hide bogus IntelliJ suggestion
-private fun Metadata.extractExifCapturedDate(): LocalDate? {
+/**
+ * All the known EXIF date/time formats in actual use. This is from [Directory.getDate] but that
+ * function has different behavior than we want.
+ */
+private val exifDateTimeFormatters =
+    listOf(
+            "yyyy:MM:dd HH:mm:ss",
+            "yyyy:MM:dd HH:mm",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd HH:mm",
+            "yyyy.MM.dd HH:mm:ss",
+            "yyyy.MM.dd HH:mm",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd'T'HH:mm",
+            "yyyy-MM-dd",
+            "yyyy-MM",
+            "yyyyMMdd", // as used in IPTC data
+            "yyyy",
+        )
+        .map { DateTimeFormatter.ofPattern(it) }
+
+/** Extracts the captured date and time, if any, from EXIF metadata. */
+private fun Metadata.extractExifCapturedTime(): LocalDateTime? {
   // Try the original (capture) date first, then digitization date, then modification date.
   val dateStr =
       getString<ExifSubIFDDirectory>(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)
@@ -58,16 +79,17 @@ private fun Metadata.extractExifCapturedDate(): LocalDate? {
     log.warn("EXIF date string is too short: $dateStr")
     null
   } else {
-    // EXIF date/time strings always start with a 4-digit year, but after that there can be a
-    // variety of separators (2025:11:22, 2025-11-22, 2025.11-22) or no separator (20251122).
-    // And there can be a time of day after the date, or not.
-    val separator = if (dateStr[4].isDigit()) "" else dateStr.substring(4, 5)
-    val formatter = DateTimeFormatter.ofPattern("yyyy${separator}MM${separator}dd")
-    LocalDate.parse(dateStr.take(8 + separator.length * 2), formatter)
+    exifDateTimeFormatters.firstNotNullOfOrNull { formatter ->
+      try {
+        LocalDateTime.parse(dateStr, formatter)
+      } catch (_: DateTimeParseException) {
+        null
+      }
+    }
   }
 }
 
-private fun Metadata.extractVideoCapturedDate(): LocalDate? {
+private fun Metadata.extractVideoCapturedTime(): LocalDateTime? {
   val date =
       getDate<QuickTimeDirectory>(QuickTimeDirectory.TAG_CREATION_TIME)
           ?: getDate<Mp4Directory>(Mp4Directory.TAG_CREATION_TIME)
@@ -79,7 +101,7 @@ private fun Metadata.extractVideoCapturedDate(): LocalDate? {
     return null
   }
 
-  return LocalDate.ofInstant(date.toInstant(), ZoneOffset.UTC)
+  return LocalDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC)
 }
 
 /** Extracts GPS coordinates, if any, from EXIF metadata. */

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ActivityMediaServiceTest.kt
@@ -41,6 +41,7 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -124,7 +125,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores photo and extracts date and GPS metadata`() {
       assertMediaFileEquals(
           storeMedia("photoWithDateAndGps.jpg"),
-          capturedDate = LocalDate.of(2023, 5, 15),
+          capturedLocalTime = LocalDateTime.of(2023, 5, 15, 14, 30, 25),
           geolocation = point(-122.4194, 37.7749),
       )
     }
@@ -133,7 +134,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores iPhone video and extracts date and GPS metadata`() {
       assertMediaFileEquals(
           storeMedia("videoIphone.mov"),
-          capturedDate = LocalDate.of(2024, 6, 15),
+          capturedLocalTime = LocalDateTime.of(2024, 6, 15, 12, 34, 56),
           geolocation = point(-122.4194, 37.7749),
           type = ActivityMediaType.Video,
       )
@@ -143,7 +144,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores Android video and extracts date and GPS metadata`() {
       assertMediaFileEquals(
           storeMedia("videoAndroid.mp4"),
-          capturedDate = LocalDate.of(2024, 6, 15),
+          capturedLocalTime = LocalDateTime.of(2024, 6, 15, 12, 34, 56),
           geolocation = point(-122.4194, 37.7749),
           type = ActivityMediaType.Video,
       )
@@ -153,7 +154,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores photo and extracts date only when no GPS present`() {
       assertMediaFileEquals(
           storeMedia("photoWithDate.jpg"),
-          capturedDate = LocalDate.of(2022, 12, 25),
+          capturedLocalTime = LocalDateTime.of(2022, 12, 25, 9, 15, 0),
           geolocation = null,
       )
     }
@@ -162,7 +163,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores photo and extracts GPS only when no date present`() {
       assertMediaFileEquals(
           storeMedia("photoWithGps.jpg"),
-          capturedDate = LocalDate.EPOCH,
+          capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
           geolocation = point(-74.006, 40.7128),
       )
     }
@@ -171,7 +172,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores photo with no metadata using defaults`() {
       assertMediaFileEquals(
           storeMedia("pixel.png", pngMetadata),
-          capturedDate = LocalDate.EPOCH,
+          capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
           geolocation = null,
       )
     }
@@ -180,7 +181,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `stores video with no metadata using defaults`() {
       assertMediaFileEquals(
           storeMedia("videoHeaderOnly.mp4", mp4Metadata),
-          capturedDate = LocalDate.EPOCH,
+          capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
           geolocation = null,
           type = ActivityMediaType.Video,
       )
@@ -218,7 +219,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertMediaFileEquals(
           storeMediaBytes(corruptedData),
-          capturedDate = LocalDate.EPOCH,
+          capturedLocalTime = LocalDate.EPOCH.atStartOfDay(),
           geolocation = null,
       )
     }
@@ -247,7 +248,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     private fun assertMediaFileEquals(
         fileId: FileId,
-        capturedDate: LocalDate,
+        capturedLocalTime: LocalDateTime,
         geolocation: Point? = null,
         type: ActivityMediaType = ActivityMediaType.Photo,
     ) {
@@ -267,7 +268,7 @@ internal class ActivityMediaServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       )
 
       val filesRow = filesDao.fetchOneById(fileId)!!
-      assertEquals(filesRow.capturedLocalTime?.toLocalDate(), capturedDate, "Captured date")
+      assertEquals(filesRow.capturedLocalTime, capturedLocalTime, "Captured date")
 
       if (geolocation != null) {
         assertGeometryEquals(geolocation, filesRow.geolocation)

--- a/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileServiceTest.kt
@@ -216,7 +216,7 @@ class FileServiceTest : DatabaseTest(), RunsAsUser {
 
       val filesRecord = dslContext.fetchSingle(FILES)
       assertEquals(
-          LocalDateTime.of(2023, 5, 15, 0, 0, 0),
+          LocalDateTime.of(2023, 5, 15, 14, 30, 25),
           filesRecord.capturedLocalTime,
           "Should have used captured time from file",
       )


### PR DESCRIPTION
Although the requirements for the activity log feature only call for showing the
capture dates of photos and videos, the EXIF data also includes time of day.
Extract the time as well.