### PR TITLE
SW-7607 Reduce boilerplate for polymorphic payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/api/UpdateMetricTargetPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/api/UpdateMetricTargetPayloads.kt
@@ -9,8 +9,6 @@ import com.terraformation.backend.db.accelerator.ReportId
 import com.terraformation.backend.db.accelerator.StandardMetricId
 import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.default_schema.ProjectId
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
-import io.swagger.v3.oas.annotations.media.Schema
 
 data class ReportMetricTargetPayload(
     val reportId: ReportId,
@@ -23,23 +21,6 @@ data class ReportMetricTargetPayload(
     JsonSubTypes.Type(name = "system", value = UpdateSystemMetricTargetsPayload::class),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(
-                value = "project",
-                schema = UpdateProjectMetricTargetsPayload::class,
-            ),
-            DiscriminatorMapping(
-                value = "standard",
-                schema = UpdateStandardMetricTargetsPayload::class,
-            ),
-            DiscriminatorMapping(
-                value = "system",
-                schema = UpdateSystemMetricTargetsPayload::class,
-            ),
-        ]
-)
 sealed interface UpdateMetricTargetsPayload {
   val targets: List<ReportMetricTargetPayload>
 

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentHistoryPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/DocumentHistoryPayloads.kt
@@ -9,7 +9,6 @@ import com.terraformation.backend.db.docprod.VariableValueId
 import com.terraformation.backend.db.docprod.tables.pojos.DocumentsRow
 import com.terraformation.backend.documentproducer.model.EditHistoryModel
 import com.terraformation.backend.documentproducer.model.ExistingSavedVersionModel
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
@@ -25,15 +24,6 @@ enum class DocumentHistoryPayloadType {
     JsonSubTypes.Type(value = DocumentHistorySavedPayload::class, name = "Saved"),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(schema = DocumentHistoryCreatedPayload::class, value = "Created"),
-            DiscriminatorMapping(schema = DocumentHistoryEditedPayload::class, value = "Edited"),
-            DiscriminatorMapping(schema = DocumentHistorySavedPayload::class, value = "Saved"),
-        ],
-    discriminatorProperty = "type",
-)
 sealed interface DocumentHistoryPayload {
   val createdBy: UserId
   val createdTime: Instant

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ExistingValuePayloads.kt
@@ -33,7 +33,6 @@ import com.terraformation.backend.documentproducer.model.SectionValueVariable
 import com.terraformation.backend.documentproducer.model.SelectValue
 import com.terraformation.backend.documentproducer.model.TableValue
 import com.terraformation.backend.documentproducer.model.TextValue
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.net.URI
@@ -67,29 +66,6 @@ enum class ExistingValuePayloadType {
     JsonSubTypes.Type(value = ExistingTextValuePayload::class, name = "Text"),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(schema = ExistingDateValuePayload::class, value = "Date"),
-            DiscriminatorMapping(schema = ExistingDeletedValuePayload::class, value = "Deleted"),
-            DiscriminatorMapping(schema = ExistingEmailValuePayload::class, value = "Email"),
-            DiscriminatorMapping(schema = ExistingImageValuePayload::class, value = "Image"),
-            DiscriminatorMapping(schema = ExistingLinkValuePayload::class, value = "Link"),
-            DiscriminatorMapping(schema = ExistingNumberValuePayload::class, value = "Number"),
-            DiscriminatorMapping(
-                schema = ExistingSectionTextValuePayload::class,
-                value = "SectionText",
-            ),
-            DiscriminatorMapping(
-                schema = ExistingSectionVariableValuePayload::class,
-                value = "SectionVariable",
-            ),
-            DiscriminatorMapping(schema = ExistingSelectValuePayload::class, value = "Select"),
-            DiscriminatorMapping(schema = ExistingTableValuePayload::class, value = "Table"),
-            DiscriminatorMapping(schema = ExistingTextValuePayload::class, value = "Text"),
-        ],
-    discriminatorProperty = "type",
-)
 sealed interface ExistingValuePayload {
   val id: VariableValueId
   val listPosition: Int

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/NewValuePayloads.kt
@@ -25,7 +25,6 @@ import com.terraformation.backend.documentproducer.model.SelectValue
 import com.terraformation.backend.documentproducer.model.TableValue
 import com.terraformation.backend.documentproducer.model.TextValue
 import com.terraformation.backend.documentproducer.model.VariableValue
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.net.URI
@@ -47,24 +46,7 @@ import java.time.LocalDate
 @Schema(
     description =
         "Supertype for payloads that represent new variable values. See the descriptions of " +
-            "individual payload types for more details.",
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(schema = NewDateValuePayload::class, value = "Date"),
-            DiscriminatorMapping(schema = NewEmailValuePayload::class, value = "Email"),
-            DiscriminatorMapping(schema = NewImageValuePayload::class, value = "Image"),
-            DiscriminatorMapping(schema = NewLinkValuePayload::class, value = "Link"),
-            DiscriminatorMapping(schema = NewNumberValuePayload::class, value = "Number"),
-            DiscriminatorMapping(schema = NewSectionTextValuePayload::class, value = "SectionText"),
-            DiscriminatorMapping(
-                schema = NewSectionVariableValuePayload::class,
-                value = "SectionVariable",
-            ),
-            DiscriminatorMapping(schema = NewSelectValuePayload::class, value = "Select"),
-            DiscriminatorMapping(schema = NewTableValuePayload::class, value = "Table"),
-            DiscriminatorMapping(schema = NewTextValuePayload::class, value = "Text"),
-        ],
-    discriminatorProperty = "type",
+            "individual payload types for more details."
 )
 sealed interface NewValuePayload {
   @get:JsonIgnore val citation: String?

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValueOperationPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/ValueOperationPayloads.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.documentproducer.model.DeleteValueOperation
 import com.terraformation.backend.documentproducer.model.ReplaceValuesOperation
 import com.terraformation.backend.documentproducer.model.UpdateValueOperation
 import com.terraformation.backend.documentproducer.model.ValueOperation
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 
 enum class ValueOperationType {
@@ -32,15 +31,7 @@ enum class ValueOperationType {
 @Schema(
     description =
         "Supertype of the payloads that describe which operations to perform on a variable's " +
-            "value(s). See the descriptions of the individual operations for details.",
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(schema = AppendValueOperationPayload::class, value = "Append"),
-            DiscriminatorMapping(schema = DeleteValueOperationPayload::class, value = "Delete"),
-            DiscriminatorMapping(schema = ReplaceValuesOperationPayload::class, value = "Replace"),
-            DiscriminatorMapping(schema = UpdateValueOperationPayload::class, value = "Update"),
-        ],
-    discriminatorProperty = "operation",
+            "value(s). See the descriptions of the individual operations for details."
 )
 sealed interface ValueOperationPayload {
   // Dummy property so the OpenAPI schema will include the enum values

--- a/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/documentproducer/api/VariablesController.kt
@@ -28,7 +28,6 @@ import com.terraformation.backend.documentproducer.model.Variable
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.ws.rs.BadRequestException
 import org.springframework.web.bind.annotation.GetMapping
@@ -103,21 +102,7 @@ class VariablesController(
     Type(value = TextVariablePayload::class, name = "Text"),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(schema = DateVariablePayload::class, value = "Date"),
-            DiscriminatorMapping(schema = EmailVariablePayload::class, value = "Email"),
-            DiscriminatorMapping(schema = ImageVariablePayload::class, value = "Image"),
-            DiscriminatorMapping(schema = LinkVariablePayload::class, value = "Link"),
-            DiscriminatorMapping(schema = NumberVariablePayload::class, value = "Number"),
-            DiscriminatorMapping(schema = SectionVariablePayload::class, value = "Section"),
-            DiscriminatorMapping(schema = SelectVariablePayload::class, value = "Select"),
-            DiscriminatorMapping(schema = TableVariablePayload::class, value = "Table"),
-            DiscriminatorMapping(schema = TextVariablePayload::class, value = "Text"),
-        ]
-)
-interface VariablePayload {
+sealed interface VariablePayload {
   @get:JsonIgnore val model: Variable
 
   val deliverableId: DeliverableId?

--- a/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/BatchesHistoryController.kt
@@ -1,6 +1,8 @@
 package com.terraformation.backend.nursery.api
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.api.ApiResponse200
 import com.terraformation.backend.api.ApiResponse404
 import com.terraformation.backend.api.NurseryEndpoint
@@ -30,7 +32,6 @@ import com.terraformation.backend.db.nursery.tables.pojos.BatchWithdrawalsRow
 import com.terraformation.backend.db.nursery.tables.pojos.WithdrawalsRow
 import com.terraformation.backend.log.perClassLogger
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.time.LocalDate
@@ -166,40 +167,13 @@ sealed interface BatchHistoryPayloadCommonProps {
   val version: Int?
 }
 
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+)
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(
-                schema = BatchHistoryDetailsEditedPayload::class,
-                value = "DetailsEdited",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryIncomingWithdrawalPayload::class,
-                value = "IncomingWithdrawal",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryOutgoingWithdrawalPayload::class,
-                value = "OutgoingWithdrawal",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryPhotoCreatedPayload::class,
-                value = "PhotoCreated",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryPhotoDeletedPayload::class,
-                value = "PhotoDeleted",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryQuantityEditedPayload::class,
-                value = "QuantityEdited",
-            ),
-            DiscriminatorMapping(
-                schema = BatchHistoryStatusChangedPayload::class,
-                value = "StatusChanged",
-            ),
-        ],
-    discriminatorProperty = "type",
     oneOf =
         [
             BatchHistoryDetailsEditedPayload::class,
@@ -233,6 +207,7 @@ data class BatchHistorySubLocationPayload(
   ) : this(row.subLocationId, row.subLocationName!!)
 }
 
+@JsonTypeName("DetailsEdited")
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
     description = "A change to the non-quantity-related details of a batch.",
@@ -287,6 +262,7 @@ data class BatchHistoryDetailsEditedPayload(
     @Schema(allowableValues = ["DetailsEdited"]) get() = "DetailsEdited"
 }
 
+@JsonTypeName("QuantityEdited")
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
     description = "A manual edit of a batch's remaining quantities.",
@@ -319,6 +295,7 @@ data class BatchHistoryQuantityEditedPayload(
     @Schema(allowableValues = ["QuantityEdited"]) get() = "QuantityEdited"
 }
 
+@JsonTypeName("StatusChanged")
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
     description =
@@ -354,6 +331,7 @@ data class BatchHistoryStatusChangedPayload(
     @Schema(allowableValues = ["StatusChanged"]) get() = "StatusChanged"
 }
 
+@JsonTypeName("IncomingWithdrawal")
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
     description =
@@ -395,6 +373,7 @@ data class BatchHistoryIncomingWithdrawalPayload(
     @Schema(allowableValues = ["IncomingWithdrawal"]) get() = "IncomingWithdrawal"
 }
 
+@JsonTypeName("OutgoingWithdrawal")
 @Schema(
     allOf = [BatchHistoryPayloadCommonProps::class],
     description =
@@ -437,6 +416,7 @@ data class BatchHistoryOutgoingWithdrawalPayload(
     @Schema(allowableValues = ["OutgoingWithdrawal"]) get() = "OutgoingWithdrawal"
 }
 
+@JsonTypeName("PhotoCreated")
 @Schema(allOf = [BatchHistoryPayloadCommonProps::class])
 data class BatchHistoryPhotoCreatedPayload(
     override val createdBy: UserId,
@@ -452,6 +432,7 @@ data class BatchHistoryPhotoCreatedPayload(
     @JsonIgnore get() = null
 }
 
+@JsonTypeName("PhotoDeleted")
 @Schema(allOf = [BatchHistoryPayloadCommonProps::class])
 data class BatchHistoryPhotoDeletedPayload(
     override val createdBy: UserId,

--- a/src/main/kotlin/com/terraformation/backend/report/api/PayloadInterfaces.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/api/PayloadInterfaces.kt
@@ -9,8 +9,6 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.report.model.LatestSeedFundReportBodyModel
 import com.terraformation.backend.report.model.SeedFundReportBodyModelV1
 import com.terraformation.backend.report.model.SeedFundReportModel
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
-import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 
 /**
@@ -59,12 +57,6 @@ interface ReportMetadataFields {
     JsonSubTypes.Type(GetReportPayloadV1::class),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "version")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(value = "1", schema = GetReportPayloadV1::class),
-        ]
-)
 sealed interface GetReportPayload : ReportMetadataFields {
   companion object {
     fun of(model: SeedFundReportModel, getFullName: (UserId) -> String?): GetReportPayload {
@@ -89,12 +81,6 @@ sealed interface GetReportPayload : ReportMetadataFields {
     JsonSubTypes.Type(name = "1", value = PutReportPayloadV1::class),
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "version")
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(value = "1", schema = PutReportPayloadV1::class),
-        ]
-)
 sealed interface PutReportPayload : EditableReportFields {
   /**
    * Overwrites the fields in a report body with the values from this payload. Note that

--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -17,7 +17,6 @@ import com.terraformation.backend.search.SearchNode
 import com.terraformation.backend.search.SearchResults
 import com.terraformation.backend.search.SearchSortField
 import io.swagger.v3.oas.annotations.media.ArraySchema
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 
@@ -93,15 +92,8 @@ data class SearchSortOrderElement(
             NotNodePayload::class,
             OrNodePayload::class,
         ],
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(value = "and", schema = AndNodePayload::class),
-            DiscriminatorMapping(value = "field", schema = FieldNodePayload::class),
-            DiscriminatorMapping(value = "not", schema = NotNodePayload::class),
-            DiscriminatorMapping(value = "or", schema = OrNodePayload::class),
-        ],
 )
-interface SearchNodePayload {
+sealed interface SearchNodePayload {
   fun toSearchNode(prefix: SearchFieldPrefix): SearchNode
 }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/BiomassPayloads.kt
@@ -16,7 +16,6 @@ import com.terraformation.backend.tracking.model.ExistingBiomassDetailsModel
 import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.tracking.model.NewBiomassDetailsModel
 import com.terraformation.backend.tracking.model.NewRecordedTreeModel
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.time.Instant
@@ -161,13 +160,6 @@ data class ExistingTreePayload(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY,
     property = "growthForm",
-)
-@Schema(
-    discriminatorMapping =
-        [
-            DiscriminatorMapping(value = "shrub", schema = NewShrubPayload::class),
-            DiscriminatorMapping(value = "tree", schema = NewTreeWithTrunksPayload::class),
-        ]
 )
 sealed interface NewTreePayload {
   @get:Schema(description = "GPS coordinates where plant was observed.") //


### PR DESCRIPTION
If a payload class includes a property whose type is an interface, the serialized
JSON includes a "discriminator" property to identify which concrete type the
property's value is. The mapping between discriminator values and subclasses is
in annotations that are read by Jackson.

But Springdoc-OpenAPI doesn't automatically reflect the Jackson annotations in
the OpenAPI schema, so we also had to include a second version of the exact same
mappings in the `@Schema` annotation.

We're about to start adding even more polymorphic payloads for different kinds
of events from the event log, so the amount of this boilerplate would have kept
growing over time.

Add logic to auto-populate the schema in cases where the superclass is a sealed
class or interface, and remove the now-redundant discriminator mappings from
the paylaod class schemas.