### PR TITLE
SW-7942 Use project names in notifications

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/AppNotificationService.kt
@@ -5,7 +5,6 @@ import com.terraformation.backend.accelerator.db.ActivityStore
 import com.terraformation.backend.accelerator.db.DeliverableStore
 import com.terraformation.backend.accelerator.db.ModuleEventStore
 import com.terraformation.backend.accelerator.db.ModuleStore
-import com.terraformation.backend.accelerator.db.ParticipantStore
 import com.terraformation.backend.accelerator.db.ReportStore
 import com.terraformation.backend.accelerator.event.AcceleratorReportPublishedEvent
 import com.terraformation.backend.accelerator.event.AcceleratorReportUpcomingEvent
@@ -89,7 +88,6 @@ class AppNotificationService(
     private val notificationStore: NotificationStore,
     private val organizationStore: OrganizationStore,
     private val parentStore: ParentStore,
-    private val participantStore: ParticipantStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val projectAcceleratorDetailsService: ProjectAcceleratorDetailsService,
     private val projectStore: ProjectStore,
@@ -333,13 +331,12 @@ class AppNotificationService(
 
     val species = speciesStore.fetchSpeciesById(event.speciesId)
 
-    val participant = participantStore.fetchOneById(project.participantId)
     val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
     val deliverableUrl =
         webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
     val renderMessage = {
       messages.participantProjectSpeciesApprovedSpeciesEdited(
-          participantName = participant.name,
+          projectName = project.name,
           speciesName = species.scientificName,
       )
     }
@@ -369,13 +366,11 @@ class AppNotificationService(
 
     val species = speciesStore.fetchSpeciesById(event.speciesId)
 
-    val participant = participantStore.fetchOneById(project.participantId)
     val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
     val deliverableUrl =
         webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
     val renderMessage = {
       messages.participantProjectSpeciesAddedToProject(
-          participantName = participant.name,
           projectName = project.name,
           speciesName = species.scientificName,
       )
@@ -462,15 +457,14 @@ class AppNotificationService(
         return@run
       }
 
-      val participant = participantStore.fetchOneById(project.participantId)
       val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
       val deliverableUrl =
           webAppUrls.acceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-      val renderMessage = { messages.deliverableReadyForReview(participant.name) }
+      val renderMessage = { messages.deliverableReadyForReview(project.name) }
 
       log.info(
-          "Creating app notifications for project ${event.projectId} participant " +
-              "${project.participantId} deliverable ${event.deliverableId} ready for review"
+          "Creating app notifications for project ${event.projectId} " +
+              "deliverable ${event.deliverableId} ready for review"
       )
 
       insertAcceleratorNotification(

--- a/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/EmailNotificationService.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.email
 import com.terraformation.backend.accelerator.ProjectAcceleratorDetailsService
 import com.terraformation.backend.accelerator.db.ActivityStore
 import com.terraformation.backend.accelerator.db.DeliverableStore
-import com.terraformation.backend.accelerator.db.ParticipantStore
 import com.terraformation.backend.accelerator.db.ReportStore
 import com.terraformation.backend.accelerator.event.AcceleratorReportPublishedEvent
 import com.terraformation.backend.accelerator.event.AcceleratorReportUpcomingEvent
@@ -141,7 +140,6 @@ class EmailNotificationService(
     private val observationStore: ObservationStore,
     private val organizationStore: OrganizationStore,
     private val parentStore: ParentStore,
-    private val participantStore: ParticipantStore,
     private val plantingSiteStore: PlantingSiteStore,
     private val projectAcceleratorDetailsService: ProjectAcceleratorDetailsService,
     private val projectStore: ProjectStore,
@@ -604,20 +602,19 @@ class EmailNotificationService(
   @EventListener
   fun on(event: ParticipantProjectSpeciesAddedToProjectNotificationDueEvent) {
     val project = projectStore.fetchOneById(event.projectId)
-    val participant = participantStore.fetchOneById(project.participantId!!)
     val species = speciesStore.fetchSpeciesById(event.speciesId)
     val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
 
     sendToAccelerator(
         project.organizationId,
         ParticipantProjectSpeciesAdded(
-            config,
-            webAppUrls
-                .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-                .toString(),
-            participant.name,
-            project.name,
-            species.scientificName,
+            config = config,
+            deliverableUrl =
+                webAppUrls
+                    .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+                    .toString(),
+            projectName = project.name,
+            speciesName = species.scientificName,
         ),
         deliverableCategory.internalInterestId,
     )
@@ -626,19 +623,19 @@ class EmailNotificationService(
   @EventListener
   fun on(event: ParticipantProjectSpeciesApprovedSpeciesEditedNotificationDueEvent) {
     val project = projectStore.fetchOneById(event.projectId)
-    val participant = participantStore.fetchOneById(project.participantId!!)
     val species = speciesStore.fetchSpeciesById(event.speciesId)
     val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
 
     sendToAccelerator(
         project.organizationId,
         ParticipantProjectSpeciesEdited(
-            config,
-            webAppUrls
-                .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-                .toString(),
-            participant.name,
-            species.scientificName,
+            config = config,
+            deliverableUrl =
+                webAppUrls
+                    .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+                    .toString(),
+            projectName = project.name,
+            speciesName = species.scientificName,
         ),
         deliverableCategory.internalInterestId,
     )
@@ -690,17 +687,17 @@ class EmailNotificationService(
       }
 
       val deliverableCategory = deliverableStore.fetchDeliverableCategory(event.deliverableId)
-      val participant = participantStore.fetchOneById(project.participantId)
 
       sendToAccelerator(
           project.organizationId,
           DeliverableReadyForReview(
-              config,
-              webAppUrls
-                  .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
-                  .toString(),
-              deliverableSubmission,
-              participant.name,
+              config = config,
+              deliverableUrl =
+                  webAppUrls
+                      .fullAcceleratorConsoleDeliverable(event.deliverableId, event.projectId)
+                      .toString(),
+              deliverable = deliverableSubmission,
+              projectName = project.name,
           ),
           deliverableCategory.internalInterestId,
       )

--- a/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/email/model/Models.kt
@@ -408,7 +408,6 @@ class PlantingSeasonNotScheduledSupport(
 class ParticipantProjectSpeciesAdded(
     config: TerrawareServerConfig,
     val deliverableUrl: String,
-    val participantName: String,
     val projectName: String,
     val speciesName: String,
 ) : EmailTemplateModel(config) {
@@ -419,7 +418,7 @@ class ParticipantProjectSpeciesAdded(
 class ParticipantProjectSpeciesEdited(
     config: TerrawareServerConfig,
     val deliverableUrl: String,
-    val participantName: String,
+    val projectName: String,
     val speciesName: String,
 ) : EmailTemplateModel(config) {
   override val templateDir: String
@@ -440,7 +439,7 @@ class DeliverableReadyForReview(
     config: TerrawareServerConfig,
     val deliverableUrl: String,
     val deliverable: DeliverableSubmissionModel,
-    val participantName: String,
+    val projectName: String,
 ) : EmailTemplateModel(config) {
   override val templateDir: String
     get() = "deliverable/readyForReview"

--- a/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
+++ b/src/main/kotlin/com/terraformation/backend/i18n/Messages.kt
@@ -417,10 +417,10 @@ class Messages {
     )
   }
 
-  fun deliverableReadyForReview(participantName: String): NotificationMessage {
+  fun deliverableReadyForReview(projectName: String): NotificationMessage {
     return NotificationMessage(
         title = "Review a submitted deliverable",
-        body = "A deliverable from $participantName is ready for review for approval.",
+        body = "A deliverable from $projectName is ready for review for approval.",
     )
   }
 
@@ -432,13 +432,11 @@ class Messages {
   }
 
   fun participantProjectSpeciesAddedToProject(
-      participantName: String,
       projectName: String,
       speciesName: String,
   ): NotificationMessage {
     return NotificationMessage(
-        title =
-            getMessage("notification.participantProjectSpecies.added.app.title", participantName),
+        title = getMessage("notification.participantProjectSpecies.added.app.title", projectName),
         body =
             getMessage(
                 "notification.participantProjectSpecies.added.app.body",
@@ -449,12 +447,11 @@ class Messages {
   }
 
   fun participantProjectSpeciesApprovedSpeciesEdited(
-      participantName: String,
+      projectName: String,
       speciesName: String,
   ): NotificationMessage {
     return NotificationMessage(
-        title =
-            getMessage("notification.participantProjectSpecies.edited.app.title", participantName),
+        title = getMessage("notification.participantProjectSpecies.edited.app.title", projectName),
         body = getMessage("notification.participantProjectSpecies.edited.app.body", speciesName),
     )
   }

--- a/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
+++ b/src/main/kotlin/com/terraformation/backend/support/FailureReportingService.kt
@@ -1,6 +1,5 @@
 package com.terraformation.backend.support
 
-import com.terraformation.backend.accelerator.db.ParticipantStore
 import com.terraformation.backend.accelerator.event.DeliverableDocumentUploadFailedEvent
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.db.OrganizationStore
@@ -16,7 +15,6 @@ class FailureReportingService(
     private val config: TerrawareServerConfig,
     private val deliverablesDao: DeliverablesDao,
     private val organizationStore: OrganizationStore,
-    private val participantStore: ParticipantStore,
     private val projectStore: ProjectStore,
     private val supportService: SupportService,
 ) {
@@ -28,7 +26,6 @@ class FailureReportingService(
       val deliverablesRow = deliverablesDao.fetchOneById(event.deliverableId)
       val project = projectStore.fetchOneById(event.projectId)
       val organization = organizationStore.fetchOneById(project.organizationId)
-      val participant = project.participantId?.let { participantStore.fetchOneById(it) }
 
       val description =
           """
@@ -37,7 +34,6 @@ class FailureReportingService(
             Reason: ${event.reason.description}
             
             Organization: ${organization.name}
-            Participant: ${participant?.name ?: "N/A"}
             Project: ${project.name}
             
             Deliverable: ${deliverablesRow?.name ?: "N/A"} (ID ${event.deliverableId})

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -398,7 +398,7 @@ notification.participantProjectSpecies.added.app.body={0} has been submitted for
 notification.participantProjectSpecies.added.app.title=A species has been added to project {0}.
 # {0} is the scientific name of a species. {1} is the project name it was added to.
 notification.participantProjectSpecies.added.email.body.1={0} has been submitted for use for {1}.
-# {0} is the project name. {1} is the scientific name of a species.
+# {0} is the scientific name of a species. {1} is the project name it was added to.
 notification.participantProjectSpecies.added.email.body.2={0} has submitted {1} for use and is ready for approval.
 notification.participantProjectSpecies.added.email.buttonLabel=Review in Terraware
 notification.participantProjectSpecies.added.email.subject=A species has been added to project {0}.

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -395,25 +395,23 @@ notification.organization.email.buttonIntro=Please click the button below to go 
 notification.organization.email.linkIntro=Please click the link below to go to your Terraware account where you can view the organization.
 # {0} is the scientific name of a species. {1} is the project name it was added to.
 notification.participantProjectSpecies.added.app.body={0} has been submitted for use for {1}.
-# {0} is the participant name.
-notification.participantProjectSpecies.added.app.title=A species has been added to a project for {0}.
+notification.participantProjectSpecies.added.app.title=A species has been added to project {0}.
 # {0} is the scientific name of a species. {1} is the project name it was added to.
 notification.participantProjectSpecies.added.email.body.1={0} has been submitted for use for {1}.
-# {0} is the participant name. {1} is the scientific name of a species. {2} is the project name the species was added to.
-notification.participantProjectSpecies.added.email.body.2={0} has submitted {1} for use for {2} and is ready for approval.
+# {0} is the project name. {1} is the scientific name of a species.
+notification.participantProjectSpecies.added.email.body.2={0} has submitted {1} for use and is ready for approval.
 notification.participantProjectSpecies.added.email.buttonLabel=Review in Terraware
-# {0} is the participant name.
-notification.participantProjectSpecies.added.email.subject=A species has been added to a project for {0}.
+notification.participantProjectSpecies.added.email.subject=A species has been added to project {0}.
 # {0} is the scientific name of a species.
 notification.participantProjectSpecies.edited.app.body={0} has been edited and is ready for approval.
-# {0} is the participant name.
+# {0} is the project name.
 notification.participantProjectSpecies.edited.app.title=An approved species has been edited for {0}.
 # {0} is the scientific name of a species.
 notification.participantProjectSpecies.edited.email.body.1={0} has been edited and is ready for approval.
-# {0} is the participant name. {1} is the scientific name of a species.
+# {0} is the project name. {1} is the scientific name of a species.
 notification.participantProjectSpecies.edited.email.body.2={0} has edited {1} and is ready for approval.
 notification.participantProjectSpecies.edited.email.buttonLabel=Review in Terraware
-# {0} is the participant name.
+# {0} is the project name.
 notification.participantProjectSpecies.edited.email.subject=An approved species has been edited for {0}.
 notification.plantingSeason.notScheduled.1.app.body=It''s time to schedule your next planting season
 notification.plantingSeason.notScheduled.1.app.title=Add your next planting season

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -635,28 +635,28 @@ notification.organization.email.buttonIntro=Haz clic en el siguiente botón para
 notification.organization.email.linkIntro=Haz clic en el siguiente enlace para ir a tu cuenta Terraware, donde podrás ver la organización.
 # 443b71a3
 notification.participantProjectSpecies.added.app.body={0} ha sido enviada para su uso en {1}.
-# 24d594cc
-notification.participantProjectSpecies.added.app.title=Una especie fue agregada a un proyecto para {0}.
+# 1a51e3c4
+notification.participantProjectSpecies.added.app.title=Se ha añadido una especie al proyecto {0}.
 # 443b71a3
 notification.participantProjectSpecies.added.email.body.1={0} ha sido enviada para su uso en {1}.
-# 8e8cb382
-notification.participantProjectSpecies.added.email.body.2={0} ha enviado {1} para su uso en {2} y está lista para su aprobación.
+# 170ca303
+notification.participantProjectSpecies.added.email.body.2={0} ha presentado {1} para su uso y está listo para su aprobación.
 # b4c689fa
 notification.participantProjectSpecies.added.email.buttonLabel=Revisar en Terraware
-# 24d594cc
-notification.participantProjectSpecies.added.email.subject=Una especie fue agregada a un proyecto para {0}.
+# 1a51e3c4
+notification.participantProjectSpecies.added.email.subject=Se ha añadido una especie al proyecto {0}.
 # 549de4d6
 notification.participantProjectSpecies.edited.app.body={0} ha sido editada y está lista para su aprobación.
-# db1625c0
-notification.participantProjectSpecies.edited.app.title=Una especie aprobada ha sido editada para {0}.
+# cc613f03
+notification.participantProjectSpecies.edited.app.title=Se ha editado una especie aprobada para {0}.
 # 549de4d6
 notification.participantProjectSpecies.edited.email.body.1={0} ha sido editada y está lista para su aprobación.
-# 38bc69d7
-notification.participantProjectSpecies.edited.email.body.2={0} ha editado {1} y está lista para su aprobación.
+# 309dd8df
+notification.participantProjectSpecies.edited.email.body.2={0} ha editado {1} y está listo para su aprobación.
 # b4c689fa
 notification.participantProjectSpecies.edited.email.buttonLabel=Revisar en Terraware
-# db1625c0
-notification.participantProjectSpecies.edited.email.subject=Una especie aprobada ha sido editada para {0}.
+# cc613f03
+notification.participantProjectSpecies.edited.email.subject=Se ha editado una especie aprobada para {0}.
 # b2d49a08
 notification.plantingSeason.notScheduled.1.app.body=Es hora de programar su próxima temporada de siembra
 # 41425189

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -635,27 +635,27 @@ notification.organization.email.buttonIntro=Veuillez cliquer sur le bouton ci-de
 notification.organization.email.linkIntro=Veuillez cliquer sur le lien ci-dessous pour accéder à votre compte Terraware où vous pourrez voir l''organisation.
 # 443b71a3
 notification.participantProjectSpecies.added.app.body={0} a été envoyé en vue de son utilisation pour {1}.
-# 24d594cc
-notification.participantProjectSpecies.added.app.title=Une espèce a été ajoutée à un projet pour {0}.
+# 1a51e3c4
+notification.participantProjectSpecies.added.app.title=Une espèce a été ajoutée au projet {0}.
 # 443b71a3
 notification.participantProjectSpecies.added.email.body.1={0} a été envoyé en vue de son utilisation pour {1}.
-# 8e8cb382
-notification.participantProjectSpecies.added.email.body.2={0} a été envoyé {1} en vue de son utilisation pour {2} et est prêt à être approuvé.
+# 170ca303
+notification.participantProjectSpecies.added.email.body.2={0} a soumis {1} pour utilisation et est prêt pour approbation.
 # b4c689fa
 notification.participantProjectSpecies.added.email.buttonLabel=Réviser dans Terraware
-# 24d594cc
-notification.participantProjectSpecies.added.email.subject=Une espèce a été ajoutée à un projet pour {0}.
+# 1a51e3c4
+notification.participantProjectSpecies.added.email.subject=Une espèce a été ajoutée au projet {0}.
 # 549de4d6
 notification.participantProjectSpecies.edited.app.body={0} a été modifié et est prêt à être approuvé.
-# db1625c0
+# cc613f03
 notification.participantProjectSpecies.edited.app.title=Une espèce approuvée a été modifiée pour {0}.
 # 549de4d6
 notification.participantProjectSpecies.edited.email.body.1={0} a été modifié et est prêt à être approuvé.
-# 38bc69d7
-notification.participantProjectSpecies.edited.email.body.2={0} a modifié {1} et est prêt à être approuvé.
+# 309dd8df
+notification.participantProjectSpecies.edited.email.body.2={0} a modifié {1} et est prêt pour approbation.
 # b4c689fa
 notification.participantProjectSpecies.edited.email.buttonLabel=Réviser dans Terraware
-# db1625c0
+# cc613f03
 notification.participantProjectSpecies.edited.email.subject=Une espèce approuvée a été modifiée pour {0}.
 # b2d49a08
 notification.plantingSeason.notScheduled.1.app.body=Il est temps de planifier la prochaine saison de plantation

--- a/src/main/resources/templates/email/deliverable/readyForReview/body.ftlh.mjml
+++ b/src/main/resources/templates/email/deliverable/readyForReview/body.ftlh.mjml
@@ -8,13 +8,13 @@
         <mj-section padding="0px">
             <mj-column mj-class="body-wrapper">
                 <mj-text mj-class="text-headline06-bold">
-                  Deliverable was submitted by ${participantName}
+                  Deliverable was submitted by ${projectName}
                 </mj-text>
                 <mj-text mj-class="text-body03">
-                  A deliverable was submitted by ${participantName} and is ready for review for approval.
+                  A deliverable was submitted by ${projectName} and is ready for review for approval.
                 </mj-text>
                 <mj-text mj-class="text-body03">
-                    <b>Project:</b> ${deliverable.projectName}
+                    <b>Project:</b> ${projectName}
                 </mj-text>
                 <mj-text mj-class="text-body03">
                     <b>Deliverable:</b> ${deliverable.name}

--- a/src/main/resources/templates/email/deliverable/readyForReview/body.txt.ftl
+++ b/src/main/resources/templates/email/deliverable/readyForReview/body.txt.ftl
@@ -1,7 +1,7 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeliverableReadyForReview" -->
-Deliverable was submitted by ${participantName}
+Deliverable was submitted by ${projectName}
 
-A deliverable was submitted by ${participantName} and is ready for review for approval.
+A deliverable was submitted by ${projectName} and is ready for review for approval.
 
 ${deliverableUrl}
 Project: ${deliverable.projectName}

--- a/src/main/resources/templates/email/deliverable/readyForReview/subject.ftl
+++ b/src/main/resources/templates/email/deliverable/readyForReview/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.DeliverableReadyForReview" -->
-A deliverable from ${participantName} is ready for review
+A deliverable from ${projectName} is ready for review

--- a/src/main/resources/templates/email/participantProjectSpecies/added/body.ftlh.mjml
+++ b/src/main/resources/templates/email/participantProjectSpecies/added/body.ftlh.mjml
@@ -11,7 +11,7 @@
                   ${strings("notification.participantProjectSpecies.added.email.body.1", speciesName, projectName)}
                 </mj-text>
                 <mj-text mj-class="text-body03">
-                  ${strings("notification.participantProjectSpecies.added.email.body.2", participantName, speciesName, projectName)}
+                  ${strings("notification.participantProjectSpecies.added.email.body.2", projectName, speciesName)}
                 </mj-text>
                 <mj-button mj-class="btn-productive-primary-md"
                            href="${deliverableUrl?no_esc}">${strings("notification.participantProjectSpecies.added.email.buttonLabel")}

--- a/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
@@ -1,7 +1,7 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesAdded" -->
 ${strings("notification.participantProjectSpecies.added.email.body.1", speciesName, projectName)}
 
-${strings("notification.participantProjectSpecies.added.email.body.2", speciesName, projectName)}
+${strings("notification.participantProjectSpecies.added.email.body.2", projectName, speciesName)}
 
 ${deliverableUrl}
 

--- a/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
@@ -1,5 +1,5 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesAdded" -->
-${strings("notification.participantProjectSpecies.added.email.body.1", projectName)}
+${strings("notification.participantProjectSpecies.added.email.body.1", speciesName, projectName)}
 
 ${strings("notification.participantProjectSpecies.added.email.body.2", speciesName, projectName)}
 

--- a/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/added/body.txt.ftl
@@ -1,5 +1,5 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesAdded" -->
-${strings("notification.participantProjectSpecies.added.email.body.1", participantName)}
+${strings("notification.participantProjectSpecies.added.email.body.1", projectName)}
 
 ${strings("notification.participantProjectSpecies.added.email.body.2", speciesName, projectName)}
 

--- a/src/main/resources/templates/email/participantProjectSpecies/added/subject.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/added/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesAdded" -->
-${strings("notification.participantProjectSpecies.added.email.subject", participantName)}
+${strings("notification.participantProjectSpecies.added.email.subject", projectName)}

--- a/src/main/resources/templates/email/participantProjectSpecies/edited/body.ftlh.mjml
+++ b/src/main/resources/templates/email/participantProjectSpecies/edited/body.ftlh.mjml
@@ -11,7 +11,7 @@
                   ${strings("notification.participantProjectSpecies.edited.email.body.1", speciesName)}
                 </mj-text>
                 <mj-text mj-class="text-body03">
-                  ${strings("notification.participantProjectSpecies.edited.email.body.2", participantName, speciesName)}
+                  ${strings("notification.participantProjectSpecies.edited.email.body.2", projectName, speciesName)}
                 </mj-text>
                 <mj-button mj-class="btn-productive-primary-md"
                            href="${deliverableUrl?no_esc}">${strings("notification.participantProjectSpecies.edited.email.buttonLabel")}

--- a/src/main/resources/templates/email/participantProjectSpecies/edited/body.txt.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/edited/body.txt.ftl
@@ -1,5 +1,5 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesEdited" -->
-${strings("notification.participantProjectSpecies.edited.email.body.1", projectName)}
+${strings("notification.participantProjectSpecies.edited.email.body.1", speciesName)}
 
 ${strings("notification.participantProjectSpecies.edited.email.body.2", projectName, speciesName)}
 

--- a/src/main/resources/templates/email/participantProjectSpecies/edited/body.txt.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/edited/body.txt.ftl
@@ -1,7 +1,7 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesEdited" -->
-${strings("notification.participantProjectSpecies.edited.email.body.1", participantName)}
+${strings("notification.participantProjectSpecies.edited.email.body.1", projectName)}
 
-${strings("notification.participantProjectSpecies.edited.email.body.2", speciesName)}
+${strings("notification.participantProjectSpecies.edited.email.body.2", projectName, speciesName)}
 
 ${deliverableUrl}
 

--- a/src/main/resources/templates/email/participantProjectSpecies/edited/subject.ftl
+++ b/src/main/resources/templates/email/participantProjectSpecies/edited/subject.ftl
@@ -1,2 +1,2 @@
 <#-- @ftlvariable name="" type="com.terraformation.backend.email.model.ParticipantProjectSpeciesEdited" -->
-${strings("notification.participantProjectSpecies.edited.email.subject", participantName)}
+${strings("notification.participantProjectSpecies.edited.email.subject", projectName)}

--- a/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/email/EmailNotificationServiceTest.kt
@@ -3,7 +3,6 @@ package com.terraformation.backend.email
 import com.terraformation.backend.accelerator.ProjectAcceleratorDetailsService
 import com.terraformation.backend.accelerator.db.ActivityStore
 import com.terraformation.backend.accelerator.db.DeliverableStore
-import com.terraformation.backend.accelerator.db.ParticipantStore
 import com.terraformation.backend.accelerator.db.ReportStore
 import com.terraformation.backend.accelerator.event.AcceleratorReportPublishedEvent
 import com.terraformation.backend.accelerator.event.AcceleratorReportUpcomingEvent
@@ -199,7 +198,6 @@ internal class EmailNotificationServiceTest {
   private val observationStore: ObservationStore = mockk()
   private val organizationStore: OrganizationStore = mockk()
   private val parentStore: ParentStore = mockk()
-  private val participantStore: ParticipantStore = mockk()
   private val plantingSiteStore: PlantingSiteStore = mockk()
   private val projectAcceleratorDetailsService: ProjectAcceleratorDetailsService = mockk()
   private val projectStore: ProjectStore = mockk()
@@ -242,7 +240,6 @@ internal class EmailNotificationServiceTest {
           observationStore,
           organizationStore,
           parentStore,
-          participantStore,
           plantingSiteStore,
           projectAcceleratorDetailsService,
           projectStore,
@@ -601,7 +598,6 @@ internal class EmailNotificationServiceTest {
     every { parentStore.getOrganizationId(plantingSite.id) } returns organization.id
     every { parentStore.getOrganizationId(project.id) } returns organization.id
     every { parentStore.getPlantingSiteId(monitoringPlot.id) } returns plantingSite.id
-    every { participantStore.fetchOneById(participant.id) } returns participant
     every { plantingSiteStore.fetchSiteById(plantingSite.id, any()) } returns plantingSite
     every { projectAcceleratorDetailsService.fetchOneById(project.id) } returns
         projectAcceleratorDetails
@@ -1263,8 +1259,7 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("added to")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
     assertBodyContains(project.name, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("submitted for use", message = message)
@@ -1287,8 +1282,7 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("added to")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
     assertBodyContains(project.name, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("submitted for use", message = message)
@@ -1308,8 +1302,8 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("has been edited")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
+    assertBodyContains(project.name, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("has been edited", message = message)
 
@@ -1331,8 +1325,8 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("has been edited")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
+    assertBodyContains(project.name, message = message)
     assertBodyContains(species.scientificName, message = message)
     assertBodyContains("has been edited", message = message)
 
@@ -1646,8 +1640,8 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
+    assertBodyContains(project.name, message = message)
 
     assertRecipientsEqual(setOf(tfContactEmail1, tfContactEmail2, acceleratorUser.email))
   }
@@ -1664,8 +1658,8 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
+    assertBodyContains(project.name, message = message)
 
     assertRecipientsEqual(setOf(tfContactEmail1, tfContactEmail2, acceleratorUser.email))
 
@@ -1681,8 +1675,8 @@ internal class EmailNotificationServiceTest {
     service.on(event)
 
     val message = sentMessageWithSubject("is ready for review")
-    assertSubjectContains(participant.name, message = message)
-    assertBodyContains(participant.name, message = message)
+    assertSubjectContains(project.name, message = message)
+    assertBodyContains(project.name, message = message)
 
     assertRecipientsEqual(setOf(acceleratorUser.email))
   }


### PR DESCRIPTION
The email and in-app notifications that go out to accelerator admins when
accelerator projects perform deliverable-related actions used to include the
participant name; switch them to use the project name instead in preparation
for removing participants from the system.