### PR TITLE
SW-7969 APIs for Gaussian splatting models

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.session:spring-session-jdbc")
 
+  implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.4.2"))
+  implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")
+
   implementation(platform("org.springframework.ai:spring-ai-bom:1.1.2"))
   implementation("org.springframework.ai:spring-ai-starter-model-openai")
   implementation("org.springframework.ai:spring-ai-starter-vector-store-pgvector")

--- a/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Annotations.kt
@@ -86,6 +86,15 @@ annotation class ApiResponse200(
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
+@ApiResponse(responseCode = "202")
+annotation class ApiResponse202(
+    @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
+    val description: String =
+        "The requested resource is not available yet, but should become available later."
+)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
 @ApiResponseSimpleError(responseCode = "400")
 annotation class ApiResponse400(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
@@ -138,6 +147,14 @@ annotation class ApiResponse413(
 annotation class ApiResponse415(
     @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
     val description: String = "The media type is not supported."
+)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@ApiResponseSimpleError(responseCode = "422")
+annotation class ApiResponse422(
+    @get:AliasFor(annotation = ApiResponse::class, attribute = "description")
+    val description: String = "The requested content could not be processed."
 )
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
+++ b/src/main/kotlin/com/terraformation/backend/config/TerrawareServerConfig.kt
@@ -124,6 +124,9 @@ class TerrawareServerConfig(
     val requestLog: RequestLogConfig = RequestLogConfig(),
     val report: ReportConfig = ReportConfig(),
 
+    /** Configures the 3D Gaussian splatting service. */
+    val splatter: SplatterConfig = SplatterConfig(),
+
     /** Terraware support email config */
     val support: SupportConfig = SupportConfig(),
 ) {
@@ -395,6 +398,26 @@ class TerrawareServerConfig(
                   tokenSecret == null)
       ) {
         throw IllegalArgumentException("Token and signing key are required for Mux")
+      }
+    }
+  }
+
+  class SplatterConfig(
+      val enabled: Boolean = false,
+      /**
+       * URL of SQS queue to send outgoing requests to. This should be the queue that the splatter
+       * service is listening to.
+       */
+      val requestQueueUrl: URI? = null,
+      /**
+       * URL of SQS queue where we will receive responses from the splatter service. This queue
+       * should not be shared across environments; each environment should have its own queue.
+       */
+      val responseQueueUrl: URI? = null,
+  ) {
+    init {
+      if (enabled && (requestQueueUrl == null || responseQueueUrl == null)) {
+        throw IllegalArgumentException("Request and response queue URLs are required for Splatter")
       }
     }
   }

--- a/src/main/kotlin/com/terraformation/backend/splat/Exceptions.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Exceptions.kt
@@ -1,0 +1,9 @@
+package com.terraformation.backend.splat
+
+import com.terraformation.backend.db.default_schema.FileId
+
+data class SplatGenerationFailedException(val fileId: FileId) :
+    Exception("Failed to generate splat for file $fileId")
+
+data class SplatNotReadyException(val fileId: FileId) :
+    Exception("Splat not ready for file $fileId")

--- a/src/main/kotlin/com/terraformation/backend/splat/Models.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/Models.kt
@@ -1,0 +1,26 @@
+package com.terraformation.backend.splat
+
+import com.terraformation.backend.db.default_schema.AssetStatus
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import org.jooq.Record
+
+data class ObservationSplatModel(
+    val assetStatus: AssetStatus,
+    val fileId: FileId,
+    val monitoringPlotId: MonitoringPlotId,
+    val observationId: ObservationId,
+) {
+  companion object {
+    fun of(record: Record) =
+        ObservationSplatModel(
+            assetStatus = record[SPLATS.ASSET_STATUS_ID]!!,
+            fileId = record[SPLATS.FILE_ID]!!,
+            monitoringPlotId = record[OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID]!!,
+            observationId = record[OBSERVATION_MEDIA_FILES.OBSERVATION_ID]!!,
+        )
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -1,0 +1,192 @@
+package com.terraformation.backend.splat
+
+import com.terraformation.backend.auth.currentUser
+import com.terraformation.backend.config.TerrawareServerConfig
+import com.terraformation.backend.customer.model.requirePermissions
+import com.terraformation.backend.db.FileNotFoundException
+import com.terraformation.backend.db.default_schema.AssetStatus
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.tables.references.FILES
+import com.terraformation.backend.db.default_schema.tables.references.SPLATS
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.db.tracking.tables.references.OBSERVATION_MEDIA_FILES
+import com.terraformation.backend.file.S3FileStore
+import com.terraformation.backend.file.SizedInputStream
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.splat.sqs.SplatterRequestFileLocation
+import com.terraformation.backend.splat.sqs.SplatterRequestMessage
+import io.awspring.cloud.sqs.operations.SqsTemplate
+import jakarta.inject.Named
+import java.time.InstantSource
+import kotlin.io.path.Path
+import kotlin.io.path.pathString
+import org.jooq.DSLContext
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.MediaType
+
+@ConditionalOnProperty("terraware.splatter.enabled")
+@Named
+class SplatService(
+    private val clock: InstantSource,
+    config: TerrawareServerConfig,
+    private val dslContext: DSLContext,
+    private val fileStore: S3FileStore,
+    private val sqsTemplate: SqsTemplate,
+) {
+  private val log = perClassLogger()
+
+  private val splatFileExtension = ".sog"
+  private val splatMimeType = MediaType.APPLICATION_OCTET_STREAM_VALUE
+
+  private val requestQueueUrl = requireNotNull(config.splatter.requestQueueUrl).toString()
+  private val responseQueueUrl = requireNotNull(config.splatter.responseQueueUrl)
+  private val s3BucketName = requireNotNull(config.s3BucketName)
+
+  fun listObservationSplats(
+      observationId: ObservationId,
+      monitoringPlotId: MonitoringPlotId? = null,
+      fileId: FileId? = null,
+  ): List<ObservationSplatModel> {
+    requirePermissions { readObservation(observationId) }
+
+    val conditions =
+        with(OBSERVATION_MEDIA_FILES) {
+          listOfNotNull(
+              OBSERVATION_ID.eq(observationId),
+              monitoringPlotId?.let { MONITORING_PLOT_ID.eq(monitoringPlotId) },
+              fileId?.let { FILE_ID.eq(fileId) },
+          )
+        }
+
+    return dslContext
+        .select(
+            OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID,
+            OBSERVATION_MEDIA_FILES.OBSERVATION_ID,
+            SPLATS.ASSET_STATUS_ID,
+            SPLATS.FILE_ID,
+        )
+        .from(OBSERVATION_MEDIA_FILES)
+        .join(SPLATS)
+        .on(OBSERVATION_MEDIA_FILES.FILE_ID.eq(SPLATS.FILE_ID))
+        .where(conditions)
+        .orderBy(OBSERVATION_MEDIA_FILES.MONITORING_PLOT_ID, OBSERVATION_MEDIA_FILES.FILE_ID)
+        .fetch { ObservationSplatModel.of(it) }
+  }
+
+  fun readObservationSplat(observationId: ObservationId, fileId: FileId): SizedInputStream {
+    ensureObservationFile(observationId, fileId)
+
+    return readSplat(fileId)
+  }
+
+  fun generateObservationSplat(observationId: ObservationId, fileId: FileId) {
+    ensureObservationFile(observationId, fileId)
+
+    generateSplat(fileId)
+  }
+
+  fun recordSplatError(fileId: FileId, errorMessage: String) {
+    log.error("Splat generation failed for file $fileId: $errorMessage")
+
+    with(SPLATS) {
+      dslContext
+          .update(SPLATS)
+          .set(ASSET_STATUS_ID, AssetStatus.Errored)
+          .set(ERROR_MESSAGE, errorMessage)
+          .where(FILE_ID.eq(fileId))
+          .execute()
+    }
+  }
+
+  fun recordSplatSuccess(fileId: FileId) {
+    log.info("Splat generation completed for file $fileId")
+
+    with(SPLATS) {
+      dslContext
+          .update(SPLATS)
+          .set(ASSET_STATUS_ID, AssetStatus.Ready)
+          .set(COMPLETED_TIME, clock.instant())
+          .where(FILE_ID.eq(fileId))
+          .execute()
+    }
+  }
+
+  private fun generateSplat(fileId: FileId) {
+    val videoUrl =
+        dslContext.fetchValue(FILES.STORAGE_URL, FILES.ID.eq(fileId))
+            ?: throw FileNotFoundException(fileId)
+    val videoKey = videoUrl.path.trimStart('/')
+    val videoPath = fileStore.getPath(videoUrl)
+    val splatPath = Path(videoPath.pathString.substringBeforeLast('.') + splatFileExtension)
+    val splatUrl = fileStore.getUrl(splatPath)
+    val splatKey = splatUrl.path.trimStart('/')
+
+    dslContext.transaction { _ ->
+      val rowsInserted =
+          with(SPLATS) {
+            dslContext
+                .insertInto(SPLATS)
+                .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+                .set(CREATED_BY, currentUser().userId)
+                .set(CREATED_TIME, clock.instant())
+                .set(FILE_ID, fileId)
+                .set(SPLAT_STORAGE_URL, splatUrl)
+                .onConflictDoNothing()
+                .execute()
+          }
+
+      if (rowsInserted == 1) {
+        val requestMessage =
+            SplatterRequestMessage(
+                fileId.toString(),
+                responseQueueUrl,
+                SplatterRequestFileLocation(
+                    s3BucketName,
+                    videoKey,
+                ),
+                SplatterRequestFileLocation(
+                    s3BucketName,
+                    splatKey,
+                ),
+            )
+
+        sqsTemplate.send(requestQueueUrl, requestMessage)
+
+        log.info("Requested splat generation for file $fileId")
+      } else {
+        log.info(
+            "Splat record already exists for file $fileId; ignoring additional generation request"
+        )
+      }
+    }
+  }
+
+  private fun readSplat(fileId: FileId): SizedInputStream {
+    val splatsRecord =
+        dslContext.fetchOne(SPLATS, SPLATS.FILE_ID.eq(fileId))
+            ?: throw FileNotFoundException(fileId)
+
+    return when (splatsRecord.assetStatusId!!) {
+      AssetStatus.Errored -> throw SplatGenerationFailedException(fileId)
+      AssetStatus.Preparing -> throw SplatNotReadyException(fileId)
+      AssetStatus.Ready ->
+          fileStore.read(splatsRecord.splatStorageUrl!!).withContentType(splatMimeType)
+    }
+  }
+
+  private fun ensureObservationFile(observationId: ObservationId, fileId: FileId) {
+    requirePermissions { readObservation(observationId) }
+
+    val associationExists =
+        dslContext.fetchExists(
+            OBSERVATION_MEDIA_FILES,
+            OBSERVATION_MEDIA_FILES.OBSERVATION_ID.eq(observationId)
+                .and(OBSERVATION_MEDIA_FILES.FILE_ID.eq(fileId)),
+        )
+
+    if (!associationExists) {
+      throw FileNotFoundException(fileId)
+    }
+  }
+}

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -93,6 +93,7 @@ class SplatService(
       dslContext
           .update(SPLATS)
           .set(ASSET_STATUS_ID, AssetStatus.Errored)
+          .set(COMPLETED_TIME, clock.instant())
           .set(ERROR_MESSAGE, errorMessage)
           .where(FILE_ID.eq(fileId))
           .execute()

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -20,7 +20,7 @@ import com.terraformation.backend.splat.SplatNotReadyException
 import com.terraformation.backend.splat.SplatService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-@ConditionalOnBean(SplatService::class)
+@ConditionalOnProperty("terraware.splatter.enabled")
 @RequestMapping
 @RestController
 @TrackingEndpoint

--- a/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/api/SplatsController.kt
@@ -1,0 +1,126 @@
+package com.terraformation.backend.splat.api
+
+import com.terraformation.backend.api.ApiResponse200
+import com.terraformation.backend.api.ApiResponse202
+import com.terraformation.backend.api.ApiResponse404
+import com.terraformation.backend.api.ApiResponse422
+import com.terraformation.backend.api.ErrorDetails
+import com.terraformation.backend.api.SimpleErrorResponsePayload
+import com.terraformation.backend.api.SimpleSuccessResponsePayload
+import com.terraformation.backend.api.SuccessResponsePayload
+import com.terraformation.backend.api.TrackingEndpoint
+import com.terraformation.backend.api.toResponseEntity
+import com.terraformation.backend.db.default_schema.AssetStatus
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.tracking.MonitoringPlotId
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.splat.ObservationSplatModel
+import com.terraformation.backend.splat.SplatGenerationFailedException
+import com.terraformation.backend.splat.SplatNotReadyException
+import com.terraformation.backend.splat.SplatService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@ConditionalOnBean(SplatService::class)
+@RequestMapping
+@RestController
+@TrackingEndpoint
+class SplatsController(
+    private val splatService: SplatService,
+) {
+  @ApiResponse200
+  @ApiResponse404("The observation does not exist.")
+  @GetMapping("/api/v1/tracking/observations/{observationId}/splats")
+  @Operation(summary = "Gets information about the 3D Gaussian splat models from an observation.")
+  fun listObservationSplats(
+      @PathVariable observationId: ObservationId,
+      @Parameter(description = "If present, only list splats for this monitoring plot.")
+      @RequestParam
+      monitoringPlotId: MonitoringPlotId?,
+      @Parameter(
+          description = "If present, only return information about the splat for this video file."
+      )
+      @RequestParam
+      fileId: FileId?,
+  ): ListObservationSplatsResponsePayload {
+    val models = splatService.listObservationSplats(observationId, monitoringPlotId, fileId)
+
+    return ListObservationSplatsResponsePayload(models.map { ObservationSplatPayload.of(it) })
+  }
+
+  @ApiResponse200
+  @ApiResponse202("The video is still being processed and the model is not ready yet.")
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a video with the requested ID."
+  )
+  @ApiResponse422("The system was unable to generate a splat from the requested file.")
+  @GetMapping("/api/v1/tracking/observations/{observationId}/splats/{fileId}")
+  @Operation(
+      summary = "Downloads a 3D model of a Gaussian splat from an observation video.",
+  )
+  fun getObservationSplatFile(
+      @PathVariable observationId: ObservationId,
+      @PathVariable fileId: FileId,
+  ): ResponseEntity<*> {
+    return try {
+      splatService.readObservationSplat(observationId, fileId).toResponseEntity()
+    } catch (_: SplatGenerationFailedException) {
+      ResponseEntity.unprocessableEntity()
+          .body(SimpleErrorResponsePayload(ErrorDetails("Splat generation failed.")))
+    } catch (_: SplatNotReadyException) {
+      ResponseEntity.accepted()
+          .body(SimpleErrorResponsePayload(ErrorDetails("Splat is not ready yet.")))
+    }
+  }
+
+  @ApiResponse200
+  @ApiResponse404(
+      "The plot observation does not exist, or does not have a video with the requested ID."
+  )
+  @PostMapping("/api/v1/tracking/observations/{observationId}/splats")
+  @Operation(
+      summary =
+          "Initiates the generation of a 3D model of a Gaussian splat from an observation video.",
+      description = "If the video was already being processed, returns a success response.",
+  )
+  fun generateObservationSplatFile(
+      @PathVariable observationId: ObservationId,
+      @RequestBody payload: GenerateSplatRequestPayload,
+  ): SimpleSuccessResponsePayload {
+    splatService.generateObservationSplat(observationId, payload.fileId)
+
+    return SimpleSuccessResponsePayload()
+  }
+}
+
+data class ObservationSplatPayload(
+    val fileId: FileId,
+    val monitoringPlotId: MonitoringPlotId,
+    val status: AssetStatus,
+) {
+  companion object {
+    fun of(model: ObservationSplatModel) =
+        ObservationSplatPayload(
+            fileId = model.fileId,
+            monitoringPlotId = model.monitoringPlotId,
+            status = model.assetStatus,
+        )
+  }
+}
+
+data class GenerateSplatRequestPayload(
+    val fileId: FileId,
+)
+
+data class ListObservationSplatsResponsePayload(
+    val splats: List<ObservationSplatPayload>,
+) : SuccessResponsePayload

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
@@ -1,0 +1,40 @@
+package com.terraformation.backend.splat.sqs
+
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.log.perClassLogger
+import com.terraformation.backend.splat.SplatService
+import io.awspring.cloud.sqs.annotation.SqsListener
+import jakarta.inject.Named
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+
+@ConditionalOnBean(SplatService::class)
+@Named
+class SplatsSqsListener(private val splatService: SplatService) {
+  private val log = perClassLogger()
+
+  @SqsListener($$"${terraware.splatter.response-queue-url}")
+  fun receiveSplatterResponse(payload: SplatterResponsePayload) {
+    log.info("Got response from Splatter service: $payload")
+
+    if (payload.success) {
+      splatService.recordSplatSuccess(payload.jobId)
+    } else {
+      splatService.recordSplatError(
+          payload.jobId,
+          payload.errorMessage ?: "No error message received",
+      )
+    }
+  }
+}
+
+data class SplatterResponseOutputPayload(
+    val bucket: String,
+    val key: String,
+)
+
+data class SplatterResponsePayload(
+    val errorMessage: String?,
+    val jobId: FileId,
+    val output: SplatterResponseOutputPayload?,
+    val success: Boolean,
+)

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatsSqsListener.kt
@@ -5,9 +5,9 @@ import com.terraformation.backend.log.perClassLogger
 import com.terraformation.backend.splat.SplatService
 import io.awspring.cloud.sqs.annotation.SqsListener
 import jakarta.inject.Named
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
-@ConditionalOnBean(SplatService::class)
+@ConditionalOnProperty("terraware.splatter.enabled")
 @Named
 class SplatsSqsListener(private val splatService: SplatService) {
   private val log = perClassLogger()

--- a/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/sqs/SplatterRequestMessage.kt
@@ -1,0 +1,16 @@
+package com.terraformation.backend.splat.sqs
+
+import java.net.URI
+
+data class SplatterRequestFileLocation(
+    val bucket: String,
+    val key: String,
+)
+
+data class SplatterRequestMessage(
+    val jobId: String,
+    val responseQueueUrl: URI,
+    val input: SplatterRequestFileLocation,
+    val output: SplatterRequestFileLocation,
+    val args: List<String>? = null,
+)

--- a/src/main/resources/application-default.yaml
+++ b/src/main/resources/application-default.yaml
@@ -17,6 +17,13 @@ terraware:
     email-regex: ".*"
 
 spring:
+  cloud:
+    aws:
+      sqs:
+        listener:
+          # Use a short poll timeout in dev environments because a long timeout makes server
+          # shutdown take longer (it waits for the current poll request to time out).
+          poll-timeout: "PT1S"
   flyway:
     # During development, it is convenient to temporarily add a repeatable migration and work on it
     # until it's correct, then make it a versioned migration. By default, Flyway would bomb out due

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -143,6 +143,7 @@ springdoc:
     - "com.terraformation.backend.search.api"
     - "com.terraformation.backend.seedbank.api"
     - "com.terraformation.backend.species.api"
+    - "com.terraformation.backend.splat.api"
     - "com.terraformation.backend.support.api"
     - "com.terraformation.backend.time.api"
     - "com.terraformation.backend.tracking.api"

--- a/src/main/resources/db/migration/0400/V442__Splats.sql
+++ b/src/main/resources/db/migration/0400/V442__Splats.sql
@@ -1,0 +1,9 @@
+CREATE TABLE splats (
+    file_id BIGINT PRIMARY KEY REFERENCES files,
+    created_by BIGINT NOT NULL REFERENCES users,
+    created_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    asset_status_id INTEGER NOT NULL REFERENCES asset_statuses,
+    completed_time TIMESTAMP WITH TIME ZONE,
+    splat_storage_url TEXT,
+    error_message TEXT
+);

--- a/src/main/resources/db/migration/R__Comments.sql
+++ b/src/main/resources/db/migration/R__Comments.sql
@@ -217,6 +217,8 @@ COMMENT ON TABLE species_problem_types IS '(Enum) Specific types of problems tha
 
 COMMENT ON TABLE species_problems IS 'Problems found in species data. Rows are deleted from this table when the problem is marked as ignored by the user or the user accepts the suggested fix.';
 
+COMMENT ON TABLE splats IS 'Information about 3D Gaussian splatting models generated from video files.';
+
 COMMENT ON TABLE spring_session IS 'Active login sessions. Used by Spring Session, not the application.';
 
 COMMENT ON TABLE spring_session_attributes IS 'Data associated with a login session. Used by Spring Session, not the application.';

--- a/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
+++ b/src/test/kotlin/com/terraformation/backend/db/SchemaDocsGenerator.kt
@@ -330,6 +330,7 @@ class SchemaDocsGenerator : DatabaseTest() {
                   "species_problem_types" to setOf(ALL, SPECIES),
                   "species_problems" to setOf(ALL, SPECIES),
                   "species_successional_groups" to setOf(ALL, SPECIES),
+                  "splats" to setOf(ALL),
                   "sub_locations" to setOf(ALL, SEEDBANK),
                   "successional_groups" to setOf(ALL, SPECIES),
                   "test_clock" to setOf(ALL),


### PR DESCRIPTION
Add three new endpoints for generating 3D models from observation plot videos using
3D Gaussian splatting. We refer to these models as "splats."

`POST /api/v1/tracking/observations/{observationId}/splats` starts generating a
splat for a video file in an observation. The request body contains the file ID.

`GET /api/v1/tracking/observations/{observationId}/splats` lists the splats for
an observation. It takes optional query-string parameters to limit the results
to a particular monitoring plot and/or a specific video file.

`GET /api/v1/tracking/observations/{observationId}/splats/{fileId}` downloads
the splat for a given video file, if any.

For local dev/testing, this requires some infrastructure/setup:

- You need to be using S3 for photo/file storage. It won't work if you're using
  the local filesystem.
- The S3 bucket you're using needs to be accessible by the splatter service.
- You need permission to send messages to the splatter service's request queue.
- You need a response queue for your environment.
- The splatter service needs permission to send messages to your response queue.

The configuration in `application-dev.yaml` will look like

    terraware:
      s3BucketName: "your s3 bucket"
      # And maybe s3KeyPrefix, if you're using a shared S3 bucket

      splatter:
        enabled: true
        requestQueueUrl: "SQS URL of splatter request queue"
        responseQueueUrl: "SQS URL of your environment's response queue"