### PR TITLE
SW-7695 Add RecordedTreeCreatedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -13,11 +13,13 @@ import com.terraformation.backend.eventlog.api.FieldUpdatedActionPayload
 import com.terraformation.backend.eventlog.api.ObservationPlotMediaSubjectPayload
 import com.terraformation.backend.eventlog.api.OrganizationSubjectPayload
 import com.terraformation.backend.eventlog.api.ProjectSubjectPayload
+import com.terraformation.backend.eventlog.api.RecordedTreeSubjectPayload
 import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
+import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
 
 @Named
@@ -74,6 +76,7 @@ class EventLogPayloadTransformer(
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
       is OrganizationPersistentEvent -> OrganizationSubjectPayload.forEvent(event, context)
       is ProjectPersistentEvent -> ProjectSubjectPayload.forEvent(event, context)
+      is RecordedTreePersistentEvent -> RecordedTreeSubjectPayload.forEvent(event, context)
       else -> {
         log.error("Cannot construct subject for event ${event.javaClass.name}")
         null

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.event
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.BiomassSpeciesId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
@@ -11,6 +12,8 @@ import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.db.tracking.PlantingSeasonId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.RecordedTreeId
+import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
@@ -24,6 +27,7 @@ import com.terraformation.backend.tracking.model.ReplacementDuration
 import com.terraformation.backend.tracking.model.ReplacementResult
 import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
 import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
+import java.math.BigDecimal
 import java.time.Duration
 import java.time.LocalDate
 import org.locationtech.jts.geom.Point
@@ -294,3 +298,34 @@ data class ObservationMediaFileUploadedEventV1(
 ) : EntityCreatedPersistentEvent, ObservationMediaFilePersistentEvent
 
 typealias ObservationMediaFileUploadedEvent = ObservationMediaFileUploadedEventV1
+
+sealed interface RecordedTreePersistentEvent : PersistentEvent {
+  val monitoringPlotId: MonitoringPlotId
+  val observationId: ObservationId
+  val organizationId: OrganizationId
+  val plantingSiteId: PlantingSiteId
+  val recordedTreeId: RecordedTreeId
+}
+
+data class RecordedTreeCreatedEventV1(
+    val biomassSpeciesId: BiomassSpeciesId,
+    val description: String? = null,
+    val diameterAtBreastHeightCm: BigDecimal? = null,
+    val gpsCoordinates: Point? = null,
+    val heightM: BigDecimal? = null,
+    val isDead: Boolean,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    val pointOfMeasurementM: BigDecimal? = null,
+    override val recordedTreeId: RecordedTreeId,
+    val shrubDiameterCm: Int? = null,
+    val speciesId: SpeciesId? = null,
+    val speciesName: String? = null,
+    val treeGrowthForm: TreeGrowthForm,
+    val treeNumber: Int,
+    val trunkNumber: Int,
+) : EntityCreatedPersistentEvent, RecordedTreePersistentEvent
+
+typealias RecordedTreeCreatedEvent = RecordedTreeCreatedEventV1

--- a/src/main/resources/db/migration/0400/V426__RecordedTreeCreatedEvent.sql
+++ b/src/main/resources/db/migration/0400/V426__RecordedTreeCreatedEvent.sql
@@ -1,0 +1,37 @@
+CALL event_log_create_id_index('recordedTreeId');
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    op.completed_by,
+    op.completed_time,
+    'com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'biomassSpeciesId' VALUE obs.id,
+        'description' VALUE rt.description,
+        'diameterAtBreastHeightCm' VALUE rt.diameter_at_breast_height_cm,
+        'gpsCoordinates' VALUE st_asgeojson(rt.gps_coordinates)::JSONB,
+        'heightM' VALUE rt.height_m,
+        'isDead' VALUE rt.is_dead,
+        'monitoringPlotId' VALUE rt.monitoring_plot_id,
+        'observationId' VALUE o.id,
+        'organizationId' VALUE ps.organization_id,
+        'plantingSiteId' VALUE ps.id,
+        'pointOfMeasurementM' VALUE rt.point_of_measurement_m,
+        'recordedTreeId' VALUE rt.id,
+        'shrubDiameterCm' VALUE rt.shrub_diameter_cm,
+        'speciesId' VALUE obs.species_id,
+        'speciesName' VALUE obs.scientific_name,
+        'treeGrowthForm' VALUE tgf.name,
+        'treeNumber' VALUE rt.tree_number,
+        'trunkNumber' VALUE rt.trunk_number
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.recorded_trees rt
+JOIN tracking.tree_growth_forms tgf ON rt.tree_growth_form_id = tgf.id
+JOIN tracking.observation_biomass_species obs ON rt.biomass_species_id = obs.id
+JOIN tracking.observations o ON rt.observation_id = o.id
+JOIN tracking.observation_plots op
+    ON rt.observation_id = op.observation_id
+    AND rt.monitoring_plot_id = op.monitoring_plot_id
+JOIN tracking.planting_sites ps ON o.planting_site_id = ps.id;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -90,6 +90,9 @@ eventSubject.Organization.short=Organization
 eventSubject.Project.field.name=name
 eventSubject.Project.full=Project {0}
 eventSubject.Project.short=Project
+# {0} is a growth form (tree, shrub) and {1} is a numeric identifier
+eventSubject.RecordedTree.full={0} {1}
+eventSubject.RecordedTree.short={0}
 formerUser=Former User
 historyAccessionCreated=created accession
 historyAccessionQuantityUpdated=updated the quantity to {0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -155,6 +155,10 @@ eventSubject.Project.field.name=nombre
 eventSubject.Project.full=Proyecto {0}
 # 162b4c3f
 eventSubject.Project.short=Proyecto
+# 0481a943
+eventSubject.RecordedTree.full={0} {1}
+# 61e0214b
+eventSubject.RecordedTree.short={0}
 # 897498fc
 formerUser=Usuario anterior
 # 11138bfd

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -155,6 +155,10 @@ eventSubject.Project.field.name=nom
 eventSubject.Project.full=Projet {0}
 # 162b4c3f
 eventSubject.Project.short=Projet
+# 0481a943
+eventSubject.RecordedTree.full={0} {1}
+# 61e0214b
+eventSubject.RecordedTree.short={0}
 # 897498fc
 formerUser=Ancien utilisateur
 # 11138bfd

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -37,6 +37,16 @@ com.terraformation.backend.eventlog.PersistentEventTest$TestChildFieldEventV1/ch
 com.terraformation.backend.eventlog.PersistentEventTest$TestNonPrimaryConstructorPropertyEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV2/x: Int
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/recordedTreeId: RecordedTreeId
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/treeGrowthForm: TreeGrowthForm
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/treeNumber: Int
+com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/trunkNumber: Int
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/fileId: FileId
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/monitoringPlotId: MonitoringPlotId
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/observationId: ObservationId


### PR DESCRIPTION
To support showing the change history of recorded trees in biomass observation
once we add the ability to edit their data, start writing the initial values to
the event log. Backfill events for existing recorded trees.