### PR TITLE
Move inputs into their <label>s in admin UI

### DIFF
--- a/src/main/resources/templates/admin/deviceManager.html
+++ b/src/main/resources/templates/admin/deviceManager.html
@@ -28,62 +28,85 @@
 
 <form th:action="|/admin/deviceManagers/${manager.id}|" method="POST">
 
-    <label for="sensorKitId">Sensor Kit ID</label>
-    <input type="text" name="sensorKitId" id="sensorKitId" th:value="${manager.sensorKitId}"/>
+    <label>
+        Sensor Kit ID
+        <input type="text" name="sensorKitId" th:value="${manager.sensorKitId}"/>
+    </label>
     <br/>
 
-    <label for="facilityId">Facility ID</label>
-    <input type="text" name="facilityId" id="facilityId" th:value="${manager.facilityId}"/>
+    <label>
+        Facility ID
+        <input type="text" name="facilityId" th:value="${manager.facilityId}"/>
+    </label>
     If this isn't set, the device manager is not connected yet.
     <br/>
 
-    <label for="isOnline">Online?</label>
-    <select name="isOnline" id="isOnline">
-        <option value="true" th:selected="${manager.isOnline()}">Yes</option>
-        <option value="false" th:selected="!${manager.isOnline()}">No</option>
+    <label>
+        Online?
+        <select name="isOnline">
+            <option value="true" th:selected="${manager.isOnline()}">Yes</option>
+            <option value="false" th:selected="!${manager.isOnline()}">No</option>
     </select>
     <br/>
 
-    <label for="updateProgress">Update Progress</label>
-    <input type="number" name="updateProgress" id="updateProgress" min="0" max="100"
+    <label>
+        Update Progress
+        <input type="number" name="updateProgress" min="0" max="100"
            th:value="${manager.updateProgress}"/>
+    </label>
     Progress percentage of software update. Null if no update in progress.
     <br/>
 
     <span id="advanced" style="display: none;">
 
-    <label for="userId">User ID</label>
-    <input type="text" name="userId" id="userId" th:value="${manager.userId}"/>
+    <label>
+        User ID
+        <input type="text" name="userId" th:value="${manager.userId}"/>
+    </label>
     <br/>
 
-    <label for="balenaId">Balena ID</label>
-    <input type="number" name="balenaId" id="balenaId" th:value="${manager.balenaId}"/>
+    <label>
+        Balena ID
+        <input type="number" name="balenaId" th:value="${manager.balenaId}"/>
+    </label>
     <br/>
 
-    <label for="balenaUuid">Balena UUID</label>
-    <input type="text" name="balenaUuid" id="balenaUuid" th:value="${manager.balenaUuid}"/>
+    <label>
+        Balena UUID
+        <input type="text" name="balenaUuid" th:value="${manager.balenaUuid}"/>
+    </label>
     <br/>
 
-    <label for="balenaModifiedTime">Balena Modified Time</label>
-    <input type="text" name="balenaModifiedTime" id="balenaModifiedTime"
+    <label>
+        Balena Modified Time
+        <input type="text" name="balenaModifiedTime"
            th:value="${manager.balenaModifiedTime}"/>
+    </label>
     <br/>
 
-    <label for="deviceName">Balena Name</label>
-    <input type="text" name="deviceName" id="deviceName" th:value="${manager.deviceName}"/>
+    <label>
+        Balena Name
+        <input type="text" name="deviceName" th:value="${manager.deviceName}"/>
+    </label>
     <br/>
 
-    <label for="lastConnectivityEvent">Last Connectivity</label>
-    <input type="text" name="lastConnectivityEvent" id="lastConnectivityEvent"
+    <label>
+        Last Connectivity
+        <input type="text" name="lastConnectivityEvent"
            th:value="${manager.lastConnectivityEvent}"/>
+    </label>
     <br/>
 
-    <label for="createdTime">Created Time</label>
-    <input type="text" name="createdTime" id="createdTime" th:value="${manager.createdTime}"/>
+    <label>
+        Created Time
+        <input type="text" name="createdTime" th:value="${manager.createdTime}"/>
+    </label>
     <br/>
 
