### PR TITLE
SW-7897 Endpoint to download observation videos

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -191,6 +191,18 @@ class ObservationService(
     }
   }
 
+  fun readMediaFile(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId,
+      fileId: FileId,
+  ): SizedInputStream {
+    requirePermissions { readObservation(observationId) }
+
+    ensureMediaFileExists(observationId, monitoringPlotId, fileId)
+
+    return fileService.readFile(fileId)
+  }
+
   fun readPhoto(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -464,6 +464,23 @@ class ObservationsController(
     return GetMuxStreamResponsePayload(streamModel)
   }
 
+  @ApiResponse200
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a video with the requested ID."
+  )
+  @GetMapping("/{observationId}/plots/{plotId}/media/{fileId}")
+  @Operation(
+      summary = "Downloads a video or photo of an observation.",
+      description = "For videos, this returns a video file, not a stream.",
+  )
+  fun getObservationMediaFile(
+      @PathVariable observationId: ObservationId,
+      @PathVariable plotId: MonitoringPlotId,
+      @PathVariable fileId: FileId,
+  ): ResponseEntity<InputStreamResource> {
+    return observationService.readMediaFile(observationId, plotId, fileId).toResponseEntity()
+  }
+
   @ApiResponse404(
       "The plot observation does not exist, or does not have a photo with the requested ID."
   )


### PR DESCRIPTION
`GET /api/v1/tracking/observations/{observationId}/plots/{plotId}/media/{fileId}`
will download the original version of a media (video or photo) file from an
observation.