### PR TITLE
SW-7685 Add later-observed species to t0 densities when assigning observation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -120,6 +120,29 @@ class T0Store(
               .and(SPECIES_ID.notIn(observationDensities.keys))
               .fetchSet(SPECIES_ID.asNonNullable())
         }
+    // Get species from later observation that were not included in the first observation
+    val observedSpeciesNotInObservation: Set<SpeciesId> =
+        with(OBSERVED_PLOT_SPECIES_TOTALS) {
+          dslContext
+              .select(SPECIES_ID)
+              .from(this)
+              .join(MONITORING_PLOTS)
+              .on(MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
+              .join(OBSERVATIONS)
+              .on(OBSERVATIONS.ID.eq(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID))
+              .where(MONITORING_PLOTS.ID.eq(monitoringPlotId))
+              .and(OBSERVATION_ID.ne(observationId))
+              .and(
+                  OBSERVATIONS.STATE_ID.`in`(
+                      listOf(ObservationState.Completed, ObservationState.Abandoned)
+                  )
+              )
+              .and(SPECIES_ID.notIn(observationDensities.keys))
+              .and(DSL.or(TOTAL_LIVE.gt(0), TOTAL_DEAD.gt(0)))
+              .fetchSet(SPECIES_ID.asNonNullable())
+        }
+    val speciesNotInObservation =
+        withdrawnSpeciesNotInObservation.plus(observedSpeciesNotInObservation)
 
     dslContext.transaction { _ ->
       with(PLOT_T0_OBSERVATIONS) {
@@ -180,7 +203,7 @@ class T0Store(
         }
 
         // Any species withdrawn to the subzone that aren't in the observation need a density of 0
-        withdrawnSpeciesNotInObservation.forEach { speciesId ->
+        speciesNotInObservation.forEach { speciesId ->
           insertQuery =
               insertQuery.values(
                   monitoringPlotId,
@@ -211,7 +234,7 @@ class T0Store(
 
     val newDensities =
         observationDensities.mapValues { it.value.toBigDecimal().toPlantsPerHectare() } +
-            withdrawnSpeciesNotInObservation.associateWith { BigDecimal.ZERO }
+            speciesNotInObservation.associateWith { BigDecimal.ZERO }
     val speciesDensityChanges = buildSpeciesDensityChangeList(existingDensities, newDensities)
 
     return PlotT0DensityChangedModel(


### PR DESCRIPTION
When assigning an observation as t0 for a plot, species that were withdrawn but not recorded in the observation are set to 0 for their t0 density. We want to also include species that were recorded in later observations, regardless of if they were withdrawn or not. Add these species to the "zero list". 