### PR TITLE
SW-7984 Allow optional S3 key prefixes

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -44,6 +44,12 @@ class TerrawareServerConfig(
     val s3BucketName: String? = null,
 
     /**
+     * Prefix to use for S3 keys. This can be used when multiple environments are sharing a single
+     * S3 bucket and want to avoid name collisions.
+     */
+    val s3KeyPrefix: String? = null,
+
+    /**
      * Directory to use for local photo storage. If not specified, photos won't be stored on the
      * local filesystem. The server will attempt to create this directory if it doesn't exist.
      */

--- a/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/FileStore.kt
@@ -75,6 +75,9 @@ interface FileStore {
   /** Returns the URL of a file with a given relative path on this file store. */
   fun getUrl(path: Path): URI
 
+  /** Returns the relative path of a file on this file store with a given URL. */
+  fun getPath(url: URI): Path
+
   /**
    * Creates a new URL for a file of a particular category with a particular content type.
    *

--- a/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/LocalFileStore.kt
@@ -76,6 +76,10 @@ class LocalFileStore(
     return URI("file:///${relativePath.invariantSeparatorsPathString}")
   }
 
+  override fun getPath(url: URI): Path {
+    return Path(url.path.trimStart('/'))
+  }
+
   override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {
     return getUrl(pathGenerator.generatePath(timestamp, category, contentType))
   }

--- a/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
@@ -11,6 +11,7 @@ import java.nio.file.FileSystemException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.time.Instant
+import kotlin.io.path.Path
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.relativeTo
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -154,6 +155,15 @@ class S3FileStore(config: TerrawareServerConfig, private val pathGenerator: Path
   override fun getUrl(path: Path): URI {
     val relativePath = if (path.isAbsolute) path.relativeTo(path.root) else path
     return URI("s3://$bucketName/$keyPrefix${relativePath.invariantSeparatorsPathString}")
+  }
+
+  override fun getPath(url: URI): Path {
+    val fullPath = url.path.trimStart('/')
+    return if (fullPath.startsWith(keyPrefix)) {
+      Path(fullPath.substring(keyPrefix.length))
+    } else {
+      Path(fullPath)
+    }
   }
 
   override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {

--- a/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/S3FileStore.kt
@@ -40,6 +40,7 @@ class S3FileStore(config: TerrawareServerConfig, private val pathGenerator: Path
   private val bucketName =
       config.s3BucketName
           ?: throw IllegalArgumentException("No S3 bucket name found in configuration")
+  private val keyPrefix = config.s3KeyPrefix?.let { it.trim('/') + '/' } ?: ""
 
   override fun delete(url: URI) {
     // Test whether the file exists; S3's delete endpoint doesn't return "not found" responses.
@@ -152,7 +153,7 @@ class S3FileStore(config: TerrawareServerConfig, private val pathGenerator: Path
 
   override fun getUrl(path: Path): URI {
     val relativePath = if (path.isAbsolute) path.relativeTo(path.root) else path
-    return URI("s3://$bucketName/${relativePath.invariantSeparatorsPathString}")
+    return URI("s3://$bucketName/$keyPrefix${relativePath.invariantSeparatorsPathString}")
   }
 
   override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {

--- a/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/ThumbnailStore.kt
@@ -22,7 +22,6 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import javax.imageio.ImageIO
-import kotlin.io.path.Path
 import kotlin.io.path.nameWithoutExtension
 import net.coobird.thumbnailator.Thumbnails
 import net.coobird.thumbnailator.resizers.configurations.ScalingMode
@@ -392,7 +391,7 @@ class ThumbnailStore(
    * Thumbnails are currently always JPEG images, so the file extension is always `.jpg`.
    */
   private fun getThumbnailUrl(photoUrl: URI, width: Int, height: Int): URI {
-    val originalPath = Path(photoUrl.path)
+    val originalPath = fileStore.getPath(photoUrl)
     val originalFilename = originalPath.fileName
     val originalBaseName = originalFilename.nameWithoutExtension
     val thumbPath =

--- a/src/test/kotlin/com/terraformation/backend/file/FileStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/FileStoreTest.kt
@@ -125,6 +125,14 @@ abstract class FileStoreTest {
     assertTrue(store.canAccept(url))
   }
 
+  @Test
+  fun `getPath and getUrl are idempotent`() {
+    val path = Path("abc/def")
+    val url = store.getUrl(path)
+
+    assertEquals(path, store.getPath(url), "Path from URL")
+  }
+
   protected abstract fun makeUrl(): URI
 
   protected abstract fun createFile(url: URI, content: ByteArray = Random.nextBytes(1))

--- a/src/test/kotlin/com/terraformation/backend/file/InMemoryFileStore.kt
+++ b/src/test/kotlin/com/terraformation/backend/file/InMemoryFileStore.kt
@@ -11,6 +11,7 @@ import java.nio.file.FileAlreadyExistsException
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.time.Instant
+import kotlin.io.path.Path
 import kotlin.io.path.relativeTo
 import org.junit.jupiter.api.fail
 import org.springframework.http.MediaType
@@ -103,6 +104,10 @@ class InMemoryFileStore(private val pathGenerator: PathGenerator? = null) :
   override fun getUrl(path: Path): URI {
     val relativePath = if (path.isAbsolute) path.relativeTo(path.root) else path
     return URI("file:///$relativePath")
+  }
+
+  override fun getPath(url: URI): Path {
+    return Path(url.path.trimStart('/'))
   }
 
   override fun newUrl(timestamp: Instant, category: String, contentType: String): URI {


### PR DESCRIPTION
To support multiple dev environments sharing a single S3 bucket without the risk
of name collisions, add a config option `terraware.s3KeyPrefix` to allow prefixing
generated S3 keys with the configured value. Each dev environment can set a unique
prefix, giving each one its own namespace in the bucket.