### PR TITLE
SW-7599 Add captions to observation photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -198,6 +198,7 @@ class ObservationService(
       position: ObservationPlotPosition?,
       data: InputStream,
       metadata: NewFileMetadata,
+      caption: String?,
       type: ObservationPhotoType = ObservationPhotoType.Plot,
   ): FileId {
     requirePermissions { updateObservation(observationId) }
@@ -217,6 +218,7 @@ class ObservationService(
         fileService.storeFile("observation", data, metadata) { (fileId) ->
           observationPhotosDao.insert(
               ObservationPhotosRow(
+                  caption = caption,
                   fileId = fileId,
                   monitoringPlotId = monitoringPlotId,
                   observationId = observationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -417,6 +417,7 @@ class ObservationsController(
             position = payload.position,
             data = file.inputStream,
             metadata = FileMetadata.of(contentType, filename, file.size, payload.gpsCoordinates),
+            caption = payload.caption,
             type = payload.type ?: ObservationPhotoType.Plot,
         )
 
@@ -767,6 +768,7 @@ data class RecordedPlantPayload(
 }
 
 data class ObservationMonitoringPlotPhotoPayload(
+    val caption: String?,
     val fileId: FileId,
     val gpsCoordinates: Point,
     val position: ObservationPlotPosition?,
@@ -774,7 +776,7 @@ data class ObservationMonitoringPlotPhotoPayload(
 ) {
   constructor(
       model: ObservationMonitoringPlotPhotoModel
-  ) : this(model.fileId, model.gpsCoordinates, model.position, model.type)
+  ) : this(model.caption, model.fileId, model.gpsCoordinates, model.position, model.type)
 }
 
 data class ObservationMonitoringPlotCoordinatesPayload(
@@ -1497,6 +1499,7 @@ data class UpdatePlotObservationRequestPayload(
 )
 
 data class UploadPlotPhotoRequestPayload(
+    val caption: String?,
     val gpsCoordinates: Point,
     val position: ObservationPlotPosition?,
     @Schema(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -431,6 +431,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
   private val photosMultiset =
       DSL.multiset(
               DSL.select(
+                      OBSERVATION_PHOTOS.CAPTION,
                       OBSERVATION_PHOTOS.FILE_ID,
                       photosGpsField,
                       OBSERVATION_PHOTOS.POSITION_ID,
@@ -446,6 +447,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
           .convertFrom { result ->
             result.map { record ->
               ObservationMonitoringPlotPhotoModel(
+                  caption = record[OBSERVATION_PHOTOS.CAPTION],
                   fileId = record[OBSERVATION_PHOTOS.FILE_ID.asNonNullable()],
                   gpsCoordinates = record[photosGpsField.asNonNullable()] as Point,
                   position = record[OBSERVATION_PHOTOS.POSITION_ID],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -31,6 +31,7 @@ import org.locationtech.jts.geom.Point
 import org.locationtech.jts.geom.Polygon
 
 data class ObservationMonitoringPlotPhotoModel(
+    val caption: String?,
     val fileId: FileId,
     val gpsCoordinates: Point,
     val position: ObservationPlotPosition?,

--- a/src/main/resources/db/migration/0400/V420__ObservationPhotoCaption.sql
+++ b/src/main/resources/db/migration/0400/V420__ObservationPhotoCaption.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tracking.observation_photos ADD COLUMN caption TEXT;

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3073,6 +3073,7 @@ abstract class DatabaseBackedTest {
 
   fun insertObservationPhoto(
       row: ObservationPhotosRow = ObservationPhotosRow(),
+      caption: String? = row.caption,
       fileId: FileId = row.fileId ?: inserted.fileId,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
@@ -3081,6 +3082,7 @@ abstract class DatabaseBackedTest {
   ) {
     val rowWithDefaults =
         row.copy(
+            caption = caption,
             fileId = fileId,
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -629,11 +629,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       fun setUp() {
         fileId =
             service.storePhoto(
-                observationId,
-                plotId,
-                ObservationPlotPosition.NortheastCorner,
-                content.inputStream(),
-                metadata,
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = ObservationPlotPosition.NortheastCorner,
+                data = content.inputStream(),
+                metadata = metadata,
+                caption = null,
             )
       }
 
@@ -695,21 +696,23 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       fun `associates photo with observation and plot`() {
         val fileId1 =
             service.storePhoto(
-                observationId,
-                plotId,
-                ObservationPlotPosition.NortheastCorner,
-                byteArrayOf(1).inputStream(),
-                metadata,
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = ObservationPlotPosition.NortheastCorner,
+                data = byteArrayOf(1).inputStream(),
+                metadata = metadata,
+                caption = "caption",
             )
 
         val fileId2 =
             service.storePhoto(
-                observationId,
-                plotId,
-                null,
-                byteArrayOf(1).inputStream(),
-                metadata,
-                ObservationPhotoType.Soil,
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = null,
+                data = byteArrayOf(1).inputStream(),
+                metadata = metadata,
+                caption = null,
+                type = ObservationPhotoType.Soil,
             )
 
         fileStore.assertFileExists(filesDao.fetchOneById(fileId1)!!.storageUrl!!)
@@ -723,6 +726,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                     plotId,
                     ObservationPlotPosition.NortheastCorner,
                     ObservationPhotoType.Plot,
+                    "caption",
                 ),
                 ObservationPhotosRecord(
                     fileId2,
@@ -751,12 +755,13 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       fun `throws exception for missing photo position for Quadrat photos`() {
         assertThrows<IllegalArgumentException> {
           service.storePhoto(
-              observationId,
-              plotId,
-              null,
-              byteArrayOf(1).inputStream(),
-              metadata,
-              ObservationPhotoType.Quadrat,
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              position = null,
+              data = byteArrayOf(1).inputStream(),
+              metadata = metadata,
+              caption = null,
+              type = ObservationPhotoType.Quadrat,
           )
         }
       }
@@ -765,12 +770,13 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       fun `throws exception for providing photo position for Soil photos`() {
         assertThrows<IllegalArgumentException> {
           service.storePhoto(
-              observationId,
-              plotId,
-              ObservationPlotPosition.SoutheastCorner,
-              byteArrayOf(1).inputStream(),
-              metadata,
-              ObservationPhotoType.Soil,
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              position = ObservationPlotPosition.SoutheastCorner,
+              data = byteArrayOf(1).inputStream(),
+              metadata = metadata,
+              caption = null,
+              type = ObservationPhotoType.Soil,
           )
         }
       }
@@ -781,11 +787,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
         assertThrows<ObservationNotFoundException> {
           service.storePhoto(
-              observationId,
-              plotId,
-              ObservationPlotPosition.NortheastCorner,
-              byteArrayOf(1).inputStream(),
-              metadata,
+              observationId = observationId,
+              monitoringPlotId = plotId,
+              position = ObservationPlotPosition.NortheastCorner,
+              data = byteArrayOf(1).inputStream(),
+              metadata = metadata,
+              caption = null,
           )
         }
       }
@@ -797,11 +804,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       fun `only deletes photos for planting site that is being deleted`() {
         val fileId =
             service.storePhoto(
-                observationId,
-                plotId,
-                ObservationPlotPosition.NortheastCorner,
-                onePixelPng.inputStream(),
-                metadata,
+                observationId = observationId,
+                monitoringPlotId = plotId,
+                position = ObservationPlotPosition.NortheastCorner,
+                data = onePixelPng.inputStream(),
+                metadata = metadata,
+                caption = null,
             )
 
         insertPlantingSite()
@@ -813,11 +821,12 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
         val otherSiteFileId =
             service.storePhoto(
-                inserted.observationId,
-                inserted.monitoringPlotId,
-                ObservationPlotPosition.SouthwestCorner,
-                onePixelPng.inputStream(),
-                metadata,
+                observationId = inserted.observationId,
+                monitoringPlotId = inserted.monitoringPlotId,
+                position = ObservationPlotPosition.SouthwestCorner,
+                data = onePixelPng.inputStream(),
+                metadata = metadata,
+                caption = null,
             )
 
         service.on(PlantingSiteDeletionStartedEvent(plantingSiteId))

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -111,17 +111,18 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
       insertObservation(completedTime = Instant.EPOCH)
       insertObservationPlot(claimedBy = user.userId, completedBy = user.userId)
       insertFile(geolocation = gpsCoordinates)
-      insertObservationPhoto(position = position)
+      insertObservationPhoto(caption = "selfie", position = position)
 
       val results = resultsStore.fetchByOrganizationId(organizationId)
 
       assertEquals(
           listOf(
               ObservationMonitoringPlotPhotoModel(
-                  inserted.fileId,
-                  gpsCoordinates,
-                  position,
-                  ObservationPhotoType.Plot,
+                  caption = "selfie",
+                  fileId = inserted.fileId,
+                  gpsCoordinates = gpsCoordinates,
+                  position = position,
+                  type = ObservationPhotoType.Plot,
               )
           ),
           results[0].plantingZones[0].plantingSubzones[0].monitoringPlots[0].photos,


### PR DESCRIPTION
Allow clients to supply captions when uploading new observation photos and return
the captions alongside other observation photo information.

A separate change will add an endpoint to update the captions of existing photos.