### PR TITLE
Move ExistingRecordedTreeModel creation to helper

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -48,7 +48,6 @@ import com.terraformation.backend.tracking.model.BiomassQuadratModel
 import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
 import com.terraformation.backend.tracking.model.BiomassSpeciesModel
 import com.terraformation.backend.tracking.model.ExistingBiomassDetailsModel
-import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.tracking.model.ObservationMonitoringPlotMediaModel
 import com.terraformation.backend.tracking.model.ObservationMonitoringPlotResultsModel
 import com.terraformation.backend.tracking.model.ObservationPlantingSubzoneResultsModel
@@ -60,6 +59,7 @@ import com.terraformation.backend.tracking.model.ObservationRollupResultsModel
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
 import com.terraformation.backend.tracking.model.ObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.RecordedPlantModel
+import com.terraformation.backend.tracking.model.RecordedTreeModel
 import com.terraformation.backend.tracking.model.calculateMortalityRate
 import com.terraformation.backend.tracking.model.calculateStandardDeviation
 import com.terraformation.backend.tracking.model.calculateSurvivalRate
@@ -307,38 +307,20 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                         IS_DEAD,
                         POINT_OF_MEASUREMENT_M,
                         SHRUB_DIAMETER_CM,
-                        OBSERVATION_BIOMASS_SPECIES.SPECIES_ID,
-                        OBSERVATION_BIOMASS_SPECIES.SCIENTIFIC_NAME,
+                        recordedTreesBiomassSpeciesIdFkey.SPECIES_ID,
+                        recordedTreesBiomassSpeciesIdFkey.SCIENTIFIC_NAME,
                         TREE_GROWTH_FORM_ID,
                         TREE_NUMBER,
                         TRUNK_NUMBER,
                         recordedTreesGpsCoordinatesField,
                     )
                     .from(this)
-                    .join(OBSERVATION_BIOMASS_SPECIES)
-                    .on(BIOMASS_SPECIES_ID.eq(OBSERVATION_BIOMASS_SPECIES.ID))
                     .where(OBSERVATION_ID.eq(OBSERVATION_BIOMASS_DETAILS.OBSERVATION_ID))
                     .and(MONITORING_PLOT_ID.eq(OBSERVATION_BIOMASS_DETAILS.MONITORING_PLOT_ID))
                     .orderBy(TREE_NUMBER, TRUNK_NUMBER)
             )
             .convertFrom { result ->
-              result.map {
-                ExistingRecordedTreeModel(
-                    id = it[ID]!!,
-                    description = it[DESCRIPTION],
-                    diameterAtBreastHeightCm = it[DIAMETER_AT_BREAST_HEIGHT_CM],
-                    gpsCoordinates = it[recordedTreesGpsCoordinatesField] as? Point,
-                    heightM = it[HEIGHT_M],
-                    isDead = it[IS_DEAD]!!,
-                    pointOfMeasurementM = it[POINT_OF_MEASUREMENT_M],
-                    shrubDiameterCm = it[SHRUB_DIAMETER_CM],
-                    speciesId = it[OBSERVATION_BIOMASS_SPECIES.SPECIES_ID],
-                    speciesName = it[OBSERVATION_BIOMASS_SPECIES.SCIENTIFIC_NAME],
-                    treeGrowthForm = it[TREE_GROWTH_FORM_ID]!!,
-                    treeNumber = it[TREE_NUMBER]!!,
-                    trunkNumber = it[TRUNK_NUMBER]!!,
-                )
-              }
+              result.map { RecordedTreeModel.of(it, recordedTreesGpsCoordinatesField) }
             }
       }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -8,8 +8,12 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import java.math.BigDecimal
 import java.time.Instant
+import org.jooq.Field
+import org.jooq.Record
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.geom.Point
 
 data class BiomassSpeciesKey(
@@ -85,6 +89,31 @@ data class RecordedTreeModel<TreeId : RecordedTreeId?>(
         if (pointOfMeasurementM == null) {
           throw IllegalStateException("Tree $treeNumber: pointOfMeasurement missing for Trunk")
         }
+      }
+    }
+  }
+
+  companion object {
+    fun of(
+        record: Record,
+        gpsCoordinatesField: Field<Geometry?> = RECORDED_TREES.GPS_COORDINATES,
+    ): ExistingRecordedTreeModel {
+      return with(RECORDED_TREES) {
+        ExistingRecordedTreeModel(
+            description = record[DESCRIPTION],
+            diameterAtBreastHeightCm = record[DIAMETER_AT_BREAST_HEIGHT_CM],
+            gpsCoordinates = record[gpsCoordinatesField] as? Point,
+            heightM = record[HEIGHT_M],
+            id = record[ID]!!,
+            isDead = record[IS_DEAD]!!,
+            pointOfMeasurementM = record[POINT_OF_MEASUREMENT_M],
+            shrubDiameterCm = record[SHRUB_DIAMETER_CM],
+            speciesId = record[recordedTreesBiomassSpeciesIdFkey.SPECIES_ID],
+            speciesName = record[recordedTreesBiomassSpeciesIdFkey.SCIENTIFIC_NAME],
+            treeGrowthForm = record[TREE_GROWTH_FORM_ID]!!,
+            treeNumber = record[TREE_NUMBER]!!,
+            trunkNumber = record[TRUNK_NUMBER]!!,
+        )
       }
     }
   }


### PR DESCRIPTION
Support constructing `ExistingRecordedTreeModel`s from database queries that
aren't part of the full observation results structure by moving the mapping
code to a helper method. To make it more generic, use a jOOQ implicit join
to fetch the species ID and name rather than requiring the caller to do an
explicit join.