### PR TITLE
Fix planting site ID lookup for ad-hoc plots

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -216,11 +216,7 @@ class ParentStore(private val dslContext: DSLContext) {
       fetchFieldById(uploadId, UPLOADS.ID, UPLOADS.ORGANIZATION_ID)
 
   fun getPlantingSiteId(monitoringPlotId: MonitoringPlotId): PlantingSiteId? =
-      fetchFieldById(
-          monitoringPlotId,
-          MONITORING_PLOTS.ID,
-          MONITORING_PLOTS.plantingSubzones.PLANTING_SITE_ID,
-      )
+      fetchFieldById(monitoringPlotId, MONITORING_PLOTS.ID, MONITORING_PLOTS.PLANTING_SITE_ID)
 
   fun getPlantingSiteId(observationId: ObservationId): PlantingSiteId? =
       fetchFieldById(observationId, OBSERVATIONS.ID, OBSERVATIONS.PLANTING_SITE_ID)


### PR DESCRIPTION
The `ParentStore` function to look up a planting site ID for a monitoring plot ID
was assuming that the plot was in a subzone, which was a safe assumption when the
function was written but stopped being safe when we added ad-hoc plots.