### PR TITLE
Move updated event values calculations to edit models

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
@@ -27,16 +27,12 @@ import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.tracking.event.BiomassDetailsCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEvent
-import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassQuadratCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEvent
-import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEvent
-import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventValues
 import com.terraformation.backend.tracking.event.RecordedTreeCreatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEvent
-import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventValues
 import com.terraformation.backend.tracking.model.BiomassSpeciesKey
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
@@ -44,7 +40,6 @@ import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
 import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.tracking.model.NewBiomassDetailsModel
 import com.terraformation.backend.tracking.model.RecordedTreeModel
-import com.terraformation.backend.util.nullIfEquals
 import jakarta.inject.Named
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
@@ -475,16 +470,8 @@ class BiomassStore(
 
       val updated = updateFunc(existing)
 
-      val changedFrom =
-          BiomassDetailsUpdatedEventValues(
-              description = existing.description.nullIfEquals(updated.description),
-              soilAssessment = existing.soilAssessment.nullIfEquals(updated.soilAssessment),
-          )
-      val changedTo =
-          BiomassDetailsUpdatedEventValues(
-              description = updated.description.nullIfEquals(existing.description),
-              soilAssessment = updated.soilAssessment.nullIfEquals(existing.soilAssessment),
-          )
+      val changedFrom = existing.toEventValues(updated)
+      val changedTo = updated.toEventValues(existing)
 
       if (changedFrom != changedTo) {
         with(OBSERVATION_BIOMASS_DETAILS) {
@@ -563,14 +550,8 @@ class BiomassStore(
       val existing = EditableBiomassSpeciesModel.of(biomassSpeciesRecord)
       val updated = updateFunc(existing)
 
-      fun eventValues(ours: EditableBiomassSpeciesModel, theirs: EditableBiomassSpeciesModel) =
-          BiomassSpeciesUpdatedEventValues(
-              isInvasive = ours.isInvasive.nullIfEquals(theirs.isInvasive),
-              isThreatened = ours.isThreatened.nullIfEquals(theirs.isThreatened),
-          )
-
-      val changedFrom = eventValues(existing, updated)
-      val changedTo = eventValues(updated, existing)
+      val changedFrom = existing.toEventValues(updated)
+      val changedTo = updated.toEventValues(existing)
 
       if (changedFrom != changedTo) {
         with(OBSERVATION_BIOMASS_SPECIES) {
@@ -627,14 +608,8 @@ class BiomassStore(
       val editable = existing ?: EditableBiomassQuadratDetailsModel()
       val updated = updateFunc(editable)
 
-      val changedFrom =
-          BiomassQuadratDetailsUpdatedEventValues(
-              description = editable.description.nullIfEquals(updated.description),
-          )
-      val changedTo =
-          BiomassQuadratDetailsUpdatedEventValues(
-              description = updated.description.nullIfEquals(editable.description),
-          )
+      val changedFrom = editable.toEventValues(updated)
+      val changedTo = updated.toEventValues(editable)
 
       if (changedFrom != changedTo) {
         with(OBSERVATION_BIOMASS_QUADRAT_DETAILS) {
@@ -694,14 +669,8 @@ class BiomassStore(
       val existing = fetchRecordedTree(observationId, recordedTreeId)
       val updated = updateFunc(existing)
 
-      val changedFrom =
-          RecordedTreeUpdatedEventValues(
-              description = existing.description.nullIfEquals(updated.description),
-          )
-      val changedTo =
-          RecordedTreeUpdatedEventValues(
-              description = updated.description.nullIfEquals(existing.description),
-          )
+      val changedFrom = existing.toEventValues(updated)
+      val changedTo = updated.toEventValues(existing)
 
       if (changedFrom != changedTo) {
         with(RECORDED_TREES) {

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -9,6 +9,8 @@ import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.db.tracking.TreeGrowthForm
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
+import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventValues
+import com.terraformation.backend.util.nullIfEquals
 import java.math.BigDecimal
 import java.time.Instant
 import org.jooq.Field
@@ -55,6 +57,11 @@ data class RecordedTreeModel<TreeId : RecordedTreeId?>(
     val treeNumber: Int,
     val trunkNumber: Int,
 ) {
+  fun toEventValues(other: RecordedTreeModel<*>) =
+      RecordedTreeUpdatedEventValues(
+          description = description.nullIfEquals(other.description),
+      )
+
   fun validate() {
     if (speciesId == null && speciesName == null) {
       throw IllegalStateException("Tree $treeNumber: speciesId or speciesName missing")

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
@@ -5,6 +5,9 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOM
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_DETAILS
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventValues
+import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventValues
+import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventValues
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
 import com.terraformation.backend.util.nullIfEquals
 import org.jooq.Field
@@ -14,6 +17,12 @@ data class EditableBiomassDetailsModel(
     val description: String?,
     val soilAssessment: String,
 ) {
+  fun toEventValues(other: EditableBiomassDetailsModel) =
+      BiomassDetailsUpdatedEventValues(
+          description = description.nullIfEquals(other.description),
+          soilAssessment = soilAssessment.nullIfEquals(other.soilAssessment),
+      )
+
   companion object {
     fun of(record: Record): EditableBiomassDetailsModel {
       return with(OBSERVATION_BIOMASS_DETAILS) {
@@ -29,6 +38,11 @@ data class EditableBiomassDetailsModel(
 data class EditableBiomassQuadratDetailsModel(
     val description: String? = null,
 ) {
+  fun toEventValues(other: EditableBiomassQuadratDetailsModel) =
+      BiomassQuadratDetailsUpdatedEventValues(
+          description = description.nullIfEquals(other.description),
+      )
+
   companion object {
     fun of(record: Record): EditableBiomassQuadratDetailsModel {
       return with(OBSERVATION_BIOMASS_QUADRAT_DETAILS) {
@@ -44,6 +58,12 @@ data class EditableBiomassSpeciesModel(
     val isInvasive: Boolean,
     val isThreatened: Boolean,
 ) {
+  fun toEventValues(other: EditableBiomassSpeciesModel) =
+      BiomassSpeciesUpdatedEventValues(
+          isInvasive = isInvasive.nullIfEquals(other.isInvasive),
+          isThreatened = isThreatened.nullIfEquals(other.isThreatened),
+      )
+
   companion object {
     fun of(record: Record): EditableBiomassSpeciesModel {
       return with(OBSERVATION_BIOMASS_SPECIES) {


### PR DESCRIPTION
Reduce some clutter in `ObservationStore` and `BiomassStore` by moving the
calculation of the `changedFrom` and `changedTo` values of the various
fields-updated events into the model classes that edits are applied to.