### PR TITLE
Observation test DSL: add expectUnchangedResults

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -1212,9 +1212,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
         }
       }
 
-      expectResults(observation = 1, baseline = observation1Results) {
-        // Results shouldn't have changed.
-      }
+      expectUnchangedResults(observation = 1, baseline = observation1Results)
 
       expectResults(observation = 2) {
         survivalRate(92)

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -139,6 +139,13 @@ class ObservationScenario(
     )
   }
 
+  fun expectUnchangedResults(
+      observation: Int,
+      baseline: ExpectedSiteResultStep,
+  ): ExpectedSiteResultStep {
+    return expectResults(observation, baseline) {}
+  }
+
   fun observation(
       number: Int,
       init: ObservationCompletedStep.() -> Unit,


### PR DESCRIPTION
Add a convenience/clarity wrapper to assert that the results for an observation
should exactly match the baseline value that was asserted earlier in the test.