### PR TITLE
SW-7829 Rename zone->strata in api response payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
@@ -51,6 +51,7 @@ class DeliveriesController(
   }
 }
 
+// response payload
 data class PlantingPayload(
     val id: PlantingId,
     @Schema(description = "If type is \"Reassignment To\", the reassignment notes, if any.")
@@ -61,7 +62,7 @@ data class PlantingPayload(
                 "will be negative."
     )
     val numPlants: Int,
-    val plantingSubzoneId: SubstratumId?,
+    val substratumId: SubstratumId?,
     val speciesId: SpeciesId,
     val type: PlantingType,
 ) {
@@ -71,12 +72,17 @@ data class PlantingPayload(
       id = model.id,
       notes = model.notes,
       numPlants = model.numPlants,
-      plantingSubzoneId = model.substratumId,
+      substratumId = model.substratumId,
       speciesId = model.speciesId,
       type = model.type,
   )
+
+  @Deprecated("Use substratumId instead.")
+  val plantingSubzoneId: SubstratumId?
+    get() = substratumId
 }
 
+// response payload
 data class DeliveryPayload(
     val id: DeliveryId,
     val plantings: List<PlantingPayload>,
@@ -93,13 +99,14 @@ data class DeliveryPayload(
   )
 }
 
+// request payload
 data class ReassignmentPayload(
     val fromPlantingId: PlantingId,
     @JsonSetter(nulls = Nulls.FAIL)
     @Min(1)
     @Schema(
         description =
-            "Number of plants to reassign from the planting's original subzone to the new one. " +
+            "Number of plants to reassign from the planting's original substratum to the new one. " +
                 "Must be less than or equal to the number of plants in the original planting."
     )
     val numPlants: Int,

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DraftPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DraftPlantingSitesController.kt
@@ -77,6 +77,7 @@ class DraftPlantingSitesController(
   }
 }
 
+// response payload
 data class DraftPlantingSitePayload(
     @Schema(
         description =
@@ -99,12 +100,12 @@ data class DraftPlantingSitePayload(
         description =
             "If the user has started defining substrata, the number of substrata defined so far."
     )
-    val numPlantingSubzones: Int?,
+    val numSubstrata: Int?,
     @Schema(
         description =
             "If the user has started defining strata, the number of strata defined so far."
     )
-    val numPlantingZones: Int?,
+    val numStrata: Int?,
     val organizationId: OrganizationId,
     @Schema(description = "If the draft is associated with a project, its ID.")
     val projectId: ProjectId?,
@@ -126,6 +127,14 @@ data class DraftPlantingSitePayload(
       record.projectId,
       record.timeZone,
   )
+
+  @Deprecated("Use numSubstrata instead.")
+  val numPlantingSubzones: Int?
+    get() = numSubstrata
+
+  @Deprecated("Use numStrata instead.")
+  val numPlantingZones: Int?
+    get() = numStrata
 }
 
 data class GetDraftPlantingSiteResponsePayload(val site: DraftPlantingSitePayload) :

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -767,6 +767,7 @@ class ObservationsController(
   }
 }
 
+// response payload
 data class ObservationPayload(
     @Schema(description = "Date this observation is scheduled to end.") //
     val endDate: LocalDate,
@@ -797,7 +798,7 @@ data class ObservationPayload(
                     "If specific substrata were requested for this observation, their IDs."
             )
     )
-    val requestedSubzoneIds: Set<SubstratumId>?,
+    val requestedSubstratumIds: Set<SubstratumId>?,
     @Schema(description = "Date this observation started.") //
     val startDate: LocalDate,
     val state: ObservationState,
@@ -817,11 +818,15 @@ data class ObservationPayload(
       plantingSiteHistoryId = model.plantingSiteHistoryId,
       plantingSiteId = model.plantingSiteId,
       plantingSiteName = plantingSiteName,
-      requestedSubzoneIds = model.requestedSubstratumIds.ifEmpty { null },
+      requestedSubstratumIds = model.requestedSubstratumIds.ifEmpty { null },
       startDate = model.startDate,
       state = model.state,
       type = model.observationType,
   )
+
+  @Deprecated("Use requestedSubstratumIds instead.")
+  val requestedSubzoneIds: Set<SubstratumId>?
+    get() = requestedSubstratumIds
 }
 
 data class GetObservationResponsePayload(val observation: ObservationPayload) :