-    <label for="refreshedTime">Refreshed Time</label>
-    <input type="text" name="refreshedTime" id="refreshedTime" th:value="${manager.refreshedTime}"/>
+    <label>
+        Refreshed Time
+        <input type="text" name="refreshedTime" th:value="${manager.refreshedTime}"/>
+    </label>
     <br/>
 
     </span>

--- a/src/main/resources/templates/admin/documentProducer.html
+++ b/src/main/resources/templates/admin/documentProducer.html
@@ -21,20 +21,25 @@
 </table>
 
 <form method="POST" action="/admin/document-producer/createDocumentTemplate">
-    <label for="newDocumentTemplateName">Name</label>
-    <input type="text" id="newDocumentTemplateName" name="name" minlength="1"/>
+    <label>
+        Name
+        <input type="text" name="name" minlength="1"/>
+    </label>
     <input type="submit" value="Create Document Template"/>
 </form>
 
 <h2>Import Variable Manifest CSV</h2>
 
 <form method="POST" action="/admin/document-producer/uploadManifest" enctype="multipart/form-data">
-    <label for="uploadManifestCsv">CSV</label>
-    <input type="file" id="uploadManifestCsv" name="file" minlength="1"/>
+    <label>
+        CSV
+        <input type="file" name="file" minlength="1"/>
+    </label>
     <br>
-    <label for="uploadManifestDocumentTemplateName">Document Template ID</label>
-    <select id="uploadManifestDocumentTemplateName" name="documentTemplateId">
-        <option th:each="documentTemplate: ${documentTemplates}" th:value="${documentTemplate.id}"
+    <label>
+        Document Template ID
+        <select name="documentTemplateId">
+            <option th:each="documentTemplate: ${documentTemplates}" th:value="${documentTemplate.id}"
                 th:text="${documentTemplate.name}"/>
     </select>
     <br>
@@ -44,8 +49,10 @@
 <h2>Import All Variable CSV</h2>
 
 <form method="POST" action="/admin/document-producer/uploadAllVariables" enctype="multipart/form-data">
-    <label for="uploadManifestCsv">CSV</label>
-    <input type="file" id="uploadAllVariableCsv" name="file" minlength="1"/>
+    <label>
+        CSV
+        <input type="file" name="file" minlength="1"/>
+    </label>
     <br>
     <input type="submit" value="Import"/>
 </form>

--- a/src/main/resources/templates/admin/email.html
+++ b/src/main/resources/templates/admin/email.html
@@ -18,22 +18,30 @@
 <h2>Send Test Email</h2>
 
 <form method="POST" action="/admin/sendEmail" th:if="${isEmailEnabled}">
-    <label for="recipient">Recipient</label>
-    <input type="email" name="recipient" id="recipient" required/>
-    <input type="checkbox" id="sendToAll" name="sendToAll">
-    <label for="sendToAll"> Send to all users</label>
+    <label>
+        Recipient
+        <input type="email" name="recipient" id="recipient" required/>
+    </label>
+    <label>
+        <input type="checkbox" id="sendToAll" name="sendToAll">
+        Send to all users
+    </label>
     <br/>
-    <label for="emailName">Email to Send</label>
-    <select name="emailName" id="emailName">
-        <option th:value="DocumentsUpdate">Documents Update (EULA, TOS, Privacy update)</option>
-        <option th:value="GenericEmail">Generic Email</option>
-    </select>
+    <label>
+        Email to Send
+        <select name="emailName" id="emailName">
+            <option th:value="DocumentsUpdate">Documents Update (EULA, TOS, Privacy update)</option>
+            <option th:value="GenericEmail">Generic Email</option>
+        </select>
+    </label>
     <br/>
     <div id="genericEmailFields" style="display: none;">
-        <label for="subject">Subject</label>
-        <input type="text" name="subject" id="subject"/>
+        <label>
+            Subject
+            <input type="text" name="subject"/>
+        </label>
         <br/>
-        <label for="emailBody">Email Body</label>
+        <label>Email Body</label>
         <div id="quill-editor"></div>
         <!-- Hidden textarea to store Quill content -->
         <textarea name="emailBody" id="emailBody" style="display: none;"></textarea>

