### PR TITLE
SW-7788 Fix NPE when fetching old plot details

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -829,7 +829,7 @@ data class AssignedPlotPayload(
     val isFirstObservation: Boolean,
     val isPermanent: Boolean,
     val observationId: ObservationId,
-    val plantingSubzoneId: PlantingSubzoneId,
+    val plantingSubzoneId: PlantingSubzoneId?,
     val plantingSubzoneName: String,
     val plantingZoneName: String,
     val plotId: MonitoringPlotId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -222,9 +222,10 @@ class ObservationStore(
             OBSERVATION_PLOTS.OBSERVATION_ID,
             OBSERVATION_PLOTS.monitoringPlots.BOUNDARY,
             OBSERVATION_PLOTS.monitoringPlots.ELEVATION_METERS,
-            OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME,
-            OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID,
-            OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.plotsPlantingZoneIdFkey.NAME,
+            OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories.FULL_NAME,
+            OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories.PLANTING_SUBZONE_ID,
+            OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories.plantingZoneHistories
+                .NAME,
             OBSERVATION_PLOTS.monitoringPlots.PLOT_NUMBER,
             OBSERVATION_PLOTS.monitoringPlots.SIZE_METERS,
             claimedByNameField,
@@ -242,12 +243,18 @@ class ObservationStore(
               completedByName = record[completedByNameField],
               elevationMeters = record[OBSERVATION_PLOTS.monitoringPlots.ELEVATION_METERS],
               isFirstObservation = record[isFirstObservationField]!!,
-              plantingSubzoneId = record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.ID]!!,
+              plantingSubzoneId =
+                  record[
+                      OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories
+                          .PLANTING_SUBZONE_ID],
               plantingSubzoneName =
-                  record[OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.FULL_NAME]!!,
+                  record[
+                      OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories
+                          .FULL_NAME]!!,
               plantingZoneName =
                   record[
-                      OBSERVATION_PLOTS.monitoringPlots.plantingSubzones.plotsPlantingZoneIdFkey
+                      OBSERVATION_PLOTS.monitoringPlotHistories.plantingSubzoneHistories
+                          .plantingZoneHistories
                           .NAME]!!,
               plotNumber = record[OBSERVATION_PLOTS.monitoringPlots.PLOT_NUMBER]!!,
               sizeMeters = record[OBSERVATION_PLOTS.monitoringPlots.SIZE_METERS]!!,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/AssignedPlotDetails.kt
@@ -16,7 +16,8 @@ data class AssignedPlotDetails(
     val completedByName: String?,
     val elevationMeters: BigDecimal?,
     val isFirstObservation: Boolean,
-    val plantingSubzoneId: PlantingSubzoneId,
+    /** Null if the monitoring plot no longer falls within a subzone (due to a map edit). */
+    val plantingSubzoneId: PlantingSubzoneId?,
     val plantingSubzoneName: String,
     val plantingZoneName: String,
     val plotNumber: Long,


### PR DESCRIPTION
Exporting assigned plots to a GPX file for an old observation failed if there was
a map edit that caused one of the observation's plots to no longer lie within the
site boundary. The export would also have used the wrong subzone and zone names
if a map edit caused a plot to move to a different subzone. Update the code to
look up the subzone and zone names as of the time of the observation, and don't
return a subzone ID if the plot is no longer in the site.