### PR TITLE
SW-7817 Add plantingSiteId to observation summaries endpoint

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/MonitoringResultsPayloads.kt
@@ -564,6 +564,7 @@ data class PlantingSiteObservationSummaryPayload(
     )
     val plantingDensity: Int,
     val plantingDensityStdDev: Int?,
+    val plantingSiteId: PlantingSiteId,
     val plantingZones: List<PlantingZoneObservationSummaryPayload>,
     @Schema(
         description =
@@ -600,6 +601,7 @@ data class PlantingSiteObservationSummaryPayload(
       mortalityRateStdDev = model.mortalityRateStdDev,
       plantingDensity = model.plantingDensity,
       plantingDensityStdDev = model.plantingDensityStdDev,
+      plantingSiteId = model.plantingSiteId,
       plantingZones = model.plantingZones.map { PlantingZoneObservationSummaryPayload(it) },
       species =
           model.species


### PR DESCRIPTION
To simplify the FE work, add the `plantingSiteId` that already exists in the model to the controller payload.