### PR TITLE
SW-7725 Only use t0 data from plots that were in the area at the time of the observation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -35,7 +35,6 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SP
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SITE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBZONE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SPECIES_TOTALS
-import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONES
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_SUBZONE_HISTORIES
@@ -828,21 +827,6 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
       )
 
   private fun plantingSubzoneSpeciesMultiset(): Field<List<ObservationSpeciesResultsModel>> {
-    listOf(
-            PLOT_T0_DENSITIES,
-            MONITORING_PLOTS,
-            MONITORING_PLOT_HISTORIES,
-            PLANTING_SUBZONES,
-            PLANTING_SUBZONE_HISTORIES,
-            PLANTING_ZONES,
-            PLANTING_ZONE_HISTORIES,
-            PLANTING_SITES,
-            PLANTING_SITE_HISTORIES,
-            OBSERVATION_PLOTS,
-            OBSERVATIONS,
-        )
-        .forEach { println("${it.name}\n${dslContext.fetch(it)}") }
-
     val permanentSubzoneT0 =
         with(PLOT_T0_DENSITIES) {
           DSL.select(

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -73,7 +73,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
   }
   protected val resultsStore by lazy { ObservationResultsStore(dslContext) }
 
-  protected lateinit var plotIds: Map<String, MonitoringPlotId>
+  protected lateinit var plotIds: MutableMap<String, MonitoringPlotId>
   protected lateinit var subzoneHistoryIds: Map<PlantingSubzoneId, PlantingSubzoneHistoryId>
   protected lateinit var subzoneIds: Map<String, PlantingSubzoneId>
   protected lateinit var zoneHistoryIds: Map<PlantingZoneId, PlantingZoneHistoryId>
@@ -779,7 +779,10 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
     subzoneHistoryIds = newSubzoneHistoryIds
   }
 
-  protected fun importPlotsCsv(prefix: String, sizeMeters: Int): Map<String, MonitoringPlotId> {
+  protected fun importPlotsCsv(
+      prefix: String,
+      sizeMeters: Int,
+  ): MutableMap<String, MonitoringPlotId> {
     return associateCsv("$prefix/Plots.csv") { cols ->
       val subzoneName = cols[0]
       val plotNumber = cols[1]
@@ -1211,8 +1214,8 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
       path: String,
       skipRows: Int = 1,
       func: (Array<String>) -> Pair<String, T>,
-  ): Map<String, T> {
-    return mapCsv(path, skipRows, func).toMap()
+  ): MutableMap<String, T> {
+    return mapCsv(path, skipRows, func).toMap().toMutableMap()
   }
 
   /**

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -798,7 +798,10 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
               sizeMeters = sizeMeters,
               permanentIndex = if (isPermanent) plotNumber.toInt() else null,
           )
-      insertMonitoringPlotHistory(plantingSubzoneHistoryId = subzoneHistoryId)
+      insertMonitoringPlotHistory(
+          plantingSubzoneId = subzoneId,
+          plantingSubzoneHistoryId = subzoneHistoryId,
+      )
 
       if (isPermanent) {
         permanentPlotNumbers.add(plotNumber)
@@ -1123,6 +1126,8 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
                   }
 
               if (plotName !in observedPlotNames) {
+                // technically this needs plot history id also. Leaving this comment in case someone
+                // else runs into this
                 insertObservationPlot(
                     claimedBy = user.userId,
                     claimedTime = Instant.EPOCH,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -565,14 +565,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         insertPlantingSite(x = 0, areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = false)
     every { user.canReadPlantingSite(newPlantingSiteId) } returns true
 
-    val prefix = "/tracking/observation/SurvivalRateSiteGeometryChange"
-    val numSpecies = 2
-
-    runSurvivalRateScenario(
-        prefix,
-        numSpecies,
-    ) {
-      // todo see if this can be replaced with `plantingSiteStore.applyPlantingSiteEdit` to simplify
+    fun updatePlantingSite() {
+      // moves plot 112 to subzone2 (from subzone1) and adds plot 312 to site
+      // adds all history objects that would occur with this edit
       insertPlantingSiteHistory()
       val zone1 = zoneIds["Zone1"]!!
       val zone2 = zoneIds["Zone2"]!!
@@ -648,6 +643,16 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
           speciesId = species2,
           plotDensity = BigDecimal.valueOf(100).toPlantsPerHectare(),
       )
+    }
+
+    val prefix = "/tracking/observation/SurvivalRateSiteGeometryChange"
+    val numSpecies = 2
+
+    runSurvivalRateScenario(
+        prefix,
+        numSpecies,
+    ) {
+      updatePlantingSite()
 
       importObservationsCsv(prefix, numSpecies, 1, Instant.EPOCH.plusSeconds(10), false)
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -9,11 +9,13 @@ import com.terraformation.backend.db.tracking.PlantingZoneId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.PLANTING_ZONE_T0_TEMP_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationScenarioTest
+import com.terraformation.backend.tracking.model.ObservationResultsModel
 import com.terraformation.backend.util.toPlantsPerHectare
 import io.mockk.every
 import java.math.BigDecimal
@@ -77,7 +79,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     )
 
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(plotId to mapOf(speciesId to null)),
             mapOf(subzoneId to mapOf(speciesId to null)),
             mapOf(zoneId to mapOf(speciesId to null)),
@@ -124,7 +126,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     )
 
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(
                 plotId to mapOf(speciesId to BigDecimal.ZERO),
                 plotId2 to mapOf(speciesId to BigDecimal.ZERO),
@@ -147,7 +149,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     )
 
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(
                 plotId to mapOf(speciesId to BigDecimal.ZERO),
                 plotId2 to mapOf(speciesId to BigDecimal.ZERO),
@@ -194,7 +196,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     )
 
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(plotId to mapOf(speciesId to 0)),
             mapOf(subzoneId to mapOf(speciesId to null)),
             mapOf(zoneId to mapOf(speciesId to null)),
@@ -234,7 +236,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
     val allSurvivalRate = (100.0 * 1 / 11)
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(plotId to mapOf(speciesId1 to allSurvivalRate, null to allSurvivalRate)),
             mapOf(subzoneId to mapOf(speciesId1 to allSurvivalRate, null to allSurvivalRate)),
             mapOf(zoneId to mapOf(speciesId1 to allSurvivalRate, null to allSurvivalRate)),
@@ -324,7 +326,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         )
 
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             plot1SurvivalRates + mapOf(plot2 to mapOf(speciesId1 to 0, speciesId2 to 0, null to 0)),
             mapOf(subzoneId to survivalRates1),
             mapOf(zoneId to survivalRates1),
@@ -377,7 +379,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             null to 100.0 * (9 + 10 + 17 + 18 + 27 + 25) / (15 + 9 + 23 + 19 + 31),
         )
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             plot1SurvivalRates + plot2SurvivalRates,
             mapOf(subzoneId to survivalRates1And2),
             mapOf(zoneId to survivalRates1And2),
@@ -437,7 +439,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             null to 100.0 * (10 + 15) / (15 + 30),
         )
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             mapOf(tempPlot1 to plot1SurvivalRates),
             mapOf(subzone1 to plot1SurvivalRates),
             mapOf(zoneId to plot1SurvivalRates),
@@ -470,7 +472,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             null to 100.0 * (10 + 4 + 15 + 9) / (15 + 15 + 30 + 30),
         )
     assertSurvivalRates(
-        listOf(
+        SurvivalRates(
             // excludes plot1 because it's in a different observation
             mapOf(tempPlot2 to plot2SurvivalRates),
             mapOf(subzone2 to plot2SurvivalRates),
@@ -509,30 +511,23 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
   @Test
   fun `survival rate is updated when t0 density changes`() {
-    runSurvivalRateScenario("/tracking/observation/SurvivalRateT0DensityChange", numSpecies = 2)
+    runSurvivalRateScenario("/tracking/observation/SurvivalRateT0DensityChange", numSpecies = 2) {
+      val species1 = speciesIds["Species 0"]!!
+      val plot1 = plotIds["111"]!!
 
-    val species1 = speciesIds["Species 0"]!!
-    val plot1 = plotIds["111"]!!
-
-    with(PLOT_T0_DENSITIES) {
-      dslContext
-          .update(this)
-          .set(
-              PLOT_DENSITY,
-              BigDecimal.valueOf(20).toPlantsPerHectare(),
-          )
-          .where(MONITORING_PLOT_ID.eq(plot1))
-          .and(SPECIES_ID.eq(species1))
-          .execute()
+      with(PLOT_T0_DENSITIES) {
+        dslContext
+            .update(this)
+            .set(
+                PLOT_DENSITY,
+                BigDecimal.valueOf(20).toPlantsPerHectare(),
+            )
+            .where(MONITORING_PLOT_ID.eq(plot1))
+            .and(SPECIES_ID.eq(species1))
+            .execute()
+      }
+      observationStore.recalculateSurvivalRates(plot1)
     }
-    observationStore.recalculateSurvivalRates(plot1)
-
-    val ratesAfterUpdate =
-        loadExpectedSurvivalRates(
-            "/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate",
-            2,
-        )
-    assertSurvivalRates(ratesAfterUpdate, "Rates After Update")
   }
 
   @Test
@@ -542,35 +537,96 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
     every { user.canReadPlantingSite(newPlantingSiteId) } returns true
 
-    runSurvivalRateScenario("/tracking/observation/SurvivalRateT0ZoneDensityChange", numSpecies = 2)
+    runSurvivalRateScenario(
+        "/tracking/observation/SurvivalRateT0ZoneDensityChange",
+        numSpecies = 2,
+    ) {
+      val species1 = speciesIds["Species 0"]!!
+      val zone1 = zoneIds["Zone1"]!!
 
-    val species1 = speciesIds["Species 0"]!!
-    val zone1 = zoneIds["Zone1"]!!
-
-    with(PLANTING_ZONE_T0_TEMP_DENSITIES) {
-      dslContext
-          .update(this)
-          .set(
-              ZONE_DENSITY,
-              BigDecimal.valueOf(20).toPlantsPerHectare(),
-          )
-          .where(PLANTING_ZONE_ID.eq(zone1))
-          .and(SPECIES_ID.eq(species1))
-          .execute()
+      with(PLANTING_ZONE_T0_TEMP_DENSITIES) {
+        dslContext
+            .update(this)
+            .set(
+                ZONE_DENSITY,
+                BigDecimal.valueOf(20).toPlantsPerHectare(),
+            )
+            .where(PLANTING_ZONE_ID.eq(zone1))
+            .and(SPECIES_ID.eq(species1))
+            .execute()
+      }
+      observationStore.recalculateSurvivalRates(zone1)
     }
-    observationStore.recalculateSurvivalRates(zone1)
+  }
 
-    val ratesAfterUpdate =
-        loadExpectedSurvivalRates(
-            "/tracking/observation/SurvivalRateT0ZoneDensityChange/AfterUpdate",
-            2,
+  @Test
+  fun `survival rate with geometry change between observations`() {
+    val newPlantingSiteId =
+        insertPlantingSite(x = 0, areaHa = BigDecimal(2500), survivalRateIncludesTempPlots = true)
+    every { user.canReadPlantingSite(newPlantingSiteId) } returns true
+
+    val prefix = "/tracking/observation/SurvivalRateSiteGeometryChange"
+    val numSpecies = 2
+
+    runSurvivalRateScenario(
+        prefix,
+        numSpecies,
+    ) {
+      val subzone3 = subzoneIds["Subzone3"]!!
+      val subzoneHistoryId3 = subzoneHistoryIds[subzone3]!!
+      val newPlotId =
+          insertMonitoringPlot(
+              insertHistory = false,
+              plantingSubzoneId = subzone3,
+              plotNumber = 312,
+              sizeMeters = 30,
+              permanentIndex = 312,
+          )
+      insertMonitoringPlotHistory(plantingSubzoneHistoryId = subzoneHistoryId3)
+      permanentPlotNumbers.add("312")
+      permanentPlotIds.add(newPlotId)
+      plotIds["312"] = newPlotId
+      val species1 = speciesIds["Species 0"]!!
+      val species2 = speciesIds["Species 1"]!!
+      insertPlotT0Density(
+          speciesId = species1,
+          plotDensity = BigDecimal.valueOf(90).toPlantsPerHectare(),
+      )
+      insertPlotT0Density(
+          speciesId = species2,
+          plotDensity = BigDecimal.valueOf(100).toPlantsPerHectare(),
+      )
+
+      val plot2 = plotIds["112"]!!
+      val subzone2 = subzoneIds["Subzone2"]!!
+      dslContext
+          .update(MONITORING_PLOTS)
+          .set(MONITORING_PLOTS.PLANTING_SUBZONE_ID, subzone2)
+          .where(MONITORING_PLOTS.ID.eq(plot2))
+          .execute()
+
+      importObservationsCsv(prefix, numSpecies, 1, Instant.EPOCH.plusSeconds(10), false)
+      //      observationStore.recalculateSurvivalRates(plot2)
+      //      observationStore.recalculateSurvivalRates(newPlotId)
+    }
+
+    // ensure that observation1 didn't change
+    val observation1Expected = loadExpectedSurvivalRates(prefix, numSpecies)
+    val observation1Actual =
+        ratesObjectFromResults(
+            resultsStore.fetchByPlantingSiteId(inserted.plantingSiteId, limit = 2)[1],
+            inserted.plantingSiteId,
         )
-    assertSurvivalRates(ratesAfterUpdate, "Rates After Update")
+    assertSurvivalRates(observation1Expected, observation1Actual, "Observation 1 didn't change")
   }
 
   private var lastCoord: Int = 1
 
-  private fun runSurvivalRateScenario(prefix: String, numSpecies: Int) {
+  private fun runSurvivalRateScenario(
+      prefix: String,
+      numSpecies: Int,
+      changeFunction: (() -> Unit)? = null,
+  ) {
     importSiteFromCsvFile(prefix, 30)
     observationId = insertObservation()
     importT0DensitiesCsv(prefix)
@@ -579,18 +635,25 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
 
     val expectedRates = loadExpectedSurvivalRates(prefix, numSpecies)
     assertSurvivalRates(expectedRates, "$prefix - Survival Rate")
+
+    if (changeFunction == null) return
+
+    changeFunction()
+
+    val ratesAfterChange = loadExpectedSurvivalRates("$prefix/AfterUpdate", numSpecies)
+    assertSurvivalRates(ratesAfterChange, "$prefix - Survival Rate After Change")
   }
 
   private fun loadExpectedSurvivalRates(
       prefix: String,
       numSpecies: Int,
-  ): List<Map<Any, Map<SpeciesId?, Number?>>> {
+  ): SurvivalRates {
     val speciesIds = (0 until numSpecies).map { "Species $it" to this.speciesIds["Species $it"]!! }
 
     val plotRates = mutableMapOf<Any, Map<SpeciesId?, Number?>>()
     mapCsv("$prefix/PlotRates.csv", 1) { cols ->
       val plotName = cols[0]
-      val plotId = plotIds[plotName]!!
+      val plotId = plotIds[plotName] ?: throw IllegalArgumentException("Plot $plotName not found")
       val ratesMap = mutableMapOf<SpeciesId?, Number?>()
 
       for ((index, speciesPair) in speciesIds.withIndex()) {
@@ -609,7 +672,9 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val subzoneRates = mutableMapOf<Any, Map<SpeciesId?, Number?>>()
     mapCsv("$prefix/SubzoneRates.csv", 1) { cols ->
       val subzoneName = cols[0]
-      val subzoneId = subzoneIds[subzoneName]!!
+      val subzoneId =
+          subzoneIds[subzoneName]
+              ?: throw IllegalArgumentException("Subzone $subzoneName not found")
       val ratesMap = mutableMapOf<SpeciesId?, Number?>()
 
       for ((index, speciesPair) in speciesIds.withIndex()) {
@@ -628,7 +693,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
     val zoneRates = mutableMapOf<Any, Map<SpeciesId?, Number?>>()
     mapCsv("$prefix/ZoneRates.csv", 1) { cols ->
       val zoneName = cols[0]
-      val zoneId = zoneIds[zoneName]!!
+      val zoneId = zoneIds[zoneName] ?: throw IllegalArgumentException("Zone $zoneName not found")
       val ratesMap = mutableMapOf<SpeciesId?, Number?>()
 
       for ((index, speciesPair) in speciesIds.withIndex()) {
@@ -661,7 +726,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       siteRates[inserted.plantingSiteId] = ratesMap
     }
 
-    return listOf(plotRates, subzoneRates, zoneRates, siteRates)
+    return SurvivalRates(plotRates, subzoneRates, zoneRates, siteRates)
   }
 
   private fun createPlantsRows(
@@ -688,57 +753,70 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
    * survival rate for that area, e.g. the Plot Survival Rate, across all species in that plot.
    */
   private fun assertSurvivalRates(
-      expected: List<Map<Any, Map<SpeciesId?, Number?>>>,
+      expected: SurvivalRates,
       message: String,
   ) {
-    val idFields = listOf("Plot", "Subzone", "Zone", "Site")
-    val actualList = fetchSurvivalRates(inserted.plantingSiteId)
+    val actual = fetchSurvivalRates(inserted.plantingSiteId)
+    assertSurvivalRates(expected, actual, message)
+  }
 
+  private fun assertSurvivalRates(
+      expected: SurvivalRates,
+      actual: SurvivalRates,
+      message: String,
+  ) {
     assertAll(
-        expected.mapIndexed { index, expectedByIdMap ->
-          {
-            val level = idFields[index]
-            val actualByIdMap = actualList[index]
-
-            val allIdsMatch =
-                actualByIdMap.all { (id, actualSpeciesMap) ->
-                  val expectedSpeciesMap = expectedByIdMap[id] ?: return@all false
-
-                  actualSpeciesMap.all { (speciesId, actualRate) ->
-                    val expectedRate = expectedSpeciesMap[speciesId]
-                    when {
-                      expectedRate == null -> actualRate == null
-                      actualRate == null -> false
-                      expectedRate is Double -> expectedRate.roundToInt() == actualRate
-                      else -> expectedRate == actualRate
-                    }
-                  } &&
-                      expectedSpeciesMap.all { (speciesId, _) ->
-                        actualSpeciesMap.containsKey(speciesId)
-                      }
-                } && expectedByIdMap.all { (id, _) -> actualByIdMap.containsKey(id) }
-
-            if (!allIdsMatch) {
-              val expectedString =
-                  expectedByIdMap.entries.joinToString("\n") { (id, speciesMap) ->
-                    "$level $id: {${speciesMap.entries.joinToString(", ") { "SpeciesId: ${it.key} -> SurvivalRate: ${it.value?.let { value -> if (value is Double) value.roundToInt() else value }}" }}}"
-                  }
-              val actualString =
-                  actualByIdMap.entries.joinToString("\n") { (id, speciesMap) ->
-                    "$level $id: {${speciesMap.entries.joinToString(", ") { "SpeciesId: ${it.key} -> SurvivalRate: ${it.value}" }}}"
-                  }
-              assertEquals(expectedString, actualString, "$message - $level")
-            }
-          }
-        }
+        assertSurvivalRates(expected.plotRates, actual.plotRates, "Plot", message),
+        assertSurvivalRates(expected.subzoneRates, actual.subzoneRates, "Subzone", message),
+        assertSurvivalRates(expected.zoneRates, actual.zoneRates, "Zone", message),
+        assertSurvivalRates(expected.siteRates, actual.siteRates, "Site", message),
     )
   }
 
-  private fun fetchSurvivalRates(
-      plantingSiteId: PlantingSiteId
-  ): List<Map<Any, Map<SpeciesId?, Int?>>> {
+  private fun assertSurvivalRates(
+      expected: Map<Any, Map<SpeciesId?, Number?>>,
+      actual: Map<Any, Map<SpeciesId?, Number?>>,
+      level: String,
+      message: String,
+  ): () -> Unit = {
+    val allIdsMatch =
+        actual.all { (id, actualSpeciesMap) ->
+          val expectedSpeciesMap = expected[id] ?: return@all false
+
+          actualSpeciesMap.all { (speciesId, actualRate) ->
+            val expectedRate = expectedSpeciesMap[speciesId]
+            when {
+              expectedRate == null -> actualRate == null
+              actualRate == null -> false
+              expectedRate is Double -> expectedRate.roundToInt() == actualRate
+              else -> expectedRate == actualRate
+            }
+          } && expectedSpeciesMap.all { (speciesId, _) -> actualSpeciesMap.containsKey(speciesId) }
+        } && expected.all { (id, _) -> actual.containsKey(id) }
+
+    if (!allIdsMatch) {
+      val expectedString =
+          expected.entries.joinToString("\n") { (id, speciesMap) ->
+            "$level $id: {${speciesMap.entries.joinToString(", ") { "SpeciesId: ${it.key} -> SurvivalRate: ${it.value?.let { value -> if (value is Double) value.roundToInt() else value }}" }}}"
+          }
+      val actualString =
+          actual.entries.joinToString("\n") { (id, speciesMap) ->
+            "$level $id: {${speciesMap.entries.joinToString(", ") { "SpeciesId: ${it.key} -> SurvivalRate: ${it.value}" }}}"
+          }
+      assertEquals(expectedString, actualString, "$message - $level")
+    }
+  }
+
+  private fun fetchSurvivalRates(plantingSiteId: PlantingSiteId): SurvivalRates {
     val siteResults = resultsStore.fetchByPlantingSiteId(plantingSiteId, limit = 1)[0]
 
+    return ratesObjectFromResults(siteResults, plantingSiteId)
+  }
+
+  private fun ratesObjectFromResults(
+      siteResults: ObservationResultsModel,
+      plantingSiteId: PlantingSiteId,
+  ): SurvivalRates {
     val siteMap = mutableMapOf<SpeciesId?, Int?>()
     val allZonesMap = mutableMapOf<Any, Map<SpeciesId?, Int?>>()
     val allSubzonesMap = mutableMapOf<Any, Map<SpeciesId?, Int?>>()
@@ -784,6 +862,13 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
       }
     }
 
-    return listOf(allPlotsMap, allSubzonesMap, allZonesMap, mapOf(plantingSiteId to siteMap))
+    return SurvivalRates(allPlotsMap, allSubzonesMap, allZonesMap, mapOf(plantingSiteId to siteMap))
   }
+
+  data class SurvivalRates(
+      val plotRates: Map<Any, Map<SpeciesId?, Number?>>,
+      val subzoneRates: Map<Any, Map<SpeciesId?, Number?>>,
+      val zoneRates: Map<Any, Map<SpeciesId?, Number?>>,
+      val siteRates: Map<Any, Map<SpeciesId?, Number?>>,
+  )
 }

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/PlotRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/PlotRates.csv
@@ -1,0 +1,6 @@
+Plot Number,Plot Survival Rate,Species A Survival Rate,Species B Survival Rate
+111,90%,80%,95%
+112,97%,100%,95%
+211,94%,102%,87%
+311,87%,86%,87%
+312,95%,90%,99%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/SiteRates.csv
@@ -1,0 +1,2 @@
+Site Name,Site Survival Rate,Species A Survival Rate,Species B Survival Rate
+Demo Site,92%,92%,93%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/SubzoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/SubzoneRates.csv
@@ -1,0 +1,4 @@
+Subzone Name,Subzone Survival Rate,Species A Survival Rate,Species B Survival Rate
+Subzone1,90%,80%,95%
+Subzone2,95%,101%,90%
+Subzone3,91%,88%,94%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/AfterUpdate/ZoneRates.csv
@@ -1,0 +1,3 @@
+Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
+Zone1,94%,99%,91%
+Zone2,91%,88%,94%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Observation-1.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Observation-1.csv
@@ -1,0 +1,6 @@
+Plot,Species 0,,,Species 1,,,Unknown,,Other,
+,Existing,Live,Dead,Existing,Live,Dead,Live,Dead,Live,Dead
+111,0,9,0,0,20,0,0,0,0,0
+112,0,30,0,0,39,0,0,0,0,0
+211,0,55,0,0,55,0,0,0,0,0
+311,0,61,0,0,78,0,0,0,0,0

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Observation-2.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Observation-2.csv
@@ -1,0 +1,7 @@
+Plot,Species 0,,,Species 1,,,Unknown,,Other,
+,Existing,Live,Dead,Existing,Live,Dead,Live,Dead,Live,Dead
+111,0,8,0,0,19,0,0,0,0,0
+112,0,30,0,0,38,0,0,0,0,0
+211,0,51,0,0,52,0,0,0,0,0
+311,0,60,0,0,70,0,0,0,0,0
+312,0,81,0,0,99,0,0,0,0,0

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/PlotRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/PlotRates.csv
@@ -1,0 +1,5 @@
+Plot Number,Plot Survival Rate,Species A Survival Rate,Species B Survival Rate
+111,97%,90%,100%
+112,99%,100%,98%
+211,100%,110%,92%
+311,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Plots.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Plots.csv
@@ -1,0 +1,5 @@
+Subzone,Name,Type,Area (ha)
+Subzone1,111,Permanent,0.0625
+Subzone1,112,Permanent,0.0625
+Subzone2,211,Permanent,0.0625
+Subzone3,311,Permanent,0.0625

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/SiteRates.csv
@@ -1,0 +1,2 @@
+Site Name,Site Survival Rate,Species A Survival Rate,Species B Survival Rate
+Demo Site,96%,97%,96%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/SubzoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/SubzoneRates.csv
@@ -1,0 +1,4 @@
+Subzone Name,Subzone Survival Rate,Species A Survival Rate,Species B Survival Rate
+Subzone1,98%,98%,98%
+Subzone2,100%,110%,92%
+Subzone3,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Subzones.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Subzones.csv
@@ -1,0 +1,5 @@
+,,
+Zone,Name,Area (ha)
+Zone1,Subzone1,50
+Zone1,Subzone2,50
+Zone2,Subzone3,200

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/T0Densities.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/T0Densities.csv
@@ -1,0 +1,5 @@
+Plot,Species 0 Density,Species 1 Density
+111,10,20
+112,30,40
+211,50,60
+311,70,80

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/ZoneRates.csv
@@ -1,0 +1,3 @@
+Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
+Zone1,99%,104%,95%
+Zone2,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Zones.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateSiteGeometryChange/Zones.csv
@@ -1,0 +1,4 @@
+,,
+Site,Name,Area (ha)
+Demo Site,Zone1,100
+Demo Site,Zone2,200


### PR DESCRIPTION
If a plot changes subzone, survival rates for that subzone should not change for historical observations. Update the results store to use plot histories to ensure this.

Note that this PR only handles permanent plots. It was growing large so temporary plots will be handled in the next PR.