### PR TITLE
Specify Spanish translation for "quadrat"

### DIFF
--- a/src/main/resources/i18n/instructions-es.txt
+++ b/src/main/resources/i18n/instructions-es.txt
@@ -9,5 +9,6 @@ check in: ingresar
 family: familia
 outplant (n): plantas en campo
 outplant (v): transplantar
+quadrat: cuadrícula
 scientific name: nombre científico
 seed bank: banco de semillas


### PR DESCRIPTION
We'll be adding some strings that reference quadrats, and by default autotranslate
chooses a different Spanish word than we use in the web app.