--- a/src/main/resources/templates/admin/facility.html
+++ b/src/main/resources/templates/admin/facility.html
@@ -69,36 +69,46 @@
 
 <form method="POST" action="/admin/updateFacility" th:if="${canUpdateFacility}">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
-    <label for="name">Name</label>
-    <input type="text" name="name" id="name" required th:value="${facility.name}"/>
+    <label>
+        Name
+        <input type="text" name="name" required th:value="${facility.name}"/>
+    </label>
     <br/>
-    <label for="description">Description</label>
-    <input type="text" name="description" id="description" th:value="${facility.description}"/>
+    <label>
+        Description
+        <input type="text" name="description" th:value="${facility.description}"/>
+    </label>
     <br/>
-    <label for="type">Type</label>
-    <select name="type" id="type">
-        <option th:each="type : ${facilityTypes}"
-                th:selected="${facility.type} == ${type}"
-                th:text="${type.jsonValue}"
-                th:value="${type.id}">
-            Type
-        </option>
-    </select>
+    <label>
+        Type
+        <select name="type">
+            <option th:each="type : ${facilityTypes}"
+                    th:selected="${facility.type} == ${type}"
+                    th:text="${type.jsonValue}"
+                    th:value="${type.id}">
+                Type
+            </option>
+        </select>
+    </label>
     <br/>
-    <label for="maxIdleMinutes">Max Idle</label>
-    <input type="number" name="maxIdleMinutes" id="maxIdleMinutes" maxlength="4" size="4" min="1"
-           required th:value="${facility.maxIdleMinutes}"/>
+    <label>
+        Max Idle
+        <input type="number" name="maxIdleMinutes" maxlength="4" size="4" min="1"
+               required th:value="${facility.maxIdleMinutes}"/>
+    </label>
     minutes (for updates from device manager)
     <br/>
-    <label for="connectionState">Connection</label>
-    <select name="connectionState" id="connectionState">
-        <option th:each="state: ${connectionStates}"
-                th:selected="${facility.connectionState} == ${state}"
-                th:text="${state.jsonValue}"
-                th:value="${state}">
-            State
-        </option>
-    </select>
+    <label>
+        Connection
+        <select name="connectionState">
+            <option th:each="state: ${connectionStates}"
+                    th:selected="${facility.connectionState} == ${state}"
+                    th:text="${state.jsonValue}"
+                    th:value="${state}">
+                State
+            </option>
+        </select>
+    </label>
     <br/>
     <input type="submit" value=" Update Facility "/>
 </form>
@@ -156,46 +166,62 @@
     </div>
 
     <div>
-        <label for="deviceType">Type</label>
-        <input type="text" id="deviceType" name="type" required/>
+        <label>
+            Type
+            <input type="text" id="deviceType" name="type" required/>
+        </label>
     </div>
 
     <div>
-        <label for="make">Make</label>
-        <input type="text" id="make" name="make" required/>
+        <label>
+            Make
+            <input type="text" id="make" name="make" required/>
+        </label>
     </div>
 
     <div>
-        <label for="model">Model</label>
-        <input type="text" id="model" name="model" required/>
+        <label>
+            Model
+            <input type="text" id="model" name="model" required/>
+        </label>
     </div>
 
     <div>
-        <label for="model">Protocol</label>
-        <input type="text" id="protocol" name="protocol"/>
+        <label>
+            Protocol
+            <input type="text" id="protocol" name="protocol"/>
+        </label>
     </div>
 
     <div>
-        <label for="deviceName">Name</label>
-        <input type="text" id="deviceName" name="name"/>
+        <label>
+            Name
+            <input type="text" id="deviceName" name="name"/>
+        </label>
         Leave blank for a random hex code.
     </div>
 
     <div>
-        <label for="address">Address</label>
-        <input type="text" id="address" name="address"/>
+        <label>
+            Address
+            <input type="text" id="address" name="address"/>
+        </label>
         Leave blank to use the device name.
     </div>
 
     <div>
