### PR TITLE
SW-7695 Add BiomassDetailsCreatedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.eventlog
 import com.terraformation.backend.customer.db.SimpleUserStore
 import com.terraformation.backend.customer.event.OrganizationPersistentEvent
 import com.terraformation.backend.customer.event.ProjectPersistentEvent
+import com.terraformation.backend.eventlog.api.BiomassDetailsSubjectPayload
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
 import com.terraformation.backend.eventlog.api.DeletedActionPayload
 import com.terraformation.backend.eventlog.api.EventActionPayload
@@ -18,6 +19,7 @@ import com.terraformation.backend.eventlog.db.EventLogStore
 import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
@@ -72,6 +74,7 @@ class EventLogPayloadTransformer(
       context: EventLogPayloadContext,
   ): EventSubjectPayload? {
     return when (event) {
+      is BiomassDetailsPersistentEvent -> BiomassDetailsSubjectPayload.forEvent(event, context)
       is ObservationMediaFilePersistentEvent ->
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
       is OrganizationPersistentEvent -> OrganizationSubjectPayload.forEvent(event, context)

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -73,7 +73,6 @@ data class BiomassDetailsSubjectPayload(
         event: BiomassDetailsPersistentEvent,
         context: EventLogPayloadContext,
     ): BiomassDetailsSubjectPayload {
-      // TODO: Do we want something other than observation ID in the full text? Date or plot number?
       return BiomassDetailsSubjectPayload(
           fullText = context.subjectFullText<BiomassDetailsSubjectPayload>(event.observationId),
           monitoringPlotId = event.monitoringPlotId,

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.eventlog.EventLogPayloadContext
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.file.api.MediaKind
+import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
@@ -57,6 +58,31 @@ sealed interface EventSubjectPayload {
       example = "Project",
   )
   val shortText: String
+}
+
+@JsonTypeName("BiomassDetails")
+data class BiomassDetailsSubjectPayload(
+    override val fullText: String,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    override val shortText: String,
+) : EventSubjectPayload {
+  companion object {
+    fun forEvent(
+        event: BiomassDetailsPersistentEvent,
+        context: EventLogPayloadContext,
+    ): BiomassDetailsSubjectPayload {
+      // TODO: Do we want something other than observation ID in the full text? Date or plot number?
+      return BiomassDetailsSubjectPayload(
+          fullText = context.subjectFullText<BiomassDetailsSubjectPayload>(event.observationId),
+          monitoringPlotId = event.monitoringPlotId,
+          observationId = event.observationId,
+          plantingSiteId = event.plantingSiteId,
+          shortText = context.subjectShortText<BiomassDetailsSubjectPayload>(),
+      )
+    }
+  }
 }
 
 @JsonTypeName("ObservationPlotMedia")
@@ -221,6 +247,7 @@ data class RecordedTreeSubjectPayload(
  * classes.
  */
 enum class EventSubjectName(val eventInterface: KClass<out PersistentEvent>) {
+  BiomassDetails(BiomassDetailsPersistentEvent::class),
   ObservationPlotMedia(ObservationMediaFilePersistentEvent::class),
   Organization(OrganizationPersistentEvent::class),
   Project(ProjectPersistentEvent::class),

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -3,7 +3,9 @@ package com.terraformation.backend.tracking.event
 import com.terraformation.backend.db.default_schema.FileId
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.BiomassSpeciesId
+import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
@@ -29,6 +31,7 @@ import com.terraformation.backend.tracking.model.SpeciesDensityChangedEventModel
 import com.terraformation.backend.tracking.model.ZoneT0DensityChangedEventModel
 import java.math.BigDecimal
 import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import org.locationtech.jts.geom.Point
 
@@ -298,6 +301,33 @@ data class ObservationMediaFileUploadedEventV1(
 ) : EntityCreatedPersistentEvent, ObservationMediaFilePersistentEvent
 
 typealias ObservationMediaFileUploadedEvent = ObservationMediaFileUploadedEventV1
+
+sealed interface BiomassDetailsPersistentEvent : PersistentEvent {
+  val monitoringPlotId: MonitoringPlotId
+  val observationId: ObservationId
+  val organizationId: OrganizationId
+  val plantingSiteId: PlantingSiteId
+}
+
+data class BiomassDetailsCreatedEventV1(
+    val description: String? = null,
+    val forestType: BiomassForestType,
+    val herbaceousCoverPercent: Int,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    val ph: BigDecimal? = null,
+    override val plantingSiteId: PlantingSiteId,
+    val salinityPpt: BigDecimal? = null,
+    val smallTreesCountHigh: Int,
+    val smallTreesCountLow: Int,
+    val soilAssessment: String,
+    val tide: MangroveTide? = null,
+    val tideTime: Instant? = null,
+    val waterDepthCm: Int? = null,
+) : EntityCreatedPersistentEvent, BiomassDetailsPersistentEvent
+
+typealias BiomassDetailsCreatedEvent = BiomassDetailsCreatedEventV1
 
 sealed interface RecordedTreePersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId

--- a/src/main/resources/db/migration/0400/V427__BiomassDetailsCreatedEvent.sql
+++ b/src/main/resources/db/migration/0400/V427__BiomassDetailsCreatedEvent.sql
@@ -1,0 +1,32 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    op.completed_by,
+    op.completed_time,
+    'com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'description' VALUE obd.description,
+        'forestType' VALUE bft.name,
+        'herbaceousCoverPercent' VALUE obd.herbaceous_cover_percent,
+        'monitoringPlotId' VALUE obd.monitoring_plot_id,
+        'observationId' VALUE o.id,
+        'organizationId' VALUE ps.organization_id,
+        'ph' VALUE obd.ph,
+        'plantingSiteId' VALUE ps.id,
+        'salinityPpt' VALUE obd.salinity_ppt,
+        'smallTreesCountHigh' VALUE obd.small_trees_count_high,
+        'smallTreesCountLow' VALUE obd.small_trees_count_low,
+        'soilAssessment' VALUE obd.soil_assessment,
+        'tide' VALUE mt.name,
+        'tideTime' VALUE obd.tide_time,
+        'waterDepthCm' VALUE obd.water_depth_cm
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.observation_biomass_details obd
+JOIN tracking.biomass_forest_types bft ON obd.forest_type_id = bft.id
+LEFT JOIN tracking.mangrove_tides mt ON obd.tide_id = mt.id
+JOIN tracking.observations o ON obd.observation_id = o.id
+JOIN tracking.observation_plots op
+    ON obd.observation_id = op.observation_id
+    AND obd.monitoring_plot_id = op.monitoring_plot_id
+JOIN tracking.planting_sites ps ON o.planting_site_id = ps.id;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -80,6 +80,8 @@ csvSubLocationNotFound=Sub-location does not exist
 csvWrongFieldCount=Expected row to have {0} fields, not {1}
 disabled=Disabled
 enabled=Enabled
+eventSubject.BiomassDetails.full=Biomass observation {0}
+eventSubject.BiomassDetails.short=Observation
 eventSubject.ObservationPlotMedia.field.caption=caption
 # {0} is media kind, {1} is file ID
 eventSubject.ObservationPlotMedia.full={0} {1}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -137,6 +137,10 @@ csvWrongFieldCount=Se espera que la fila tenga {0} campos, no {1}.
 disabled=Deshabilitado
 # 0cbb9a69
 enabled=Habilitado
+# 0bf84458
+eventSubject.BiomassDetails.full=Observación de biomasa {0}
+# ac4f24f0
+eventSubject.BiomassDetails.short=Observación
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=leyenda
 # 0ff64395

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -137,6 +137,10 @@ csvWrongFieldCount=La ligne devait contenir {0} champs, pas {1}
 disabled=Désactivé
 # 0cbb9a69
 enabled=Activé
+# 0bf84458
+eventSubject.BiomassDetails.full=Observation de la biomasse {0}
+# ac4f24f0
+eventSubject.BiomassDetails.short=Observation
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=légende
 # 0ff64395

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
@@ -16,6 +16,7 @@ import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
+import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
 import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
@@ -217,6 +218,26 @@ class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
             waterDepthCm = 2,
         ),
         "Biomass details table",
+    )
+
+    eventPublisher.assertEventPublished(
+        BiomassDetailsCreatedEvent(
+            description = "description",
+            forestType = BiomassForestType.Mangrove,
+            herbaceousCoverPercent = 10,
+            monitoringPlotId = plotId,
+            observationId = observationId,
+            organizationId = organizationId,
+            ph = BigDecimal.valueOf(6.5),
+            plantingSiteId = plantingSiteId,
+            salinityPpt = BigDecimal.valueOf(20),
+            smallTreesCountHigh = 10,
+            smallTreesCountLow = 0,
+            soilAssessment = "soil",
+            tide = MangroveTide.High,
+            tideTime = Instant.ofEpochSecond(123),
+            waterDepthCm = 2,
+        )
     )
 
     val biomassSpeciesIdsBySpeciesKey =

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -37,6 +37,15 @@ com.terraformation.backend.eventlog.PersistentEventTest$TestChildFieldEventV1/ch
 com.terraformation.backend.eventlog.PersistentEventTest$TestNonPrimaryConstructorPropertyEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV1/x: Int
 com.terraformation.backend.eventlog.PersistentEventTest$TestUpgradableEventV2/x: Int
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/forestType: BiomassForestType
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/herbaceousCoverPercent: Int
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/smallTreesCountHigh: Int
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/smallTreesCountLow: Int
+com.terraformation.backend.tracking.event.BiomassDetailsCreatedEventV1/soilAssessment: String
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add an event to track the creation of new biomass observation details. Backfill
events for existing biomass observations. This will be used to support tracking
changes to biomass details once an update API is introduced for them.