### PR TITLE
Support distinct null and absent payload properties

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/OpenApiConfig.kt
@@ -18,14 +18,17 @@ import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.security.SecurityScheme
 import jakarta.inject.Named
 import java.time.ZoneId
+import java.util.Optional
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createType
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 import org.jooq.DSLContext
 import org.springdoc.core.customizers.OpenApiCustomizer
@@ -156,6 +159,13 @@ class OpenApiConfig(private val keycloakInfo: KeycloakInfo) : OpenApiCustomizer 
           // objects, which is wrong; values could be other JSON types too.
           if (propertySchema is ArraySchema && propertySchema.items is MapSchema) {
             propertySchema.items.additionalProperties = true
+          }
+
+          // Optional<*> properties should be marked as nullable in the schema.
+          if (
+              propertySchema != null && property.returnType.jvmErasure.isSubclassOf(Optional::class)
+          ) {
+            propertySchema.nullable = true
           }
         }
       }

--- a/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/util/Extensions.kt
@@ -257,9 +257,6 @@ fun Geometry.differenceNullable(other: Geometry?): Geometry =
  * example, say an entity has a property `notes` of type `String?`. We'd want to handle a `PATCH`
  * request as follows:
  *
- * In the context of a PATCH endpoint where a property represents a possible change to an existing
- * value, we'd want to handle it as follows, respectively:
- *
  * | JSON               | Desired end result      |
  * |--------------------|-------------------------|
  * | `{}`               | Keep the original notes |


### PR DESCRIPTION
To support PATCH-style API semantics, we need to be able to distinguish between
a payload property being absent from the incoming JSON (in which case the existing
value should be left as is) and the property being present with a value of `null`
(in which case the client is asking us to remove the existing value).

Jackson supports using the Java `Optional` class to distinguish those two cases,
but it's a little cumbersome out of the box; add an extension method to simplify
using it for PATCH-style operations.

The distinction between "not required" and "can be null" needs to be reflected
in the OpenAPI schema as well. We could do it by adding `@Schema(nullable = true)`
to payload properties, but that'll add a lot of noise, so instead add logic to
automatically mark all `Optional` payload properties as allowing null values.