### PR TITLE
SW-7720 Return full-sized published activity JPEGs

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailService.kt
@@ -82,7 +82,7 @@ class ThumbnailService(
 
     val jpegImage = converter.convertToJpeg(fileId)
     val image = ImageIO.read(ByteArrayInputStream(jpegImage))
-    thumbnailStore.storeThumbnail(fileId, jpegImage, image.width, image.height)
+    thumbnailStore.storeThumbnail(fileId, jpegImage, image.width, image.height, isFullSize = true)
 
     if (maxWidth == null && maxHeight == null) {
       // Return the full-sized JPEG we just created.

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -28,6 +28,7 @@ import net.coobird.thumbnailator.Thumbnails
 import net.coobird.thumbnailator.resizers.configurations.ScalingMode
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.http.MediaType
 
 @Named
@@ -187,6 +188,7 @@ class ThumbnailStore(
       content: ByteArray,
       width: Int,
       height: Int,
+      isFullSize: Boolean,
       contentType: MediaType = MediaType.IMAGE_JPEG,
   ) {
     val filesRow = filesDao.fetchOneById(fileId) ?: throw FileNotFoundException(fileId)
@@ -203,25 +205,43 @@ class ThumbnailStore(
       // We will still attempt to insert the database row in this case, though, to recover from
       // situations where we'd previously written the file to the file store but failed to insert
       // a row for it in the thumbnails table.
+      //
+      // We also backfill the is_full_size value here for full-sized thumbnails that were generated
+      // before that column was added.
       log.warn("File $fileId thumbnail $thumbUrl already exists; keeping existing file")
       size = fileStore.size(thumbUrl).toInt()
     }
     val thumbnailId =
         with(THUMBNAILS) {
-          dslContext
-              .insertInto(THUMBNAILS)
-              .set(CONTENT_TYPE, contentType.toString())
-              .set(CREATED_TIME, clock.instant())
-              .set(HEIGHT, height)
-              .set(FILE_ID, fileId)
-              .set(SIZE, size)
-              .set(STORAGE_URL, thumbUrl)
-              .set(WIDTH, width)
-              .onConflictDoNothing()
-              .returning(ID)
-              .fetchOne()
-              ?.id
+          try {
+            dslContext.transactionResult { _ ->
+              dslContext
+                  .insertInto(THUMBNAILS)
+                  .set(CONTENT_TYPE, contentType.toString())
+                  .set(CREATED_TIME, clock.instant())
+                  .set(HEIGHT, height)
+                  .set(FILE_ID, fileId)
+                  .set(IS_FULL_SIZE, isFullSize)
+                  .set(SIZE, size)
+                  .set(STORAGE_URL, thumbUrl)
+                  .set(WIDTH, width)
+                  .returning(ID)
+                  .fetchOne()
+                  ?.id
+            }
+          } catch (_: DuplicateKeyException) {
+            // Can't use "ON CONFLICT" here because there are multiple unique constraints on the
+            // thumbnails table and the database doesn't guarantee which one is checked first.
+            dslContext
+                .update(THUMBNAILS)
+                .set(IS_FULL_SIZE, isFullSize)
+                .where(STORAGE_URL.eq(thumbUrl))
+                .returning(ID)
+                .fetchOne()
+                ?.id
+          }
         }
+
     log.info("Created file $fileId thumbnail $thumbnailId dimensions $width x $height bytes $size")
   }
 
@@ -245,12 +265,16 @@ class ThumbnailStore(
         }
       }
 
-      val resizedImage = scalePhoto(photoUrl, maxWidth, maxHeight)
-      val width = resizedImage.width
-      val height = resizedImage.height
+      val originalImage =
+          log.debugWithTiming("Loaded $photoUrl into image buffer") { imageUtils.read(photoUrl) }
+      val resizedImage = scalePhoto(originalImage, maxWidth, maxHeight)
       val buffer = encodeAsJpeg(resizedImage)
 
-      storeThumbnail(fileId, buffer, width, height)
+      val width = resizedImage.width
+      val height = resizedImage.height
+      val isFullSize = width == originalImage.width && height == originalImage.height
+
+      storeThumbnail(fileId, buffer, width, height, isFullSize)
 
       return SizedInputStream(
           ByteArrayInputStream(buffer),
@@ -270,10 +294,11 @@ class ThumbnailStore(
   }
 
   /** Scales an existing photo to a new set of maximum dimensions. */
-  private fun scalePhoto(photoUrl: URI, maxWidth: Int?, maxHeight: Int?): BufferedImage {
-    val originalImage =
-        log.debugWithTiming("Loaded $photoUrl into image buffer") { imageUtils.read(photoUrl) }
-
+  private fun scalePhoto(
+      originalImage: BufferedImage,
+      maxWidth: Int?,
+      maxHeight: Int?,
+  ): BufferedImage {
     // Draw image onto a background that has been filled white. This ensures that transparent areas
     // are rendered white.
     val newImage =
@@ -344,15 +369,14 @@ class ThumbnailStore(
           }
           width != null -> THUMBNAILS.WIDTH.eq(width)
           height != null -> THUMBNAILS.HEIGHT.eq(height)
-          // Return the largest available thumbnail.
-          else -> null
+          // Return a full-sized thumbnail.
+          else -> THUMBNAILS.IS_FULL_SIZE.eq(true)
         }
-
-    val conditions = listOfNotNull(THUMBNAILS.FILE_ID.eq(fileId), sizeCondition)
 
     return dslContext
         .selectFrom(THUMBNAILS)
-        .where(conditions)
+        .where(THUMBNAILS.FILE_ID.eq(fileId))
+        .and(sizeCondition)
         .orderBy(THUMBNAILS.WIDTH.desc(), THUMBNAILS.HEIGHT.desc())
         .limit(1)
         .fetchOneInto(ThumbnailsRow::class.java)

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -158,9 +158,9 @@ class ThumbnailStore(
   }
 
   /**
-   * Uses the largest existing thumbnail for a file to generate a new thumbnail of a particular
-   * size. This can be used in cases where it's expensive to extract a thumbnail from the original
-   * file; a large "thumbnail" can be extracted once, and then smaller ones can be generated
+   * Uses the full-sized thumbnail for a file to generate a new thumbnail of a particular size. This
+   * can be used in cases where it's expensive to extract a thumbnail from the original file; a
+   * full-sized "thumbnail" can be extracted once, and then smaller ones can be generated
    * inexpensively as needed.
    */
   fun generateThumbnailFromExistingThumbnail(
@@ -174,8 +174,7 @@ class ThumbnailStore(
               .select(STORAGE_URL)
               .from(THUMBNAILS)
               .where(FILE_ID.eq(fileId))
-              .orderBy(WIDTH.desc(), HEIGHT.desc())
-              .limit(1)
+              .and(IS_FULL_SIZE.eq(true))
               .fetchOne(STORAGE_URL)
         } ?: return null
 

--- a/src/main/resources/db/migration/0400/V424__ThumbnailsFullSize.sql
+++ b/src/main/resources/db/migration/0400/V424__ThumbnailsFullSize.sql
@@ -1,0 +1,1 @@
+ALTER TABLE thumbnails ADD COLUMN is_full_size BOOLEAN;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -232,7 +232,8 @@ COMMENT ON COLUMN test_clock.real_time IS 'What time it was in the real world wh
 
 COMMENT ON TABLE time_zones IS '(Enum) Valid time zone names. This is populated with the list of names from the IANA time zone database.';
 
-COMMENT ON TABLE thumbnails IS 'Information about scaled-down versions of photos.';
+COMMENT ON TABLE thumbnails IS 'Information about server-generated versions of photos and still images of videos.';
+COMMENT ON COLUMN thumbnails.is_full_size IS 'True if this thumbnail''s dimensions are the same as the original photo or video.';
 
 COMMENT ON TABLE timeseries IS 'Properties of a series of values collected from a device. Each device metric is represented as a timeseries.';
 COMMENT ON COLUMN timeseries.decimal_places IS 'For numeric timeseries, the number of digits after the decimal point to display.';

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailServiceTest.kt
@@ -148,7 +148,7 @@ class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
           {
             if (stillImageStored) SizedInputStream(thumbnailData.inputStream(), 10) else null
           }
-      every { thumbnailStore.storeThumbnail(fileId, any(), 1, 1) } answers
+      every { thumbnailStore.storeThumbnail(fileId, any(), 1, 1, true) } answers
           {
             stillImageStored = true
           }
@@ -158,7 +158,7 @@ class ThumbnailServiceTest : DatabaseTest(), RunsAsUser {
       verify { converter1.canConvertToJpeg(videoMetadata.contentType) }
       verify { converter2.canConvertToJpeg(videoMetadata.contentType) }
       verify { converter2.convertToJpeg(fileId) }
-      verify { thumbnailStore.storeThumbnail(fileId, any(), 1, 1) }
+      verify { thumbnailStore.storeThumbnail(fileId, any(), 1, 1, true) }
 
       assertArrayEquals(thumbnailData, stream.readAllBytes())
     }

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -408,13 +408,16 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
   @Nested
   inner class GenerateThumbnailFromExistingThumbnail {
     @Test
-    fun `returns null if there is no existing thumbnail`() {
+    fun `returns null if there is no full-size thumbnail`() {
+      insertThumbnail(64, 48, getJpegData(64, 48), isFullSize = false)
+
       assertNull(store.generateThumbnailFromExistingThumbnail(fileId, 50, 50))
     }
 
     @Test
     fun `stores new thumbnail in thumb subdirectory of original file`() {
-      val existingThumbnailUrl = insertThumbnail(64, 48, getJpegData(64, 48)).storageUrl!!
+      val existingThumbnailUrl =
+          insertThumbnail(64, 48, getJpegData(64, 48), isFullSize = true).storageUrl!!
 
       val thumbnailStream = store.generateThumbnailFromExistingThumbnail(fileId, 32, null)
       assertNotNull(thumbnailStream)

--- a/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/ThumbnailStoreTest.kt
@@ -75,6 +75,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
       height: Int,
       imageData: ByteArray = Random.nextBytes(10),
       storageUrl: URI = URI("file:///a/b/c/thumb/original-${width}x$height.jpg"),
+      isFullSize: Boolean = false,
   ): ThumbnailsRow {
     val thumbnailsRow =
         ThumbnailsRow(
@@ -83,6 +84,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
             height = height,
             contentType = MediaType.IMAGE_JPEG_VALUE,
             createdTime = clock.instant(),
+            isFullSize = isFullSize,
             size = imageData.size,
             storageUrl = storageUrl,
         )
@@ -157,7 +159,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
       val expected = Random.nextBytes(10)
 
       insertThumbnail(photoWidth - 1, photoHeight - 1)
-      insertThumbnail(photoWidth, photoHeight, expected)
+      insertThumbnail(photoWidth, photoHeight, expected, isFullSize = true)
 
       val actual = store.getThumbnailData(fileId, null, null)
 
@@ -316,10 +318,31 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
               fileId = fileId,
               width = width,
               height = height,
+              isFullSize = false,
               contentType = MediaType.IMAGE_JPEG_VALUE,
               createdTime = Instant.EPOCH,
               size = photoJpegData.size,
               storageUrl = storageUrl,
+          )
+      )
+    }
+
+    @Test
+    fun `updates full-size flag for existing full-size thumbnail`() {
+      val row = insertThumbnail(photoWidth, photoHeight, photoJpegData, isFullSize = false)
+
+      store.getThumbnailData(fileId, null, null)
+
+      assertTableEquals(
+          ThumbnailsRecord(
+              fileId = fileId,
+              width = photoWidth,
+              height = photoHeight,
+              isFullSize = true,
+              contentType = MediaType.IMAGE_JPEG_VALUE,
+              createdTime = Instant.EPOCH,
+              size = photoJpegData.size,
+              storageUrl = row.storageUrl,
           )
       )
     }
@@ -342,6 +365,7 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
               fileId = fileId,
               width = width,
               height = height,
+              isFullSize = false,
               contentType = MediaType.IMAGE_JPEG_VALUE,
               createdTime = Instant.EPOCH,
               size = actual.size.toInt(),
@@ -371,6 +395,13 @@ internal class ThumbnailStoreTest : DatabaseTest(), RunsAsUser {
       insertThumbnail(30, 20, Random.nextBytes(10))
 
       assertNull(store.getExistingThumbnailData(fileId, 33, 22))
+    }
+
+    @Test
+    fun `returns null if no size is requested and there is no full-size thumbnail`() {
+      insertThumbnail(30, 20, Random.nextBytes(10))
+
+      assertNull(store.getExistingThumbnailData(fileId, null, null))
     }
   }
 


### PR DESCRIPTION
If a published activity had a JPEG image, and someone had previously requested a
scaled-down thumbnail version, subsequent requests to fetch the full-sized
version would return the thumbnail instead because we assumed that the largest
existing thumbnail was always the full-sized version of the image. That's true
for HEIC images but not necessarily true for JPEGs.

Track whether or not each thumbnail is the same size as the original image, and
when a full-sized JPEG is requested, search for a full-sized thumbnail rather
than blindly returning the largest one.