-        <label for="address">Parent ID</label>
-        <input type="text" id="parentId" name="parentId"/>
+        <label>
+            Parent ID
+            <input type="text" name="parentId"/>
+        </label>
         Optional. Use this if you are adding a sensor that sits behind a hub. Put the hub's ID here.
     </div>
 
     <div>
-        <label for="count">Count</label>
-        <input type="number" id="count" name="count" value="1" min="1" max="50"/>
+        <label>
+            Count
+            <input type="number" name="count" value="1" min="1" max="50"/>
+        </label>
         Increase this to create multiple devices at once.
     </div>
 
@@ -230,8 +256,10 @@
 
 <form method="POST" action="/admin/createSubLocation" th:if="${canUpdateFacility}">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
-    <label for="subLocationName">Name</label>
-    <input type="text" name="name" id="subLocationName" required/>
+    <label>
+        Name
+        <input type="text" name="name" required/>
+    </label>
     <br/>
     <input type="submit" value=" Create Sub-Location "/>
 </form>
@@ -251,12 +279,15 @@
 
 <form method="POST" action="/admin/sendAlert">
     <input type="hidden" name="facilityId" th:value="${facility.id}"/>
-    <label for="subject">Subject</label>
-    <input type="text" name="subject" id="subject" value="Testing Alert Email"/>
+    <label>
+        Subject
+        <input type="text" name="subject" value="Testing Alert Email"/>
+    </label>
     <br/>
-    <label for="body">Body</label>
-    <textarea rows="5" cols="40" name="body"
-              id="body">This is a test of facility alert email.</textarea>
+    <label>
+        Body
+        <textarea rows="5" cols="40" name="body">This is a test of facility alert email.</textarea>
+    </label>
     <br/>
     <input type="submit" value=" Send Alert "/>
 </form>

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -80,8 +80,10 @@
         </p>
 
         <form method="POST" enctype="multipart/form-data" action="importGbif">
-            <label for="gbifUrl">URL of backbone.zip</label>
-            <input id="gbifUrl" type="url" name="url" required/>
+            <label>
+                URL of backbone.zip
+                <input type="url" name="url" required/>
+            </label>
             <input type="submit" value="Import"/>
             (can take several minutes)
         </form>
@@ -136,18 +138,22 @@
         </p>
 
         <form method="POST" action="/admin/addOrganizationUser">
-            <label for="addUserEmail">Email (user must already exist)</label>
-            <input id="addUserEmail" type="email" name="email" required/>
-            <label for="addUserOrganizationId">Organization</label>
-            <select id="addUserOrganizationId" name="organizationId">
-                <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
+            <label>
+                Email (user must already exist)
+                <input type="email" name="email" required/>
+            </label>
+            <label>
+                Organization
+                <select name="organizationId">
+                    <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
                         th:text="|${organization.name} (${organization.id})|">
                     My Org (123)
                 </option>
             </select>
-            <label for="addUserRole">Role</label>
-            <select id="addUserRole" name="role">
-                <option th:each="role : ${roles}"
+            <label>
+                Role
+                <select name="role">
+                    <option th:each="role : ${roles}"
                         th:value="${role.first}"
                         th:text="${role.second}"
                         th:selected="${role.second} == 'Admin'">
@@ -162,11 +168,14 @@
         <h2>Remove Organization User</h2>
 
         <form method="POST" action="/admin/removeOrganizationUser">
-            <label for="removeOrgUserEmail">Email (user must already exist)</label>
-            <input id="removeOrgUserEmail" type="email" name="email" required/>
-            <label for="removeOrgUserOrganizationId">Organization</label>
-            <select id="removeOrgUserOrganizationId" name="organizationId">
-                <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
+            <label>
+                Email (user must already exist)
+                <input type="email" name="email" required/>
+            </label>
+            <label>
+                Organization
+                <select name="organizationId">
+                    <option th:each="organization : ${allOrganizations}" th:value="${organization.id}"
                         th:text="|${organization.name} (${organization.id})|">
                     My Org (123)
                 </option>
@@ -179,10 +188,14 @@
         <h2>Delete User</h2>
 
         <form method="POST" action="/admin/users/delete">
