### PR TITLE
SW-7600 Centralize video-related API structures

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/ActivitiesController.kt
@@ -22,10 +22,9 @@ import com.terraformation.backend.db.accelerator.ActivityStatus
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
-import com.terraformation.backend.file.SUPPORTED_VIDEO_TYPES
+import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
+import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.file.model.FileMetadata
-import com.terraformation.backend.file.mux.MuxStreamModel
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Schema
@@ -58,8 +57,6 @@ class ActivitiesController(
     private val activityMediaStore: ActivityMediaStore,
     private val activityStore: ActivityStore,
 ) {
-  private val supportedMediaTypes = SUPPORTED_PHOTO_TYPES + SUPPORTED_VIDEO_TYPES
-
   @Operation(summary = "Lists all of a project's activities.")
   @GetMapping
   fun listActivities(
@@ -123,7 +120,7 @@ class ActivitiesController(
       listPositionStr: String?,
       @RequestPart("file") file: MultipartFile,
   ): UploadActivityMediaResponsePayload {
-    val contentType = file.getPlainContentType(supportedMediaTypes)
+    val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
     val filename = file.getFilename("media")
     val listPosition: Int? =
         try {
@@ -183,10 +180,10 @@ class ActivitiesController(
   fun getActivityMediaStream(
       @PathVariable activityId: ActivityId,
       @PathVariable fileId: FileId,
-  ): GetActivityStreamResponsePayload {
+  ): GetMuxStreamResponsePayload {
     val stream = activityMediaService.getMuxStreamInfo(activityId, fileId)
 
-    return GetActivityStreamResponsePayload(stream)
+    return GetMuxStreamResponsePayload(stream)
   }
 
   @Operation(summary = "Updates information about a media file for an activity.")
@@ -312,15 +309,6 @@ data class UpdateActivityRequestPayload(
 }
 
 data class GetActivityResponsePayload(val activity: ActivityPayload) : SuccessResponsePayload
-
-data class GetActivityStreamResponsePayload(
-    val playbackId: String,
-    val playbackToken: String,
-) : SuccessResponsePayload {
-  constructor(
-      model: MuxStreamModel
-  ) : this(playbackId = model.playbackId, playbackToken = model.playbackToken)
-}
 
 data class ListActivitiesResponsePayload(val activities: List<ActivityPayload>) :
     SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/MediaTypes.kt
@@ -9,4 +9,8 @@ import org.springframework.http.MediaType
 val SUPPORTED_PHOTO_TYPES =
     setOf(MediaType.valueOf("image/heic"), MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG)
 
-val SUPPORTED_VIDEO_TYPES = setOf(MediaType.valueOf("video/*"))
+/**
+ * List of supported audiovisual media content types. We delegate video handling to Mux, which
+ * supports all the widely-used video formats.
+ */
+val SUPPORTED_MEDIA_TYPES = SUPPORTED_PHOTO_TYPES + setOf(MediaType.valueOf("video/*"))

--- a/src/main/kotlin/com/terraformation/backend/file/api/GetMuxStreamResponsePayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/GetMuxStreamResponsePayload.kt
@@ -1,0 +1,13 @@
+package com.terraformation.backend.file.api
+
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.file.mux.MuxStreamModel
+
+data class GetMuxStreamResponsePayload(
+    val playbackId: String,
+    val playbackToken: String,
+) : SuccessResponsePayload {
+  constructor(
+      model: MuxStreamModel
+  ) : this(playbackId = model.playbackId, playbackToken = model.playbackToken)
+}

--- a/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/funder/api/FunderActivitiesController.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.funder.api
 
-import com.terraformation.backend.accelerator.api.GetActivityStreamResponsePayload
 import com.terraformation.backend.api.FunderEndpoint
 import com.terraformation.backend.api.PHOTO_MAXHEIGHT_DESCRIPTION
 import com.terraformation.backend.api.PHOTO_MAXWIDTH_DESCRIPTION
@@ -12,6 +11,7 @@ import com.terraformation.backend.db.accelerator.ActivityMediaType
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.funder.PublishedActivityService
 import com.terraformation.backend.funder.db.PublishedActivityStore
 import com.terraformation.backend.funder.model.PublishedActivityMediaModel
@@ -80,10 +80,10 @@ class FunderActivitiesController(
   fun getActivityMediaStream(
       @PathVariable activityId: ActivityId,
       @PathVariable fileId: FileId,
-  ): GetActivityStreamResponsePayload {
+  ): GetMuxStreamResponsePayload {
     val stream = publishedActivityService.getMuxStreamInfo(activityId, fileId)
 
-    return GetActivityStreamResponsePayload(stream)
+    return GetMuxStreamResponsePayload(stream)
   }
 }
 


### PR DESCRIPTION
Move the list of accepted media types and the response payload for fetching Mux
streams out of the activities package since they will be used elsewhere when
we add video support to other parts of the app.