### PR TITLE
SW-7843 Include is-original flag in photo subjects

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -221,6 +221,12 @@ data class ObservationPlotMediaSubjectPayload(
     override val deleted: Boolean?,
     val fileId: FileId,
     override val fullText: String,
+    @Schema(
+        description =
+            "True if this file was uploaded as part of the original submission of observation " +
+                "data; false if it was uploaded later."
+    )
+    val isOriginal: Boolean,
     val mediaKind: MediaKind,
     val monitoringPlotId: MonitoringPlotId,
     val observationId: ObservationId,
@@ -246,6 +252,7 @@ data class ObservationPlotMediaSubjectPayload(
           deleted = if (deleteEvent != null) true else null,
           fileId = event.fileId,
           fullText = fullText,
+          isOriginal = createEvent.isOriginal,
           mediaKind = mediaKind,
           monitoringPlotId = event.monitoringPlotId,
           observationId = event.observationId,

--- a/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformerTest.kt
@@ -81,6 +81,7 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
             deleted = null,
             fileId = fileId,
             fullText = "Photo $fileId",
+            isOriginal = true,
             mediaKind = MediaKind.Photo,
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,
@@ -173,6 +174,7 @@ class EventLogPayloadTransformerTest : DatabaseTest(), RunsAsDatabaseUser {
             deleted = true, // This will be set on the created action, not just the deleted one
             fileId = fileId,
             fullText = "Photo $fileId",
+            isOriginal = true,
             mediaKind = MediaKind.Photo,
             monitoringPlotId = monitoringPlotId,
             observationId = observationId,


### PR DESCRIPTION
The event log subject for observation media files needs to include the flag that
indicates whether or not the file was uploaded as part of the original observation
data; that way the client can differentiate or exclude those files from the
observation history in the UI.