### PR TITLE
Add BiomassStore for biomass observation code

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.file.mux.MuxService
 import com.terraformation.backend.file.mux.MuxStreamModel
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
+import com.terraformation.backend.tracking.db.BiomassStore
 import com.terraformation.backend.tracking.db.InvalidObservationEndDateException
 import com.terraformation.backend.tracking.db.InvalidObservationStartDateException
 import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
@@ -83,6 +84,7 @@ const val CLOCK_TOLERANCE_SECONDS: Long = 3600
 
 @Named
 class ObservationService(
+    private val biomassStore: BiomassStore,
     private val clock: InstantSource,
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
@@ -653,7 +655,7 @@ class ObservationService(
 
       observationStore.claimPlot(observationId, plotId)
 
-      biomassDetails?.let { observationStore.insertBiomassDetails(observationId, plotId, it) }
+      biomassDetails?.let { biomassStore.insertBiomassDetails(observationId, plotId, it) }
 
       observationStore.completePlot(
           observationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
@@ -1,0 +1,278 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.asNonNullable
+import com.terraformation.backend.db.attach
+import com.terraformation.backend.db.tracking.BiomassForestType
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.ObservationType
+import com.terraformation.backend.db.tracking.TreeGrowthForm
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassDetailsRecord
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratDetailsRecord
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassSpeciesRecord
+import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
+import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
+import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
+import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
+import com.terraformation.backend.tracking.model.BiomassSpeciesKey
+import com.terraformation.backend.tracking.model.NewBiomassDetailsModel
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.springframework.context.ApplicationEventPublisher
+
+@Named
+class BiomassStore(
+    private val dslContext: DSLContext,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val parentStore: ParentStore,
+) {
+  fun insertBiomassDetails(
+      observationId: ObservationId,
+      plotId: MonitoringPlotId,
+      model: NewBiomassDetailsModel,
+  ) {
+    requirePermissions { updateObservation(observationId) }
+
+    val plantingSiteId =
+        parentStore.getPlantingSiteId(plotId) ?: throw PlotNotFoundException(plotId)
+    val organizationId =
+        parentStore.getOrganizationId(plantingSiteId) ?: throw PlotNotFoundException(plotId)
+
+    val (observationType, observationState) =
+        with(OBSERVATION_PLOTS) {
+          dslContext
+              .select(
+                  observations.OBSERVATION_TYPE_ID.asNonNullable(),
+                  observations.STATE_ID.asNonNullable(),
+              )
+              .from(this)
+              .where(OBSERVATION_ID.eq(observationId))
+              .and(MONITORING_PLOT_ID.eq(plotId))
+              .fetchOne()
+              ?: throw IllegalStateException(
+                  "Plot $plotId is not part of observation $observationId"
+              )
+        }
+
+    if (observationState == ObservationState.Completed) {
+      throw IllegalStateException("Observation $observationId is already completed.")
+    }
+
+    if (observationType != ObservationType.BiomassMeasurements) {
+      throw IllegalStateException("Observation $observationId is not a biomass measurement")
+    }
+
+    model.validate()
+
+    dslContext.transaction { _ ->
+      val observationBiomassDetailsRecord =
+          ObservationBiomassDetailsRecord(
+                  observationId = observationId,
+                  monitoringPlotId = plotId,
+                  description = model.description,
+                  forestTypeId = model.forestType,
+                  smallTreesCountLow = model.smallTreeCountRange.first,
+                  smallTreesCountHigh = model.smallTreeCountRange.second,
+                  herbaceousCoverPercent = model.herbaceousCoverPercent,
+                  soilAssessment = model.soilAssessment,
+                  waterDepthCm =
+                      if (model.forestType == BiomassForestType.Mangrove) model.waterDepthCm
+                      else null,
+                  salinityPpt =
+                      if (model.forestType == BiomassForestType.Mangrove) model.salinityPpt
+                      else null,
+                  ph = if (model.forestType == BiomassForestType.Mangrove) model.ph else null,
+                  tideId = if (model.forestType == BiomassForestType.Mangrove) model.tide else null,
+                  tideTime =
+                      if (model.forestType == BiomassForestType.Mangrove) model.tideTime else null,
+              )
+              .attach(dslContext)
+
+      observationBiomassDetailsRecord.insert()
+
+      eventPublisher.publishEvent(
+          BiomassDetailsCreatedEvent(
+              description = model.description,
+              forestType = model.forestType,
+              herbaceousCoverPercent = model.herbaceousCoverPercent,
+              monitoringPlotId = plotId,
+              observationId = observationId,
+              organizationId = organizationId,
+              ph = observationBiomassDetailsRecord.ph,
+              plantingSiteId = plantingSiteId,
+              salinityPpt = observationBiomassDetailsRecord.salinityPpt,
+              smallTreesCountHigh = model.smallTreeCountRange.second,
+              smallTreesCountLow = model.smallTreeCountRange.first,
+              soilAssessment = model.soilAssessment,
+              tide = observationBiomassDetailsRecord.tideId,
+              tideTime = observationBiomassDetailsRecord.tideTime,
+              waterDepthCm = observationBiomassDetailsRecord.waterDepthCm,
+          )
+      )
+
+      model.species.forEach { speciesModel ->
+        val record =
+            ObservationBiomassSpeciesRecord(
+                    observationId = observationId,
+                    monitoringPlotId = plotId,
+                    commonName = speciesModel.commonName,
+                    isInvasive = speciesModel.isInvasive,
+                    isThreatened = speciesModel.isThreatened,
+                    scientificName = speciesModel.scientificName,
+                    speciesId = speciesModel.speciesId,
+                )
+                .attach(dslContext)
+
+        record.insert()
+
+        eventPublisher.publishEvent(
+            BiomassSpeciesCreatedEvent(
+                biomassSpeciesId = record.id!!,
+                commonName = speciesModel.commonName,
+                isInvasive = speciesModel.isInvasive,
+                isThreatened = speciesModel.isThreatened,
+                monitoringPlotId = plotId,
+                observationId = observationId,
+                organizationId = organizationId,
+                plantingSiteId = plantingSiteId,
+                scientificName = speciesModel.scientificName,
+                speciesId = speciesModel.speciesId,
+            )
+        )
+      }
+
+      val biomassSpeciesIdsBySpeciesIdentifiers =
+          with(OBSERVATION_BIOMASS_SPECIES) {
+            dslContext
+                .select(ID.asNonNullable(), SCIENTIFIC_NAME, SPECIES_ID)
+                .from(this)
+                .where(OBSERVATION_ID.eq(observationId))
+                .fetch()
+                .associate {
+                  BiomassSpeciesKey(it[SPECIES_ID], it[SCIENTIFIC_NAME]) to it[ID.asNonNullable()]
+                }
+          }
+
+      model.quadrats.forEach { (position, details) ->
+        val record =
+            ObservationBiomassQuadratDetailsRecord(
+                    observationId = observationId,
+                    monitoringPlotId = plotId,
+                    positionId = position,
+                    description = details.description,
+                )
+                .attach(dslContext)
+
+        record.insert()
+
+        eventPublisher.publishEvent(
+            BiomassQuadratCreatedEvent(
+                description = details.description,
+                monitoringPlotId = plotId,
+                observationId = observationId,
+                organizationId = organizationId,
+                plantingSiteId = plantingSiteId,
+                position = position,
+            )
+        )
+      }
+
+      val quadratSpeciesRecords =
+          model.quadrats.flatMap { (position, details) ->
+            details.species.map {
+              ObservationBiomassQuadratSpeciesRecord(
+                  observationId = observationId,
+                  monitoringPlotId = plotId,
+                  positionId = position,
+                  biomassSpeciesId =
+                      biomassSpeciesIdsBySpeciesIdentifiers[
+                          BiomassSpeciesKey(it.speciesId, it.speciesName)]
+                          ?: throw IllegalArgumentException(
+                              "Biomass species ${it.speciesName ?: "#${it.speciesId}"} not found."
+                          ),
+                  abundancePercent = it.abundancePercent,
+              )
+            }
+          }
+      dslContext.batchInsert(quadratSpeciesRecords).execute()
+
+      model.trees.forEach { treeModel ->
+        val record =
+            RecordedTreesRecord(
+                    observationId = observationId,
+                    monitoringPlotId = plotId,
+                    biomassSpeciesId =
+                        biomassSpeciesIdsBySpeciesIdentifiers[
+                            BiomassSpeciesKey(treeModel.speciesId, treeModel.speciesName)]
+                            ?: throw IllegalArgumentException(
+                                "Biomass species ${treeModel.speciesName ?: "#${treeModel.speciesId}"} not found."
+                            ),
+                    treeNumber = treeModel.treeNumber,
+                    trunkNumber = treeModel.trunkNumber,
+                    treeGrowthFormId = treeModel.treeGrowthForm,
+                    gpsCoordinates = treeModel.gpsCoordinates,
+                    isDead = treeModel.isDead,
+                    diameterAtBreastHeightCm =
+                        if (
+                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
+                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
+                        )
+                            treeModel.diameterAtBreastHeightCm
+                        else null,
+                    pointOfMeasurementM =
+                        if (
+                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
+                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
+                        )
+                            treeModel.pointOfMeasurementM
+                        else null,
+                    heightM =
+                        if (
+                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
+                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
+                        )
+                            treeModel.heightM
+                        else null,
+                    shrubDiameterCm =
+                        if (treeModel.treeGrowthForm == TreeGrowthForm.Shrub)
+                            treeModel.shrubDiameterCm
+                        else null,
+                    description = treeModel.description,
+                )
+                .attach(dslContext)
+
+        record.insert()
+
+        eventPublisher.publishEvent(
+            RecordedTreeCreatedEvent(
+                biomassSpeciesId = record.biomassSpeciesId!!,
+                description = treeModel.description,
+                diameterAtBreastHeightCm = record.diameterAtBreastHeightCm,
+                gpsCoordinates = treeModel.gpsCoordinates,
+                heightM = record.heightM,
+                isDead = treeModel.isDead,
+                monitoringPlotId = plotId,
+                observationId = observationId,
+                organizationId = organizationId,
+                plantingSiteId = plantingSiteId,
+                pointOfMeasurementM = record.pointOfMeasurementM,
+                recordedTreeId = record.id!!,
+                shrubDiameterCm = record.shrubDiameterCm,
+                speciesId = treeModel.speciesId,
+                speciesName = treeModel.speciesName,
+                treeGrowthForm = treeModel.treeGrowthForm,
+                treeNumber = treeModel.treeNumber,
+                trunkNumber = treeModel.trunkNumber,
+            )
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -5,12 +5,10 @@ import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.asNonNullable
-import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.default_schema.SpeciesIdConverter
 import com.terraformation.backend.db.default_schema.tables.references.USERS
-import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
@@ -26,7 +24,6 @@ import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertaintyConverter
 import com.terraformation.backend.db.tracking.RecordedTreeId
-import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotConditionsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
 import com.terraformation.backend.db.tracking.tables.daos.ObservationRequestedSubzonesDao
@@ -37,13 +34,8 @@ import com.terraformation.backend.db.tracking.tables.pojos.ObservationRequestedS
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationsRow
 import com.terraformation.backend.db.tracking.tables.pojos.PlantingSitesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
-import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassDetailsRecord
-import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratDetailsRecord
-import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassQuadratSpeciesRecord
-import com.terraformation.backend.db.tracking.tables.records.ObservationBiomassSpeciesRecord
 import com.terraformation.backend.db.tracking.tables.records.ObservedPlotSpeciesTotalsRecord
 import com.terraformation.backend.db.tracking.tables.records.RecordedPlantsRecord
-import com.terraformation.backend.db.tracking.tables.records.RecordedTreesRecord
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOTS
 import com.terraformation.backend.db.tracking.tables.references.MONITORING_PLOT_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
@@ -71,29 +63,24 @@ import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
-import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEvent
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventValues
-import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventValues
 import com.terraformation.backend.tracking.event.ObservationStateUpdatedEvent
-import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventValues
 import com.terraformation.backend.tracking.event.T0PlotDataAssignedEvent
 import com.terraformation.backend.tracking.event.T0ZoneDataAssignedEvent
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
-import com.terraformation.backend.tracking.model.BiomassSpeciesKey
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
-import com.terraformation.backend.tracking.model.NewBiomassDetailsModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NewObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.ObservationModel
@@ -1009,249 +996,6 @@ class ObservationStore(
           .where(ID.eq(plantingSubzoneId))
           .and(OBSERVED_TIME.isNull.or(OBSERVED_TIME.lt(observedTime)))
           .execute()
-    }
-  }
-
-  fun insertBiomassDetails(
-      observationId: ObservationId,
-      plotId: MonitoringPlotId,
-      model: NewBiomassDetailsModel,
-  ) {
-    requirePermissions { updateObservation(observationId) }
-
-    val plantingSiteId =
-        parentStore.getPlantingSiteId(plotId) ?: throw PlotNotFoundException(plotId)
-    val organizationId =
-        parentStore.getOrganizationId(plantingSiteId) ?: throw PlotNotFoundException(plotId)
-
-    val (observationType, observationState) =
-        with(OBSERVATION_PLOTS) {
-          dslContext
-              .select(
-                  observations.OBSERVATION_TYPE_ID.asNonNullable(),
-                  observations.STATE_ID.asNonNullable(),
-              )
-              .from(this)
-              .where(OBSERVATION_ID.eq(observationId))
-              .and(MONITORING_PLOT_ID.eq(plotId))
-              .fetchOne()
-              ?: throw IllegalStateException(
-                  "Plot $plotId is not part of observation $observationId"
-              )
-        }
-
-    if (observationState == ObservationState.Completed) {
-      throw IllegalStateException("Observation $observationId is already completed.")
-    }
-
-    if (observationType != ObservationType.BiomassMeasurements) {
-      throw IllegalStateException("Observation $observationId is not a biomass measurement")
-    }
-
-    model.validate()
-
-    dslContext.transaction { _ ->
-      val observationBiomassDetailsRecord =
-          ObservationBiomassDetailsRecord(
-                  observationId = observationId,
-                  monitoringPlotId = plotId,
-                  description = model.description,
-                  forestTypeId = model.forestType,
-                  smallTreesCountLow = model.smallTreeCountRange.first,
-                  smallTreesCountHigh = model.smallTreeCountRange.second,
-                  herbaceousCoverPercent = model.herbaceousCoverPercent,
-                  soilAssessment = model.soilAssessment,
-                  waterDepthCm =
-                      if (model.forestType == BiomassForestType.Mangrove) model.waterDepthCm
-                      else null,
-                  salinityPpt =
-                      if (model.forestType == BiomassForestType.Mangrove) model.salinityPpt
-                      else null,
-                  ph = if (model.forestType == BiomassForestType.Mangrove) model.ph else null,
-                  tideId = if (model.forestType == BiomassForestType.Mangrove) model.tide else null,
-                  tideTime =
-                      if (model.forestType == BiomassForestType.Mangrove) model.tideTime else null,
-              )
-              .attach(dslContext)
-
-      observationBiomassDetailsRecord.insert()
-
-      eventPublisher.publishEvent(
-          BiomassDetailsCreatedEvent(
-              description = model.description,
-              forestType = model.forestType,
-              herbaceousCoverPercent = model.herbaceousCoverPercent,
-              monitoringPlotId = plotId,
-              observationId = observationId,
-              organizationId = organizationId,
-              ph = observationBiomassDetailsRecord.ph,
-              plantingSiteId = plantingSiteId,
-              salinityPpt = observationBiomassDetailsRecord.salinityPpt,
-              smallTreesCountHigh = model.smallTreeCountRange.second,
-              smallTreesCountLow = model.smallTreeCountRange.first,
-              soilAssessment = model.soilAssessment,
-              tide = observationBiomassDetailsRecord.tideId,
-              tideTime = observationBiomassDetailsRecord.tideTime,
-              waterDepthCm = observationBiomassDetailsRecord.waterDepthCm,
-          )
-      )
-
-      model.species.forEach { speciesModel ->
-        val record =
-            ObservationBiomassSpeciesRecord(
-                    observationId = observationId,
-                    monitoringPlotId = plotId,
-                    commonName = speciesModel.commonName,
-                    isInvasive = speciesModel.isInvasive,
-                    isThreatened = speciesModel.isThreatened,
-                    scientificName = speciesModel.scientificName,
-                    speciesId = speciesModel.speciesId,
-                )
-                .attach(dslContext)
-
-        record.insert()
-
-        eventPublisher.publishEvent(
-            BiomassSpeciesCreatedEvent(
-                biomassSpeciesId = record.id!!,
-                commonName = speciesModel.commonName,
-                isInvasive = speciesModel.isInvasive,
-                isThreatened = speciesModel.isThreatened,
-                monitoringPlotId = plotId,
-                observationId = observationId,
-                organizationId = organizationId,
-                plantingSiteId = plantingSiteId,
-                scientificName = speciesModel.scientificName,
-                speciesId = speciesModel.speciesId,
-            )
-        )
-      }
-
-      val biomassSpeciesIdsBySpeciesIdentifiers =
-          with(OBSERVATION_BIOMASS_SPECIES) {
-            dslContext
-                .select(ID.asNonNullable(), SCIENTIFIC_NAME, SPECIES_ID)
-                .from(this)
-                .where(OBSERVATION_ID.eq(observationId))
-                .fetch()
-                .associate {
-                  BiomassSpeciesKey(it[SPECIES_ID], it[SCIENTIFIC_NAME]) to it[ID.asNonNullable()]
-                }
-          }
-
-      model.quadrats.forEach { (position, details) ->
-        val record =
-            ObservationBiomassQuadratDetailsRecord(
-                    observationId = observationId,
-                    monitoringPlotId = plotId,
-                    positionId = position,
-                    description = details.description,
-                )
-                .attach(dslContext)
-
-        record.insert()
-
-        eventPublisher.publishEvent(
-            BiomassQuadratCreatedEvent(
-                description = details.description,
-                monitoringPlotId = plotId,
-                observationId = observationId,
-                organizationId = organizationId,
-                plantingSiteId = plantingSiteId,
-                position = position,
-            )
-        )
-      }
-
-      val quadratSpeciesRecords =
-          model.quadrats.flatMap { (position, details) ->
-            details.species.map {
-              ObservationBiomassQuadratSpeciesRecord(
-                  observationId = observationId,
-                  monitoringPlotId = plotId,
-                  positionId = position,
-                  biomassSpeciesId =
-                      biomassSpeciesIdsBySpeciesIdentifiers[
-                          BiomassSpeciesKey(it.speciesId, it.speciesName)]
-                          ?: throw IllegalArgumentException(
-                              "Biomass species ${it.speciesName ?: "#${it.speciesId}"} not found."
-                          ),
-                  abundancePercent = it.abundancePercent,
-              )
-            }
-          }
-      dslContext.batchInsert(quadratSpeciesRecords).execute()
-
-      model.trees.forEach { treeModel ->
-        val record =
-            RecordedTreesRecord(
-                    observationId = observationId,
-                    monitoringPlotId = plotId,
-                    biomassSpeciesId =
-                        biomassSpeciesIdsBySpeciesIdentifiers[
-                            BiomassSpeciesKey(treeModel.speciesId, treeModel.speciesName)]
-                            ?: throw IllegalArgumentException(
-                                "Biomass species ${treeModel.speciesName ?: "#${treeModel.speciesId}"} not found."
-                            ),
-                    treeNumber = treeModel.treeNumber,
-                    trunkNumber = treeModel.trunkNumber,
-                    treeGrowthFormId = treeModel.treeGrowthForm,
-                    gpsCoordinates = treeModel.gpsCoordinates,
-                    isDead = treeModel.isDead,
-                    diameterAtBreastHeightCm =
-                        if (
-                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
-                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
-                        )
-                            treeModel.diameterAtBreastHeightCm
-                        else null,
-                    pointOfMeasurementM =
-                        if (
-                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
-                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
-                        )
-                            treeModel.pointOfMeasurementM
-                        else null,
-                    heightM =
-                        if (
-                            treeModel.treeGrowthForm == TreeGrowthForm.Tree ||
-                                treeModel.treeGrowthForm == TreeGrowthForm.Trunk
-                        )
-                            treeModel.heightM
-                        else null,
-                    shrubDiameterCm =
-                        if (treeModel.treeGrowthForm == TreeGrowthForm.Shrub)
-                            treeModel.shrubDiameterCm
-                        else null,
-                    description = treeModel.description,
-                )
-                .attach(dslContext)
-
-        record.insert()
-
-        eventPublisher.publishEvent(
-            RecordedTreeCreatedEvent(
-                biomassSpeciesId = record.biomassSpeciesId!!,
-                description = treeModel.description,
-                diameterAtBreastHeightCm = record.diameterAtBreastHeightCm,
-                gpsCoordinates = treeModel.gpsCoordinates,
-                heightM = record.heightM,
-                isDead = treeModel.isDead,
-                monitoringPlotId = plotId,
-                observationId = observationId,
-                organizationId = organizationId,
-                plantingSiteId = plantingSiteId,
-                pointOfMeasurementM = record.pointOfMeasurementM,
-                recordedTreeId = record.id!!,
-                shrubDiameterCm = record.shrubDiameterCm,
-                speciesId = treeModel.speciesId,
-                speciesName = treeModel.speciesName,
-                treeGrowthForm = treeModel.treeGrowthForm,
-                treeNumber = treeModel.treeNumber,
-                trunkNumber = treeModel.trunkNumber,
-            )
-        )
-      }
     }
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -60,6 +60,7 @@ import com.terraformation.backend.i18n.TimeZones
 import com.terraformation.backend.onePixelPng
 import com.terraformation.backend.point
 import com.terraformation.backend.rectangle
+import com.terraformation.backend.tracking.db.BiomassStore
 import com.terraformation.backend.tracking.db.InvalidObservationEndDateException
 import com.terraformation.backend.tracking.db.InvalidObservationStartDateException
 import com.terraformation.backend.tracking.db.ObservationAlreadyStartedException
@@ -137,6 +138,9 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     FileService(dslContext, clock, eventPublisher, filesDao, fileStore)
   }
   private val thumbnailService: ThumbnailService = mockk()
+  private val biomassStore: BiomassStore by lazy {
+    BiomassStore(dslContext, eventPublisher, parentStore)
+  }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
@@ -168,6 +172,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
   private val service: ObservationService by lazy {
     ObservationService(
+        biomassStore,
         clock,
         dslContext,
         eventPublisher,

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -65,6 +65,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
   }
   private val observationService: ObservationService by lazy {
     ObservationService(
+        mockk(),
         clock,
         dslContext,
         eventPublisher,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
@@ -1,0 +1,38 @@
+package com.terraformation.backend.tracking.db.biomassStore
+
+import com.terraformation.backend.RunsAsUser
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.OrganizationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.BiomassStore
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+
+abstract class BaseBiomassStoreTest : DatabaseTest(), RunsAsUser {
+  override val user: TerrawareUser = mockUser()
+
+  protected val eventPublisher = TestEventPublisher()
+  protected val store: BiomassStore by lazy {
+    BiomassStore(dslContext, eventPublisher, ParentStore(dslContext))
+  }
+
+  protected lateinit var organizationId: OrganizationId
+  protected lateinit var plantingSiteId: PlantingSiteId
+
+  @BeforeEach
+  fun setUp() {
+    organizationId = insertOrganization()
+    plantingSiteId = insertPlantingSite(x = 0)
+
+    every { user.canCreateObservation(any()) } returns true
+    every { user.canManageObservation(any()) } returns true
+    every { user.canReadObservation(any()) } returns true
+    every { user.canReadPlantingSite(any()) } returns true
+    every { user.canScheduleAdHocObservation(any()) } returns true
+    every { user.canUpdateObservation(any()) } returns true
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreInsertBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreInsertBiomassDetailsTest.kt
@@ -1,4 +1,4 @@
-package com.terraformation.backend.tracking.db.observationStore
+package com.terraformation.backend.tracking.db.biomassStore
 
 import com.terraformation.backend.auth.currentUser
 import com.terraformation.backend.db.tracking.BiomassForestType
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.security.access.AccessDeniedException
 
-class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
+class BiomassStoreInsertBiomassDetailsTest : BaseBiomassStoreTest() {
   private lateinit var observationId: ObservationId
   private lateinit var plotId: MonitoringPlotId
 
@@ -45,7 +45,7 @@ class ObservationStoreInsertBiomassDetailsTest : BaseObservationStoreTest() {
     plotId = insertMonitoringPlot(isAdHoc = true)
     observationId =
         insertObservation(isAdHoc = true, observationType = ObservationType.BiomassMeasurements)
-    insertObservationPlot(claimedBy = currentUser().userId, claimedTime = clock.instant)
+    insertObservationPlot(claimedBy = currentUser().userId, claimedTime = Instant.EPOCH)
   }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeOtherSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreMergeOtherSpeciesTest.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.BiomassSpeciesId
@@ -28,6 +29,7 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVED_SUBZONE
 import com.terraformation.backend.db.tracking.tables.references.OBSERVED_ZONE_SPECIES_TOTALS
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.point
+import com.terraformation.backend.tracking.db.BiomassStore
 import com.terraformation.backend.tracking.db.SpeciesInWrongOrganizationException
 import com.terraformation.backend.tracking.model.BiomassQuadratModel
 import com.terraformation.backend.tracking.model.BiomassQuadratSpeciesModel
@@ -367,7 +369,9 @@ class ObservationStoreMergeOtherSpeciesTest : BaseObservationStoreTest() {
     val speciesId1 = insertSpecies()
     val speciesId2 = insertSpecies()
 
-    store.insertBiomassDetails(
+    // Temporary during ObservationStore split
+    val biomassStore = BiomassStore(dslContext, eventPublisher, ParentStore(dslContext))
+    biomassStore.insertBiomassDetails(
         observationId,
         monitoringPlotId,
         NewBiomassDetailsModel(
@@ -592,7 +596,9 @@ class ObservationStoreMergeOtherSpeciesTest : BaseObservationStoreTest() {
     insertObservationPlot(claimedBy = user.userId, isPermanent = false)
     val speciesId = insertSpecies()
 
-    store.insertBiomassDetails(
+    // Temporary during ObservationStore split
+    val biomassStore = BiomassStore(dslContext, eventPublisher, ParentStore(dslContext))
+    biomassStore.insertBiomassDetails(
         observationId,
         monitoringPlotId,
         NewBiomassDetailsModel(


### PR DESCRIPTION
`ObservationStore` is getting unreasonably large. The functionality related to
biomass observations is largely separate from the monitoring observation logic,
so start splitting it off into its own separate class.

This initial change just moves the `insertBiomassDetails` method, but it also
lays some groundwork for later changes.