### PR TITLE
SW-7600 Support video files on observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -185,8 +185,7 @@ class ObservationService(
   ): SizedInputStream {
     requirePermissions { readObservation(observationId) }
 
-    // Make sure the file is for the right plot and observation.
-    fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
+    ensureMediaFileExists(observationId, monitoringPlotId, fileId)
 
     return thumbnailService.readFile(fileId, maxWidth, maxHeight)
   }
@@ -198,7 +197,7 @@ class ObservationService(
   ): MuxStreamModel {
     requirePermissions { readObservation(observationId) }
 
-    fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
+    ensureMediaFileExists(observationId, monitoringPlotId, fileId)
 
     return muxService.getMuxStream(fileId)
   }
@@ -279,6 +278,14 @@ class ObservationService(
     }
 
     deleteMediaWhere(OBSERVATION_MEDIA_FILES.FILE_ID.eq(fileId))
+  }
+
+  private fun ensureMediaFileExists(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId,
+      fileId: FileId,
+  ) {
+    fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
   }
 
   private fun fetchMediaFilesRow(

--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -24,6 +24,8 @@ import com.terraformation.backend.file.SizedInputStream
 import com.terraformation.backend.file.ThumbnailService
 import com.terraformation.backend.file.event.FileReferenceDeletedEvent
 import com.terraformation.backend.file.model.NewFileMetadata
+import com.terraformation.backend.file.mux.MuxService
+import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
 import com.terraformation.backend.tracking.db.InvalidObservationEndDateException
@@ -77,6 +79,7 @@ class ObservationService(
     private val eventPublisher: ApplicationEventPublisher,
     private val fileService: FileService,
     private val monitoringPlotsDao: MonitoringPlotsDao,
+    private val muxService: MuxService,
     private val observationMediaFilesDao: ObservationMediaFilesDao,
     private val observationStore: ObservationStore,
     private val plantingSiteStore: PlantingSiteStore,
@@ -186,6 +189,18 @@ class ObservationService(
     fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
 
     return thumbnailService.readFile(fileId, maxWidth, maxHeight)
+  }
+
+  fun getMuxStreamInfo(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId,
+      fileId: FileId,
+  ): MuxStreamModel {
+    requirePermissions { readObservation(observationId) }
+
+    fetchMediaFilesRow(observationId, monitoringPlotId, fileId)
+
+    return muxService.getMuxStream(fileId)
   }
 
   fun storeMediaFile(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -38,7 +38,9 @@ import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationMediaFilesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
 import com.terraformation.backend.file.SUPPORTED_PHOTO_TYPES
+import com.terraformation.backend.file.api.GetMuxStreamResponsePayload
 import com.terraformation.backend.file.model.FileMetadata
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.tracking.ObservationService
@@ -397,6 +399,22 @@ class ObservationsController(
         .toResponseEntity()
   }
 
+  @ApiResponse200
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a video with the requested ID."
+  )
+  @GetMapping("/{observationId}/plots/{plotId}/media/{fileId}/stream")
+  @Operation(summary = "Gets streaming details for a video for an observation.")
+  fun getObservationMediaStream(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+      @PathVariable fileId: FileId,
+  ): GetMuxStreamResponsePayload {
+    val streamModel = observationService.getMuxStreamInfo(observationId, plotId, fileId)
+
+    return GetMuxStreamResponsePayload(streamModel)
+  }
+
   @ApiResponse404(
       "The plot observation does not exist, or does not have a photo with the requested ID."
   )
@@ -482,7 +500,7 @@ class ObservationsController(
       @RequestPart("file") file: MultipartFile,
       @RequestPart("payload") payload: UploadPlotMediaRequestPayload,
   ): UploadPlotPhotoResponsePayload {
-    val contentType = file.getPlainContentType(SUPPORTED_PHOTO_TYPES)
+    val contentType = file.getPlainContentType(SUPPORTED_MEDIA_TYPES)
     val filename = file.getFilename("photo")
 
     val fileId =

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -69,6 +69,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         eventPublisher,
         mockk(),
         monitoringPlotsDao,
+        mockk(),
         observationMediaFilesDao,
         observationStore,
         plantingSiteStore,


### PR DESCRIPTION
Add support for uploading videos of observed plots. This works similarly to the
way video support works for the activity log:

`POST /api/v1/tracking/observations/{observationId}/plots/{plotId}/otherMedia` now
accepts video files as well as photo files.

`GET /api/v1/tracking/observations/{observationId}/plots/{plotId}/photos/{fileId}`
returns a still image in JPEG format if the file is a video.

`GET /api/v1/tracking/observations/{observationId}/plots/{plotId}/media/{fileId}/stream`
returns a Mux playback ID and token for use in an embedded video player.

Videos are only supported for "other" media, that is, media uploaded after the
observation. Original (observation-time) media must still be photos, though it
will be trivial to accept videos there too if the requirements call for it in the
future.