### PR TITLE
SW-7822 Fix biomass detail edit event log payload

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/event/Events.kt
@@ -426,7 +426,7 @@ data class BiomassDetailsUpdatedEventV1(
               messages.numericValueOrNull(changedTo.salinity),
           ),
           createUpdatedField(
-              "smallTreeCount",
+              "smallTreeCountRange",
               renderSmallTreeCountRange(changedFrom, messages),
               renderSmallTreeCountRange(changedTo, messages),
           ),


### PR DESCRIPTION
If a user edited the small tree count range on a biomass observation, querying the
observation's events from the event log would throw a server error because it
wasn't able to look up the correct localized field name.