### PR TITLE
Use fields-updated format in OrganizationRenamedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
@@ -1,11 +1,39 @@
 package com.terraformation.backend.customer.event
 
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
-import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
+import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
+import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.eventlog.db.EventUpgradeUtils
 
 data class OrganizationRenamedEventV1(
-    override val organizationId: OrganizationId,
+    val organizationId: OrganizationId,
     val name: String,
-) : EntityUpdatedPersistentEvent, OrganizationPersistentEvent
+) : UpgradableEvent {
+  override fun toNextVersion(
+      eventLogId: EventLogId,
+      eventUpgradeUtils: EventUpgradeUtils,
+  ): OrganizationRenamedEventV2 {
+    val previousName = eventUpgradeUtils.getPreviousOrganizationName(organizationId, eventLogId)
+    return OrganizationRenamedEventV2(
+        changedFrom = OrganizationRenamedEventV2.Values(previousName),
+        changedTo = OrganizationRenamedEventV2.Values(name),
+        organizationId = organizationId,
+    )
+  }
+}
 
-typealias OrganizationRenamedEvent = OrganizationRenamedEventV1
+data class OrganizationRenamedEventV2(
+    val changedFrom: Values,
+    val changedTo: Values,
+    override val organizationId: OrganizationId,
+) : FieldsUpdatedPersistentEvent, OrganizationPersistentEvent {
+  data class Values(val name: String?)
+
+  override fun listUpdatedFields() =
+      listOfNotNull(createUpdatedField("name", changedFrom.name, changedTo.name))
+}
+
+typealias OrganizationRenamedEvent = OrganizationRenamedEventV2
+
+typealias OrganizationRenamedEventValues = OrganizationRenamedEventV2.Values

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -2,7 +2,6 @@ package com.terraformation.backend.eventlog
 
 import com.terraformation.backend.customer.db.SimpleUserStore
 import com.terraformation.backend.customer.event.OrganizationPersistentEvent
-import com.terraformation.backend.customer.event.OrganizationRenamedEvent
 import com.terraformation.backend.customer.event.ProjectPersistentEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
