### PR TITLE
Add Claude skill for persistent event creation

### DIFF
--- a/.claude/skills/adding-persistent-event/SKILL.md
+++ b/.claude/skills/adding-persistent-event/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: adding-persistent-event
+description: Adds a new type of event that gets persisted to the event log. Use this when adding new kinds of write operations to the system or when adding new events to existing code.
+---
+
+# Adding Persistent Event
+
+## Instructions
+
+Copy this checklist and check off items as you complete them. Note that some items are conditional:
+
+```
+Task Progress:
+- [ ] Create a new sealed interface if needed.
+- [ ] Create the event class.
+- [ ] Create typealias(es) for the event class.
+- [ ] Create a new subject payload class if needed.
+- [ ] Make sure the subject is handled in EventLogPayloadTransformer.
+- [ ] Add custom FieldsUpdatedAction logic to EventLogPayloadTransformer if needed.
+- [ ] Add a database migration to backfill events for existing entities if needed.
+- [ ] Add code to publish the new event.
+- [ ] Add test(s) for any new logic in EventLogPayloadTransformer.
+- [ ] Add test(s) or modify existing tests to verify code that publishes the new event.
+- [ ] Generate translations of localized strings with `yarn translate`.
+- [ ] Format code with `./gradlew spotlessApply`.
+- [ ] Run all tests with `./gradlew test`.
+```
+
+## Reference
+
+See [EVENTS.md](../../../docs/EVENTS.md) for detailed documentation including best practices.

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ openapi.yaml
 docker/volumes
 
 # Share Claude Code skills, but not local configuration
-.claude
+.claude/*
 !.claude/skills
 
 # Kotlin compiler temporary files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@ Format the code when you're done working. There's no need to rerun tests after c
 If the Jetbrains MCP service is available, don't use it to run Gradle or other shell commands; run those using Bash instead. But use the Jetbrains MCP service for everything other than running commands.
 
 If the Context7 MCP service is available, use it to look up documentation for any libraries you aren't sure how to use correctly.
+
+## Skill Use
+
+If you are able to use Claude-style skills, do so when appropriate instead of figuring tasks out from scratch.


### PR DESCRIPTION
Define a Claude "skill" (a canned set of instructions for a particular kind of
task) for adding new persistent events to the code.

This leans heavily on the documentation in `EVENTS.md`, and includes some changes
to that file to fill in a couple gaps and help Claude work better.

We may at some point want to split that file up into smaller ones so Claude
doesn't have to read the whole thing, but as an initial cut, this setup seems to
work acceptably well.