### PR TITLE
SW-7942 Fix misnamed search sublist

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -40,7 +40,7 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
           accessions.asMultiValueSublist("accessions", PROJECTS.ID.eq(ACCESSIONS.PROJECT_ID)),
           batches.asMultiValueSublist("batches", PROJECTS.ID.eq(BATCHES.PROJECT_ID)),
           cohorts.asSingleValueSublist(
-              "cohorts",
+              "cohort",
               PROJECTS.COHORT_ID.eq(COHORTS.ID),
               isRequired = false,
           ),


### PR DESCRIPTION
A project can only have one cohort, so the sublist name under the projects
search table should be singular, not plural.