### PR TITLE
SW-7695 Add endpoint to edit observation details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -1,0 +1,23 @@
+package com.terraformation.backend.tracking.api
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
+import com.terraformation.backend.util.patchNullable
+import java.util.Optional
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+sealed interface ObservationUpdateOperationPayload
+
+@JsonTypeName("Biomass")
+data class BiomassUpdateOperationPayload(
+    val description: Optional<String?>?,
+    val soilAssessment: String?,
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: EditableBiomassDetailsModel): EditableBiomassDetailsModel {
+    return model.copy(
+        description = description.patchNullable(model.description),
+        soilAssessment = soilAssessment ?: model.soilAssessment,
+    )
+  }
+}


### PR DESCRIPTION
`PATCH /api/v1/tracking/observations/{observationId}/plots/{plotId}` updates
information about completed observations of monitoring plots. It will eventually
replace the existing `PUT` endpoint.

Initially, it only supports updating the description and soil assessment
properties of biomass observations, but it's structured to support editing
additional kinds of details in future changes.

The request payload uses `PATCH` semantics, where omitting a property means
leaving the current value in place.