-            <label for="deleteUserEmail">Email (user must already exist)</label>
-            <input id="deleteUserEmail" type="email" name="email" required/>
-            <label for="deleteUserConfirm">Confirm for deleting user (This is irreversible)</label>
-            <input id="deleteUserConfirm" type="checkbox" name="confirm"/>
+            <label>
+                Email (user must already exist)
+                <input type="email" name="email" required/>
+            </label>
+            <label>
+                Confirm for deleting user (This is irreversible)
+                <input type="checkbox" name="confirm"/>
+            </label>
             <input type="submit" value="Delete User"/>
         </form>
     </th:block>

--- a/src/main/resources/templates/admin/internalTag.html
+++ b/src/main/resources/templates/admin/internalTag.html
@@ -46,11 +46,11 @@
     <table>
         <tr>
             <td><label for="name">Name</label></td>
-            <td><input type="text" id="name" name="name" th:value="${tag.name}"/></td>
+            <td><input type="text" name="name" th:value="${tag.name}"/></td>
         </tr>
         <tr>
             <td><label for="description">Description</label></td>
-            <td><input type="text" id="description" name="description" th:value="${tag.description}"/></td>
+            <td><input type="text" name="description" th:value="${tag.description}"/></td>
         </tr>
         <tr>
             <td>Type</td>

--- a/src/main/resources/templates/admin/internalTag.html
+++ b/src/main/resources/templates/admin/internalTag.html
@@ -46,11 +46,11 @@
     <table>
         <tr>
             <td><label for="name">Name</label></td>
-            <td><input type="text" name="name" th:value="${tag.name}"/></td>
+            <td><input type="text" id="name" name="name" th:value="${tag.name}"/></td>
         </tr>
         <tr>
             <td><label for="description">Description</label></td>
-            <td><input type="text" name="description" th:value="${tag.description}"/></td>
+            <td><input type="text" id="description" name="description" th:value="${tag.description}"/></td>
         </tr>
         <tr>
             <td>Type</td>

--- a/src/main/resources/templates/admin/listDeviceManagers.html
+++ b/src/main/resources/templates/admin/listDeviceManagers.html
@@ -46,8 +46,10 @@
     </p>
 
     <form action="/admin/deviceManagers" method="POST">
-        <label for="sensorKitId">Sensor Kit ID</label>
-        <input type="text" name="sensorKitId" id="sensorKitId"/>
+        <label>
+            Sensor Kit ID
+            <input type="text" name="sensorKitId"/>
+        </label>
         <br/>
 
         <input type="submit" value="Create"/>

--- a/src/main/resources/templates/admin/listInternalTags.html
+++ b/src/main/resources/templates/admin/listInternalTags.html
@@ -26,10 +26,14 @@
 </ul>
 
 <form method="POST" action="/admin/createInternalTag">
-    <label for="name">Name</label>
-    <input type="text" id="name" name="name" size="15" required/>
-    <label for="description">Description</label>
-    <input type="text" id="description" name="description" size="50"/>
+    <label>
+        Name
+        <input type="text" name="name" size="15" required/>
+    </label>
+    <label>
+        Description
+        <input type="text" name="description" size="50"/>
+    </label>
     <input type="submit" value="Create Tag"/>
 </form>
 

--- a/src/main/resources/templates/admin/organization.html
+++ b/src/main/resources/templates/admin/organization.html
@@ -210,11 +210,14 @@
     <h4>Create Facility</h4>
 
     <input type="hidden" name="organizationId" th:value="${organization.id}"/>
-    <label for="facilityName">Name</label>
-    <input type="text" name="name" id="facilityName" required/>
-    <label for="facilityType">Type</label>
-    <select name="type" id="facilityType">
-        <option th:each="type : ${facilityTypes}" th:value="${type.id}"
+    <label>
+        Name
+        <input type="text" name="name" required/>
+    </label>
+    <label>
+        Type
+        <select name="type">
+            <option th:each="type : ${facilityTypes}" th:value="${type.id}"
                 th:text="${type.jsonValue}">Type
         </option>
     </select>
