### PR TITLE
SW-7607 Interface for "field(s) updated" events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedEvent.kt
@@ -1,0 +1,44 @@
+package com.terraformation.backend.eventlog
+
+/**
+ * Common interface for events that represent one or more fields of an entity being updated. This is
+ * used to render [PersistentEvent]s into API payloads for event log queries. Update events should
+ * either implement this interface or be handled explicitly in
+ * [EventLogPayloadTransformer.getActions].
+ */
+interface FieldsUpdatedEvent {
+  /**
+   * Returns a list of all the fields that were updated by the operation this event represents.
+   * Fields that weren't modified shouldn't be included in the list. If the event represents a
+   * single field change, this should return a list of length 1.
+   */
+  fun listUpdatedFields(): List<UpdatedField>
+
+  /** Represents a change to a single field. */
+  data class UpdatedField(
+      /**
+       * Canonical name of the field. This will generally be the same as the name of the Kotlin
+       * property of the entity's model class. Do not use localized names here; localization of
+       * field names is handled elsewhere.
+       */
+      val fieldName: String,
+      /**
+       * Previous value of the field, or null if it had no previous value. For scalar fields, this
+       * list will have one element, but it can have multiple elements if a field is, e.g., a set of
+       * enum values.
+       */
+      val changedFrom: List<String>?,
+      /**
+       * Previous value of the field, or null if the event represents the value being removed. For
+       * scalar fields, this list will have one element, but it can have multiple elements if a
+       * field is, e.g., a set of enum values.
+       */
+      val changedTo: List<String>?,
+  ) {
+    constructor(
+        fieldName: String,
+        changedFrom: String?,
+        changedTo: String?,
+    ) : this(fieldName, changedFrom?.let { listOf(it) }, changedTo?.let { listOf(it) })
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
+import com.terraformation.backend.eventlog.FieldsUpdatedEvent
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.ratelimit.RateLimitedEvent
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
@@ -266,10 +267,13 @@ data class ObservationMediaFileEditedEventV1(
     override val observationId: ObservationId,
     override val organizationId: OrganizationId,
     override val plantingSiteId: PlantingSiteId,
-) : EntityUpdatedPersistentEvent, ObservationMediaFilePersistentEvent {
+) : EntityUpdatedPersistentEvent, FieldsUpdatedEvent, ObservationMediaFilePersistentEvent {
   data class Values(
       val caption: String?,
   )
+
+  override fun listUpdatedFields() =
+      listOf(FieldsUpdatedEvent.UpdatedField("caption", changedFrom.caption, changedTo.caption))
 }
 
 typealias ObservationMediaFileEditedEvent = ObservationMediaFileEditedEventV1


### PR DESCRIPTION
To reduce the amount of repetitive boilerplate as we add more persistent events,
add an interface that events representing updates to entity fields can implement
to get automatic conversion to `EventActionPayload` when they're queried via the
event log API.