### PR TITLE
Fix permission inversion in observation editing

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/ObservationService.kt
@@ -731,9 +731,15 @@ class ObservationService(
   fun <T> updateCompletedPlot(
       observationId: ObservationId,
       monitoringPlotId: MonitoringPlotId,
+      includesQuantityUpdates: Boolean = false,
       func: () -> T,
   ): T {
-    requirePermissions { updateObservation(observationId) }
+    requirePermissions {
+      if (includesQuantityUpdates) {
+        updateObservationQuantities(observationId)
+      }
+      updateObservation(observationId)
+    }
 
     val plotStatus =
         dslContext.fetchValue(

--- a/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/ObservationsController.kt
@@ -334,7 +334,10 @@ class ObservationsController(
       @PathVariable plotId: MonitoringPlotId,
       @RequestBody payload: UpdateObservationRequestPayload,
   ): SimpleSuccessResponsePayload {
-    observationService.updateCompletedPlot(observationId, plotId) {
+    val includesQuantityUpdates =
+        payload.updates.any { it is MonitoringSpeciesUpdateOperationPayload }
+
+    observationService.updateCompletedPlot(observationId, plotId, includesQuantityUpdates) {
       payload.updates.forEach { element ->
         when (element) {
           is BiomassSpeciesUpdateOperationPayload ->

--- a/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/ObservationServiceTest.kt
@@ -2891,7 +2891,7 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `calls function to perform updates`() {
       val initial = dslContext.fetchSingle(OBSERVATION_PLOTS)
 
-      service.updateCompletedPlot(observationId, monitoringPlotId) {
+      service.updateCompletedPlot(observationId, monitoringPlotId, includesQuantityUpdates = true) {
         dslContext.update(OBSERVATION_PLOTS).set(OBSERVATION_PLOTS.NOTES, "new notes").execute()
       }
 
@@ -2939,6 +2939,20 @@ class ObservationServiceTest : DatabaseTest(), RunsAsDatabaseUser {
 
       assertThrows<ObservationNotFoundException> {
         service.updateCompletedPlot(observationId, monitoringPlotId) {}
+      }
+    }
+
+    @Test
+    fun `throws exception if no permission to update observation quantities`() {
+      deleteOrganizationUser()
+      insertOrganizationUser(role = Role.Contributor)
+
+      assertThrows<AccessDeniedException> {
+        service.updateCompletedPlot(
+            observationId,
+            monitoringPlotId,
+            includesQuantityUpdates = true,
+        ) {}
       }
     }
   }


### PR DESCRIPTION
The request handler for observation editing calls a generic "edit the observation"
function that was checking for `updateObservation` permission, but for monitoring
observation plant count edits, we need to check for `updateObservationQuantities`
permission first since it's more restrictive.