### PR TITLE
SW-7683 Only include completed/abandoned observations in all set species check

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -652,7 +652,14 @@ class T0Store(
             .from(MONITORING_PLOTS)
             .join(OBSERVED_PLOT_SPECIES_TOTALS)
             .on(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(ID))
+            .join(OBSERVATIONS)
+            .on(OBSERVATIONS.ID.eq(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID))
             .where(PLANTING_SITE_ID.eq(plantingSiteId))
+            .and(
+                OBSERVATIONS.STATE_ID.`in`(
+                    listOf(ObservationState.Completed, ObservationState.Abandoned)
+                )
+            )
             .and(
                 DSL.or(
                     OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_LIVE.gt(0),

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -338,6 +338,13 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           completedBy = user.userId,
           isPermanent = false,
       )
+
+      insertObservedPlotSpeciesTotals(
+          monitoringPlotId = monitoringPlotId,
+          speciesId = speciesId2,
+          totalLive = 1,
+      )
+
       // plots without completed or abandoned observations are excluded
       insertObservation(state = ObservationState.InProgress)
       insertMonitoringPlot(plotNumber = 101, permanentIndex = 101)
@@ -345,12 +352,19 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertMonitoringPlot(plotNumber = 102, permanentIndex = null)
       insertObservationPlot()
 
+      // species from observations that are not complete are excluded
+      val speciesId3 = insertSpecies()
+      insertObservedPlotSpeciesTotals(
+          monitoringPlotId = monitoringPlotId,
+          speciesId = speciesId3,
+          totalLive = 1,
+      )
+
       insertPlantingZoneT0TempDensity(speciesId = speciesId1)
       insertPlantingZoneT0TempDensity(speciesId = speciesId2)
       insertPlotT0Density(speciesId = speciesId1, monitoringPlotId = monitoringPlotId)
       insertPlotT0Density(speciesId = speciesId2, monitoringPlotId = monitoringPlotId)
       insertPlantingSubzonePopulation(speciesId = speciesId1)
-      insertObservedPlotSpeciesTotals(speciesId = speciesId2, totalLive = 1)
 
       assertTrue(
           store.fetchAllT0SiteDataSet(plantingSiteId),


### PR DESCRIPTION
While working on [SW-7685](https://terraformation.atlassian.net/browse/SW-7685) it was determined that only Completed or Abandoned observations should be used for finding species to check against (regarding the survival rate All Set check). Update to only include Completed/Abandoned observations.

[SW-7685]: https://terraformation.atlassian.net/browse/SW-7685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