### PR TITLE
Gitignore Claude Code non-skill files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,9 @@ openapi.yaml
 .run
 docker/volumes
 
+# Share Claude Code skills, but not local configuration
+.claude
+!.claude/skills
+
 # Kotlin compiler temporary files
 .kotlin


### PR DESCRIPTION
The `.claude` directory can contain local settings, which we don't want to commit
to git, but can also contain definitions of skills, which we want to share.