### PR TITLE
SW-7829 Rename zone->strata in tracking api request payloads

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DeliveriesController.kt
@@ -111,9 +111,22 @@ data class ReassignmentPayload(
     )
     val numPlants: Int,
     val notes: String?,
-    val toPlantingSubzoneId: SubstratumId,
+    @Schema(description = "Use toSubstratumId instead", deprecated = true)
+    val toPlantingSubzoneId: SubstratumId?,
+    // make non-nullable once FE is no longer using toPlantingSubzoneId
+    val toSubstratumId: SubstratumId?,
 ) {
-  fun toModel() = DeliveryStore.Reassignment(fromPlantingId, numPlants, notes, toPlantingSubzoneId)
+  fun toModel() =
+      DeliveryStore.Reassignment(
+          fromPlantingId,
+          numPlants,
+          notes,
+          toSubstratumId
+              ?: toPlantingSubzoneId
+              ?: throw IllegalArgumentException(
+                  "Must specify either toSubstratumId or toPlantingSubzoneId"
+              ),
+      )
 }
 
 data class GetDeliveryResponsePayload(val delivery: DeliveryPayload) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/DraftPlantingSitesController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/DraftPlantingSitesController.kt
@@ -47,8 +47,8 @@ class DraftPlantingSitesController(
             data = payload.data,
             description = payload.description,
             name = payload.name,
-            numSubstrata = payload.numPlantingSubzones,
-            numStrata = payload.numPlantingZones,
+            numStrata = payload.numStrata ?: payload.numPlantingZones,
+            numSubstrata = payload.numSubstrata ?: payload.numPlantingSubzones,
             organizationId = payload.organizationId,
             projectId = payload.projectId,
             timeZone = payload.timeZone,
@@ -151,17 +151,21 @@ data class CreateDraftPlantingSiteRequestPayload(
     val data: ArbitraryJsonObject,
     val description: String?,
     val name: String,
+    @Schema(description = "Use numSubstrata instead", deprecated = true)
+    val numPlantingSubzones: Int?,
+    @Schema(description = "Use numStrata instead", deprecated = true) //
+    val numPlantingZones: Int?,
+    @Schema(
+        description =
+            "If the user has started defining strata, the number of strata defined so far."
+    )
+    val numStrata: Int?,
     @Schema(
         description =
             "If the user has started defining substrata, the number of substrata defined " +
                 "so far."
     )
-    val numPlantingSubzones: Int?,
-    @Schema(
-        description =
-            "If the user has started defining strata, the number of strata defined so far."
-    )
-    val numPlantingZones: Int?,
+    val numSubstrata: Int?,
     val organizationId: OrganizationId,
     @Schema(description = "If the draft is associated with a project, its ID.")
     val projectId: ProjectId?,
@@ -180,17 +184,21 @@ data class UpdateDraftPlantingSiteRequestPayload(
     val data: ArbitraryJsonObject,
     val description: String?,
     val name: String,
+    @Schema(description = "Use numSubstrata instead", deprecated = true)
+    val numPlantingSubzones: Int?,
+    @Schema(description = "Use numStrata instead", deprecated = true) //
+    val numPlantingZones: Int?,
+    @Schema(
+        description =
+            "If the user has started defining strata, the number of strata defined so far."
+    )
+    val numStrata: Int?,
     @Schema(
         description =
             "If the user has started defining substrata, the number of substrata defined " +
                 "so far."
     )
-    val numPlantingSubzones: Int?,
-    @Schema(
-        description =
-            "If the user has started defining strata, the number of strata defined so far."
-    )
-    val numPlantingZones: Int?,
+    val numSubstrata: Int?,
     @Schema(description = "If the draft is associated with a project, its ID.")
     val projectId: ProjectId?,
     val timeZone: ZoneId?,
@@ -199,8 +207,8 @@ data class UpdateDraftPlantingSiteRequestPayload(
     record.data = data
     record.description = description
     record.name = name
-    record.numSubstrata = numPlantingSubzones
-    record.numStrata = numPlantingZones
+    record.numSubstrata = numSubstrata ?: numPlantingSubzones
+    record.numStrata = numStrata ?: numPlantingZones
     record.projectId = projectId
     record.timeZone = timeZone
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -18,6 +18,7 @@ import com.terraformation.backend.tracking.model.SiteT0DataModel
 import com.terraformation.backend.tracking.model.SpeciesDensityModel
 import com.terraformation.backend.tracking.model.StratumT0TempDataModel
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -87,7 +88,14 @@ class T0Controller(
   fun assignT0TempSiteData(
       @RequestBody payload: AssignSiteT0TempDataRequestPayload
   ): SimpleSuccessResponsePayload {
-    t0Service.assignT0TempStratumData(payload.zones.map { it.toModel() })
+    require(payload.strata != null || payload.zones != null) {
+      "Must specify either strata or zones"
+    }
+    if (payload.strata != null) {
+      t0Service.assignT0TempStratumData(payload.strata.map { it.toModel() })
+    } else if (payload.zones != null) {
+      t0Service.assignT0TempStratumData(payload.zones.map { it.toModel() })
+    }
 
     return SimpleSuccessResponsePayload()
   }
@@ -224,5 +232,8 @@ data class AssignSiteT0DataRequestPayload(
 
 data class AssignSiteT0TempDataRequestPayload(
     val plantingSiteId: PlantingSiteId,
-    val zones: List<ZoneT0DataPayload> = emptyList(),
+    @Schema(description = "Use strata instead", deprecated = true)
+    val zones: List<ZoneT0DataPayload>?,
+    // make non-nullable once FE is no longer using zones
+    val strata: List<StratumT0DataPayload>?,
 )


### PR DESCRIPTION
Rename properties in request payloads by providing the ability to specify either the old or the new. Do this for files in the `tracking` folder to keep the PR small.