### PR TITLE
Include default field search type in OpenAPI schema

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchPayloads.kt
@@ -166,7 +166,7 @@ data class FieldNodePayload(
     )
     @NotEmpty
     val values: List<String?>,
-    val type: SearchFilterType = SearchFilterType.Exact,
+    @Schema(defaultValue = "Exact") val type: SearchFilterType = SearchFilterType.Exact,
 ) : SearchNodePayload {
   override fun toSearchNode(prefix: SearchFieldPrefix): SearchNode {
     return FieldNode(prefix.resolve(field), values, type)


### PR DESCRIPTION
There is a default vaule for the matching type in search API requests, but the
default wasn't reflected in the OpenAPI schema.