### PR TITLE
SW-7874 Delete mortality rate system metric and temporary project metrics

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1704,7 +1704,6 @@ class ReportStore(
   private val systemTerrawareValueField =
       DSL.coalesce(
           DSL.case_()
-              .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.MortalityRate), mortalityRateField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.Seedlings), seedlingsField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SeedsCollected), seedsCollectedField)
               .`when`(SYSTEM_METRICS.ID.eq(SystemMetric.SpeciesPlanted), speciesPlantedField)

--- a/src/main/resources/db/migration/0400/V431__DeleteMortalityRateMetric.sql
+++ b/src/main/resources/db/migration/0400/V431__DeleteMortalityRateMetric.sql
@@ -4,10 +4,10 @@ DELETE FROM funder.published_report_system_metrics WHERE system_metric_id = 5;
 DELETE FROM accelerator.system_metrics WHERE id = 5;
 
 -- delete project metrics that were setup temporarily for survival rate
-DELETE FROM accelerator.report_project_metrics WHERE project_metric_id IN (
-    SELECT id FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%'
+DELETE FROM accelerator.report_project_metrics WHERE project_metric_id = (
+    SELECT id FROM accelerator.project_metrics WHERE name = 'Survival rate (%) of planted mangroves'
 );
-DELETE FROM funder.published_report_project_metrics WHERE project_metric_id IN (
-    SELECT id FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%'
+DELETE FROM funder.published_report_project_metrics WHERE project_metric_id = (
+    SELECT id FROM accelerator.project_metrics WHERE name = 'Survival rate (%) of planted mangroves'
 );
-DELETE FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%';
+DELETE FROM accelerator.project_metrics WHERE name = 'Survival rate (%) of planted mangroves';

--- a/src/main/resources/db/migration/0400/V431__DeleteMortalityRateMetric.sql
+++ b/src/main/resources/db/migration/0400/V431__DeleteMortalityRateMetric.sql
@@ -1,0 +1,13 @@
+-- system_metric_id of 5 is mortality rate
+DELETE FROM accelerator.report_system_metrics WHERE system_metric_id = 5;
+DELETE FROM funder.published_report_system_metrics WHERE system_metric_id = 5;
+DELETE FROM accelerator.system_metrics WHERE id = 5;
+
+-- delete project metrics that were setup temporarily for survival rate
+DELETE FROM accelerator.report_project_metrics WHERE project_metric_id IN (
+    SELECT id FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%'
+);
+DELETE FROM funder.published_report_project_metrics WHERE project_metric_id IN (
+    SELECT id FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%'
+);
+DELETE FROM accelerator.project_metrics WHERE name LIKE 'Survival rate%';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -541,7 +541,6 @@ VALUES (1, 'Seeds Collected', 'Total seed count checked-into accessions.', 2, 2,
        (2, 'Seedlings', 'Plants in the nursery, including those provided by partners, where available. Not applicable for mangrove projects (input 0).', 2, 2, '1.2', true),
        (3, 'Trees Planted', 'Total trees (and plants) planted in the field.', 2, 2, '1.3', true),
        (4, 'Species Planted', 'Total species of the plants/trees planted.', 2, 2, '1.4', true),
-       (5, 'Mortality Rate', 'Mortality rate of plantings.', 3, 2, '2', false),
        (6, 'Hectares Planted', 'This is the hectares marked as “Planting Complete” within the Project Area.', 2, 2, '1.1.1.1', true),
        (7, 'Survival Rate', 'Survival rate of plantings.', 3, 2, '2', true)
 ON CONFLICT (id) DO UPDATE

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -5278,7 +5278,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 6,
         totalLive = 6,
-        cumulativeDead = 1000,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1OldObservationId,
@@ -5289,7 +5288,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         // total live at a site level can be lower than subzone level because of disjoint subzones
         // set this to 0 to ensure that tests use subzone level for temp plots in survival rates
         totalLive = 0,
-        cumulativeDead = 1000,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1OldObservationId,
@@ -5298,7 +5296,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 11,
         totalLive = 11,
-        cumulativeDead = 1000,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1OldObservationId,
@@ -5307,7 +5304,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 11,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1OldObservationId,
@@ -5316,7 +5312,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 6,
         totalLive = 6,
-        cumulativeDead = 1000,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1OldObservationId,
@@ -5325,7 +5320,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 6,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
 
     val site1observation2 =
@@ -5351,7 +5345,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 6,
         totalLive = 6,
-        cumulativeDead = 1,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1observation2,
@@ -5360,7 +5353,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 6,
         totalLive = 0,
-        cumulativeDead = 1,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1observation2,
@@ -5369,7 +5361,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 11,
         totalLive = 11,
-        cumulativeDead = 3,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1observation2,
@@ -5378,7 +5369,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 11,
         totalLive = 0,
-        cumulativeDead = 3,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1observation2,
@@ -5387,7 +5377,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 6,
         totalLive = 6,
-        cumulativeDead = 7,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1observation2,
@@ -5396,7 +5385,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 6,
         totalLive = 0,
-        cumulativeDead = 7,
     )
     // Unknown plants are not counted towards survival rates
     insertObservedSubzoneSpeciesTotals(
@@ -5405,7 +5393,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 0,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1observation2,
@@ -5413,7 +5400,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 0,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
 
     // future observations are not counted towards survival rates
@@ -5441,7 +5427,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 12,
         totalLive = 12,
-        cumulativeDead = 4,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5450,7 +5435,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = otherSpeciesId,
         permanentLive = 12,
         totalLive = 0,
-        cumulativeDead = 4,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5459,7 +5443,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 7,
         totalLive = 7,
-        cumulativeDead = 2,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5468,7 +5451,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 7,
         totalLive = 0,
-        cumulativeDead = 2,
     )
     insertObservedSubzoneSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5477,7 +5459,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 7,
         totalLive = 7,
-        cumulativeDead = 8,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5486,7 +5467,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesName = "Other",
         permanentLive = 7,
         totalLive = 0,
-        cumulativeDead = 8,
     )
     // Unknown plants are not counted towards survival rate
     insertObservedSubzoneSpeciesTotals(
@@ -5495,7 +5475,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 1,
         totalLive = 1,
-        cumulativeDead = 100,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site1FutureObservationId,
@@ -5503,7 +5482,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         certainty = RecordedSpeciesCertainty.Unknown,
         permanentLive = 1,
         totalLive = 10,
-        cumulativeDead = 100,
     )
 
     // Latest observation before the reporting period counts towards survival rate
@@ -5531,7 +5509,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 7,
         totalLive = 7,
-        cumulativeDead = 9,
     )
     insertObservedSiteSpeciesTotals(
         observationId = site2ObservationId,
@@ -5540,7 +5517,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 7,
         totalLive = 0,
-        cumulativeDead = 9,
     )
 
     // Planting sites not part of the project is never counted
