### PR TITLE
SW-7695 Add endpoint to edit recorded tree

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -34,6 +34,7 @@ import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationMediaFilesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
@@ -48,6 +49,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
+import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NewObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.ObservationPlotCounts
@@ -330,6 +332,19 @@ class ObservationsController(
     val coordinateModels = payload.coordinates.map { it.toModel() }
 
     observationStore.updatePlotObservation(observationId, plotId, coordinateModels)
+
+    return SimpleSuccessResponsePayload()
+  }
+
+  @ApiResponseSimpleSuccess
+  @Operation(summary = "Updates information about a recorded tree from a biomass observation.")
+  @PutMapping("/{observationId}/trees/{treeId}")
+  fun updateRecordedTree(
+      @PathVariable observationId: ObservationId,
+      @PathVariable treeId: RecordedTreeId,
+      @RequestBody payload: UpdateRecordedTreeRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    observationStore.updateRecordedTree(observationId, treeId, payload::applyTo)
 
     return SimpleSuccessResponsePayload()
   }
@@ -1024,6 +1039,14 @@ data class UpdatePlotPhotoRequestPayload(
     val caption: String?,
 ) {
   fun applyTo(row: ObservationMediaFilesRow) = row.copy(caption = caption)
+}
+
+data class UpdateRecordedTreeRequestPayload(
+    val description: String?,
+) {
+  fun applyTo(model: ExistingRecordedTreeModel): ExistingRecordedTreeModel {
+    return model.copy(description = description)
+  }
 }
 
 data class UploadPlotMediaRequestPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.tracking.PlantingSiteHistoryId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.PlantingZoneId
+import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.tracking.model.PlantingSiteValidationFailure
 import java.time.LocalDate
 
@@ -150,6 +151,9 @@ class ReassignmentTooLargeException(val plantingId: PlantingId) :
 
 class ReassignmentToSamePlotNotAllowedException(val plantingId: PlantingId) :
     IllegalArgumentException("Cannot reassign from planting $plantingId to its original plot")
+
+class RecordedTreeNotFoundException(val recordedTreeId: RecordedTreeId) :
+    EntityNotFoundException("Recorded tree $recordedTreeId not found")
 
 class ObservationRescheduleStateException(val observationId: ObservationId) :
     MismatchedStateException("Observation $observationId cannot be rescheduled")

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -329,3 +329,27 @@ data class RecordedTreeCreatedEventV1(
 ) : EntityCreatedPersistentEvent, RecordedTreePersistentEvent
 
 typealias RecordedTreeCreatedEvent = RecordedTreeCreatedEventV1
+
+data class RecordedTreeUpdatedEventV1(
+    val changedFrom: Values,
+    val changedTo: Values,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    override val recordedTreeId: RecordedTreeId,
+) : FieldsUpdatedPersistentEvent, RecordedTreePersistentEvent {
+  data class Values(
+      val description: String?,
+  )
+
+  override fun listUpdatedFields(): List<FieldsUpdatedPersistentEvent.UpdatedField> {
+    return listOfNotNull(
+        createUpdatedField("description", changedFrom.description, changedTo.description)
+    )
+  }
+}
+
+typealias RecordedTreeUpdatedEvent = RecordedTreeUpdatedEventV1
+
+typealias RecordedTreeUpdatedEventValues = RecordedTreeUpdatedEventV1.Values

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -36,6 +36,9 @@ import org.locationtech.jts.geom.util.GeometryFixer
 /** Transforms a Collection to null if it is empty. */
 fun <T : Collection<*>> T.orNull(): T? = ifEmpty { null }
 
+/** Returns null if this value is equal to another value, or this value if they differ. */
+fun <T : Any?> T.nullIfEquals(other: T): T? = if (this == other) null else this
+
 /** Tests two nullable BigDecimal values for equality ignoring their scale. */
 fun BigDecimal?.equalsIgnoreScale(other: BigDecimal?) =
     this == null && other == null || this != null && other != null && compareTo(other) == 0

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -90,6 +90,7 @@ eventSubject.Organization.short=Organization
 eventSubject.Project.field.name=name
 eventSubject.Project.full=Project {0}
 eventSubject.Project.short=Project
