### PR TITLE
SW-7783 Implement monitoring observation editing

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/Exceptions.kt
@@ -173,6 +173,9 @@ class ShapefilesInvalidException(val problems: List<String>) :
 class SpeciesInWrongOrganizationException(val speciesId: SpeciesId) :
     MismatchedStateException("Species $speciesId is in the wrong organization")
 
+class SpeciesNotInObservationException(val speciesId: SpeciesId?, val speciesName: String?) :
+    EntityNotFoundException("Species ${speciesId ?: speciesName} not found in observation")
+
 class StratumNotFoundException(val stratumId: StratumId) :
     EntityNotFoundException("Stratum $stratumId not found")
 

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -15,6 +15,7 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.ObservationIdConverter
 import com.terraformation.backend.db.tracking.ObservationPlotStatus
 import com.terraformation.backend.db.tracking.ObservationState
+import com.terraformation.backend.db.tracking.ObservationType
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
@@ -51,6 +52,7 @@ import com.terraformation.backend.db.tracking.tables.references.PLANTING_SITE_PO
 import com.terraformation.backend.db.tracking.tables.references.PLOT_T0_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.RECORDED_PLANTS
 import com.terraformation.backend.db.tracking.tables.references.STRATA
+import com.terraformation.backend.db.tracking.tables.references.STRATUM_HISTORIES
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_POPULATIONS
 import com.terraformation.backend.db.tracking.tables.references.STRATUM_T0_TEMP_DENSITIES
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATA
@@ -58,12 +60,14 @@ import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_HISTO
 import com.terraformation.backend.db.tracking.tables.references.SUBSTRATUM_POPULATIONS
 import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.log.withMDC
+import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotCreatedEvent
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEvent
 import com.terraformation.backend.tracking.event.ObservationStateUpdatedEvent
 import com.terraformation.backend.tracking.event.T0PlotDataAssignedEvent
 import com.terraformation.backend.tracking.event.T0StratumDataAssignedEvent
 import com.terraformation.backend.tracking.model.AssignedPlotDetails
+import com.terraformation.backend.tracking.model.EditableMonitoringSpeciesModel
 import com.terraformation.backend.tracking.model.EditableObservationPlotDetailsModel
 import com.terraformation.backend.tracking.model.ExistingObservationModel
 import com.terraformation.backend.tracking.model.NewObservationModel
