### PR TITLE
SW-7581 Add HEIC to upload endpoint OpenAPI schemas

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -196,7 +196,9 @@ annotation class ApiResponse200Photo
                         Encoding(
                             name = "file",
                             contentType =
-                                "${MediaType.IMAGE_JPEG_VALUE}, ${MediaType.IMAGE_PNG_VALUE}",
+                                "${MediaType.IMAGE_JPEG_VALUE}, " +
+                                    "${MediaType.IMAGE_PNG_VALUE}, " +
+                                    "image/heic",
                         )
                     ]
             )


### PR DESCRIPTION
Our photo upload endpoints accept files in HEIC format as of commit 7b2fdce,
but the OpenAPI schema still claimed they only accepted JPEG and PNG files.

This doesn't change the behavior of the endpoints, just makes their OpenAPI
schemas reflect the actual list of file types they accept.