@@ -236,17 +239,25 @@
     <h4>Create Planting Site from Shapefiles</h4>
 
     <input type="hidden" name="organizationId" th:value="${organization.id}"/>
-    <label for="siteName">Name</label>
-    <input type="text" name="siteName" id="siteName" required/>
+    <label>
+        Name
+        <input type="text" name="siteName" required/>
+    </label>
     <br/>
     Grid Origin (optional). To specify grid origin for generating monitoring plots.
-    <label for="gridOriginLat">Latitude</label>
-    <input type="text" name="gridOriginLat" id="gridOriginLat"/>
-    <label for="gridOriginLong">Longitude</label>
-    <input type="text" name="gridOriginLong" id="gridOriginLong"/>
+    <label>
+        Latitude
+        <input type="text" name="gridOriginLat"/>
+    </label>
+    <label>
+        Longitude
+        <input type="text" name="gridOriginLong"/>
+    </label>
     <br/>
-    <label for="zipfile">Zipfile</label>
-    <input type="file" name="zipfile" id="zipfile" required/>
+    <label>
+        Zipfile
+        <input type="file" name="zipfile" required/>
+    </label>
     Must contain either one or two shapefiles (exclusions shapefile is optional) and their
     associated supplementary datafiles.
     <br/>
@@ -264,11 +275,14 @@
     </p>
 
     <input type="hidden" name="organizationId" th:value="${organization.id}"/>
-    <label for="siteName">Name</label>
-    <input type="text" name="siteName" id="siteName" required/>
+    <label>
+        Name
+        <input type="text" name="siteName" required/>
+    </label>
     <br/>
-    <label for="boundary">Boundary (GeoJSON polygon)</label>
-    <textarea name="boundary" id="boundary" rows="2" cols="40"></textarea>
+    <label>
+        Boundary (GeoJSON polygon)
+        <textarea name="boundary" id="boundary" rows="2" cols="40"></textarea>
     <button type="button" id="showMap">Draw Boundary on Map</button>
 
     <span id="mapInstructions">
@@ -289,10 +303,11 @@
     <span id="map"></span>
     <br/>
 
-    <label for="siteType">Site Type</label>
-    <select name="siteType" id="siteType">
-        <option value="detailed" selected>Detailed (with zones and subzones)</option>
-        <option value="simple">Simple (site boundary only)</option>
+    <label>
+        Site Type
+        <select name="siteType">
+            <option value="detailed" selected>Detailed (with zones and subzones)</option>
+            <option value="simple">Simple (site boundary only)</option>
     </select>
     <br/>
     <input id="mapSubmit" type="submit" disabled value=" Create Planting Site "/>

--- a/src/main/resources/templates/admin/plantingSite.html
+++ b/src/main/resources/templates/admin/plantingSite.html
@@ -152,11 +152,15 @@
 
 <form method="POST" action="/admin/updatePlantingSite" th:if="${canUpdatePlantingSite}">
     <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
-    <label for="siteName">Name</label>
-    <input type="text" id="siteName" name="siteName" th:value="${site.name}" minlength="1"
+    <label>
+        Name
+        <input type="text" name="siteName" th:value="${site.name}" minlength="1"
            required/>
-    <label for="description">Description</label>
-    <input type="text" id="description" name="description" th:value="${site.description}"/>
+    </label>
+    <label>
+        Description
+        <input type="text" name="description" th:value="${site.description}"/>
+    </label>
     <br/>
     <input type="submit" value="Update"/>
 </form>
@@ -206,9 +210,10 @@
     </p>
 
     <input type="hidden" name="plantingSiteId" th:value="${site.id}"/>
-    <label for="organizationId">Organization</label>
-    <select id="organizationId" name="organizationId">
-        <option th:each="org : ${allOrganizations}" th:value="${org.id}"
+    <label>
+        Organization
+        <select id="organizationId" name="organizationId">
+            <option th:each="org : ${allOrganizations}" th:value="${org.id}"
                 th:text="|${org.name} (${org.id})|"
                 th:selected="${org.id == organization.id}">
             My Org (123)


### PR DESCRIPTION
Make the admin UI's HTML a little less verbose by moving inputs into the
corresponding labels where the two were adjacent before.