### PR TITLE
Include user email in request error log messages

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/ControllerExceptionHandler.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.databind.exc.PropertyBindingException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import com.opencsv.CSVWriter
+import com.terraformation.backend.auth.CurrentUserHolder
 import com.terraformation.backend.db.DuplicateEntityException
 import com.terraformation.backend.db.EntityNotFoundException
 import com.terraformation.backend.db.EntityStaleException
@@ -326,10 +327,13 @@ class ControllerExceptionHandler : ResponseEntityExceptionHandler() {
   }
 
   private fun logError(ex: Exception, request: WebRequest) {
-    val description = request.getDescription(false)
+    val requestDescription = request.getDescription(false)
+    val userDescription = CurrentUserHolder.getCurrentUser()?.description ?: "unauthenticated user"
+
     controllerLogger(ex)
         .error(
-            "${ex.javaClass.simpleName} thrown while handling request $description: ${ex.message}",
+            "${ex.javaClass.simpleName} thrown while handling request $requestDescription " +
+                "for $userDescription: ${ex.message}",
             ex,
         )
   }

--- a/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/DeviceManagerUser.kt
@@ -34,6 +34,9 @@ data class DeviceManagerUser(
     private const val EMAIL = "deviceManagerUser@terraformation.com"
   }
 
+  override val description: String
+    get() = "device manager user $userId"
+
   override val timeZone: ZoneId
     get() = ZoneOffset.UTC
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/FunderUser.kt
@@ -30,6 +30,9 @@ data class FunderUser(
     private val parentStore: ParentStore,
     private val permissionStore: PermissionStore,
 ) : TerrawareUser {
+  override val description: String
+    get() = "funder user $email"
+
   private val _fundingEntityId = ResettableLazy { permissionStore.fetchFundingEntity(userId) }
   override val fundingEntityId: FundingEntityId? by _fundingEntityId
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -103,6 +103,9 @@ data class IndividualUser(
     val log = perClassLogger()
   }
 
+  override val description: String
+    get() = "user $email"
+
   private val _organizationRoles = ResettableLazy { permissionStore.fetchOrganizationRoles(userId) }
   override val organizationRoles: Map<OrganizationId, Role> by _organizationRoles
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/SystemUser.kt
@@ -52,6 +52,9 @@ class SystemUser(
     private const val EMAIL = "systemUser@terraformation.com"
   }
 
+  override val description: String
+    get() = "system user"
+
   override val timeZone: ZoneId
     get() = ZoneOffset.UTC
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -116,6 +116,9 @@ interface TerrawareUser : Principal, UserDetails {
    */
   val authId: String?
 
+  /** A human-readable description of the user for use in log messages. */
+  val description: String
+
   override fun getName(): String = authId ?: throw IllegalStateException("User is unregistered")
 
   override fun getUsername(): String = authId ?: throw IllegalStateException("User is unregistered")


### PR DESCRIPTION
When error messages are relayed to Slack, it's useful to be able to quickly see
which user triggered them. Include the user's email (or user ID in the case of
device managers) in the text of the log message.