### PR TITLE
SW-7695 Support editing biomass quadrat details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -2,12 +2,26 @@ package com.terraformation.backend.tracking.api
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
+import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
 import com.terraformation.backend.util.patchNullable
 import java.util.Optional
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 sealed interface ObservationUpdateOperationPayload
+
+@JsonTypeName("Quadrat")
+data class QuadratUpdateOperationPayload(
+    val description: Optional<String>?,
+    val position: ObservationPlotPosition,
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: EditableBiomassQuadratDetailsModel): EditableBiomassQuadratDetailsModel {
+    return model.copy(
+        description = description.patchNullable(model.description),
+    )
+  }
+}
 
 @JsonTypeName("Biomass")
 data class BiomassUpdateOperationPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -340,6 +340,14 @@ class ObservationsController(
         when (element) {
           is BiomassUpdateOperationPayload ->
               observationStore.updateBiomassDetails(observationId, plotId, element::applyTo)
+          is QuadratUpdateOperationPayload -> {
+            observationStore.updateBiomassQuadratDetails(
+                observationId,
+                plotId,
+                element.position,
+                element::applyTo,
+            )
+          }
         }
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -376,6 +376,29 @@ data class BiomassQuadratCreatedEventV1(
 
 typealias BiomassQuadratCreatedEvent = BiomassQuadratCreatedEventV1
 
+data class BiomassQuadratDetailsUpdatedEventV1(
+    val changedFrom: Values,
+    val changedTo: Values,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    override val position: ObservationPlotPosition,
+) : BiomassQuadratPersistentEvent, FieldsUpdatedPersistentEvent {
+  data class Values(
+      val description: String?,
+  )
+
+  override fun listUpdatedFields() =
+      listOfNotNull(
+          createUpdatedField("description", changedFrom.description, changedTo.description),
+      )
+}
+
+typealias BiomassQuadratDetailsUpdatedEvent = BiomassQuadratDetailsUpdatedEventV1
+
+typealias BiomassQuadratDetailsUpdatedEventValues = BiomassQuadratDetailsUpdatedEventV1.Values
+
 sealed interface RecordedTreePersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableBiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableBiomassDetailsModel.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
 import org.jooq.Record
 
 data class EditableBiomassDetailsModel(
@@ -13,6 +14,20 @@ data class EditableBiomassDetailsModel(
         EditableBiomassDetailsModel(
             description = record[DESCRIPTION],
             soilAssessment = record[SOIL_ASSESSMENT]!!,
+        )
+      }
+    }
+  }
+}
+
+data class EditableBiomassQuadratDetailsModel(
+    val description: String? = null,
+) {
+  companion object {
+    fun of(record: Record): EditableBiomassQuadratDetailsModel {
+      return with(OBSERVATION_BIOMASS_QUADRAT_DETAILS) {
+        EditableBiomassQuadratDetailsModel(
+            description = record[DESCRIPTION],
         )
       }
     }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -84,6 +84,7 @@ eventSubject.BiomassDetails.field.description=plot description
 eventSubject.BiomassDetails.field.soilAssessment=soil description/notes
 eventSubject.BiomassDetails.full=Biomass observation {0}
 eventSubject.BiomassDetails.short=Observation
+eventSubject.BiomassQuadrat.field.description=description
 # {0} is a compass direction like "northwest"
 eventSubject.BiomassQuadrat.full={0} quadrat
 eventSubject.BiomassQuadrat.short=Quadrat

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -145,6 +145,8 @@ eventSubject.BiomassDetails.field.soilAssessment=descripción/notas del suelo
 eventSubject.BiomassDetails.full=Observación de biomasa {0}
 # ac4f24f0
 eventSubject.BiomassDetails.short=Observación
+# e119fcaa
+eventSubject.BiomassQuadrat.field.description=descripción
 # 6bbebea6
 eventSubject.BiomassQuadrat.full=Cuadrícula {0}
 # 11b386ec

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -145,6 +145,8 @@ eventSubject.BiomassDetails.field.soilAssessment=description/remarques sur le so
 eventSubject.BiomassDetails.full=Observation de la biomasse {0}
 # ac4f24f0
 eventSubject.BiomassDetails.short=Observation
+# e119fcaa
+eventSubject.BiomassQuadrat.field.description=description
 # 6bbebea6
 eventSubject.BiomassQuadrat.full=Quadrat {0}
 # 11b386ec

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateBiomassQuadratDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateBiomassQuadratDetailsTest.kt
@@ -1,0 +1,139 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratDetailsRecord
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
+import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventValues
+import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationStoreUpdateBiomassQuadratDetailsTest : BaseObservationStoreTest() {
+  @BeforeEach
+  fun setUpBiomassDetails() {
+    insertPlantingZone()
+    insertPlantingSubzone()
+    insertMonitoringPlot(isAdHoc = true)
+    insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
+    insertObservationPlot(completedBy = user.userId)
+    insertObservationBiomassDetails()
+    insertObservationBiomassQuadratDetails(
+        description = "Original description",
+        position = ObservationPlotPosition.NortheastCorner,
+    )
+  }
+
+  @Test
+  fun `updates editable fields of existing quadrat`() {
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_QUADRAT_DETAILS)
+
+    store.updateBiomassQuadratDetails(
+        inserted.observationId,
+        inserted.monitoringPlotId,
+        ObservationPlotPosition.NortheastCorner,
+    ) {
+      it.copy(description = "New description")
+    }
+
+    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
+      it.copy(
+          description = "New description",
+          soilAssessment = "New soil assessment",
+      )
+    }
+
+    val expected = before.copy().apply { description = "New description" }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassQuadratDetailsUpdatedEvent(
+            changedFrom =
+                BiomassQuadratDetailsUpdatedEventValues(
+                    description = "Original description",
+                ),
+            changedTo =
+                BiomassQuadratDetailsUpdatedEventValues(
+                    description = "New description",
+                ),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+            position = ObservationPlotPosition.NortheastCorner,
+        )
+    )
+  }
+
+  @Test
+  fun `creates quadrat that was not previously present`() {
+    val northeastCorner = dslContext.fetchSingle(OBSERVATION_BIOMASS_QUADRAT_DETAILS)
+
+    store.updateBiomassQuadratDetails(
+        inserted.observationId,
+        inserted.monitoringPlotId,
+        ObservationPlotPosition.SouthwestCorner,
+    ) {
+      it.copy(description = "New description")
+    }
+
+    val southwestCorner =
+        ObservationBiomassQuadratDetailsRecord(
+            description = "New description",
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            positionId = ObservationPlotPosition.SouthwestCorner,
+        )
+
+    assertTableEquals(setOf(northeastCorner, southwestCorner))
+
+    eventPublisher.assertEventPublished(
+        BiomassQuadratCreatedEvent(
+            description = "New description",
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+            position = ObservationPlotPosition.SouthwestCorner,
+        )
+    )
+  }
+
+  @Test
+  fun `does not publish event or modify database if nothing changed`() {
+    val unmodifiedTable = dslContext.fetch(OBSERVATION_BIOMASS_QUADRAT_DETAILS)
+
+    store.updateBiomassQuadratDetails(
+        inserted.observationId,
+        inserted.monitoringPlotId,
+        ObservationPlotPosition.NortheastCorner,
+    ) {
+      it
+    }
+
+    assertTableEquals(unmodifiedTable)
+
+    eventPublisher.assertEventNotPublished<BiomassQuadratPersistentEvent>()
+  }
+
+  @Test
+  fun `throws exception if no permission to update observation`() {
+    every { user.canUpdateObservation(inserted.observationId) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.updateBiomassQuadratDetails(
+          inserted.observationId,
+          inserted.monitoringPlotId,
+          ObservationPlotPosition.NortheastCorner,
+      ) {
+        it
+      }
+    }
+  }
+}

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -55,6 +55,11 @@ com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/observati
 com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.BiomassQuadratCreatedEventV1/position: ObservationPlotPosition
+com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/position: ObservationPlotPosition
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add a new update type to the observation editing PATCH payload to support updating
information about quadrats in biomass monitoring observations. "Information"
really just means the optional description; other quadrat-level information is
per-species and will be covered by a different update operation. Updates are also
written to the event log so they're queryable later.