### PR TITLE
Make generic exception log message more informative

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -327,7 +327,11 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
 
   private fun logError(ex: Exception, request: WebRequest) {
     val description = request.getDescription(false)
-    controllerLogger(ex).error("Exception thrown while handling request $description", ex)
+    controllerLogger(ex)
+        .error(
+            "${ex.javaClass.simpleName} thrown while handling request $description: ${ex.message}",
+            ex,
+        )
   }
 
   /**


### PR DESCRIPTION
If a controller throws an exception that isn't one of the ones we have
special-case handling for, we log a generic "exception thrown" error message.
From the message alone, you can't tell what the error was; you have to go
look at the attached stack trace.

Update the logged error to include the exception name and its message.