### PR TITLE
SW-7783 API payload for monitoring species edits

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -7,6 +7,7 @@ import com.terraformation.backend.db.tracking.BiomassForestType
 import com.terraformation.backend.db.tracking.MangroveTide
 import com.terraformation.backend.db.tracking.ObservableCondition
 import com.terraformation.backend.db.tracking.ObservationPlotPosition
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
 import com.terraformation.backend.db.tracking.RecordedTreeId
 import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
@@ -99,6 +100,22 @@ data class BiomassUpdateOperationPayload(
     )
   }
 }
+
+@JsonTypeName("MonitoringSpecies")
+data class MonitoringSpeciesUpdateOperationPayload(
+    val certainty: RecordedSpeciesCertainty,
+    @Schema(
+        description = "Required if certainty is Known. Ignored if certainty is Other or Unknown."
+    )
+    val speciesId: SpeciesId?,
+    @Schema(
+        description = "Required if certainty is Other. Ignored if certainty is Known or Unknown."
+    )
+    val speciesName: String?,
+    val totalDead: Int?,
+    val totalExisting: Int?,
+    val totalLive: Int?,
+) : ObservationUpdateOperationPayload
 
 @JsonTypeName("ObservationPlot")
 data class ObservationPlotUpdateOperationPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -348,6 +348,7 @@ class ObservationsController(
               )
           is BiomassUpdateOperationPayload ->
               biomassStore.updateBiomassDetails(observationId, plotId, element::applyTo)
+          is MonitoringSpeciesUpdateOperationPayload -> Unit
           is ObservationPlotUpdateOperationPayload ->
               observationStore.updateObservationPlotDetails(observationId, plotId, element::applyTo)
           is QuadratSpeciesUpdateOperationPayload ->


### PR DESCRIPTION
Add the definition of the PATCH payload for editing plant counts on completed
monitoring observations. It doesn't actually do anything yet (it's silently
ignored by the server) but this will allow the client side to use the generated
types from the OpenAPI schema to start implementing the edit flow.