### PR TITLE
SW-7856 Update to new logic for project level survival rates in reports

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1516,10 +1516,10 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                                   .or(
                                       SPECIES_ID.isNull
                                           .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.isNull)
-                                          .and(CERTAINTY_ID.ne(RecordedSpeciesCertainty.Unknown))
+                                          .and(CERTAINTY_ID.eq(RecordedSpeciesCertainty.Other))
                                           .and(
-                                              OBSERVED_SITE_SPECIES_TOTALS.CERTAINTY_ID.ne(
-                                                  RecordedSpeciesCertainty.Unknown
+                                              OBSERVED_SITE_SPECIES_TOTALS.CERTAINTY_ID.eq(
+                                                  RecordedSpeciesCertainty.Other
                                               )
                                           )
                                   )

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationResultsStore.kt
@@ -1503,10 +1503,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
     val latestLiveField =
         with(OBSERVED_SUBZONE_SPECIES_TOTALS) {
           DSL.field(
-              DSL.select(
-                      DSL.sum(DSL.coalesce(OBSERVED_SUBZONE_SPECIES_TOTALS.TOTAL_LIVE, 0))
-                          .cast(SQLDataType.INTEGER)
-                  )
+              DSL.select(DSL.sum(DSL.coalesce(TOTAL_LIVE, 0)).cast(SQLDataType.INTEGER))
                   .from(PLANTING_SUBZONES)
                   .join(OBSERVED_SUBZONE_SPECIES_TOTALS)
                   .on(PLANTING_SUBZONE_ID.eq(PLANTING_SUBZONES.ID))
@@ -1514,7 +1511,19 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
                       PLANTING_SUBZONES.PLANTING_SITE_ID.eq(
                               OBSERVED_SITE_SPECIES_TOTALS.PLANTING_SITE_ID
                           )
-                          .and(SPECIES_ID.eq(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID))
+                          .and(
+                              SPECIES_ID.eq(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID)
+                                  .or(
+                                      SPECIES_ID.isNull
+                                          .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.isNull)
+                                          .and(CERTAINTY_ID.ne(RecordedSpeciesCertainty.Unknown))
+                                          .and(
+                                              OBSERVED_SITE_SPECIES_TOTALS.CERTAINTY_ID.ne(
+                                                  RecordedSpeciesCertainty.Unknown
+                                              )
+                                          )
+                                  )
+                          )
                   )
                   .and(
                       OBSERVATION_ID.eq(
@@ -1701,6 +1710,7 @@ class ObservationResultsStore(private val dslContext: DSLContext) {
               startDate = record[OBSERVATIONS.START_DATE.asNonNullable()],
               state = record[OBSERVATIONS.STATE_ID.asNonNullable()],
               survivalRate = survivalRate,
+              survivalRateIncludesTempPlots = survivalRateIncludesTempPlots,
               survivalRateStdDev = survivalRateStdDev,
               totalPlants = totalPlants,
               totalSpecies = totalSpecies,

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/ObservationResultsModel.kt
@@ -276,6 +276,7 @@ data class ObservationResultsModel(
     val plantingZones: List<ObservationPlantingZoneResultsModel>,
     override val species: List<ObservationSpeciesResultsModel>,
     override val survivalRate: Int?,
+    val survivalRateIncludesTempPlots: Boolean,
     override val survivalRateStdDev: Int?,
     val startDate: LocalDate,
     val state: ObservationState,
@@ -561,6 +562,10 @@ fun List<ObservationSpeciesResultsModel>.calculateSurvivalRate(
   val numKnownLive =
       if (includeTempPlots) this.sumOf { it.latestLive } else this.sumOf { it.permanentLive }
 
+  return calculateSurvivalRate(numKnownLive, sumDensity)
+}
+
+fun calculateSurvivalRate(numKnownLive: Int, sumDensity: BigDecimal?): Int? {
   val numerator = (numKnownLive * 100.0).toBigDecimal()
 
   return if (sumDensity != null && sumDensity > BigDecimal.ZERO) {

--- a/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/AppNotificationServiceTest.kt
@@ -95,6 +95,7 @@ import com.terraformation.backend.seedbank.db.WithdrawalStore
 import com.terraformation.backend.seedbank.event.AccessionDryingEndEvent
 import com.terraformation.backend.seedbank.model.AccessionModel
 import com.terraformation.backend.species.db.SpeciesStore
+import com.terraformation.backend.tracking.db.ObservationResultsStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
 import com.terraformation.backend.tracking.event.ObservationStartedEvent
 import com.terraformation.backend.tracking.event.ObservationUpcomingNotificationDueEvent
@@ -144,6 +145,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
   private lateinit var moduleEventStore: ModuleEventStore
   private lateinit var moduleStore: ModuleStore
   private lateinit var notificationStore: NotificationStore
+  private lateinit var observationResultsStore: ObservationResultsStore
   private lateinit var organizationStore: OrganizationStore
   private lateinit var parentStore: ParentStore
   private lateinit var participantStore: ParticipantStore
@@ -210,6 +212,7 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
     moduleStore = ModuleStore(dslContext)
     notificationStore = NotificationStore(dslContext, clock)
     organizationStore = OrganizationStore(clock, dslContext, organizationsDao, publisher)
+    observationResultsStore = ObservationResultsStore(dslContext)
     participantStore = ParticipantStore(clock, dslContext, publisher, participantsDao)
     plantingSiteStore =
         PlantingSiteStore(
@@ -228,7 +231,15 @@ internal class AppNotificationServiceTest : DatabaseTest(), RunsAsUser {
         )
     projectStore = ProjectStore(clock, dslContext, publisher, parentStore, projectsDao)
     reportStore =
-        ReportStore(clock, dslContext, publisher, messages, reportsDao, SystemUser(usersDao))
+        ReportStore(
+            clock,
+            dslContext,
+            publisher,
+            messages,
+            observationResultsStore,
+            reportsDao,
+            SystemUser(usersDao),
+        )
     speciesStore =
         SpeciesStore(
             clock,


### PR DESCRIPTION
The logic for handling multiple planting sites for a survival rate had not yet been implemented for reports. Implement this using the `ObservationResultsStore` in order to decrease duplication and because the logic for checking multiple planting sites' survival rates is even more complex than what we have for reports currently.