### PR TITLE
Add interface for generated ID wrappers

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/IdWrapper.kt
@@ -3,7 +3,11 @@ package com.terraformation.backend.jooq
 import org.jooq.codegen.JavaWriter
 import org.jooq.meta.jaxb.ForcedType
 
-class IdWrapper(private val className: String, includeExpressions: List<String>) {
+class IdWrapper(
+    private val className: String,
+    includeExpressions: List<String>,
+    private val eventLogPropertyName: String = className.replaceFirstChar { it.lowercase() },
+) {
   private val converterName = "${className}Converter"
   private val includeExpression = "(?i:" + includeExpressions.joinToString("|") + ")"
 
@@ -20,9 +24,9 @@ class IdWrapper(private val className: String, includeExpressions: List<String>)
   fun render(out: JavaWriter) {
     out.println(
         """
-      class $className @JsonCreator constructor(@get:JsonValue val value: Long) : Comparable<$className> {
+      class $className @JsonCreator constructor(@get:JsonValue override val value: Long) : LongIdWrapper<$className> {
         constructor(value: String) : this(value.toLong())
-        override fun compareTo(other: $className) = value.compareTo(other.value)
+        override val eventLogPropertyName: String get() = "$eventLogPropertyName"
         override fun equals(other: Any?): Boolean = other is $className && other.value == value
         override fun hashCode(): Int = value.hashCode()
         override fun toString(): String = value.toString()

--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/TerrawareGenerator.kt
@@ -32,6 +32,7 @@ class TerrawareGenerator : KotlinGenerator() {
         import com.fasterxml.jackson.annotation.JsonValue
         import com.terraformation.backend.db.EnumFromReferenceTable
         import com.terraformation.backend.db.LocalizableEnum
+        import com.terraformation.backend.db.LongIdWrapper
         import com.terraformation.backend.i18n.currentLocale
         import java.util.Locale
         import java.util.concurrent.ConcurrentHashMap

--- a/src/main/kotlin/com/terraformation/backend/db/LongIdWrapper.kt
+++ b/src/main/kotlin/com/terraformation/backend/db/LongIdWrapper.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.db
+
+interface LongIdWrapper<T : LongIdWrapper<T>> : Comparable<T> {
+  val value: Long
+  val eventLogPropertyName: String
+
+  override fun compareTo(other: T): Int = value.compareTo(other.value)
+}


### PR DESCRIPTION
To support querying the event log using an arbitrary list of wrapped IDs, add an
interface that all the ID wrapper classes implement.