### PR TITLE
SW-7783 Don't allow Contributors to edit plant counts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/IndividualUser.kt
@@ -694,6 +694,9 @@ data class IndividualUser(
   override fun canUpdateObservation(observationId: ObservationId) =
       isMember(parentStore.getOrganizationId(observationId))
 
+  override fun canUpdateObservationQuantities(observationId: ObservationId) =
+      isManagerOrHigher(parentStore.getOrganizationId(observationId))
+
   override fun canUpdateOrganization(organizationId: OrganizationId) =
       isAdminOrHigher(organizationId)
 

--- a/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/PermissionRequirements.kt
@@ -1772,6 +1772,15 @@ class PermissionRequirements(private val user: TerrawareUser) {
     }
   }
 
+  fun updateObservationQuantities(observationId: ObservationId) {
+    user.recordPermissionChecks {
+      if (!user.canUpdateObservationQuantities(observationId)) {
+        readObservation(observationId)
+        throw AccessDeniedException("No permission to update observation $observationId quantities")
+      }
+    }
+  }
+
   fun updateOrganization(organizationId: OrganizationId) {
     user.recordPermissionChecks {
       if (!user.canUpdateOrganization(organizationId)) {

--- a/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/model/TerrawareUser.kt
@@ -618,6 +618,8 @@ interface TerrawareUser : Principal, UserDetails {
 
   fun canUpdateObservation(observationId: ObservationId): Boolean = defaultPermission
 
+  fun canUpdateObservationQuantities(observationId: ObservationId): Boolean = defaultPermission
+
   fun canUpdateOrganization(organizationId: OrganizationId): Boolean = defaultPermission
 
   fun canUpdateParticipant(participantId: ParticipantId): Boolean = defaultPermission

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/ObservationStore.kt
@@ -1189,10 +1189,7 @@ class ObservationStore(
       speciesName: String?,
       updateFunc: (EditableMonitoringSpeciesModel) -> EditableMonitoringSpeciesModel,
   ) {
-    requirePermissions {
-      updateT0(monitoringPlotId) // TODO: Get clarification from product about permission behavior
-      updateObservation(observationId)
-    }
+    requirePermissions { updateObservationQuantities(observationId) }
 
     observationLocker.withLockedObservation(observationId) { observation ->
       if (observation.observationType != ObservationType.Monitoring) {

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionRequirementsTest.kt
@@ -1128,6 +1128,13 @@ internal class PermissionRequirementsTest : RunsAsUser {
       allow { updateObservation(observationId) } ifUser { canUpdateObservation(observationId) }
 
   @Test
+  fun updateObservationQuantities() =
+      allow { updateObservationQuantities(observationId) } ifUser
+          {
+            canUpdateObservationQuantities(observationId)
+          }
+
+  @Test
   fun updateOrganization() =
       allow { updateOrganization(organizationId) } ifUser { canUpdateOrganization(organizationId) }
 

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -694,6 +694,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -978,6 +979,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -1180,6 +1182,7 @@ internal class PermissionTest : DatabaseTest() {
         *observationIds.forOrg1(),
         readObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -1664,6 +1667,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -1832,6 +1836,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -2108,6 +2113,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -2386,6 +2392,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot = true,
         rescheduleObservation = true,
         updateObservation = true,
+        updateObservationQuantities = true,
     )
 
     permissions.expect(
@@ -4100,6 +4107,7 @@ internal class PermissionTest : DatabaseTest() {
         replaceObservationPlot: Boolean = false,
         rescheduleObservation: Boolean = false,
         updateObservation: Boolean = false,
+        updateObservationQuantities: Boolean = false,
     ) {
       observationIds.forEach { observationId ->
         val idInDatabase = getDatabaseId(observationId)
@@ -4128,6 +4136,11 @@ internal class PermissionTest : DatabaseTest() {
             updateObservation,
             user.canUpdateObservation(idInDatabase),
             "Can update observation $observationId",
+        )
+        assertEquals(
+            updateObservationQuantities,
+            user.canUpdateObservationQuantities(idInDatabase),
+            "Can update observation quantities $observationId",
         )
 
         uncheckedObservations.remove(observationId)

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/observationStore/ObservationStoreUpdateMonitoringSpeciesTest.kt
@@ -15,8 +15,10 @@ import com.terraformation.backend.util.nullSafeMapOf
 import com.terraformation.backend.util.nullSafeMutableMapOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.security.access.AccessDeniedException
 
 /**
  * Tests the behavior of editing plant counts on monitoring observations, primarily verifying that
@@ -1082,6 +1084,21 @@ class ObservationStoreUpdateMonitoringSpeciesTest : DatabaseTest(), RunsAsDataba
       observationEdited(1) { plot(2) { species(0, live = 22) } }
 
       assertResultsMatchNumbersFromObsLive()
+    }
+  }
+
+  @Test
+  fun `throws exception if no permission to edit quantities`() {
+    scenario {
+      siteCreated { stratum(1) { substratum(1) { plot(1) } } }
+      observation(1) { plot(1) { species(0, live = 1) } }
+
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        observationEdited(1) { plot(1) { species(0, live = 2) } }
+      }
     }
   }
 


### PR DESCRIPTION
The initial requirements called for allowing all organization roles to edit
quantitative monitoring observation data, but that conflicted with the existing
permissions for editing t0 density data, which required Manager or higher;
you could have bypassed the t0 permission check by editing observation data if
the t0 densities were from an observation.

After discussion with the product team, we've decided to only allow Manager or
higher to edit quantitative monitoring observation data. Contributors can
continue to edit qualitative data (field notes, etc.)