### PR TITLE
SW-7207 Add validation to search api filter prefixes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/api/SearchController.kt
@@ -76,6 +76,8 @@ class SearchController(
     val rootPrefix = resolvePrefix(payload.prefix)
     val count = if (payload.count > 0) payload.count else Int.MAX_VALUE
 
+    validateFilterPrefixes(payload, rootPrefix)
+
     return SearchResponsePayload(
         searchService.search(
             rootPrefix,
@@ -186,6 +188,15 @@ class SearchController(
         }
 
     return SearchFieldPrefix(table)
+  }
+
+  private fun validateFilterPrefixes(payload: SearchRequestPayload, rootPrefix: SearchFieldPrefix) {
+    payload.filters?.forEach { filter ->
+      rootPrefix.relativeSublistPrefix(filter.prefix)
+          ?: throw IllegalArgumentException(
+              "Filter prefix ${filter.prefix} is not a sublist of ${payload.prefix}"
+          )
+    }
   }
 }
 


### PR DESCRIPTION
The `filters` field in the search api payload allows for filtering sublists to only contain values, instead of only filtering the top level results. Currently, non-existent filter prefixes do nothing and don't filter the sublist. Add validation to throw an error for non-existent filter prefixes.