### PR TITLE
SW-7910 Publish notification event on plant count edit

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/PlotAssignmentTest.kt
@@ -80,6 +80,7 @@ class PlotAssignmentTest : DatabaseTest(), RunsAsUser {
         observationStore,
         plantingSiteStore,
         parentStore,
+        eventPublisher,
         SystemUser(usersDao),
         mockk(),
     )


### PR DESCRIPTION
When a plant count for a monitoring observation is edited, publish a rate-limited
event with the edit details broken out into line items. This will trigger email
notifications.