### PR TITLE
SW-7650 Fix division by zero error when calculating survival rate

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1653,17 +1653,9 @@ class ObservationStore(
               )
           val survivalRate =
               if (liveAndDeadForZone.first().survivalRateIncludesTempPlots) {
-                DSL.if_(
-                    survivalRateDenominator.eq(BigDecimal.ZERO),
-                    DSL.zero(),
-                    DSL.value(totalLive).mul(100).div(survivalRateDenominator),
-                )
+                getSurvivalRate(DSL.value(totalLive), survivalRateDenominator)
               } else {
-                DSL.if_(
-                    survivalRateDenominator.eq(BigDecimal.ZERO),
-                    DSL.zero(),
-                    DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator),
-                )
+                getSurvivalRate(DSL.value(totalPermanentLive), survivalRateDenominator)
               }
 
           val rowsInserted =
@@ -1727,17 +1719,9 @@ class ObservationStore(
             )
         val survivalRate =
             if (zoneToLiveAndDead.flatMap { it.value }.first().survivalRateIncludesTempPlots) {
-              DSL.if_(
-                  survivalRateDenominator.eq(BigDecimal.ZERO),
-                  DSL.zero(),
-                  DSL.value(totalLive).mul(100).div(survivalRateDenominator),
-              )
+              getSurvivalRate(DSL.value(totalLive), survivalRateDenominator)
             } else {
-              DSL.if_(
-                  survivalRateDenominator.eq(BigDecimal.ZERO),
-                  DSL.zero(),
-                  DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator),
-              )
+              getSurvivalRate(DSL.value(totalPermanentLive), survivalRateDenominator)
             }
 
         val rowsInserted =
@@ -2319,17 +2303,9 @@ class ObservationStore(
             )
         val survivalRate =
             if (plantingSite.survivalRateIncludesTempPlots!! && speciesKey.id != null) {
-              DSL.if_(
-                  survivalRateDenominator.eq(BigDecimal.ZERO),
-                  DSL.zero(),
-                  DSL.value(totalLive).mul(100).div(survivalRateDenominator),
-              )
+              getSurvivalRate(DSL.value(totalLive), survivalRateDenominator)
             } else if (isPermanent && speciesKey.id != null) {
-              DSL.if_(
-                  survivalRateDenominator.eq(BigDecimal.ZERO),
-                  DSL.zero(),
-                  DSL.value(permanentLive).mul(100).div(survivalRateDenominator),
-              )
+              getSurvivalRate(DSL.value(permanentLive), survivalRateDenominator)
             } else {
               DSL.castNull(SQLDataType.INTEGER)
             }
@@ -2520,6 +2496,13 @@ class ObservationStore(
                 )
         )
       }
+
+  private fun getSurvivalRate(numerator: Field<Int>, denominator: Field<BigDecimal>) =
+      DSL.if_(
+          denominator.eq(BigDecimal.ZERO),
+          DSL.zero(),
+          numerator.mul(100).div(denominator),
+      )
 
   private fun validateAdHocPlotInPlantingSite(
       plantingSiteId: PlantingSiteId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1653,9 +1653,17 @@ class ObservationStore(
               )
           val survivalRate =
               if (liveAndDeadForZone.first().survivalRateIncludesTempPlots) {
-                DSL.value(totalLive).mul(100).div(survivalRateDenominator)
+                DSL.if_(
+                    survivalRateDenominator.eq(BigDecimal.ZERO),
+                    DSL.zero(),
+                    DSL.value(totalLive).mul(100).div(survivalRateDenominator),
+                )
               } else {
-                DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator)
+                DSL.if_(
+                    survivalRateDenominator.eq(BigDecimal.ZERO),
+                    DSL.zero(),
+                    DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator),
+                )
               }
 
           val rowsInserted =
@@ -1719,9 +1727,17 @@ class ObservationStore(
             )
         val survivalRate =
             if (zoneToLiveAndDead.flatMap { it.value }.first().survivalRateIncludesTempPlots) {
-              DSL.value(totalLive).mul(100).div(survivalRateDenominator)
+              DSL.if_(
+                  survivalRateDenominator.eq(BigDecimal.ZERO),
+                  DSL.zero(),
+                  DSL.value(totalLive).mul(100).div(survivalRateDenominator),
+              )
             } else {
-              DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator)
+              DSL.if_(
+                  survivalRateDenominator.eq(BigDecimal.ZERO),
+                  DSL.zero(),
+                  DSL.value(totalPermanentLive).mul(100).div(survivalRateDenominator),
+              )
             }
 
         val rowsInserted =
@@ -2303,9 +2319,17 @@ class ObservationStore(
             )
         val survivalRate =
             if (plantingSite.survivalRateIncludesTempPlots!! && speciesKey.id != null) {
-              DSL.value(totalLive).mul(100).div(survivalRateDenominator)
+              DSL.if_(
+                  survivalRateDenominator.eq(BigDecimal.ZERO),
+                  DSL.zero(),
+                  DSL.value(totalLive).mul(100).div(survivalRateDenominator),
+              )
             } else if (isPermanent && speciesKey.id != null) {
-              DSL.value(permanentLive).mul(100).div(survivalRateDenominator)
+              DSL.if_(
+                  survivalRateDenominator.eq(BigDecimal.ZERO),
+                  DSL.zero(),
+                  DSL.value(permanentLive).mul(100).div(survivalRateDenominator),
+              )
             } else {
               DSL.castNull(SQLDataType.INTEGER)
             }
@@ -2379,12 +2403,20 @@ class ObservationStore(
 
           val survivalRate =
               if (plantingSite.survivalRateIncludesTempPlots!! && speciesKey.id != null) {
-                totalLiveField.plus(totalLive).mul(100).div(survivalRateDenominator)
+                DSL.if_(
+                    survivalRateDenominator.eq(BigDecimal.ZERO),
+                    DSL.zero(),
+                    totalLiveField.plus(totalLive).mul(100).div(survivalRateDenominator),
+                )
               } else if (isPermanent && speciesKey.id != null) {
-                permanentLiveField
-                    .plus(permanentLive)
-                    .mul(100)
-                    .div(survivalRatePermanentDenominator)
+                DSL.if_(
+                    survivalRatePermanentDenominator.eq(BigDecimal.ZERO),
+                    DSL.zero(),
+                    permanentLiveField
+                        .plus(permanentLive)
+                        .mul(100)
+                        .div(survivalRatePermanentDenominator),
+                )
               } else {
                 survivalRateField
               }


### PR DESCRIPTION
If a t0 density is set to 0 for a species, then some of the survival rate calculations will fail with a `Division by 0` error. Fix this by setting survival rate to 0 in these scenario.