### PR TITLE
Use fields-updated format in ProjectRenamedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ProjectStore.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserAddedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserRemovedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
+import com.terraformation.backend.customer.event.ProjectRenamedEventValues
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
 import com.terraformation.backend.customer.model.ProjectInternalUserModel
@@ -134,7 +135,8 @@ class ProjectStore(
       if (existing.name != updated.name) {
         eventPublisher.publishEvent(
             ProjectRenamedEvent(
-                name = updated.name,
+                changedFrom = ProjectRenamedEventValues(name = existing.name),
+                changedTo = ProjectRenamedEventValues(name = updated.name),
                 organizationId = existing.organizationId,
                 projectId = projectId,
             )

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
@@ -1,14 +1,45 @@
 package com.terraformation.backend.customer.event
 
+import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
-import com.terraformation.backend.eventlog.EntityUpdatedPersistentEvent
+import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
+import com.terraformation.backend.eventlog.UpgradableEvent
+import com.terraformation.backend.eventlog.db.EventUpgradeUtils
 
-/** Published when a project's name is changed. */
 data class ProjectRenamedEventV1(
     val name: String,
+    val organizationId: OrganizationId,
+    val projectId: ProjectId,
+) : UpgradableEvent {
+  override fun toNextVersion(
+      eventLogId: EventLogId,
+      eventUpgradeUtils: EventUpgradeUtils,
+  ): ProjectRenamedEventV2 {
+    val previousName = eventUpgradeUtils.getPreviousProjectNameFromV1Events(projectId, eventLogId)
+
+    return ProjectRenamedEventV2(
+        changedFrom = ProjectRenamedEventV2.Values(previousName),
+        changedTo = ProjectRenamedEventV2.Values(name),
+        organizationId = organizationId,
+        projectId = projectId,
+    )
+  }
+}
+
+/** Published when a project's name is changed. */
+data class ProjectRenamedEventV2(
+    val changedFrom: Values,
+    val changedTo: Values,
     override val organizationId: OrganizationId,
     override val projectId: ProjectId,
-) : EntityUpdatedPersistentEvent, ProjectPersistentEvent
+) : FieldsUpdatedPersistentEvent, ProjectPersistentEvent {
+  data class Values(val name: String?)
 
-typealias ProjectRenamedEvent = ProjectRenamedEventV1
+  override fun listUpdatedFields() =
+      listOfNotNull(createUpdatedField("name", changedFrom.name, changedTo.name))
+}
+
+typealias ProjectRenamedEvent = ProjectRenamedEventV2
+
+typealias ProjectRenamedEventValues = ProjectRenamedEventV2.Values

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.eventlog
 import com.terraformation.backend.customer.db.SimpleUserStore
 import com.terraformation.backend.customer.event.OrganizationPersistentEvent
 import com.terraformation.backend.customer.event.ProjectPersistentEvent
-import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
 import com.terraformation.backend.eventlog.api.DeletedActionPayload
 import com.terraformation.backend.eventlog.api.EventActionPayload
@@ -87,14 +86,10 @@ class EventLogPayloadTransformer(
       context: EventLogPayloadContext,
   ): List<EventActionPayload> {
     return when (event) {
-      is ProjectRenamedEvent ->
-          listOf(
-              FieldUpdatedActionPayload(
-                  fieldName = "name",
-                  changedFrom = listOf(ProjectSubjectPayload.getPreviousName(event, context)),
-                  changedTo = listOf(event.name),
-              )
-          )
+      // Any fields-updated events that don't implement FieldsUpdatedPersistentEvent should be
+      // handled here.
+
+      // (Currently there aren't any.)
 
       // Events that can self-describe which fields were updated can be transformed generically.
       is FieldsUpdatedPersistentEvent ->

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -157,7 +157,7 @@ data class ProjectSubjectPayload(
     fun getPreviousName(event: ProjectPersistentEvent, context: EventLogPayloadContext): String {
       val lastRename =
           context.lastEventBefore<ProjectRenamedEvent>(event) { it.projectId == event.projectId }
-      return lastRename?.name
+      return lastRename?.changedFrom?.name
           ?: context.first<ProjectCreatedEvent> { it.projectId == event.projectId }.name
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -157,7 +157,7 @@ data class ProjectSubjectPayload(
     fun getPreviousName(event: ProjectPersistentEvent, context: EventLogPayloadContext): String {
       val lastRename =
           context.lastEventBefore<ProjectRenamedEvent>(event) { it.projectId == event.projectId }
-      return lastRename?.changedFrom?.name
+      return lastRename?.changedTo?.name
           ?: context.first<ProjectCreatedEvent> { it.projectId == event.projectId }.name
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtils.kt
@@ -2,9 +2,13 @@ package com.terraformation.backend.eventlog.db
 
 import com.terraformation.backend.customer.event.OrganizationCreatedEvent
 import com.terraformation.backend.customer.event.OrganizationRenamedEvent
+import com.terraformation.backend.customer.event.ProjectCreatedEvent
+import com.terraformation.backend.customer.event.ProjectRenamedEvent
 import com.terraformation.backend.db.OrganizationNotFoundException
+import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.UpgradableEvent
 import org.jooq.DSLContext
 
@@ -29,5 +33,18 @@ class EventUpgradeUtils(
             ?.event
             ?.name
         ?: throw OrganizationNotFoundException(organizationId)
+  }
+
+  fun getPreviousProjectNameFromV1Events(
+      projectId: ProjectId,
+      beforeEventLogId: EventLogId,
+  ): String {
+    val lastRename = eventLogStore.fetchLastById<ProjectRenamedEvent>(projectId, beforeEventLogId)
+    return lastRename?.event?.changedTo?.name
+        ?: eventLogStore
+            .fetchLastById<ProjectCreatedEvent>(projectId, beforeEventLogId)
+            ?.event
+            ?.name
+        ?: throw ProjectNotFoundException(projectId)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/report/SeedFundReportService.kt
+++ b/src/main/kotlin/com/terraformation/backend/report/SeedFundReportService.kt
@@ -143,7 +143,9 @@ class SeedFundReportService(
 
   @EventListener
   fun on(event: ProjectRenamedEvent) {
-    seedFundReportStore.updateProjectName(event.projectId, event.name)
+    event.changedTo.name?.let { name ->
+      seedFundReportStore.updateProjectName(event.projectId, name)
+    }
   }
 
   @EventListener

--- a/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/ProjectStoreTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserAddedEvent
 import com.terraformation.backend.customer.event.ProjectInternalUserRemovedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
+import com.terraformation.backend.customer.event.ProjectRenamedEventValues
 import com.terraformation.backend.customer.model.ExistingProjectModel
 import com.terraformation.backend.customer.model.NewProjectModel
 import com.terraformation.backend.customer.model.ProjectInternalUserModel
@@ -289,7 +290,8 @@ class ProjectStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       eventPublisher.assertEventPublished(
           ProjectRenamedEvent(
-              name = "New name",
+              changedFrom = ProjectRenamedEventValues(name = "Project 1"),
+              changedTo = ProjectRenamedEventValues(name = "New name"),
               organizationId = organizationId,
               projectId = projectId,
           )

--- a/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/db/EventUpgradeUtilsTest.kt
@@ -6,10 +6,14 @@ import com.terraformation.backend.TestClock
 import com.terraformation.backend.customer.event.OrganizationCreatedEventV1
 import com.terraformation.backend.customer.event.OrganizationRenamedEventV1
 import com.terraformation.backend.customer.event.OrganizationRenamedEventV2
+import com.terraformation.backend.customer.event.ProjectCreatedEventV1
+import com.terraformation.backend.customer.event.ProjectRenamedEventV1
+import com.terraformation.backend.customer.event.ProjectRenamedEventV2
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.EventLogId
 import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.eventlog.UpgradableEvent
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -28,10 +32,10 @@ class EventUpgradeUtilsTest : DatabaseTest(), RunsAsDatabaseUser {
   }
 
   private val organizationId = OrganizationId(1)
+  private val projectId = ProjectId(2)
 
   @Nested
   inner class GetPreviousOrganizationName {
-
     @Test
     fun `upgrades first OrganizationRenamedEventV1`() {
       insertEvent(OrganizationCreatedEventV1(organizationId, "Old name"))
@@ -80,6 +84,65 @@ class EventUpgradeUtilsTest : DatabaseTest(), RunsAsDatabaseUser {
               changedFrom = OrganizationRenamedEventV2.Values("Middle name"),
               changedTo = OrganizationRenamedEventV2.Values("New name"),
               organizationId = organizationId,
+          ),
+      )
+    }
+  }
+
+  @Nested
+  inner class GetPreviousProjectName {
+    @Test
+    fun `upgrades first ProjectRenamedEventV1`() {
+      insertEvent(ProjectCreatedEventV1("Old name", organizationId, projectId))
+
+      testUpgrade(
+          ProjectRenamedEventV1("New name", organizationId, projectId),
+          ProjectRenamedEventV2(
+              changedFrom = ProjectRenamedEventV2.Values("Old name"),
+              changedTo = ProjectRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+              projectId = projectId,
+          ),
+      )
+    }
+
+    @Test
+    fun `upgrades second ProjectRenamedEventV1`() {
+      insertEvent(ProjectCreatedEventV1("Old name", organizationId, projectId))
+      insertEvent(ProjectRenamedEventV1("Middle name", organizationId, projectId))
+
+      testUpgrade(
+          ProjectRenamedEventV1("New name", organizationId, projectId),
+          ProjectRenamedEventV2(
+              changedFrom = ProjectRenamedEventV2.Values("Middle name"),
+              changedTo = ProjectRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+              projectId = projectId,
+          ),
+      )
+    }
+
+    // This could happen if there are two V1 renames and we're querying them for the first time; the
+    // first one would be upgraded and written to the database before the second one was upgraded.
+    @Test
+    fun `upgrades ProjectRenamedEventV1 that follows an already-upgraded rename`() {
+      insertEvent(ProjectCreatedEventV1("Old name", organizationId, projectId))
+      insertEvent(
+          ProjectRenamedEventV2(
+              changedFrom = ProjectRenamedEventV2.Values("Old name"),
+              changedTo = ProjectRenamedEventV2.Values("Middle name"),
+              organizationId = organizationId,
+              projectId = projectId,
+          )
+      )
+
+      testUpgrade(
+          ProjectRenamedEventV1("New name", organizationId, projectId),
+          ProjectRenamedEventV2(
+              changedFrom = ProjectRenamedEventV2.Values("Middle name"),
+              changedTo = ProjectRenamedEventV2.Values("New name"),
+              organizationId = organizationId,
+              projectId = projectId,
           ),
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/report/SeedFundReportServiceTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.customer.db.ProjectStore
 import com.terraformation.backend.customer.event.OrganizationDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectDeletionStartedEvent
 import com.terraformation.backend.customer.event.ProjectRenamedEvent
+import com.terraformation.backend.customer.event.ProjectRenamedEventValues
 import com.terraformation.backend.customer.model.InternalTagIds
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.daily.DailyTaskTimeArrivedEvent
@@ -1010,7 +1011,14 @@ class SeedFundReportServiceTest : DatabaseTest(), RunsAsUser {
           )
       val orgReportId = insertSeedFundReport(status = SeedFundReportStatus.New, year = 1994)
 
-      service.on(ProjectRenamedEvent("New Name", organizationId, projectId))
+      service.on(
+          ProjectRenamedEvent(
+              changedFrom = ProjectRenamedEventValues(name = "Project 1"),
+              changedTo = ProjectRenamedEventValues(name = "New Name"),
+              organizationId = organizationId,
+              projectId = projectId,
+          )
+      )
 
       assertEquals(
           mapOf(

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -25,6 +25,8 @@ com.terraformation.backend.customer.event.ProjectDeletedEventV1/projectId: Proje
 com.terraformation.backend.customer.event.ProjectRenamedEventV1/name: String
 com.terraformation.backend.customer.event.ProjectRenamedEventV1/organizationId: OrganizationId
 com.terraformation.backend.customer.event.ProjectRenamedEventV1/projectId: ProjectId
+com.terraformation.backend.customer.event.ProjectRenamedEventV2/organizationId: OrganizationId
+com.terraformation.backend.customer.event.ProjectRenamedEventV2/projectId: ProjectId
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestCircularEventV3/organizationId: OrganizationId
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestOrganizationCreatedEventV1/name: String
 com.terraformation.backend.eventlog.db.EventLogStoreTest$TestOrganizationCreatedEventV1/organizationId: OrganizationId


### PR DESCRIPTION
`ProjectRenamedEventV1` was added before `FieldsUpdatedPersistentEvent` was
defined, so it didn't follow that interface's conventions. Introduce a new version
that follows the more recent pattern.