### PR TITLE
SW-7695 Move recorded tree update to PATCH endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.db.default_schema.SpeciesId
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
 import com.terraformation.backend.tracking.model.EditableObservationPlotDetailsModel
+import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.util.patchNullable
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.Optional
@@ -65,5 +67,15 @@ data class ObservationPlotUpdateOperationPayload(
     return model.copy(
         notes = notes.patchNullable(model.notes),
     )
+  }
+}
+
+@JsonTypeName("RecordedTree")
+data class RecordedTreeUpdateOperationPayload(
+    val description: Optional<String>?,
+    @Schema(description = "ID of tree to update.") val recordedTreeId: RecordedTreeId,
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: ExistingRecordedTreeModel): ExistingRecordedTreeModel {
+    return model.copy(description = description.patchNullable(model.description))
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -34,7 +34,6 @@ import com.terraformation.backend.db.tracking.PlantingSubzoneId
 import com.terraformation.backend.db.tracking.RecordedPlantId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
-import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.tables.pojos.ObservationMediaFilesRow
 import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
 import com.terraformation.backend.file.SUPPORTED_MEDIA_TYPES
@@ -50,7 +49,6 @@ import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.ExistingPlantingSiteModel
-import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.tracking.model.NewObservationModel
 import com.terraformation.backend.tracking.model.NewObservedPlotCoordinatesModel
 import com.terraformation.backend.tracking.model.ObservationPlotCounts
@@ -360,6 +358,12 @@ class ObservationsController(
                 element::applyTo,
             )
           }
+          is RecordedTreeUpdateOperationPayload ->
+              biomassStore.updateRecordedTree(
+                  observationId,
+                  element.recordedTreeId,
+                  element::applyTo,
+              )
         }
       }
     }
@@ -377,19 +381,6 @@ class ObservationsController(
     val coordinateModels = payload.coordinates.map { it.toModel() }
 
     observationStore.updateObservedPlotCoordinates(observationId, plotId, coordinateModels)
-
-    return SimpleSuccessResponsePayload()
-  }
-
-  @ApiResponseSimpleSuccess
-  @Operation(summary = "Updates information about a recorded tree from a biomass observation.")
-  @PutMapping("/{observationId}/trees/{treeId}")
-  fun updateRecordedTree(
-      @PathVariable observationId: ObservationId,
-      @PathVariable treeId: RecordedTreeId,
-      @RequestBody payload: UpdateRecordedTreeRequestPayload,
-  ): SimpleSuccessResponsePayload {
-    biomassStore.updateRecordedTree(observationId, treeId, payload::applyTo)
 
     return SimpleSuccessResponsePayload()
   }
@@ -1096,14 +1087,6 @@ data class UpdatePlotPhotoRequestPayload(
     val caption: String?,
 ) {
   fun applyTo(row: ObservationMediaFilesRow) = row.copy(caption = caption)
-}
-
-data class UpdateRecordedTreeRequestPayload(
-    val description: String?,
-) {
-  fun applyTo(model: ExistingRecordedTreeModel): ExistingRecordedTreeModel {
-    return model.copy(description = description)
-  }
 }
 
 data class UploadPlotMediaRequestPayload(


### PR DESCRIPTION
Initially we were going to add separate API endpoints for updating each of the
kinds of observation data we need to be able to edit, but we switched to using
a single endpoint that can accept a list of changes. Add support for editing
recorded tree descriptions to the new endpoint and remove the old one, which
nothing is calling yet on the client side.