### PR TITLE
SW-7650 Only check Known species in all-set check

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -843,6 +843,7 @@ class T0Store(
             .join(OBSERVATIONS)
             .on(OBSERVATIONS.ID.eq(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID))
             .where(PLANTING_SITE_ID.eq(plantingSiteId))
+            .and(OBSERVED_PLOT_SPECIES_TOTALS.CERTAINTY_ID.eq(RecordedSpeciesCertainty.Known))
             .and(
                 OBSERVATIONS.STATE_ID.`in`(
                     listOf(ObservationState.Completed, ObservationState.Abandoned)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -299,6 +299,8 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertPlotT0Density(speciesId = speciesId1, monitoringPlotId = monitoringPlotId)
       insertPlantingZoneT0TempDensity(speciesId = speciesId1)
       insertObservedPlotSpeciesTotals(speciesId = speciesId2, totalLive = 1)
+      // Unknown species are excluded in the check:
+      insertObservedPlotSpeciesTotals(certainty = RecordedSpeciesCertainty.Unknown, totalLive = 2)
       insertPlotT0Density(speciesId = speciesId2, monitoringPlotId = monitoringPlotId)
 
       assertTrue(


### PR DESCRIPTION
We only check for known species in `observed_plot_species_totals` in the endpoint for all species, but need to check it for the all-set check.