+eventSubject.RecordedTree.field.description=description
 # {0} is a growth form (tree, shrub) and {1} is a numeric identifier
 eventSubject.RecordedTree.full={0} {1}
 eventSubject.RecordedTree.short={0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -155,6 +155,8 @@ eventSubject.Project.field.name=nombre
 eventSubject.Project.full=Proyecto {0}
 # 162b4c3f
 eventSubject.Project.short=Proyecto
+# e119fcaa
+eventSubject.RecordedTree.field.description=descripción
 # 0481a943
 eventSubject.RecordedTree.full={0} {1}
 # 61e0214b

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -155,6 +155,8 @@ eventSubject.Project.field.name=nom
 eventSubject.Project.full=Projet {0}
 # 162b4c3f
 eventSubject.Project.short=Projet
+# e119fcaa
+eventSubject.RecordedTree.field.description=description
 # 0481a943
 eventSubject.RecordedTree.full={0} {1}
 # 61e0214b

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateRecordedTreeTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateRecordedTreeTest.kt
@@ -1,0 +1,83 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.TreeGrowthForm
+import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
+import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEvent
+import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventValues
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationStoreUpdateRecordedTreeTest : BaseObservationStoreTest() {
+  @BeforeEach
+  fun setUpRecordedTree() {
+    insertPlantingZone()
+    insertPlantingSubzone()
+    insertMonitoringPlot(isAdHoc = true)
+    insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
+    insertObservationPlot(completedBy = user.userId)
+    insertObservationBiomassDetails()
+    insertSpecies()
+    insertObservationBiomassSpecies(speciesId = inserted.speciesId)
+    insertRecordedTree(
+        description = "Original description",
+        shrubDiameterCm = 1,
+        treeGrowthForm = TreeGrowthForm.Shrub,
+    )
+  }
+
+  @Test
+  fun `updates editable fields`() {
+    val before = dslContext.fetchSingle(RECORDED_TREES)
+
+    store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) {
+      it.copy(
+          description = "New description",
+          treeGrowthForm = TreeGrowthForm.Tree,
+          shrubDiameterCm = null,
+          speciesName = "New species",
+      )
+    }
+
+    val expected = before.copy().apply { description = "New description" }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        RecordedTreeUpdatedEvent(
+            changedFrom = RecordedTreeUpdatedEventValues(description = "Original description"),
+            changedTo = RecordedTreeUpdatedEventValues(description = "New description"),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+            recordedTreeId = inserted.recordedTreeId,
+        )
+    )
+  }
+
+  @Test
+  fun `does not publish event or modify database if nothing changed`() {
+    val unmodifiedTable = dslContext.fetch(RECORDED_TREES)
+
+    store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) { it }
+
+    assertTableEquals(unmodifiedTable)
+
+    eventPublisher.assertEventNotPublished<RecordedTreeUpdatedEvent>()
+  }
+
+  @Test
+  fun `throws exception if no permission to update observation`() {
+    every { user.canUpdateObservation(inserted.observationId) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) {
+        it.copy(description = "New description")
+      }
+    }
+  }
+}

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -47,6 +47,11 @@ com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/recordedTre
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/treeGrowthForm: TreeGrowthForm
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/treeNumber: Int
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/trunkNumber: Int
+com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventV1/recordedTreeId: RecordedTreeId
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/fileId: FileId
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/monitoringPlotId: MonitoringPlotId
 com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEventV1/observationId: ObservationId


### PR DESCRIPTION
`PUT /api/v1/tracking/observations/{observationId}/trees/{recordedTreeId}` can
edit the description of an existing recorded tree. The edit is recorded in the
event log.