### PR TITLE
SW-7783 Define event for monitoring observation edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContext.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadContext.kt
@@ -79,7 +79,9 @@ class EventLogPayloadContext(
       when (certainty) {
         RecordedSpeciesCertainty.Known ->
             dslContext.fetchValue(SPECIES.SCIENTIFIC_NAME, SPECIES.ID.eq(speciesId)) ?: "$speciesId"
-        RecordedSpeciesCertainty.Other -> speciesName!!
+        RecordedSpeciesCertainty.Other ->
+            speciesName
+                ?: throw IllegalArgumentException("Species name required for certainty Other")
         RecordedSpeciesCertainty.Unknown -> "Unknown" // TODO: i18n
       }
     }

--- a/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/EventLogPayloadTransformer.kt
@@ -14,6 +14,7 @@ import com.terraformation.backend.eventlog.api.EventLogEntryPayload
 import com.terraformation.backend.eventlog.api.EventSubjectName
 import com.terraformation.backend.eventlog.api.EventSubjectPayload
 import com.terraformation.backend.eventlog.api.FieldUpdatedActionPayload
+import com.terraformation.backend.eventlog.api.MonitoringSpeciesSubjectPayload
 import com.terraformation.backend.eventlog.api.ObservationPlotMediaSubjectPayload
 import com.terraformation.backend.eventlog.api.ObservationPlotSubjectPayload
 import com.terraformation.backend.eventlog.api.OrganizationSubjectPayload
@@ -27,6 +28,7 @@ import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
+import com.terraformation.backend.tracking.event.MonitoringSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.ObservationPlotPersistentEvent
 import com.terraformation.backend.tracking.event.RecordedTreePersistentEvent
