### PR TITLE
Enable Gradle configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 kotlin.code.style=official
 #
+org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 #


### PR DESCRIPTION
Speed up local dev environment builds slightly by enabling Gradle's configuration
cache, which lets Gradle skip some of its usual initialization process.