### PR TITLE
SW-7891 Get plot observations with species densities

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/api/T0Controller.kt
@@ -61,12 +61,12 @@ class T0Controller(
           "Lists all permanent plots with completed observations, and the observations' recorded species for a planting site"
   )
   @GetMapping("/site/{plantingSiteId}/observations")
-  fun getT0PlotObservationsForPlantingSite(
+  fun getPlotObservationDensitiesForPlantingSite(
       @PathVariable plantingSiteId: PlantingSiteId
-  ): GetT0SitePlotObservationsResponsePayload {
+  ): GetSitePlotObservationDensitiesResponsePayload {
     val plotData = t0Store.fetchPlotObservationSpeciesDensities(plantingSiteId)
 
-    return GetT0SitePlotObservationsResponsePayload(
+    return GetSitePlotObservationDensitiesResponsePayload(
         plotData.map { PlotObservationSpeciesDensityPayload(it) }
     )
   }
@@ -285,6 +285,6 @@ data class ObservationSpeciesDensityPayload(
   )
 }
 
-data class GetT0SitePlotObservationsResponsePayload(
+data class GetSitePlotObservationDensitiesResponsePayload(
     val data: List<PlotObservationSpeciesDensityPayload>
 ) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/model/T0DataModel.kt
@@ -6,6 +6,8 @@ import com.terraformation.backend.db.tracking.ObservationId
 import com.terraformation.backend.db.tracking.PlantingSiteId
 import com.terraformation.backend.db.tracking.StratumId
 import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
 
 data class SpeciesDensityModel(
     val speciesId: SpeciesId,
@@ -15,6 +17,18 @@ data class SpeciesDensityModel(
 data class OptionalSpeciesDensityModel(
     val speciesId: SpeciesId,
     val density: BigDecimal?,
+)
+
+data class ObservationSpeciesDensityModel(
+    val observationId: ObservationId,
+    val observationStartDate: LocalDate,
+    val observationCompletedTime: Instant,
+    val species: List<SpeciesDensityModel>,
+)
+
+data class PlotObservationSpeciesDensityModel(
+    val monitoringPlotId: MonitoringPlotId,
+    val observations: List<ObservationSpeciesDensityModel>,
 )
 
 data class SiteT0DataModel(


### PR DESCRIPTION
We want to display the species in each observation when selecting observations in addition to when viewing survival rate settings.
Add an endpoint to return the list of observations and their species densities for each plot. This will replace the data currently returned by the search api.