### PR TITLE
SW-7695 Support editing biomass species

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -104,6 +104,8 @@ class Messages {
           getMessage("notification.application.submitted.app.body", organizationName),
       )
 
+  fun booleanOrNull(value: Boolean?): String? = value?.let { getMessage("boolean.$it") }
+
   fun csvBadHeader() = getMessage("csvBadHeader")
 
   fun csvRequiredFieldMissing() = getMessage("csvRequiredFieldMissing")

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -2,10 +2,13 @@ package com.terraformation.backend.tracking.api
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
+import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
 import com.terraformation.backend.util.patchNullable
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.Optional
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -19,6 +22,23 @@ data class QuadratUpdateOperationPayload(
   fun applyTo(model: EditableBiomassQuadratDetailsModel): EditableBiomassQuadratDetailsModel {
     return model.copy(
         description = description.patchNullable(model.description),
+    )
+  }
+}
+
+@JsonTypeName("BiomassSpecies")
+data class BiomassSpeciesUpdateOperationPayload(
+    val isInvasive: Boolean?,
+    val isThreatened: Boolean?,
+    @Schema(description = "ID of species to update. Either this or scientificName must be present.")
+    val speciesId: SpeciesId?,
+    @Schema(description = "Name of species to update. Either this or speciesId must be present.")
+    val scientificName: String?,
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: EditableBiomassSpeciesModel): EditableBiomassSpeciesModel {
+    return model.copy(
+        isInvasive = isInvasive ?: model.isInvasive,
+        isThreatened = isThreatened ?: model.isThreatened,
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -338,6 +338,14 @@ class ObservationsController(
     observationService.updateCompletedPlot(observationId, plotId) {
       payload.updates.forEach { element ->
         when (element) {
+          is BiomassSpeciesUpdateOperationPayload ->
+              observationStore.updateBiomassSpecies(
+                  observationId,
+                  plotId,
+                  element.speciesId,
+                  element.scientificName,
+                  element::applyTo,
+              )
           is BiomassUpdateOperationPayload ->
               observationStore.updateBiomassDetails(observationId, plotId, element::applyTo)
           is QuadratUpdateOperationPayload -> {

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -19,6 +19,9 @@ import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.tracking.model.PlantingSiteValidationFailure
 import java.time.LocalDate
 
+class BiomassSpeciesNotFoundException(val speciesId: SpeciesId?, val speciesName: String?) :
+    EntityNotFoundException("Species ${speciesId ?: speciesName} not found in observation")
+
 class CrossDeliveryReassignmentNotAllowedException(
     val plantingId: PlantingId,
     val plantingDeliveryId: DeliveryId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -423,6 +423,39 @@ data class BiomassSpeciesCreatedEventV1(
 
 typealias BiomassSpeciesCreatedEvent = BiomassSpeciesCreatedEventV1
 
+data class BiomassSpeciesUpdatedEventV1(
+    val changedFrom: Values,
+    val changedTo: Values,
+    override val biomassSpeciesId: BiomassSpeciesId,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+) : BiomassSpeciesPersistentEvent, FieldsUpdatedPersistentEvent {
+  data class Values(
+      val isInvasive: Boolean?,
+      val isThreatened: Boolean?,
+  )
+
+  override fun listUpdatedFields(messages: Messages) =
+      listOfNotNull(
+          createUpdatedField(
+              "isInvasive",
+              messages.booleanOrNull(changedFrom.isInvasive),
+              messages.booleanOrNull(changedTo.isInvasive),
+          ),
+          createUpdatedField(
+              "isThreatened",
+              messages.booleanOrNull(changedFrom.isThreatened),
+              messages.booleanOrNull(changedTo.isThreatened),
+          ),
+      )
+}
+
+typealias BiomassSpeciesUpdatedEvent = BiomassSpeciesUpdatedEventV1
+
+typealias BiomassSpeciesUpdatedEventValues = BiomassSpeciesUpdatedEventV1.Values
+
 sealed interface RecordedTreePersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableBiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableBiomassDetailsModel.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.tracking.model
 
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import org.jooq.Record
 
 data class EditableBiomassDetailsModel(
@@ -28,6 +29,22 @@ data class EditableBiomassQuadratDetailsModel(
       return with(OBSERVATION_BIOMASS_QUADRAT_DETAILS) {
         EditableBiomassQuadratDetailsModel(
             description = record[DESCRIPTION],
+        )
+      }
+    }
+  }
+}
+
+data class EditableBiomassSpeciesModel(
+    val isInvasive: Boolean,
+    val isThreatened: Boolean,
+) {
+  companion object {
+    fun of(record: Record): EditableBiomassSpeciesModel {
+      return with(OBSERVATION_BIOMASS_SPECIES) {
+        EditableBiomassSpeciesModel(
+            isInvasive = record[IS_INVASIVE]!!,
+            isThreatened = record[IS_THREATENED]!!,
         )
       }
     }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -88,6 +88,8 @@ eventSubject.BiomassQuadrat.field.description=description
 # {0} is a compass direction like "northwest"
 eventSubject.BiomassQuadrat.full={0} quadrat
 eventSubject.BiomassQuadrat.short=Quadrat
+eventSubject.BiomassSpecies.field.isInvasive=invasive
+eventSubject.BiomassSpecies.field.isThreatened=threatened
 eventSubject.BiomassSpecies.full=Species {0}
 eventSubject.BiomassSpecies.short=Species
 eventSubject.ObservationPlotMedia.field.caption=caption

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -151,6 +151,10 @@ eventSubject.BiomassQuadrat.field.description=descripción
 eventSubject.BiomassQuadrat.full=Cuadrícula {0}
 # 11b386ec
 eventSubject.BiomassQuadrat.short=Cuadrícula
+# 6bbf8163
+eventSubject.BiomassSpecies.field.isInvasive=invasora
+# 9aec946d
+eventSubject.BiomassSpecies.field.isThreatened=amenazada
 # fd7f5baf
 eventSubject.BiomassSpecies.full=Especie {0}
 # bb344d18

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -151,6 +151,10 @@ eventSubject.BiomassQuadrat.field.description=description
 eventSubject.BiomassQuadrat.full=Quadrat {0}
 # 11b386ec
 eventSubject.BiomassQuadrat.short=Quadrat
+# 6bbf8163
+eventSubject.BiomassSpecies.field.isInvasive=envahissante
+# 9aec946d
+eventSubject.BiomassSpecies.field.isThreatened=menacée
 # fd7f5baf
 eventSubject.BiomassSpecies.full=Espèce {0}
 # bb344d18

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateBiomassSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateBiomassSpeciesTest.kt
@@ -1,0 +1,96 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
+import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEvent
+import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventValues
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationStoreUpdateBiomassSpeciesTest : BaseObservationStoreTest() {
+  @BeforeEach
+  fun setUpRecordedTree() {
+    insertPlantingZone()
+    insertPlantingSubzone()
+    insertMonitoringPlot(isAdHoc = true)
+    insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
+    insertObservationPlot(completedBy = user.userId)
+    insertObservationBiomassDetails()
+    insertSpecies()
+    insertObservationBiomassSpecies(speciesId = inserted.speciesId)
+  }
+
+  @Test
+  fun `updates editable fields`() {
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_SPECIES)
+
+    store.updateBiomassSpecies(
+        inserted.observationId,
+        inserted.monitoringPlotId,
+        inserted.speciesId,
+        null,
+    ) {
+      it.copy(
+          isInvasive = true,
+          isThreatened = true,
+      )
+    }
+
+    val expected =
+        before.copy().apply {
+          isInvasive = true
+          isThreatened = true
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassSpeciesUpdatedEvent(
+            BiomassSpeciesUpdatedEventValues(isInvasive = false, isThreatened = false),
+            BiomassSpeciesUpdatedEventValues(isInvasive = true, isThreatened = true),
+            inserted.biomassSpeciesId,
+            inserted.monitoringPlotId,
+            inserted.observationId,
+            inserted.organizationId,
+            inserted.plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `does not publish event or modify database if nothing changed`() {
+    val unmodifiedTable = dslContext.fetch(OBSERVATION_BIOMASS_SPECIES)
+
+    store.updateBiomassSpecies(
+        inserted.observationId,
+        inserted.monitoringPlotId,
+        inserted.speciesId,
+        null,
+    ) {
+      it
+    }
+
+    assertTableEquals(unmodifiedTable)
+
+    eventPublisher.assertEventNotPublished<BiomassSpeciesUpdatedEvent>()
+  }
+
+  @Test
+  fun `throws exception if no permission to update observation`() {
+    every { user.canUpdateObservation(inserted.observationId) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.updateBiomassSpecies(
+          inserted.observationId,
+          inserted.monitoringPlotId,
+          inserted.speciesId,
+          null,
+      ) {
+        it.copy(isThreatened = true)
+      }
+    }
+  }
+}

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -67,6 +67,11 @@ com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/monitorin
 com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/observationId: ObservationId
 com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/biomassSpeciesId: BiomassSpeciesId
+com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add a new update type to the observation editing PATCH payload to support
updating biomass-observation-specific information about species (currently
just the flags for invasive and threatened status). Updates are also
written to the event log so they're queryable later.