### PR TITLE
Use 8-core GitHub Actions runner for main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       name: ${{ (github.ref == 'refs/heads/main' && 'staging') || (startsWith(github.ref, 'refs/tags/v2') && 'prod') || null }}
       url: ${{ (github.ref == 'refs/heads/main' && 'https://staging.terraware.io/') || (startsWith(github.ref, 'refs/tags/v2') && 'https://terraware.io/') || null }}
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24-8core
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Change the main GitHub Actions workflow to use 8-core runners instead of the
default ones. This should speed up our CI builds.

The docs and scripts workflows continue to use the default runners for now.