### PR TITLE
SW-7697 Add BiomassQuadratCreatedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -4,6 +4,7 @@ import com.terraformation.backend.customer.db.SimpleUserStore
 import com.terraformation.backend.customer.event.OrganizationPersistentEvent
 import com.terraformation.backend.customer.event.ProjectPersistentEvent
 import com.terraformation.backend.eventlog.api.BiomassDetailsSubjectPayload
+import com.terraformation.backend.eventlog.api.BiomassQuadratSubjectPayload
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
 import com.terraformation.backend.eventlog.api.DeletedActionPayload
 import com.terraformation.backend.eventlog.api.EventActionPayload
@@ -20,6 +21,7 @@ import com.terraformation.backend.eventlog.model.EventLogEntry
 import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
@@ -75,6 +77,7 @@ class EventLogPayloadTransformer(
   ): EventSubjectPayload? {
     return when (event) {
       is BiomassDetailsPersistentEvent -> BiomassDetailsSubjectPayload.forEvent(event, context)
+      is BiomassQuadratPersistentEvent -> BiomassQuadratSubjectPayload.forEvent(event, context)
       is ObservationMediaFilePersistentEvent ->
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
       is OrganizationPersistentEvent -> OrganizationSubjectPayload.forEvent(event, context)

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
@@ -21,6 +22,7 @@ import com.terraformation.backend.eventlog.EventLogPayloadContext
 import com.terraformation.backend.eventlog.PersistentEvent
 import com.terraformation.backend.file.api.MediaKind
 import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
@@ -79,6 +81,34 @@ data class BiomassDetailsSubjectPayload(
           observationId = event.observationId,
           plantingSiteId = event.plantingSiteId,
           shortText = context.subjectShortText<BiomassDetailsSubjectPayload>(),
+      )
+    }
+  }
+}
+
+@JsonTypeName("BiomassQuadrat")
+data class BiomassQuadratSubjectPayload(
+    override val fullText: String,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    val position: ObservationPlotPosition,
+    override val shortText: String,
+) : EventSubjectPayload {
+  companion object {
+    fun forEvent(
+        event: BiomassQuadratPersistentEvent,
+        context: EventLogPayloadContext,
+    ): BiomassQuadratSubjectPayload {
+      val localizedPosition = event.position.getDisplayName(currentUser().locale)
+
+      return BiomassQuadratSubjectPayload(
+          fullText = context.subjectFullText<BiomassQuadratSubjectPayload>(localizedPosition),
+          monitoringPlotId = event.monitoringPlotId,
+          observationId = event.observationId,
+          plantingSiteId = event.plantingSiteId,
+          position = event.position,
+          shortText = context.subjectShortText<BiomassQuadratSubjectPayload>(),
       )
     }
   }
@@ -247,6 +277,7 @@ data class RecordedTreeSubjectPayload(
  */
 enum class EventSubjectName(val eventInterface: KClass<out PersistentEvent>) {
   BiomassDetails(BiomassDetailsPersistentEvent::class),
+  BiomassQuadrat(BiomassQuadratPersistentEvent::class),
   ObservationPlotMedia(ObservationMediaFilePersistentEvent::class),
   Organization(OrganizationPersistentEvent::class),
   Project(ProjectPersistentEvent::class),

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -357,6 +357,25 @@ typealias BiomassDetailsUpdatedEvent = BiomassDetailsUpdatedEventV1
 
 typealias BiomassDetailsUpdatedEventValues = BiomassDetailsUpdatedEventV1.Values
 
+sealed interface BiomassQuadratPersistentEvent : PersistentEvent {
+  val monitoringPlotId: MonitoringPlotId
+  val observationId: ObservationId
+  val organizationId: OrganizationId
+  val plantingSiteId: PlantingSiteId
+  val position: ObservationPlotPosition
+}
+
+data class BiomassQuadratCreatedEventV1(
+    val description: String?,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    override val position: ObservationPlotPosition,
+) : BiomassQuadratPersistentEvent, EntityCreatedPersistentEvent
+
+typealias BiomassQuadratCreatedEvent = BiomassQuadratCreatedEventV1
+
 sealed interface RecordedTreePersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId

--- a/src/main/resources/db/migration/0400/V428__BiomassQuadratCreatedEvent.sql
+++ b/src/main/resources/db/migration/0400/V428__BiomassQuadratCreatedEvent.sql
@@ -1,0 +1,31 @@
+-- We want to be able to rely on quadrat details (and thus the quadrat creation event) always
+-- existing if there's any quadrat-level information.
+ALTER TABLE tracking.observation_biomass_quadrat_species
+    ADD CONSTRAINT quadrat_species_requires_quadrat_details
+        FOREIGN KEY (observation_id, monitoring_plot_id, position_id)
+            REFERENCES tracking.observation_biomass_quadrat_details
+                (observation_id, monitoring_plot_id, position_id)
+            ON DELETE CASCADE;
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    op.completed_by,
+    op.completed_time,
+    'com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'description' VALUE obqd.description,
+        'monitoringPlotId' VALUE obqd.monitoring_plot_id,
+        'observationId' VALUE o.id,
+        'organizationId' VALUE ps.organization_id,
+        'plantingSiteId' VALUE ps.id,
+        'position' VALUE opp.name
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.observation_biomass_quadrat_details obqd
+JOIN tracking.observation_plot_positions opp ON obqd.position_id = opp.id
+JOIN tracking.observations o ON obqd.observation_id = o.id
+JOIN tracking.observation_plots op
+    ON obqd.observation_id = op.observation_id
+    AND obqd.monitoring_plot_id = op.monitoring_plot_id
+JOIN tracking.planting_sites ps ON o.planting_site_id = ps.id;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -84,6 +84,9 @@ eventSubject.BiomassDetails.field.description=plot description
 eventSubject.BiomassDetails.field.soilAssessment=soil description/notes
 eventSubject.BiomassDetails.full=Biomass observation {0}
 eventSubject.BiomassDetails.short=Observation
+# {0} is a compass direction like "northwest"
+eventSubject.BiomassQuadrat.full={0} quadrat
+eventSubject.BiomassQuadrat.short=Quadrat
 eventSubject.ObservationPlotMedia.field.caption=caption
 # {0} is media kind, {1} is file ID
 eventSubject.ObservationPlotMedia.full={0} {1}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -145,6 +145,10 @@ eventSubject.BiomassDetails.field.soilAssessment=descripción/notas del suelo
 eventSubject.BiomassDetails.full=Observación de biomasa {0}
 # ac4f24f0
 eventSubject.BiomassDetails.short=Observación
+# 6bbebea6
+eventSubject.BiomassQuadrat.full=Cuadrícula {0}
+# 11b386ec
+eventSubject.BiomassQuadrat.short=Cuadrícula
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=leyenda
 # 0ff64395

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -145,6 +145,10 @@ eventSubject.BiomassDetails.field.soilAssessment=description/remarques sur le so
 eventSubject.BiomassDetails.full=Observation de la biomasse {0}
 # ac4f24f0
 eventSubject.BiomassDetails.short=Observation
+# 6bbebea6
+eventSubject.BiomassQuadrat.full=Quadrat {0}
+# 11b386ec
+eventSubject.BiomassQuadrat.short=Quadrat
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=légende
 # 0ff64395

--- a/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/TrackingSearchTest.kt
@@ -239,6 +239,9 @@ class TrackingSearchTest : DatabaseTest(), RunsAsUser {
         treeNumber = 1,
         trunkNumber = 2,
     )
+    insertObservationBiomassQuadratDetails(
+        position = ObservationPlotPosition.NorthwestCorner,
+    )
     insertObservationBiomassQuadratSpecies(
         abundancePercent = 33,
         biomassSpeciesId = inserted.biomassSpeciesId,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
@@ -13,10 +13,12 @@ import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQ
 import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
 import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
@@ -343,6 +345,22 @@ class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
             ),
         ),
         "Biomass quadrat details table",
+    )
+
+    eventPublisher.assertEventsPublished(
+        dslContext
+            .fetch(OBSERVATION_BIOMASS_QUADRAT_DETAILS)
+            .map { record ->
+              BiomassQuadratCreatedEvent(
+                  record.description,
+                  plotId,
+                  observationId,
+                  organizationId,
+                  plantingSiteId,
+                  record.positionId!!,
+              )
+            }
+            .toSet()
     )
 
     assertTableEquals(

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -50,6 +50,11 @@ com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventV1/monitorin
 com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventV1/observationId: ObservationId
 com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/position: ObservationPlotPosition
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add an event to track the creation of new per-quadrat details for a biomass
observation. Backfill events for existing biomass observations. This will be
used to support tracking changes to quadrat details.