### PR TITLE
SW-7565 Add State enum to ObservationsTable

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ObservationsTable.kt
@@ -47,6 +47,7 @@ class ObservationsTable(private val tables: SearchTables) : SearchTable() {
             PlantingSiteHistoryId(it)
           },
           dateField("startDate", OBSERVATIONS.START_DATE),
+          nonLocalizableEnumField("state", OBSERVATIONS.STATE_ID),
           enumField("type", OBSERVATIONS.OBSERVATION_TYPE_ID),
       )
 

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -701,6 +701,7 @@ search.observations.endDate=Observation end date
 search.observations.id=Observation ID
 search.observations.isAdHoc=Observation is ad-hoc
 search.observations.plantingSiteHistoryId=Observation planting site history ID
+search.observations.state=Observation state
 search.observations.startDate=Observation start date
 search.observations.type=Observation type
 search.organizationInternalTags.name=Organization internal tag name

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1229,6 +1229,8 @@ search.observations.isAdHoc=La observación es ad hoc
 search.observations.plantingSiteHistoryId=ID del historial del sitio de plantación de observación
 # 3504403e
 search.observations.startDate=Fecha de inicio de la observación
+# c003400e
+search.observations.state=Estado de la observación
 # a89b4a46
 search.observations.type=Tipo de observación
 # e864482a

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1229,6 +1229,8 @@ search.observations.isAdHoc=L''observation est ad-hoc
 search.observations.plantingSiteHistoryId=Identifiant de l''historique des observations du site de plantation
 # 3504403e
 search.observations.startDate=Date de début de l''observation
+# c003400e
+search.observations.state=État de l''observation
 # a89b4a46
 search.observations.type=Type d''observation
 # e864482a


### PR DESCRIPTION
The state enum of observations was missing from the `ObservationsTable`. Add this.

It seems like we don't have tests for every field in search tables, so no test was added/updated.