### PR TITLE
SW-7685 Add new observation species to t0 for plots with t0 observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -497,8 +497,7 @@ class T0Store(
     }
   }
 
-  // only public for testability
-  fun assignNewObservationSpeciesZero(observationId: ObservationId) {
+  private fun assignNewObservationSpeciesZero(observationId: ObservationId) {
     val currentUserId = currentUser().userId
     val now = clock.instant()
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -1258,6 +1258,67 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
   }
 
+  @Nested
+  inner class AssignNewObservationSpeciesZero {
+    @Test
+    fun `t0 densities are not changed when no new species in observation`() {
+      val speciesId1 = insertSpecies()
+
+      val t0ObservationId = insertObservation()
+      insertObservationPlot()
+      insertObservedPlotSpeciesTotals(
+          observationId = t0ObservationId,
+          speciesId = speciesId1,
+          totalLive = 1,
+      )
+      store.assignT0PlotObservation(monitoringPlotId, t0ObservationId)
+
+      insertObservedPlotSpeciesTotals(
+          observationId = observationId,
+          speciesId = speciesId1,
+          totalLive = 5,
+      )
+
+      store.assignNewObservationSpeciesZero(observationId)
+
+      assertTableEquals(
+          listOf(
+              plotDensityRecord(monitoringPlotId, speciesId1, BigDecimal.ONE.toPlantsPerHectare())
+          )
+      )
+    }
+
+    @Test
+    fun `t0 densities are added with zeros when new species in observation`() {
+      val speciesId1 = insertSpecies()
+      val speciesId2 = insertSpecies()
+
+      val t0ObservationId = insertObservation()
+      insertObservationPlot()
+      insertObservedPlotSpeciesTotals(
+          observationId = t0ObservationId,
+          speciesId = speciesId1,
+          totalLive = 10,
+      )
+      store.assignT0PlotObservation(monitoringPlotId, t0ObservationId)
+
+      insertObservedPlotSpeciesTotals(
+          observationId = observationId,
+          speciesId = speciesId2,
+          totalLive = 5,
+      )
+
+      store.assignNewObservationSpeciesZero(observationId)
+
+      assertTableEquals(
+          listOf(
+              plotDensityRecord(monitoringPlotId, speciesId1, BigDecimal.TEN.toPlantsPerHectare()),
+              plotDensityRecord(monitoringPlotId, speciesId2, BigDecimal.ZERO),
+          )
+      )
+    }
+  }
+
   private fun plotDensityRecord(
       plotId: MonitoringPlotId,
       speciesId: SpeciesId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -27,6 +27,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_OBSERVAT
 import com.terraformation.backend.multiPolygon
 import com.terraformation.backend.point
 import com.terraformation.backend.toBigDecimal
+import com.terraformation.backend.tracking.event.ObservationStateUpdatedEvent
 import com.terraformation.backend.tracking.event.T0PlotDataAssignedEvent
 import com.terraformation.backend.tracking.event.T0ZoneDataAssignedEvent
 import com.terraformation.backend.tracking.model.OptionalSpeciesDensityModel
@@ -1279,7 +1280,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           totalLive = 5,
       )
 
-      store.assignNewObservationSpeciesZero(observationId)
+      store.on(ObservationStateUpdatedEvent(observationId, ObservationState.Completed))
 
       assertTableEquals(
           listOf(
@@ -1308,12 +1309,41 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
           totalLive = 5,
       )
 
-      store.assignNewObservationSpeciesZero(observationId)
+      store.on(ObservationStateUpdatedEvent(observationId, ObservationState.Abandoned))
 
       assertTableEquals(
           listOf(
               plotDensityRecord(monitoringPlotId, speciesId1, BigDecimal.TEN.toPlantsPerHectare()),
               plotDensityRecord(monitoringPlotId, speciesId2, BigDecimal.ZERO),
+          )
+      )
+    }
+
+    @Test
+    fun `t0 densities are not added when new observation state is not Completed or Abandoned`() {
+      val speciesId1 = insertSpecies()
+      val speciesId2 = insertSpecies()
+
+      val t0ObservationId = insertObservation()
+      insertObservationPlot()
+      insertObservedPlotSpeciesTotals(
+          observationId = t0ObservationId,
+          speciesId = speciesId1,
+          totalLive = 10,
+      )
+      store.assignT0PlotObservation(monitoringPlotId, t0ObservationId)
+
+      insertObservedPlotSpeciesTotals(
+          observationId = observationId,
+          speciesId = speciesId2,
+          totalLive = 5,
+      )
+
+      store.on(ObservationStateUpdatedEvent(observationId, ObservationState.InProgress))
+
+      assertTableEquals(
+          listOf(
+              plotDensityRecord(monitoringPlotId, speciesId1, BigDecimal.TEN.toPlantsPerHectare())
           )
       )
     }


### PR DESCRIPTION
When an observation is completed or abandoned, for any plots that had t0 assigned using an observation, add 0-value t0 densities to the plot for any species in the new observation that were not in the t0 observation.