### PR TITLE
Move full name calculation to SimpleUserModel.create

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1380,7 +1380,8 @@ class ReportStore(
                 .map {
                   SimpleUserModel.create(
                       it[ID.asNonNullable()],
-                      "${it[FIRST_NAME]} ${it[LAST_NAME]}",
+                      it[FIRST_NAME],
+                      it[LAST_NAME],
                       it[EMAIL.asNonNullable()],
                       it[sameOrgField],
                       it[DELETED_TIME] != null,

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SimpleUserModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SimpleUserModel.kt
@@ -7,7 +7,7 @@ import com.terraformation.backend.log.perClassLogger
 
 data class SimpleUserModel(
     val userId: UserId,
-    val fullName: String = "",
+    val fullName: String,
 ) {
   companion object {
     private val log = perClassLogger()
@@ -18,7 +18,8 @@ data class SimpleUserModel(
 
     fun create(
         userId: UserId,
-        fullName: String,
+        firstName: String?,
+        lastName: String?,
         email: String,
         userIsInSameOrg: Boolean,
         userIsDeleted: Boolean,
@@ -26,12 +27,15 @@ data class SimpleUserModel(
     ): SimpleUserModel {
       return when {
         !userIsDeleted && (userIsInSameOrg || currentUser().canReadUser(userId)) ->
-            SimpleUserModel(userId, fullName)
+            SimpleUserModel(
+                userId,
+                TerrawareUser.makeFullName(firstName, lastName) ?: messages.inaccessibleUser(),
+            )
         emailIsTf(email) -> SimpleUserModel(userId, messages.terraformationTeam())
         userIsDeleted -> SimpleUserModel(userId, messages.formerUser())
         else -> {
           log.error("User {} cannot read name of user {}", currentUser().userId, userId)
-          return SimpleUserModel(userId)
+          return SimpleUserModel(userId, messages.inaccessibleUser())
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -534,6 +534,8 @@ class Messages {
 
   fun terraformationTeam() = getMessage("terraformationTeam")
 
+  fun inaccessibleUser() = getMessage("inaccessibleUser")
+
   fun timeZoneWithCity(timeZoneName: String, cityName: String) =
       getMessage("timeZoneWithCity", timeZoneName, cityName)
 

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -94,6 +94,7 @@ historyAccessionWithdrawnForNursery=withdrew seeds for nursery
 historyAccessionWithdrawnForOther=withdrew seeds for other
 historyAccessionWithdrawnForOutPlanting=withdrew seeds for outplanting
 historyAccessionWithdrawnForViabilityTesting=withdrew seeds for viability testing
+inaccessibleUser=Terraware User
 manifestCsvColumnName.0=Name
 manifestCsvColumnName.1=ID
 manifestCsvColumnName.10=Max Value

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -165,6 +165,8 @@ historyAccessionWithdrawnForOther=quitaron semillas para otro
 historyAccessionWithdrawnForOutPlanting=quitaron semillas para transplantar
 # d516861c
 historyAccessionWithdrawnForViabilityTesting=quitaron semillas para prueba de viabilidad
+# a216cd1c
+inaccessibleUser=Usuario de Terraware
 # e7c2678c
 manifestCsvColumnName.0=Nombre
 # 0ba65e03

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -165,6 +165,8 @@ historyAccessionWithdrawnForOther=a retiré des semences pour autre
 historyAccessionWithdrawnForOutPlanting=a retiré des semences pour les transplanter
 # d516861c
 historyAccessionWithdrawnForViabilityTesting=a retiré des semences pour les soumettre à un test de viabilité
+# a216cd1c
+inaccessibleUser=Utilisateur Terraware
 # e7c2678c
 manifestCsvColumnName.0=Nom
 # 0ba65e03

--- a/src/test/kotlin/com/terraformation/backend/customer/model/SimpleUserModelTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/SimpleUserModelTest.kt
@@ -30,7 +30,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(systemUser.userId, "Terraformation Team"),
           SimpleUserModel.create(
               userId = systemUser.userId,
-              fullName = "Terraware System",
+              firstName = "Terraware",
+              lastName = "System",
               email = SystemUser.USERNAME,
               userIsInSameOrg = false,
               userIsDeleted = false,
@@ -48,7 +49,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(userId, "Terraformation Team"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "Some Name",
+              firstName = "Some",
+              lastName = "Name",
               email = "test@terraformation.com",
               userIsInSameOrg = false,
               userIsDeleted = false,
@@ -66,7 +68,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(userId, "Terraformation Team"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "Some Name",
+              firstName = "Some",
+              lastName = "Name",
               email = "test@terraformation.com",
               userIsInSameOrg = false,
               userIsDeleted = true,
@@ -85,7 +88,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(userId, "Former User"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "Some Name",
+              firstName = "Some",
+              lastName = "Name",
               email = "test@other.com",
               userIsInSameOrg = false,
               userIsDeleted = true,
@@ -102,7 +106,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(userId, "First Last"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "First Last",
+              firstName = "First",
+              lastName = "Last",
               email = "test@terraformation.com",
               userIsInSameOrg = true,
               userIsDeleted = false,
@@ -121,7 +126,8 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
           SimpleUserModel(userId, "First2 Last"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "First2 Last",
+              firstName = "First2",
+              lastName = "Last",
               email = "test@terraformation.com",
               userIsInSameOrg = false,
               userIsDeleted = false,
@@ -136,10 +142,11 @@ class SimpleUserModelTest : DatabaseTest(), RunsAsUser {
       val userId = UserId(1003)
 
       assertEquals(
-          SimpleUserModel(userId, ""),
+          SimpleUserModel(userId, "Terraware User"),
           SimpleUserModel.create(
               userId = userId,
-              fullName = "First3 Last",
+              firstName = "First3",
+              lastName = "Last",
               email = "test@other.com",
               userIsInSameOrg = false,
               userIsDeleted = false,


### PR DESCRIPTION
In preparation for using SimpleUserModel from more places, move the calculation of
the user's full name into the factory method, and use the same logic that's used
by UserModel.

In cases where there is no full name (first and last name are null) or the current
user doesn't have permission to see the full name, return a localized "Terraware
User" name rather than an empty string.