### PR TITLE
SW-7892 Support tiny substrata

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/plantingSiteStore/PlantingSiteStoreCreateSiteTest.kt
@@ -118,22 +118,6 @@ internal class PlantingSiteStoreCreateSiteTest : BasePlantingSiteStoreTest() {
     }
 
     @Test
-    fun `does not store area for simple site with tiny boundary`() {
-      val boundary = Turtle(point(1)).makeMultiPolygon { square(5) }
-
-      val model =
-          store.createPlantingSite(
-              PlantingSiteModel.create(
-                  boundary = boundary,
-                  name = "name",
-                  organizationId = organizationId,
-              )
-          )
-
-      assertNull(plantingSitesDao.fetchOneById(model.id)!!.areaHa, "Planting site area")
-    }
-
-    @Test
     fun `inserts detailed planting site`() {
       val gridOrigin = point(0.0, 51.0) // Southeastern Great Britain
       val siteBoundary = Turtle(gridOrigin).makeMultiPolygon { rectangle(200, 150) }

--- a/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/ExtensionsTest.kt
@@ -1,6 +1,7 @@
 package com.terraformation.backend.util
 
 import com.terraformation.backend.db.SRID
+import com.terraformation.backend.point
 import java.math.BigDecimal
 import java.time.Instant
 import java.time.LocalDate
@@ -87,6 +88,18 @@ class ExtensionsTest {
           )
 
       assertEquals(BigDecimal("101.8"), geometry.calculateAreaHectares())
+    }
+
+    @Test
+    fun `uses additional decimal places for small areas`() {
+      listOf(
+              11.0 to BigDecimal("0.01"),
+              .00201 to BigDecimal("0.0000000004"),
+          )
+          .forEach { (length, expectedArea) ->
+            val geometry = Turtle(point(0)).makePolygon { square(length) }
+            assertEquals(expectedArea, geometry.calculateAreaHectares(), "Square of length $length")
+          }
     }
   }
 


### PR DESCRIPTION
We round geometry areas to one decimal place, which means that the area of a
substratum of less than 0.05 hectares gets rounded down to zero. This causes
planting site creation to fail because substratum areas must be greater than
zero.

Update the rounding logic so that it uses as many digits as needed for very
small areas.

This only applies to substrata; there is a minimum size requirement for strata
(they have to be big enough to hold monitoring plots) which is still enforced.