### PR TITLE
SW-7857 Use web app's internal role name translations

### DIFF
--- a/src/main/resources/i18n/Enums_es.properties
+++ b/src/main/resources/i18n/Enums_es.properties
@@ -446,13 +446,13 @@ public.ProjectInternalRole.ClimateImpactLead=Responsable del impacto climático
 # 910885ab
 public.ProjectInternalRole.Consultant=Consultor
 # 0095925f
-public.ProjectInternalRole.GISLead=Responsable del GIS
+public.ProjectInternalRole.GISLead=Responsable de SIG
 # f425b493
 public.ProjectInternalRole.LegalLead=Responsable legal
 # 61bccaa9
-public.ProjectInternalRole.PhaseLead=Responsable de la fase
+public.ProjectInternalRole.PhaseLead=Responsable de fase
 # de2a4d84
-public.ProjectInternalRole.ProjectFinanceLead=Responsable de finanzas del proyecto
+public.ProjectInternalRole.ProjectFinanceLead=Responsable de finanzas de proyecto
 # abaeba3a
 public.ProjectInternalRole.ProjectLead=Responsable del proyecto
 # f75cdb69

--- a/src/main/resources/i18n/Enums_fr.properties
+++ b/src/main/resources/i18n/Enums_fr.properties
@@ -440,27 +440,27 @@ public.PlantMaterialSourcingMethod.VegetativePropagation=Propagation végétativ
 # 1cbd60d2
 public.PlantMaterialSourcingMethod.WildlingHarvest=Récolte de semis naturels spontanés
 # 894929ea
-public.ProjectInternalRole.CarbonLead=Responsable Carbone
+public.ProjectInternalRole.CarbonLead=Responsable carbone
 # b00dd731
-public.ProjectInternalRole.ClimateImpactLead=Responsable Impact Climatique
+public.ProjectInternalRole.ClimateImpactLead=Responsable de l'impact climatique
 # 910885ab
 public.ProjectInternalRole.Consultant=Consultant
 # 0095925f
 public.ProjectInternalRole.GISLead=Responsable SIG
 # f425b493
-public.ProjectInternalRole.LegalLead=Responsable Légal
+public.ProjectInternalRole.LegalLead=Responsable juridique
 # 61bccaa9
-public.ProjectInternalRole.PhaseLead=Responsable Étape
+public.ProjectInternalRole.PhaseLead=Responsable de phase
 # de2a4d84
-public.ProjectInternalRole.ProjectFinanceLead=Responsable Financement de Projet
+public.ProjectInternalRole.ProjectFinanceLead=Responsable du financement du projet
 # abaeba3a
-public.ProjectInternalRole.ProjectLead=Responsable Projet
+public.ProjectInternalRole.ProjectLead=Responsable de projet
 # f75cdb69
-public.ProjectInternalRole.RegionalExpert=Expert Régional
+public.ProjectInternalRole.RegionalExpert=Expert régional
 # 62691aa4
-public.ProjectInternalRole.RestorationLead=Responsable Rénovation
+public.ProjectInternalRole.RestorationLead=Responsable de la restauration
 # 87aa1342
-public.ProjectInternalRole.SocialLead=Responsable Social
+public.ProjectInternalRole.SocialLead=Responsable social
 # 83997d9b
 public.Region.Antarctica=Antarctique
 # 949d95a7


### PR DESCRIPTION
The Spanish and French translations for project internal role names didn't match
between terraware-web and this repo, so when the frontend tried to use a role as a
search filter, it didn't work because the search string wasn't recognized as a
valid enum value. Update the translations to match the ones in terraware-web.