@@ -843,6 +848,7 @@ data class ListObservationsResponsePayload(
     val totalUnclaimedPlots: Int,
 ) : SuccessResponsePayload
 
+// response payload
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class AssignedPlotPayload(
     val boundary: Geometry,
@@ -856,9 +862,9 @@ data class AssignedPlotPayload(
     val isFirstObservation: Boolean,
     val isPermanent: Boolean,
     val observationId: ObservationId,
-    val plantingSubzoneId: SubstratumId?,
-    val plantingSubzoneName: String,
-    val plantingZoneName: String,
+    val substratumId: SubstratumId?,
+    val substratumName: String,
+    val stratumName: String,
     val plotId: MonitoringPlotId,
     val plotName: String,
     val plotNumber: Long,
@@ -878,14 +884,26 @@ data class AssignedPlotPayload(
       isFirstObservation = details.isFirstObservation,
       isPermanent = details.model.isPermanent,
       observationId = details.model.observationId,
-      plantingSubzoneId = details.substratumId,
-      plantingSubzoneName = details.substratumName,
-      plantingZoneName = details.stratumName,
+      substratumId = details.substratumId,
+      substratumName = details.substratumName,
+      stratumName = details.stratumName,
       plotId = details.model.monitoringPlotId,
       plotName = "${details.plotNumber}",
       plotNumber = details.plotNumber,
       sizeMeters = details.sizeMeters,
   )
+
+  @Deprecated("Use substratumId instead")
+  val plantingSubzoneId: SubstratumId?
+    get() = substratumId
+
+  @Deprecated("Use substratumName instead")
+  val plantingSubzoneName: String
+    get() = substratumName
+
+  @Deprecated("Use stratumName instead")
+  val plantingZoneName: String
+    get() = stratumName
 }
 
 data class RecordedPlantPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/PlantingSitesController.kt
@@ -265,7 +265,39 @@ data class MonitoringPlotHistoryPayload(
   )
 }
 
+// response payload
+@Schema(description = "Use SubstratumResponsePayload instead", deprecated = true)
 data class PlantingSubzonePayload(
+    val areaHa: BigDecimal,
+    val boundary: MultiPolygon,
+    val fullName: String,
+    val id: SubstratumId,
+    val latestObservationCompletedTime: Instant?,
+    val latestObservationId: ObservationId?,
+    val monitoringPlots: List<MonitoringPlotPayload>,
+    val name: String,
+    val observedTime: Instant?,
+    val plantingCompleted: Boolean,
+    val plantingCompletedTime: Instant?,
+) {
+  constructor(
+      model: ExistingSubstratumModel
+  ) : this(
+      areaHa = model.areaHa,
+      boundary = model.boundary,
+      fullName = model.fullName,
+      id = model.id,
+      latestObservationCompletedTime = model.latestObservationCompletedTime,
+      latestObservationId = model.latestObservationId,
+      monitoringPlots = model.monitoringPlots.map { MonitoringPlotPayload(it) },
+      name = model.name,
+      observedTime = model.observedTime,
+      plantingCompleted = model.plantingCompletedTime != null,
+      plantingCompletedTime = model.plantingCompletedTime,
+  )
+}
+
+data class SubstratumResponsePayload(
     @Schema(description = "Area of substratum in hectares.") //
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
@@ -298,15 +330,11 @@ data class PlantingSubzonePayload(
   )
 }
 
+// response payload
+@Schema(description = "Use StratumResponsePayload instead", deprecated = true)
 data class PlantingZonePayload(
-    @Schema(description = "Area of stratum in hectares.") //
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
-    @Schema(
-        description =
-            "When the boundary of this stratum was last modified. Modifications of other " +
-                "attributes of the stratum do not cause this timestamp to change."
-    )
     val boundaryModifiedTime: Instant,
     val id: StratumId,
     val latestObservationCompletedTime: Instant?,
@@ -334,6 +362,42 @@ data class PlantingZonePayload(
   )
 }
 
