### PR TITLE
SW-7919 Allow assigning formerly-permanent plot as t0

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -180,7 +180,7 @@ class T0Store(
   ): PlotT0DensityChangedModel {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    require(isMonitoringPlotPermanent(monitoringPlotId)) {
+    require(wasMonitoringPlotPermanent(monitoringPlotId, observationId)) {
       "Cannot assign T0 data to non-permanent plot $monitoringPlotId."
     }
 
@@ -679,6 +679,20 @@ class T0Store(
       dslContext.fetchExists(
           this,
           ID.eq(monitoringPlotId).and(PERMANENT_INDEX.isNotNull),
+      )
+    }
+  }
+
+  private fun wasMonitoringPlotPermanent(
+      monitoringPlotId: MonitoringPlotId,
+      observationId: ObservationId,
+  ): Boolean {
+    return with(OBSERVATION_PLOTS) {
+      dslContext.fetchExists(
+          this,
+          MONITORING_PLOT_ID.eq(monitoringPlotId)
+              .and(OBSERVATION_ID.eq(observationId))
+              .and(IS_PERMANENT.isTrue),
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/T0ServiceTest.kt
@@ -62,7 +62,7 @@ internal class T0ServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertSubstratum()
     monitoringPlotId1 = insertMonitoringPlot(permanentIndex = 1)
     observationId = insertObservation()
-    insertObservationPlot()
+    insertObservationPlot(isPermanent = true)
     monitoringPlotId2 = insertMonitoringPlot(permanentIndex = 2)
     stratumId2 = insertStratum()
     speciesId1 = insertSpecies()

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -729,7 +729,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 1)
       insertObservedPlotSpeciesTotals(totalLive = 1, totalDead = 1)
       val secondObservationId = insertObservation(plantingSiteId = plantingSiteId)
-      insertObservationPlot()
+      insertObservationPlot(isPermanent = true)
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 1)
       insertObservedPlotSpeciesTotals(totalLive = 2, totalDead = 2)
 
@@ -910,6 +910,32 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
             "Should store plot density with a scale of 10",
         )
       })
+    }
+
+    @Test
+    fun `allows assigning plot that was permanent in its observation but no longer is`() {
+      insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 2)
+      dslContext
+          .update(MONITORING_PLOTS)
+          .setNull(MONITORING_PLOTS.PERMANENT_INDEX)
+          .where(MONITORING_PLOTS.ID.eq(monitoringPlotId))
+          .execute()
+
+      store.assignT0PlotObservation(monitoringPlotId, observationId)
+
+      assertTableEquals(
+          listOf(
+              PlotT0ObservationsRecord(
+                  monitoringPlotId = monitoringPlotId,
+                  observationId = observationId,
+                  createdBy = user.userId,
+                  modifiedBy = user.userId,
+                  createdTime = clock.instant(),
+                  modifiedTime = clock.instant(),
+              )
+          ),
+          "Should connect plot to observation",
+      )
     }
   }
 
@@ -1344,7 +1370,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val speciesId1 = insertSpecies()
 
       val t0ObservationId = insertObservation()
-      insertObservationPlot()
+      insertObservationPlot(isPermanent = true)
       insertObservedPlotSpeciesTotals(
           observationId = t0ObservationId,
           speciesId = speciesId1,
@@ -1373,7 +1399,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val speciesId2 = insertSpecies()
 
       val t0ObservationId = insertObservation()
-      insertObservationPlot()
+      insertObservationPlot(isPermanent = true)
       insertObservedPlotSpeciesTotals(
           observationId = t0ObservationId,
           speciesId = speciesId1,
@@ -1400,7 +1426,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `unknown and other species are not included in t0 densities`() {
       val t0ObservationId = insertObservation()
-      insertObservationPlot()
+      insertObservationPlot(isPermanent = true)
       insertObservedPlotSpeciesTotals(
           certainty = RecordedSpeciesCertainty.Other,
           observationId = t0ObservationId,
@@ -1437,7 +1463,7 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val speciesId2 = insertSpecies()
 
       val t0ObservationId = insertObservation()
-      insertObservationPlot()
+      insertObservationPlot(isPermanent = true)
       insertObservedPlotSpeciesTotals(
           observationId = t0ObservationId,
           speciesId = speciesId1,

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -41,8 +41,6 @@ import com.terraformation.backend.tracking.model.StratumT0TempDataModel
 import com.terraformation.backend.tracking.model.StratumT0TempDensityChangedModel
 import com.terraformation.backend.util.toPlantsPerHectare
 import java.math.BigDecimal
-import kotlin.IllegalArgumentException
-import kotlin.lazy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION
If you tried to assign a plot's t0 densities from an observation where the plot
was a permanent plot, it would fail if the plot was no longer permanent (e.g.,
due to a map edit). Update the "t0 must be from a permanent plot" check to look
at whether the plot was permanent in the requested observation, not whether it's
currently eligible for use as a permanent plot.