### PR TITLE
Observation test DSL: Flexible plot number types

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
@@ -25,11 +25,11 @@ class ObservationCompletedStep(val scenario: ObservationScenario, val number: In
   lateinit var observationId: ObservationId
 
   fun plot(
-      number: Long,
+      number: Number,
       isPermanent: Boolean = true,
       conditions: Set<ObservableCondition> = emptySet(),
       init: Plot.() -> Unit = {},
-  ) = initChild(Plot(number, isPermanent, conditions), init)
+  ) = initChild(Plot(number.toLong(), isPermanent, conditions), init)
 
   override fun prepare() {
     val plantingSiteHistoryId =

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/T0DensitySetStep.kt
@@ -12,7 +12,7 @@ class T0DensitySetStep(val scenario: ObservationScenario) :
   private val test: DatabaseBackedTest
     get() = scenario.test
 
-  fun plot(number: Long, init: Plot.() -> Unit) = initChild(Plot(number), init)
+  fun plot(number: Number, init: Plot.() -> Unit) = initChild(Plot(number.toLong()), init)
 
   fun stratum(number: Int, init: Stratum.() -> Unit) = initAndAppend(Stratum(number), strata, init)
 


### PR DESCRIPTION
Support passing plot numbers to `plot()` functions as either Long or Int values.