### PR TITLE
SW-7783 Apply changes from observation edit API

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationUpdateOperationPayload.kt
@@ -13,6 +13,7 @@ import com.terraformation.backend.tracking.model.EditableBiomassDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratDetailsModel
 import com.terraformation.backend.tracking.model.EditableBiomassQuadratSpeciesModel
 import com.terraformation.backend.tracking.model.EditableBiomassSpeciesModel
+import com.terraformation.backend.tracking.model.EditableMonitoringSpeciesModel
 import com.terraformation.backend.tracking.model.EditableObservationPlotDetailsModel
 import com.terraformation.backend.tracking.model.ExistingRecordedTreeModel
 import com.terraformation.backend.util.patchNullable
@@ -115,7 +116,15 @@ data class MonitoringSpeciesUpdateOperationPayload(
     val totalDead: Int?,
     val totalExisting: Int?,
     val totalLive: Int?,
-) : ObservationUpdateOperationPayload
+) : ObservationUpdateOperationPayload {
+  fun applyTo(model: EditableMonitoringSpeciesModel): EditableMonitoringSpeciesModel {
+    return model.copy(
+        totalDead = totalDead ?: model.totalDead,
+        totalExisting = totalExisting ?: model.totalExisting,
+        totalLive = totalLive ?: model.totalLive,
+    )
+  }
+}
 
 @JsonTypeName("ObservationPlot")
 data class ObservationPlotUpdateOperationPayload(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -347,7 +347,15 @@ class ObservationsController(
               )
           is BiomassUpdateOperationPayload ->
               biomassStore.updateBiomassDetails(observationId, plotId, element::applyTo)
-          is MonitoringSpeciesUpdateOperationPayload -> Unit
+          is MonitoringSpeciesUpdateOperationPayload ->
+              observationStore.updateMonitoringSpecies(
+                  observationId,
+                  plotId,
+                  element.certainty,
+                  element.speciesId,
+                  element.speciesName,
+                  element::applyTo,
+              )
           is ObservationPlotUpdateOperationPayload ->
               observationStore.updateObservationPlotDetails(observationId, plotId, element::applyTo)
           is QuadratSpeciesUpdateOperationPayload ->


### PR DESCRIPTION
The observation update payload for modifying plant counts in monitoring
observations was accepted but treated as a no-op; make it actually work.