### PR TITLE
SW-7684 Add endpoint for species required for t0 data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/nursery/api/WithdrawalsController.kt
@@ -94,6 +94,7 @@ class WithdrawalsController(
 
   @GetMapping("/plantingSite/{plantingSiteId}/species")
   @Operation(summary = "Lists all the species that have been withdrawn to a planting site.")
+  @Deprecated("Prefer /api/v1/tracking/t0/site/{plantingSiteId}/species")
   fun getSpeciesWithdrawnToPlantingSite(
       @PathVariable("plantingSiteId") plantingSiteId: PlantingSiteId
   ): GetSitePlotSpeciesResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -52,7 +52,14 @@ class T0Controller(
   }
 
   @GetMapping("/plantingSite/{plantingSiteId}/species")
-  @Operation(summary = "Lists all the species that have been withdrawn to a planting site.")
+  @Operation(
+      summary =
+          "Lists all the species that have been withdrawn to a planting site or recorded in " +
+              "observations (if not withdrawn).",
+      description =
+          "Species with densities are species that were withdrawn, species with null densities are " +
+              "species that were recorded in observations but not withdrawn to the plot's subzone.",
+  )
   fun getSpeciesWithdrawnToPlantingSite(
       @PathVariable("plantingSiteId") plantingSiteId: PlantingSiteId
   ): GetSitePlotSpeciesResponsePayload {

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -60,7 +60,7 @@ class T0Controller(
           "Species with densities are species that were withdrawn, species with null densities are " +
               "species that were recorded in observations but not withdrawn to the plot's subzone.",
   )
-  fun getSpeciesWithdrawnToPlantingSite(
+  fun getT0SpeciesForPlantingSite(
       @PathVariable("plantingSiteId") plantingSiteId: PlantingSiteId
   ): GetSitePlotSpeciesResponsePayload {
     val plots = t0Store.fetchSiteSpeciesByPlot(plantingSiteId)

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -112,9 +112,11 @@ class T0Store(
         DSL.select(
                 MONITORING_PLOTS.ID,
                 OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID.`as`("species_id"),
-                DSL.inline(null, BigDecimal::class.java).`as`("density"),
+                DSL.castNull(SQLDataType.NUMERIC).`as`("density"),
             )
             .from(MONITORING_PLOTS)
+            .join(PLANTING_SUBZONES)
+            .on(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
             .join(OBSERVED_PLOT_SPECIES_TOTALS)
             .on(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
             .join(OBSERVATIONS)
@@ -142,6 +144,15 @@ class T0Store(
                                 PLANTING_SUBZONE_POPULATIONS.SPECIES_ID.eq(
                                     OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID
                                 )
+                            )
+                            .and(
+                                DSL.round(
+                                        PLANTING_SUBZONE_POPULATIONS.TOTAL_PLANTS.cast(
+                                            SQLDataType.NUMERIC
+                                        ) / PLANTING_SUBZONES.AREA_HA,
+                                        1,
+                                    )
+                                    .ge(BigDecimal.valueOf(0.05))
                             )
                     )
             )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -115,8 +115,6 @@ class T0Store(
                 DSL.castNull(SQLDataType.NUMERIC).`as`("density"),
             )
             .from(MONITORING_PLOTS)
-            .join(PLANTING_SUBZONES)
-            .on(PLANTING_SUBZONES.ID.eq(MONITORING_PLOTS.PLANTING_SUBZONE_ID))
             .join(OBSERVED_PLOT_SPECIES_TOTALS)
             .on(OBSERVED_PLOT_SPECIES_TOTALS.MONITORING_PLOT_ID.eq(MONITORING_PLOTS.ID))
             .join(OBSERVATIONS)
@@ -136,6 +134,8 @@ class T0Store(
             .andNotExists(
                 DSL.selectOne()
                     .from(PLANTING_SUBZONE_POPULATIONS)
+                    .join(PLANTING_SUBZONES)
+                    .on(PLANTING_SUBZONES.ID.eq(PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID))
                     .where(
                         PLANTING_SUBZONE_POPULATIONS.PLANTING_SUBZONE_ID.eq(
                                 MONITORING_PLOTS.PLANTING_SUBZONE_ID

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
@@ -12,11 +12,21 @@ data class SpeciesDensityModel(
     val density: BigDecimal,
 )
 
+data class OptionalSpeciesDensityModel(
+    val speciesId: SpeciesId,
+    val density: BigDecimal?,
+)
+
 data class SiteT0DataModel(
     val plantingSiteId: PlantingSiteId,
     val survivalRateIncludesTempPlots: Boolean,
     val plots: List<PlotT0DataModel> = emptyList(),
     val zones: List<ZoneT0TempDataModel> = emptyList(),
+)
+
+data class PlotSpeciesModel(
+    val monitoringPlotId: MonitoringPlotId,
+    val species: List<OptionalSpeciesDensityModel> = emptyList(),
 )
 
 data class PlotT0DataModel(


### PR DESCRIPTION
The previous `getSpeciesWithdrawnToPlantingSite` endpoint only included species that were withdrawn to plots and their existing densities (for pre-population in the FE). We want to also know any species that were recorded in observations but not withdrawn to the plot's subzone.
Create a new endpoint that combines both lists of species. Use the same basic format for the return but make the density optional, such that null densities should be treated as species still required for t0 data, even though they don't have withdrawal densities to pre-populate the FE with.

The existing endpoint `getSpeciesWithdrawnToPlantingSite` will get removed in https://terraformation.atlassian.net/browse/SW-7688.