### PR TITLE
SW-7942 Add cohort and phase to projects table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/ProjectPhaseService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/ProjectPhaseService.kt
@@ -1,0 +1,94 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
+import com.terraformation.backend.accelerator.event.CohortParticipantRemovedEvent
+import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectAddedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectRemovedEvent
+import com.terraformation.backend.db.accelerator.tables.references.COHORTS
+import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import jakarta.inject.Named
+import org.jooq.DSLContext
+import org.springframework.context.event.EventListener
+
+/**
+ * Temporary event listeners to keep the cohort and phase values up to date on the projects table
+ * based on the project's participant. This will go away once we've removed participants and
+ * cohorts.
+ */
+@Named
+class ProjectPhaseService(private val dslContext: DSLContext) {
+  @EventListener
+  fun on(event: CohortParticipantAddedEvent) {
+    val phase = dslContext.fetchValue(COHORTS.PHASE_ID, COHORTS.ID.eq(event.cohortId))
+
+    with(PROJECTS) {
+      dslContext
+          .update(PROJECTS)
+          .set(COHORT_ID, event.cohortId)
+          .set(PHASE_ID, phase)
+          .where(PARTICIPANT_ID.eq(event.participantId))
+          .execute()
+    }
+  }
+
+  @EventListener
+  fun on(event: CohortParticipantRemovedEvent) {
+    with(PROJECTS) {
+      dslContext
+          .update(PROJECTS)
+          .setNull(COHORT_ID)
+          .setNull(PHASE_ID)
+          .where(PARTICIPANT_ID.eq(event.participantId))
+          .execute()
+    }
+  }
+
+  @EventListener
+  fun on(event: CohortPhaseUpdatedEvent) {
+    with(PROJECTS) {
+      dslContext
+          .update(PROJECTS)
+          .set(PHASE_ID, event.newPhase)
+          .where(COHORT_ID.eq(event.cohortId))
+          .execute()
+    }
+  }
+
+  @EventListener
+  fun on(event: ParticipantProjectAddedEvent) {
+    val (cohortId, phase) =
+        dslContext
+            .select(PARTICIPANTS.COHORT_ID, COHORTS.PHASE_ID)
+            .from(PARTICIPANTS)
+            .leftJoin(COHORTS)
+            .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+            .where(PARTICIPANTS.ID.eq(event.participantId))
+            .fetchOne()
+            ?: throw IllegalStateException(
+                "Unable to get cohort for participant ${event.participantId}"
+            )
+
+    with(PROJECTS) {
+      dslContext
+          .update(PROJECTS)
+          .set(COHORT_ID, cohortId)
+          .set(PHASE_ID, phase)
+          .where(ID.eq(event.projectId))
+          .execute()
+    }
+  }
+
+  @EventListener
+  fun on(event: ParticipantProjectRemovedEvent) {
+    with(PROJECTS) {
+      dslContext
+          .update(PROJECTS)
+          .setNull(COHORT_ID)
+          .setNull(PHASE_ID)
+          .where(ID.eq(event.projectId))
+          .execute()
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantStore.kt
@@ -2,6 +2,7 @@ package com.terraformation.backend.accelerator.db
 
 import com.terraformation.backend.accelerator.ParticipantService
 import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
+import com.terraformation.backend.accelerator.event.CohortParticipantRemovedEvent
 import com.terraformation.backend.accelerator.model.ExistingParticipantModel
 import com.terraformation.backend.accelerator.model.NewParticipantModel
 import com.terraformation.backend.accelerator.model.ParticipantModel
@@ -117,8 +118,15 @@ class ParticipantStore(
         throw ParticipantNotFoundException(participantId)
       }
 
-      if (existing.cohortId != updated.cohortId && updated.cohortId != null) {
-        eventPublisher.publishEvent(CohortParticipantAddedEvent(updated.cohortId, participantId))
+      if (existing.cohortId != updated.cohortId) {
+        if (existing.cohortId != null) {
+          eventPublisher.publishEvent(
+              CohortParticipantRemovedEvent(existing.cohortId, participantId)
+          )
+        }
+        if (updated.cohortId != null) {
+          eventPublisher.publishEvent(CohortParticipantAddedEvent(updated.cohortId, participantId))
+        }
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortParticipantRemovedEvent.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/event/CohortParticipantRemovedEvent.kt
@@ -1,0 +1,10 @@
+package com.terraformation.backend.accelerator.event
+
+import com.terraformation.backend.db.accelerator.CohortId
+import com.terraformation.backend.db.accelerator.ParticipantId
+
+/** Published when a participant's cohort association is removed. */
+data class CohortParticipantRemovedEvent(
+    val cohortId: CohortId,
+    val participantId: ParticipantId,
+)

--- a/src/main/resources/db/migration/0400/V437__AddProjectCohortPhase.sql
+++ b/src/main/resources/db/migration/0400/V437__AddProjectCohortPhase.sql
@@ -1,0 +1,11 @@
+ALTER TABLE projects ADD COLUMN cohort_id BIGINT REFERENCES accelerator.cohorts (id);
+ALTER TABLE projects ADD COLUMN phase_id INTEGER REFERENCES accelerator.cohort_phases (id);
+
+UPDATE projects
+SET (cohort_id, phase_id) = (
+    SELECT ap.cohort_id, c.phase_id
+    FROM accelerator.participants ap
+    LEFT JOIN accelerator.cohorts c on ap.cohort_id = c.id
+    WHERE ap.id = projects.participant_id
+)
+WHERE participant_id IS NOT NULL;

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ProjectPhaseServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ProjectPhaseServiceTest.kt
@@ -1,0 +1,188 @@
+package com.terraformation.backend.accelerator
+
+import com.terraformation.backend.RunsAsDatabaseUser
+import com.terraformation.backend.accelerator.event.CohortParticipantAddedEvent
+import com.terraformation.backend.accelerator.event.CohortParticipantRemovedEvent
+import com.terraformation.backend.accelerator.event.CohortPhaseUpdatedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectAddedEvent
+import com.terraformation.backend.accelerator.event.ParticipantProjectRemovedEvent
+import com.terraformation.backend.customer.model.TerrawareUser
+import com.terraformation.backend.db.DatabaseTest
+import com.terraformation.backend.db.accelerator.CohortPhase
+import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ProjectPhaseServiceTest : DatabaseTest(), RunsAsDatabaseUser {
+  override lateinit var user: TerrawareUser
+
+  private val service: ProjectPhaseService by lazy { ProjectPhaseService(dslContext) }
+
+  @BeforeEach
+  fun setUp() {
+    insertOrganization()
+  }
+
+  @Nested
+  inner class OnCohortParticipantAddedEvent {
+    @Test
+    fun `updates cohort and phase for participant projects`() {
+      val cohortId = insertCohort(phase = CohortPhase.Phase0DueDiligence)
+      val participantId = insertParticipant()
+      val projectId1 = insertProject(participantId = participantId)
+      val projectId2 = insertProject(participantId = participantId)
+
+      insertParticipant()
+      insertProject(participantId = inserted.participantId)
+      insertProject()
+
+      val expected =
+          dslContext.fetch(PROJECTS).onEach { record ->
+            if (record.id == projectId1 || record.id == projectId2) {
+              record.cohortId = cohortId
+              record.phaseId = CohortPhase.Phase0DueDiligence
+            }
+          }
+
+      service.on(CohortParticipantAddedEvent(cohortId, participantId))
+
+      assertTableEquals(expected)
+    }
+  }
+
+  @Nested
+  inner class OnCohortParticipantRemovedEvent {
+    @Test
+    fun `clears cohort and phase for participant projects`() {
+      val cohortId = insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
+      val participantId = insertParticipant()
+      val projectId1 =
+          insertProject(
+              cohortId = cohortId,
+              participantId = participantId,
+              phase = CohortPhase.Phase1FeasibilityStudy,
+          )
+      val projectId2 =
+          insertProject(
+              cohortId = cohortId,
+              participantId = participantId,
+              phase = CohortPhase.Phase1FeasibilityStudy,
+          )
+
+      insertProject(participantId = insertParticipant())
+      insertProject()
+
+      val expected =
+          dslContext.fetch(PROJECTS).onEach { record ->
+            if (record.id == projectId1 || record.id == projectId2) {
+              record.cohortId = null
+              record.phaseId = null
+            }
+          }
+
+      service.on(CohortParticipantRemovedEvent(cohortId, participantId))
+
+      assertTableEquals(expected)
+    }
+  }
+
+  @Nested
+  inner class OnCohortPhaseUpdatedEvent {
+    @Test
+    fun `updates phase for all projects in cohort`() {
+      val cohortId = insertCohort(phase = CohortPhase.Phase0DueDiligence)
+      val participantId = insertParticipant(cohortId = cohortId)
+      val projectId1 =
+          insertProject(
+              participantId = participantId,
+              cohortId = cohortId,
+              phase = CohortPhase.Phase0DueDiligence,
+          )
+      val projectId2 =
+          insertProject(
+              participantId = participantId,
+              cohortId = cohortId,
+              phase = CohortPhase.Phase0DueDiligence,
+          )
+
+      insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
+      insertParticipant(cohortId = inserted.cohortId)
+      insertProject(
+          participantId = inserted.participantId,
+          cohortId = inserted.cohortId,
+          phase = CohortPhase.Phase1FeasibilityStudy,
+      )
+      insertProject()
+
+      val expected =
+          dslContext.fetch(PROJECTS).onEach { record ->
+            if (record.id == projectId1 || record.id == projectId2) {
+              record.phaseId = CohortPhase.Phase3ImplementAndMonitor
+            }
+          }
+
+      service.on(CohortPhaseUpdatedEvent(cohortId, CohortPhase.Phase3ImplementAndMonitor))
+
+      assertTableEquals(expected)
+    }
+  }
+
+  @Nested
+  inner class OnParticipantProjectAddedEvent {
+    @Test
+    fun `updates cohort and phase to participant values`() {
+      val cohortId = insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
+      val participantId = insertParticipant(cohortId = cohortId)
+      insertProject(
+          cohortId = cohortId,
+          participantId = participantId,
+          phase = CohortPhase.Phase1FeasibilityStudy,
+      )
+      insertProject()
+
+      val projectId = insertProject()
+
+      val expected =
+          dslContext.fetch(PROJECTS).onEach { record ->
+            if (record.id == projectId) {
+              record.cohortId = cohortId
+              record.phaseId = CohortPhase.Phase1FeasibilityStudy
+            }
+          }
+
+      service.on(ParticipantProjectAddedEvent(user.userId, participantId, projectId))
+
+      assertTableEquals(expected)
+    }
+  }
+
+  @Nested
+  inner class OnParticipantProjectRemovedEvent {
+    @Test
+    fun `clears cohort and phase when project removed from participant`() {
+      val cohortId = insertCohort(phase = CohortPhase.Phase2PlanAndScale)
+      val participantId = insertParticipant()
+      val projectId =
+          insertProject(
+              participantId = participantId,
+              cohortId = cohortId,
+              phase = CohortPhase.Phase2PlanAndScale,
+          )
+
+      insertProject()
+
+      val expected =
+          dslContext.fetch(PROJECTS).onEach { record ->
+            if (record.id == projectId) {
+              record.cohortId = null
+              record.phaseId = null
+            }
+          }
+
+      service.on(ParticipantProjectRemovedEvent(participantId, projectId, user.userId))
+
+      assertTableEquals(expected)
+    }
+  }
+}

--- a/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/DatabaseBackedTest.kt
@@ -846,14 +846,17 @@ abstract class DatabaseBackedTest {
   protected fun insertProject(
       organizationId: OrganizationId = inserted.organizationId,
       name: String = "Project ${nextProjectNumber++}",
+      cohortId: CohortId? = null,
       createdBy: UserId = currentUser().userId,
       createdTime: Instant = Instant.EPOCH,
       description: String? = null,
       participantId: ParticipantId? = null,
+      phase: CohortPhase? = null,
       countryCode: String? = null,
   ): ProjectId {
     val row =
         ProjectsRow(
+            cohortId = cohortId,
             countryCode = countryCode,
             createdBy = createdBy,
             createdTime = createdTime,
@@ -863,6 +866,7 @@ abstract class DatabaseBackedTest {
             name = name,
             organizationId = organizationId,
             participantId = participantId,
+            phaseId = phase,
         )
 
     projectsDao.insert(row)


### PR DESCRIPTION
In preparation for removing participants, add columns to the projects table to
hold the participant's cohort ID and that cohort's phase. Add logic to keep
them up to date as participants and cohorts are modified.

Nothing uses these new columns yet; this initial change just adds them and
ensures they're updated as needed.