### PR TITLE
SW-7694 All Set check should check all definitions of plot permanence

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -719,6 +719,7 @@ class T0Store(
               .where(PLANTING_SITE_ID.eq(plantingSiteId))
               .and(IS_AD_HOC.eq(false))
               .and(PERMANENT_INDEX.isNotNull)
+              .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(true))
               .and(PLOT_T0_DENSITIES.PLOT_DENSITY.isNull)
               .and(
                   OBSERVATIONS.STATE_ID.`in`(
@@ -792,6 +793,7 @@ class T0Store(
               .where(PLANTING_SITE_ID.eq(plantingSiteId))
               .and(IS_AD_HOC.eq(false))
               .and(PERMANENT_INDEX.isNull)
+              .and(OBSERVATION_PLOTS.IS_PERMANENT.eq(false))
               .and(PLANTING_ZONE_T0_TEMP_DENSITIES.ZONE_DENSITY.isNull)
               .and(
                   OBSERVATIONS.STATE_ID.`in`(


### PR DESCRIPTION
When checking if all permanent plots have t0 data set, change the definition to include all of the following (previously was just numbers 1 & 2):

1. currently permanent
1. have a completed or abandoned observation
1. within that observation the plot was also permanent

This helps ensure that if a plot was previously temporary, had an observation, then was changed to permanent via a site geometry change, it will not be included incorrectly in the permanent plot list until it's had a completed observation.

Do the same thing for temporary plots in reverse.