+data class StratumResponsePayload(
+    @Schema(description = "Area of stratum in hectares.") //
+    val areaHa: BigDecimal,
+    val boundary: MultiPolygon,
+    @Schema(
+        description =
+            "When the boundary of this stratum was last modified. Modifications of other " +
+                "attributes of the stratum do not cause this timestamp to change."
+    )
+    val boundaryModifiedTime: Instant,
+    val id: StratumId,
+    val latestObservationCompletedTime: Instant?,
+    val latestObservationId: ObservationId?,
+    val name: String,
+    val numPermanentPlots: Int,
+    val numTemporaryPlots: Int,
+    val substrata: List<SubstratumResponsePayload>,
+    val targetPlantingDensity: BigDecimal,
+) {
+  constructor(
+      model: ExistingStratumModel
+  ) : this(
+      model.areaHa,
+      model.boundary,
+      model.boundaryModifiedTime,
+      model.id,
+      latestObservationCompletedTime = model.latestObservationCompletedTime,
+      latestObservationId = model.latestObservationId,
+      model.name,
+      model.numPermanentPlots,
+      model.numTemporaryPlots,
+      model.substrata.map { SubstratumResponsePayload(it) },
+      model.targetPlantingDensity,
+  )
+}
+
 data class PlantingSeasonPayload(
     val endDate: LocalDate,
     val id: PlantingSeasonId,
@@ -348,6 +412,7 @@ data class PlantingSeasonPayload(
   )
 }
 
