### PR TITLE
SW-7783 Update survival rates on t0 observation edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1190,7 +1190,8 @@ class ObservationStore(
       updateFunc: (EditableMonitoringSpeciesModel) -> EditableMonitoringSpeciesModel,
   ) {
     requirePermissions {
-      updateObservation(observationId) //
+      updateT0(monitoringPlotId) // TODO: Get clarification from product about permission behavior
+      updateObservation(observationId)
     }
 
     observationLocker.withLockedObservation(observationId) { observation ->


### PR DESCRIPTION
When the plant counts are edited on a monitoring observation that is set as the
source of t0 density data for the plot in question, repopulate the t0 density
numbers and recalculate survival rates.