### PR TITLE
Let fields-updated events localize their values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/OrganizationRenamedEvent.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
 import com.terraformation.backend.eventlog.UpgradableEvent
 import com.terraformation.backend.eventlog.db.EventUpgradeUtils
+import com.terraformation.backend.i18n.Messages
 
 data class OrganizationRenamedEventV1(
     val organizationId: OrganizationId,
@@ -30,7 +31,7 @@ data class OrganizationRenamedEventV2(
 ) : FieldsUpdatedPersistentEvent, OrganizationPersistentEvent {
   data class Values(val name: String?)
 
-  override fun listUpdatedFields() =
+  override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(createUpdatedField("name", changedFrom.name, changedTo.name))
 }
 

--- a/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/event/ProjectRenamedEvent.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
 import com.terraformation.backend.eventlog.UpgradableEvent
 import com.terraformation.backend.eventlog.db.EventUpgradeUtils
+import com.terraformation.backend.i18n.Messages
 
 data class ProjectRenamedEventV1(
     val name: String,
@@ -36,7 +37,7 @@ data class ProjectRenamedEventV2(
 ) : FieldsUpdatedPersistentEvent, ProjectPersistentEvent {
   data class Values(val name: String?)
 
-  override fun listUpdatedFields() =
+  override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(createUpdatedField("name", changedFrom.name, changedTo.name))
 }
 

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -102,7 +102,7 @@ class EventLogPayloadTransformer(
 
       // Events that can self-describe which fields were updated can be transformed generically.
       is FieldsUpdatedPersistentEvent ->
-          event.listUpdatedFields().map {
+          event.listUpdatedFields(messages).map {
             FieldUpdatedActionPayload(it.fieldName, it.changedFrom, it.changedTo)
           }
 

--- a/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedPersistentEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/FieldsUpdatedPersistentEvent.kt
@@ -1,5 +1,7 @@
 package com.terraformation.backend.eventlog
 
+import com.terraformation.backend.i18n.Messages
+
 /**
  * Common interface for events that represent one or more fields of an entity being updated. This is
  * used to render [PersistentEvent]s into API payloads for event log queries. Update events should
@@ -48,7 +50,7 @@ interface FieldsUpdatedPersistentEvent : EntityUpdatedPersistentEvent {
    * Fields that weren't modified shouldn't be included in the list. If the event represents a
    * single field change, this should return a list of length 1.
    */
-  fun listUpdatedFields(): List<UpdatedField>
+  fun listUpdatedFields(messages: Messages): List<UpdatedField>
 
   /** Represents a change to a single field. */
   data class UpdatedField(

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -20,6 +20,7 @@ import com.terraformation.backend.eventlog.EntityCreatedPersistentEvent
 import com.terraformation.backend.eventlog.EntityDeletedPersistentEvent
 import com.terraformation.backend.eventlog.FieldsUpdatedPersistentEvent
 import com.terraformation.backend.eventlog.PersistentEvent
+import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.ratelimit.RateLimitedEvent
 import com.terraformation.backend.tracking.edit.PlantingSiteEdit
 import com.terraformation.backend.tracking.model.ExistingObservationModel
@@ -278,7 +279,7 @@ data class ObservationMediaFileEditedEventV1(
       val caption: String?,
   )
 
-  override fun listUpdatedFields() =
+  override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(createUpdatedField("caption", changedFrom.caption, changedTo.caption))
 }
 
@@ -342,7 +343,7 @@ data class BiomassDetailsUpdatedEventV1(
       val soilAssessment: String?,
   )
 
-  override fun listUpdatedFields() =
+  override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(
           createUpdatedField("description", changedFrom.description, changedTo.description),
           createUpdatedField(
@@ -389,7 +390,7 @@ data class BiomassQuadratDetailsUpdatedEventV1(
       val description: String?,
   )
 
-  override fun listUpdatedFields() =
+  override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(
           createUpdatedField("description", changedFrom.description, changedTo.description),
       )
@@ -443,11 +444,10 @@ data class RecordedTreeUpdatedEventV1(
       val description: String?,
   )
 
-  override fun listUpdatedFields(): List<FieldsUpdatedPersistentEvent.UpdatedField> {
-    return listOfNotNull(
-        createUpdatedField("description", changedFrom.description, changedTo.description)
-    )
-  }
+  override fun listUpdatedFields(messages: Messages) =
+      listOfNotNull(
+          createUpdatedField("description", changedFrom.description, changedTo.description)
+      )
 }
 
 typealias RecordedTreeUpdatedEvent = RecordedTreeUpdatedEventV1


### PR DESCRIPTION
The list of changed values returned by event classes that implement
`FieldsUpdatedPersistentEvent` are supposed to be localized, but there was
no good way for those classes to look up localized values other than enum
display names. Pass the `Messages` object to the list-changes function
so it can look up any other localized text it needs.

This change just adds the capability. None of the existing event classes
use it, but upcoming ones will.