### PR TITLE
SW-7919 Allow assigning temporary plot t0 observations

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -180,6 +180,10 @@ class T0Store(
   ): PlotT0DensityChangedModel {
     requirePermissions { updateT0(monitoringPlotId) }
 
+    if (!wasMonitoringPlotInObservation(monitoringPlotId, observationId)) {
+      throw PlotNotInObservationException(observationId, monitoringPlotId)
+    }
+
     val now = clock.instant()
     val currentUserId = currentUser().userId
 
@@ -675,6 +679,18 @@ class T0Store(
       dslContext.fetchExists(
           this,
           ID.eq(monitoringPlotId).and(PERMANENT_INDEX.isNotNull),
+      )
+    }
+  }
+
+  private fun wasMonitoringPlotInObservation(
+      monitoringPlotId: MonitoringPlotId,
+      observationId: ObservationId,
+  ): Boolean {
+    return with(OBSERVATION_PLOTS) {
+      dslContext.fetchExists(
+          this,
+          MONITORING_PLOT_ID.eq(monitoringPlotId).and(OBSERVATION_ID.eq(observationId)),
       )
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
+++ b/src/main/kotlin/com/terraformation/backend/tracking/db/T0Store.kt
@@ -180,10 +180,6 @@ class T0Store(
   ): PlotT0DensityChangedModel {
     requirePermissions { updateT0(monitoringPlotId) }
 
-    require(wasMonitoringPlotPermanent(monitoringPlotId, observationId)) {
-      "Cannot assign T0 data to non-permanent plot $monitoringPlotId."
-    }
-
     val now = clock.instant()
     val currentUserId = currentUser().userId
 
@@ -679,20 +675,6 @@ class T0Store(
       dslContext.fetchExists(
           this,
           ID.eq(monitoringPlotId).and(PERMANENT_INDEX.isNotNull),
-      )
-    }
-  }
-
-  private fun wasMonitoringPlotPermanent(
-      monitoringPlotId: MonitoringPlotId,
-      observationId: ObservationId,
-  ): Boolean {
-    return with(OBSERVATION_PLOTS) {
-      dslContext.fetchExists(
-          this,
-          MONITORING_PLOT_ID.eq(monitoringPlotId)
-              .and(OBSERVATION_ID.eq(observationId))
-              .and(IS_PERMANENT.isTrue),
       )
     }
   }

--- a/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/tracking/db/T0StoreTest.kt
@@ -595,6 +595,15 @@ internal class T0StoreTest : DatabaseTest(), RunsAsDatabaseUser {
     }
 
     @Test
+    fun `throws exception if plot was not in requested observation`() {
+      val otherMonitoringPlotId = insertMonitoringPlot()
+
+      assertThrows<PlotNotInObservationException> {
+        store.assignT0PlotObservation(otherMonitoringPlotId, observationId)
+      }
+    }
+
+    @Test
     fun `stores observation and all species densities`() {
       insertObservedPlotSpeciesTotals(speciesId = speciesId1, totalLive = 1, totalDead = 2)
       insertObservedPlotSpeciesTotals(speciesId = speciesId2, totalLive = 3, totalDead = 4)


### PR DESCRIPTION
We previously only allowed permanent plots to have t0 observations assigned, but
that caused inconsistent behavior when plots' permanent statuses varied over time
due to map edits.

It's harmless to have t0 data for temporary plots, so remove the restriction on
plot type.