### PR TITLE
SW-7606 Differentiate photos from original observation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -194,6 +194,7 @@ class ObservationService(
       data: InputStream,
       metadata: NewFileMetadata,
       caption: String?,
+      isOriginal: Boolean,
       type: ObservationPhotoType = ObservationPhotoType.Plot,
   ): FileId {
     requirePermissions { updateObservation(observationId) }
@@ -215,6 +216,7 @@ class ObservationService(
               ObservationPhotosRow(
                   caption = caption,
                   fileId = fileId,
+                  isOriginal = isOriginal,
                   monitoringPlotId = monitoringPlotId,
                   observationId = observationId,
                   positionId = position,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -416,7 +416,12 @@ class ObservationsController(
     return SimpleSuccessResponsePayload()
   }
 
-  @Operation(summary = "Uploads a photo of a monitoring plot.")
+  @Operation(
+      summary = "Uploads a photo of a monitoring plot as part of the observation.",
+      description =
+          "Photos uploaded via this endpoint are considered to be part of the original " +
+              "observation and cannot be deleted later.",
+  )
   @PostMapping(
       "/{observationId}/plots/{plotId}/photos",
       consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
@@ -439,6 +444,7 @@ class ObservationsController(
             data = file.inputStream,
             metadata = FileMetadata.of(contentType, filename, file.size, payload.gpsCoordinates),
             caption = payload.caption,
+            isOriginal = true,
             type = payload.type ?: ObservationPhotoType.Plot,
         )
 
@@ -792,12 +798,25 @@ data class ObservationMonitoringPlotPhotoPayload(
     val caption: String?,
     val fileId: FileId,
     val gpsCoordinates: Point,
+    @Schema(
+        description =
+            "If true, this photo was uploaded as part of the original observation. If false, it " +
+                "was uploaded later."
+    )
+    val isOriginal: Boolean,
     val position: ObservationPlotPosition?,
     val type: ObservationPhotoType,
 ) {
   constructor(
       model: ObservationMonitoringPlotPhotoModel
-  ) : this(model.caption, model.fileId, model.gpsCoordinates, model.position, model.type)
+  ) : this(
+      model.caption,
+      model.fileId,
+      model.gpsCoordinates,
+      model.isOriginal,
+      model.position,
+      model.type,
+  )
 }
 
 data class ObservationMonitoringPlotCoordinatesPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -434,6 +434,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       OBSERVATION_PHOTOS.CAPTION,
                       OBSERVATION_PHOTOS.FILE_ID,
                       photosGpsField,
+                      OBSERVATION_PHOTOS.IS_ORIGINAL,
                       OBSERVATION_PHOTOS.POSITION_ID,
                       OBSERVATION_PHOTOS.TYPE_ID,
                   )
@@ -450,6 +451,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                   caption = record[OBSERVATION_PHOTOS.CAPTION],
                   fileId = record[OBSERVATION_PHOTOS.FILE_ID.asNonNullable()],
                   gpsCoordinates = record[photosGpsField.asNonNullable()] as Point,
+                  isOriginal = record[OBSERVATION_PHOTOS.IS_ORIGINAL.asNonNullable()],
                   position = record[OBSERVATION_PHOTOS.POSITION_ID],
                   type = record[OBSERVATION_PHOTOS.TYPE_ID.asNonNullable()],
               )

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -34,6 +34,7 @@ data class ObservationMonitoringPlotPhotoModel(
     val caption: String?,
     val fileId: FileId,
     val gpsCoordinates: Point,
+    val isOriginal: Boolean,
     val position: ObservationPlotPosition?,
     val type: ObservationPhotoType,
 )

--- a/src/main/resources/db/migration/0400/V421__ObservationPhotoOriginal.sql
+++ b/src/main/resources/db/migration/0400/V421__ObservationPhotoOriginal.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tracking.observation_photos ADD COLUMN is_original BOOLEAN;
+
+UPDATE tracking.observation_photos SET is_original = TRUE;
+
+ALTER TABLE tracking.observation_photos ALTER COLUMN is_original SET NOT NULL;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -416,6 +416,7 @@ COMMENT ON COLUMN tracking.monitoring_plots.size_meters IS 'Length in meters of 
 COMMENT ON TABLE tracking.observable_conditions IS '(Enum) Conditions that can be observed in a monitoring plot.';
 
 COMMENT ON TABLE tracking.observation_photos IS 'Observation-specific details about a photo of a monitoring plot. Generic metadata is in the `files` table.';
+COMMENT ON COLUMN tracking.observation_photos.is_original IS 'If true, this photo was uploaded as part of the original observation data. If false, this photo was added after the observation.';
 
 COMMENT ON TABLE tracking.observation_photo_types IS '(Enum) Types of observation plot photo.';
 

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -3075,6 +3075,7 @@ abstract class DatabaseBackedTest {
       row: ObservationPhotosRow = ObservationPhotosRow(),
       caption: String? = row.caption,
       fileId: FileId = row.fileId ?: inserted.fileId,
+      isOriginal: Boolean = row.isOriginal ?: true,
       observationId: ObservationId = row.observationId ?: inserted.observationId,
       monitoringPlotId: MonitoringPlotId = row.monitoringPlotId ?: inserted.monitoringPlotId,
       position: ObservationPlotPosition = row.positionId ?: ObservationPlotPosition.SouthwestCorner,
@@ -3084,6 +3085,7 @@ abstract class DatabaseBackedTest {
         row.copy(
             caption = caption,
             fileId = fileId,
+            isOriginal = isOriginal,
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,
             positionId = position,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -627,6 +627,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = content.inputStream(),
                 metadata = metadata,
                 caption = null,
+                isOriginal = true,
             )
       }
 
@@ -694,6 +695,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = byteArrayOf(1).inputStream(),
                 metadata = metadata,
                 caption = "caption",
+                isOriginal = true,
             )
 
         val fileId2 =
@@ -704,6 +706,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = byteArrayOf(1).inputStream(),
                 metadata = metadata,
                 caption = null,
+                isOriginal = false,
                 type = ObservationPhotoType.Soil,
             )
 
