### PR TITLE
SW-7807 Remove mortality rate mention from admin UI

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -77,7 +77,7 @@ class AdminController(
     )
     model.addAttribute("canReadCohorts", currentUser().canReadCohorts())
     model.addAttribute(
-        "canRecalculateMortalityRates",
+        "canRecalculateSurvivalRates",
         GlobalRole.SuperAdmin in currentUser().globalRoles,
     )
     model.addAttribute(

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminPlantingSitesController.kt
@@ -719,7 +719,7 @@ class AdminPlantingSitesController(
     return redirectToPlantingSite(plantingSiteId)
   }
 
-  @PostMapping("/recalculateMortalityRates")
+  @PostMapping("/recalculateSurvivalRates")
   fun recalculateMortalityRates(
       @RequestParam observationId: ObservationId,
       @RequestParam plantingSiteId: PlantingSiteId,
@@ -728,12 +728,12 @@ class AdminPlantingSitesController(
     requirePermissions { manageObservation(observationId) }
 
     try {
-      observationStore.recalculateSurvivalMortalityRates(observationId, plantingSiteId)
+      observationStore.recalculateSurvivalRates(observationId, plantingSiteId)
       redirectAttributes.successMessage =
-          "Recalculated mortality rates for observation $observationId."
+          "Recalculated survival rates for observation $observationId."
     } catch (e: Exception) {
-      log.warn("Mortality rate recalculation failed", e)
-      redirectAttributes.failureMessage = "Failed to recalculate mortality rates: ${e.message}"
+      log.warn("Survival rate recalculation failed", e)
+      redirectAttributes.failureMessage = "Failed to recalculate survival rates: ${e.message}"
     }
 
     return redirectToAdminHome()

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1275,12 +1275,12 @@ class ObservationStore(
     if (!isAdHoc) {
       // Ad-hoc observations do not reset unobserved populations
       resetPlantPopulationSinceLastObservation(plantingSiteId)
-      recalculateSurvivalMortalityRates(observationId, plantingSiteId)
+      recalculateSurvivalRates(observationId, plantingSiteId)
     }
   }
 
   /** Recalculates the stratum- and site-level survival rates for an observation. */
-  fun recalculateSurvivalMortalityRates(
+  fun recalculateSurvivalRates(
       observationId: ObservationId,
       plantingSiteId: PlantingSiteId,
   ) {

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -234,16 +234,16 @@
         </form>
     </th:block>
 
-    <th:block th:if="${canRecalculateMortalityRates}">
-        <h3>Recalculate Mortality Rates</h3>
+    <th:block th:if="${canRecalculateSurvivalRates}">
+        <h3>Recalculate Survival Rates</h3>
 
         <p>
-            This updates the stratum- and site-level mortality rates for a partial observation of a
+            This updates the stratum- and site-level survival rates for a partial observation of a
             planting site to take into account plants from substrata that weren't observed this
             time.
         </p>
 
-        <form method="POST" action="/admin/recalculateMortalityRates">
+        <form method="POST" action="/admin/recalculateSurvivalRates">
             <label>
                 Planting Site ID:
                 <input type="text" name="plantingSiteId"/>


### PR DESCRIPTION
The admin UI function to recalculate survival and mortality rates now only
recalculates survival rates; rename and relabel it accordingly.