### PR TITLE
Move withLockedObservation to separate class

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
@@ -36,6 +36,7 @@ import org.springframework.context.ApplicationEventPublisher
 class BiomassStore(
     private val dslContext: DSLContext,
     private val eventPublisher: ApplicationEventPublisher,
+    private val observationLocker: ObservationLocker,
     private val parentStore: ParentStore,
 ) {
   private val log = perClassLogger()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationLocker.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationLocker.kt
@@ -1,0 +1,37 @@
+package com.terraformation.backend.tracking.db
+
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATIONS
+import com.terraformation.backend.tracking.model.ExistingObservationModel
+import com.terraformation.backend.tracking.model.ObservationModel
+import jakarta.inject.Named
+import org.jooq.DSLContext
+
+@Named
+class ObservationLocker(val dslContext: DSLContext) {
+  /**
+   * Locks an observation and calls a function. Starts a database transaction; the function is
+   * called with the transaction open, such that the lock is held while the function runs.
+   */
+  fun <T> withLockedObservation(
+      observationId: ObservationId,
+      func: (ExistingObservationModel) -> T,
+  ): T {
+    requirePermissions { updateObservation(observationId) }
+
+    return dslContext.transactionResult { _ ->
+      val model =
+          dslContext
+              .select(OBSERVATIONS.asterisk(), ObservationStore.requestedSubzoneIdsField)
+              .from(OBSERVATIONS)
+              .where(OBSERVATIONS.ID.eq(observationId))
+              .forUpdate()
+              .of(OBSERVATIONS)
+              .fetchOne { ObservationModel.of(it, ObservationStore.requestedSubzoneIdsField) }
+              ?: throw ObservationNotFoundException(observationId)
+
+      func(model)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.IdentifierGenerator
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.ObservationState
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteImporter
 import com.terraformation.backend.tracking.db.PlantingSiteStore
@@ -32,11 +33,13 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
   private val clock = TestClock()
   private val eventPublisher = TestEventPublisher()
   private val parentStore: ParentStore by lazy { ParentStore(dslContext) }
+  private val observationLocker: ObservationLocker by lazy { ObservationLocker(dslContext) }
   private val observationStore: ObservationStore by lazy {
     ObservationStore(
         clock,
         dslContext,
         eventPublisher,
+        observationLocker,
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,
@@ -73,6 +76,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         monitoringPlotsDao,
         mockk(),
         observationMediaFilesDao,
+        observationLocker,
         observationStore,
         plantingSiteStore,
         parentStore,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -65,6 +65,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
         clock,
         dslContext,
         eventPublisher,
+        ObservationLocker(dslContext),
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BaseBiomassStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.mockUser
 import com.terraformation.backend.tracking.db.BiomassStore
+import com.terraformation.backend.tracking.db.ObservationLocker
 import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 
@@ -17,7 +18,7 @@ abstract class BaseBiomassStoreTest : DatabaseTest(), RunsAsUser {
 
   protected val eventPublisher = TestEventPublisher()
   protected val store: BiomassStore by lazy {
-    BiomassStore(dslContext, eventPublisher, ParentStore(dslContext))
+    BiomassStore(dslContext, eventPublisher, ObservationLocker(dslContext), ParentStore(dslContext))
   }
 
   protected lateinit var organizationId: OrganizationId

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
@@ -9,6 +9,7 @@ import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.mockUser
+import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.ObservationTestHelper
 import io.mockk.every
@@ -24,6 +25,7 @@ abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
         clock,
         dslContext,
         eventPublisher,
+        ObservationLocker(dslContext),
         observationsDao,
         observationPlotConditionsDao,
         observationPlotsDao,


### PR DESCRIPTION
In preparation for moving some biomass-related update functions to `BiomassStore`,
split the observation locking function out into its own class that can be a
dependency of both `BiomassStore` and `ObservationStore`. Otherwise we would have
to make `BiomassStore` depend on `ObservationStore` which we try to avoid.