### PR TITLE
SW-7782 Support updating numeric recorded tree values

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -22,6 +22,7 @@ import com.terraformation.backend.support.atlassian.model.SupportRequestType
 import com.terraformation.backend.util.equalsIgnoreScale
 import jakarta.inject.Named
 import java.math.BigDecimal
+import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -264,6 +265,12 @@ class Messages {
   fun monitoringPlotTypePermanent() = getMessage("monitoringPlotTypePermanent")
 
   fun monitoringPlotTypeTemporary() = getMessage("monitoringPlotTypeTemporary")
+
+  fun numericValueOrNull(value: BigDecimal?) = value?.let { decimalFormat().format(it) }
+
+  fun numericValueOrNull(value: Int?) = value?.let { decimalFormat().format(it) }
+
+  fun numericValueOrNull(value: Long?) = value?.let { decimalFormat().format(it) }
 
   fun speciesCsvColumnName(position: Int) = getMessage("speciesCsvColumnName.$position")
 
@@ -670,6 +677,9 @@ class Messages {
 
   private fun eventSubjectPrefix(kClass: KClass<*>) =
       "eventSubject.${kClass.findAnnotation<JsonTypeName>()!!.value}"
+
+  private fun decimalFormat(): DecimalFormat =
+      NumberFormat.getNumberInstance(currentLocale()) as DecimalFormat
 
   private val validAccessionStates
     get() = getEnumValuesList(AccessionState.entries.filter { it.isV2Compatible })

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.tracking.model.EditableObservationPlotDetailsM
 import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.util.patchNullable
 import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
 import java.util.Optional
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -76,9 +77,26 @@ data class ObservationPlotUpdateOperationPayload(
 @JsonTypeName("RecordedTree")
 data class RecordedTreeUpdateOperationPayload(
     val description: Optional<String>?,
-    @Schema(description = "ID of tree to update.") val recordedTreeId: RecordedTreeId,
+    @Schema(description = "Only valid for Tree and Trunk growth forms.") //
+    val diameterAtBreastHeight: BigDecimal?,
+    @Schema(description = "Only valid for Tree and Trunk growth forms.") //
+    val height: BigDecimal?,
+    val isDead: Boolean?,
+    @Schema(description = "ID of tree to update.") //
+    val recordedTreeId: RecordedTreeId,
+    @Schema(description = "Only valid for Tree and Trunk growth forms.") //
+    val pointOfMeasurement: BigDecimal?,
+    @Schema(description = "Only valid for Shrub growth form.") //
+    val shrubDiameter: Int?,
 ) : ObservationUpdateOperationPayload {
   fun applyTo(model: ExistingRecordedTreeModel): ExistingRecordedTreeModel {
-    return model.copy(description = description.patchNullable(model.description))
+    return model.copy(
+        description = description.patchNullable(model.description),
+        diameterAtBreastHeightCm = diameterAtBreastHeight ?: model.diameterAtBreastHeightCm,
+        heightM = height ?: model.heightM,
+        isDead = isDead ?: model.isDead,
+        pointOfMeasurementM = pointOfMeasurement ?: model.pointOfMeasurementM,
+        shrubDiameterCm = shrubDiameter ?: model.shrubDiameterCm,
+    )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -546,12 +546,42 @@ data class RecordedTreeUpdatedEventV1(
     override val recordedTreeId: RecordedTreeId,
 ) : FieldsUpdatedPersistentEvent, RecordedTreePersistentEvent {
   data class Values(
-      val description: String?,
+      val description: String? = null,
+      val diameterAtBreastHeightCm: BigDecimal? = null,
+      val heightM: BigDecimal? = null,
+      val isDead: Boolean? = null,
+      val pointOfMeasurementM: BigDecimal? = null,
+      val shrubDiameterCm: Int? = null,
   )
 
   override fun listUpdatedFields(messages: Messages) =
       listOfNotNull(
-          createUpdatedField("description", changedFrom.description, changedTo.description)
+          createUpdatedField("description", changedFrom.description, changedTo.description),
+          createUpdatedField(
+              "diameterAtBreastHeightCm",
+              messages.numericValueOrNull(changedFrom.diameterAtBreastHeightCm),
+              messages.numericValueOrNull(changedTo.diameterAtBreastHeightCm),
+          ),
+          createUpdatedField(
+              "heightM",
+              messages.numericValueOrNull(changedFrom.heightM),
+              messages.numericValueOrNull(changedTo.heightM),
+          ),
+          createUpdatedField(
+              "isDead",
+              messages.booleanOrNull(changedFrom.isDead),
+              messages.booleanOrNull(changedTo.isDead),
+          ),
+          createUpdatedField(
+              "pointOfMeasurementM",
+              messages.numericValueOrNull(changedFrom.pointOfMeasurementM),
+              messages.numericValueOrNull(changedTo.pointOfMeasurementM),
+          ),
+          createUpdatedField(
+              "shrubDiameterCm",
+              messages.numericValueOrNull(changedFrom.shrubDiameterCm),
+              messages.numericValueOrNull(changedTo.shrubDiameterCm),
+          ),
       )
 }
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/BiomassDetailsModel.kt
@@ -60,6 +60,12 @@ data class RecordedTreeModel<TreeId : RecordedTreeId?>(
   fun toEventValues(other: RecordedTreeModel<*>) =
       RecordedTreeUpdatedEventValues(
           description = description.nullIfEquals(other.description),
+          diameterAtBreastHeightCm =
+              diameterAtBreastHeightCm.nullIfEquals(other.diameterAtBreastHeightCm),
+          heightM = heightM.nullIfEquals(other.heightM),
+          isDead = isDead.nullIfEquals(other.isDead),
+          pointOfMeasurementM = pointOfMeasurementM.nullIfEquals(other.pointOfMeasurementM),
+          shrubDiameterCm = shrubDiameterCm.nullIfEquals(other.shrubDiameterCm),
       )
 
   fun validate() {

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -107,6 +107,11 @@ eventSubject.Project.field.name=name
 eventSubject.Project.full=Project {0}
 eventSubject.Project.short=Project
 eventSubject.RecordedTree.field.description=description
+eventSubject.RecordedTree.field.diameterAtBreastHeightCm=DBH
+eventSubject.RecordedTree.field.heightM=height
+eventSubject.RecordedTree.field.isDead=dead status
+eventSubject.RecordedTree.field.pointOfMeasurementM=POM
+eventSubject.RecordedTree.field.shrubDiameterCm=crown diameter
 # {0} is a growth form (tree, shrub) and {1} is a numeric identifier
 eventSubject.RecordedTree.full={0} {1}
 eventSubject.RecordedTree.short={0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -187,6 +187,16 @@ eventSubject.Project.full=Proyecto {0}
 eventSubject.Project.short=Proyecto
 # e119fcaa
 eventSubject.RecordedTree.field.description=descripción
+# ae31b475
+eventSubject.RecordedTree.field.diameterAtBreastHeightCm=DAP
+# d53494a0
+eventSubject.RecordedTree.field.heightM=altura
+# 7a93240a
+eventSubject.RecordedTree.field.isDead=estado de muerte
+# 3091a320
+eventSubject.RecordedTree.field.pointOfMeasurementM=MDP
+# 11ab0697
+eventSubject.RecordedTree.field.shrubDiameterCm=diámetro de copa
 # 0481a943
 eventSubject.RecordedTree.full={0} {1}
 # 61e0214b

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -187,6 +187,16 @@ eventSubject.Project.full=Projet {0}
 eventSubject.Project.short=Projet
 # e119fcaa
 eventSubject.RecordedTree.field.description=description
+# ae31b475
+eventSubject.RecordedTree.field.diameterAtBreastHeightCm=DHP
+# d53494a0
+eventSubject.RecordedTree.field.heightM=hauteur
+# 7a93240a
+eventSubject.RecordedTree.field.isDead=statut de mortalité
+# 3091a320
+eventSubject.RecordedTree.field.pointOfMeasurementM=PDM
+# 11ab0697
+eventSubject.RecordedTree.field.shrubDiameterCm=diamètre de la couronne
 # 0481a943
 eventSubject.RecordedTree.full={0} {1}
 # 61e0214b

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateRecordedTreeTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateRecordedTreeTest.kt
@@ -6,6 +6,7 @@ import com.terraformation.backend.db.tracking.tables.references.RECORDED_TREES
 import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEvent
 import com.terraformation.backend.tracking.event.RecordedTreeUpdatedEventValues
 import io.mockk.every
+import java.math.BigDecimal
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -22,34 +23,111 @@ class BiomassStoreUpdateRecordedTreeTest : BaseBiomassStoreTest() {
     insertObservationBiomassDetails()
     insertSpecies()
     insertObservationBiomassSpecies(speciesId = inserted.speciesId)
+  }
+
+  @Test
+  fun `updates editable fields for shrubs`() {
     insertRecordedTree(
         description = "Original description",
         shrubDiameterCm = 1,
         treeGrowthForm = TreeGrowthForm.Shrub,
     )
-  }
 
-  @Test
-  fun `updates editable fields`() {
     val before = dslContext.fetchSingle(RECORDED_TREES)
 
     store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) {
       it.copy(
           description = "New description",
-          treeGrowthForm = TreeGrowthForm.Tree,
-          shrubDiameterCm = null,
-          speciesName = "New species",
+          isDead = true,
+          treeGrowthForm = TreeGrowthForm.Tree, // Shouldn't be editable
+          shrubDiameterCm = 2,
+          speciesName = "New species", // Shouldn't be editable
       )
     }
 
-    val expected = before.copy().apply { description = "New description" }
+    val expected =
+        before.copy().apply {
+          description = "New description"
+          isDead = true
+          shrubDiameterCm = 2
+        }
 
     assertTableEquals(expected)
 
     eventPublisher.assertEventPublished(
         RecordedTreeUpdatedEvent(
-            changedFrom = RecordedTreeUpdatedEventValues(description = "Original description"),
-            changedTo = RecordedTreeUpdatedEventValues(description = "New description"),
+            changedFrom =
+                RecordedTreeUpdatedEventValues(
+                    description = "Original description",
+                    isDead = false,
+                    shrubDiameterCm = 1,
+                ),
+            changedTo =
+                RecordedTreeUpdatedEventValues(
+                    description = "New description",
+                    isDead = true,
+                    shrubDiameterCm = 2,
+                ),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+            recordedTreeId = inserted.recordedTreeId,
+        )
+    )
+  }
+
+  @Test
+  fun `updates editable fields for trees`() {
+    insertRecordedTree(
+        description = "Original description",
+        diameterAtBreastHeightCm = BigDecimal(1),
+        heightM = BigDecimal(2),
+        pointOfMeasurementM = BigDecimal(3),
+        treeGrowthForm = TreeGrowthForm.Tree,
+    )
+
+    val before = dslContext.fetchSingle(RECORDED_TREES)
+
+    store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) {
+      it.copy(
+          description = "New description",
+          diameterAtBreastHeightCm = BigDecimal(4),
+          heightM = BigDecimal(5),
+          isDead = true,
+          pointOfMeasurementM = BigDecimal(6),
+      )
+    }
+
+    val expected =
+        before.copy().apply {
+          description = "New description"
+          diameterAtBreastHeightCm = BigDecimal(4)
+          heightM = BigDecimal(5)
+          isDead = true
+          pointOfMeasurementM = BigDecimal(6)
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        RecordedTreeUpdatedEvent(
+            changedFrom =
+                RecordedTreeUpdatedEventValues(
+                    description = "Original description",
+                    diameterAtBreastHeightCm = BigDecimal(1),
+                    heightM = BigDecimal(2),
+                    isDead = false,
+                    pointOfMeasurementM = BigDecimal(3),
+                ),
+            changedTo =
+                RecordedTreeUpdatedEventValues(
+                    description = "New description",
+                    diameterAtBreastHeightCm = BigDecimal(4),
+                    heightM = BigDecimal(5),
+                    isDead = true,
+                    pointOfMeasurementM = BigDecimal(6),
+                ),
             monitoringPlotId = inserted.monitoringPlotId,
             observationId = inserted.observationId,
             organizationId = inserted.organizationId,
@@ -61,6 +139,8 @@ class BiomassStoreUpdateRecordedTreeTest : BaseBiomassStoreTest() {
 
   @Test
   fun `does not publish event or modify database if nothing changed`() {
+    insertRecordedTree(shrubDiameterCm = 1, treeGrowthForm = TreeGrowthForm.Shrub)
+
     val unmodifiedTable = dslContext.fetch(RECORDED_TREES)
 
     store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) { it }
@@ -71,7 +151,20 @@ class BiomassStoreUpdateRecordedTreeTest : BaseBiomassStoreTest() {
   }
 
   @Test
+  fun `throws exception if editing value for wrong kind of growth form`() {
+    insertRecordedTree(shrubDiameterCm = 1, treeGrowthForm = TreeGrowthForm.Shrub)
+
+    assertThrows<IllegalArgumentException> {
+      store.updateRecordedTree(inserted.observationId, inserted.recordedTreeId) {
+        it.copy(heightM = BigDecimal.ONE)
+      }
+    }
+  }
+
+  @Test
   fun `throws exception if no permission to update observation`() {
+    insertRecordedTree(shrubDiameterCm = 1, treeGrowthForm = TreeGrowthForm.Shrub)
+
     every { user.canUpdateObservation(inserted.observationId) } returns false
 
     assertThrows<AccessDeniedException> {


### PR DESCRIPTION
Change the recorded tree update `PATCH` payload to include the various numeric
measurements we store.