### PR TITLE
SW-7910 Email TF Contacts on observation quantity edit

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -11,7 +11,10 @@ import com.terraformation.backend.db.LocalizableEnum
 import com.terraformation.backend.db.accelerator.ActivityType
 import com.terraformation.backend.db.default_schema.OrganizationId
 import com.terraformation.backend.db.default_schema.tables.pojos.DevicesRow
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
+import com.terraformation.backend.db.tracking.RecordedPlantStatus
 import com.terraformation.backend.i18n.FormattingResourceBundleModel
 import com.terraformation.backend.i18n.currentLocale
 import com.terraformation.backend.tracking.model.PlotT0DensityChangedEventModel
@@ -554,6 +557,29 @@ class ActivityCreated(
 ) : EmailTemplateModel(config) {
   override val templateDir: String
     get() = "accelerator/activity/created"
+}
+
+class MonitoringSpeciesTotalsEdited(
+    config: TerrawareServerConfig,
+    val changes: List<Change>,
+    val observationsUrl: String,
+    val organizationName: String,
+    val plantingSiteId: PlantingSiteId,
+    val plantingSiteName: String,
+) : EmailTemplateModel(config) {
+  class Change(
+      val changedFrom: Int?,
+      val changedTo: Int?,
+      val monitoringPlotId: MonitoringPlotId,
+      val monitoringPlotNumber: Long,
+      val observationId: ObservationId,
+      val observationName: String,
+      val plantStatus: RecordedPlantStatus,
+      val speciesName: String,
+  )
+
+  override val templateDir: String
+    get() = "observation/monitoringTotalsEdited"
 }
 
 class T0DataSet(

--- a/src/main/resources/templates/email/head.ftlh.mjml
+++ b/src/main/resources/templates/email/head.ftlh.mjml
@@ -161,6 +161,18 @@
         <mj-class name="social-icons" padding="0px 8px 0px 8px"/>
     </mj-attributes>
     <mj-style>
+        td.number {
+            text-align: right;
+        }
+
+        th {
+            text-align: left;
+        }
+
+        th.number {
+            text-align: right;
+        }
+
         .text-link {
             color: #2C8658;
         }

--- a/src/main/resources/templates/email/observation/monitoringTotalsEdited/body.ftlh.mjml
+++ b/src/main/resources/templates/email/observation/monitoringTotalsEdited/body.ftlh.mjml
@@ -1,0 +1,48 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.MonitoringSpeciesTotalsEdited" -->
+<!-- <#setting date_format="full"> -->
+<mjml>
+    <mj-include path="../../head.ftlh.mjml"/>
+
+    <mj-body>
+        <mj-include path="../../logo.ftlh.mjml"/>
+
+        <mj-section padding="0px">
+            <mj-column mj-class="body-wrapper">
+                <mj-text mj-class="text-body03">
+                    The following changes have been made to Observations for ${plantingSiteName}:
+                </mj-text>
+
+                <mj-table>
+                    <tr>
+                        <th>Date Observed</th>
+                        <th>Plot#</th>
+                        <th>Species</th>
+                        <th>Status</th>
+                        <th class="number">Previous</th>
+                        <th class="number">New</th>
+                    </tr>
+                    <mj-raw>
+                        <#list changes as change>
+                    </mj-raw>
+                            <tr>
+                                <td>${change.observationName}</td>
+                                <td>${change.monitoringPlotNumber}</td>
+                                <td>${change.speciesName}</td>
+                                <td>${change.plantStatus}</td>
+                                <td class="number">${change.changedFrom}</td>
+                                <td class="number">${change.changedTo}</td>
+                            </tr>
+                    <mj-raw>
+                        </#list>
+                    </mj-raw>
+                </mj-table>
+
+                <mj-button mj-class="btn-productive-primary-md" href="${observationsUrl}">
+                    See Observations
+                </mj-button>
+
+                <mj-include path="../../footer.ftlh.mjml"/>
+            </mj-column>
+        </mj-section>
+    </mj-body>
+</mjml>

--- a/src/main/resources/templates/email/observation/monitoringTotalsEdited/subject.ftl
+++ b/src/main/resources/templates/email/observation/monitoringTotalsEdited/subject.ftl
@@ -1,0 +1,2 @@
+<#-- @ftlvariable name="" type="com.terraformation.backend.email.model.MonitoringSpeciesTotalsEdited" -->
+Organization ${organizationName} has made updates to the plant counts in an Observation for the planting site ${plantingSiteName}


### PR DESCRIPTION
When plant counts are edited on monitoring observations, send notifications to the
organization's TF Contact users. The notifications are rate-limited to once per
day per planting site, and include a list of all the values that were edited.