### PR TITLE
SW-7850 Add survivalRateIncludesTempPlots to planting site payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -373,6 +373,7 @@ data class PlantingSitePayload(
     val plantingSeasons: List<PlantingSeasonPayload>,
     val plantingZones: List<PlantingZonePayload>?,
     val projectId: ProjectId? = null,
+    val survivalRateIncludesTempPlots: Boolean?,
     val timeZone: ZoneId?,
 ) {
   constructor(
@@ -392,6 +393,7 @@ data class PlantingSitePayload(
       plantingSeasons = model.plantingSeasons.map { PlantingSeasonPayload(it) },
       plantingZones = model.plantingZones.map { PlantingZonePayload(it) },
       projectId = model.projectId,
+      survivalRateIncludesTempPlots = model.survivalRateIncludesTempPlots,
       timeZone = model.timeZone,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/PlantingSiteModel.kt
@@ -57,8 +57,8 @@ data class PlantingSiteModel<
     val plantingSeasons: List<ExistingPlantingSeasonModel> = emptyList(),
     val plantingZones: List<PlantingZoneModel<PZID, PSZID, TIMESTAMP>> = emptyList(),
     val projectId: ProjectId? = null,
-    val timeZone: ZoneId? = null,
     val survivalRateIncludesTempPlots: Boolean = false,
+    val timeZone: ZoneId? = null,
 ) {
   /**
    * Returns the start date of the next observation for this planting site, or null if the planting


### PR DESCRIPTION
The flag for `survivalRateIncludesTempPlots` was not included in the planting site payload, causing it to get overwritten whenever an edit was made to the planting site. This is because the updatePlantingSite endpoint assumed that the content of the update payload contained what the planting site should be, and thus set the flag to false since it wasn't included. 
Add the flag to the payload.
(also correct an alphabetical typo)