### PR TITLE
SW-7697 Look up biomass species names for events

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -31,9 +31,11 @@ import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentE
 import com.terraformation.backend.tracking.event.ObservationPlotPersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
 import jakarta.inject.Named
+import org.jooq.DSLContext
 
 @Named
 class EventLogPayloadTransformer(
+    private val dslContext: DSLContext,
     private val messages: Messages,
     private val simpleUserStore: SimpleUserStore,
 ) {
@@ -54,7 +56,7 @@ class EventLogPayloadTransformer(
    * chronological results, so this usually doesn't require any additional work.
    */
   fun eventsToPayloads(entries: List<EventLogEntry<PersistentEvent>>): List<EventLogEntryPayload> {
-    val context = EventLogPayloadContext(entries, messages)
+    val context = EventLogPayloadContext(dslContext, entries, messages)
     val users = simpleUserStore.fetchSimpleUsersById(entries.map { it.createdBy }.distinct())
 
     return entries.flatMap { entry ->

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -25,7 +25,6 @@ import com.terraformation.backend.file.api.MediaKind
 import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratSpeciesPersistentEvent
-import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
@@ -136,27 +135,22 @@ data class BiomassQuadratSpeciesSubjectPayload(
         event: BiomassQuadratSpeciesPersistentEvent,
         context: EventLogPayloadContext,
     ): BiomassQuadratSpeciesSubjectPayload {
-      val createEvent =
-          context.first<BiomassSpeciesCreatedEvent> {
-            it.biomassSpeciesId == event.biomassSpeciesId
-          }
-      // TODO: Fetch scientific name for species ID
-      val speciesText = createEvent.scientificName ?: "${createEvent.speciesId}"
+      val biomassSpecies = context.getBiomassSpecies(event.biomassSpeciesId)
       val localizedPosition = event.position.getDisplayName(currentUser().locale)
 
       return BiomassQuadratSpeciesSubjectPayload(
           fullText =
               context.subjectFullText<BiomassQuadratSpeciesSubjectPayload>(
                   localizedPosition,
-                  speciesText,
+                  biomassSpecies.displayName,
               ),
           monitoringPlotId = event.monitoringPlotId,
           observationId = event.observationId,
           plantingSiteId = event.plantingSiteId,
           position = event.position,
           shortText = context.subjectShortText<BiomassQuadratSpeciesSubjectPayload>(),
-          scientificName = createEvent.scientificName,
-          speciesId = createEvent.speciesId,
+          scientificName = biomassSpecies.scientificName,
+          speciesId = biomassSpecies.speciesId,
       )
     }
   }
@@ -177,21 +171,17 @@ data class BiomassSpeciesSubjectPayload(
         event: BiomassSpeciesPersistentEvent,
         context: EventLogPayloadContext,
     ): BiomassSpeciesSubjectPayload {
-      val createEvent =
-          context.first<BiomassSpeciesCreatedEvent> {
-            it.biomassSpeciesId == event.biomassSpeciesId
-          }
-      // TODO: Fetch scientific name for species ID
-      val speciesText = createEvent.scientificName ?: "${createEvent.speciesId}"
+      val biomassSpecies = context.getBiomassSpecies(event.biomassSpeciesId)
 
       return BiomassSpeciesSubjectPayload(
-          fullText = context.subjectFullText<BiomassSpeciesSubjectPayload>(speciesText),
+          fullText =
+              context.subjectFullText<BiomassSpeciesSubjectPayload>(biomassSpecies.displayName),
           monitoringPlotId = event.monitoringPlotId,
           observationId = event.observationId,
           plantingSiteId = event.plantingSiteId,
           shortText = context.subjectShortText<BiomassSpeciesSubjectPayload>(),
-          speciesId = createEvent.speciesId,
-          scientificName = createEvent.scientificName,
+          speciesId = biomassSpecies.speciesId,
+          scientificName = biomassSpecies.scientificName,
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContextTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContextTest.kt
@@ -1,0 +1,118 @@
+package com.terraformation.backend.eventlog
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.EventLogId
+import com.terraformation.backend.db.default_schema.tables.references.SPECIES
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
+import com.terraformation.backend.eventlog.model.EventLogEntry
+import com.terraformation.backend.i18n.Messages
+import com.terraformation.backend.polygon
+import com.terraformation.backend.tracking.event.BiomassSpeciesCreatedEvent
+import java.time.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EventLogPayloadContextTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val messages = Messages()
+
+  @Nested
+  inner class GetBiomassSpecies {
+    @BeforeEach
+    fun setUp() {
+      insertOrganization()
+      insertPlantingSite(boundary = polygon(1))
+      insertPlantingZone()
+      insertPlantingSubzone()
+      insertMonitoringPlot()
+      insertObservation()
+      insertObservationPlot()
+      insertObservationBiomassDetails()
+      insertSpecies(scientificName = "Species name")
+    }
+
+    @Test
+    fun `looks up species name from species ID`() {
+      val biomassSpeciesId = insertObservationBiomassSpecies(speciesId = inserted.speciesId)
+
+      val context = EventLogPayloadContext(dslContext, emptyList(), messages)
+
+      val expected = EventLogPayloadContext.BiomassSpecies("Species name", null, inserted.speciesId)
+
+      assertEquals(expected, context.getBiomassSpecies(biomassSpeciesId), "Lookup from database")
+
+      dslContext.update(SPECIES).set(SPECIES.SCIENTIFIC_NAME, "New name").execute()
+
+      assertEquals(expected, context.getBiomassSpecies(biomassSpeciesId), "Lookup from cache")
+    }
+
+    @Test
+    fun `looks up scientific name of Other species`() {
+      val biomassSpeciesId = insertObservationBiomassSpecies(scientificName = "Other species")
+
+      val context = EventLogPayloadContext(dslContext, emptyList(), messages)
+
+      val expected = EventLogPayloadContext.BiomassSpecies("Other species", "Other species", null)
+
+      assertEquals(expected, context.getBiomassSpecies(biomassSpeciesId), "Lookup from database")
+
+      dslContext
+          .update(OBSERVATION_BIOMASS_SPECIES)
+          .set(OBSERVATION_BIOMASS_SPECIES.SCIENTIFIC_NAME, "New name")
+          .execute()
+
+      assertEquals(expected, context.getBiomassSpecies(biomassSpeciesId), "Lookup from cache")
+    }
+
+    @Test
+    fun `uses name from creation event if available`() {
+      val biomassSpeciesId = insertObservationBiomassSpecies(scientificName = "Other species")
+
+      val context =
+          EventLogPayloadContext(
+              dslContext,
+              listOf(
+                  eventLogEntry(
+                      BiomassSpeciesCreatedEvent(
+                          biomassSpeciesId,
+                          null,
+                          false,
+                          false,
+                          inserted.monitoringPlotId,
+                          inserted.observationId,
+                          inserted.organizationId,
+                          inserted.plantingSiteId,
+                          "Name from created event",
+                          null,
+                      )
+                  )
+              ),
+              messages,
+          )
+
+      val expected =
+          EventLogPayloadContext.BiomassSpecies(
+              "Name from created event",
+              "Name from created event",
+              null,
+          )
+
+      assertEquals(expected, context.getBiomassSpecies(biomassSpeciesId))
+    }
+  }
+
+  private var nextEventLogId: Long = 1
+
+  private fun eventLogEntry(event: PersistentEvent): EventLogEntry<PersistentEvent> =
+      EventLogEntry(
+          createdBy = user.userId,
+          createdTime = Instant.ofEpochSecond(nextEventLogId),
+          event = event,
+          id = EventLogId(nextEventLogId++),
+      )
+}

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -38,7 +38,7 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
   private val messages = Messages()
   private val simpleUserStore: SimpleUserStore by lazy { SimpleUserStore(dslContext, messages) }
   private val transformer: EventLogPayloadTransformer by lazy {
-    EventLogPayloadTransformer(messages, simpleUserStore)
+    EventLogPayloadTransformer(dslContext, messages, simpleUserStore)
   }
 
   private val fileId = FileId(1)


### PR DESCRIPTION
If an event log query returns subjects related to species from biomass
observations, we want their text renderings to include the species names
even if the actual events only refer to species IDs.