### PR TITLE
SW-7899 Only copy known species t0 densities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -540,6 +540,7 @@ class T0Store(
                     )
                 )
                 .and(OBSERVED_PLOT_SPECIES_TOTALS.OBSERVATION_ID.eq(observationId))
+                .and(OBSERVED_PLOT_SPECIES_TOTALS.SPECIES_ID.isNotNull)
                 .and(PLOT_T0_DENSITIES.SPECIES_ID.isNull)
         )
         .execute()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -1398,6 +1398,40 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `unknown and other species are not included in t0 densities`() {
+      val t0ObservationId = insertObservation()
+      insertObservationPlot()
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Other,
+          observationId = t0ObservationId,
+          speciesName = "testing",
+          totalLive = 10,
+      )
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Unknown,
+          observationId = t0ObservationId,
+          totalLive = 11,
+      )
+      store.assignT0PlotObservation(monitoringPlotId, t0ObservationId)
+
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Other,
+          observationId = observationId,
+          speciesName = "testing",
+          totalLive = 5,
+      )
+      insertObservedPlotSpeciesTotals(
+          certainty = RecordedSpeciesCertainty.Unknown,
+          observationId = observationId,
+          totalLive = 6,
+      )
+
+      store.on(ObservationStateUpdatedEvent(observationId, ObservationState.Abandoned))
+
+      assertTableEmpty(PLOT_T0_DENSITIES)
+    }
+
+    @Test
     fun `t0 densities are not added when new observation state is not Completed or Abandoned`() {
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()


### PR DESCRIPTION
Ignore Unknown and Other species when copying live plant counts from an
observation to the t0 densities table. Otherwise we try to insert null
species IDs into that table, which causes a failure because the species
ID isn't nullable.