@@ -997,7 +1001,7 @@ class ObservationStore(
               ?: throw PlantingSiteNotFoundException(plantingSiteId)
 
       // Add the plot-level live/dead/existing counts to the target species. This propagates the
-      // changes up to the zone and site totals.
+      // changes up to the stratum and site totals.
       updateSpeciesTotals(
           observationId,
           plantingSite,
@@ -1171,6 +1175,153 @@ class ObservationStore(
                 observationId = observationId,
                 organizationId = organizationId,
                 plantingSiteId = observation.plantingSiteId,
+            )
+        )
+      }
+    }
+  }
+
+  fun updateMonitoringSpecies(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId,
+      certainty: RecordedSpeciesCertainty,
+      speciesId: SpeciesId?,
+      speciesName: String?,
+      updateFunc: (EditableMonitoringSpeciesModel) -> EditableMonitoringSpeciesModel,
+  ) {
+    requirePermissions {
+      updateObservation(observationId) //
+    }
+
+    observationLocker.withLockedObservation(observationId) { observation ->
+      if (observation.observationType != ObservationType.Monitoring) {
+        throw IllegalArgumentException("Observation type is not Monitoring")
+      }
+
+      val existing =
+          with(OBSERVED_PLOT_SPECIES_TOTALS) {
+            dslContext
+                .select(TOTAL_DEAD, TOTAL_LIVE, TOTAL_EXISTING)
+                .from(OBSERVED_PLOT_SPECIES_TOTALS)
+                .where(OBSERVATION_ID.eq(observationId))
+                .and(MONITORING_PLOT_ID.eq(monitoringPlotId))
+                .and(CERTAINTY_ID.eq(certainty))
+                .and(SPECIES_ID.eqOrIsNull(speciesId))
+                .and(SPECIES_NAME.eqOrIsNull(speciesName))
+                .fetchOne { EditableMonitoringSpeciesModel.of(it) }
+                ?: throw SpeciesNotInObservationException(speciesId, speciesName)
+          }
+
+      val updated = updateFunc(existing)
+
+      if (updated != existing) {
+        // We need to update the totals for the stratum and substratum the plot was in at the time
+        // of the observation, which might not be where it currently is.
+        val (isPermanent, substratumId, stratumId) =
+            dslContext
+                .select(
+                    OBSERVATION_PLOTS.IS_PERMANENT.asNonNullable(),
+                    OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories.SUBSTRATUM_ID,
+                    OBSERVATION_PLOTS.monitoringPlotHistories.substratumHistories.stratumHistories
+                        .STRATUM_ID,
+                )
+                .from(OBSERVATION_PLOTS)
+                .where(OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId))
+                .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(monitoringPlotId))
+                .fetchOne() ?: throw PlotNotInObservationException(observationId, monitoringPlotId)
+
+        val plantingSitesRow =
+            dslContext
+                .selectFrom(PLANTING_SITES)
+                .where(PLANTING_SITES.ID.eq(observation.plantingSiteId))
+                .fetchOneInto(PlantingSitesRow::class.java)
+                ?: throw PlantingSiteNotFoundException(observation.plantingSiteId)
+
+        val plantCountAdjustments =
+            mapOf(
+                RecordedSpeciesKey(certainty, speciesId, speciesName) to
+                    mapOf(
+                        RecordedPlantStatus.Dead to updated.totalDead - existing.totalDead,
+                        RecordedPlantStatus.Existing to
+                            updated.totalExisting - existing.totalExisting,
+                        RecordedPlantStatus.Live to updated.totalLive - existing.totalLive,
+                    )
+            )
+
+        updateSpeciesTotals(
+            observationId,
+            plantingSitesRow,
+            stratumId,
+            substratumId,
+            monitoringPlotId,
+            observation.isAdHoc,
+            isPermanent,
+            plantCountAdjustments,
+        )
+
+        val latestObservations = OBSERVATIONS.`as`("latest_observations")
+        val observationWithLatestResultsForSubstratum =
+            DSL.field(
+                DSL.select(latestObservations.ID)
+                    .from(latestObservations)
+                    .join(OBSERVATION_REQUESTED_SUBSTRATA)
+                    .on(latestObservations.ID.eq(OBSERVATION_REQUESTED_SUBSTRATA.OBSERVATION_ID))
+                    .where(latestObservations.COMPLETED_TIME.ge(observation.completedTime))
+                    .and(OBSERVATION_REQUESTED_SUBSTRATA.SUBSTRATUM_ID.eq(substratumId))
+                    .orderBy(latestObservations.COMPLETED_TIME.desc(), latestObservations.ID.desc())
+                    .limit(1)
+            )
+        val stratumIdAtTimeOfObservation =
+            DSL.field(
+                DSL.select(STRATUM_HISTORIES.STRATUM_ID)
+                    .from(STRATUM_HISTORIES)
+                    .join(SUBSTRATUM_HISTORIES)
+                    .on(STRATUM_HISTORIES.ID.eq(SUBSTRATUM_HISTORIES.STRATUM_HISTORY_ID))
+                    .where(
+                        STRATUM_HISTORIES.PLANTING_SITE_HISTORY_ID.eq(
+                            OBSERVATIONS.PLANTING_SITE_HISTORY_ID
+                        )
+                    )
+                    .and(SUBSTRATUM_HISTORIES.SUBSTRATUM_ID.eq(substratumId))
+            )
+        val laterObservationsWithoutThisSubstratum =
+            dslContext
+                .select(
+                    OBSERVATIONS.ID.asNonNullable(),
+                    stratumIdAtTimeOfObservation.asNonNullable(),
+                )
+                .from(OBSERVATIONS)
+                .where(OBSERVATIONS.PLANTING_SITE_ID.eq(observation.plantingSiteId))
+                .and(OBSERVATIONS.COMPLETED_TIME.gt(observation.completedTime))
+                .and(observationWithLatestResultsForSubstratum.eq(observationId))
+                .and(OBSERVATIONS.OBSERVATION_TYPE_ID.eq(ObservationType.Monitoring))
+                .fetch()
+
+        laterObservationsWithoutThisSubstratum.forEach {
+            (laterObservationId, stratumIdInLaterObservation) ->
+          updateSpeciesTotals(
+              observationId = laterObservationId,
+              plantingSite = plantingSitesRow,
+              stratumId = stratumIdInLaterObservation,
+              substratumId = null,
+              monitoringPlotId = null,
+              isAdHoc = observation.isAdHoc,
+              isPermanent = isPermanent,
+              plantCountsBySpecies = plantCountAdjustments,
+          )
+        }
+
+        eventPublisher.publishEvent(
+            MonitoringSpeciesTotalsEditedEvent(
+                certainty = certainty,
+                changedFrom = existing.toEventValues(updated),
+                changedTo = updated.toEventValues(existing),
+                monitoringPlotId = monitoringPlotId,
+                observationId = observationId,
+                organizationId = plantingSitesRow.organizationId!!,
+                plantingSiteId = observation.plantingSiteId,
+                speciesId = speciesId,
+                speciesName = speciesName,
             )
         )
       }

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/EditableObservationModels.kt
@@ -8,10 +8,12 @@ import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOM
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_QUADRAT_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_BIOMASS_SPECIES
 import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+import com.terraformation.backend.db.tracking.tables.references.OBSERVED_PLOT_SPECIES_TOTALS
 import com.terraformation.backend.tracking.event.BiomassDetailsUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassQuadratDetailsUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassQuadratSpeciesUpdatedEventValues
 import com.terraformation.backend.tracking.event.BiomassSpeciesUpdatedEventValues
+import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventValues
 import com.terraformation.backend.tracking.event.ObservationPlotEditedEventValues
 import com.terraformation.backend.util.nullIfEquals
 import java.math.BigDecimal