@@ -88,14 +87,6 @@ class EventLogPayloadTransformer(
       context: EventLogPayloadContext,
   ): List<EventActionPayload> {
     return when (event) {
-      is OrganizationRenamedEvent ->
-          listOf(
-              FieldUpdatedActionPayload(
-                  fieldName = "name",
-                  changedFrom = listOf(OrganizationSubjectPayload.getPreviousName(event, context)),
-                  changedTo = listOf(event.name),
-              )
-          )
       is ProjectRenamedEvent ->
           listOf(
               FieldUpdatedActionPayload(

--- a/src/main/kotlin/com/terraformation/backend/eventlog/UpgradableEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/UpgradableEvent.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.eventlog
 
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.eventlog.db.EventUpgradeUtils
 
 /** Interface implemented by old versions of persistent events. */
@@ -10,6 +11,9 @@ interface UpgradableEvent : PersistentEvent {
    *
    * For example, if this event class is `RandomEventV3`, [toNextVersion] would typically return
    * `RandomEventV4`.
+   *
+   * @param eventLogId ID of the event being upgraded. This can be used to, e.g., scan for previous
+   *   events of the same type.
    */
-  fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils): PersistentEvent
+  fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils): PersistentEvent
 }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -126,7 +126,7 @@ data class OrganizationSubjectPayload(
           context.lastEventBefore<OrganizationRenamedEvent>(event) {
             it.organizationId == event.organizationId
           }
-      return lastRename?.name
+      return lastRename?.changedTo?.name
           ?: context
               .first<OrganizationCreatedEvent> { it.organizationId == event.organizationId }
               .name

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -1,7 +1,11 @@
 package com.terraformation.backend.eventlog.db
 
+import com.terraformation.backend.customer.event.OrganizationCreatedEvent
+import com.terraformation.backend.customer.event.OrganizationRenamedEvent
+import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.eventlog.UpgradableEvent
-import jakarta.inject.Named
 import org.jooq.DSLContext
 
 /**
@@ -9,9 +13,21 @@ import org.jooq.DSLContext
  * included in the previous version, [UpgradableEvent.toNextVersion] needs to be able to pull the
  * data from the database. An instance of this class is passed to that method to allow it to do so.
  */
-@Named
 class EventUpgradeUtils(
     val dslContext: DSLContext,
+    val eventLogStore: EventLogStore,
 ) {
-  // Add any accessor functions needed by UpgradableEvent.toNextVersion implementations.
+  fun getPreviousOrganizationName(
+      organizationId: OrganizationId,
+      beforeEventLogId: EventLogId,
+  ): String {
+    val lastRename =
+        eventLogStore.fetchLastById<OrganizationRenamedEvent>(organizationId, beforeEventLogId)
+    return lastRename?.event?.changedTo?.name
+        ?: eventLogStore
+            .fetchLastById<OrganizationCreatedEvent>(organizationId, beforeEventLogId)
+            ?.event
+            ?.name
+        ?: throw OrganizationNotFoundException(organizationId)
+  }
 }

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationStoreTest.kt
@@ -5,6 +5,8 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.customer.event.OrganizationAbandonedEvent
+import com.terraformation.backend.customer.event.OrganizationRenamedEvent
+import com.terraformation.backend.customer.event.OrganizationRenamedEventValues
 import com.terraformation.backend.customer.event.OrganizationTimeZoneChangedEvent
 import com.terraformation.backend.customer.model.FacilityModel
 import com.terraformation.backend.customer.model.InternalTagIds
@@ -405,6 +407,14 @@ internal class OrganizationStoreTest : DatabaseTest(), RunsAsUser {
     val actual = organizationsDao.fetchOneById(organizationId)!!
 
     assertEquals(expected, actual)
+
+    publisher.assertEventPublished(
+        OrganizationRenamedEvent(
+            changedFrom = OrganizationRenamedEventValues(name = "Organization 1"),
+            changedTo = OrganizationRenamedEventValues(name = "New Name"),
+            organizationId = organizationId,
+        )
+    )
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/eventlog/PersistentEventTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/PersistentEventTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.eventlog
 
 import com.fasterxml.jackson.annotation.JsonValue
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.eventlog.db.EventUpgradeUtils
 import java.util.TreeSet
 import java.util.concurrent.ConcurrentHashMap
@@ -126,8 +127,9 @@ class PersistentEventTest {
     return kClass.memberFunctions
         .first { func ->
           func.name == "toNextVersion" &&
-              func.parameters.size == 2 && // First parameter is the receiver
-              func.parameters[1].type.jvmErasure == EventUpgradeUtils::class
+              func.parameters.size == 3 && // First parameter is the receiver
+              func.parameters[1].type.jvmErasure == EventLogId::class &&
+              func.parameters[2].type.jvmErasure == EventUpgradeUtils::class
         }
         .returnType
         .jvmErasure
@@ -208,7 +210,8 @@ class PersistentEventTest {
   /** Happy-path upgradable event. */
   @Suppress("unused")
   class TestUpgradableEventV1(val x: Int) : UpgradableEvent {
-    override fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils) = TestUpgradableEventV2(x)
+    override fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils) =
+        TestUpgradableEventV2(x)
   }
 
   class TestUpgradableEventV2(val x: Int) : PersistentEvent

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventLogStoreTest.kt
@@ -29,9 +29,7 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val clock = TestClock()
   private val objectMapper = jacksonObjectMapper()
-  private val store: EventLogStore by lazy {
-    EventLogStore(clock, dslContext, EventUpgradeUtils(dslContext), objectMapper)
-  }
+  private val store: EventLogStore by lazy { EventLogStore(clock, dslContext, objectMapper) }
 
   @Nested
   inner class FetchByIds {
@@ -359,7 +357,7 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val organizationId: OrganizationId,
       val dummy1: Int = 1,
   ) : TestOrganizationEvent, UpgradableEvent {
-    override fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils) =
+    override fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils) =
         TestOrganizationDeletedEventV2(organizationId)
   }
 
@@ -367,7 +365,7 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val organizationId: OrganizationId,
       val dummy2: Int = 2,
   ) : TestOrganizationEvent, UpgradableEvent {
-    override fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils) =
+    override fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils) =
         TestOrganizationDeletedEventV3(organizationId)
   }
 