@@ -5570,7 +5546,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 0,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
     insertObservedSiteSpeciesTotals(
         observationId = otherSiteObservationId,
@@ -5579,7 +5554,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         speciesId = speciesId,
         permanentLive = 0,
         totalLive = 0,
-        cumulativeDead = 1000,
     )
     // Total plants: 50
     // Dead plants: 20

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -501,13 +501,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                       ),
               ),
               ReportSystemMetricModel(
-                  metric = SystemMetric.MortalityRate,
-                  entry =
-                      ReportSystemMetricEntryModel(
-                          systemValue = 0,
-                      ),
-              ),
-              ReportSystemMetricModel(
                   metric = SystemMetric.SurvivalRate,
                   entry = ReportSystemMetricEntryModel(systemValue = 0),
               ),
@@ -589,13 +582,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   entry =
                       ReportSystemMetricEntryModel(
                           systemValue = 1,
-                      ),
-              ),
-              ReportSystemMetricModel(
-                  metric = SystemMetric.MortalityRate,
-                  entry =
-                      ReportSystemMetricEntryModel(
-                          systemValue = 40,
                       ),
               ),
               ReportSystemMetricModel(
@@ -1229,13 +1215,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
               ReportSystemMetricModel(
                   metric = SystemMetric.SpeciesPlanted,
-                  entry =
-                      ReportSystemMetricEntryModel(
-                          systemValue = 0,
-                      ),
-              ),
-              ReportSystemMetricModel(
-                  metric = SystemMetric.MortalityRate,
                   entry =
                       ReportSystemMetricEntryModel(
                           systemValue = 0,
@@ -3147,15 +3126,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ReportSystemMetricsRecord(
                   reportId = reportId,
                   target = 0,
-                  systemMetricId = SystemMetric.MortalityRate,
-                  systemValue = 40,
-                  systemTime = clock.instant,
-                  modifiedBy = user.userId,
-                  modifiedTime = clock.instant,
-              ),
-              ReportSystemMetricsRecord(
-                  reportId = reportId,
-                  target = 0,
                   systemMetricId = SystemMetric.SurvivalRate,
                   systemValue =
                       (sitesLiveSum * 100.0 / (site1T0Density + site2T0Density)).roundToInt(),
@@ -4325,14 +4295,6 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           systemValue = 100,
       )
 
-      // mortality rate is not publishable
-      insertReportSystemMetric(
-          reportId = reportId,
-          metric = SystemMetric.MortalityRate,
-          status = ReportMetricStatus.Unlikely,
-          target = 0,
-          systemValue = 50,
-      )
       insertReportSystemMetric(
           reportId = reportId,
           metric = SystemMetric.SurvivalRate,
@@ -5290,7 +5252,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         numPlants = 9,
     )
 
-    // Not the latest observation, so the number does not count towards mortality/survival rates
+    // Not the latest observation, so the number does not count towards survival rates
     val observationDate = getRandomDate(reportStartDate, reportEndDate.minusDays(1))
     val observationTime = observationDate.atStartOfDay().toInstant(ZoneOffset.UTC)
     val site1OldObservationId =
@@ -5436,7 +5398,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         totalLive = 0,
         cumulativeDead = 7,
     )
-    // Unknown plants are not counted towards mortality/survival rates
+    // Unknown plants are not counted towards survival rates
     insertObservedSubzoneSpeciesTotals(
         observationId = site1observation2,
         plantingSubzoneId = subzoneId1,
@@ -5454,7 +5416,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         cumulativeDead = 1000,
     )
 
-    // future observations are not counted towards mortality/survival rates
+    // future observations are not counted towards survival rates
     val futureObservationDate = reportEndDate.plusDays(1)
     val site1FutureObservationId =
         insertObservation(
@@ -5526,7 +5488,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         totalLive = 0,
         cumulativeDead = 8,
     )
-    // Unknown plants are not counted towards mortality/survival rate
+    // Unknown plants are not counted towards survival rate
     insertObservedSubzoneSpeciesTotals(
         observationId = site1FutureObservationId,
         plantingSubzoneId = subzoneId1,
@@ -5544,7 +5506,7 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
         cumulativeDead = 100,
     )
 
-    // Latest observation before the reporting period counts towards mortality/survival rate
+    // Latest observation before the reporting period counts towards survival rate
     val site2ObservationTime = reportStartDate.minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC)
     val site2ObservationId =
         insertObservation(

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedReportStoreTest.kt
@@ -165,14 +165,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertPublishedReportSystemMetric(
           reportId = reportId1,
-          metric = SystemMetric.MortalityRate,
-          target = 0,
-          value = 5,
-          projectsComments = "Some plants had died.",
-          status = ReportMetricStatus.Unlikely,
-      )
-      insertPublishedReportSystemMetric(
-          reportId = reportId1,
           metric = SystemMetric.SurvivalRate,
           target = 6,
           value = 6,
@@ -303,20 +295,6 @@ class PublishedReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
                   startDate = LocalDate.of(2025, 1, 1),
                   systemMetrics =
                       listOf(
-                          PublishedReportMetricModel(
-                              component = SystemMetric.MortalityRate.componentId,
-                              description = SystemMetric.MortalityRate.description,
-                              metricId = SystemMetric.MortalityRate,
-                              name = SystemMetric.MortalityRate.jsonValue,
-                              reference = SystemMetric.MortalityRate.reference,
-                              status = ReportMetricStatus.Unlikely,
-                              target = 0,
-                              type = SystemMetric.MortalityRate.typeId,
-                              progressNotes = null,
-                              projectsComments = "Some plants had died.",
-                              value = 5,
-                              unit = null,
-                          ),
                           PublishedReportMetricModel(
                               component = SystemMetric.SurvivalRate.componentId,
                               description = SystemMetric.SurvivalRate.description,


### PR DESCRIPTION
Product decided that they wanted to do a clean break from mortality rate, even in older reports (including published). They have already recorded all current mortality rate values in case these values are needed in older reports later on.
Delete the mortality rate system metric.

Additionally, a project in prod had setup a project metric for survival rate temporarily until the real survival rate was merged which is happening in the next release. Product has also already recorded all current survival rate values for this project metric in order to go back into old reports and republish them with an overridden value of what was used with this project metric.
Delete this project metric in prod as well.
