### PR TITLE
SW-7695 Support editing plot field notes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
+import com.terraformation.backend.tracking.model.EditableObservationPlotDetailsModel
 import com.terraformation.backend.util.patchNullable
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.Optional
@@ -52,6 +53,17 @@ data class BiomassUpdateOperationPayload(
     return model.copy(
         description = description.patchNullable(model.description),
         soilAssessment = soilAssessment ?: model.soilAssessment,
+    )
+  }
+}
+
+@JsonTypeName("ObservationPlot")
+data class ObservationPlotUpdateOperationPayload(
+    val notes: Optional<String>?,
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: EditableObservationPlotDetailsModel): EditableObservationPlotDetailsModel {
+    return model.copy(
+        notes = notes.patchNullable(model.notes),
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -350,6 +350,8 @@ class ObservationsController(
               )
           is BiomassUpdateOperationPayload ->
               biomassStore.updateBiomassDetails(observationId, plotId, element::applyTo)
+          is ObservationPlotUpdateOperationPayload ->
+              observationStore.updateObservationPlotDetails(observationId, plotId, element::applyTo)
           is QuadratUpdateOperationPayload -> {
             biomassStore.updateBiomassQuadratDetails(
                 observationId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -323,6 +323,28 @@ data class ObservationPlotCreatedEventV1(
 
 typealias ObservationPlotCreatedEvent = ObservationPlotCreatedEventV1
 
+data class ObservationPlotEditedEventV1(
+    val changedFrom: Values,
+    val changedTo: Values,
+    override val monitoringPlotId: MonitoringPlotId,
+    override val observationId: ObservationId,
+    override val organizationId: OrganizationId,
+    override val plantingSiteId: PlantingSiteId,
+) : FieldsUpdatedPersistentEvent, ObservationPlotPersistentEvent {
+  data class Values(
+      val notes: String?,
+  )
+
+  override fun listUpdatedFields(messages: Messages) =
+      listOfNotNull(
+          createUpdatedField("notes", changedFrom.notes, changedTo.notes),
+      )
+}
+
+typealias ObservationPlotEditedEvent = ObservationPlotEditedEventV1
+
+typealias ObservationPlotEditedEventValues = ObservationPlotEditedEventV1.Values
+
 sealed interface BiomassDetailsPersistentEvent : PersistentEvent {
   val monitoringPlotId: MonitoringPlotId
   val observationId: ObservationId

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
@@ -3,6 +3,9 @@ package com.terraformation.backend.tracking.model
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
+import com.terraformation.backend.util.nullIfEquals
 import org.jooq.Record
 
 data class EditableBiomassDetailsModel(
@@ -45,6 +48,25 @@ data class EditableBiomassSpeciesModel(
         EditableBiomassSpeciesModel(
             isInvasive = record[IS_INVASIVE]!!,
             isThreatened = record[IS_THREATENED]!!,
+        )
+      }
+    }
+  }
+}
+
+data class EditableObservationPlotDetailsModel(
+    val notes: String?,
+) {
+  fun toEventValues(other: EditableObservationPlotDetailsModel) =
+      ObservationPlotEditedEventValues(
+          notes = notes.nullIfEquals(other.notes),
+      )
+
+  companion object {
+    fun of(record: Record): EditableObservationPlotDetailsModel {
+      return with(OBSERVATION_PLOTS) {
+        EditableObservationPlotDetailsModel(
+            notes = record[NOTES],
         )
       }
     }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -92,6 +92,7 @@ eventSubject.BiomassSpecies.field.isInvasive=invasive
 eventSubject.BiomassSpecies.field.isThreatened=threatened
 eventSubject.BiomassSpecies.full=Species {0}
 eventSubject.BiomassSpecies.short=Species
+eventSubject.ObservationPlot.field.notes=field notes
 eventSubject.ObservationPlot.full=Plot {0}
 eventSubject.ObservationPlot.short=Plot
 eventSubject.ObservationPlotMedia.field.caption=caption

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -159,6 +159,8 @@ eventSubject.BiomassSpecies.field.isThreatened=amenazada
 eventSubject.BiomassSpecies.full=Especie {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Especie
+# c0427d5c
+eventSubject.ObservationPlot.field.notes=notas de campo
 # 552268c9
 eventSubject.ObservationPlot.full=Cuadrícula {0}
 # 8d3cefee

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -159,6 +159,8 @@ eventSubject.BiomassSpecies.field.isThreatened=menacée
 eventSubject.BiomassSpecies.full=Espèce {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Espèce
+# c0427d5c
+eventSubject.ObservationPlot.field.notes=notes de terrain
 # 552268c9
 eventSubject.ObservationPlot.full=Parcelle {0}
 # 8d3cefee

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservationPlotDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservationPlotDetailsTest.kt
@@ -1,0 +1,64 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.tracking.db.PlotNotCompletedException
+import com.terraformation.backend.tracking.event.ObservationPlotEditedEvent
+import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.security.access.AccessDeniedException
+
+class ObservationStoreUpdateObservationPlotDetailsTest : BaseObservationStoreTest() {
+  @Test
+  fun `updates editable fields and publishes event`() {
+    val observationId = insertObservation()
+    val monitoringPlotId = insertMonitoringPlot()
+    insertObservationPlot(completedBy = user.userId)
+
+    val before = dslContext.fetchSingle(OBSERVATION_PLOTS)
+
+    store.updateObservationPlotDetails(observationId, monitoringPlotId) {
+      it.copy(notes = "New notes")
+    }
+
+    val expected = before.copy().apply { notes = "New notes" }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        ObservationPlotEditedEvent(
+            changedFrom = ObservationPlotEditedEventValues(notes = null),
+            changedTo = ObservationPlotEditedEventValues(notes = "New notes"),
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            organizationId = organizationId,
+            plantingSiteId = plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `throws exception if plot is not completed yet`() {
+    val observationId = insertObservation()
+    val monitoringPlotId = insertMonitoringPlot()
+    insertObservationPlot()
+
+    assertThrows<PlotNotCompletedException> {
+      store.updateObservationPlotDetails(observationId, monitoringPlotId) { it }
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to update observation`() {
+    val observationId = insertObservation()
+    val monitoringPlotId = insertMonitoringPlot()
+    insertObservationPlot()
+
+    every { user.canUpdateObservation(observationId) } returns false
+
+    assertThrows<AccessDeniedException> {
+      store.updateObservationPlotDetails(observationId, monitoringPlotId) { it }
+    }
+  }
+}

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -113,6 +113,10 @@ com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/observed
 com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.ObservationPlotCreatedEventV1/plotNumber: Long
+com.terraformation.backend.tracking.event.ObservationPlotEditedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.ObservationPlotEditedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.ObservationPlotEditedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.ObservationPlotEditedEventV1/plantingSiteId: PlantingSiteId
 
 #
 # Please add new entries in alphabetical (case-sensitive ASCII) order.


### PR DESCRIPTION
Add a new updated type to the observation editing PATCH payload to support
updating the field notes of a completed observation. The notes are editable
on both biomass and plant-monitoring observations.