@@ -89,6 +91,8 @@ class EventLogPayloadTransformer(
       is BiomassQuadratSpeciesPersistentEvent ->
           BiomassQuadratSpeciesSubjectPayload.forEvent(event, context)
       is BiomassSpeciesPersistentEvent -> BiomassSpeciesSubjectPayload.forEvent(event, context)
+      is MonitoringSpeciesPersistentEvent ->
+          MonitoringSpeciesSubjectPayload.forEvent(event, context)
       is ObservationMediaFilePersistentEvent ->
           ObservationPlotMediaSubjectPayload.forEvent(event, context)
       is ObservationPlotPersistentEvent -> ObservationPlotSubjectPayload.forEvent(event, context)

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -202,7 +202,7 @@ data class MonitoringSpeciesSubjectPayload(
     fun forEvent(
         event: MonitoringSpeciesPersistentEvent,
         context: EventLogPayloadContext,
-    ): BiomassSpeciesSubjectPayload {
+    ): MonitoringSpeciesSubjectPayload {
       val displayName =
           context.getRecordedSpeciesName(
               event.certainty,
@@ -210,7 +210,7 @@ data class MonitoringSpeciesSubjectPayload(
               event.speciesName,
           )
 
-      return BiomassSpeciesSubjectPayload(
+      return MonitoringSpeciesSubjectPayload(
           fullText = context.subjectFullText<MonitoringSpeciesSubjectPayload>(displayName),
           monitoringPlotId = event.monitoringPlotId,
           observationId = event.observationId,

--- a/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/eventlog/api/EventSubjectPayload.kt
@@ -26,6 +26,7 @@ import com.terraformation.backend.tracking.event.BiomassDetailsPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassQuadratSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.BiomassSpeciesPersistentEvent
+import com.terraformation.backend.tracking.event.MonitoringSpeciesPersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileDeletedEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFilePersistentEvent
 import com.terraformation.backend.tracking.event.ObservationMediaFileUploadedEvent
@@ -182,6 +183,41 @@ data class BiomassSpeciesSubjectPayload(
           shortText = context.subjectShortText<BiomassSpeciesSubjectPayload>(),
           speciesId = biomassSpecies.speciesId,
           scientificName = biomassSpecies.scientificName,
+      )
+    }
+  }
+}
+
+@JsonTypeName("MonitoringSpecies")
+data class MonitoringSpeciesSubjectPayload(
+    override val fullText: String,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+    val plantingSiteId: PlantingSiteId,
+    override val shortText: String,
+    val speciesId: SpeciesId?,
+    val scientificName: String?,
+) : EventSubjectPayload {
+  companion object {
+    fun forEvent(
+        event: MonitoringSpeciesPersistentEvent,
+        context: EventLogPayloadContext,
+    ): BiomassSpeciesSubjectPayload {
+      val displayName =
+          context.getRecordedSpeciesName(
+              event.certainty,
+              event.speciesId,
+              event.speciesName,
+          )
+
+      return BiomassSpeciesSubjectPayload(
+          fullText = context.subjectFullText<MonitoringSpeciesSubjectPayload>(displayName),
+          monitoringPlotId = event.monitoringPlotId,
+          observationId = event.observationId,
+          plantingSiteId = event.plantingSiteId,
+          shortText = context.subjectShortText<MonitoringSpeciesSubjectPayload>(),
+          speciesId = event.speciesId,
+          scientificName = event.speciesName,
       )
     }
   }
@@ -386,6 +422,7 @@ enum class EventSubjectName(val eventInterface: KClass<out PersistentEvent>) {
   BiomassQuadrat(BiomassQuadratPersistentEvent::class),
   BiomassQuadratSpecies(BiomassQuadratSpeciesPersistentEvent::class),
   BiomassSpecies(BiomassSpeciesPersistentEvent::class),
+  MonitoringSpecies(MonitoringSpeciesPersistentEvent::class),
   ObservationPlot(ObservationPlotPersistentEvent::class),
   ObservationPlotMedia(ObservationMediaFilePersistentEvent::class),
   Organization(OrganizationPersistentEvent::class),

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -105,6 +105,14 @@ eventSubject.BiomassSpecies.field.isInvasive=invasive
 eventSubject.BiomassSpecies.field.isThreatened=threatened
 eventSubject.BiomassSpecies.full=Species {0}
 eventSubject.BiomassSpecies.short=Species
+# Count of the number of dead plants
+eventSubject.MonitoringSpecies.field.totalDead=dead count
+# Count of the number of existing plants
+eventSubject.MonitoringSpecies.field.totalExisting=existing count
+# Count of the number of live plants
+eventSubject.MonitoringSpecies.field.totalLive=live count
+eventSubject.MonitoringSpecies.full=Species {0}
+eventSubject.MonitoringSpecies.short=Species
 eventSubject.ObservationPlot.field.conditions=plot conditions
 eventSubject.ObservationPlot.field.notes=field notes
 eventSubject.ObservationPlot.full=Plot {0}

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -181,6 +181,16 @@ eventSubject.BiomassSpecies.field.isThreatened=amenazada
 eventSubject.BiomassSpecies.full=Especie {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Especie
+# e960326f
+eventSubject.MonitoringSpecies.field.totalDead=conteo de plantas muertas
+# eb305026
+eventSubject.MonitoringSpecies.field.totalExisting=conteo de plantas existentes
+# 5d07caad
+eventSubject.MonitoringSpecies.field.totalLive=conteo de plantas vivas
+# fd7f5baf
+eventSubject.MonitoringSpecies.full=Especies {0}
+# bb344d18
+eventSubject.MonitoringSpecies.short=Especies
 # a87ad7da
 eventSubject.ObservationPlot.field.conditions=condiciones de la parcela
 # c0427d5c

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -181,6 +181,16 @@ eventSubject.BiomassSpecies.field.isThreatened=menacée
 eventSubject.BiomassSpecies.full=Espèce {0}
 # bb344d18
 eventSubject.BiomassSpecies.short=Espèce
+# e960326f
+eventSubject.MonitoringSpecies.field.totalDead=nombre de plants morts
+# eb305026
+eventSubject.MonitoringSpecies.field.totalExisting=nombre de plants existants
+# 5d07caad
+eventSubject.MonitoringSpecies.field.totalLive=nombre de plants vivants
+# fd7f5baf
+eventSubject.MonitoringSpecies.full=Espèce {0}
+# bb344d18
+eventSubject.MonitoringSpecies.short=Espèce
 # a87ad7da
 eventSubject.ObservationPlot.field.conditions=conditions de la parcelle
 # c0427d5c

--- a/src/test/resources/eventlog/eventProperties.txt
+++ b/src/test/resources/eventlog/eventProperties.txt
@@ -78,6 +78,11 @@ com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/monitorin
 com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/observationId: ObservationId
 com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/organizationId: OrganizationId
 com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventV1/plantingSiteId: PlantingSiteId
+com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventV1/certainty: RecordedSpeciesCertainty
+com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventV1/monitoringPlotId: MonitoringPlotId
+com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventV1/observationId: ObservationId
+com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventV1/organizationId: OrganizationId
+com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventV1/plantingSiteId: PlantingSiteId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/biomassSpeciesId: BiomassSpeciesId
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/isDead: Boolean
 com.terraformation.backend.tracking.event.RecordedTreeCreatedEventV1/monitoringPlotId: MonitoringPlotId


### PR DESCRIPTION
Add a new persistent event to record when plant counts are edited on monitoring
observations. This is modeled after the existing event for biomass observation
edits.