### PR TITLE
Removed oneOf annotations for Search Payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -85,13 +85,6 @@ data class SearchSortOrderElement(
         "A search criterion. The search will return results that match this criterion. The " +
             "criterion can be composed of other search criteria to form arbitrary Boolean " +
             "search expressions. TYPESCRIPT-OVERRIDE-TYPE-WITH-ANY",
-    oneOf =
-        [
-            AndNodePayload::class,
-            FieldNodePayload::class,
-            NotNodePayload::class,
-            OrNodePayload::class,
-        ],
 )
 sealed interface SearchNodePayload {
   fun toSearchNode(prefix: SearchFieldPrefix): SearchNode


### PR DESCRIPTION
This will results in correct OpenAPI doc. This will also allow for correct type generation in the FE without circular references. 

The `openapi-ts` package used in the FE still has a bug that requires manual overwrite. That script will be updated at the same time as this PR to ensure correctness. 