### PR TITLE
SW-7600 Indicate videos in observation results

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/api/MediaKind.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/api/MediaKind.kt
@@ -1,0 +1,19 @@
+package com.terraformation.backend.file.api
+
+/**
+ * Indicates what kind of media a media file is. This is a broad categorization for cases where it's
+ * not appropriate to expose a more precise MIME type to clients.
+ */
+enum class MediaKind {
+  Photo,
+  Video;
+
+  companion object {
+    fun forMimeType(mimeType: String): MediaKind =
+        when {
+          mimeType.startsWith("image/") -> Photo
+          mimeType.startsWith("video/") -> Video
+          else -> throw IllegalArgumentException("Unsupported MIME type: $mimeType")
+        }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -1005,7 +1005,6 @@ data class ObservationMonitoringPlotResultsPayload(
     val overlappedByPlotIds: Set<MonitoringPlotId>,
     @Schema(description = "IDs of any older monitoring plots this one overlaps with.")
     val overlapsWithPlotIds: Set<MonitoringPlotId>,
-    val photos: List<ObservationMonitoringPlotMediaPayload>,
     @Schema(description = "Number of live plants per hectare.") //
     val plantingDensity: Int,
     val plants: List<RecordedPlantPayload>?,
@@ -1055,8 +1054,6 @@ data class ObservationMonitoringPlotResultsPayload(
       notes = model.notes,
       overlappedByPlotIds = model.overlappedByPlotIds,
       overlapsWithPlotIds = model.overlapsWithPlotIds,
-      // TODO: Remove this once frontend is updated to read the "media" property
-      photos = model.media.map { ObservationMonitoringPlotMediaPayload(it) },
       plantingDensity = model.plantingDensity,
       plants = model.plants?.map { RecordedPlantPayload(it) },
       sizeMeters = model.sizeMeters,
@@ -1073,6 +1070,10 @@ data class ObservationMonitoringPlotResultsPayload(
               .firstOrNull { it.certainty == RecordedSpeciesCertainty.Unknown }
               ?.let { ObservationSpeciesResultsPayload(it) },
   )
+
+  // TODO: Remove this once frontend is updated to read the "media" property
+  val photos: List<ObservationMonitoringPlotMediaPayload>
+    get() = media
 }
 
 data class ObservationPlantingSubzoneResultsPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -431,9 +431,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
   private val mediaMultiset =
       DSL.multiset(
               DSL.select(
+                      FILES.CONTENT_TYPE,
+                      filesGeolocationField,
                       OBSERVATION_MEDIA_FILES.CAPTION,
                       OBSERVATION_MEDIA_FILES.FILE_ID,
-                      filesGeolocationField,
                       OBSERVATION_MEDIA_FILES.IS_ORIGINAL,
                       OBSERVATION_MEDIA_FILES.POSITION_ID,
                       OBSERVATION_MEDIA_FILES.TYPE_ID,
@@ -449,6 +450,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
             result.map { record ->
               ObservationMonitoringPlotMediaModel(
                   caption = record[OBSERVATION_MEDIA_FILES.CAPTION],
+                  contentType = record[FILES.CONTENT_TYPE.asNonNullable()],
                   fileId = record[OBSERVATION_MEDIA_FILES.FILE_ID.asNonNullable()],
                   gpsCoordinates = record[filesGeolocationField]?.centroid,
                   isOriginal = record[OBSERVATION_MEDIA_FILES.IS_ORIGINAL.asNonNullable()],

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -32,6 +32,7 @@ import org.locationtech.jts.geom.Polygon
 
 data class ObservationMonitoringPlotMediaModel(
     val caption: String?,
+    val contentType: String,
     val fileId: FileId,
     val gpsCoordinates: Point?,
     val isOriginal: Boolean,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStoreTest.kt
@@ -119,6 +119,7 @@ class ObservationResultsStoreTest : ObservationScenarioTest() {
           listOf(
               ObservationMonitoringPlotMediaModel(
                   caption = "selfie",
+                  contentType = "image/jpeg",
                   fileId = inserted.fileId,
                   gpsCoordinates = gpsCoordinates,
                   isOriginal = true,


### PR DESCRIPTION
Add a new `mediaKind` property to the observation results photo payload to
indicate whether a given media file is a photo or a video.

Rename the payload class to replace `Photo` with `Media`. This affects the payload
name in the OpenAPI schema, but we aren't looking payload types up by name in our
client code, so this shouldn't require client changes.

Add a `media` property to the monitoring plot results payload alongside the
existing `photos` property (with identical contents) to allow the frontend code
to switch to the more accurate name at leisure.