### PR TITLE
Fix 500 when unknown/other species in observed totals

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -51,7 +51,7 @@ class T0Controller(
     return GetAllSiteT0DataSetResponsePayload(allSet = allSet)
   }
 
-  @GetMapping("/plantingSite/{plantingSiteId}/species")
+  @GetMapping("/site/{plantingSiteId}/species")
   @Operation(
       summary =
           "Lists all the species that have been withdrawn to a planting site or recorded in " +

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
@@ -133,6 +134,7 @@ class T0Store(
                     OBSERVED_PLOT_SPECIES_TOTALS.TOTAL_DEAD.gt(0),
                 )
             )
+            .and(OBSERVED_PLOT_SPECIES_TOTALS.CERTAINTY_ID.eq(RecordedSpeciesCertainty.Known))
             .andNotExists(
                 DSL.selectOne()
                     .from(PLANTING_SUBZONE_POPULATIONS)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -389,6 +389,8 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `fetches site species from observations with no withdrawn data`() {
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1)
+      // Unknown species are excluded:
+      insertObservedPlotSpeciesTotals(certainty = RecordedSpeciesCertainty.Unknown, totalLive = 2)
       insertObservedPlotSpeciesTotals(speciesId = speciesId2, totalLive = 1)
       insertObservedPlotSpeciesTotals(
           monitoringPlotId = tempPlotId,


### PR DESCRIPTION
The new t0 required species endpoint was throwing a 500 when there were recorded plants that were either unknown or other. Exclude these in the sql.

Also make the endpoint consistent with the others in the controller by changing `/plantingSite` to `/site`