### PR TITLE
Improve TestEventPublisher assertion failure message

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
+++ b/src/test/kotlin/com/terraformation/backend/TestEventPublisher.kt
@@ -56,7 +56,7 @@ class TestEventPublisher : ApplicationEventPublisher, RateLimitedEventPublisher 
   fun assertEventsPublished(events: Set<Any>, message: String = "Expected events not published") {
     val publishedEventsFromExpectedSet = publishedEvents.filter { it in events }.toSet()
 
-    assertEquals(events, publishedEventsFromExpectedSet, message)
+    assertSetEquals(events, publishedEventsFromExpectedSet, message)
   }
 
   /**


### PR DESCRIPTION
Use our `assertSetEquals` function to check for published events; it produces more
human-friendly assertion failure messages than `assertEquals`.