@@ -135,6 +137,31 @@ data class EditableBiomassSpeciesModel(
         EditableBiomassSpeciesModel(
             isInvasive = record[IS_INVASIVE]!!,
             isThreatened = record[IS_THREATENED]!!,
+        )
+      }
+    }
+  }
+}
+
+data class EditableMonitoringSpeciesModel(
+    val totalDead: Int,
+    val totalExisting: Int,
+    val totalLive: Int,
+) {
+  fun toEventValues(other: EditableMonitoringSpeciesModel) =
+      MonitoringSpeciesTotalsEditedEventValues(
+          totalDead = totalDead.nullIfEquals(other.totalDead),
+          totalExisting = totalExisting.nullIfEquals(other.totalExisting),
+          totalLive = totalLive.nullIfEquals(other.totalLive),
+      )
+
+  companion object {
+    fun of(record: Record): EditableMonitoringSpeciesModel {
+      return with(OBSERVED_PLOT_SPECIES_TOTALS) {
+        EditableMonitoringSpeciesModel(
+            totalDead = record[TOTAL_DEAD]!!,
+            totalExisting = record[TOTAL_EXISTING]!!,
+            totalLive = record[TOTAL_LIVE]!!,
         )
       }
     }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
@@ -161,6 +161,7 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
       fun assertResultsMatchPlantCounts() {
         expectResults(observation = 1) {
           survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+          // Unknown species are not included at the site level, just known and Other ones.
           species(
               OTHER,
               survivalRate = null,
@@ -168,28 +169,15 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
               totalDead = otherDeadCount,
               totalExisting = otherExistingCount,
           )
-          species(
-              UNKNOWN,
-              survivalRate = null,
-              totalLive = unknownLiveCount,
-              totalDead = unknownDeadCount,
-              totalExisting = unknownExistingCount,
-          )
           stratum(1) {
             survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+            // Unknown species are not included at the stratum level, just known and Other ones.
             species(
                 OTHER,
                 survivalRate = null,
                 totalLive = otherLiveCount,
                 totalDead = otherDeadCount,
                 totalExisting = otherExistingCount,
-            )
-            species(
-                UNKNOWN,
-                survivalRate = null,
-                totalLive = unknownLiveCount,
-                totalDead = unknownDeadCount,
-                totalExisting = unknownExistingCount,
             )
             substratum(1) {
               survivalRate(percent(otherLiveCount + unknownLiveCount, density))

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
@@ -1,0 +1,989 @@
+package com.terraformation.backend.tracking.db.observationStore
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.TestEventPublisher
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.default_schema.Role
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEvent
+import com.terraformation.backend.tracking.event.MonitoringSpeciesTotalsEditedEventValues
+import com.terraformation.backend.tracking.scenario.ObservationScenario
+import com.terraformation.backend.tracking.scenario.ObservationScenario.Companion.OTHER
+import com.terraformation.backend.tracking.scenario.ObservationScenario.Companion.UNKNOWN
+import com.terraformation.backend.util.nullSafeMapOf
+import com.terraformation.backend.util.nullSafeMutableMapOf
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Tests the behavior of editing plant counts on monitoring observations, primarily verifying that
+ * survival rates are properly updated.
+ *
+ * Most of these tests follow a similar pattern:
+ * 1. Declare the site map.
+ * 2. Define the per-plot densities in a nested Map (usually called `densities`).
+ * 3. Define the per-plot live plant counts in a nested Map (usually called `obsLive`).
+ * 4. Populate the t0 densities from the values in `densities`.
+ * 5. Create the observation(s) using the live plant counts from `obsLive`.
+ * 6. Define and call a function `assertResultsMatchNumbersFromObsLive` that checks that the
+ *    observation results match the numbers in `obsLive` and `densities`.
+ * 7. Modify one or more of the live plant counts in `obsLive` to reflect the observation edit under
+ *    test.
+ * 8. Call `observationEdited` to apply the live plant count changes to the observation.
+ * 9. Call `assertResultsMatchNumbersFromObsLive` again. Since we've modified `obsLive`, this will
+ *    verify that the edits were applied correctly, that is, that the numbers in the observation
+ *    results are based on the updated plant counts rather than the original ones.
+ *
+ * This is just the general pattern. Not all the tests look _exactly_ like the above; there will be
+ * additional steps depending on what the test is checking, e.g., there might be a map edit.
+ */
+class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val eventPublisher = TestEventPublisher()
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+    insertOrganizationUser(role = Role.Admin)
+  }
+
+  @Test
+  fun `updates plant counts for known species`() {
+    scenario {
+      siteCreated { stratum(1) { substratum(1) { plot(1) } } }
+
+      val density = 100
+
+      t0DensitySet { plot(1) { species(0, density = density) } }
+
+      var liveCount = 6
+      var deadCount = 7
+      var existingCount = 8
+
+      observation(1) {
+        plot(1) { species(0, live = liveCount, dead = deadCount, existing = existingCount) }
+      }
+
+      fun assertResultsMatchPlantCounts() {
+        expectResults(observation = 1) {
+          survivalRate(percent(liveCount, density))
+          species(
+              0,
+              survivalRate = percent(liveCount, density),
+              totalLive = liveCount,
+              totalDead = deadCount,
+              totalExisting = existingCount,
+          )
+          stratum(1) {
+            survivalRate(percent(liveCount, density))
+            species(
+                0,
+                survivalRate = percent(liveCount, density),
+                totalLive = liveCount,
+                totalDead = deadCount,
+                totalExisting = existingCount,
+            )
+            substratum(1) {
+              survivalRate(percent(liveCount, density))
+              species(
+                  0,
+                  survivalRate = percent(liveCount, density),
+                  totalLive = liveCount,
+                  totalDead = deadCount,
+                  totalExisting = existingCount,
+              )
+              plot(1) {
+                survivalRate(percent(liveCount, density))
+                species(
+                    0,
+                    survivalRate = percent(liveCount, density),
+                    totalLive = liveCount,
+                    totalDead = deadCount,
+                    totalExisting = existingCount,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      assertResultsMatchPlantCounts()
+
+      liveCount = 1
+      deadCount = 2
+      existingCount = 3
+
+      observationEdited(1) {
+        plot(1) { species(0, live = liveCount, dead = deadCount, existing = existingCount) }
+      }
+
+      assertResultsMatchPlantCounts()
+    }
+  }
+
+  @Test
+  fun `updates plant counts for unknown and Other species`() {
+    scenario {
+      siteCreated { stratum(1) { substratum(1) { plot(1) } } }
+
+      val density = 100
+
+      t0DensitySet { plot(1) { species(0, density = density) } }
+
+      var otherLiveCount = 11
+      var otherDeadCount = 12
+      var otherExistingCount = 13
+      var unknownLiveCount = 14
+      var unknownDeadCount = 15
+      var unknownExistingCount = 16
+
+      observation(1) {
+        plot(1) {
+          species(
+              OTHER,
+              live = otherLiveCount,
+              dead = otherDeadCount,
+              existing = otherExistingCount,
+          )
+          species(
+              UNKNOWN,
+              live = unknownLiveCount,
+              dead = unknownDeadCount,
+              existing = unknownExistingCount,
+          )
+        }
+      }
+
+      fun assertResultsMatchPlantCounts() {
+        expectResults(observation = 1) {
+          survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+          species(
+              OTHER,
+              survivalRate = null,
+              totalLive = otherLiveCount,
+              totalDead = otherDeadCount,
+              totalExisting = otherExistingCount,
+          )
+          species(
+              UNKNOWN,
+              survivalRate = null,
+              totalLive = unknownLiveCount,
+              totalDead = unknownDeadCount,
+              totalExisting = unknownExistingCount,
+          )
+          stratum(1) {
+            survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+            species(
+                OTHER,
+                survivalRate = null,
+                totalLive = otherLiveCount,
+                totalDead = otherDeadCount,
+                totalExisting = otherExistingCount,
+            )
+            species(
+                UNKNOWN,
+                survivalRate = null,
+                totalLive = unknownLiveCount,
+                totalDead = unknownDeadCount,
+                totalExisting = unknownExistingCount,
+            )
+            substratum(1) {
+              survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+              species(
+                  OTHER,
+                  survivalRate = null,
+                  totalLive = otherLiveCount,
+                  totalDead = otherDeadCount,
+                  totalExisting = otherExistingCount,
+              )
+              species(
+                  UNKNOWN,
+                  survivalRate = null,
+                  totalLive = unknownLiveCount,
+                  totalDead = unknownDeadCount,
+                  totalExisting = unknownExistingCount,
+              )
+              plot(1) {
+                survivalRate(percent(otherLiveCount + unknownLiveCount, density))
+                species(
+                    OTHER,
+                    survivalRate = null,
+                    totalLive = otherLiveCount,
+                    totalDead = otherDeadCount,
+                    totalExisting = otherExistingCount,
+                )
+                species(
+                    UNKNOWN,
+                    survivalRate = null,
+                    totalLive = unknownLiveCount,
+                    totalDead = unknownDeadCount,
+                    totalExisting = unknownExistingCount,
+                )
+              }
+            }
+          }
+        }
+      }
+
+      assertResultsMatchPlantCounts()
+
+      otherLiveCount = 21
+      otherDeadCount = 22
+      otherExistingCount = 23
+
+      observationEdited(1) {
+        plot(1) {
+          species(
+              OTHER,
+              live = otherLiveCount,
+              dead = otherDeadCount,
+              existing = otherExistingCount,
+          )
+        }
+      }
+
+      assertResultsMatchPlantCounts()
+
+      unknownLiveCount = 24
+      unknownDeadCount = 25
+      unknownExistingCount = 26
+
+      observationEdited(1) {
+        plot(1) {
+          species(
+              UNKNOWN,
+              live = unknownLiveCount,
+              dead = unknownDeadCount,
+              existing = unknownExistingCount,
+          )
+        }
+      }
+
+      assertResultsMatchPlantCounts()
+    }
+  }
+
+  @Test
+  fun `updates aggregate survival rates when most recent observation is edited`() {
+    scenario {
+      siteCreated {
+        stratum(1) {
+          substratum(1) {
+            plot(111)
+            plot(112)
+          }
+          substratum(2) {
+            plot(211) //
+          }
+        }
+        stratum(2) {
+          substratum(3) {
+            plot(311) //
+          }
+        }
+      }
+
+      // Map<plot number, Map<species number, density>>
+      val densities =
+          nullSafeMapOf(
+              111 to nullSafeMapOf(0 to 10, 1 to 20),
+              112 to nullSafeMapOf(0 to 30, 1 to 40),
+              211 to nullSafeMapOf(0 to 50, 1 to 60),
+              311 to nullSafeMapOf(0 to 70, 1 to 80),
+          )
+
+      t0DensitySet {
+        densities.forEach { (plotNumber, speciesDensities) ->
+          plot(plotNumber) {
+            speciesDensities.forEach { (speciesNumber, density) ->
+              species(speciesNumber, density = density)
+            }
+          }
+        }
+      }
+
+      // Map<plot number, Map<species number, live count>>
+      val obsLive =
+          nullSafeMapOf(
+              111 to nullSafeMutableMapOf(0 to 9, 1 to 2),
+              112 to nullSafeMutableMapOf(0 to 3, 1 to 5),
+              211 to nullSafeMutableMapOf(0 to 5, 1 to 6),
+              311 to nullSafeMutableMapOf(0 to 6, 1 to 7),
+          )
+
+      observation(1) {
+        obsLive.forEach { (plotNumber, plotLiveCounts) ->
+          plot(plotNumber) {
+            plotLiveCounts.forEach { (speciesNumber, live) -> species(speciesNumber, live = live) }
+          }
+        }
+      }
+
+      fun assertResultsMatchNumbersFromObsLive() {
+        expectResults(observation = 1) {
+          survivalRate(
+              percent(
+                  obsLive[111][0] +
+                      obsLive[111][1] +
+                      obsLive[112][0] +
+                      obsLive[112][1] +
+                      obsLive[211][0] +
+                      obsLive[211][1] +
+                      obsLive[311][0] +
+                      obsLive[311][1],
+                  densities[111][0] +
+                      densities[111][1] +
+                      densities[112][0] +
+                      densities[112][1] +
+                      densities[211][0] +
+                      densities[211][1] +
+                      densities[311][0] +
+                      densities[311][1],
+              )
+          )
+          species(
+              0,
+              survivalRate =
+                  percent(
+                      obsLive[111][0] + obsLive[112][0] + obsLive[211][0] + obsLive[311][0],
+                      densities[111][0] + densities[112][0] + densities[211][0] + densities[311][0],
+                  ),
+              totalLive = obsLive[111][0] + obsLive[112][0] + obsLive[211][0] + obsLive[311][0],
+          )
+          species(
+              1,
+              survivalRate =
+                  percent(
+                      obsLive[111][1] + obsLive[112][1] + obsLive[211][1] + obsLive[311][1],
+                      densities[111][1] + densities[112][1] + densities[211][1] + densities[311][1],
+                  ),
+              totalLive = obsLive[111][1] + obsLive[112][1] + obsLive[211][1] + obsLive[311][1],
+          )
+          stratum(1) {
+            survivalRate(
+                percent(
+                    obsLive[111][0] +
+                        obsLive[111][1] +
+                        obsLive[112][0] +
+                        obsLive[112][1] +
+                        obsLive[211][0] +
+                        obsLive[211][1],
+                    densities[111][0] +
+                        densities[111][1] +
+                        densities[112][0] +
+                        densities[112][1] +
+                        densities[211][0] +
+                        densities[211][1],
+                )
+            )
+            species(
+                0,
+                survivalRate =
+                    percent(
+                        obsLive[111][0] + obsLive[112][0] + obsLive[211][0],
+                        densities[111][0] + densities[112][0] + densities[211][0],
+                    ),
+                totalLive = obsLive[111][0] + obsLive[112][0] + obsLive[211][0],
+            )
+            species(
+                1,
+                survivalRate =
+                    percent(
+                        obsLive[111][1] + obsLive[112][1] + obsLive[211][1],
+                        densities[111][1] + densities[112][1] + densities[211][1],
+                    ),
+                totalLive = obsLive[111][1] + obsLive[112][1] + obsLive[211][1],
+            )
+            substratum(1) {
+              survivalRate(
+                  percent(
+                      obsLive[111][0] + obsLive[111][1] + obsLive[112][0] + obsLive[112][1],
+                      densities[111][0] + densities[111][1] + densities[112][0] + densities[112][1],
+                  )
+              )
+              species(
+                  0,
+                  survivalRate =
+                      percent(
+                          obsLive[111][0] + obsLive[112][0],
+                          densities[111][0] + densities[112][0],
+                      ),
+                  totalLive = obsLive[111][0] + obsLive[112][0],
+              )
+              species(
+                  1,
+                  survivalRate =
+                      percent(
+                          obsLive[111][1] + obsLive[112][1],
+                          densities[111][1] + densities[112][1],
+                      ),
+                  totalLive = obsLive[111][1] + obsLive[112][1],
+              )
+              plot(111) {
+                survivalRate(
+                    percent(
+                        obsLive[111][0] + obsLive[111][1],
+                        densities[111][0] + densities[111][1],
+                    )
+                )
+                species(
+                    0,
+                    survivalRate = percent(obsLive[111][0], densities[111][0]),
+                    totalLive = obsLive[111][0],
+                )
+                species(
+                    1,
+                    survivalRate = percent(obsLive[111][1], densities[111][1]),
+                    totalLive = obsLive[111][1],
+                )
+              }
+              plot(112) {
+                survivalRate(
+                    percent(
+                        obsLive[112][0] + obsLive[112][1],
+                        densities[112][0] + densities[112][1],
+                    )
+                )
+                species(
+                    0,
+                    survivalRate = percent(obsLive[112][0], densities[112][0]),
+                    totalLive = obsLive[112][0],
+                )
+                species(
+                    1,
+                    survivalRate = percent(obsLive[112][1], densities[112][1]),
+                    totalLive = obsLive[112][1],
+                )
+              }
+            }
+            substratum(2) {
+              survivalRate(
+                  percent(
+                      obsLive[211][0] + obsLive[211][1],
+                      densities[211][0] + densities[211][1],
+                  )
+              )
+              species(
+                  0,
+                  survivalRate = percent(obsLive[211][0], densities[211][0]),
+                  totalLive = obsLive[211][0],
+              )
+              species(
+                  1,
+                  survivalRate = percent(obsLive[211][1], densities[211][1]),
+                  totalLive = obsLive[211][1],
+              )
+              plot(211) {
+                survivalRate(
+                    percent(
+                        obsLive[211][0] + obsLive[211][1],
+                        densities[211][0] + densities[211][1],
+                    )
+                )
+                species(
+                    0,
+                    survivalRate = percent(obsLive[211][0], densities[211][0]),
+                    totalLive = obsLive[211][0],
+                )
+                species(
+                    1,
+                    survivalRate = percent(obsLive[211][1], densities[211][1]),
+                    totalLive = obsLive[211][1],
+                )
+              }
+            }
+          }
+          stratum(2) {
+            survivalRate(
+                percent(obsLive[311][0] + obsLive[311][1], densities[311][0] + densities[311][1])
+            )
+            species(0, survivalRate = percent(obsLive[311][0], densities[311][0]))
+            species(1, survivalRate = percent(obsLive[311][1], densities[311][1]))
+            substratum(3) {
+              survivalRate(
+                  percent(
+                      obsLive[311][0] + obsLive[311][1],
+                      densities[311][0] + densities[311][1],
+                  )
+              )
+              species(0, survivalRate = percent(obsLive[311][0], densities[311][0]))
+              species(1, survivalRate = percent(obsLive[311][1], densities[311][1]))
+              plot(311) {
+                survivalRate(
+                    percent(
+                        obsLive[311][0] + obsLive[311][1],
+                        densities[311][0] + densities[311][1],
+                    )
+                )
+                species(0, survivalRate = percent(obsLive[311][0], densities[311][0]))
+                species(1, survivalRate = percent(obsLive[311][1], densities[311][1]))
+              }
+            }
+          }
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+
+      obsLive[111][0] = 18
+      observationEdited(1) {
+        plot(111) { //
+          species(0, live = 18)
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+
+      eventPublisher.assertEventPublished(
+          MonitoringSpeciesTotalsEditedEvent(
+              certainty = RecordedSpeciesCertainty.Known,
+              changedFrom = MonitoringSpeciesTotalsEditedEventValues(totalLive = 9),
+              changedTo = MonitoringSpeciesTotalsEditedEventValues(totalLive = 18),
+              monitoringPlotId = monitoringPlotIds[111]!!,
+              observationId = observationIds[1]!!,
+              organizationId = inserted.organizationId,
+              plantingSiteId = plantingSiteId,
+              speciesId = speciesIds[0]!!,
+              speciesName = null,
+          )
+      )
+    }
+  }
+
+  @Test
+  fun `survival rates in later observations are not affected by edit of non-t0 observation`() {
+    scenario {
+      siteCreated {
+        stratum(1) {
+          substratum(1) {
+            plot(111) //
+          }
+        }
+      }
+
+      t0DensitySet { plot(111) { species(0, density = 10) } }
+
+      observation(1) { plot(111) { species(0, live = 9) } }
+
+      observation(2) { plot(111) { species(0, live = 8) } }
+
+      observation(3) { plot(111) { species(0, live = 7) } }
+
+      expectResults(observation = 1) {
+        survivalRate(90)
+        species(0, survivalRate = 90)
+        stratum(1) {
+          survivalRate(90)
+          species(0, survivalRate = 90)
+          substratum(1) {
+            survivalRate(90)
+            species(0, survivalRate = 90)
+            plot(111) {
+              survivalRate(90)
+              species(0, survivalRate = 90)
+            }
+          }
+        }
+      }
+
+      val baseline2 =
+          expectResults(observation = 2) {
+            survivalRate(80)
+            species(0, survivalRate = 80)
+            stratum(1) {
+              survivalRate(80)
+              species(0, survivalRate = 80)
+              substratum(1) {
+                survivalRate(80)
+                species(0, survivalRate = 80)
+                plot(111) {
+                  survivalRate(80)
+                  species(0, survivalRate = 80)
+                }
+              }
+            }
+          }
+
+      val baseline3 =
+          expectResults(observation = 3) {
+            survivalRate(70)
+            species(0, survivalRate = 70)
+            stratum(1) {
+              survivalRate(70)
+              species(0, survivalRate = 70)
+              substratum(1) {
+                survivalRate(70)
+                species(0, survivalRate = 70)
+                plot(111) {
+                  survivalRate(70)
+                  species(0, survivalRate = 70)
+                }
+              }
+            }
+          }
+
+      observationEdited(1) {
+        plot(111) { //
+          species(0, live = 6)
+        }
+      }
+
+      expectResults(observation = 1) {
+        survivalRate(60)
+        species(0, survivalRate = 60)
+        stratum(1) {
+          survivalRate(60)
+          species(0, survivalRate = 60)
+          substratum(1) {
+            survivalRate(60)
+            species(0, survivalRate = 60)
+            plot(111) {
+              survivalRate(60)
+              species(0, survivalRate = 60)
+            }
+          }
+        }
+      }
+
+      expectUnchangedResults(observation = 2, baseline = baseline2)
+
+      expectUnchangedResults(observation = 3, baseline = baseline3)
+    }
+  }
+
+  @Test
+  fun `edit of earlier observation affects aggregated survival rates of later observations that do not include the edited observation's substratum`() {
+    scenario {
+      siteCreated {
+        stratum(1) {
+          substratum(11) { plot(111) }
+          substratum(12) { plot(121) }
+        }
+        stratum(2) { substratum(21) { plot(211) } }
+      }
+
+      // Map<plot number, density>
+      val densities = nullSafeMapOf(111 to 4, 121 to 5, 211 to 6)
+      t0DensitySet {
+        plot(111) { species(0, density = densities[111]) }
+        plot(121) { species(0, density = densities[121]) }
+        plot(211) { species(0, density = densities[211]) }
+      }
+
+      // Map<observation number, Map<plot number, live count>>
+      val obsLive =
+          nullSafeMapOf(
+              1 to nullSafeMutableMapOf(111 to 4),
+              2 to nullSafeMutableMapOf(121 to 3),
+              3 to nullSafeMutableMapOf(211 to 2),
+          )
+
+      observation(1) { plot(111) { species(0, live = obsLive[1][111]) } }
+      observation(2) { plot(121) { species(0, live = obsLive[2][121]) } }
+      observation(3) { plot(211) { species(0, live = obsLive[3][211]) } }
+
+      fun assertResultsMatchNumbersFromObsLive() {
+        expectResults(observation = 1) {
+          survivalRate(percent(obsLive[1][111], densities[111]))
+          stratum(1) {
+            survivalRate(percent(obsLive[1][111], densities[111]))
+            substratum(11) {
+              survivalRate(percent(obsLive[1][111], densities[111]))
+              plot(111) {
+                survivalRate(percent(obsLive[1][111], densities[111]))
+                species(0, survivalRate = percent(obsLive[1][111], densities[111]))
+              }
+            }
+          }
+        }
+
+        expectResults(observation = 2) {
+          survivalRate(percent(obsLive[1][111] + obsLive[2][121], densities[111] + densities[121]))
+          stratum(1) {
+            survivalRate(
+                percent(obsLive[1][111] + obsLive[2][121], densities[111] + densities[121])
+            )
+            substratum(12) {
+              survivalRate(percent(obsLive[2][121], densities[121]))
+              plot(121) {
+                survivalRate(percent(obsLive[2][121], densities[121]))
+                species(0, survivalRate = percent(3, densities[121]))
+              }
+            }
+          }
+        }
+
+        expectResults(observation = 3) {
+          survivalRate(
+              percent(
+                  obsLive[1][111] + obsLive[2][121] + obsLive[3][211],
+                  densities[111] + densities[121] + densities[211],
+              )
+          )
+          stratum(2) {
+            survivalRate(percent(obsLive[3][211], densities[211]))
+            substratum(21) {
+              survivalRate(percent(obsLive[3][211], densities[211]))
+              plot(211) {
+                survivalRate(percent(obsLive[3][211], densities[211]))
+                species(0, survivalRate = percent(obsLive[3][211], densities[211]))
+              }
+            }
+          }
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+
+      obsLive[1][111] = 1
+      observationEdited(1) {
+        plot(111) {
+          species(0, live = obsLive[1][111]) //
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+    }
+  }
+
+  @Test
+  fun `stratum-level survival rates account for map edits that cause substrata to move from one stratum to another`() {
+    scenario {
+      siteCreated {
+        stratum(1) {
+          substratum(1) { plot(1) }
+          substratum(2) { plot(2) }
+        }
+        stratum(2) { substratum(3) { plot(3) } }
+      }
+
+      val densities = nullSafeMapOf(1 to 30, 2 to 40, 3 to 50)
+      t0DensitySet {
+        plot(1) { species(0, density = densities[1]) }
+        plot(2) { species(0, density = densities[2]) }
+        plot(3) { species(0, density = densities[3]) }
+      }
+
+      // Map<observation number, Map<plot number, live plant count>>
+      val obsLive =
+          nullSafeMapOf(
+              1 to nullSafeMutableMapOf(1 to 13, 2 to 14, 3 to 15),
+              2 to nullSafeMutableMapOf(1 to 23),
+              3 to nullSafeMutableMapOf(3 to 35),
+          )
+
+      observation(1) {
+        plot(1) { species(0, live = obsLive[1][1]) }
+        plot(2) { species(0, live = obsLive[1][2]) }
+        plot(3) { species(0, live = obsLive[1][3]) }
+      }
+
+      observation(2) { plot(1) { species(0, live = obsLive[2][1]) } }
+
+      siteEdited {
+        stratum(1) { //
+          substratum(1) { plot(1) }
+        }
+        stratum(2) {
+          substratum(2) { plot(2) } // Moved from stratum 1
+          substratum(3) { plot(3) }
+        }
+      }
+
+      observation(3) { plot(3) { species(0, live = obsLive[3][3]) } }
+
+      fun assertResultsMatchNumbersFromObsLive() {
+        expectResults(observation = 1) {
+          survivalRate(
+              percent(
+                  obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
+                  densities[1] + densities[2] + densities[3],
+              )
+          )
+          stratum(1) {
+            survivalRate(percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2]))
+            substratum(1) {
+              survivalRate(percent(obsLive[1][1], densities[1]))
+              plot(1) { survivalRate(percent(obsLive[1][1], densities[1])) }
+            }
+            substratum(2) {
+              survivalRate(percent(obsLive[1][2], densities[2]))
+              plot(2) { survivalRate(percent(obsLive[1][2], densities[2])) }
+            }
+          }
+          stratum(2) {
+            survivalRate(percent(obsLive[1][3], densities[3]))
+            substratum(3) {
+              survivalRate(percent(obsLive[1][3], densities[3]))
+              plot(3) { survivalRate(percent(obsLive[1][3], densities[3])) }
+            }
+          }
+        }
+
+        expectResults(observation = 2) {
+          survivalRate(
+              percent(
+                  obsLive[2][1] + obsLive[1][2] + obsLive[1][3],
+                  densities[1] + densities[2] + densities[3],
+              )
+          )
+          stratum(1) {
+            survivalRate(percent(obsLive[2][1] + obsLive[1][2], densities[1] + densities[2]))
+            substratum(1) {
+              survivalRate(percent(obsLive[2][1], densities[1]))
+              plot(1) { survivalRate(percent(obsLive[2][1], densities[1])) }
+            }
+            noResultForSubstratum(2)
+          }
+          noResultForStratum(2)
+        }
+
+        expectResults(observation = 3) {
+          survivalRate(
+              percent(
+                  obsLive[2][1] + obsLive[1][2] + obsLive[3][3],
+                  densities[1] + densities[2] + densities[3],
+              )
+          )
+          noResultForStratum(1)
+          stratum(2) {
+            // Should pull substratum 2 rate from observation 1, but credit it to stratum 2
+            // thanks to the map edit
+            survivalRate(percent(obsLive[1][2] + obsLive[3][3], densities[2] + densities[3]))
+            noResultForSubstratum(2)
+            substratum(3) { survivalRate(percent(obsLive[3][3], densities[3])) }
+          }
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+
+      obsLive[1][2] = 44
+      observationEdited(1) { plot(2) { species(0, live = obsLive[1][2]) } }
+
+      // This will use the updated obsLive[1][2] value, i.e., it will assert that the results are
+      // what we would have gotten if the original observation had used the edited number.
+      assertResultsMatchNumbersFromObsLive()
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = [true, false])
+  fun `edits to temporary plot observation data only affect aggregated survival rates if enabled for site`(
+      survivalRateIncludesTempPlots: Boolean
+  ) {
+    scenario {
+      siteCreated(survivalRateIncludesTempPlots = survivalRateIncludesTempPlots) {
+        stratum(1) {
+          substratum(1) {
+            plot(1)
+            plot(2, permanentIndex = null)
+          }
+          substratum(2) { plot(3) }
+        }
+      }
+
+      val obsLive =
+          nullSafeMapOf(
+              1 to nullSafeMutableMapOf(1 to 11, 2 to 12, 3 to 13),
+              2 to nullSafeMutableMapOf(3 to 23),
+          )
+      val densities = nullSafeMutableMapOf(1 to 10, 2 to 20, 3 to 30)
+
+      t0DensitySet {
+        plot(1) { species(0, densities[1]) }
+        stratum(1) { species(0, densities[2]) }
+        plot(3) { species(0, densities[3]) }
+      }
+
+      observation(1) {
+        plot(1) { species(0, live = obsLive[1][1]) }
+        plot(2, isPermanent = false) { species(0, live = obsLive[1][2]) }
+        plot(3) { species(0, live = obsLive[1][3]) }
+      }
+
+      observation(2) { plot(3) { species(0, live = obsLive[2][3]) } }
+
+      // Now we'll use obsLive to calculate expected survival rates, and we want to disregard the
+      // live count and density for the temporary plot if survivalRateIncludesTempPlots is false.
+      if (!survivalRateIncludesTempPlots) {
+        obsLive[1][2] = 0
+        densities[2] = 0
+      }
+
+      fun assertResultsMatchNumbersFromObsLive() {
+        expectResults(observation = 1) {
+          survivalRate(
+              percent(
+                  obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
+                  densities[1] + densities[2] + densities[3],
+              )
+          )
+          stratum(1) {
+            survivalRate(
+                percent(
+                    obsLive[1][1] + obsLive[1][2] + obsLive[1][3],
+                    densities[1] + densities[2] + densities[3],
+                )
+            )
+            substratum(1) {
+              survivalRate(percent(obsLive[1][1] + obsLive[1][2], densities[1] + densities[2]))
+              plot(1) { survivalRate(percent(obsLive[1][1], densities[1])) }
+              plot(2) {
+                if (survivalRateIncludesTempPlots) {
+                  survivalRate(percent(obsLive[1][2], densities[2]))
+                } else {
+                  // Survival rate shouldn't be set at all if we aren't counting temp plots
+                  survivalRate(null)
+                }
+              }
+            }
+            substratum(2) {
+              survivalRate(percent(obsLive[1][3], densities[3]))
+              plot(3) { survivalRate(percent(obsLive[1][3], densities[3])) }
+            }
+          }
+        }
+
+        expectResults(observation = 2) {
+          survivalRate(
+              percent(
+                  obsLive[1][1] + obsLive[1][2] + obsLive[2][3],
+                  densities[1] + densities[2] + densities[3],
+              )
+          )
+          stratum(1) {
+            survivalRate(
+                percent(
+                    obsLive[1][1] + obsLive[1][2] + obsLive[2][3],
+                    densities[1] + densities[2] + densities[3],
+                )
+            )
+            noResultForSubstratum(1)
+            substratum(2) {
+              survivalRate(percent(obsLive[2][3], densities[3]))
+              plot(3) { survivalRate(percent(obsLive[2][3], densities[3])) }
+            }
+          }
+        }
+      }
+
+      assertResultsMatchNumbersFromObsLive()
+
+      if (survivalRateIncludesTempPlots) {
+        obsLive[1][2] = 22
+      }
+      observationEdited(1) { plot(2) { species(0, live = 22) } }
+
+      assertResultsMatchNumbersFromObsLive()
+    }
+  }
+
+  fun scenario(init: ObservationScenario.() -> Unit) {
+    ObservationScenario.forTest(this, eventPublisher = eventPublisher).init()
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationEditedStep.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationEditedStep.kt
@@ -1,0 +1,95 @@
+package com.terraformation.backend.tracking.scenario
+
+import com.terraformation.backend.db.default_schema.SpeciesId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.RecordedSpeciesCertainty
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_PLOTS
+
+class ObservationEditedStep(
+    private val observationScenario: ObservationScenario,
+    val scenario: ObservationScenario,
+    val number: Int,
+) : NodeWithChildren<ObservationEditedStep.Plot>() {
+  lateinit var observationId: ObservationId
+
+  fun plot(number: Number, init: Plot.() -> Unit) = initChild(Plot(number.toLong()), init)
+
+  override fun prepare() {
+    observationId =
+        scenario.observationIds[number]
+            ?: throw IllegalArgumentException("Observation $number edited but was never completed")
+  }
+
+  inner class Plot(val number: Long) : NodeWithChildren<Plot.Species>() {
+    private lateinit var monitoringPlotId: MonitoringPlotId
+
+    override fun prepare() {
+      monitoringPlotId = observationScenario.getMonitoringPlotId(number)
+      if (
+          !observationScenario.test.dslContext.fetchExists(
+              OBSERVATION_PLOTS,
+              OBSERVATION_PLOTS.OBSERVATION_ID.eq(observationId)
+                  .and(OBSERVATION_PLOTS.MONITORING_PLOT_ID.eq(monitoringPlotId)),
+          )
+      ) {
+        throw IllegalArgumentException(
+            "Plot $number not in observation ${this@ObservationEditedStep.number}"
+        )
+      }
+    }
+
+    fun species(
+        number: Int,
+        existing: Int? = null,
+        live: Int? = null,
+        dead: Int? = null,
+        init: Species.() -> Unit = {},
+    ) = initChild(Species(number, existing, live, dead), init)
+
+    inner class Species(
+        val number: Int,
+        var existing: Int? = null,
+        var live: Int? = null,
+        var dead: Int? = null,
+    ) : ScenarioNode {
+      override fun prepare() {
+        val certainty: RecordedSpeciesCertainty
+        val speciesId: SpeciesId?
+        val speciesName: String?
+
+        when (number) {
+          ObservationScenario.UNKNOWN -> {
+            certainty = RecordedSpeciesCertainty.Unknown
+            speciesId = null
+            speciesName = null
+          }
+          ObservationScenario.OTHER -> {
+            certainty = RecordedSpeciesCertainty.Other
+            speciesId = null
+            speciesName = "Other"
+          }
+          else -> {
+            certainty = RecordedSpeciesCertainty.Known
+            speciesId = observationScenario.getOrInsertSpecies(number)
+            speciesName = null
+          }
+        }
+
+        scenario.observationStore.updateMonitoringSpecies(
+            observationId,
+            monitoringPlotId,
+            certainty,
+            speciesId,
+            speciesName,
+        ) { model ->
+          model.copy(
+              totalDead = dead ?: model.totalDead,
+              totalExisting = existing ?: model.totalExisting,
+              totalLive = live ?: model.totalLive,
+          )
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/scenario/ObservationScenario.kt
@@ -160,6 +160,9 @@ class ObservationScenario(
       init: ObservationCompletedStep.() -> Unit,
   ) = initChild(ObservationCompletedStep(this, number), init).andAdvanceClock()
 
+  fun observationEdited(number: Int, init: ObservationEditedStep.() -> Unit) =
+      initChild(ObservationEditedStep(this, this, number), init).andAdvanceClock()
+
   fun siteCreated(
       survivalRateIncludesTempPlots: Boolean = false,
       init: SiteCreatedStep.() -> Unit,


### PR DESCRIPTION
Add a new method to `ObservationStore` to update plant counts in monitoring
observations, including updating survival rates as needed.

Add a new step type to the observation test DSL to allow tests to call this
new method.

This does not include logic for updating plant densities when a t0 observation is
edited; that will be added separately.