### PR TITLE
SW-7942 Remove unused participant from activity tests

### DIFF
--- a/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/PublishedActivityServiceTest.kt
@@ -60,9 +60,7 @@ class PublishedActivityServiceTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     organizationId = insertOrganization()
-    val cohortId = insertCohort()
-    val participantId = insertParticipant(cohortId = cohortId)
-    projectId = insertProject(participantId = participantId)
+    projectId = insertProject()
 
     activityId =
         insertActivity(

--- a/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/funder/db/PublishedActivityStoreTest.kt
@@ -49,9 +49,7 @@ class PublishedActivityStoreTest : DatabaseTest(), RunsAsDatabaseUser {
   @BeforeEach
   fun setUp() {
     insertOrganization()
-    val cohortId = insertCohort()
-    val participantId = insertParticipant(cohortId = cohortId)
-    projectId = insertProject(participantId = participantId)
+    projectId = insertProject()
 
     activityId =
         insertActivity(


### PR DESCRIPTION
Nothing in `PublishedActivityStore` depends on projects being in cohorts,
so there's no need for the tests to create cohorts or participants.