### PR TITLE
Name plot coordinate update method more precisely

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -374,7 +374,7 @@ class ObservationsController(
   ): SimpleSuccessResponsePayload {
     val coordinateModels = payload.coordinates.map { it.toModel() }
 
-    observationStore.updatePlotObservation(observationId, plotId, coordinateModels)
+    observationStore.updateObservedPlotCoordinates(observationId, plotId, coordinateModels)
 
     return SimpleSuccessResponsePayload()
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1092,7 +1092,7 @@ class ObservationStore(
         .fetchOne(DSL.max(OBSERVATIONS.COMPLETED_TIME))
   }
 
-  fun updatePlotObservation(
+  fun updateObservedPlotCoordinates(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,
       coordinates: List<NewObservedPlotCoordinatesModel>,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservedPlotCoordinatesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservedPlotCoordinatesTest.kt
@@ -6,7 +6,7 @@ import com.terraformation.backend.tracking.model.NewObservedPlotCoordinatesModel
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class ObservationStoreUpdatePlotObservationTest : BaseObservationStoreTest() {
+class ObservationStoreUpdateObservedPlotCoordinatesTest : BaseObservationStoreTest() {
   @Test
   fun `can add and remove observed coordinates`() {
     insertPlantingZone()
@@ -19,7 +19,7 @@ class ObservationStoreUpdatePlotObservationTest : BaseObservationStoreTest() {
         position = ObservationPlotPosition.NorthwestCorner,
     )
 
-    store.updatePlotObservation(
+    store.updateObservedPlotCoordinates(
         inserted.observationId,
         inserted.monitoringPlotId,
         listOf(


### PR DESCRIPTION
Rename `ObservationStore.updatePlotObservation` to be more descriptive of the fact
that it actually edits the observed coordinates of a plot.