### PR TITLE
SW-7783 Add DSL for observation test scenarios

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/ObservationScenarioTest.kt
@@ -30,6 +30,7 @@ import com.terraformation.backend.tracking.model.ObservationResultsDepth
 import com.terraformation.backend.tracking.model.ObservationResultsModel
 import com.terraformation.backend.tracking.model.ObservationRollupResultsModel
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
+import com.terraformation.backend.tracking.scenario.ObservationScenario
 import com.terraformation.backend.util.calculateAreaHectares
 import com.terraformation.backend.util.toPlantsPerHectare
 import io.mockk.every
@@ -1297,5 +1298,16 @@ abstract class ObservationScenarioTest : DatabaseTest(), RunsAsUser {
     }
 
     throw RuntimeException("Unable to generate square with requested area $areaHa")
+  }
+
+  protected fun scenario(init: ObservationScenario.() -> Unit) {
+    ObservationScenario.forTest(
+            this,
+            clock = clock,
+            eventPublisher = eventPublisher,
+            observationResultsStore = resultsStore,
+            observationStore = observationStore,
+        )
+        .init()
   }
 }

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
@@ -1,0 +1,78 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.tracking.model.BaseMonitoringResult
+import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
+import org.junit.jupiter.api.Assertions
+
+/**
+ * Superclass for DSL nodes that specify expected observation results. The format of expected
+ * results is more or less the same at each level of the site map hierarchy.
+ *
+ * @param baseline A previous expected result for the same level of the site map hierarchy. The
+ *   expected results specified in the current step are merged with the expected baseline results,
+ *   such that a scenario that verifies results multiple times only needs to specify the values that
+ *   should have changed from one step to the next.
+ */
+abstract class ExpectedObservationResult<
+    T : BaseMonitoringResult,
+    B : ExpectedObservationResult<T, B>,
+>(
+    val name: String,
+    val scenario: ObservationScenario,
+    val actualResult: T,
+    var survivalRate: Int? = null,
+    val baseline: B? = null,
+) : NodeWithChildren<ExpectedObservationResult.Species>() {
+  private var survivalRateSet: Boolean = survivalRate != null
+
+  fun survivalRate(expected: Int?) = apply {
+    survivalRate = expected
+    survivalRateSet = true
+    Assertions.assertEquals(expected, actualResult.survivalRate, "$name survival rate")
+  }
+
+  fun species(
+      number: Int,
+      survivalRate: Int? = null,
+      init: Species.() -> Unit = {},
+  ): Species {
+    val speciesId = scenario.getOrInsertSpecies(number)
+    return initChild(
+        Species(
+            name,
+            number,
+            actualResult.species.firstOrNull { it.speciesId == speciesId },
+            survivalRate,
+        ),
+        init,
+    )
+  }
+
+  protected fun mergeBaselineRates() {
+    if (baseline != null) {
+      if (!survivalRateSet && baseline.survivalRateSet) {
+        survivalRate(baseline.survivalRate)
+      }
+
+      val ourSpeciesNumbers = children.map { it.number }.toSet()
+      baseline.children
+          .filter { it.number !in ourSpeciesNumbers }
+          .forEach { species(it.number, it.survivalRate) }
+    }
+  }
+
+  class Species(
+      val parentName: String,
+      val number: Int,
+      val speciesResult: ObservationSpeciesResultsModel?,
+      val survivalRate: Int?,
+  ) : ScenarioNode {
+    override fun finish() {
+      Assertions.assertEquals(
+          survivalRate,
+          speciesResult?.survivalRate,
+          "$parentName species $number survival rate",
+      )
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
@@ -104,7 +104,13 @@ class ExpectedSiteResultStep(
         }
       }
 
-      private fun resultForPlot(number: Long) =
+      /**
+       * Returns the actual result for the monitoring plot of the given number.
+       *
+       * @throws IllegalArgumentException There weren't any results for the requested plot in this
+       *   observation.
+       */
+      private fun resultForPlot(number: Long): ObservationMonitoringPlotResultsModel =
           actualResult.monitoringPlots.firstOrNull { it.monitoringPlotNumber == number }
               ?: throw IllegalArgumentException(
                   "No result for $name plot $number in observation $observation"

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
@@ -1,0 +1,132 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.tracking.model.ObservationMonitoringPlotResultsModel
+import com.terraformation.backend.tracking.model.ObservationResultsModel
+import com.terraformation.backend.tracking.model.ObservationStratumResultsModel
+import com.terraformation.backend.tracking.model.ObservationSubstratumResultsModel
+
+class ExpectedSiteResultStep(
+    scenario: ObservationScenario,
+    val observation: Int,
+    actualResult: ObservationResultsModel,
+    survivalRate: Int? = null,
+    baseline: ExpectedSiteResultStep? = null,
+) :
+    ExpectedObservationResult<ObservationResultsModel, ExpectedSiteResultStep>(
+        "Site",
+        scenario,
+        actualResult,
+        survivalRate,
+        baseline,
+    ) {
+  val strata = mutableListOf<Stratum>()
+
+  fun stratum(number: Int, survivalRate: Int? = null, init: Stratum.() -> Unit) =
+      initAndAppend(
+          Stratum(
+              number,
+              survivalRate,
+              baseline?.strata?.firstOrNull { it.number == number },
+          ),
+          strata,
+          init,
+      )
+
+  override fun finish() {
+    if (baseline != null) {
+      mergeBaselineRates()
+
+      val stratumNumbers = strata.map { it.number }.toSet()
+      baseline.strata.filter { it.number !in stratumNumbers }.forEach { stratum(it.number) {} }
+    }
+  }
+
+  inner class Stratum(val number: Int, survivalRate: Int? = null, baseline: Stratum?) :
+      ExpectedObservationResult<ObservationStratumResultsModel, Stratum>(
+          "Stratum $number",
+          scenario,
+          actualResult.strata.first { it.name == "$number" },
+          survivalRate,
+          baseline,
+      ) {
+    val substrata = mutableListOf<Substratum>()
+
+    fun substratum(number: Int, survivalRate: Int? = null, init: Substratum.() -> Unit) =
+        initAndAppend(
+            Substratum(
+                number,
+                survivalRate,
+                baseline?.substrata?.firstOrNull { it.number == number },
+            ),
+            substrata,
+            init,
+        )
+
+    override fun finish() {
+      if (baseline != null) {
+        mergeBaselineRates()
+
+        val ourSubstratumNumbers = substrata.map { it.number }.toSet()
+        baseline.substrata
+            .filter { it.number !in ourSubstratumNumbers }
+            .forEach { substratum(it.number) {} }
+      }
+    }
+
+    inner class Substratum(val number: Int, survivalRate: Int?, baseline: Substratum?) :
+        ExpectedObservationResult<ObservationSubstratumResultsModel, Substratum>(
+            "$name substratum $number",
+            scenario,
+            actualResult.substrata.first { it.name == "$number" },
+            survivalRate,
+            baseline,
+        ) {
+      val plots = mutableListOf<Plot>()
+
+      fun plot(number: Long, survivalRate: Int? = null, init: Plot.() -> Unit) =
+          initAndAppend(
+              Plot(
+                  number,
+                  resultForPlot(number),
+                  survivalRate,
+                  baseline?.plots?.firstOrNull { it.number == number },
+              ),
+              plots,
+              init,
+          )
+
+      override fun finish() {
+        if (baseline != null) {
+          mergeBaselineRates()
+
+          val ourPlotNumbers = plots.map { it.number }.toSet()
+          baseline.plots.filter { it.number !in ourPlotNumbers }.forEach { plot(it.number) {} }
+        }
+      }
+
+      private fun resultForPlot(number: Long) =
+          actualResult.monitoringPlots.firstOrNull { it.monitoringPlotNumber == number }
+              ?: throw IllegalArgumentException(
+                  "No result for $name plot $number in observation $observation"
+              )
+
+      inner class Plot(
+          val number: Long,
+          actualResult: ObservationMonitoringPlotResultsModel,
+          survivalRate: Int?,
+          baseline: Plot?,
+      ) :
+          ExpectedObservationResult<ObservationMonitoringPlotResultsModel, Plot>(
+              "$name plot $number",
+              scenario,
+              actualResult,
+              survivalRate,
+              baseline,
+          ) {
+        override fun finish() {
+          mergeBaselineRates()
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/NodeWithChildren.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/NodeWithChildren.kt
@@ -1,0 +1,28 @@
+package com.terraformation.backend.tracking.scenario
+
+/**
+ * Superclass for DSL nodes that have a list of child nodes of a particular type. Implements the
+ * common behavior for child nodes (prepare, process the initializer lambda, finish).
+ */
+abstract class NodeWithChildren<T : ScenarioNode> : ScenarioNode {
+  val children = mutableListOf<T>()
+
+  /**
+   * Initializes a child node and adds it to a list of children. This only needs to be called
+   * directly when a node has multiple lists of children; for a simple single-child-list node, call
+   * [initChild] instead.
+   */
+  fun <C : ScenarioNode> initAndAppend(
+      child: C,
+      list: MutableList<in C>,
+      init: C.() -> Unit,
+  ): C {
+    child.prepare()
+    child.init()
+    child.finish()
+    list.add(child)
+    return child
+  }
+
+  fun <U : T> initChild(child: U, init: U.() -> Unit) = initAndAppend(child, children, init)
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
@@ -1,0 +1,160 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.db.DatabaseBackedTest
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservableCondition
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.pojos.RecordedPlantsRow
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_HISTORIES
+import com.terraformation.backend.point
+import org.jooq.impl.DSL
+
+class ObservationCompletedStep(val scenario: ObservationScenario, val number: Int) :
+    NodeWithChildren<ObservationCompletedStep.Plot>() {
+  private val test: DatabaseBackedTest
+    get() = scenario.test
+
+  val requestedSubstratumIds = mutableSetOf<SubstratumId>()
+
+  lateinit var observationId: ObservationId
+
+  fun plot(
+      number: Long,
+      isPermanent: Boolean = true,
+      conditions: Set<ObservableCondition> = emptySet(),
+      init: Plot.() -> Unit = {},
+  ) = initChild(Plot(number, isPermanent, conditions), init)
+
+  override fun prepare() {
+    val plantingSiteHistoryId =
+        test.dslContext
+            .select(DSL.max(PLANTING_SITE_HISTORIES.ID))
+            .from(PLANTING_SITE_HISTORIES)
+            .where(PLANTING_SITE_HISTORIES.PLANTING_SITE_ID.eq(scenario.plantingSiteId))
+            .fetchSingle()
+            .value1()!!
+    observationId =
+        test.insertObservation(
+            plantingSiteHistoryId = plantingSiteHistoryId,
+            plantingSiteId = scenario.plantingSiteId,
+            state = ObservationState.InProgress,
+        )
+    scenario.observationIds[number] = observationId
+  }
+
+  override fun finish() {
+    // We need to complete all the plots here, rather than immediately completing them as they're
+    // declared. Otherwise the observation would be marked complete after the first plot was
+    // finished (since it will look like the last incomplete one).
+    children.forEach { it.completePlot() }
+  }
+
+  inner class Plot(
+      val number: Long,
+      val isPermanent: Boolean,
+      val conditions: Set<ObservableCondition>,
+  ) : NodeWithChildren<Plot.Species>() {
+    private lateinit var monitoringPlotId: MonitoringPlotId
+
+    val unknown = -1
+    val other = -2
+
+    fun completePlot() {
+      scenario.observationStore.completePlot(
+          observationId = observationId,
+          monitoringPlotId = monitoringPlotId,
+          conditions = conditions,
+          notes = null,
+          observedTime = scenario.clock.instant(),
+          plants = children.flatMap { species -> species.toRecordedPlantsRows() },
+      )
+    }
+
+    override fun prepare() {
+      monitoringPlotId = scenario.getMonitoringPlotId(number)
+      test.insertObservationPlot(
+          claimedBy = currentUser().userId,
+          isPermanent = isPermanent,
+          monitoringPlotId = monitoringPlotId,
+          monitoringPlotHistoryId = scenario.monitoringPlotHistoryIds[monitoringPlotId]!!,
+      )
+
+      val substratumId = scenario.monitoringPlotSubstratumIds[monitoringPlotId]!!
+      if (substratumId !in requestedSubstratumIds) {
+        test.insertObservationRequestedSubstratum(substratumId = substratumId)
+        requestedSubstratumIds.add(substratumId)
+      }
+    }
+
+    fun species(
+        number: Int,
+        existing: Int? = null,
+        live: Int? = null,
+        dead: Int? = null,
+        init: Species.() -> Unit = {},
+    ) = initChild(Species(number, existing, live, dead), init)
+
+    inner class Species(
+        val number: Int,
+        var existing: Int? = null,
+        var live: Int? = null,
+        var dead: Int? = null,
+    ) : ScenarioNode {
+      private lateinit var certainty: RecordedSpeciesCertainty
+      private var speciesId: SpeciesId? = null
+      private var speciesName: String? = null
+
+      fun toRecordedPlantsRows(): List<RecordedPlantsRow> {
+        return toRecordedPlantsRows(RecordedPlantStatus.Dead, dead) +
+            toRecordedPlantsRows(RecordedPlantStatus.Existing, existing) +
+            toRecordedPlantsRows(RecordedPlantStatus.Live, live)
+      }
+
+      private fun toRecordedPlantsRows(
+          status: RecordedPlantStatus,
+          count: Int?,
+      ): List<RecordedPlantsRow> {
+        return (0..<(count ?: 0)).map { toRecordedPlantsRow(status) }
+      }
+
+      private fun toRecordedPlantsRow(status: RecordedPlantStatus) =
+          RecordedPlantsRow(
+              certaintyId = certainty,
+              gpsCoordinates = point(1),
+              monitoringPlotId = monitoringPlotId,
+              observationId = observationId,
+              speciesId = speciesId,
+              speciesName = speciesName,
+              statusId = status,
+          )
+
+      override fun prepare() {
+        when (number) {
+          unknown -> {
+            certainty = RecordedSpeciesCertainty.Unknown
+          }
+          other -> {
+            certainty = RecordedSpeciesCertainty.Other
+            speciesName = "Other"
+          }
+          else -> {
+            certainty = RecordedSpeciesCertainty.Known
+            speciesId = scenario.getOrInsertSpecies(number)
+          }
+        }
+      }
+
+      infix fun dead(value: Int) = apply { dead = value }
+
+      infix fun existing(value: Int) = apply { existing = value }
+
+      infix fun live(value: Int) = apply { live = value }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -1,0 +1,168 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.TestClock
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.db.ParentStore
+import com.terraformation.backend.db.DatabaseBackedTest
+import com.terraformation.backend.db.IdentifierGenerator
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotHistoryId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.daos.MonitoringPlotsDao
+import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotConditionsDao
+import com.terraformation.backend.db.tracking.tables.daos.ObservationPlotsDao
+import com.terraformation.backend.db.tracking.tables.daos.ObservationRequestedSubstrataDao
+import com.terraformation.backend.db.tracking.tables.daos.ObservationsDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSeasonsDao
+import com.terraformation.backend.db.tracking.tables.daos.PlantingSitesDao
+import com.terraformation.backend.db.tracking.tables.daos.StrataDao
+import com.terraformation.backend.db.tracking.tables.daos.SubstrataDao
+import com.terraformation.backend.gis.CountryDetector
+import com.terraformation.backend.tracking.db.ObservationLocker
+import com.terraformation.backend.tracking.db.ObservationResultsStore
+import com.terraformation.backend.tracking.db.ObservationStore
+import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.model.ObservationResultsDepth
+import java.time.temporal.ChronoUnit
+import org.jooq.Configuration
+
+/**
+ * Top-level element of the observation scenario testing DSL. This is intended to make it easy to
+ * specify test scenarios in reasonably human-readable form, such that they can be reviewed by
+ * someone who doesn't have deep Kotlin knowledge.
+ *
+ * The DSL structures scenarios as a sequence of top-level steps, each of which can be composed of
+ * smaller steps internally. Steps are executed in order, and the implementation tries, whenever
+ * possible, to do the requested work (e.g., inserting into the database) synchronously such that
+ * failures have meaningful stack traces that indicate which specific step failed.
+ *
+ * In addition to immediately doing the requested work, the DSL builds up an in-memory data
+ * structure that holds IDs and other information about the work that's been done. This allows the
+ * current state of the scenario, including the results of previous steps, to be inspected in a
+ * debugger or introspected by test code.
+ *
+ * Though a scenario using this DSL will often look like it's being specified declaratively (and
+ * that's one of the DSL's design goals), note that it's actually just Kotlin code. Tests are free
+ * to intersperse DSL function calls with other arbitrary code as needed, e.g., if they want to
+ * update a value in the database in a way that the DSL doesn't support, or if they want to specify
+ * an expected value using an expression rather than a hardwired constant.
+ *
+ * Nested elements of the DSL are implemented as inner classes, with the nesting mirroring the
+ * nesting of elements in scenarios. We do not use Kotlin's `DslMarker` annotation, since that
+ * annotation makes it awkward for inner classes to access properties of their enclosing classes.
+ */
+class ObservationScenario(
+    val clock: TestClock,
+    val observationResultsStore: ObservationResultsStore,
+    val observationStore: ObservationStore,
+    val plantingSiteStore: PlantingSiteStore,
+    val test: DatabaseBackedTest,
+) : NodeWithChildren<ScenarioNode>() {
+  companion object {
+    fun forTest(
+        test: DatabaseBackedTest,
+        clock: TestClock = TestClock(),
+        eventPublisher: TestEventPublisher = TestEventPublisher(),
+        identifierGenerator: IdentifierGenerator = IdentifierGenerator(clock, test.dslContext),
+        observationResultsStore: ObservationResultsStore = ObservationResultsStore(test.dslContext),
+        observationLocker: ObservationLocker = ObservationLocker(test.dslContext),
+        parentStore: ParentStore = ParentStore(test.dslContext),
+        configuration: Configuration = test.dslContext.configuration(),
+        observationStore: ObservationStore =
+            ObservationStore(
+                clock,
+                test.dslContext,
+                eventPublisher,
+                observationLocker,
+                ObservationsDao(configuration),
+                ObservationPlotConditionsDao(configuration),
+                ObservationPlotsDao(configuration),
+                ObservationRequestedSubstrataDao(configuration),
+                parentStore,
+            ),
+        plantingSiteStore: PlantingSiteStore =
+            PlantingSiteStore(
+                clock,
+                CountryDetector(),
+                test.dslContext,
+                eventPublisher,
+                identifierGenerator,
+                MonitoringPlotsDao(configuration),
+                parentStore,
+                PlantingSeasonsDao(configuration),
+                PlantingSitesDao(configuration),
+                eventPublisher,
+                StrataDao(configuration),
+                SubstrataDao(configuration),
+            ),
+    ): ObservationScenario {
+      return ObservationScenario(
+          clock,
+          observationResultsStore,
+          observationStore,
+          plantingSiteStore,
+          test,
+      )
+    }
+  }
+
+  val monitoringPlotHistoryIds = mutableMapOf<MonitoringPlotId, MonitoringPlotHistoryId>()
+  val monitoringPlotIds = mutableMapOf<Long, MonitoringPlotId>()
+  val monitoringPlotSubstratumIds = mutableMapOf<MonitoringPlotId, SubstratumId>()
+  val observationIds = mutableMapOf<Int, ObservationId>()
+  val speciesIds = mutableMapOf<Int, SpeciesId>()
+  val stratumIds = mutableMapOf<Int, StratumId>()
+  lateinit var plantingSiteId: PlantingSiteId
+
+  fun expectResults(
+      observation: Int,
+      baseline: ExpectedSiteResultStep? = null,
+      init: ExpectedSiteResultStep.() -> Unit,
+  ): ExpectedSiteResultStep {
+    val observationId =
+        observationIds[observation]
+            ?: throw IllegalArgumentException(
+                "Observation $observation was not declared before being referenced"
+            )
+    return initChild(
+        ExpectedSiteResultStep(
+            this,
+            observation,
+            observationResultsStore.fetchOneById(observationId, ObservationResultsDepth.Plant),
+            baseline = baseline,
+        ),
+        init,
+    )
+  }
+
+  fun observation(
+      number: Int,
+      init: ObservationCompletedStep.() -> Unit,
+  ) = initChild(ObservationCompletedStep(this, number), init).andAdvanceClock()
+
+  fun siteCreated(
+      survivalRateIncludesTempPlots: Boolean = false,
+      init: SiteCreatedStep.() -> Unit,
+  ) = initChild(SiteCreatedStep(this, survivalRateIncludesTempPlots), init).andAdvanceClock()
+
+  fun t0DensitySet(init: T0DensitySetStep.() -> Unit) =
+      initChild(T0DensitySetStep(this), init).andAdvanceClock()
+
+  fun getOrInsertSpecies(number: Int): SpeciesId {
+    return speciesIds.getOrPut(number) { test.insertSpecies("Species $number") }
+  }
+
+  fun getMonitoringPlotId(number: Long): MonitoringPlotId =
+      monitoringPlotIds[number]
+          ?: throw IllegalArgumentException(
+              "Monitoring plot $number was not declared before being referenced"
+          )
+
+  private fun <T> T.andAdvanceClock(): T = apply {
+    clock.instant = clock.instant.plus(1, ChronoUnit.DAYS)
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ScenarioNode.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ScenarioNode.kt
@@ -1,0 +1,15 @@
+package com.terraformation.backend.tracking.scenario
+
+interface ScenarioNode {
+  /**
+   * Called before the node's init function is invoked. Can be used to insert any database objects
+   * that are prerequisites of child objects that would be inserted in the init function.
+   */
+  fun prepare(): Unit = Unit
+
+  /**
+   * Called after the node's init function is invoked. The [finish] methods, if any, of child
+   * objects created in the init function will have already been called.
+   */
+  fun finish(): Unit = Unit
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteCreatedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteCreatedStep.kt
@@ -1,0 +1,115 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.db.DatabaseBackedTest
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.StratumId
+import com.terraformation.backend.db.tracking.SubstratumId
+import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITES
+import com.terraformation.backend.db.tracking.tables.references.STRATA
+import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
+import com.terraformation.backend.point
+import com.terraformation.backend.rectangle
+import com.terraformation.backend.rectanglePolygon
+import com.terraformation.backend.tracking.model.MONITORING_PLOT_SIZE
+import com.terraformation.backend.util.toMultiPolygon
+import java.time.Instant
+import org.locationtech.jts.geom.MultiPolygon
+
+class SiteCreatedStep(
+    val scenario: ObservationScenario,
+    val survivalRateIncludesTempPlots: Boolean,
+) : NodeWithChildren<SiteCreatedStep.Stratum>() {
+  var boundary: MultiPolygon = rectangle(0)
+
+  private val test: DatabaseBackedTest
+    get() = scenario.test
+
+  fun stratum(number: Int, init: Stratum.() -> Unit) = initChild(Stratum(number), init)
+
+  override fun prepare() {
+    scenario.plantingSiteId =
+        test.insertPlantingSite(
+            boundary = rectangle(1),
+            gridOrigin = point(0),
+            survivalRateIncludesTempPlots = survivalRateIncludesTempPlots,
+        )
+  }
+
+  override fun finish() {
+    children.forEach { boundary = boundary.union(it.boundary).toMultiPolygon() }
+
+    test.dslContext
+        .update(PLANTING_SITES)
+        .set(PLANTING_SITES.BOUNDARY, boundary)
+        .where(PLANTING_SITES.ID.eq(scenario.plantingSiteId))
+        .execute()
+  }
+
+  inner class Stratum(val number: Int) : NodeWithChildren<Stratum.Substratum>() {
+    var boundary: MultiPolygon = rectangle(0)
+    var area: Int = 0
+
+    lateinit var stratumId: StratumId
+
+    fun substratum(number: Int, area: Int = 1, init: Substratum.() -> Unit): Substratum {
+      this.area += area
+      return initChild(Substratum(number, area), init)
+    }
+
+    override fun prepare() {
+      stratumId = test.insertStratum(name = "$number")
+      scenario.stratumIds[number] = stratumId
+    }
+
+    override fun finish() {
+      children.forEach { boundary = boundary.union(it.boundary).toMultiPolygon() }
+
+      test.dslContext
+          .update(STRATA)
+          .set(STRATA.AREA_HA, area.toBigDecimal())
+          .set(STRATA.BOUNDARY, boundary)
+          .where(STRATA.ID.eq(stratumId))
+          .execute()
+    }
+
+    inner class Substratum(val number: Int, val area: Int) : NodeWithChildren<Substratum.Plot>() {
+      var boundary: MultiPolygon = rectangle(0)
+      lateinit var substratumId: SubstratumId
+
+      fun plot(plotNum: Long, init: Plot.() -> Unit = {}) = initChild(Plot(plotNum), init)
+
+      override fun prepare() {
+        substratumId =
+            test.insertSubstratum(
+                fullName = "${this@Stratum.number}-$number",
+                name = "$number",
+                plantingCompletedTime = Instant.EPOCH,
+            )
+      }
+
+      override fun finish() {
+        children.forEach { boundary = boundary.union(it.boundary).toMultiPolygon() }
+
+        test.dslContext
+            .update(SUBSTRATA)
+            .set(SUBSTRATA.BOUNDARY, boundary)
+            .where(SUBSTRATA.ID.eq(substratumId))
+            .execute()
+      }
+
+      inner class Plot(val number: Long) : ScenarioNode {
+        val boundary =
+            rectanglePolygon(width = MONITORING_PLOT_SIZE, x = number * MONITORING_PLOT_SIZE * 2)
+        lateinit var monitoringPlotId: MonitoringPlotId
+
+        override fun prepare() {
+          monitoringPlotId = test.insertMonitoringPlot(plotNumber = number, boundary = boundary)
+          scenario.monitoringPlotIds[number] = monitoringPlotId
+          scenario.monitoringPlotSubstratumIds[monitoringPlotId] = substratumId
+          scenario.monitoringPlotHistoryIds[monitoringPlotId] =
+              test.inserted.monitoringPlotHistoryId
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
@@ -1,0 +1,81 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.db.DatabaseBackedTest
+import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
+import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
+import com.terraformation.backend.util.toPlantsPerHectare
+
+class T0DensitySetStep(val scenario: ObservationScenario) :
+    NodeWithChildren<T0DensitySetStep.Plot>() {
+  val strata = mutableListOf<Stratum>()
+
+  private val test: DatabaseBackedTest
+    get() = scenario.test
+
+  fun plot(number: Long, init: Plot.() -> Unit) = initChild(Plot(number), init)
+
+  fun stratum(number: Int, init: Stratum.() -> Unit) = initAndAppend(Stratum(number), strata, init)
+
+  inner class Stratum(val number: Int) : NodeWithChildren<Stratum.Species>() {
+    val stratumId =
+        scenario.stratumIds[number] ?: throw IllegalArgumentException("Stratum $number not found")
+
+    fun species(speciesId: Int, density: Int?, init: Species.() -> Unit = {}) =
+        initChild(Species(speciesId, density), init)
+
+    override fun finish() {
+      scenario.observationStore.recalculateSurvivalRates(stratumId)
+    }
+
+    inner class Species(val number: Int, val density: Int?) : ScenarioNode {
+      override fun finish() {
+        val speciesId = scenario.getOrInsertSpecies(number)
+
+        test.dslContext
+            .deleteFrom(STRATUM_T0_TEMP_DENSITIES)
+            .where(STRATUM_T0_TEMP_DENSITIES.STRATUM_ID.eq(stratumId))
+            .and(STRATUM_T0_TEMP_DENSITIES.SPECIES_ID.eq(speciesId))
+            .execute()
+
+        if (density != null) {
+          test.insertStratumT0TempDensity(
+              speciesId = speciesId,
+              stratumDensity = density.toBigDecimal().toPlantsPerHectare(),
+              stratumId = stratumId,
+          )
+        }
+      }
+    }
+  }
+
+  inner class Plot(val number: Long) : NodeWithChildren<Plot.Species>() {
+    val monitoringPlotId = scenario.getMonitoringPlotId(number)
+
+    fun species(speciesId: Int, density: Int?, init: Species.() -> Unit = {}) =
+        initChild(Species(speciesId, density), init)
+
+    override fun finish() {
+      scenario.observationStore.recalculateSurvivalRates(monitoringPlotId)
+    }
+
+    inner class Species(val number: Int, val density: Int?) : ScenarioNode {
+      override fun finish() {
+        val speciesId = scenario.getOrInsertSpecies(number)
+
+        test.dslContext
+            .deleteFrom(PLOT_T0_DENSITIES)
+            .where(PLOT_T0_DENSITIES.MONITORING_PLOT_ID.eq(monitoringPlotId))
+            .and(PLOT_T0_DENSITIES.SPECIES_ID.eq(speciesId))
+            .execute()
+
+        if (density != null) {
+          test.insertPlotT0Density(
+              monitoringPlotId = monitoringPlotId,
+              plotDensity = density.toBigDecimal().toPlantsPerHectare(),
+              speciesId = speciesId,
+          )
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/PlotRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/PlotRates.csv
@@ -1,5 +1,0 @@
-Plot Number,Plot Survival Rate,Species A Survival Rate,Species B Survival Rate
-111,73%,45%,100%
-112,99%,100%,98%
-211,100%,110%,92%
-311,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/SiteRates.csv
@@ -1,2 +1,0 @@
-Site Name,Site Survival Rate,Species A Survival Rate,Species B Survival Rate
-Demo Site,94%,91%,96%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/SubzoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/SubzoneRates.csv
@@ -1,4 +1,0 @@
-Subzone Name,Subzone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Subzone1,89%,78%,98%
-Subzone2,100%,110%,92%
-Subzone3,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/AfterUpdate/ZoneRates.csv
@@ -1,3 +1,0 @@
-Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Zone1,95%,94%,95%
-Zone2,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Observation-1.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Observation-1.csv
@@ -1,6 +1,0 @@
-Plot,Species 0,,,Species 1,,,Unknown,,Other,
-,Existing,Live,Dead,Existing,Live,Dead,Live,Dead,Live,Dead
-111,0,9,0,0,20,0,0,0,0,0
-112,0,30,0,0,39,0,0,0,0,0
-211,0,55,0,0,55,0,0,0,0,0
-311,0,61,0,0,78,0,0,0,0,0

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/PlotRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/PlotRates.csv
@@ -1,5 +1,0 @@
-Plot Number,Plot Survival Rate,Species A Survival Rate,Species B Survival Rate
-111,97%,90%,100%
-112,99%,100%,98%
-211,100%,110%,92%
-311,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Plots.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Plots.csv
@@ -1,5 +1,0 @@
-Subzone,Name,Type
-Subzone1,111,Permanent
-Subzone1,112,Permanent
-Subzone2,211,Permanent
-Subzone3,311,Permanent

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/SiteRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/SiteRates.csv
@@ -1,2 +1,0 @@
-Site Name,Site Survival Rate,Species A Survival Rate,Species B Survival Rate
-Demo Site,96%,97%,96%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/SubzoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/SubzoneRates.csv
@@ -1,4 +1,0 @@
-Subzone Name,Subzone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Subzone1,98%,98%,98%
-Subzone2,100%,110%,92%
-Subzone3,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Subzones.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Subzones.csv
@@ -1,5 +1,0 @@
-
-Zone,Name,Area
-Zone1,Subzone1,50
-Zone1,Subzone2,50
-Zone2,Subzone3,200

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/T0Densities.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/T0Densities.csv
@@ -1,5 +1,0 @@
-Plot,Species 0 Density,Species 1 Density
-111,10,20
-112,30,40
-211,50,60
-311,70,80

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/ZoneRates.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/ZoneRates.csv
@@ -1,3 +1,0 @@
-Zone Name,Zone Survival Rate,Species A Survival Rate,Species B Survival Rate
-Zone1,99%,104%,95%
-Zone2,93%,87%,97%

--- a/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Zones.csv
+++ b/src/test/resources/tracking/observation/SurvivalRateT0DensityChange/Zones.csv
@@ -1,4 +1,0 @@
-
-Site,Name,Area (ha)
-Demo Site,Zone1,100
-Demo Site,Zone2,200


### PR DESCRIPTION
In preparation for testing the ability to edit observation results, add a little
DSL that allows tests to specify test scenarios in a structured, human-friendly
way instead of requiring tests to come with lots of little CSV files.

To demonstrate how the DSL is used, convert the existing "survival rate is
updated when t0 density changes" test case. Additional tests will be converted
in later changes.