@@ -713,19 +716,20 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         assertTableEquals(
             listOf(
                 ObservationPhotosRecord(
-                    fileId1,
-                    observationId,
-                    plotId,
-                    ObservationPlotPosition.NortheastCorner,
-                    ObservationPhotoType.Plot,
-                    "caption",
+                    fileId = fileId1,
+                    observationId = observationId,
+                    monitoringPlotId = plotId,
+                    positionId = ObservationPlotPosition.NortheastCorner,
+                    typeId = ObservationPhotoType.Plot,
+                    caption = "caption",
+                    isOriginal = true,
                 ),
                 ObservationPhotosRecord(
-                    fileId2,
-                    observationId,
-                    plotId,
-                    null,
-                    ObservationPhotoType.Soil,
+                    fileId = fileId2,
+                    observationId = observationId,
+                    monitoringPlotId = plotId,
+                    typeId = ObservationPhotoType.Soil,
+                    isOriginal = false,
                 ),
             )
         )
@@ -753,6 +757,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               data = byteArrayOf(1).inputStream(),
               metadata = metadata,
               caption = null,
+              isOriginal = true,
               type = ObservationPhotoType.Quadrat,
           )
         }
@@ -768,6 +773,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               data = byteArrayOf(1).inputStream(),
               metadata = metadata,
               caption = null,
+              isOriginal = true,
               type = ObservationPhotoType.Soil,
           )
         }
@@ -785,6 +791,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
               data = byteArrayOf(1).inputStream(),
               metadata = metadata,
               caption = null,
+              isOriginal = true,
           )
         }
       }
@@ -802,6 +809,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = byteArrayOf(1).inputStream(),
                 metadata = metadata,
                 caption = "caption",
+                isOriginal = true,
                 type = ObservationPhotoType.Quadrat,
             )
 
@@ -826,6 +834,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 ObservationPlotPosition.NortheastCorner,
                 ObservationPhotoType.Quadrat,
                 "new caption",
+                true,
             )
         )
 
@@ -842,6 +851,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = byteArrayOf(1).inputStream(),
                 metadata = metadata,
                 caption = "caption",
+                isOriginal = true,
                 type = ObservationPhotoType.Quadrat,
             )
 
@@ -865,6 +875,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = onePixelPng.inputStream(),
                 metadata = metadata,
                 caption = null,
+                isOriginal = true,
             )
 
         insertPlantingSite()
@@ -882,6 +893,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 data = onePixelPng.inputStream(),
                 metadata = metadata,
                 caption = null,
+                isOriginal = true,
             )
 
         service.on(PlantingSiteDeletionStartedEvent(plantingSiteId))

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -121,6 +121,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
                   caption = "selfie",
                   fileId = inserted.fileId,
                   gpsCoordinates = gpsCoordinates,
+                  isOriginal = true,
                   position = position,
                   type = ObservationPhotoType.Plot,
               )


### PR DESCRIPTION
Add a flag to observation photos to indicate whether a given photo was uploaded as
part of the original observation data or added later.

Currently, the flag is always true since there isn't yet any way to upload photos
after the fact, but future changes will add an alternate upload endpoint for
additional photo uploads.

Include the flag in the photo data that's returned as part of observation results
so the originality of photos can be indicated in the web app UI.