### PR TITLE
Increase request size limit to 5GB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,7 +105,8 @@ spring:
 
 server:
   tomcat:
-    max-http-form-post-size: 5GB
+    # Tomcat only allows limits up to 2GB, so disable Tomcat's limit and rely on Spring's.
+    max-http-form-post-size: -1
 
 management:
   health:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -96,8 +96,8 @@ spring:
   servlet:
     multipart:
       enabled: true
-      max-request-size: 200MB
-      max-file-size: 200MB
+      max-request-size: 5GB
+      max-file-size: 5GB
 
   threads:
     virtual:
@@ -105,7 +105,7 @@ spring:
 
 server:
   tomcat:
-    max-http-form-post-size: 200MB
+    max-http-form-post-size: 5GB
 
 management:
   health:


### PR DESCRIPTION
The previous 200MB limit was too small for high-resolution videos, which users are
going to start uploading to the activity log.