+// response payload
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 data class PlantingSitePayload(
     val adHocPlots: List<MonitoringPlotPayload>,
@@ -363,8 +428,10 @@ data class PlantingSitePayload(
     val name: String,
     val organizationId: OrganizationId,
     val plantingSeasons: List<PlantingSeasonPayload>,
+    @Schema(description = "Use strata instead", deprecated = true)
     val plantingZones: List<PlantingZonePayload>?,
     val projectId: ProjectId? = null,
+    val strata: List<StratumResponsePayload>?,
     val survivalRateIncludesTempPlots: Boolean?,
     val timeZone: ZoneId?,
 ) {
@@ -385,11 +452,14 @@ data class PlantingSitePayload(
       plantingSeasons = model.plantingSeasons.map { PlantingSeasonPayload(it) },
       plantingZones = model.strata.map { PlantingZonePayload(it) },
       projectId = model.projectId,
+      strata = model.strata.map { StratumResponsePayload(it) },
       survivalRateIncludesTempPlots = model.survivalRateIncludesTempPlots,
       timeZone = model.timeZone,
   )
 }
 
+// response payload
+@Schema(description = "Use SubstratumHistoryResponsePayload instead", deprecated = true)
 data class PlantingSubzoneHistoryPayload(
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
@@ -397,7 +467,6 @@ data class PlantingSubzoneHistoryPayload(
     val id: SubstratumHistoryId,
     val monitoringPlots: List<MonitoringPlotHistoryPayload>,
     val name: String,
-    @Schema(description = "ID of substratum if it exists in the current version of the site.")
     val plantingSubzoneId: SubstratumId?,
 ) {
   constructor(
@@ -413,13 +482,37 @@ data class PlantingSubzoneHistoryPayload(
   )
 }
 
+data class SubstratumHistoryResponsePayload(
+    val areaHa: BigDecimal,
+    val boundary: MultiPolygon,
+    val fullName: String,
+    val id: SubstratumHistoryId,
+    val monitoringPlots: List<MonitoringPlotHistoryPayload>,
+    val name: String,
+    @Schema(description = "ID of substratum if it exists in the current version of the site.")
+    val substratumId: SubstratumId?,
+) {
+  constructor(
+      model: SubstratumHistoryModel
+  ) : this(
+      areaHa = model.areaHa,
+      boundary = model.boundary,
+      fullName = model.fullName,
+      id = model.id,
+      monitoringPlots = model.monitoringPlots.map { MonitoringPlotHistoryPayload(it) },
+      name = model.name,
+      substratumId = model.substratumId,
+  )
+}
+
+// response payload
+@Schema(description = "Use StratumHistoryResponsePayload instead", deprecated = true)
 data class PlantingZoneHistoryPayload(
     val areaHa: BigDecimal,
     val boundary: MultiPolygon,
     val id: StratumHistoryId,
     val name: String,
     val plantingSubzones: List<PlantingSubzoneHistoryPayload>,
-    @Schema(description = "ID of stratum if it exists in the current version of the site.")
     val plantingZoneId: StratumId?,
 ) {
   constructor(
@@ -434,6 +527,28 @@ data class PlantingZoneHistoryPayload(
   )
 }
 
+data class StratumHistoryResponsePayload(
+    val areaHa: BigDecimal,
+    val boundary: MultiPolygon,
+    val id: StratumHistoryId,
+    val name: String,
+    val substrata: List<SubstratumHistoryResponsePayload>,
+    @Schema(description = "ID of stratum if it exists in the current version of the site.")
+    val stratumId: StratumId?,
+) {
+  constructor(
+      model: StratumHistoryModel
+  ) : this(
+      areaHa = model.areaHa,
+      boundary = model.boundary,
+      id = model.id,
+      name = model.name,
+      substrata = model.substrata.map { SubstratumHistoryResponsePayload(it) },
+      stratumId = model.stratumId,
+  )
+}
+
+// response payload
 data class PlantingSiteHistoryPayload(
     val areaHa: BigDecimal?,
     val boundary: MultiPolygon,
@@ -441,7 +556,9 @@ data class PlantingSiteHistoryPayload(
     val exclusion: MultiPolygon? = null,
     val id: PlantingSiteHistoryId,
     val plantingSiteId: PlantingSiteId,
+    @Schema(description = "Use strata instead", deprecated = true)
     val plantingZones: List<PlantingZoneHistoryPayload>,
+    val strata: List<StratumHistoryResponsePayload>,
 ) {
   constructor(
       model: PlantingSiteHistoryModel
@@ -453,9 +570,12 @@ data class PlantingSiteHistoryPayload(
       id = model.id,
       plantingSiteId = model.plantingSiteId,
       plantingZones = model.strata.map { PlantingZoneHistoryPayload(it) },
+      strata = model.strata.map { StratumHistoryResponsePayload(it) },
   )
 }
 
+// response payload
+@Schema(description = "Use SubstratumReportedPlantsResponsePayload instead", deprecated = true)
 data class PlantingSubzoneReportedPlantsPayload(
     val id: SubstratumId,
     val plantsSinceLastObservation: Int,
@@ -464,16 +584,36 @@ data class PlantingSubzoneReportedPlantsPayload(
     val totalSpecies: Int,
 ) {
   constructor(
-      subzoneTotals: PlantingSiteReportedPlantTotals.Substratum
+      substratumTotals: PlantingSiteReportedPlantTotals.Substratum
   ) : this(
-      id = subzoneTotals.id,
-      plantsSinceLastObservation = subzoneTotals.plantsSinceLastObservation,
-      species = subzoneTotals.species.map { ReportedSpeciesPayload(it) },
-      totalPlants = subzoneTotals.totalPlants,
-      totalSpecies = subzoneTotals.totalSpecies,
+      id = substratumTotals.id,
+      plantsSinceLastObservation = substratumTotals.plantsSinceLastObservation,
+      species = substratumTotals.species.map { ReportedSpeciesPayload(it) },
+      totalPlants = substratumTotals.totalPlants,
+      totalSpecies = substratumTotals.totalSpecies,
   )
 }
 
+data class SubstratumReportedPlantsResponsePayload(
+    val id: SubstratumId,
+    val plantsSinceLastObservation: Int,
+    val species: List<ReportedSpeciesPayload>,
+    val totalPlants: Int,
+    val totalSpecies: Int,
+) {
+  constructor(
+      substratumTotals: PlantingSiteReportedPlantTotals.Substratum
+  ) : this(
+      id = substratumTotals.id,
+      plantsSinceLastObservation = substratumTotals.plantsSinceLastObservation,
+      species = substratumTotals.species.map { ReportedSpeciesPayload(it) },
+      totalPlants = substratumTotals.totalPlants,
+      totalSpecies = substratumTotals.totalSpecies,
+  )
+}
+
+// response payload
+@Schema(description = "Use StratumReportedPlantsResponsePayload instead", deprecated = true)
 data class PlantingZoneReportedPlantsPayload(
     val id: StratumId,
     val plantsSinceLastObservation: Int,
@@ -484,24 +624,49 @@ data class PlantingZoneReportedPlantsPayload(
     val totalSpecies: Int,
 ) {
   constructor(
-      zoneTotals: PlantingSiteReportedPlantTotals.Stratum
+      stratumTotals: PlantingSiteReportedPlantTotals.Stratum
   ) : this(
-      id = zoneTotals.id,
-      plantsSinceLastObservation = zoneTotals.plantsSinceLastObservation,
-      plantingSubzones = zoneTotals.substrata.map { PlantingSubzoneReportedPlantsPayload(it) },
-      progressPercent = zoneTotals.progressPercent,
-      species = zoneTotals.species.map { ReportedSpeciesPayload(it) },
-      totalPlants = zoneTotals.totalPlants,
-      totalSpecies = zoneTotals.totalSpecies,
+      id = stratumTotals.id,
+      plantsSinceLastObservation = stratumTotals.plantsSinceLastObservation,
+      plantingSubzones = stratumTotals.substrata.map { PlantingSubzoneReportedPlantsPayload(it) },
+      progressPercent = stratumTotals.progressPercent,
+      species = stratumTotals.species.map { ReportedSpeciesPayload(it) },
+      totalPlants = stratumTotals.totalPlants,
+      totalSpecies = stratumTotals.totalSpecies,
   )
 }
 
+data class StratumReportedPlantsResponsePayload(
+    val id: StratumId,
+    val plantsSinceLastObservation: Int,
+    val substrata: List<SubstratumReportedPlantsResponsePayload>,
+    val progressPercent: Int,
+    val species: List<ReportedSpeciesPayload>,
+    val totalPlants: Int,
+    val totalSpecies: Int,
+) {
+  constructor(
+      stratumTotals: PlantingSiteReportedPlantTotals.Stratum
+  ) : this(
+      id = stratumTotals.id,
+      plantsSinceLastObservation = stratumTotals.plantsSinceLastObservation,
+      substrata = stratumTotals.substrata.map { SubstratumReportedPlantsResponsePayload(it) },
+      progressPercent = stratumTotals.progressPercent,
+      species = stratumTotals.species.map { ReportedSpeciesPayload(it) },
+      totalPlants = stratumTotals.totalPlants,
+      totalSpecies = stratumTotals.totalSpecies,
+  )
+}
+
+// response payload
 data class PlantingSiteReportedPlantsPayload(
     val id: PlantingSiteId,
+    @Schema(description = "Use strata instead", deprecated = true)
     val plantingZones: List<PlantingZoneReportedPlantsPayload>,
     val plantsSinceLastObservation: Int,
     val progressPercent: Int?,
     val species: List<ReportedSpeciesPayload>,
+    val strata: List<StratumReportedPlantsResponsePayload>,
     val totalPlants: Int,
 ) {
   constructor(
@@ -512,6 +677,7 @@ data class PlantingSiteReportedPlantsPayload(
       plantsSinceLastObservation = totals.plantsSinceLastObservation,
       progressPercent = totals.progressPercent,
       species = totals.species.map { ReportedSpeciesPayload(it) },
+      strata = totals.strata.map { StratumReportedPlantsResponsePayload(it) },
       totalPlants = totals.totalPlants,
   )
 }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/SubstrataController.kt
@@ -28,7 +28,7 @@ class SubstrataController(
     private val plantingSiteStore: PlantingSiteStore,
     private val speciesStore: SpeciesStore,
 ) {
-  @GetMapping("/subzones/{id}/species")
+  @GetMapping("/subzones/{id}/species", "/substrata/{id}/species")
   @Operation(
       summary = "Gets a list of the species that may have been planted in a substratum.",
       description =

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -149,11 +149,30 @@ data class ZoneT0DataPayload(
       )
 }
 
+data class StratumT0DataPayload(
+    val stratumId: StratumId,
+    val densityData: List<SpeciesDensityPayload> = emptyList(),
+) {
+  constructor(
+      model: StratumT0TempDataModel
+  ) : this(
+      stratumId = model.stratumId,
+      densityData = model.densityData.map { SpeciesDensityPayload(it) },
+  )
+
+  fun toModel() =
+      StratumT0TempDataModel(
+          stratumId = stratumId,
+          densityData = densityData.map { it.toModel() },
+      )
+}
+
 data class SiteT0DataResponsePayload(
     val plantingSiteId: PlantingSiteId,
     val survivalRateIncludesTempPlots: Boolean = false,
     val plots: List<PlotT0DataPayload> = emptyList(),
     val zones: List<ZoneT0DataPayload> = emptyList(),
+    val strata: List<StratumT0DataPayload> = emptyList(),
 ) {
   constructor(
       model: SiteT0DataModel
@@ -162,6 +181,7 @@ data class SiteT0DataResponsePayload(
       survivalRateIncludesTempPlots = model.survivalRateIncludesTempPlots,
       plots = model.plots.map { PlotT0DataPayload(it) },
       zones = model.strata.map { ZoneT0DataPayload(it) },
+      strata = model.strata.map { StratumT0DataPayload(it) },
   )
 }
 


### PR DESCRIPTION
Rename properties in response payloads and add `get`ters for simple properties, and new response classes for more complex renames. Add deprecations around old property names.