### PR TITLE
SW-7607 Add event log query endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContext.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContext.kt
@@ -1,0 +1,92 @@
+package com.terraformation.backend.eventlog
+
+import com.terraformation.backend.eventlog.api.EventSubjectPayload
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.i18n.Messages
+import kotlin.reflect.KClass
+
+/**
+ * Context used when transforming event log entries into payload objects. This is typically passed
+ * to factory methods on the payload classes. They can use it to pull information from earlier
+ * events or to render localized text.
+ *
+ * @param entries List of event log entries in chronological order.
+ */
+class EventLogPayloadContext(
+    private val entries: List<EventLogEntry<PersistentEvent>>,
+    private val messages: Messages,
+) {
+  private val eventsByClass = entries.map { it.event }.groupBy { it::class }
+
+  /** Returns the localized short text for a subject. */
+  fun subjectShortText(kClass: KClass<out EventSubjectPayload>, args: Array<out Any>) =
+      messages.eventSubjectShortText(kClass, *args)
+
+  /** Returns the localized short text for a subject. */
+  inline fun <reified T : EventSubjectPayload> subjectShortText(vararg args: Any) =
+      subjectShortText(T::class, args)
+
+  /** Returns the localized full text for a subject. */
+  fun subjectFullText(kClass: KClass<out EventSubjectPayload>, args: Array<out Any>) =
+      messages.eventSubjectFullText(kClass, *args)
+
+  /** Returns the localized full text for a subject. */
+  inline fun <reified T : EventSubjectPayload> subjectFullText(vararg args: Any) =
+      subjectFullText(T::class, args)
+
+  /** Returns all the events of a given class that were fetched from the database. */
+  fun <T : PersistentEvent> getEvents(kClass: KClass<T>): List<T> {
+    @Suppress("UNCHECKED_CAST")
+    return (eventsByClass[kClass] as? List<T>) ?: emptyList()
+  }
+
+  /**
+   * Returns the first event of a given class that matches a condition, or null if no events match.
+   */
+  inline fun <reified T : PersistentEvent> firstOrNull(predicate: (T) -> Boolean): T? =
+      getEvents(T::class).firstOrNull { predicate(it) }
+
+  /** Returns the first event of a given class that matches a condition. */
+  inline fun <reified T : PersistentEvent> first(predicate: (T) -> Boolean): T =
+      firstOrNull<T>(predicate)
+          ?: throw IllegalStateException(
+              "No matching event of type ${T::class.qualifiedName} found"
+          )
+
+  /**
+   * Returns the first event of a given class that matches a condition and that was published before
+   * the specified event, or null if no matching events were published before the specified one.
+   * This can be used to find, e.g., the most recent rename event.
+   */
+  @Suppress("UNCHECKED_CAST")
+  fun <T : PersistentEvent> lastEventBefore(
+      event: Any,
+      kClass: KClass<T>,
+      predicate: (T) -> Boolean,
+  ): T? {
+    var lastMatch: EventLogEntry<PersistentEvent>? = null
+
+    for (entry in entries) {
+      if (entry.event === event) {
+        return lastMatch?.event as T?
+      }
+      if (kClass.isInstance(entry.event) && predicate(entry.event as T)) {
+        lastMatch = entry
+      }
+    }
+
+    throw IllegalArgumentException("Stopping-point event does not appear in context")
+  }
+
+  /**
+   * Returns the first event of a given class that matches a condition and that was published before
+   * the specified event, or null if no matching events were published before the specified one.
+   * This can be used to find, e.g., the most recent rename event.
+   */
+  inline fun <reified T : PersistentEvent> lastEventBefore(
+      event: Any,
+      noinline predicate: (T) -> Boolean,
+  ): T? {
+    return lastEventBefore(event, T::class, predicate)
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -1,0 +1,101 @@
+package com.terraformation.backend.eventlog
+
+import com.terraformation.backend.customer.db.SimpleUserStore
+import com.terraformation.backend.eventlog.api.CreatedActionPayload
+import com.terraformation.backend.eventlog.api.DeletedActionPayload
+import com.terraformation.backend.eventlog.api.EventActionPayload
+import com.terraformation.backend.eventlog.api.EventLogEntryPayload
+import com.terraformation.backend.eventlog.api.EventSubjectName
+import com.terraformation.backend.eventlog.api.EventSubjectPayload
+import com.terraformation.backend.eventlog.api.FieldUpdatedActionPayload
+import com.terraformation.backend.eventlog.api.ObservationPlotMediaSubjectPayload
+import com.terraformation.backend.eventlog.db.EventLogStore
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
+import jakarta.inject.Named
+
+@Named
+class EventLogPayloadTransformer(
+    private val messages: Messages,
+    private val simpleUserStore: SimpleUserStore,
+) {
+  private val log = perClassLogger()
+
+  /**
+   * Returns a list of [EventLogEntryPayload] objects representing a sequence of events. This is not
+   * necessarily a 1:1 mapping; a single event can map to multiple payloads, e.g., if the event
+   * describes an update of multiple fields.
+   *
+   * The logic that produces a payload for a given event can refer to earlier events in the list,
+   * e.g., to pull an entity's name from its "created" event. Therefore, it's important that
+   * [entries] include all the events for each entity whose events are included. This should happen
+   * automatically if the list of events is queried using the event interfaces from
+   * [EventSubjectName].
+   *
+   * The list of entries must be in chronological order; the query methods in [EventLogStore] return
+   * chronological results, so this usually doesn't require any additional work.
+   */
+  fun eventsToPayloads(entries: List<EventLogEntry<PersistentEvent>>): List<EventLogEntryPayload> {
+    val context = EventLogPayloadContext(entries, messages)
+    val users = simpleUserStore.fetchSimpleUsersById(entries.map { it.createdBy }.distinct())
+
+    return entries.flatMap { entry ->
+      val actions = getActions(entry.event)
+      val subject = getSubject(entry.event, context)
+
+      if (actions.isNotEmpty() && subject != null) {
+        actions.map { action ->
+          EventLogEntryPayload(
+              action = action,
+              subject = subject,
+              timestamp = entry.createdTime,
+              userId = entry.createdBy,
+              userName = users[entry.createdBy]?.fullName ?: messages.formerUser(),
+          )
+        }
+      } else {
+        emptyList()
+      }
+    }
+  }
+
+  private fun getSubject(
+      event: PersistentEvent,
+      context: EventLogPayloadContext,
+  ): EventSubjectPayload? {
+    return when (event) {
+      is ObservationMediaFilePersistentEvent ->
+          ObservationPlotMediaSubjectPayload.forEvent(event, context)
+      else -> {
+        log.error("Cannot construct subject for event ${event.javaClass.name}")
+        null
+      }
+    }
+  }
+
+  private fun getActions(event: PersistentEvent): List<EventActionPayload> {
+    return when (event) {
+      is ObservationMediaFileEditedEvent ->
+          listOf(
+              FieldUpdatedActionPayload(
+                  "caption", // TODO: i18n
+                  listOfNotNull(event.changedFrom.caption),
+                  listOfNotNull(event.changedTo.caption),
+              )
+          )
+
+      // Create and delete actions don't need any event-type-specific arguments because the details
+      // are already in the subject.
+      is EntityCreatedPersistentEvent -> listOf(CreatedActionPayload())
+      is EntityDeletedPersistentEvent -> listOf(DeletedActionPayload())
+
+      else -> {
+        log.error("Cannot construct actions for event ${event.javaClass.name}")
+        emptyList()
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventActionPayload.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.eventlog.api
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+sealed interface EventActionPayload
+
+@JsonTypeName("Created")
+class CreatedActionPayload : EventActionPayload {
+  override fun equals(other: Any?) = other is CreatedActionPayload
+
+  override fun hashCode() = javaClass.hashCode() xor 1
+}
+
+@JsonTypeName("Deleted")
+class DeletedActionPayload : EventActionPayload {
+  override fun equals(other: Any?) = other is DeletedActionPayload
+
+  override fun hashCode() = javaClass.hashCode() xor 1
+}
+
+@JsonTypeName("FieldUpdated")
+data class FieldUpdatedActionPayload(
+    val fieldName: String,
+    val changedFrom: List<String>?,
+    val changedTo: List<String>?,
+) : EventActionPayload

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventLogController.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventLogController.kt
@@ -1,0 +1,77 @@
+package com.terraformation.backend.eventlog.api
+
+import com.terraformation.backend.api.CustomerEndpoint
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.eventlog.EventLogPayloadTransformer
+import com.terraformation.backend.eventlog.db.EventLogStore
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@CustomerEndpoint
+@RestController
+@RequestMapping("/api/v1/events")
+class EventLogController(
+    private val eventLogStore: EventLogStore,
+    private val eventLogPayloadTransformer: EventLogPayloadTransformer,
+) {
+  @Operation(summary = "Lists the entries from the event log that relate to a particular entity.")
+  @PostMapping("/list")
+  fun listEventLogEntries(
+      @RequestBody payload: ListEventLogEntriesRequestPayload
+  ): ListEventLogEntriesResponsePayload {
+    requirePermissions { readOrganization(payload.organizationId) }
+
+    val eventLogEntries =
+        eventLogStore.fetchByIds(
+            listOfNotNull(
+                payload.fileId,
+                payload.monitoringPlotId,
+                payload.observationId,
+                payload.organizationId,
+                payload.plantingSiteId,
+            ),
+            requestedClasses = payload.subjects?.map { it.eventInterface }?.ifEmpty { null },
+        )
+
+    val payloads = eventLogPayloadTransformer.eventsToPayloads(eventLogEntries)
+
+    return ListEventLogEntriesResponsePayload(payloads)
+  }
+}
+
+@Schema(
+    description =
+        "Specifies which entities' events should be retrieved. Organization ID is mandatory, but " +
+            "other IDs can also be specified here. Entities have to match all the requested IDs. " +
+            "For example, if you specify observationId and monitoringPlotId, you will only get " +
+            "events related to one monitoring plot in one observation, whereas if you specify " +
+            "just observationId, you will get events related to all monitoring plots in that " +
+            "observation. The subjects property may be used to narrow the search further."
+)
+data class ListEventLogEntriesRequestPayload(
+    val fileId: FileId? = null,
+    val monitoringPlotId: MonitoringPlotId? = null,
+    val observationId: ObservationId? = null,
+    val organizationId: OrganizationId,
+    val plantingSiteId: PlantingSiteId? = null,
+    @Schema(
+        description =
+            "If specified, only return event log entries for specific subject types. This can be " +
+                "used to narrow the scope of the results in cases where there might be events " +
+                "related to child entities and you don't care about those."
+    )
+    val subjects: Set<EventSubjectName>? = null,
+)
+
+data class ListEventLogEntriesResponsePayload(val events: List<EventLogEntryPayload>) :
+    SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventLogEntryPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventLogEntryPayload.kt
@@ -1,0 +1,20 @@
+package com.terraformation.backend.eventlog.api
+
+import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.db.default_schema.UserId
+import java.time.Instant
+
+data class EventLogEntryPayload(
+    val action: EventActionPayload,
+    val subject: EventSubjectPayload,
+    val timestamp: Instant,
+    val userId: UserId,
+    val userName: String,
+) {
+  constructor(
+      action: EventActionPayload,
+      subject: EventSubjectPayload,
+      timestamp: Instant,
+      user: SimpleUserModel,
+  ) : this(action, subject, timestamp, user.userId, user.fullName)
+}

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -1,0 +1,102 @@
+package com.terraformation.backend.eventlog.api
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.eventlog.EventLogPayloadContext
+import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.file.api.MediaKind
+import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
+import io.swagger.v3.oas.annotations.media.Schema
+import kotlin.reflect.KClass
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+sealed interface EventSubjectPayload {
+  @get:Schema(
+      description =
+          "If this is true, the entity referred to by this subject has been deleted. This " +
+              "property will be omitted if the entity still exists, i.e., this property will " +
+              "always be true if it exists."
+  )
+  val deleted: Boolean?
+    get() = null
+
+  @get:Schema(
+      description =
+          "A localized extended human-readable description of the subject of the event, suitable " +
+              "for display in cases where events for many subjects are being shown in the same " +
+              "list.",
+      example = "Project Backyard Garden",
+  )
+  val fullText: String
+
+  @get:Schema(
+      description =
+          "A localized short human-readable name (often a single word) for the subject of the " +
+              "event, suitable for display in cases where only events for a single subject are " +
+              "being shown or where the subject doesn't need to be distinguished from others " +
+              "of the same type.",
+      example = "Project",
+  )
+  val shortText: String
+}
+
+@JsonTypeName("ObservationPlotMedia")
+data class ObservationPlotMediaSubjectPayload(
+    override val deleted: Boolean?,
+    val fileId: FileId,
+    override val fullText: String,
+    val mediaKind: MediaKind,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    override val shortText: String,
+) : EventSubjectPayload {
+  companion object {
+    fun forEvent(
+        event: ObservationMediaFilePersistentEvent,
+        context: EventLogPayloadContext,
+    ): ObservationPlotMediaSubjectPayload {
+      val createEvent =
+          context.first<ObservationMediaFileUploadedEvent> { it.fileId == event.fileId }
+      val deleteEvent =
+          context.firstOrNull<ObservationMediaFileDeletedEvent> { it.fileId == event.fileId }
+
+      val mediaKind = MediaKind.forMimeType(createEvent.contentType)
+      val mediaKindName = mediaKind.getDisplayName(currentUser().locale)
+      val fullText =
+          context.subjectFullText<ObservationPlotMediaSubjectPayload>(
+              mediaKindName,
+              event.fileId.value,
+          )
+
+      return ObservationPlotMediaSubjectPayload(
+          deleted = if (deleteEvent != null) true else null,
+          fileId = event.fileId,
+          fullText = fullText,
+          mediaKind = mediaKind,
+          monitoringPlotId = event.monitoringPlotId,
+          observationId = event.observationId,
+          plantingSiteId = event.plantingSiteId,
+          shortText = mediaKindName,
+      )
+    }
+  }
+}
+
+/**
+ * Types of subjects that can be returned by the event log query API. Each subject maps to an
+ * interface that's implemented by events related to that subject.
+ *
+ * The entries in this enum must match the [JsonTypeName] annotations on the subject payload
+ * classes.
+ */
+enum class EventSubjectName(val eventInterface: KClass<out PersistentEvent>) {
+  ObservationPlotMedia(ObservationMediaFilePersistentEvent::class),
+}

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.i18n
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.accelerator.MODULE_EVENT_NOTIFICATION_LEAD_TIME
 import com.terraformation.backend.db.LocalizableEnum
 import com.terraformation.backend.db.accelerator.ActivityType
@@ -25,6 +26,8 @@ import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
 import org.springframework.context.support.ResourceBundleMessageSource
 
 /** Helper class to encapsulate notification message semantics */
@@ -223,6 +226,12 @@ class Messages {
   fun batchCsvColumnName(position: Int) = getMessage("batchCsvColumnName.$position")
 
   fun batchCsvQuantityInvalid() = getMessage("batchCsvQuantityInvalid")
+
+  fun eventSubjectFullText(subjectClass: KClass<*>, vararg args: Any) =
+      getMessage("${eventSubjectPrefix(subjectClass)}.full", *args)
+
+  fun eventSubjectShortText(subjectClass: KClass<*>, vararg args: Any) =
+      getMessage("${eventSubjectPrefix(subjectClass)}.short", *args)
 
   fun monitoringPlotNortheastCorner(plotNumber: Long) =
       getMessage("monitoringPlotNortheastCorner", plotNumber)
@@ -648,6 +657,9 @@ class Messages {
       getMessage("variablesCsvVariableParentDoesNotExist")
 
   fun variablesCsvWrongDataTypeForChild() = getMessage("variablesCsvWrongDataTypeForChild")
+
+  private fun eventSubjectPrefix(kClass: KClass<*>) =
+      "eventSubject.${kClass.findAnnotation<JsonTypeName>()!!.value}"
 
   private val validAccessionStates
     get() = getEnumValuesList(AccessionState.entries.filter { it.isV2Compatible })

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -131,6 +131,7 @@ springdoc:
     - "com.terraformation.backend.documentproducer.api"
     - "com.terraformation.backend.customer.api"
     - "com.terraformation.backend.device.api"
+    - "com.terraformation.backend.eventlog.api"
     - "com.terraformation.backend.file.api"
     - "com.terraformation.backend.funder.api"
     - "com.terraformation.backend.gis.api"

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -80,6 +80,9 @@ csvSubLocationNotFound=Sub-location does not exist
 csvWrongFieldCount=Expected row to have {0} fields, not {1}
 disabled=Disabled
 enabled=Enabled
+# {0} is media kind, {1} is file ID
+eventSubject.ObservationPlotMedia.full={0} {1}
+eventSubject.ObservationPlotMedia.short={0}
 formerUser=Former User
 historyAccessionCreated=created accession
 historyAccessionQuantityUpdated=updated the quantity to {0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -137,6 +137,10 @@ csvWrongFieldCount=Se espera que la fila tenga {0} campos, no {1}.
 disabled=Deshabilitado
 # 0cbb9a69
 enabled=Habilitado
+# 0ff64395
+eventSubject.ObservationPlotMedia.full={0} {1}
+# 61e0214b
+eventSubject.ObservationPlotMedia.short={0}
 # 897498fc
 formerUser=Usuario anterior
 # 11138bfd

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -137,6 +137,10 @@ csvWrongFieldCount=La ligne devait contenir {0} champs, pas {1}
 disabled=Désactivé
 # 0cbb9a69
 enabled=Activé
+# 0ff64395
+eventSubject.ObservationPlotMedia.full={0} {1}
+# 61e0214b
+eventSubject.ObservationPlotMedia.short={0}
 # 897498fc
 formerUser=Ancien utilisateur
 # 11138bfd

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -1,0 +1,191 @@
+package com.terraformation.backend.eventlog
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.customer.db.SimpleUserStore
+import com.terraformation.backend.customer.model.SimpleUserModel
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.UserId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationMediaType
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.eventlog.api.CreatedActionPayload
+import com.terraformation.backend.eventlog.api.DeletedActionPayload
+import com.terraformation.backend.eventlog.api.EventLogEntryPayload
+import com.terraformation.backend.eventlog.api.FieldUpdatedActionPayload
+import com.terraformation.backend.eventlog.api.ObservationPlotMediaSubjectPayload
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.file.api.MediaKind
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEvent
+import com.terraformation.backend.tracking.event.ObservationMediaFileEditedEventValues
+import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class EventLogPayloadTransformerTest : RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  private val messages = Messages()
+  private val simpleUserStore: SimpleUserStore = mockk()
+  private val transformer = EventLogPayloadTransformer(messages, simpleUserStore)
+
+  private val fileId = FileId(1)
+  private val monitoringPlotId = MonitoringPlotId(2)
+  private val observationId = ObservationId(3)
+  private val organizationId = OrganizationId(4)
+  private val plantingSiteId = PlantingSiteId(5)
+  private val knownUserId = UserId(6)
+  private val unknownUserId = UserId(7)
+
+  @BeforeEach
+  fun setUp() {
+    every { simpleUserStore.fetchSimpleUsersById(any()) }
+        .answers { mapOf(knownUserId to SimpleUserModel(knownUserId, "Known User")) }
+  }
+
+  @Test
+  fun `maps create and update events to payloads`() {
+    val uploadEntry = eventLogEntry(knownUserId, uploadedEvent())
+    val editEntry =
+        eventLogEntry(
+            unknownUserId,
+            ObservationMediaFileEditedEvent(
+                changedFrom = ObservationMediaFileEditedEventValues(caption = "before"),
+                changedTo = ObservationMediaFileEditedEventValues(caption = "after"),
+                fileId = fileId,
+                monitoringPlotId = monitoringPlotId,
+                observationId = observationId,
+                organizationId = organizationId,
+                plantingSiteId = plantingSiteId,
+            ),
+        )
+
+    val subject =
+        ObservationPlotMediaSubjectPayload(
+            deleted = null,
+            fileId = fileId,
+            fullText = "Photo $fileId",
+            mediaKind = MediaKind.Photo,
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            plantingSiteId = plantingSiteId,
+            shortText = "Photo",
+        )
+
+    val expected =
+        listOf(
+            EventLogEntryPayload(
+                action = CreatedActionPayload(),
+                subject = subject,
+                timestamp = uploadEntry.createdTime,
+                userId = knownUserId,
+                userName = "Known User",
+            ),
+            EventLogEntryPayload(
+                action =
+                    FieldUpdatedActionPayload(
+                        fieldName = "caption",
+                        changedFrom = listOf("before"),
+                        changedTo = listOf("after"),
+                    ),
+                subject = subject,
+                timestamp = editEntry.createdTime,
+                userId = unknownUserId,
+                userName = "Former User",
+            ),
+        )
+
+    val actual = transformer.eventsToPayloads(listOf(uploadEntry, editEntry))
+
+    assertEquals(expected, actual)
+  }
+
+  @Test
+  fun `marks subject as deleted in all events when delete event exists`() {
+    val uploadEntry = eventLogEntry(knownUserId, uploadedEvent())
+    val deleteEntry =
+        eventLogEntry(
+            unknownUserId,
+            ObservationMediaFileDeletedEvent(
+                fileId = fileId,
+                monitoringPlotId = monitoringPlotId,
+                observationId = observationId,
+                organizationId = organizationId,
+                plantingSiteId = plantingSiteId,
+            ),
+        )
+
+    val subject =
+        ObservationPlotMediaSubjectPayload(
+            deleted = true, // This will be set on the created action, not just the deleted one
+            fileId = fileId,
+            fullText = "Photo $fileId",
+            mediaKind = MediaKind.Photo,
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            plantingSiteId = plantingSiteId,
+            shortText = "Photo",
+        )
+
+    val expected =
+        listOf(
+            EventLogEntryPayload(
+                action = CreatedActionPayload(),
+                subject = subject,
+                timestamp = uploadEntry.createdTime,
+                userId = knownUserId,
+                userName = "Known User",
+            ),
+            EventLogEntryPayload(
+                action = DeletedActionPayload(),
+                subject = subject,
+                timestamp = deleteEntry.createdTime,
+                userId = unknownUserId,
+                userName = "Former User",
+            ),
+        )
+
+    val actual = transformer.eventsToPayloads(listOf(uploadEntry, deleteEntry))
+
+    assertEquals(expected, actual)
+  }
+
+  private fun uploadedEvent(): ObservationMediaFileUploadedEvent =
+      ObservationMediaFileUploadedEvent(
+          caption = "caption",
+          contentType = "image/png",
+          fileId = fileId,
+          geolocation = null,
+          isOriginal = true,
+          monitoringPlotId = monitoringPlotId,
+          observationId = observationId,
+          organizationId = organizationId,
+          plantingSiteId = plantingSiteId,
+          position = ObservationPlotPosition.SouthwestCorner,
+          type = ObservationMediaType.Plot,
+      )
+
+  private var nextEventLogId: Long = 1
+
+  private fun eventLogEntry(
+      userId: UserId,
+      event: PersistentEvent,
+  ): EventLogEntry<PersistentEvent> =
+      EventLogEntry(
+          createdBy = userId,
+          createdTime = Instant.ofEpochSecond(nextEventLogId),
+          event = event,
+          id = EventLogId(nextEventLogId++),
+      )
+}

--- a/src/test/kotlin/com/terraformation/backend/eventlog/api/EventSubjectNameTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/api/EventSubjectNameTest.kt
@@ -1,0 +1,24 @@
+package com.terraformation.backend.eventlog.api
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.assertSetEquals
+import kotlin.reflect.full.findAnnotation
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class EventSubjectNameTest {
+  @Test
+  fun `subject payload type names match enum entry names`() {
+    val payloadClasses = EventSubjectPayload::class.sealedSubclasses
+    val payloadTypeNames =
+        payloadClasses.mapNotNull { it.findAnnotation<JsonTypeName>()?.value }.toSet()
+    val enumNames = EventSubjectName.entries.map { it.name }.toSet()
+
+    assertSetEquals(payloadTypeNames, enumNames)
+  }
+
+  @Test
+  fun `enum entries are in alphabetical order`() {
+    assertEquals(EventSubjectName.entries.sortedBy { it.name }, EventSubjectName.entries)
+  }
+}


### PR DESCRIPTION
`POST /api/v1/events/list` will search the event log for events related to the IDs
specified in the request body, optionally limited to specific kinds of entities.

In this initial change, only observation media events are supported; others will
be added later. Example payload to query the media events for a particular
observation of a particular monitoring plot:

    {
        "organizationId": 1,
        "observationId": 2,
        "monitoringPlotId": 3,
        "subjects": ["ObservationPlotMedia"]
    }

Events are represented using "subjects" and "actions," where the list of actions
is currently limited to create, delete, and field-update. These always use the
same payload format no matter what the event is. The subject's structure varies
depending on the type of entity, but always includes long and short text
descriptions which UI code can use to display line items for events it doesn't
recognize or that don't need custom rendering logic.

In this initial change, the field names in the field-update action aren't
localized; that'll come later. (I say "field names" but there's only one field
so far: the "caption" field on observation photos/videos.)