### PR TITLE
SW-7697 Add ObservationPlotCreatedEvent

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.eventlog.api.EventSubjectName
 import com.terraformation.backend.eventlog.api.EventSubjectPayload
 import com.terraformation.backend.eventlog.api.FieldUpdatedActionPayload
 import com.terraformation.backend.eventlog.api.ObservationPlotMediaSubjectPayload
+import com.terraformation.backend.eventlog.api.ObservationPlotSubjectPayload
 import com.terraformation.backend.eventlog.api.OrganizationSubjectPayload
 import com.terraformation.backend.eventlog.api.ProjectSubjectPayload
 import com.terraformation.backend.eventlog.api.RecordedTreeSubjectPayload
@@ -25,6 +26,7 @@ import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
+import com.terraformation.backend.tracking.event.ObservationPlotPersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
 
@@ -83,6 +85,7 @@ class EventLogPayloadTransformer(
       is BiomassSpeciesPersistentEvent -> BiomassSpeciesSubjectPayload.forEvent(event, context)
       is ObservationMediaFilePersistentEvent ->
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
+      is ObservationPlotPersistentEvent -> ObservationPlotSubjectPayload.forEvent(event, context)
       is OrganizationPersistentEvent -> OrganizationSubjectPayload.forEvent(event, context)
       is ProjectPersistentEvent -> ProjectSubjectPayload.forEvent(event, context)
       is RecordedTreePersistentEvent -> RecordedTreeSubjectPayload.forEvent(event, context)

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -29,6 +29,8 @@ import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotCreatedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotPersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import io.swagger.v3.oas.annotations.media.Schema
@@ -147,6 +149,35 @@ data class BiomassSpeciesSubjectPayload(
           shortText = context.subjectShortText<BiomassSpeciesSubjectPayload>(),
           speciesId = createEvent.speciesId,
           scientificName = createEvent.scientificName,
+      )
+    }
+  }
+}
+
+@JsonTypeName("ObservationPlot")
+data class ObservationPlotSubjectPayload(
+    override val fullText: String,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    override val shortText: String,
+) : EventSubjectPayload {
+  companion object {
+    fun forEvent(
+        event: ObservationPlotPersistentEvent,
+        context: EventLogPayloadContext,
+    ): ObservationPlotSubjectPayload {
+      val createEvent =
+          context.first<ObservationPlotCreatedEvent> {
+            it.observationId == event.observationId && it.monitoringPlotId == event.monitoringPlotId
+          }
+
+      return ObservationPlotSubjectPayload(
+          context.subjectFullText<ObservationPlotSubjectPayload>(createEvent.plotNumber),
+          event.monitoringPlotId,
+          event.observationId,
+          event.plantingSiteId,
+          context.subjectShortText<ObservationPlotSubjectPayload>(),
       )
     }
   }
@@ -317,6 +348,7 @@ enum class EventSubjectName(val eventInterface: KClass<out PersistentEvent>) {
   BiomassDetails(BiomassDetailsPersistentEvent::class),
   BiomassQuadrat(BiomassQuadratPersistentEvent::class),
   BiomassSpecies(BiomassSpeciesPersistentEvent::class),
+  ObservationPlot(ObservationPlotPersistentEvent::class),
   ObservationPlotMedia(ObservationMediaFilePersistentEvent::class),
   Organization(OrganizationPersistentEvent::class),
   Project(ProjectPersistentEvent::class),

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.BiomassSpeciesId
 import com.terraformation.backend.db.tracking.MangroveTide
+import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
@@ -302,6 +303,25 @@ data class ObservationMediaFileUploadedEventV1(
 ) : EntityCreatedPersistentEvent, ObservationMediaFilePersistentEvent
 
 typealias ObservationMediaFileUploadedEvent = ObservationMediaFileUploadedEventV1
+
+sealed interface ObservationPlotPersistentEvent : PersistentEvent {
+  val monitoringPlotId: MonitoringPlotId
+  val observationId: ObservationId
+  val organizationId: OrganizationId
+  val plantingSiteId: PlantingSiteId
+}
+
+data class ObservationPlotCreatedEventV1(
+    val isPermanent: Boolean,
+    val monitoringPlotHistoryId: MonitoringPlotHistoryId,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+    val plotNumber: Long,
+) : EntityCreatedPersistentEvent, ObservationPlotPersistentEvent
+
+typealias ObservationPlotCreatedEvent = ObservationPlotCreatedEventV1
 
 sealed interface BiomassDetailsPersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId

--- a/src/main/resources/db/migration/0400/V430__ObservationPlotCreatedEvent.sql
+++ b/src/main/resources/db/migration/0400/V430__ObservationPlotCreatedEvent.sql
@@ -1,0 +1,19 @@
+INSERT INTO event_log (created_by, created_time, event_class, payload)
+SELECT
+    op.created_by,
+    op.created_time,
+    'com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1',
+    json_object(
+        '_historical' VALUE true,
+        'isPermanent' VALUE op.is_permanent,
+        'monitoringPlotHistoryId' VALUE op.monitoring_plot_history_id,
+        'monitoringPlotId' VALUE op.monitoring_plot_id,
+        'observationId' VALUE op.observation_id,
+        'organizationId' VALUE ps.organization_id,
+        'plantingSiteId' VALUE ps.id,
+        'plotNumber' VALUE mp.plot_number
+        ABSENT ON NULL
+    )::JSONB
+FROM tracking.observation_plots op
+JOIN tracking.monitoring_plots mp ON op.monitoring_plot_id = mp.id
+JOIN tracking.planting_sites ps ON mp.planting_site_id = ps.id;

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -92,6 +92,8 @@ eventSubject.BiomassSpecies.field.isInvasive=invasive
 eventSubject.BiomassSpecies.field.isThreatened=threatened
 eventSubject.BiomassSpecies.full=Species {0}
 eventSubject.BiomassSpecies.short=Species
+eventSubject.ObservationPlot.full=Plot {0}
+eventSubject.ObservationPlot.short=Plot
 eventSubject.ObservationPlotMedia.field.caption=caption
 # {0} is media kind, {1} is file ID
 eventSubject.ObservationPlotMedia.full={0} {1}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -159,6 +159,10 @@ eventSubject.BiomassSpecies.field.isThreatened=amenazada
 eventSubject.BiomassSpecies.full=Especie {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Especie
+# 552268c9
+eventSubject.ObservationPlot.full=Cuadrícula {0}
+# 8d3cefee
+eventSubject.ObservationPlot.short=Cuadrícula
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=leyenda
 # 0ff64395

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -159,6 +159,10 @@ eventSubject.BiomassSpecies.field.isThreatened=menacée
 eventSubject.BiomassSpecies.full=Espèce {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Espèce
+# 552268c9
+eventSubject.ObservationPlot.full=Parcelle {0}
+# 8d3cefee
+eventSubject.ObservationPlot.short=Parcelle
 # 440368c7
 eventSubject.ObservationPlotMedia.field.caption=légende
 # 0ff64395

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -156,6 +156,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        parentStore,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {
@@ -287,8 +288,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
           "Observation state",
       )
 
-      eventPublisher.assertExactEventsPublished(
-          setOf(ObservationStartedEvent(observationStore.fetchObservationById(observationId)))
+      eventPublisher.assertEventPublished(
+          ObservationStartedEvent(observationStore.fetchObservationById(observationId))
       )
     }
 
@@ -434,8 +435,8 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
             "Observation state",
         )
 
-        eventPublisher.assertExactEventsPublished(
-            setOf(ObservationStartedEvent(observationStore.fetchObservationById(observationId)))
+        eventPublisher.assertEventPublished(
+            ObservationStartedEvent(observationStore.fetchObservationById(observationId))
         )
 
         when (numPermanentPlotsInSubzone1) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -44,6 +44,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        parentStore,
     )
   }
   private val plantingSiteStore: PlantingSiteStore by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -4,6 +4,7 @@ import com.opencsv.CSVReader
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -69,6 +70,7 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        ParentStore(dslContext),
     )
   }
   protected val resultsStore by lazy { ObservationResultsStore(dslContext) }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/BaseObservationStoreTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db.observationStore
 import com.terraformation.backend.RunsAsUser
 import com.terraformation.backend.TestClock
 import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
 import com.terraformation.backend.customer.model.TerrawareUser
 import com.terraformation.backend.db.DatabaseTest
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -29,6 +30,7 @@ abstract class BaseObservationStoreTest : DatabaseTest(), RunsAsUser {
         observationPlotConditionsDao,
         observationPlotsDao,
         observationRequestedSubzonesDao,
+        ParentStore(dslContext),
     )
   }
   protected val helper: ObservationTestHelper by lazy {

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreAddAdHocPlotToObservationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreAddAdHocPlotToObservationTest.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.db.observationStore
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.embeddables.pojos.ObservationPlotId
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationPlotsRow
+import com.terraformation.backend.tracking.event.ObservationPlotCreatedEvent
 import io.mockk.every
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -35,6 +36,18 @@ class ObservationStoreAddAdHocPlotToObservationTest : BaseObservationStoreTest()
             .fetchByObservationPlotId(ObservationPlotId(observationId, plotId))
             .single(),
         "Observation plot row",
+    )
+
+    eventPublisher.assertEventPublished(
+        ObservationPlotCreatedEvent(
+            isPermanent = false,
+            monitoringPlotHistoryId = inserted.monitoringPlotHistoryId,
+            monitoringPlotId = plotId,
+            observationId = observationId,
+            organizationId = organizationId,
+            plantingSiteId = plantingSiteId,
+            plotNumber = 1,
+        ),
     )
   }
 

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -105,6 +105,14 @@ com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/ob
 com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEventV1/type: ObservationMediaType
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/isPermanent: Boolean
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/monitoringPlotHistoryId: MonitoringPlotHistoryId
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/observedTime: Instant
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/plotNumber: Long
 
 #
 # Please add new entries in alphabetical (case-sensitive ASCII) order.


### PR DESCRIPTION
Add an event to track monitoring plots being added to observations, and backfill
it for all the existing observation plots. The event includes the plot number,
which is used when rendering the full-text name in event log query results.