### PR TITLE
SW-7695 Add generic wrapper for observation updates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -678,7 +678,7 @@ class ObservationService(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,
       func: () -> T,
-  ) {
+  ): T {
     requirePermissions { updateObservation(observationId) }
 
     val plotStatus =

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -105,6 +105,9 @@ class PlotAlreadyCompletedException(val monitoringPlotId: MonitoringPlotId) :
 class PlotNotClaimedException(val monitoringPlotId: MonitoringPlotId) :
     MismatchedStateException("Monitoring plot $monitoringPlotId is not claimed by the current user")
 
+class PlotNotCompletedException(val monitoringPlotId: MonitoringPlotId) :
+    MismatchedStateException("Monitoring plot $monitoringPlotId observation is not completed")
+
 class PlotNotFoundException(val monitoringPlotId: MonitoringPlotId) :
     EntityNotFoundException("Monitoring plot $monitoringPlotId not found")
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2830,8 +2830,6 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
     @Test
     fun `throws exception if no permission to update observation`() {
-      setUpPlot()
-
       deleteOrganizationUser()
 
       assertThrows<ObservationNotFoundException> {

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -65,6 +65,7 @@ import com.terraformation.backend.tracking.db.InvalidObservationStartDateExcepti
 import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
 import com.terraformation.backend.tracking.db.ObservationHasNoSubzonesException
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
+import com.terraformation.backend.tracking.db.ObservationPlotNotFoundException
 import com.terraformation.backend.tracking.db.ObservationRescheduleStateException
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
@@ -72,6 +73,7 @@ import com.terraformation.backend.tracking.db.PlantingSiteNotDetailedException
 import com.terraformation.backend.tracking.db.PlantingSiteNotFoundException
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.db.PlotAlreadyCompletedException
+import com.terraformation.backend.tracking.db.PlotNotCompletedException
 import com.terraformation.backend.tracking.db.PlotNotInObservationException
 import com.terraformation.backend.tracking.db.PlotSizeNotReplaceableException
 import com.terraformation.backend.tracking.db.ScheduleObservationWithoutPlantsException
@@ -2763,6 +2765,78 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           observationsDao.findAll().associate { it.id!! to it.stateId!! },
           "Observation states",
       )
+    }
+  }
+
+  @Nested
+  inner class UpdateCompletedPlot {
+    private lateinit var monitoringPlotId: MonitoringPlotId
+    private lateinit var observationId: ObservationId
+
+    @BeforeEach
+    fun setUpPlot() {
+      insertPlantingZone()
+      insertPlantingSubzone()
+      monitoringPlotId = insertMonitoringPlot()
+      observationId = insertObservation()
+      insertObservationPlot(completedBy = user.userId)
+    }
+
+    @Test
+    fun `calls function to perform updates`() {
+      val initial = dslContext.fetchSingle(OBSERVATION_PLOTS)
+
+      service.updateCompletedPlot(observationId, monitoringPlotId) {
+        dslContext.update(OBSERVATION_PLOTS).set(OBSERVATION_PLOTS.NOTES, "new notes").execute()
+      }
+
+      val expected = initial.copy().apply { notes = "new notes" }
+
+      assertTableEquals(expected)
+    }
+
+    @Test
+    fun `rolls back changes if function throws exception`() {
+      val expected = dslContext.fetch(OBSERVATION_PLOTS)
+
+      assertThrows<IllegalStateException> {
+        service.updateCompletedPlot(observationId, monitoringPlotId) {
+          dslContext.update(OBSERVATION_PLOTS).set(OBSERVATION_PLOTS.NOTES, "new notes").execute()
+          throw IllegalStateException("oops")
+        }
+      }
+
+      assertTableEquals(expected)
+    }
+
+    @Test
+    fun `throws exception if plot is not in specified observation`() {
+      val otherObservationId = insertObservation()
+
+      assertThrows<ObservationPlotNotFoundException> {
+        service.updateCompletedPlot(otherObservationId, monitoringPlotId) {}
+      }
+    }
+
+    @Test
+    fun `throws exception if plot is not completed yet`() {
+      val otherPlotId = insertMonitoringPlot()
+      insertObservationPlot()
+
+      assertThrows<PlotNotCompletedException> {
+        service.updateCompletedPlot(observationId, otherPlotId) {}
+      }
+    }
+
+    @Test
+    fun `throws exception if no permission to update observation`() {
+      setUpPlot()
+
+      deleteOrganizationUser()
+
+      assertThrows<ObservationNotFoundException> {
+        service.updateCompletedPlot(observationId, monitoringPlotId) {}
+      }
     }
   }
 


### PR DESCRIPTION
The API for updating observation data for completed plots will need to do the same
sanity checks no matter what specific parts of the observation are being updated;
add a method to `ObservationService` to support it.