### PR TITLE
SW-7969 Make Mux asset statuses more generic

### DIFF
--- a/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
+++ b/jooq/src/main/kotlin/com/terraformation/backend/jooq/Config.kt
@@ -123,6 +123,7 @@ val ENUM_TABLES =
             ),
         "public" to
             listOf(
+                EnumTable("asset_statuses", isLocalizable = false),
                 EnumTable(
                     "chat_memory_message_types",
                     listOf("chat_memory_messages\\.message_type_id"),
@@ -141,7 +142,6 @@ val ENUM_TABLES =
                 EnumTable("growth_forms"),
                 EnumTable("land_use_model_types"),
                 EnumTable("managed_location_types", isLocalizable = false),
-                EnumTable("mux_asset_statuses", isLocalizable = false),
                 EnumTable(
                     "notification_criticalities",
                     listOf(".*\\.notification_criticality_id"),

--- a/src/main/kotlin/com/terraformation/backend/file/mux/MuxPayloads.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/mux/MuxPayloads.kt
@@ -2,8 +2,8 @@
 
 package com.terraformation.backend.file.mux
 
+import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileId
-import com.terraformation.backend.db.default_schema.MuxAssetStatus
 import java.net.URI
 import java.time.Instant
 
@@ -13,10 +13,10 @@ import java.time.Instant
  */
 
 @Suppress("EnumEntryName")
-enum class MuxApiStatus(val assetStatus: MuxAssetStatus) {
-  preparing(MuxAssetStatus.Preparing),
-  ready(MuxAssetStatus.Ready),
-  errored(MuxAssetStatus.Errored),
+enum class MuxApiStatus(val assetStatus: AssetStatus) {
+  preparing(AssetStatus.Preparing),
+  ready(AssetStatus.Ready),
+  errored(AssetStatus.Errored),
 }
 
 data class MuxVideoAssetMetaPayload(

--- a/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
+++ b/src/main/kotlin/com/terraformation/backend/file/mux/MuxService.kt
@@ -3,8 +3,8 @@ package com.terraformation.backend.file.mux
 import com.terraformation.backend.config.TerrawareServerConfig
 import com.terraformation.backend.customer.model.SystemUser
 import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.default_schema.AssetStatus
 import com.terraformation.backend.db.default_schema.FileId
-import com.terraformation.backend.db.default_schema.MuxAssetStatus
 import com.terraformation.backend.db.default_schema.tables.references.FILES
 import com.terraformation.backend.db.default_schema.tables.references.MUX_ASSETS
 import com.terraformation.backend.file.FileService
@@ -126,10 +126,10 @@ class MuxService(
       dslContext
           .insertInto(MUX_ASSETS)
           .set(ASSET_ID, response.data.id)
+          .set(ASSET_STATUS_ID, response.data.status.assetStatus)
           .set(CREATED_TIME, clock.instant())
           .set(ERROR_MESSAGE, response.data.errorMessage)
           .set(FILE_ID, fileId)
-          .set(MUX_ASSET_STATUS_ID, response.data.status.assetStatus)
           .set(PLAYBACK_ID, playbackId)
           .execute()
     }
@@ -235,7 +235,7 @@ class MuxService(
       } else {
         dslContext
             .update(MUX_ASSETS)
-            .set(MUX_ASSET_STATUS_ID, MuxAssetStatus.Ready)
+            .set(ASSET_STATUS_ID, AssetStatus.Ready)
             .set(READY_TIME, clock.instant())
             .where(FILE_ID.eq(fileId))
             .and(READY_TIME.isNull)
@@ -263,8 +263,8 @@ class MuxService(
       } else {
         dslContext
             .update(MUX_ASSETS)
+            .set(ASSET_STATUS_ID, AssetStatus.Errored)
             .set(ERROR_MESSAGE, errorMessage)
-            .set(MUX_ASSET_STATUS_ID, MuxAssetStatus.Errored)
             .where(FILE_ID.eq(fileId))
             .execute()
 

--- a/src/main/resources/db/migration/0400/V441__AssetStatuses.sql
+++ b/src/main/resources/db/migration/0400/V441__AssetStatuses.sql
@@ -1,2 +1,5 @@
 ALTER TABLE mux_asset_statuses RENAME TO asset_statuses;
+ALTER TABLE asset_statuses RENAME CONSTRAINT mux_asset_statuses_pkey TO asset_statuses_pkey;
+ALTER TABLE asset_statuses RENAME CONSTRAINT mux_asset_statuses_name_key TO asset_statuses_name_key;
+
 ALTER TABLE mux_assets RENAME COLUMN mux_asset_status_id TO asset_status_id;

--- a/src/main/resources/db/migration/0400/V441__AssetStatuses.sql
+++ b/src/main/resources/db/migration/0400/V441__AssetStatuses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mux_asset_statuses RENAME TO asset_statuses;
+ALTER TABLE mux_assets RENAME COLUMN mux_asset_status_id TO asset_status_id;

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -33,6 +33,8 @@ COMMENT ON COLUMN seedbank.accessions.total_withdrawn_weight_units_id IS 'Measur
 
 COMMENT ON TABLE app_versions IS 'Minimum and recommended versions for Terraware mobile apps.';
 
+COMMENT ON TABLE asset_statuses IS '(Enum) Possible statuses of externally-generated assets as they''re processed.';
+
 COMMENT ON TABLE automations IS 'Configuration of automatic processes run by the device manager.';
 
 COMMENT ON TABLE seedbank.bags IS 'Individual bags of seeds that are part of an accession. An accession can consist of multiple bags.';
@@ -128,8 +130,6 @@ COMMENT ON TABLE internal_tags IS 'Internal (non-user-facing) tags. Low-numbered
 COMMENT ON TABLE land_use_model_types IS '(Enum) Types of ways a project''s land can be used.';
 
 COMMENT ON TABLE managed_location_types IS '(Enum) Type of managed location for business analytics purposes.';
-
-COMMENT ON TABLE mux_asset_statuses IS '(Enum) Possible statuses of Mux assets as they''re processed.';
 
 COMMENT ON TABLE mux_assets IS 'Information about Mux (video streaming) assets associated with files.';
 COMMENT ON COLUMN mux_assets.asset_id IS 'ID of the Mux asset as a whole. Used when updating or deleting assets.';

--- a/src/main/resources/db/migration/R__TypeCodes.sql
+++ b/src/main/resources/db/migration/R__TypeCodes.sql
@@ -61,6 +61,12 @@ VALUES (1, 'Not Submitted'),
        (13, 'Not Eligible')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
+INSERT INTO asset_statuses (id, name)
+VALUES (1, 'Preparing'),
+       (2, 'Ready'),
+       (3, 'Errored')
+ON CONFLICT (id) DO UPDATE SET name = excluded.name;
+
 INSERT INTO nursery.batch_quantity_history_types (id, name)
 VALUES (1, 'Observed'),
        (2, 'Computed'),
@@ -314,12 +320,6 @@ VALUES (1, 'Activity'),
        (2, 'Output'),
        (3, 'Outcome'),
        (4, 'Impact')
-ON CONFLICT (id) DO UPDATE SET name = excluded.name;
-
-INSERT INTO mux_asset_statuses (id, name)
-VALUES (1, 'Preparing'),
-       (2, 'Ready'),
-       (3, 'Errored')
 ON CONFLICT (id) DO UPDATE SET name = excluded.name;
 
 INSERT INTO notification_criticalities (id, name)

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -265,6 +265,7 @@ class SchemaDocsGenerator : DatabaseTest() {
           "public" to
               mapOf(
                   "app_versions" to setOf(ALL, CUSTOMER),
+                  "asset_statuses" to setOf(ALL),
                   "automations" to setOf(ALL, DEVICE),
                   "chat_memory_conversations" to setOf(ALL, ACCELERATOR),
                   "chat_memory_message_types" to setOf(ALL, ACCELERATOR),
@@ -295,7 +296,6 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "internal_tags" to setOf(ALL, CUSTOMER),
                   "land_use_model_types" to setOf(ALL, ACCELERATOR, CUSTOMER),
                   "managed_location_types" to setOf(ALL, CUSTOMER),
-                  "mux_asset_statuses" to setOf(ALL),
                   "mux_assets" to setOf(ALL),
                   "species_native_categories" to setOf(ALL, SPECIES),
                   "notification_criticalities" to setOf(ALL, CUSTOMER),


### PR DESCRIPTION
We're adding a new processing pipeline for videos, and it will have the same
statuses (in progress, successful, failed) as Mux assets. Rename the
`mux_asset_statuses` table to `asset_statuses` so it won't be confusing to
reuse for non-Mux-related assets.