### PR TITLE
SW-7606 Support uploading other observation photos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -199,8 +199,8 @@ class ObservationService(
   ): FileId {
     requirePermissions { updateObservation(observationId) }
 
-    if (metadata.geolocation == null) {
-      throw IllegalArgumentException("Geolocation is required for observation photos")
+    if (metadata.geolocation == null && isOriginal) {
+      throw IllegalArgumentException("Geolocation is required for original observation photos")
     }
     if (type == ObservationPhotoType.Quadrat && position == null) {
       throw IllegalArgumentException("Position is required for a quadrat photo")

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -825,7 +825,7 @@ data class RecordedPlantPayload(
 data class ObservationMonitoringPlotPhotoPayload(
     val caption: String?,
     val fileId: FileId,
-    val gpsCoordinates: Point,
+    val gpsCoordinates: Point?,
     @Schema(
         description =
             "If true, this photo was uploaded as part of the original observation. If false, it " +

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -447,7 +447,35 @@ class ObservationsController(
             isOriginal = true,
             type = payload.type ?: ObservationPhotoType.Plot,
         )
+    return UploadPlotPhotoResponsePayload(fileId)
+  }
 
+  @Operation(summary = "Adds a photo of a monitoring plot after an observation is complete.")
+  @PostMapping(
+      "/{observationId}/plots/{plotId}/otherMedia",
+      consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
+  )
+  @RequestBodyPhotoFile
+  fun uploadOtherPlotMedia(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+      @RequestPart("file") file: MultipartFile,
+      @RequestPart("payload") payload: UploadPlotMediaRequestPayload,
+  ): UploadPlotPhotoResponsePayload {
+    val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
+    val filename = file.getFilename("photo")
+
+    val fileId =
+        observationService.storePhoto(
+            observationId = observationId,
+            monitoringPlotId = plotId,
+            position = payload.position,
+            data = file.inputStream,
+            metadata = FileMetadata.of(contentType, filename, file.size),
+            caption = payload.caption,
+            isOriginal = false,
+            type = payload.type ?: ObservationPhotoType.Plot,
+        )
     return UploadPlotPhotoResponsePayload(fileId)
   }
 
@@ -1543,6 +1571,13 @@ data class UpdatePlotPhotoRequestPayload(
 ) {
   fun applyTo(row: ObservationPhotosRow) = row.copy(caption = caption)
 }
+
+data class UploadPlotMediaRequestPayload(
+    val caption: String?,
+    val position: ObservationPlotPosition?,
+    @Schema(description = "Type of subject the uploaded file depicts.", defaultValue = "Plot")
+    val type: ObservationPhotoType?,
+)
 
 data class UploadPlotPhotoRequestPayload(
     val caption: String?,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -450,7 +450,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               ObservationMonitoringPlotPhotoModel(
                   caption = record[OBSERVATION_PHOTOS.CAPTION],
                   fileId = record[OBSERVATION_PHOTOS.FILE_ID.asNonNullable()],
-                  gpsCoordinates = record[photosGpsField.asNonNullable()] as Point,
+                  gpsCoordinates = record[photosGpsField]?.centroid,
                   isOriginal = record[OBSERVATION_PHOTOS.IS_ORIGINAL.asNonNullable()],
                   position = record[OBSERVATION_PHOTOS.POSITION_ID],
                   type = record[OBSERVATION_PHOTOS.TYPE_ID.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -33,7 +33,7 @@ import org.locationtech.jts.geom.Polygon
 data class ObservationMonitoringPlotPhotoModel(
     val caption: String?,
     val fileId: FileId,
-    val gpsCoordinates: Point,
+    val gpsCoordinates: Point?,
     val isOriginal: Boolean,
     val position: ObservationPlotPosition?,
     val type: ObservationPhotoType,

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -704,7 +704,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
                 monitoringPlotId = plotId,
                 position = null,
                 data = byteArrayOf(1).inputStream(),
-                metadata = metadata,
+                metadata = metadata.copy(geolocation = null),
                 caption = null,
                 isOriginal = false,
                 type = ObservationPhotoType.Soil,
@@ -740,11 +740,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             filesRecords.single { it.id == fileId1 }.geolocation,
             "File 1",
         )
-        assertGeometryEquals(
-            point(1),
-            filesRecords.single { it.id == fileId2 }.geolocation,
-            "File 2",
-        )
+        assertNull(filesRecords.single { it.id == fileId2 }.geolocation, "File 2 geolocation")
       }
 
       @Test


### PR DESCRIPTION
Add a new endpoint for uploading additional photos (and eventually videos) after
an observation is completed.