### PR TITLE
SW-7599 Add endpoint to edit observation photo captions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -219,6 +219,26 @@ class FileService(
     return readFile(fileId)
   }
 
+  /**
+   * Updates the modified-by and modified-time values of a file. This will typically be called after
+   * updating file information in child tables.
+   */
+  fun touchFile(fileId: FileId) {
+    with(FILES) {
+      val rowsUpdated =
+          dslContext
+              .update(FILES)
+              .set(MODIFIED_BY, currentUser().userId)
+              .set(MODIFIED_TIME, clock.instant())
+              .where(ID.eq(fileId))
+              .execute()
+
+      if (rowsUpdated != 1) {
+        throw FileNotFoundException(fileId)
+      }
+    }
+  }
+
   @EventListener
   fun on(event: FileReferenceDeletedEvent) {
     val fileId = event.fileId

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -36,6 +36,7 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.pojos.ObservationPhotosRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
 import com.terraformation.backend.file.model.FileMetadata
@@ -393,6 +394,26 @@ class ObservationsController(
     return observationService
         .readPhoto(observationId, plotId, fileId, maxWidth, maxHeight)
         .toResponseEntity()
+  }
+
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a photo with the requested ID."
+  )
+  @ApiResponseSimpleSuccess
+  @PutMapping("/{observationId}/plots/{plotId}/photos/{fileId}")
+  @Operation(
+      summary =
+          "Updates information about a specific photo from an observation of a monitoring plot."
+  )
+  fun updatePlotPhoto(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+      @PathVariable fileId: FileId,
+      @RequestBody payload: UpdatePlotPhotoRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    observationService.updatePhoto(observationId, plotId, fileId, payload::applyTo)
+
+    return SimpleSuccessResponsePayload()
   }
 
   @Operation(summary = "Uploads a photo of a monitoring plot.")
@@ -1497,6 +1518,12 @@ data class UpdatePlotObservationRequestPayload(
     )
     val coordinates: List<ObservationMonitoringPlotCoordinatesPayload>,
 )
+
+data class UpdatePlotPhotoRequestPayload(
+    val caption: String?,
+) {
+  fun applyTo(row: ObservationPhotosRow) = row.copy(caption = caption)
+}
 
 data class UploadPlotPhotoRequestPayload(
     val caption: String?,


### PR DESCRIPTION
`PUT /api/v1/tracking/observations/{observationId}/plots/{plotId}/photos/{fileId}`
(a real mouthful!) will update the caption on an existing observation photo.