### PR TITLE
SW-7607 Log persistent events for observation media

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/FileService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileService.kt
@@ -179,7 +179,9 @@ class FileService(
             eventPublisher.publishEvent(VideoFileUploadedEvent(filesRow.id!!))
           }
 
-          insertChildRows(StoredFile(filesRow.id!!, fileType, exifMetadata))
+          val storedFile = StoredFile(filesRow.id!!, fullMetadata, fileType, exifMetadata)
+
+          insertChildRows(storedFile)
         }
 
         filesRow.id!!
@@ -336,7 +338,13 @@ class FileService(
    */
   data class StoredFile(
       val fileId: FileId, // This should be first so it's easily accessible via destructuring
+      /**
+       * Terraware file metadata, populated with values from EXIF and/or the metadata population
+       * callback.
+       */
+      val metadata: NewFileMetadata,
       val fileType: FileType? = null,
-      val imageMetadata: Metadata? = null,
+      /** Raw EXIF (or equivalent) metadata if the file has any. */
+      val exifMetadata: Metadata? = null,
   )
 }

--- a/src/main/resources/db/migration/0400/V423__ObservationMediaFileEvents.sql
+++ b/src/main/resources/db/migration/0400/V423__ObservationMediaFileEvents.sql
@@ -1,0 +1,29 @@
+CALL event_log_create_id_index('fileId');
+CALL event_log_create_id_index('monitoringPlotId');
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    f.created_by,
+    f.created_time,
+    'com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'caption' VALUE omf.caption,
+        'contentType' VALUE f.content_type,
+        'fileId' VALUE f.id,
+        'geolocation' VALUE st_asgeojson(f.geolocation)::JSONB,
+        'isOriginal' VALUE omf.is_original,
+        'monitoringPlotId' VALUE omf.monitoring_plot_id,
+        'observationId' VALUE omf.observation_id,
+        'organizationId' VALUE ps.organization_id,
+        'plantingSiteId' VALUE ps.id,
+        'position' VALUE opp.name,
+        'type' VALUE omt.name
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.observation_media_files omf
+JOIN tracking.observation_media_types omt ON omf.type_id = omt.id
+LEFT JOIN tracking.observation_plot_positions opp ON omf.position_id = opp.id
+JOIN tracking.observations o ON omf.observation_id = o.id
+JOIN tracking.planting_sites ps ON o.planting_site_id = ps.id
+JOIN files f ON omf.file_id = f.id;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ReportServiceTest.kt
@@ -78,7 +78,7 @@ class ReportServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         {
           val func = arg<((storedFile: FileService.StoredFile) -> Unit)?>(4)
           val fileId = insertFile()
-          func?.let { it(FileService.StoredFile(fileId)) }
+          func?.let { it(FileService.StoredFile(fileId, arg(2))) }
           fileId
         }
 

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -34,6 +34,24 @@ com.terraformation.backend.eventlog.PersistentEventTest$TestChildFieldEventV1/ch
 com.terraformation.backend.eventlog.PersistentEventTest$TestNonPrimaryConstructorPropertyEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV2/x: Int
+com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/fileId: FileId
+com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventV1/fileId: FileId
+com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/contentType: String
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/fileId: FileId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/isOriginal: Boolean
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/type: ObservationMediaType
 
 #
 # Please add new entries in alphabetical (case-sensitive ASCII) order.


### PR DESCRIPTION
Add three new event types for create, edit, and delete operations on photos and
videos of observation plots. Populate the event log with create events for
existing photos.

The edit event introduces a new pattern for tracking before-and-after values:
a nested class to hold the fields in question, and a typealias referencing that
nested class to reduce churn at call sites.