### PR TITLE
SW-7942 Don't join with participants to get cohorts

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectService.kt
@@ -4,7 +4,6 @@ import com.terraformation.backend.accelerator.model.AcceleratorProjectModel
 import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.AcceleratorProjectNotFoundException
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_VOTE_DECISIONS
 import com.terraformation.backend.db.asNonNullable
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -54,10 +53,8 @@ class AcceleratorProjectService(
             decisionsMultiset,
         )
         .from(PROJECTS)
-        .join(PARTICIPANTS)
-        .on(PARTICIPANTS.ID.eq(PROJECTS.PARTICIPANT_ID))
         .join(COHORTS)
-        .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+        .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
         .where(condition)
         .orderBy(COHORTS.ID, PROJECTS.ID)
         .fetch { AcceleratorProjectModel.of(it, decisionsMultiset) }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStore.kt
@@ -158,12 +158,10 @@ class CohortModuleStore(
 
   private fun fetchCohortId(projectId: ProjectId): CohortId {
     return dslContext
-        .select(PARTICIPANTS.COHORT_ID)
+        .select(PROJECTS.COHORT_ID)
         .from(PROJECTS)
-        .join(PARTICIPANTS)
-        .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
         .where(PROJECTS.ID.eq(projectId))
-        .fetch(PARTICIPANTS.COHORT_ID)
+        .fetch(PROJECTS.COHORT_ID)
         .firstOrNull() ?: throw ProjectNotInCohortException(projectId)
   }
 }

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStore.kt
@@ -18,7 +18,6 @@ import com.terraformation.backend.db.accelerator.tables.records.ParticipantProje
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANT_PROJECT_SPECIES
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.SpeciesId
@@ -153,11 +152,9 @@ class ParticipantProjectSpeciesStore(
         .on(SPECIES.ID.eq(PARTICIPANT_PROJECT_SPECIES.SPECIES_ID))
         .join(PROJECTS)
         .on(PARTICIPANT_PROJECT_SPECIES.PROJECT_ID.eq(PROJECTS.ID))
-        .join(PARTICIPANTS)
-        .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
         .leftOuterJoin(COHORT_MODULES)
         .on(
-            COHORT_MODULES.COHORT_ID.eq(PARTICIPANTS.COHORT_ID),
+            COHORT_MODULES.COHORT_ID.eq(PROJECTS.COHORT_ID),
             COHORT_MODULES.START_DATE.lessOrEqual(today),
         )
         .leftOuterJoin(MODULES)

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStore.kt
@@ -10,7 +10,6 @@ import com.terraformation.backend.customer.model.requirePermissions
 import com.terraformation.backend.db.ProjectNotFoundException
 import com.terraformation.backend.db.accelerator.SystemMetric
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.PROJECT_ACCELERATOR_DETAILS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.records.ProjectLandUseModelTypesRecord
@@ -70,10 +69,8 @@ class ProjectAcceleratorDetailsStore(
         .from(PROJECTS)
         .leftJoin(PROJECT_ACCELERATOR_DETAILS)
         .on(PROJECTS.ID.eq(PROJECT_ACCELERATOR_DETAILS.PROJECT_ID))
-        .leftJoin(PARTICIPANTS)
-        .on(PARTICIPANTS.ID.eq(PROJECTS.PARTICIPANT_ID))
         .leftJoin(COHORTS)
-        .on(COHORTS.ID.eq(PARTICIPANTS.COHORT_ID))
+        .on(COHORTS.ID.eq(PROJECTS.COHORT_ID))
         .where(condition)
         .filter { filterFn(it[PROJECTS.ID]!!) }
         .map {

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcher.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcher.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.db.accelerator.ApplicationStatus
 import com.terraformation.backend.db.accelerator.CohortPhase
 import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.COHORTS
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.default_schema.ProjectId
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import jakarta.inject.Named
@@ -20,10 +19,8 @@ class ProjectCohortFetcher(private val dslContext: DSLContext) {
     return dslContext
         .select(COHORTS.ID, COHORTS.PHASE_ID, APPLICATIONS.APPLICATION_STATUS_ID)
         .from(PROJECTS)
-        .leftJoin(PARTICIPANTS)
-        .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
         .leftJoin(COHORTS)
-        .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+        .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
         .leftJoin(APPLICATIONS)
         .on(PROJECTS.ID.eq(APPLICATIONS.PROJECT_ID))
         .where(PROJECTS.ID.eq(projectId))

--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/SubmissionStore.kt
@@ -12,7 +12,6 @@ import com.terraformation.backend.db.accelerator.tables.records.SubmissionsRecor
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.attach
 import com.terraformation.backend.db.default_schema.ProjectId
@@ -85,10 +84,8 @@ class SubmissionStore(
             .on(DELIVERABLES.MODULE_ID.eq(MODULES.ID))
             .join(COHORT_MODULES)
             .on(MODULES.ID.eq(COHORT_MODULES.MODULE_ID))
-            .join(PARTICIPANTS)
-            .on(COHORT_MODULES.COHORT_ID.eq(PARTICIPANTS.COHORT_ID))
             .join(PROJECTS)
-            .on(PARTICIPANTS.ID.eq(PROJECTS.PARTICIPANT_ID))
+            .on(COHORT_MODULES.COHORT_ID.eq(PROJECTS.COHORT_ID))
             .leftJoin(SUBMISSIONS)
             .on(
                 DELIVERABLES.ID.eq(SUBMISSIONS.DELIVERABLE_ID),

--- a/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStore.kt
@@ -8,7 +8,6 @@ import com.terraformation.backend.db.accelerator.tables.references.APPLICATIONS
 import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULES
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.accelerator.tables.references.REPORTS
 import com.terraformation.backend.db.accelerator.tables.references.SUBMISSIONS
 import com.terraformation.backend.db.default_schema.OrganizationId
@@ -69,10 +68,8 @@ class OrganizationFeatureStore(private val dslContext: DSLContext) {
                   .on(SUBMISSIONS.DELIVERABLE_ID.eq(DELIVERABLES.ID))
                   .leftJoin(COHORT_MODULES)
                   .on(COHORT_MODULES.MODULE_ID.eq(DELIVERABLES.MODULE_ID))
-                  .leftJoin(PARTICIPANTS)
-                  .on(PARTICIPANTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
-                  .join(PROJECTS)
-                  .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+                  .leftJoin(PROJECTS)
+                  .on(PROJECTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
                   .or(PROJECTS.ID.eq(SUBMISSIONS.PROJECT_ID))
                   .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
                   .and(MODULES.PHASE_ID.notIn(CohortPhase.PreScreen, CohortPhase.Application))
@@ -83,10 +80,8 @@ class OrganizationFeatureStore(private val dslContext: DSLContext) {
       DSL.multiset(
               DSL.select(PROJECTS.ID)
                   .from(COHORT_MODULES)
-                  .join(PARTICIPANTS)
-                  .on(PARTICIPANTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
                   .join(PROJECTS)
-                  .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+                  .on(PROJECTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
                   .where(PROJECTS.ORGANIZATION_ID.eq(ORGANIZATIONS.ID))
           )
           .convertFrom { result -> result.map { record -> record[PROJECTS.ID] }.toSet() }

--- a/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/customer/db/ParentStore.kt
@@ -366,10 +366,8 @@ class ParentStore(private val dslContext: DSLContext) {
         dslContext
             .selectOne()
             .from(COHORT_MODULES)
-            .join(PARTICIPANTS)
-            .on(PARTICIPANTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
             .join(PROJECTS)
-            .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+            .on(PROJECTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
             .join(ORGANIZATION_USERS)
             .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
             .where(ORGANIZATION_USERS.USER_ID.eq(userId))
@@ -398,10 +396,8 @@ class ParentStore(private val dslContext: DSLContext) {
       dslContext
           .selectOne()
           .from(COHORTS)
-          .join(PARTICIPANTS)
-          .on(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
           .join(PROJECTS)
-          .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+          .on(PROJECTS.COHORT_ID.eq(COHORTS.ID))
           .join(ORGANIZATION_USERS)
           .on(ORGANIZATION_USERS.ORGANIZATION_ID.eq(PROJECTS.ORGANIZATION_ID))
           .where(ORGANIZATION_USERS.USER_ID.eq(userId))
@@ -451,14 +447,14 @@ class ParentStore(private val dslContext: DSLContext) {
           (dslContext.fetchExists(
               PROJECT_ACCELERATOR_DETAILS,
               PROJECT_ACCELERATOR_DETAILS.PROJECT_ID.eq(projectId),
-          ) || dslContext.fetchExists(PROJECTS, PROJECTS.participants.COHORT_ID.isNotNull))
+          ) || isProjectInCohort(projectId))
 
   fun isProjectInCohort(projectId: ProjectId?): Boolean =
       projectId != null &&
           dslContext.fetchExists(
               PROJECTS,
               PROJECTS.ID.eq(projectId),
-              PROJECTS.participants.COHORT_ID.isNotNull,
+              PROJECTS.COHORT_ID.isNotNull,
           )
 
   /**

--- a/src/main/kotlin/com/terraformation/backend/search/table/CohortsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/CohortsTable.kt
@@ -49,10 +49,8 @@ class CohortsTable(tables: SearchTables) : SearchTable() {
     } else {
       DSL.exists(
           DSL.selectOne()
-              .from(PARTICIPANTS)
-              .join(PROJECTS)
-              .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
-              .where(PARTICIPANTS.COHORT_ID.eq(COHORTS.ID))
+              .from(PROJECTS)
+              .where(PROJECTS.COHORT_ID.eq(COHORTS.ID))
               .and(PROJECTS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys))
       )
     }

--- a/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ModulesTable.kt
@@ -6,7 +6,6 @@ import com.terraformation.backend.db.accelerator.tables.references.COHORT_MODULE
 import com.terraformation.backend.db.accelerator.tables.references.DELIVERABLES
 import com.terraformation.backend.db.accelerator.tables.references.EVENTS
 import com.terraformation.backend.db.accelerator.tables.references.MODULES
-import com.terraformation.backend.db.accelerator.tables.references.PARTICIPANTS
 import com.terraformation.backend.db.default_schema.tables.references.PROJECTS
 import com.terraformation.backend.search.SearchTable
 import com.terraformation.backend.search.SublistField
@@ -54,10 +53,8 @@ class ModulesTable(tables: SearchTables) : SearchTable() {
         DSL.exists(
             DSL.selectOne()
                 .from(COHORT_MODULES)
-                .join(PARTICIPANTS)
-                .on(PARTICIPANTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
                 .join(PROJECTS)
-                .on(PROJECTS.PARTICIPANT_ID.eq(PARTICIPANTS.ID))
+                .on(PROJECTS.COHORT_ID.eq(COHORT_MODULES.COHORT_ID))
                 .where(COHORT_MODULES.MODULE_ID.eq(MODULES.ID))
                 .and(PROJECTS.ORGANIZATION_ID.`in`(currentUser().organizationRoles.keys))
         )

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorProjectServiceTest.kt
@@ -27,8 +27,7 @@ class AcceleratorProjectServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     insertOrganization()
     insertOrganizationInternalTag(tagId = InternalTagIds.Accelerator)
     insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
-    insertParticipant(cohortId = inserted.cohortId)
-    insertProject(countryCode = "KE", participantId = inserted.participantId)
+    insertProject(cohortId = inserted.cohortId, countryCode = "KE")
     insertVoteDecision(
         projectId = inserted.projectId,
         phase = CohortPhase.Phase0DueDiligence,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/AcceleratorSearchTest.kt
@@ -379,14 +379,14 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val suffix = "${UUID.randomUUID()}"
     val cohortId1 = insertCohort(name = "Cohort 1 $suffix")
     val participantId2 = insertParticipant(cohortId = cohortId1, name = "Participant 2 $suffix")
-    val projectId2 = insertProject(participantId = participantId2)
-    val projectId3 = insertProject(participantId = participantId2)
+    val projectId2 = insertProject(cohortId = cohortId1, participantId = participantId2)
+    val projectId3 = insertProject(cohortId = cohortId1, participantId = participantId2)
     val participantId3 = insertParticipant(cohortId = cohortId1, name = "Participant 3 $suffix")
 
     // Test setup already inserts a participant+project with no cohort; also insert a second cohort
     insertCohort(name = "Cohort 2 $suffix")
     insertParticipant(cohortId = inserted.cohortId, name = "Participant 4 $suffix")
-    insertProject(participantId = inserted.participantId)
+    insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
 
     val prefix = SearchFieldPrefix(searchTables.cohorts)
     val fields =
@@ -456,6 +456,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     val participantId = insertParticipant(cohortId = inserted.cohortId)
     val projectId =
         insertProject(
+            cohortId = cohortId,
             organizationId = inserted.organizationId,
             participantId = inserted.participantId,
         )
@@ -469,6 +470,7 @@ class AcceleratorSearchTest : DatabaseTest(), RunsAsUser {
     )
     val otherParticipant = insertParticipant(cohortId = inserted.cohortId)
     insertProject(
+        cohortId = cohortId,
         organizationId = otherOrganization,
         participantId = otherParticipant,
         createdBy = otherUser,

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ModuleSearchTest.kt
@@ -226,15 +226,13 @@ class ModuleSearchTest : DatabaseTest(), RunsAsUser {
     val invisibleModule = insertModule()
 
     val userCohort = insertCohort()
-    val userParticipant = insertParticipant(cohortId = userCohort)
-    insertProject(participantId = userParticipant, organizationId = inserted.organizationId)
+    insertProject(cohortId = userCohort, organizationId = inserted.organizationId)
 
     val otherUser = insertUser()
     val otherCohort = insertCohort()
-    val otherParticipant = insertParticipant(cohortId = otherCohort)
     val otherOrganization = insertOrganization()
     insertOrganizationUser(otherUser, otherOrganization)
-    insertProject(participantId = otherParticipant, organizationId = otherOrganization)
+    insertProject(cohortId = otherCohort, organizationId = otherOrganization)
 
     insertCohortModule(userCohort, module1)
     insertCohortModule(userCohort, module2)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/ParticipantProjectSpeciesServiceTest.kt
@@ -94,7 +94,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     fun `creates a submission for the project and deliverable if one does not exist for the active module when a species is added to a project`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId, participantId = participantId)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -154,7 +154,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     fun `does not create another submission for a project if a deliverable submission for the active module already exists`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId, participantId = participantId)
       val speciesId = insertSpecies()
       val moduleId = insertModule()
       val deliverableId =
@@ -205,8 +205,8 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId, participantId = participantId)
+      val projectId2 = insertProject(cohortId = cohortId, participantId = participantId)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
 
@@ -291,8 +291,8 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
       // Between the most recent and future module
       clock.instant = Instant.EPOCH.plus(20, ChronoUnit.DAYS)
 
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId, participantId = participantId)
+      val projectId2 = insertProject(cohortId = cohortId, participantId = participantId)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
 
@@ -347,9 +347,8 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     fun `creates an entity for each project ID and species ID pairing even if there isn't any associated deliverable`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
-
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId, participantId = participantId)
+      val projectId2 = insertProject(cohortId = cohortId, participantId = participantId)
       val speciesId1 = insertSpecies()
       val speciesId2 = insertSpecies()
 
@@ -376,11 +375,9 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `updates the status for the participant project species if species fields are edited by non-accelerator-users`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
-      val projectId3 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId)
+      val projectId2 = insertProject(cohortId = cohortId)
+      val projectId3 = insertProject(cohortId = cohortId)
       val speciesId = insertSpecies()
 
       val participantProjectSpeciesId1 =
@@ -426,9 +423,7 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `does not update the status of the participant project species if the species fields are edited by accelerator-users`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
       val speciesId = insertSpecies()
 
       insertParticipantProjectSpecies(
@@ -461,13 +456,12 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `it saves a snapshot of species data if the associated submission is approved`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
       val moduleId = insertModule()
       insertCohortModule(cohortId = cohortId, moduleId = moduleId)
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 
       val speciesId1 = insertSpecies()
@@ -533,13 +527,12 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `it does nothing if the submission is not approved`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
       val moduleId = insertModule()
       insertCohortModule(cohortId = cohortId, moduleId = moduleId)
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Species)
 
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 
       val speciesId = insertSpecies()
@@ -571,13 +564,12 @@ class ParticipantProjectSpeciesServiceTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `it does nothing if the submission is not for a species list deliverable`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
       val moduleId = insertModule()
       insertCohortModule(cohortId = cohortId, moduleId = moduleId)
       val deliverableId =
           insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Document)
 
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
       val submissionId = insertSubmission(deliverableId = deliverableId, projectId = projectId)
 
       service.on(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/SpeciesNotifierTest.kt
@@ -44,9 +44,8 @@ class SpeciesNotifierTest : DatabaseTest(), RunsAsUser {
     insertModule()
     insertCohort()
     insertCohortModule()
-    insertParticipant(cohortId = inserted.cohortId)
 
-    projectId = insertProject(participantId = inserted.participantId)
+    projectId = insertProject(cohortId = inserted.cohortId)
     deliverableId = insertDeliverable(deliverableTypeId = DeliverableType.Species)
 
     every { user.canReadProjectDeliverables(any()) } returns true

--- a/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/VoteServiceTest.kt
@@ -60,8 +60,8 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `inserts voters`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
-      insertProject(participantId = participantId) // Should be ignored
-      val projectId = insertProject(participantId = participantId)
+      insertProject(cohortId = cohortId, participantId = participantId) // Should be ignored
+      val projectId = insertProject(cohortId = cohortId, participantId = participantId)
 
       service.on(ParticipantProjectAddedEvent(user.userId, participantId, projectId))
 
@@ -72,7 +72,7 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `does not modify existing voter information`() {
       val cohortId = insertCohort()
       val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId, participantId = participantId)
 
       insertVote(user = voter1, voteOption = VoteOption.No, conditionalInfo = "cond")
 
@@ -106,15 +106,15 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
     fun `inserts voters`() {
       val cohortId1 = insertCohort()
       val participantId1 = insertParticipant(cohortId = cohortId1)
-      val projectId1 = insertProject(participantId = participantId1)
-      val projectId2 = insertProject(participantId = participantId1)
+      val projectId1 = insertProject(cohortId = cohortId1, participantId = participantId1)
+      val projectId2 = insertProject(cohortId = cohortId1, participantId = participantId1)
 
       // Should leave these alone
       val otherParticipantId = insertParticipant(cohortId = cohortId1)
-      insertProject(participantId = otherParticipantId)
+      insertProject(cohortId = cohortId1, participantId = otherParticipantId)
       val otherCohortId = insertCohort()
       val otherCohortParticipantId = insertParticipant(cohortId = otherCohortId)
-      insertProject(participantId = otherCohortParticipantId)
+      insertProject(cohortId = otherCohortId, participantId = otherCohortParticipantId)
 
       service.on(CohortParticipantAddedEvent(cohortId1, participantId1))
 
@@ -141,14 +141,14 @@ class VoteServiceTest : DatabaseTest(), RunsAsDatabaseUser {
       val phase = CohortPhase.Phase1FeasibilityStudy
       val cohortId1 = insertCohort(phase = phase)
       val participantId1 = insertParticipant(cohortId = cohortId1)
-      val projectId1 = insertProject(participantId = participantId1)
+      val projectId1 = insertProject(cohortId = cohortId1, participantId = participantId1)
       val participantId2 = insertParticipant(cohortId = cohortId1)
-      val projectId2 = insertProject(participantId = participantId2)
+      val projectId2 = insertProject(cohortId = cohortId1, participantId = participantId2)
 
       // Should leave these alone
       val otherCohortId = insertCohort()
       val otherCohortParticipantId = insertParticipant(cohortId = otherCohortId)
-      insertProject(participantId = otherCohortParticipantId)
+      insertProject(cohortId = otherCohortId, participantId = otherCohortParticipantId)
       insertVote(projectId1, user = voter1)
 
       service.on(CohortPhaseUpdatedEvent(cohortId1, phase))

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ActivityStoreTest.kt
@@ -49,8 +49,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   fun setUp() {
     insertOrganization()
     val cohortId = insertCohort()
-    val participantId = insertParticipant(cohortId = cohortId)
-    projectId = insertProject(participantId = participantId)
+    projectId = insertProject(cohortId = cohortId)
   }
 
   @Nested
@@ -143,7 +142,7 @@ class ActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     @Test
     fun `throws exception if project is not in a cohort`() {
       insertOrganizationUser(role = Role.Admin)
-      dslContext.update(PROJECTS).setNull(PROJECTS.PARTICIPANT_ID).execute()
+      dslContext.update(PROJECTS).setNull(PROJECTS.COHORT_ID).execute()
 
       val model =
           NewActivityModel(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/CohortModuleStoreTest.kt
@@ -62,8 +62,8 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
       val cohortB = insertCohort(phase = CohortPhase.Phase0DueDiligence)
       val participantA = insertParticipant(cohortId = cohortA)
       val participantB = insertParticipant(cohortId = cohortB)
-      val projectA = insertProject(participantId = participantA)
-      val projectB = insertProject(participantId = participantB)
+      val projectA = insertProject(cohortId = cohortA, participantId = participantA)
+      val projectB = insertProject(cohortId = cohortB, participantId = participantB)
 
       val module1 =
           insertModule(name = "Module 1", position = 3, phase = CohortPhase.Phase1FeasibilityStudy)
@@ -302,7 +302,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(cohortId = inserted.cohortId)
-      insertProject(participantId = inserted.participantId)
+      insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertModule()
 
       assertThrows<AccessDeniedException> {
@@ -342,7 +342,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(cohortId = inserted.cohortId)
-      insertProject(participantId = inserted.participantId)
+      insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertModule()
 
       store.assign(
@@ -373,7 +373,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(cohortId = inserted.cohortId)
-      insertProject(participantId = inserted.participantId)
+      insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertModule()
 
       insertCohortModule(
@@ -453,7 +453,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(cohortId = inserted.cohortId)
-      insertProject(participantId = inserted.participantId)
+      insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertModule()
 
       assertThrows<AccessDeniedException> { //
@@ -481,7 +481,7 @@ class CohortModuleStoreTest : DatabaseTest(), RunsAsDatabaseUser {
 
       insertCohort(phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(cohortId = inserted.cohortId)
-      insertProject(participantId = inserted.participantId)
+      insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertModule()
 
       insertCohortModule(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ParticipantProjectSpeciesStoreTest.kt
@@ -211,9 +211,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       // This one should not be returned because it is not a species type deliverable
       insertDeliverable(moduleId = moduleId, deliverableTypeId = DeliverableType.Document)
 
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId)
+      val projectId2 = insertProject(cohortId = cohortId)
 
       val speciesId = insertSpecies()
       val participantProjectSpeciesId1 =
@@ -279,9 +278,8 @@ class ParticipantProjectSpeciesStoreTest : DatabaseTest(), RunsAsUser {
       // Between the most recent and future module
       clock.instant = Instant.EPOCH.plus(20, ChronoUnit.DAYS)
 
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId1 = insertProject(participantId = participantId)
-      val projectId2 = insertProject(participantId = participantId)
+      val projectId1 = insertProject(cohortId = cohortId)
+      val projectId2 = insertProject(cohortId = cohortId)
 
       val speciesId = insertSpecies()
       val participantProjectSpeciesId1 =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -52,8 +52,7 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns all details fields`() {
       insertCohort(name = "Cohort name", phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(name = "Participant name", cohortId = inserted.cohortId)
-      val projectId =
-          insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectAcceleratorDetailsStoreTest.kt
@@ -21,7 +21,7 @@ import io.mockk.every
 import java.math.BigDecimal
 import java.net.URI
 import org.jooq.impl.DSL
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -52,7 +52,8 @@ class ProjectAcceleratorDetailsStoreTest : DatabaseTest(), RunsAsUser {
     fun `returns all details fields`() {
       insertCohort(name = "Cohort name", phase = CohortPhase.Phase0DueDiligence)
       insertParticipant(name = "Participant name", cohortId = inserted.cohortId)
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId =
+          insertProject(cohortId = inserted.cohortId, participantId = inserted.participantId)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Agroforestry)
       insertProjectLandUseModelType(landUseModelType = LandUseModelType.Mangroves)
 

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcherTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectCohortFetcherTest.kt
@@ -36,8 +36,7 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches project's cohort data`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       val expected =
           ProjectCohortData(cohortId = cohortId, cohortPhase = CohortPhase.Phase0DueDiligence)
@@ -49,8 +48,7 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `uses cohort data even if project has an application`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
       insertApplication()
 
       val expected =
@@ -100,8 +98,7 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws exception if no permission to read project`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       every { user.canReadProject(projectId) } returns false
 
@@ -109,9 +106,8 @@ class ProjectCohortFetcherTest : DatabaseTest(), RunsAsUser {
     }
 
     @Test
-    fun `returns null if the project is not associated to a participant which is associated to a cohort`() {
-      val participantId = insertParticipant()
-      val projectId = insertProject(participantId = participantId)
+    fun `returns null if the project is not associated to a cohort`() {
+      val projectId = insertProject()
 
       val actual = fetcher.fetchCohortData(projectId)
       assertNull(actual)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ProjectScoreStoreTest.kt
@@ -31,7 +31,6 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   fun setUp() {
     insertOrganization()
     insertCohort(phase = CohortPhase.Phase0DueDiligence)
-    insertParticipant(cohortId = inserted.cohortId)
 
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectScores(any()) } returns true
@@ -46,7 +45,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time2 = Instant.ofEpochSecond(2)
       val time3 = Instant.ofEpochSecond(3)
 
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       insertProjectScore(
           phase = CohortPhase.Phase0DueDiligence,
@@ -90,7 +89,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
       val time3 = Instant.ofEpochSecond(3)
       val time4 = Instant.ofEpochSecond(4)
 
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       insertProjectScore(
           phase = CohortPhase.Phase0DueDiligence,
@@ -145,7 +144,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to read scores`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       every { user.canReadProjectScores(projectId) } returns false
 
@@ -157,7 +156,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
   inner class UpdateScores {
     @Test
     fun `creates scores that do not exist`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       clock.instant = Instant.ofEpochSecond(123)
 
@@ -199,7 +198,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `updates scores that already exist`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       insertProjectScore(phase = CohortPhase.Phase0DueDiligence, category = ScoreCategory.Legal)
       insertProjectScore(
@@ -249,7 +248,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if no permission to update scores`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       every { user.canUpdateProjectScores(projectId) } returns false
 
@@ -277,7 +276,7 @@ class ProjectScoreStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception if updating scores for a different phase than the current one`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       assertThrows<ProjectNotInCohortPhaseException> {
         store.updateScores(

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/SubmissionStoreTest.kt
@@ -14,7 +14,7 @@ import io.mockk.every
 import java.time.Instant
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -42,8 +42,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches the deliverable ID if no submission present for an active deliverable`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -75,8 +74,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches the deliverable ID if no submission present for the most recent inactive deliverable if there is no active deliverable`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -119,8 +117,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches both deliverable ID and submission ID if present for active deliverable`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -158,8 +155,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `fetches both deliverable ID and submission ID if present for most recent deliverable if there is no active deliverable`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       // Module goes from epoch -> epoch + 6 days
       val moduleIdOld = insertModule()
@@ -208,8 +204,7 @@ class SubmissionStoreTest : DatabaseTest(), RunsAsUser {
     @Test
     fun `throws an exception if no permission to read the submission`() {
       val cohortId = insertCohort()
-      val participantId = insertParticipant(cohortId = cohortId)
-      val projectId = insertProject(participantId = participantId)
+      val projectId = insertProject(cohortId = cohortId)
 
       val moduleId = insertModule()
       insertCohortModule(cohortId = cohortId, moduleId = moduleId)

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/VoteStoreTest.kt
@@ -15,7 +15,7 @@ import com.terraformation.backend.db.default_schema.UserId
 import com.terraformation.backend.mockUser
 import io.mockk.every
 import java.time.Instant
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -35,8 +35,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    val cohortId = insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
-    insertParticipant(cohortId = cohortId)
+    insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
 
     every { user.canReadProject(any()) } returns true
     every { user.canReadProjectVotes(any()) } returns true
@@ -47,7 +46,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVotes {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteModel>(), store.fetchAllVotes(projectId))
@@ -55,7 +54,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all votes`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -119,7 +118,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches votes by phase`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -176,7 +175,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on fetch if no permission to read votes `() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       every { user.canReadProjectVotes(projectId) } returns false
 
@@ -188,7 +187,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class FetchAllVoteDecisions {
     @Test
     fun `fetches with no vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
       assertEquals(emptyList<VoteDecisionModel>(), store.fetchAllVoteDecisions(projectId))
@@ -196,7 +195,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches all vote decisions`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       insertVoteDecision(projectId, phase, VoteOption.Yes, clock.instant)
@@ -211,7 +210,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `fetches vote decisions by phase`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
@@ -231,7 +230,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Delete {
     @Test
     fun `delete only vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val newUser = insertUser()
@@ -246,7 +245,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one vote from multiple voters`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -294,7 +293,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `delete one phase of votes from multiple phases`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -371,7 +370,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on delete if no permission to update votes `() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -395,7 +394,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on delete for wrong phase `() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -406,7 +405,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting one vote from many`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val user1 = insertUser()
@@ -427,7 +426,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on deleting only vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val newUser = insertUser()
@@ -448,7 +447,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
   inner class Upsert {
     @Test
     fun `creates blank vote for self`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
@@ -471,7 +470,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates blank vote for other user`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -495,7 +494,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `creates conditional vote for other user`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val otherUser = insertUser()
 
       clock.instant = Instant.EPOCH.plusSeconds(500)
@@ -521,7 +520,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update only voter selection`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val newUser = insertUser()
@@ -553,7 +552,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection with multiple voters`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
@@ -618,7 +617,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple phases`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase0: CohortPhase = CohortPhase.Phase0DueDiligence
       val phase1: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
@@ -667,8 +666,8 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `update voter selection for multiple projects`() {
-      val project1 = insertProject(participantId = inserted.participantId)
-      val project2 = insertProject(participantId = inserted.participantId)
+      val project1 = insertProject(cohortId = inserted.cohortId)
+      val project2 = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
 
       val createdTime = Instant.EPOCH.plusSeconds(500)
@@ -716,7 +715,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if no permission to update votes`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -742,7 +741,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `throws exception on upsert if project in wrong phase`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase0DueDiligence
       val newUser = insertUser()
       val vote = VoteOption.No
@@ -755,7 +754,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -769,7 +768,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on creating one null vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -782,7 +781,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating one vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -800,7 +799,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on upserting to a tie`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 
@@ -820,7 +819,7 @@ class VoteStoreTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `computes vote decision on updating to no vote`() {
-      val projectId = insertProject(participantId = inserted.participantId)
+      val projectId = insertProject(cohortId = inserted.cohortId)
       val phase: CohortPhase = CohortPhase.Phase1FeasibilityStudy
       clock.instant = Instant.EPOCH.plusSeconds(500)
 

--- a/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/db/OrganizationFeatureStoreTest.kt
@@ -88,8 +88,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     val cohortId = insertCohort()
-    val participantId = insertParticipant(cohortId = cohortId)
-    val projectId = insertProject(participantId = participantId)
+    val projectId = insertProject(cohortId = cohortId)
 
     insertModule()
     insertCohortModule()
@@ -113,8 +112,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     val cohortId = insertCohort()
-    val participantId = insertParticipant(cohortId = cohortId)
-    val projectId = insertProject(participantId = participantId)
+    val projectId = insertProject(cohortId = cohortId)
 
     insertModule()
     insertDeliverable()
@@ -236,8 +234,7 @@ class OrganizationFeatureStoreTest : DatabaseTest(), RunsAsDatabaseUser {
     )
 
     val cohortId = insertCohort(phase = CohortPhase.Phase1FeasibilityStudy)
-    val participantId = insertParticipant(cohortId = cohortId)
-    val moduleProjectId = insertProject(name = "Cohort project", participantId = participantId)
+    val moduleProjectId = insertProject(name = "Cohort project", cohortId = cohortId)
     insertModule(phase = CohortPhase.Phase1FeasibilityStudy)
     insertDeliverable()
     insertCohortModule()

--- a/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/customer/model/PermissionTest.kt
@@ -277,6 +277,7 @@ internal class PermissionTest : DatabaseTest() {
       putDatabaseId(
           projectId,
           insertProject(
+              cohortId = getDatabaseId(CohortId(projectId.value / 1000)),
               createdBy = userId,
               organizationId = getDatabaseId(OrganizationId(projectId.value / 1000)),
               participantId = getDatabaseId(ParticipantId(projectId.value / 1000)),


### PR DESCRIPTION
Some SQL queries were only joining with the participants table as a way to link
projects and cohorts; now that projects have cohort IDs, we can join directly
between the two.