### PR TITLE
Observation test DSL: Set t0 from observation

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.tracking.db.ObservationLocker
 import com.terraformation.backend.tracking.db.ObservationResultsStore
 import com.terraformation.backend.tracking.db.ObservationStore
 import com.terraformation.backend.tracking.db.PlantingSiteStore
+import com.terraformation.backend.tracking.db.T0Store
 import com.terraformation.backend.tracking.model.ObservationResultsDepth
 import java.time.temporal.ChronoUnit
 import org.jooq.Configuration
@@ -60,6 +61,7 @@ class ObservationScenario(
     val observationResultsStore: ObservationResultsStore,
     val observationStore: ObservationStore,
     val plantingSiteStore: PlantingSiteStore,
+    val t0Store: T0Store,
     val test: DatabaseBackedTest,
 ) : NodeWithChildren<ScenarioNode>() {
   companion object {
@@ -99,12 +101,14 @@ class ObservationScenario(
                 StrataDao(configuration),
                 SubstrataDao(configuration),
             ),
+        t0Store: T0Store = T0Store(clock, test.dslContext, eventPublisher),
     ): ObservationScenario {
       return ObservationScenario(
           clock,
           observationResultsStore,
           observationStore,
           plantingSiteStore,
+          t0Store,
           test,
       )
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
@@ -51,6 +51,14 @@ class T0DensitySetStep(val scenario: ObservationScenario) :
   inner class Plot(val number: Long) : NodeWithChildren<Plot.Species>() {
     val monitoringPlotId = scenario.getMonitoringPlotId(number)
 
+    fun observation(observation: Int) {
+      scenario.t0Store.assignT0PlotObservation(
+          monitoringPlotId,
+          scenario.observationIds[observation]
+              ?: throw IllegalArgumentException("Unknown observation $observation"),
+      )
+    }
+
     fun species(speciesId: Int, density: Int?, init: Species.() -> Unit = {}) =
         initChild(Species(speciesId, density), init)
 


### PR DESCRIPTION
Allow tests to specify that the t0 density data for a plot should come from an
observation.