### PR TITLE
Observation test DSL: Magic species numbers

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ExpectedObservationResult.kt
@@ -68,12 +68,26 @@ abstract class ExpectedObservationResult<
       totalLive: Int? = null,
       init: Species.() -> Unit = {},
   ): Species {
-    val speciesId = scenario.getOrInsertSpecies(number)
+    val speciesId =
+        when (number) {
+          ObservationScenario.OTHER,
+          ObservationScenario.UNKNOWN -> null
+          else -> scenario.getOrInsertSpecies(number)
+        }
+    val speciesName =
+        when (number) {
+          ObservationScenario.OTHER -> "Other"
+          else -> null
+        }
+
     return initChild(
         Species(
             parentName = name,
             number = number,
-            speciesResult = actualResult.species.firstOrNull { it.speciesId == speciesId },
+            speciesResult =
+                actualResult.species.firstOrNull {
+                  it.speciesId == speciesId && it.speciesName == speciesName
+                },
             survivalRate = survivalRate,
             totalDead = totalDead,
             totalExisting = totalExisting,

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationCompletedStep.kt
@@ -62,9 +62,6 @@ class ObservationCompletedStep(val scenario: ObservationScenario, val number: In
   ) : NodeWithChildren<Plot.Species>() {
     private lateinit var monitoringPlotId: MonitoringPlotId
 
-    val unknown = -1
-    val other = -2
-
     fun completePlot() {
       scenario.observationStore.completePlot(
           observationId = observationId,
@@ -136,10 +133,10 @@ class ObservationCompletedStep(val scenario: ObservationScenario, val number: In
 
       override fun prepare() {
         when (number) {
-          unknown -> {
+          ObservationScenario.UNKNOWN -> {
             certainty = RecordedSpeciesCertainty.Unknown
           }
-          other -> {
+          ObservationScenario.OTHER -> {
             certainty = RecordedSpeciesCertainty.Other
             speciesName = "Other"
           }

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -112,6 +112,11 @@ class ObservationScenario(
           test,
       )
     }
+
+    /** Magic species number that causes plants to be recorded with "Other" certainty. */
+    const val OTHER = -1
+    /** Magic species number that causes plants to be recorded with "Unknown" certainty. */
+    const val UNKNOWN = -2
   }
 
   val monitoringPlotHistoryIds = mutableMapOf<MonitoringPlotId, MonitoringPlotHistoryId>()


### PR DESCRIPTION
Move the constants that tests can use to indicate "Other" and "Unknown" species
types into the top-level scenario class so they can be consistently referred to
in different kinds of steps.

Update the result-assertion code to properly test the Other and Unknown counts.