### PR TITLE
SW-7720 Use InMemoryFileStore in ThumbnailStoreTest

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -190,7 +190,7 @@ class ThumbnailStore(
       contentType: MediaType = MediaType.IMAGE_JPEG,
   ) {
     val filesRow = filesDao.fetchOneById(fileId) ?: throw FileNotFoundException(fileId)
-    val size = content.size
+    var size: Int = content.size
     val thumbUrl = getThumbnailUrl(filesRow.storageUrl!!, width, height)
     try {
       fileStore.write(thumbUrl, ByteArrayInputStream(content))
@@ -204,6 +204,7 @@ class ThumbnailStore(
       // situations where we'd previously written the file to the file store but failed to insert
       // a row for it in the thumbnails table.
       log.warn("File $fileId thumbnail $thumbUrl already exists; keeping existing file")
+      size = fileStore.size(thumbUrl).toInt()
     }
     val thumbnailId =
         with(THUMBNAILS) {


### PR DESCRIPTION
`ThumbnailStoreTest` was written before `InMemoryFileStore` existed, so it used
MockK to simulate a file store. Update it to use `InMemoryFileStore`.

Converting it exposed a minor bug in `ThumbnailStore` that was unlikely to have
caused any issues in production: it was writing the wrong file length to the
thumbnails table when the thumbnail file already existed in the file store.