### PR TITLE
SW-7697 Add BiomassSpeciesCreatedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.customer.event.OrganizationPersistentEvent
 import com.terraformation.backend.customer.event.ProjectPersistentEvent
 import com.terraformation.backend.eventlog.api.BiomassDetailsSubjectPayload
 import com.terraformation.backend.eventlog.api.BiomassQuadratSubjectPayload
+import com.terraformation.backend.eventlog.api.BiomassSpeciesSubjectPayload
 import com.terraformation.backend.eventlog.api.CreatedActionPayload
 import com.terraformation.backend.eventlog.api.DeletedActionPayload
 import com.terraformation.backend.eventlog.api.EventActionPayload
@@ -22,6 +23,7 @@ import com.terraformation.backend.i18n.Messages
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
+import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
@@ -78,6 +80,7 @@ class EventLogPayloadTransformer(
     return when (event) {
       is BiomassDetailsPersistentEvent -> BiomassDetailsSubjectPayload.forEvent(event, context)
       is BiomassQuadratPersistentEvent -> BiomassQuadratSubjectPayload.forEvent(event, context)
+      is BiomassSpeciesPersistentEvent -> BiomassSpeciesSubjectPayload.forEvent(event, context)
       is ObservationMediaFilePersistentEvent ->
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
       is OrganizationPersistentEvent -> OrganizationSubjectPayload.forEvent(event, context)

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -400,6 +400,29 @@ typealias BiomassQuadratDetailsUpdatedEvent = BiomassQuadratDetailsUpdatedEventV
 
 typealias BiomassQuadratDetailsUpdatedEventValues = BiomassQuadratDetailsUpdatedEventV1.Values
 
+sealed interface BiomassSpeciesPersistentEvent : PersistentEvent {
+  val biomassSpeciesId: BiomassSpeciesId
+  val monitoringPlotId: MonitoringPlotId
+  val observationId: ObservationId
+  val organizationId: OrganizationId
+  val plantingSiteId: PlantingSiteId
+}
+
+data class BiomassSpeciesCreatedEventV1(
+    override val biomassSpeciesId: BiomassSpeciesId,
+    val commonName: String?,
+    val isInvasive: Boolean,
+    val isThreatened: Boolean,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    val scientificName: String?,
+    val speciesId: SpeciesId?,
+) : BiomassSpeciesPersistentEvent, EntityCreatedPersistentEvent
+
+typealias BiomassSpeciesCreatedEvent = BiomassSpeciesCreatedEventV1
+
 sealed interface RecordedTreePersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId

--- a/src/main/resources/db/migration/0400/V429__BiomassSpeciesCreatedEvent.sql
+++ b/src/main/resources/db/migration/0400/V429__BiomassSpeciesCreatedEvent.sql
@@ -1,0 +1,28 @@
+CALL event_log_create_id_index('biomassSpeciesId');
+CALL event_log_create_id_index('speciesId');
+
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    op.completed_by,
+    op.completed_time,
+    'com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'biomassSpeciesId' VALUE obs.id,
+        'commonName' VALUE obs.common_name,
+        'isInvasive' VALUE obs.is_invasive,
+        'isThreatened' VALUE obs.is_threatened,
+        'monitoringPlotId' VALUE obs.monitoring_plot_id,
+        'observationId' VALUE o.id,
+        'organizationId' VALUE ps.organization_id,
+        'plantingSiteId' VALUE ps.id,
+        'scientificName' VALUE obs.scientific_name,
+        'speciesId' VALUE obs.species_id
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.observation_biomass_species obs
+JOIN tracking.observations o ON obs.observation_id = o.id
+JOIN tracking.observation_plots op
+    ON obs.observation_id = op.observation_id
+    AND obs.monitoring_plot_id = op.monitoring_plot_id
+JOIN tracking.planting_sites ps ON o.planting_site_id = ps.id;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -88,6 +88,8 @@ eventSubject.BiomassQuadrat.field.description=description
 # {0} is a compass direction like "northwest"
 eventSubject.BiomassQuadrat.full={0} quadrat
 eventSubject.BiomassQuadrat.short=Quadrat
+eventSubject.BiomassSpecies.full=Species {0}
+eventSubject.BiomassSpecies.short=Species
 eventSubject.ObservationPlotMedia.field.caption=caption
 # {0} is media kind, {1} is file ID
 eventSubject.ObservationPlotMedia.full={0} {1}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -151,6 +151,10 @@ eventSubject.BiomassQuadrat.field.description=descripción
 eventSubject.BiomassQuadrat.full=Cuadrícula {0}
 # 11b386ec
 eventSubject.BiomassQuadrat.short=Cuadrícula
+# fd7f5baf
+eventSubject.BiomassSpecies.full=Especie {0}
+# bb344d18
+eventSubject.BiomassSpecies.short=Especie
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=leyenda
 # 0ff64395

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -151,6 +151,10 @@ eventSubject.BiomassQuadrat.field.description=description
 eventSubject.BiomassQuadrat.full=Quadrat {0}
 # 11b386ec
 eventSubject.BiomassQuadrat.short=Quadrat
+# fd7f5baf
+eventSubject.BiomassSpecies.full=Espèce {0}
+# bb344d18
+eventSubject.BiomassSpecies.short=Espèce
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=légende
 # 0ff64395

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreInsertBiomassDetailsTest.kt
@@ -14,11 +14,13 @@ import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQ
 import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.point
 import com.terraformation.backend.tracking.db.ObservationNotFoundException
 import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
+import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
 import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
@@ -248,12 +250,12 @@ class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
         }
 
     val biomassHerbaceousSpeciesId1 =
-        biomassSpeciesIdsBySpeciesKey[BiomassSpeciesKey(speciesId = herbaceousSpeciesId1)]
+        biomassSpeciesIdsBySpeciesKey[BiomassSpeciesKey(speciesId = herbaceousSpeciesId1)]!!
     val biomassHerbaceousSpeciesId2 =
-        biomassSpeciesIdsBySpeciesKey[BiomassSpeciesKey(speciesId = herbaceousSpeciesId2)]
+        biomassSpeciesIdsBySpeciesKey[BiomassSpeciesKey(speciesId = herbaceousSpeciesId2)]!!
     val biomassHerbaceousSpeciesId3 =
         biomassSpeciesIdsBySpeciesKey[
-            BiomassSpeciesKey(scientificName = "Other herbaceous species")]
+            BiomassSpeciesKey(scientificName = "Other herbaceous species")]!!
     val biomassTreeSpeciesId1 =
         biomassSpeciesIdsBySpeciesKey[BiomassSpeciesKey(speciesId = treeSpeciesId1)]!!
     val biomassTreeSpeciesId2 =
@@ -315,6 +317,26 @@ class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
             ),
         ),
         "Biomass species table",
+    )
+
+    eventPublisher.assertEventsPublished(
+        dslContext
+            .fetch(OBSERVATION_BIOMASS_SPECIES)
+            .map { record ->
+              BiomassSpeciesCreatedEvent(
+                  biomassSpeciesId = record.id!!,
+                  commonName = record.commonName,
+                  isInvasive = record.isInvasive!!,
+                  isThreatened = record.isThreatened!!,
+                  monitoringPlotId = plotId,
+                  observationId = observationId,
+                  organizationId = organizationId,
+                  plantingSiteId = plantingSiteId,
+                  scientificName = record.scientificName,
+                  speciesId = record.speciesId,
+              )
+            }
+            .toSet()
     )
 
     assertTableEquals(

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -60,6 +60,13 @@ com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/ob
 com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventV1/position: ObservationPlotPosition
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/isInvasive: Boolean
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/isThreatened: Boolean
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add an event to track the creation of new species details for a biomass
observation. Backfill events for existing biomass observations. This will be
used to support tracking changes to biomass-specific species data.