### PR TITLE
SW-7782 Support editing numeric plot-level biomass data

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -24,7 +24,11 @@ import jakarta.inject.Named
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.text.NumberFormat
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import kotlin.reflect.KClass
@@ -302,6 +306,14 @@ class Messages {
 
   fun searchFieldDisplayName(tableName: String, fieldName: String) =
       getMessage("search.$tableName.$fieldName")
+
+  fun timestampOrNull(value: ZonedDateTime?) =
+      value?.let {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).withLocale(currentLocale()).format(it)
+      }
+
+  fun timestampOrNull(value: Instant?, timeZone: ZoneId?) =
+      value?.let { timestampOrNull(it.atZone(timeZone ?: ZoneOffset.UTC)) }
 
   fun userAddedToOrganizationNotification(orgName: String): NotificationMessage =
       NotificationMessage(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -3,6 +3,8 @@ package com.terraformation.backend.tracking.api
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.BiomassForestType
+import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
 import com.terraformation.backend.db.tracking.RecordedTreeId
@@ -15,6 +17,7 @@ import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.util.patchNullable
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
+import java.time.Instant
 import java.util.Optional
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -67,13 +70,30 @@ data class BiomassSpeciesUpdateOperationPayload(
 
 @JsonTypeName("Biomass")
 data class BiomassUpdateOperationPayload(
-    val description: Optional<String?>?,
+    val description: Optional<String>?,
+    val forestType: BiomassForestType?,
+    val ph: Optional<BigDecimal>?,
+    val salinity: Optional<BigDecimal>?,
+    val smallTreeCountLow: Int?,
+    val smallTreeCountHigh: Int?,
     val soilAssessment: String?,
+    val tide: Optional<MangroveTide>?,
+    val tideTime: Optional<Instant>?,
+    val waterDepth: Optional<Int>?,
 ) : ObservationUpdateOperationPayload {
   fun applyTo(model: EditableBiomassDetailsModel): EditableBiomassDetailsModel {
     return model.copy(
+        forestType = forestType ?: model.forestType,
         description = description.patchNullable(model.description),
+        ph = ph.patchNullable(model.ph),
+        salinityPpt = salinity.patchNullable(model.salinityPpt),
         soilAssessment = soilAssessment ?: model.soilAssessment,
+        smallTreeCountRange =
+            (smallTreeCountLow ?: model.smallTreeCountRange.first) to
+                (smallTreeCountHigh ?: model.smallTreeCountRange.second),
+        tide = tide.patchNullable(model.tide),
+        tideTime = tideTime.patchNullable(model.tideTime),
+        waterDepthCm = waterDepth.patchNullable(model.waterDepthCm),
     )
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/BiomassStore.kt
@@ -463,15 +463,14 @@ class BiomassStore(
       val existing =
           with(OBSERVATION_BIOMASS_DETAILS) {
             dslContext
-                .select(DESCRIPTION, SOIL_ASSESSMENT)
-                .from(OBSERVATION_BIOMASS_DETAILS)
+                .selectFrom(OBSERVATION_BIOMASS_DETAILS)
                 .where(OBSERVATION_ID.eq(observationId))
                 .and(MONITORING_PLOT_ID.eq(plotId))
                 .fetchOne { EditableBiomassDetailsModel.of(it) }
                 ?: throw ObservationPlotNotFoundException(observationId, plotId)
           }
 
-      val updated = updateFunc(existing)
+      val updated = updateFunc(existing).sanitizeForForestType()
 
       val changedFrom = existing.toEventValues(updated)
       val changedTo = updated.toEventValues(existing)
@@ -481,7 +480,16 @@ class BiomassStore(
           dslContext
               .update(OBSERVATION_BIOMASS_DETAILS)
               .set(DESCRIPTION, updated.description)
+              .set(FOREST_TYPE_ID, updated.forestType)
+              .set(HERBACEOUS_COVER_PERCENT, updated.herbaceousCoverPercent)
+              .set(PH, updated.ph)
+              .set(SALINITY_PPT, updated.salinityPpt)
+              .set(SMALL_TREES_COUNT_LOW, updated.smallTreeCountRange.first)
+              .set(SMALL_TREES_COUNT_HIGH, updated.smallTreeCountRange.second)
               .set(SOIL_ASSESSMENT, updated.soilAssessment)
+              .set(TIDE_ID, updated.tide)
+              .set(TIDE_TIME, updated.tideTime)
+              .set(WATER_DEPTH_CM, updated.waterDepthCm)
               .where(OBSERVATION_ID.eq(observationId))
               .and(MONITORING_PLOT_ID.eq(plotId))
               .execute()

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -81,7 +81,16 @@ csvWrongFieldCount=Expected row to have {0} fields, not {1}
 disabled=Disabled
 enabled=Enabled
 eventSubject.BiomassDetails.field.description=plot description
+eventSubject.BiomassDetails.field.forestType=forest type
+eventSubject.BiomassDetails.field.herbaceousCoverPercent=herbaceous cover percent
+eventSubject.BiomassDetails.field.ph=pH
+# "ppt" means "parts per thousand"; translate it to the appropriate abbreviation or symbol
+eventSubject.BiomassDetails.field.salinity=salinity (ppt)
+eventSubject.BiomassDetails.field.smallTreeCountRange=small tree count
 eventSubject.BiomassDetails.field.soilAssessment=soil description/notes
+eventSubject.BiomassDetails.field.tide=tide
+eventSubject.BiomassDetails.field.tideTime=tide measurement time
+eventSubject.BiomassDetails.field.waterDepth=water depth (cm)
 eventSubject.BiomassDetails.full=Biomass observation {0}
 eventSubject.BiomassDetails.short=Observation
 eventSubject.BiomassQuadrat.field.description=description

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -139,8 +139,24 @@ disabled=Deshabilitado
 enabled=Habilitado
 # 906d63eb
 eventSubject.BiomassDetails.field.description=descripción de la parcela
+# d28d6a46
+eventSubject.BiomassDetails.field.forestType=tipo de bosque
+# 12be281e
+eventSubject.BiomassDetails.field.herbaceousCoverPercent=porcentaje de cobertura herbácea
+# 8e3a7381
+eventSubject.BiomassDetails.field.ph=pH
+# 4352ce95
+eventSubject.BiomassDetails.field.salinity=salinidad (‰)
+# aca8a4a6
+eventSubject.BiomassDetails.field.smallTreeCountRange=cantidad de árboles pequeños
 # f5f2468c
 eventSubject.BiomassDetails.field.soilAssessment=descripción/notas del suelo
+# 860b1cc6
+eventSubject.BiomassDetails.field.tide=marea
+# be30dece
+eventSubject.BiomassDetails.field.tideTime=hora de medición de la marea
+# 97b7c978
+eventSubject.BiomassDetails.field.waterDepth=profundidad del agua (cm)
 # 0bf84458
 eventSubject.BiomassDetails.full=Observación de biomasa {0}
 # ac4f24f0

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -139,8 +139,24 @@ disabled=Désactivé
 enabled=Activé
 # 906d63eb
 eventSubject.BiomassDetails.field.description=description de la parcelle
+# d28d6a46
+eventSubject.BiomassDetails.field.forestType=type de forêt
+# 12be281e
+eventSubject.BiomassDetails.field.herbaceousCoverPercent=pourcentage de couverture herbacée
+# 8e3a7381
+eventSubject.BiomassDetails.field.ph=pH
+# 4352ce95
+eventSubject.BiomassDetails.field.salinity=salinité (‰)
+# aca8a4a6
+eventSubject.BiomassDetails.field.smallTreeCountRange=nombre de petits arbres
 # f5f2468c
 eventSubject.BiomassDetails.field.soilAssessment=description/remarques sur le sol
+# 860b1cc6
+eventSubject.BiomassDetails.field.tide=marée
+# be30dece
+eventSubject.BiomassDetails.field.tideTime=heure de mesure de la marée
+# 97b7c978
+eventSubject.BiomassDetails.field.waterDepth=profondeur de l''eau (cm)
 # 0bf84458
 eventSubject.BiomassDetails.full=Observation de la biomasse {0}
 # ac4f24f0

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/biomassStore/BiomassStoreUpdateBiomassDetailsTest.kt
@@ -1,10 +1,14 @@
 package com.terraformation.backend.tracking.db.biomassStore
 
+import com.terraformation.backend.db.tracking.BiomassForestType
+import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_DETAILS
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEvent
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventValues
 import io.mockk.every
+import java.math.BigDecimal
+import java.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,24 +24,38 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
     insertObservationPlot(completedBy = user.userId)
     insertObservationBiomassDetails(
         description = "Original description",
+        herbaceousCoverPercent = 10,
+        smallTreesCountLow = 1,
+        smallTreesCountHigh = 4,
         soilAssessment = "Original soil assessment",
     )
   }
 
   @Test
-  fun `updates editable fields`() {
+  fun `updates editable fields for terrestrial observation`() {
     val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
 
     store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
       it.copy(
           description = "New description",
+          herbaceousCoverPercent = 13,
+          ph = BigDecimal.ONE,
+          salinityPpt = BigDecimal.ONE,
+          smallTreeCountRange = 5 to 9,
           soilAssessment = "New soil assessment",
+          tide = MangroveTide.Low,
+          tideTime = Instant.EPOCH,
+          waterDepthCm = 1,
       )
     }
 
+    // Updates to mangrove-only values should be ignored
     val expected =
         before.copy().apply {
           description = "New description"
+          herbaceousCoverPercent = 13
+          smallTreesCountLow = 5
+          smallTreesCountHigh = 9
           soilAssessment = "New soil assessment"
         }
 
@@ -48,11 +66,15 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
             changedFrom =
                 BiomassDetailsUpdatedEventValues(
                     description = "Original description",
+                    herbaceousCoverPercent = 10,
+                    smallTreeCountRange = 1 to 4,
                     soilAssessment = "Original soil assessment",
                 ),
             changedTo =
                 BiomassDetailsUpdatedEventValues(
                     description = "New description",
+                    herbaceousCoverPercent = 13,
+                    smallTreeCountRange = 5 to 9,
                     soilAssessment = "New soil assessment",
                 ),
             monitoringPlotId = inserted.monitoringPlotId,
@@ -64,7 +86,130 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
   }
 
   @Test
-  fun `updates only description when soil assessment unchanged`() {
+  fun `can change terrestrial observation to mangrove`() {
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
+
+    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
+      it.copy(
+          description = "New description",
+          forestType = BiomassForestType.Mangrove,
+          herbaceousCoverPercent = 13,
+          ph = BigDecimal.ONE,
+          salinityPpt = BigDecimal.TWO,
+          smallTreeCountRange = 5 to 9,
+          soilAssessment = "New soil assessment",
+          tide = MangroveTide.Low,
+          tideTime = Instant.EPOCH,
+          waterDepthCm = 1,
+      )
+    }
+
+    val expected =
+        before.copy().apply {
+          description = "New description"
+          forestTypeId = BiomassForestType.Mangrove
+          herbaceousCoverPercent = 13
+          ph = BigDecimal.ONE
+          salinityPpt = BigDecimal.TWO
+          smallTreesCountLow = 5
+          smallTreesCountHigh = 9
+          soilAssessment = "New soil assessment"
+          tideId = MangroveTide.Low
+          tideTime = Instant.EPOCH
+          waterDepthCm = 1
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassDetailsUpdatedEvent(
+            changedFrom =
+                BiomassDetailsUpdatedEventValues(
+                    description = "Original description",
+                    forestType = BiomassForestType.Terrestrial,
+                    herbaceousCoverPercent = 10,
+                    smallTreeCountRange = 1 to 4,
+                    soilAssessment = "Original soil assessment",
+                ),
+            changedTo =
+                BiomassDetailsUpdatedEventValues(
+                    description = "New description",
+                    forestType = BiomassForestType.Mangrove,
+                    herbaceousCoverPercent = 13,
+                    ph = BigDecimal.ONE,
+                    salinity = BigDecimal.TWO,
+                    smallTreeCountRange = 5 to 9,
+                    soilAssessment = "New soil assessment",
+                    tide = MangroveTide.Low,
+                    tideTime = Instant.EPOCH,
+                    waterDepth = 1,
+                ),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `clears mangrove-only values when changing from mangrove to terrestrial`() {
+    dslContext.deleteFrom(OBSERVATION_BIOMASS_DETAILS).execute()
+    insertObservationBiomassDetails(
+        description = "Original description",
+        forestType = BiomassForestType.Mangrove,
+        herbaceousCoverPercent = 10,
+        ph = BigDecimal.ONE,
+        salinityPpt = BigDecimal.TWO,
+        smallTreesCountLow = 1,
+        smallTreesCountHigh = 4,
+        soilAssessment = "Original soil assessment",
+        tideId = MangroveTide.Low,
+        tideTime = Instant.EPOCH,
+        waterDepthCm = 1,
+    )
+
+    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
+
+    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
+      it.copy(forestType = BiomassForestType.Terrestrial)
+    }
+
+    val expected =
+        before.copy().apply {
+          forestTypeId = BiomassForestType.Terrestrial
+          ph = null
+          salinityPpt = null
+          tideId = null
+          tideTime = null
+          waterDepthCm = null
+        }
+
+    assertTableEquals(expected)
+
+    eventPublisher.assertEventPublished(
+        BiomassDetailsUpdatedEvent(
+            changedFrom =
+                BiomassDetailsUpdatedEventValues(
+                    forestType = BiomassForestType.Mangrove,
+                    ph = BigDecimal.ONE,
+                    salinity = BigDecimal.TWO,
+                    tide = MangroveTide.Low,
+                    tideTime = Instant.EPOCH,
+                    waterDepth = 1,
+                ),
+            changedTo =
+                BiomassDetailsUpdatedEventValues(forestType = BiomassForestType.Terrestrial),
+            monitoringPlotId = inserted.monitoringPlotId,
+            observationId = inserted.observationId,
+            organizationId = inserted.organizationId,
+            plantingSiteId = inserted.plantingSiteId,
+        )
+    )
+  }
+
+  @Test
+  fun `omits unmodified values from events`() {
     val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
 
     store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
@@ -77,48 +222,8 @@ class BiomassStoreUpdateBiomassDetailsTest : BaseBiomassStoreTest() {
 
     eventPublisher.assertEventPublished(
         BiomassDetailsUpdatedEvent(
-            changedFrom =
-                BiomassDetailsUpdatedEventValues(
-                    description = "Original description",
-                    soilAssessment = null,
-                ),
-            changedTo =
-                BiomassDetailsUpdatedEventValues(
-                    description = "New description",
-                    soilAssessment = null,
-                ),
-            monitoringPlotId = inserted.monitoringPlotId,
-            observationId = inserted.observationId,
-            organizationId = inserted.organizationId,
-            plantingSiteId = inserted.plantingSiteId,
-        )
-    )
-  }
-
-  @Test
-  fun `updates only soil assessment when description unchanged`() {
-    val before = dslContext.fetchSingle(OBSERVATION_BIOMASS_DETAILS)
-
-    store.updateBiomassDetails(inserted.observationId, inserted.monitoringPlotId) {
-      it.copy(soilAssessment = "New soil assessment")
-    }
-
-    val expected = before.copy().apply { soilAssessment = "New soil assessment" }
-
-    assertTableEquals(expected)
-
-    eventPublisher.assertEventPublished(
-        BiomassDetailsUpdatedEvent(
-            changedFrom =
-                BiomassDetailsUpdatedEventValues(
-                    description = null,
-                    soilAssessment = "Original soil assessment",
-                ),
-            changedTo =
-                BiomassDetailsUpdatedEventValues(
-                    description = null,
-                    soilAssessment = "New soil assessment",
-                ),
+            changedFrom = BiomassDetailsUpdatedEventValues(description = "Original description"),
+            changedTo = BiomassDetailsUpdatedEventValues(description = "New description"),
             monitoringPlotId = inserted.monitoringPlotId,
             observationId = inserted.observationId,
             organizationId = inserted.organizationId,


### PR DESCRIPTION
Add properties to the existing PATCH payload for editing plot-level biomass
details to allow changing numberic values such as salinity and small tree
counts.