### PR TITLE
SW-7827 Rename variables in User-related files for Zone -> Strata/Stratum

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -475,14 +475,6 @@ data class IndividualUser(
       canReadAcceleratorProject(parentStore.getProjectId(plantingSiteId)) ||
           isMember(parentStore.getOrganizationId(plantingSiteId))
 
-  override fun canReadPlantingSubzone(plantingSubzoneId: SubstratumId) =
-      canReadAcceleratorProject(parentStore.getProjectId(plantingSubzoneId)) ||
-          isMember(parentStore.getOrganizationId(plantingSubzoneId))
-
-  override fun canReadPlantingZone(plantingZoneId: StratumId) =
-      canReadAcceleratorProject(parentStore.getProjectId(plantingZoneId)) ||
-          isMember(parentStore.getOrganizationId(plantingZoneId))
-
   override fun canReadProject(projectId: ProjectId): Boolean {
     val organizationId = parentStore.getOrganizationId(projectId) ?: return false
     return isMember(organizationId) ||
@@ -536,6 +528,10 @@ data class IndividualUser(
     return isMember(organizationId) || isGlobalReader(organizationId)
   }
 
+  override fun canReadStratum(stratumId: StratumId) =
+      canReadAcceleratorProject(parentStore.getProjectId(stratumId)) ||
+          isMember(parentStore.getOrganizationId(stratumId))
+
   override fun canReadSubLocation(subLocationId: SubLocationId): Boolean {
     val facilityId = parentStore.getFacilityId(subLocationId) ?: return false
     return isMember(facilityId) || isGlobalReader(parentStore.getOrganizationId(facilityId))
@@ -545,6 +541,10 @@ data class IndividualUser(
       isReadOnlyOrHigher() || isMember(parentStore.getOrganizationId(submissionId))
 
   override fun canReadSubmissionDocument(documentId: SubmissionDocumentId) = isReadOnlyOrHigher()
+
+  override fun canReadSubstratum(substratumId: SubstratumId) =
+      canReadAcceleratorProject(parentStore.getProjectId(substratumId)) ||
+          isMember(parentStore.getOrganizationId(substratumId))
 
   override fun canReadTimeseries(deviceId: DeviceId) = isMember(parentStore.getFacilityId(deviceId))
 
@@ -708,12 +708,6 @@ data class IndividualUser(
   override fun canUpdatePlantingSiteProject(plantingSiteId: PlantingSiteId) =
       isMember(parentStore.getOrganizationId(plantingSiteId))
 
-  override fun canUpdatePlantingSubzoneCompleted(plantingSubzoneId: SubstratumId) =
-      isMember(parentStore.getOrganizationId(plantingSubzoneId))
-
-  override fun canUpdatePlantingZone(plantingZoneId: StratumId) =
-      isAdminOrHigher(parentStore.getOrganizationId(plantingZoneId))
-
   override fun canUpdateProject(projectId: ProjectId): Boolean {
     val organizationId = parentStore.getOrganizationId(projectId) ?: return false
     return isAdminOrHigher(organizationId) || isGlobalWriter(organizationId)
@@ -742,17 +736,23 @@ data class IndividualUser(
   override fun canUpdateSpecies(speciesId: SpeciesId) =
       isManagerOrHigher(parentStore.getOrganizationId(speciesId))
 
+  override fun canUpdateStratum(stratumId: StratumId) =
+      isAdminOrHigher(parentStore.getOrganizationId(stratumId))
+
   override fun canUpdateSubLocation(subLocationId: SubLocationId) =
       isAdminOrHigher(parentStore.getFacilityId(subLocationId))
 
   override fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId) =
       isTFExpertOrHigher()
 
+  override fun canUpdateSubstratumCompleted(substratumId: SubstratumId) =
+      isMember(parentStore.getOrganizationId(substratumId))
+
   override fun canUpdateT0(monitoringPlotId: MonitoringPlotId) =
       isManagerOrHigher(parentStore.getOrganizationId(monitoringPlotId))
 
-  override fun canUpdateT0(plantingZoneId: StratumId) =
-      isManagerOrHigher(parentStore.getOrganizationId(plantingZoneId))
+  override fun canUpdateT0(stratumId: StratumId) =
+      isManagerOrHigher(parentStore.getOrganizationId(stratumId))
 
   override fun canUpdateTimeseries(deviceId: DeviceId) =
       isAdminOrHigher(parentStore.getFacilityId(deviceId))

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -1314,7 +1314,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun readStratum(stratumId: StratumId) {
     user.recordPermissionChecks {
-      if (!user.canReadPlantingZone(stratumId)) {
+      if (!user.canReadStratum(stratumId)) {
         throw StratumNotFoundException(stratumId)
       }
     }
@@ -1346,7 +1346,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun readSubstratum(substratumId: SubstratumId) {
     user.recordPermissionChecks {
-      if (!user.canReadPlantingSubzone(substratumId)) {
+      if (!user.canReadSubstratum(substratumId)) {
         throw SubstrataNotFoundException(substratumId)
       }
     }
@@ -1942,7 +1942,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun updateStratum(stratumId: StratumId) {
     user.recordPermissionChecks {
-      if (!user.canUpdatePlantingZone(stratumId)) {
+      if (!user.canUpdateStratum(stratumId)) {
         readStratum(stratumId)
         throw AccessDeniedException("No permission to update stratum $stratumId")
       }
@@ -1969,7 +1969,7 @@ class PermissionRequirements(private val user: TerrawareUser) {
 
   fun updateSubstratumCompleted(substratumId: SubstratumId) {
     user.recordPermissionChecks {
-      if (!user.canUpdatePlantingSubzoneCompleted(substratumId)) {
+      if (!user.canUpdateSubstratumCompleted(substratumId)) {
         readSubstratum(substratumId)
         throw AccessDeniedException("No permission to update substratum $substratumId")
       }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -473,10 +473,6 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canReadPlantingSite(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canReadPlantingSubzone(plantingSubzoneId: SubstratumId): Boolean = defaultPermission
-
-  fun canReadPlantingZone(plantingZoneId: StratumId): Boolean = defaultPermission
-
   fun canReadProject(projectId: ProjectId): Boolean = defaultPermission
 
   fun canReadProjectAcceleratorDetails(projectId: ProjectId): Boolean = defaultPermission
@@ -509,11 +505,15 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canReadSpecies(speciesId: SpeciesId): Boolean = defaultPermission
 
+  fun canReadStratum(stratumId: StratumId): Boolean = defaultPermission
+
   fun canReadSubLocation(subLocationId: SubLocationId): Boolean = defaultPermission
 
   fun canReadSubmission(submissionId: SubmissionId): Boolean = defaultPermission
 
   fun canReadSubmissionDocument(documentId: SubmissionDocumentId): Boolean = defaultPermission
+
+  fun canReadSubstratum(substratumId: SubstratumId): Boolean = defaultPermission
 
   fun canReadTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 
@@ -627,11 +627,6 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canUpdatePlantingSiteProject(plantingSiteId: PlantingSiteId): Boolean = defaultPermission
 
-  fun canUpdatePlantingSubzoneCompleted(plantingSubzoneId: SubstratumId): Boolean =
-      defaultPermission
-
-  fun canUpdatePlantingZone(plantingZoneId: StratumId): Boolean = defaultPermission
-
   fun canUpdateProject(projectId: ProjectId): Boolean = defaultPermission
 
   fun canUpdateProjectAcceleratorDetails(projectId: ProjectId): Boolean = defaultPermission
@@ -654,14 +649,18 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canUpdateSpecificGlobalRoles(globalRoles: Set<GlobalRole>): Boolean = defaultPermission
 
+  fun canUpdateStratum(stratumId: StratumId): Boolean = defaultPermission
+
   fun canUpdateSubLocation(subLocationId: SubLocationId): Boolean = defaultPermission
 
   fun canUpdateSubmissionStatus(deliverableId: DeliverableId, projectId: ProjectId): Boolean =
       defaultPermission
 
+  fun canUpdateSubstratumCompleted(substratumId: SubstratumId): Boolean = defaultPermission
+
   fun canUpdateT0(monitoringPlotId: MonitoringPlotId): Boolean = defaultPermission
 
-  fun canUpdateT0(plantingZoneId: StratumId): Boolean = defaultPermission
+  fun canUpdateT0(stratumId: StratumId): Boolean = defaultPermission
 
   fun canUpdateTimeseries(deviceId: DeviceId): Boolean = defaultPermission
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -180,13 +180,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
   private val speciesId: SpeciesId by
       readableId(SpeciesNotFoundException::class) { canReadSpecies(it) }
   private val stratumId: StratumId by
-      readableId(StratumNotFoundException::class) { canReadPlantingZone(it) }
+      readableId(StratumNotFoundException::class) { canReadStratum(it) }
   private val subLocationId: SubLocationId by
       readableId(SubLocationNotFoundException::class) { canReadSubLocation(it) }
   private val submissionDocumentId: SubmissionDocumentId by
       readableId(SubmissionDocumentNotFoundException::class) { canReadSubmissionDocument(it) }
   private val substratumId: SubstratumId by
-      readableId(SubstrataNotFoundException::class) { canReadPlantingSubzone(it) }
+      readableId(SubstrataNotFoundException::class) { canReadSubstratum(it) }
   private val uploadId: UploadId by readableId(UploadNotFoundException::class) { canReadUpload(it) }
   private val userId = UserId(1)
   private val viabilityTestId: ViabilityTestId by
@@ -1202,8 +1202,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun updateSpecies() = allow { updateSpecies(speciesId) } ifUser { canUpdateSpecies(speciesId) }
 
   @Test
-  fun updateStratum() =
-      allow { updateStratum(stratumId) } ifUser { canUpdatePlantingZone(stratumId) }
+  fun updateStratum() = allow { updateStratum(stratumId) } ifUser { canUpdateStratum(stratumId) }
 
   @Test
   fun updateSubLocation() =
@@ -1220,7 +1219,7 @@ internal class PermissionRequirementsTest : RunsAsUser {
   fun updateSubstratumCompleted() =
       allow { updateSubstratumCompleted(substratumId) } ifUser
           {
-            canUpdatePlantingSubzoneCompleted(substratumId)
+            canUpdateSubstratumCompleted(substratumId)
           }
 
   @Test

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -153,9 +153,9 @@ internal class PermissionTest : DatabaseTest() {
   private val draftPlantingSiteIds = facilityIds.map { DraftPlantingSiteId(it.value) }
   private val monitoringPlotIds = facilityIds.map { MonitoringPlotId(it.value) }
   private val plantingSiteIds = facilityIds.map { PlantingSiteId(it.value) }
-  private val plantingSubzoneIds = facilityIds.map { SubstratumId(it.value) }
-  private val plantingZoneIds = facilityIds.map { StratumId(it.value) }
   private val observationIds = plantingSiteIds.map { ObservationId(it.value) }
+  private val stratumIds = facilityIds.map { StratumId(it.value) }
+  private val substratumIds = facilityIds.map { SubstratumId(it.value) }
 
   private val projectIds = listOf(1000, 1001, 3000, 4000).map { ProjectId(it.toLong()) }
   private val moduleEventIds = listOf(1000, 1001, 3000, 4000).map { EventId(it.toLong()) }
@@ -383,23 +383,23 @@ internal class PermissionTest : DatabaseTest() {
       )
     }
 
-    plantingZoneIds.forEach { plantingZoneId ->
+    stratumIds.forEach { stratumId ->
       putDatabaseId(
-          plantingZoneId,
+          stratumId,
           insertStratum(
               createdBy = userId,
-              plantingSiteId = getDatabaseId(PlantingSiteId(plantingZoneId.value)),
+              plantingSiteId = getDatabaseId(PlantingSiteId(stratumId.value)),
           ),
       )
     }
 
-    plantingSubzoneIds.forEach { plantingSubzoneId ->
+    substratumIds.forEach { substratumId ->
       putDatabaseId(
-          plantingSubzoneId,
+          substratumId,
           insertSubstratum(
               createdBy = userId,
-              plantingSiteId = getDatabaseId(PlantingSiteId(plantingSubzoneId.value)),
-              stratumId = getDatabaseId(StratumId(plantingSubzoneId.value)),
+              plantingSiteId = getDatabaseId(PlantingSiteId(substratumId.value)),
+              stratumId = getDatabaseId(StratumId(substratumId.value)),
           ),
       )
     }
@@ -634,15 +634,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg1(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.forOrg1(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg1(),
-        readPlantingZone = true,
-        updatePlantingZone = true,
+        *stratumIds.forOrg1(),
+        readStratum = true,
+        updateStratum = true,
         updateT0 = true,
     )
 
@@ -924,15 +924,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg1(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.forOrg1(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg1(),
-        readPlantingZone = true,
-        updatePlantingZone = true,
+        *stratumIds.forOrg1(),
+        readStratum = true,
+        updateStratum = true,
         updateT0 = true,
     )
 
@@ -1133,14 +1133,14 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg1(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.forOrg1(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg1(),
-        readPlantingZone = true,
+        *stratumIds.forOrg1(),
+        readStratum = true,
         updateT0 = true,
     )
 
@@ -1312,14 +1312,14 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg1(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.forOrg1(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg1(),
-        readPlantingZone = true,
+        *stratumIds.forOrg1(),
+        readStratum = true,
     )
 
     permissions.expect(
@@ -1603,15 +1603,15 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.toTypedArray(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.toTypedArray(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.toTypedArray(),
-        readPlantingZone = true,
-        updatePlantingZone = true,
+        *stratumIds.toTypedArray(),
+        readStratum = true,
+        updateStratum = true,
         updateT0 = true,
     )
 
@@ -2828,14 +2828,14 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrg1(),
-        readPlantingSubzone = true,
-        updatePlantingSubzoneCompleted = true,
+        *substratumIds.forOrg1(),
+        readSubstratum = true,
+        updateSubstratumCompleted = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrg1(),
-        readPlantingZone = true,
+        *stratumIds.forOrg1(),
+        readStratum = true,
     )
 
     permissions.expect(
@@ -2912,13 +2912,13 @@ internal class PermissionTest : DatabaseTest() {
     )
 
     permissions.expect(
-        *plantingSubzoneIds.forOrgs(listOf(3, 4)),
-        readPlantingSubzone = true,
+        *substratumIds.forOrgs(listOf(3, 4)),
+        readSubstratum = true,
     )
 
     permissions.expect(
-        *plantingZoneIds.forOrgs(listOf(3, 4)),
-        readPlantingZone = true,
+        *stratumIds.forOrgs(listOf(3, 4)),
+        readStratum = true,
     )
 
     permissions.expect(
@@ -3173,15 +3173,15 @@ internal class PermissionTest : DatabaseTest() {
     private val uncheckedParticipantProjectSpecies = participantProjectSpeciesIds.toMutableSet()
     private val uncheckedPlantings = plantingIds.toMutableSet()
     private val uncheckedPlantingSites = plantingSiteIds.toMutableSet()
-    private val uncheckedPlantingSubzones = plantingSubzoneIds.toMutableSet()
-    private val uncheckedPlantingZones = plantingZoneIds.toMutableSet()
     private val uncheckedProjects = projectIds.toMutableSet()
     private val uncheckedReports = reportIds.toMutableSet()
     private val uncheckedSeedFundReports = seedFundReportIds.toMutableSet()
     private val uncheckedSpecies = speciesIds.toMutableSet()
+    private val uncheckedStrata = stratumIds.toMutableSet()
     private val uncheckedSubLocations = subLocationIds.toMutableSet()
     private val uncheckedSubmissionDocuments = submissionDocumentIds.toMutableSet()
     private val uncheckedSubmissions = submissionIds.toMutableSet()
+    private val uncheckedSubstrata = substratumIds.toMutableSet()
     private val uncheckedUsers = otherUserIds.values.toMutableSet()
     private val uncheckedViabilityTests = viabilityTestIds.toMutableSet()
     private val uncheckedWithdrawals = withdrawalIds.toMutableSet()
@@ -3915,54 +3915,54 @@ internal class PermissionTest : DatabaseTest() {
     }
 
     fun expect(
-        vararg plantingSubzoneIds: SubstratumId,
-        readPlantingSubzone: Boolean = false,
-        updatePlantingSubzoneCompleted: Boolean = false,
+        vararg substratumIds: SubstratumId,
+        readSubstratum: Boolean = false,
+        updateSubstratumCompleted: Boolean = false,
     ) {
-      plantingSubzoneIds.forEach { plantingSubzoneId ->
-        val idInDatabase = getDatabaseId(plantingSubzoneId)
+      substratumIds.forEach { substratumId ->
+        val idInDatabase = getDatabaseId(substratumId)
 
         assertEquals(
-            readPlantingSubzone,
-            user.canReadPlantingSubzone(idInDatabase),
-            "Can read planting subzone $plantingSubzoneId",
+            readSubstratum,
+            user.canReadSubstratum(idInDatabase),
+            "Can read substratum $substratumId",
         )
         assertEquals(
-            updatePlantingSubzoneCompleted,
-            user.canUpdatePlantingSubzoneCompleted(idInDatabase),
-            "Can update planting completed for subzone $plantingSubzoneId",
+            updateSubstratumCompleted,
+            user.canUpdateSubstratumCompleted(idInDatabase),
+            "Can update planting completed for substratum $substratumId",
         )
 
-        uncheckedPlantingSubzones.remove(plantingSubzoneId)
+        uncheckedSubstrata.remove(substratumId)
       }
     }
 
     fun expect(
-        vararg plantingZoneIds: StratumId,
-        readPlantingZone: Boolean = false,
-        updatePlantingZone: Boolean = false,
+        vararg stratumIds: StratumId,
+        readStratum: Boolean = false,
+        updateStratum: Boolean = false,
         updateT0: Boolean = false,
     ) {
-      plantingZoneIds.forEach { plantingZoneId ->
-        val idInDatabase = getDatabaseId(plantingZoneId)
+      stratumIds.forEach { stratumId ->
+        val idInDatabase = getDatabaseId(stratumId)
 
         assertEquals(
-            readPlantingZone,
-            user.canReadPlantingZone(idInDatabase),
-            "Can read planting zone $plantingZoneId",
+            readStratum,
+            user.canReadStratum(idInDatabase),
+            "Can read stratum $stratumId",
         )
         assertEquals(
-            updatePlantingZone,
-            user.canUpdatePlantingZone(idInDatabase),
-            "Can update planting zone $plantingZoneId",
+            updateStratum,
+            user.canUpdateStratum(idInDatabase),
+            "Can update stratum $stratumId",
         )
         assertEquals(
             updateT0,
             user.canUpdateT0(idInDatabase),
-            "Can update T0 for planting zone $plantingZoneId",
+            "Can update T0 for stratum $stratumId",
         )
 
-        uncheckedPlantingZones.remove(plantingZoneId)
+        uncheckedStrata.remove(stratumId)
       }
     }
 
@@ -4628,8 +4628,8 @@ internal class PermissionTest : DatabaseTest() {
       expect(*uncheckedParticipantProjectSpecies.toTypedArray())
       expect(*uncheckedPlantings.toTypedArray())
       expect(*uncheckedPlantingSites.toTypedArray())
-      expect(*uncheckedPlantingSubzones.toTypedArray())
-      expect(*uncheckedPlantingZones.toTypedArray())
+      expect(*uncheckedSubstrata.toTypedArray())
+      expect(*uncheckedStrata.toTypedArray())
       expect(*uncheckedProjects.toTypedArray())
       expect(*uncheckedReports.toTypedArray())
       expect(*uncheckedSeedFundReports.toTypedArray())

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -570,7 +570,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertDelivery()
       insertPlanting(speciesId = speciesId5)
 
-      every { user.canReadPlantingSubzone(subzoneId) } returns true
+      every { user.canReadSubstratum(subzoneId) } returns true
 
       val expected =
           listOf(
@@ -641,7 +641,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
             .insert()
       }
 
-      every { user.canReadPlantingSubzone(subzoneId) } returns true
+      every { user.canReadSubstratum(subzoneId) } returns true
 
       val expected =
           listOf(
@@ -682,7 +682,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
       insertStratum()
       val subzoneId = insertSubstratum()
 
-      every { user.canReadPlantingSubzone(subzoneId) } returns false
+      every { user.canReadSubstratum(subzoneId) } returns false
 
       assertThrows<SubstrataNotFoundException> {
         store.fetchSiteSpeciesByPlantingSubzoneId(subzoneId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -98,8 +98,8 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
     every { user.canReadObservation(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
-    every { user.canReadPlantingSubzone(any()) } returns true
-    every { user.canReadPlantingZone(any()) } returns true
+    every { user.canReadStratum(any()) } returns true
+    every { user.canReadSubstratum(any()) } returns true
     every { user.canUpdateObservation(any()) } returns true
     every { user.canUpdatePlantingSite(any()) } returns true
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/BasePlantingSiteStoreTest.kt
@@ -52,12 +52,12 @@ internal abstract class BasePlantingSiteStoreTest : DatabaseTest(), RunsAsUser {
     every { user.canCreatePlantingSite(any()) } returns true
     every { user.canMovePlantingSiteToAnyOrg(any()) } returns true
     every { user.canReadPlantingSite(any()) } returns true
-    every { user.canReadPlantingSubzone(any()) } returns true
-    every { user.canReadPlantingZone(any()) } returns true
     every { user.canReadProject(any()) } returns true
     every { user.canReadOrganization(any()) } returns true
+    every { user.canReadStratum(any()) } returns true
+    every { user.canReadSubstratum(any()) } returns true
     every { user.canUpdatePlantingSite(any()) } returns true
-    every { user.canUpdatePlantingSubzoneCompleted(any()) } returns true
-    every { user.canUpdatePlantingZone(any()) } returns true
+    every { user.canUpdateStratum(any()) } returns true
+    every { user.canUpdateSubstratumCompleted(any()) } returns true
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateStratumTest.kt
@@ -151,7 +151,7 @@ internal class PlantingSiteStoreUpdateStratumTest : BasePlantingSiteStoreTest() 
       insertPlantingSite()
       val stratumId = insertStratum()
 
-      every { user.canUpdatePlantingZone(stratumId) } returns false
+      every { user.canUpdateStratum(stratumId) } returns false
 
       assertThrows<AccessDeniedException> { store.updateStratum(stratumId) { it } }
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSubstratumCompletedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreUpdateSubstratumCompletedTest.kt
@@ -75,7 +75,7 @@ internal class PlantingSiteStoreUpdateSubstratumCompletedTest : BasePlantingSite
       insertStratum()
       val substratumId = insertSubstratum()
 
-      every { user.canUpdatePlantingSubzoneCompleted(any()) } returns false
+      every { user.canUpdateSubstratumCompleted(any()) } returns false
 
       assertThrows<AccessDeniedException> { store.updateSubstratumCompleted(substratumId, true) }
     }


### PR DESCRIPTION
Update variables (and comments) in all files related to `IndividualUser`. This was taken to the extent such that there are no more references to zones or subzones in these files, which means that some files unrelated to the `IndividualUser` were updated.