### PR TITLE
Add SimpleUserStore

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/SimpleUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/SimpleUserStore.kt
@@ -1,0 +1,59 @@
+package com.terraformation.backend.customer.db
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
+import com.terraformation.backend.db.default_schema.tables.references.USERS
+import com.terraformation.backend.i18n.Messages
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+@Named
+class SimpleUserStore(private val dslContext: DSLContext, private val messages: Messages) {
+  fun fetchSimpleUsersById(userIds: Collection<UserId>): Map<UserId, SimpleUserModel> {
+    return with(USERS) {
+      val existingUsers =
+          dslContext
+              .select(
+                  ID.asNonNullable(),
+                  EMAIL.asNonNullable(),
+                  FIRST_NAME,
+                  LAST_NAME,
+                  DSL.exists(
+                      DSL.selectOne()
+                          .from(ORGANIZATION_USERS)
+                          .where(ORGANIZATION_USERS.USER_ID.eq(ID))
+                          .and(
+                              ORGANIZATION_USERS.ORGANIZATION_ID.`in`(
+                                  currentUser().organizationRoles.keys
+                              )
+                          )
+                  ),
+              )
+              .from(USERS)
+              .where(ID.`in`(userIds))
+              .and(DELETED_TIME.isNull)
+              .fetchMap(ID.asNonNullable()) { (userId, email, firstName, lastName, isInSameOrg) ->
+                SimpleUserModel.create(
+                    email = email,
+                    firstName = firstName,
+                    lastName = lastName,
+                    messages = messages,
+                    userId = userId,
+                    userIsDeleted = false,
+                    userIsInSameOrg = isInSameOrg,
+                )
+              }
+
+      val nonexistentUsers =
+          (userIds.toSet() - existingUsers.keys).associateWith {
+            SimpleUserModel(it, messages.formerUser())
+          }
+
+      existingUsers + nonexistentUsers
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/customer/db/SimpleUserStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/SimpleUserStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.db.default_schema.tables.references.ORGANIZATION_USERS
@@ -15,6 +16,22 @@ import org.jooq.impl.DSL
 class SimpleUserStore(private val dslContext: DSLContext, private val messages: Messages) {
   fun fetchSimpleUsersById(userIds: Collection<UserId>): Map<UserId, SimpleUserModel> {
     return with(USERS) {
+      val userInSameOrgCondition =
+          if (currentUser() is SystemUser) {
+            DSL.trueCondition()
+          } else {
+            DSL.exists(
+                DSL.selectOne()
+                    .from(ORGANIZATION_USERS)
+                    .where(ORGANIZATION_USERS.USER_ID.eq(ID))
+                    .and(
+                        ORGANIZATION_USERS.ORGANIZATION_ID.`in`(
+                            currentUser().organizationRoles.keys
+                        )
+                    )
+            )
+          }
+
       val existingUsers =
           dslContext
               .select(
@@ -22,16 +39,7 @@ class SimpleUserStore(private val dslContext: DSLContext, private val messages: 
                   EMAIL.asNonNullable(),
                   FIRST_NAME,
                   LAST_NAME,
-                  DSL.exists(
-                      DSL.selectOne()
-                          .from(ORGANIZATION_USERS)
-                          .where(ORGANIZATION_USERS.USER_ID.eq(ID))
-                          .and(
-                              ORGANIZATION_USERS.ORGANIZATION_ID.`in`(
-                                  currentUser().organizationRoles.keys
-                              )
-                          )
-                  ),
+                  userInSameOrgCondition,
               )
               .from(USERS)
               .where(ID.`in`(userIds))

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SimpleUserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SimpleUserStoreTest.kt
@@ -1,0 +1,58 @@
+package com.terraformation.backend.customer.db
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.i18n.Messages
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SimpleUserStoreTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val store: SimpleUserStore by lazy { SimpleUserStore(dslContext, Messages()) }
+
+  @Nested
+  inner class FetchByIds {
+    @Test
+    fun `fetches multiple users`() {
+      insertOrganization()
+      insertOrganizationUser()
+
+      val userInSameOrg = insertUser(email = "sameorg@x.com", firstName = "Same", lastName = "Org")
+      insertOrganizationUser(userInSameOrg)
+      val userNotInSameOrg =
+          insertUser(email = "notsame@x.com", firstName = "Not", lastName = "Same")
+      val tfUser =
+          insertUser(email = "root@terraformation.com", firstName = "Super", lastName = "User")
+      val deletedUser =
+          insertUser(
+              deletedTime = Instant.EPOCH,
+              email = "deleted@x.com",
+              firstName = "Mary",
+              lastName = "Contrary",
+          )
+      val nonexistentUser = UserId(-1)
+
+      val expected =
+          mapOf(
+              userInSameOrg to SimpleUserModel(userInSameOrg, "Same Org"),
+              userNotInSameOrg to SimpleUserModel(userNotInSameOrg, "Terraware User"),
+              tfUser to SimpleUserModel(tfUser, "Terraformation Team"),
+              deletedUser to SimpleUserModel(deletedUser, "Former User"),
+              nonexistentUser to SimpleUserModel(nonexistentUser, "Former User"),
+          )
+
+      val actual =
+          store.fetchSimpleUsersById(
+              listOf(userInSameOrg, userNotInSameOrg, tfUser, deletedUser, nonexistentUser)
+          )
+
+      assertEquals(expected, actual)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/customer/db/SimpleUserStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/SimpleUserStoreTest.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.customer.db
 
 import com.terraformation.backend.RunsAsDatabaseUser
 import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.UserId
@@ -51,6 +52,16 @@ class SimpleUserStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           store.fetchSimpleUsersById(
               listOf(userInSameOrg, userNotInSameOrg, tfUser, deletedUser, nonexistentUser)
           )
+
+      assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `system user can read full name`() {
+      val userId = insertUser(email = "random@x.com", firstName = "Random", lastName = "Person")
+
+      val expected = mapOf(userId to SimpleUserModel(userId, "Random Person"))
+      val actual = SystemUser(usersDao).run { store.fetchSimpleUsersById(listOf(userId)) }
 
       assertEquals(expected, actual)
     }


### PR DESCRIPTION
Add a new store class that fetches `SimpleUserModel`s. This will be used by the
event log query API to return users' full names as part of the event details.