### PR TITLE
SW-7695 Support editing observed plot conditions

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -564,6 +564,11 @@ class Messages {
         SupportRequestType.FeatureRequest -> getMessage("support.requestType.featureRequest")
       }
 
+  fun <T : LocalizableEnum<*>> sortedEnumList(values: Collection<T>): String {
+    val locale = currentLocale()
+    return values.map { it.getDisplayName(locale) }.sorted().joinToString(listDelimiter())
+  }
+
   /**
    * Returns the string that should be used to separate items in a list. This is hardwired in the
    * code rather than in a message bundle because Phrase seems to not send strings to translators if

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -3,6 +3,7 @@ package com.terraformation.backend.tracking.api
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
@@ -61,10 +62,12 @@ data class BiomassUpdateOperationPayload(
 
 @JsonTypeName("ObservationPlot")
 data class ObservationPlotUpdateOperationPayload(
+    val conditions: Set<ObservableCondition>?,
     val notes: Optional<String>?,
 ) : ObservationUpdateOperationPayload {
   fun applyTo(model: EditableObservationPlotDetailsModel): EditableObservationPlotDetailsModel {
     return model.copy(
+        conditions = conditions ?: model.conditions,
         notes = notes.patchNullable(model.notes),
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -8,6 +8,7 @@ import com.terraformation.backend.db.tracking.BiomassSpeciesId
 import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
 import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationMediaType
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
@@ -332,11 +333,17 @@ data class ObservationPlotEditedEventV1(
     override val plantingSiteId: PlantingSiteId,
 ) : FieldsUpdatedPersistentEvent, ObservationPlotPersistentEvent {
   data class Values(
+      val conditions: Set<ObservableCondition>?,
       val notes: String?,
   )
 
   override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(
+          createUpdatedField(
+              "conditions",
+              changedFrom.conditions?.let { messages.sortedEnumList(it) },
+              changedTo.conditions?.let { messages.sortedEnumList(it) },
+          ),
           createUpdatedField("notes", changedFrom.notes, changedTo.notes),
       )
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
@@ -1,11 +1,13 @@
 package com.terraformation.backend.tracking.model
 
+import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
 import com.terraformation.backend.util.nullIfEquals
+import org.jooq.Field
 import org.jooq.Record
 
 data class EditableBiomassDetailsModel(
@@ -55,17 +57,23 @@ data class EditableBiomassSpeciesModel(
 }
 
 data class EditableObservationPlotDetailsModel(
+    val conditions: Set<ObservableCondition>,
     val notes: String?,
 ) {
   fun toEventValues(other: EditableObservationPlotDetailsModel) =
       ObservationPlotEditedEventValues(
+          conditions = conditions.nullIfEquals(other.conditions),
           notes = notes.nullIfEquals(other.notes),
       )
 
   companion object {
-    fun of(record: Record): EditableObservationPlotDetailsModel {
+    fun of(
+        record: Record,
+        conditionsField: Field<Set<ObservableCondition>?>,
+    ): EditableObservationPlotDetailsModel {
       return with(OBSERVATION_PLOTS) {
         EditableObservationPlotDetailsModel(
+            conditions = record[conditionsField] ?: emptySet(),
             notes = record[NOTES],
         )
       }

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -92,6 +92,7 @@ eventSubject.BiomassSpecies.field.isInvasive=invasive
 eventSubject.BiomassSpecies.field.isThreatened=threatened
 eventSubject.BiomassSpecies.full=Species {0}
 eventSubject.BiomassSpecies.short=Species
+eventSubject.ObservationPlot.field.conditions=plot conditions
 eventSubject.ObservationPlot.field.notes=field notes
 eventSubject.ObservationPlot.full=Plot {0}
 eventSubject.ObservationPlot.short=Plot

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -159,6 +159,8 @@ eventSubject.BiomassSpecies.field.isThreatened=amenazada
 eventSubject.BiomassSpecies.full=Especie {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Especie
+# a87ad7da
+eventSubject.ObservationPlot.field.conditions=condiciones de la parcela
 # c0427d5c
 eventSubject.ObservationPlot.field.notes=notas de campo
 # 552268c9

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -159,6 +159,8 @@ eventSubject.BiomassSpecies.field.isThreatened=menacée
 eventSubject.BiomassSpecies.full=Espèce {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Espèce
+# a87ad7da
+eventSubject.ObservationPlot.field.conditions=conditions de la parcelle
 # c0427d5c
 eventSubject.ObservationPlot.field.notes=notes de terrain
 # 552268c9

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservationPlotDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateObservationPlotDetailsTest.kt
@@ -1,6 +1,9 @@
 package com.terraformation.backend.tracking.db.observationStore
 
+import com.terraformation.backend.db.tracking.ObservableCondition
+import com.terraformation.backend.db.tracking.tables.records.ObservationPlotConditionsRecord
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOT_CONDITIONS
 import com.terraformation.backend.tracking.db.PlotNotCompletedException
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
@@ -15,21 +18,68 @@ class ObservationStoreUpdateObservationPlotDetailsTest : BaseObservationStoreTes
     val observationId = insertObservation()
     val monitoringPlotId = insertMonitoringPlot()
     insertObservationPlot(completedBy = user.userId)
+    insertObservationPlotCondition(condition = ObservableCondition.AnimalDamage)
+    insertObservationPlotCondition(condition = ObservableCondition.SeedProduction)
 
-    val before = dslContext.fetchSingle(OBSERVATION_PLOTS)
+    val plotsBefore = dslContext.fetchSingle(OBSERVATION_PLOTS)
+
+    val oldConditions = setOf(ObservableCondition.AnimalDamage, ObservableCondition.SeedProduction)
+    val newConditions = setOf(ObservableCondition.Fire, ObservableCondition.SeedProduction)
+
+    store.updateObservationPlotDetails(observationId, monitoringPlotId) {
+      it.copy(
+          conditions = newConditions,
+          notes = "New notes",
+      )
+    }
+
+    val plotsExpected = plotsBefore.copy().apply { notes = "New notes" }
+
+    assertTableEquals(plotsExpected)
+    assertTableEquals(
+        newConditions
+            .map { ObservationPlotConditionsRecord(observationId, monitoringPlotId, it) }
+            .toSet()
+    )
+
+    eventPublisher.assertEventPublished(
+        ObservationPlotEditedEvent(
+            changedFrom =
+                ObservationPlotEditedEventValues(conditions = oldConditions, notes = null),
+            changedTo =
+                ObservationPlotEditedEventValues(conditions = newConditions, notes = "New notes"),
+            monitoringPlotId = monitoringPlotId,
+            observationId = observationId,
+            organizationId = organizationId,
+            plantingSiteId = plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `leaves conditions alone if not changed`() {
+    val observationId = insertObservation()
+    val monitoringPlotId = insertMonitoringPlot()
+    insertObservationPlot(completedBy = user.userId)
+    insertObservationPlotCondition(condition = ObservableCondition.AnimalDamage)
+    insertObservationPlotCondition(condition = ObservableCondition.SeedProduction)
+
+    val conditionsBefore = dslContext.fetch(OBSERVATION_PLOT_CONDITIONS)
+    val plotsBefore = dslContext.fetchSingle(OBSERVATION_PLOTS)
 
     store.updateObservationPlotDetails(observationId, monitoringPlotId) {
       it.copy(notes = "New notes")
     }
 
-    val expected = before.copy().apply { notes = "New notes" }
+    val plotsExpected = plotsBefore.copy().apply { notes = "New notes" }
 
-    assertTableEquals(expected)
+    assertTableEquals(plotsExpected)
+    assertTableEquals(conditionsBefore)
 
     eventPublisher.assertEventPublished(
         ObservationPlotEditedEvent(
-            changedFrom = ObservationPlotEditedEventValues(notes = null),
-            changedTo = ObservationPlotEditedEventValues(notes = "New notes"),
+            changedFrom = ObservationPlotEditedEventValues(conditions = null, notes = null),
+            changedTo = ObservationPlotEditedEventValues(conditions = null, notes = "New notes"),
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,
             organizationId = organizationId,


### PR DESCRIPTION
Add a property to the PATCH payload for editing observation plots to let clients
edit the list of observed plot conditions. Render the list of conditions in
the event log API, sorted by their localized versions.