### PR TITLE
Observation test DSL: Observation number in assertions

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedSiteResultStep.kt
@@ -52,7 +52,7 @@ class ExpectedSiteResultStep(
       baseline.strata.filter { it.number !in stratumNumbers }.forEach { stratum(it.number) {} }
     }
 
-    assertAll(assertions)
+    assertAll("Observation $observation", assertions)
   }
 
   inner class Stratum(val number: Int, survivalRate: Int? = null, baseline: Stratum?) :


### PR DESCRIPTION
Include the observation number as an assertion prefix when asserting observation
results; this makes it easier to tell which observation's assertion failed when
a test involves multiple observations.