### PR TITLE
SW-7819 Don't pretty-print file IDs in event log

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -240,10 +240,7 @@ data class ObservationPlotMediaSubjectPayload(
       val mediaKind = MediaKind.forMimeType(createEvent.contentType)
       val mediaKindName = mediaKind.getDisplayName(currentUser().locale)
       val fullText =
-          context.subjectFullText<ObservationPlotMediaSubjectPayload>(
-              mediaKindName,
-              event.fileId.value,
-          )
+          context.subjectFullText<ObservationPlotMediaSubjectPayload>(mediaKindName, event.fileId)
 
       return ObservationPlotMediaSubjectPayload(
           deleted = if (deleteEvent != null) true else null,


### PR DESCRIPTION
The full text for observation media subjects in the event log API includes the
file ID, but we were treating it as an integer (which was pretty-printed with
thousands separators by the i18n code) rather than an opaque identifier that
happens to be made of digits.