### PR TITLE
SW-7607 Add subject and action event interfaces

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationCreatedEvent.kt
@@ -1,9 +1,11 @@
 package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 
-data class OrganizationCreatedEventV1(val organizationId: OrganizationId, val name: String) :
-    PersistentEvent
+data class OrganizationCreatedEventV1(
+    override val organizationId: OrganizationId,
+    val name: String,
+) : EntityCreatedPersistentEvent, OrganizationPersistentEvent
 
 typealias OrganizationCreatedEvent = OrganizationCreatedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationDeletedEvent.kt
@@ -1,8 +1,9 @@
 package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 
-data class OrganizationDeletedEventV1(val organizationId: OrganizationId) : PersistentEvent
+data class OrganizationDeletedEventV1(override val organizationId: OrganizationId) :
+    EntityDeletedPersistentEvent, OrganizationPersistentEvent
 
 typealias OrganizationDeletedEvent = OrganizationDeletedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationPersistentEvent.kt
@@ -1,0 +1,8 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+sealed interface OrganizationPersistentEvent : PersistentEvent {
+  val organizationId: OrganizationId
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
@@ -1,9 +1,11 @@
 package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
 
-data class OrganizationRenamedEventV1(val organizationId: OrganizationId, val name: String) :
-    PersistentEvent
+data class OrganizationRenamedEventV1(
+    override val organizationId: OrganizationId,
+    val name: String,
+) : EntityUpdatedPersistentEvent, OrganizationPersistentEvent
 
 typealias OrganizationRenamedEvent = OrganizationRenamedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectCreatedEvent.kt
@@ -2,12 +2,12 @@ package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 
 data class ProjectCreatedEventV1(
     val name: String,
-    val organizationId: OrganizationId,
-    val projectId: ProjectId,
-) : PersistentEvent
+    override val organizationId: OrganizationId,
+    override val projectId: ProjectId,
+) : EntityCreatedPersistentEvent, ProjectPersistentEvent
 
 typealias ProjectCreatedEvent = ProjectCreatedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectDeletedEvent.kt
@@ -2,11 +2,11 @@ package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 
 data class ProjectDeletedEventV1(
-    val organizationId: OrganizationId,
-    val projectId: ProjectId,
-) : PersistentEvent
+    override val organizationId: OrganizationId,
+    override val projectId: ProjectId,
+) : EntityDeletedPersistentEvent, ProjectPersistentEvent
 
 typealias ProjectDeletedEvent = ProjectDeletedEventV1

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectPersistentEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.customer.event
+
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
+import com.terraformation.backend.eventlog.PersistentEvent
+
+sealed interface ProjectPersistentEvent : PersistentEvent {
+  val organizationId: OrganizationId
+  val projectId: ProjectId
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
@@ -2,13 +2,13 @@ package com.terraformation.backend.customer.event
 
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
 
 /** Published when a project's name is changed. */
 data class ProjectRenamedEventV1(
     val name: String,
-    val organizationId: OrganizationId,
-    val projectId: ProjectId,
-) : PersistentEvent
+    override val organizationId: OrganizationId,
+    override val projectId: ProjectId,
+) : EntityUpdatedPersistentEvent, ProjectPersistentEvent
 
 typealias ProjectRenamedEvent = ProjectRenamedEventV1

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EntityEvents.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EntityEvents.kt
@@ -1,0 +1,16 @@
+package com.terraformation.backend.eventlog
+
+/**
+ * Marker interface for entity creation events. This is used to map the event to a "Created" action
+ * in the event log query API.
+ */
+interface EntityCreatedPersistentEvent : PersistentEvent
+
+/**
+ * Marker interface for entity deletion events. This is used to map the event to a "Deleted" action
+ * in the event log query API.
+ */
+interface EntityDeletedPersistentEvent : PersistentEvent
+
+/** Marker interface for entity update events. */
+interface EntityUpdatedPersistentEvent : PersistentEvent

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -10,6 +10,9 @@ import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
+import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
+import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.ratelimit.RateLimitedEvent
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
@@ -231,7 +234,7 @@ data class RateLimitedT0DataAssignedEvent(
   }
 }
 
-sealed interface ObservationMediaFileEvent : PersistentEvent {
+sealed interface ObservationMediaFilePersistentEvent : PersistentEvent {
   val fileId: FileId
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId
@@ -245,7 +248,7 @@ data class ObservationMediaFileDeletedEventV1(
     override val observationId: ObservationId,
     override val organizationId: OrganizationId,
     override val plantingSiteId: PlantingSiteId,
-) : ObservationMediaFileEvent
+) : EntityDeletedPersistentEvent, ObservationMediaFilePersistentEvent
 
 typealias ObservationMediaFileDeletedEvent = ObservationMediaFileDeletedEventV1
 
@@ -257,7 +260,7 @@ data class ObservationMediaFileEditedEventV1(
     override val observationId: ObservationId,
     override val organizationId: OrganizationId,
     override val plantingSiteId: PlantingSiteId,
-) : ObservationMediaFileEvent {
+) : EntityUpdatedPersistentEvent, ObservationMediaFilePersistentEvent {
   data class Values(
       val caption: String?,
   )
@@ -279,6 +282,6 @@ data class ObservationMediaFileUploadedEventV1(
     override val plantingSiteId: PlantingSiteId,
     val position: ObservationPlotPosition?,
     val type: ObservationMediaType,
-) : ObservationMediaFileEvent
+) : EntityCreatedPersistentEvent, ObservationMediaFilePersistentEvent
 
 typealias ObservationMediaFileUploadedEvent = ObservationMediaFileUploadedEventV1


### PR DESCRIPTION
Add interfaces that persistent events can implement to indicate what entity
they're related to and what category of action they represent. These will be
used to help transform events into response payloads in the event log query API.