### PR TITLE
Test disjoint substratum observations with map edit

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreSurvivalRateCalculationTest.kt
@@ -1353,6 +1353,7 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
             plot(1) { survivalRate(percent(obsLive[2][1], densities[1])) }
           }
         }
+        noResultForStratum(2)
       }
 
       siteEdited {
@@ -1375,10 +1376,12 @@ class ObservationStoreSurvivalRateCalculationTest : ObservationScenarioTest() {
                 densities[1] + densities[2] + densities[3],
             )
         )
+        noResultForStratum(1)
         stratum(2) {
           // Should pull substratum 2 rate from observation 1, but credit it to stratum 2
           // thanks to the map edit
           survivalRate(percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3]))
+          noResultForSubstratum(2)
           substratum(3) { survivalRate(percent(obsLive[3][3], densities[3])) }
         }
       }

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
@@ -2,6 +2,8 @@ package com.terraformation.backend.tracking.scenario
 
 import com.terraformation.backend.tracking.model.BaseMonitoringResult
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
+import java.math.BigDecimal
+import java.math.RoundingMode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertAll
 
@@ -32,10 +34,17 @@ abstract class ExpectedObservationResult<
 ) : NodeWithChildren<ExpectedObservationResult.Species>() {
   private var survivalRateSet: Boolean = survivalRate != null
 
-  fun survivalRate(expected: Int?) = apply {
+  fun survivalRate(expected: Int?) {
     survivalRate = expected
     survivalRateSet = true
     assertions.add { assertEquals(expected, actualResult.survivalRate, "$name survival rate") }
+  }
+
+  /** Returns the ratio between two integers as a percentage value with half-up rounding. */
+  fun percent(numerator: Int, denominator: Int): Int {
+    return BigDecimal(numerator * 100)
+        .divide(BigDecimal(denominator), 0, RoundingMode.HALF_UP)
+        .toInt()
   }
 
   fun species(

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
@@ -1,5 +1,6 @@
 package com.terraformation.backend.tracking.scenario
 
+import com.terraformation.backend.toBigDecimal
 import com.terraformation.backend.tracking.model.BaseMonitoringResult
 import com.terraformation.backend.tracking.model.ObservationSpeciesResultsModel
 import java.math.BigDecimal
@@ -41,9 +42,11 @@ abstract class ExpectedObservationResult<
   }
 
   /** Returns the ratio between two integers as a percentage value with half-up rounding. */
-  fun percent(numerator: Int, denominator: Int): Int {
-    return BigDecimal(numerator * 100)
-        .divide(BigDecimal(denominator), 0, RoundingMode.HALF_UP)
+  fun percent(numerator: Number, denominator: Number): Int {
+    return numerator
+        .toBigDecimal()
+        .multiply(BigDecimal.valueOf(100))
+        .divide(denominator.toBigDecimal(), 0, RoundingMode.HALF_UP)
         .toInt()
   }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
@@ -5,6 +5,7 @@ import com.terraformation.backend.tracking.model.ObservationResultsModel
 import com.terraformation.backend.tracking.model.ObservationStratumResultsModel
 import com.terraformation.backend.tracking.model.ObservationSubstratumResultsModel
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertNull
 
 class ExpectedSiteResultStep(
     scenario: ObservationScenario,
@@ -33,6 +34,15 @@ class ExpectedSiteResultStep(
           strata,
           init,
       )
+
+  fun noResultForStratum(number: Int) {
+    assertions.add {
+      assertNull(
+          actualResult.strata.firstOrNull { it.name == "$number" },
+          "Result for stratum $number",
+      )
+    }
+  }
 
   override fun finish() {
     if (baseline != null) {
@@ -66,6 +76,15 @@ class ExpectedSiteResultStep(
             substrata,
             init,
         )
+
+    fun noResultForSubstratum(number: Int) {
+      assertions.add {
+        assertNull(
+            actualResult.substrata.firstOrNull { it.name == "$number" },
+            "Result for $name substratum $number",
+        )
+      }
+    }
 
     override fun finish() {
       if (baseline != null) {

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteCreatedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteCreatedStep.kt
@@ -84,6 +84,7 @@ class SiteCreatedStep(
                 fullName = "${this@Stratum.number}-$number",
                 name = "$number",
                 plantingCompletedTime = Instant.EPOCH,
+                stableId = "$number",
             )
       }
 

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteEditedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/SiteEditedStep.kt
@@ -108,7 +108,7 @@ class SiteEditedStep(
               fullName = "${this@Stratum.number}-$number",
               name = "$number",
               monitoringPlots = children.map { it.toModel() },
-              stableId = StableId("${this@Stratum.number}-$number"),
+              stableId = StableId("$number"),
           )
 
       inner class Plot(val number: Long) : ScenarioNode {

--- a/src/test/kotlin/com/terraformation/backend/util/NullSafeMap.kt
+++ b/src/test/kotlin/com/terraformation/backend/util/NullSafeMap.kt
@@ -1,0 +1,36 @@
+package com.terraformation.backend.util
+
+/**
+ * A map that only allows non-null value types and throws an exception on [get] if a key isn't
+ * found. This allows calling code to do null-safe lookups without having to use `!!` or `?:`.
+ */
+class NullSafeMap<K, V : Any>(private val map: Map<K, V>) : Map<K, V> by map {
+  override operator fun get(key: K): V {
+    return map.getValue(key)
+  }
+}
+
+/**
+ * A mutable map that only allows non-null value types and throws an exception on [get] if a key
+ * isn't found. This allows calling code to do null-safe lookups without having to use `!!` or `?:`.
+ */
+class NullSafeMutableMap<K, V : Any>(private val map: MutableMap<K, V>) : MutableMap<K, V> by map {
+  override operator fun get(key: K): V {
+    return map.getValue(key)
+  }
+}
+
+/** Returns a null-safe map with a given set of elements. */
+fun <K, V : Any> nullSafeMapOf(vararg pairs: Pair<K, V>): NullSafeMap<K, V> =
+    NullSafeMap(mapOf(*pairs))
+
+/** Returns a null-safe mutable map with a given set of elements. */
+fun <K, V : Any> nullSafeMutableMapOf(vararg pairs: Pair<K, V>): NullSafeMutableMap<K, V> =
+    NullSafeMutableMap(mutableMapOf(*pairs))
+
+/** Returns a version of this map whose `get` cannot return null. */
+fun <K, V : Any> Map<K, V>.toNullSafe() = this as? NullSafeMap<K, V> ?: NullSafeMap(this)
+
+/** Returns a version of this map whose `get` cannot return null. */
+fun <K, V : Any> MutableMap<K, V>.toNullSafe() =
+    this as? NullSafeMutableMap<K, V> ?: NullSafeMutableMap(this)


### PR DESCRIPTION
Add a test case to verify (and document) how survival rates are calculated when
there are geometry changes that affect substrata that aren't observed in later
observations.

This is also a trial run of specifying the expected values in a more
self-documenting way; it includes a new null-safe wrapper for `Map` that allows
us to do null-safe array-style gets without having to litter the code with `!!`
modifiers.

The test uncovered a bug in the test DSL's site editing logic; it wasn't
maintaining consistent stable IDs when substrata moved between strata.