### PR TITLE
SW-7827 Rename variables in files outside of the tracking folder for Zone -> Strata/Stratum

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -262,9 +262,9 @@ class Messages {
 
   fun monitoringPlotDescription(
       plotType: String,
-      plantingZoneName: String,
-      plantingSubzoneName: String,
-  ) = getMessage("monitoringPlotDescription", plotType, plantingZoneName, plantingSubzoneName)
+      stratumName: String,
+      substratumName: String,
+  ) = getMessage("monitoringPlotDescription", plotType, stratumName, substratumName)
 
   fun monitoringPlotTypePermanent() = getMessage("monitoringPlotTypePermanent")
 

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -131,8 +131,8 @@ class SpeciesStore(
                   .from(OBSERVATION_BIOMASS_SPECIES)
                   .where(OBSERVATION_BIOMASS_SPECIES.SPECIES_ID.eq(SPECIES.ID))
           ),
-          // Observed site, zone, subzone, and plot totals have the same species, so checking one
-          // of them is sufficient.
+          // Observed site, stratum, substratum, and plot totals have the same species, so checking
+          // one of them is sufficient.
           DSL.exists(
               DSL.selectOne()
                   .from(OBSERVED_PLOT_SPECIES_TOTALS)
@@ -200,17 +200,15 @@ class SpeciesStore(
   }
 
   /**
-   * Returns a list of species that may be present in a given planting subzone.
+   * Returns a list of species that may be present in a given planting substratum.
    *
    * This is a combined list of all the species that have been planted and observed across the
-   * entire planting site. We can't limit the search to the specific subzone because subzone
-   * boundaries can change over time; a plant that was in subzone 1 in the past may be in subzone 2
-   * now due to a subsequent map edit.
+   * entire planting site. We can't limit the search to the specific substratum because substratum
+   * boundaries can change over time; a plant that was in substratum 1 in the past may be in
+   * substratum 2 now due to a subsequent map edit.
    */
-  fun fetchSiteSpeciesByPlantingSubzoneId(
-      plantingSubzoneId: SubstratumId
-  ): List<ExistingSpeciesModel> {
-    requirePermissions { readSubstratum(plantingSubzoneId) }
+  fun fetchSiteSpeciesBySubstratumId(substratumId: SubstratumId): List<ExistingSpeciesModel> {
+    requirePermissions { readSubstratum(substratumId) }
 
     return dslContext
         .select(
@@ -227,7 +225,7 @@ class SpeciesStore(
                     .from(PLANTINGS)
                     .join(SUBSTRATA)
                     .on(PLANTINGS.PLANTING_SITE_ID.eq(SUBSTRATA.PLANTING_SITE_ID))
-                    .where(SUBSTRATA.ID.eq(plantingSubzoneId))
+                    .where(SUBSTRATA.ID.eq(substratumId))
                     .union(
                         DSL.select(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID)
                             .from(OBSERVED_SITE_SPECIES_TOTALS)
@@ -237,7 +235,7 @@ class SpeciesStore(
                                     SUBSTRATA.PLANTING_SITE_ID
                                 )
                             )
-                            .where(SUBSTRATA.ID.eq(plantingSubzoneId))
+                            .where(SUBSTRATA.ID.eq(substratumId))
                             .and(OBSERVED_SITE_SPECIES_TOTALS.SPECIES_ID.isNotNull)
                     )
             )

--- a/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/species/db/SpeciesStore.kt
@@ -200,7 +200,7 @@ class SpeciesStore(
   }
 
   /**
-   * Returns a list of species that may be present in a given planting substratum.
+   * Returns a list of species that may be present in a given substratum.
    *
    * This is a combined list of all the species that have been planted and observed across the
    * entire planting site. We can't limit the search to the specific substratum because substratum

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
@@ -37,13 +37,8 @@ class SubstrataController(
   )
   fun listSubstratumSpecies(
       @PathVariable id: SubstratumId,
-<<<<<<< HEAD:src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
   ): ListSubstratumSpeciesResponsePayload {
-    val species = speciesStore.fetchSiteSpeciesByPlantingSubzoneId(id)
-=======
-  ): ListPlantingSubzoneSpeciesResponsePayload {
     val species = speciesStore.fetchSiteSpeciesBySubstratumId(id)
->>>>>>> 5c471a999c1 (SW-7827 Rename variables files outside of the tracking folder for Zone -> Strata/Stratum):src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
 
     return ListSubstratumSpeciesResponsePayload(species.map { SubstratumSpeciesPayload(it) })
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
@@ -37,8 +37,13 @@ class SubstrataController(
   )
   fun listSubstratumSpecies(
       @PathVariable id: SubstratumId,
+<<<<<<< HEAD:src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
   ): ListSubstratumSpeciesResponsePayload {
     val species = speciesStore.fetchSiteSpeciesByPlantingSubzoneId(id)
+=======
+  ): ListPlantingSubzoneSpeciesResponsePayload {
+    val species = speciesStore.fetchSiteSpeciesBySubstratumId(id)
+>>>>>>> 5c471a999c1 (SW-7827 Rename variables files outside of the tracking folder for Zone -> Strata/Stratum):src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSubzonesController.kt
 
     return ListSubstratumSpeciesResponsePayload(species.map { SubstratumSpeciesPayload(it) })
   }

--- a/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/species/db/SpeciesStoreTest.kt
@@ -601,7 +601,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      val actual = store.fetchSiteSpeciesByPlantingSubzoneId(subzoneId)
+      val actual = store.fetchSiteSpeciesBySubstratumId(subzoneId)
 
       assertEquals(expected, actual)
     }
@@ -671,7 +671,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
               ),
           )
 
-      val actual = store.fetchSiteSpeciesByPlantingSubzoneId(subzoneId)
+      val actual = store.fetchSiteSpeciesBySubstratumId(subzoneId)
 
       assertEquals(expected, actual)
     }
@@ -684,9 +684,7 @@ internal class SpeciesStoreTest : DatabaseTest(), RunsAsUser {
 
       every { user.canReadSubstratum(subzoneId) } returns false
 
-      assertThrows<SubstrataNotFoundException> {
-        store.fetchSiteSpeciesByPlantingSubzoneId(subzoneId)
-      }
+      assertThrows<SubstrataNotFoundException> { store.fetchSiteSpeciesBySubstratumId(subzoneId) }
     }
   }
 


### PR DESCRIPTION
Continue to rename variables and comments in files, this time for files outside of the `tracking` folder(s).

I decided to keep this one separate since these were the last referencess found that wouldn't affect the FE or the user, and earlier PRs are all pretty large already.