@@ -387,13 +385,13 @@ class EventLogStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
   @SkipPersistentEventTest
   data class TestCircularEventV1(val organizationId: OrganizationId) : UpgradableEvent {
-    override fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils) =
+    override fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils) =
         TestCircularEventV2(organizationId)
   }
 
   @SkipPersistentEventTest
   data class TestCircularEventV2(val organizationId: OrganizationId) : UpgradableEvent {
-    override fun toNextVersion(eventUpgradeUtils: EventUpgradeUtils) =
+    override fun toNextVersion(eventLogId: EventLogId, eventUpgradeUtils: EventUpgradeUtils) =
         TestCircularEventV1(organizationId)
   }
 

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
@@ -1,0 +1,99 @@
+package com.terraformation.backend.eventlog.db
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.customer.event.OrganizationCreatedEventV1
+import com.terraformation.backend.customer.event.OrganizationRenamedEventV1
+import com.terraformation.backend.customer.event.OrganizationRenamedEventV2
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.eventlog.UpgradableEvent
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EventUpgradeUtilsTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val clock = TestClock()
+  private val eventLogStore: EventLogStore by lazy {
+    EventLogStore(clock, dslContext, jacksonObjectMapper())
+  }
+  private val eventUpgradeUtils: EventUpgradeUtils by lazy {
+    EventUpgradeUtils(dslContext, eventLogStore)
+  }
+
+  private val organizationId = OrganizationId(1)
+
+  @Nested
+  inner class GetPreviousOrganizationName {
+
+    @Test
+    fun `upgrades first OrganizationRenamedEventV1`() {
+      insertEvent(OrganizationCreatedEventV1(organizationId, "Old name"))
+
+      testUpgrade(
+          OrganizationRenamedEventV1(organizationId, "New name"),
+          OrganizationRenamedEventV2(
+              changedFrom = OrganizationRenamedEventV2.Values("Old name"),
+              changedTo = OrganizationRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+          ),
+      )
+    }
+
+    @Test
+    fun `upgrades second OrganizationRenamedEventV1`() {
+      insertEvent(OrganizationCreatedEventV1(organizationId, "Old name"))
+      insertEvent(OrganizationRenamedEventV1(organizationId, "Middle name"))
+
+      testUpgrade(
+          OrganizationRenamedEventV1(organizationId, "New name"),
+          OrganizationRenamedEventV2(
+              changedFrom = OrganizationRenamedEventV2.Values("Middle name"),
+              changedTo = OrganizationRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+          ),
+      )
+    }
+
+    // This could happen if there are two V1 renames and we're querying them for the first time; the
+    // first one would be upgraded and written to the database before the second one was upgraded.
+    @Test
+    fun `upgrades OrganizationRenamedEventV1 that follows an already-upgraded rename`() {
+      insertEvent(OrganizationCreatedEventV1(organizationId, "Old name"))
+      insertEvent(
+          OrganizationRenamedEventV2(
+              changedFrom = OrganizationRenamedEventV2.Values("Old name"),
+              changedTo = OrganizationRenamedEventV2.Values("Middle name"),
+              organizationId = organizationId,
+          )
+      )
+
+      testUpgrade(
+          OrganizationRenamedEventV1(organizationId, "New name"),
+          OrganizationRenamedEventV2(
+              changedFrom = OrganizationRenamedEventV2.Values("Middle name"),
+              changedTo = OrganizationRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+          ),
+      )
+    }
+  }
+
+  private fun insertEvent(event: PersistentEvent): EventLogId {
+    clock.instant = clock.instant.plusSeconds(1)
+    return eventLogStore.insertEvent(event)
+  }
+
+  private fun testUpgrade(oldEvent: UpgradableEvent, expected: PersistentEvent) {
+    val eventLogId = insertEvent(oldEvent)
+    val upgradedEvent = oldEvent.toNextVersion(eventLogId, eventUpgradeUtils)
+
+    assertEquals(expected, upgradedEvent)
+  }
+}

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -16,6 +16,7 @@ com.terraformation.backend.customer.event.OrganizationCreatedEventV1/organizatio
 com.terraformation.backend.customer.event.OrganizationDeletedEventV1/organizationId: OrganizationId
 com.terraformation.backend.customer.event.OrganizationRenamedEventV1/name: String
 com.terraformation.backend.customer.event.OrganizationRenamedEventV1/organizationId: OrganizationId
+com.terraformation.backend.customer.event.OrganizationRenamedEventV2/organizationId: OrganizationId
 com.terraformation.backend.customer.event.ProjectCreatedEventV1/name: String
 com.terraformation.backend.customer.event.ProjectCreatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.customer.event.ProjectCreatedEventV1/projectId: ProjectId


### PR DESCRIPTION
`OrganizationRenamedEventV1` was added before `FieldsUpdatedPersistentEvent` was
defined, so it didn't follow that interface's conventions. Introduce a new version
that follows the more recent pattern.

This is the first time we've added upgrade logic for an actual event, and it
exposed the fact that upgrades need to be able to fetch earlier events from the
log without worrying about whether the earlier events are themselves out of date.
`EventUpgradeUtils` can now call `EventLogStore` query methods, and the current
event's ID is passed to `UpgradableEvent.toNextVersion()` to allow it to limit
its searches to prior events.