### PR TITLE
Disable SQS integration by default

### DIFF
--- a/src/main/resources/application-aws.yaml
+++ b/src/main/resources/application-aws.yaml
@@ -1,6 +1,10 @@
 # Configuration that's only used by the "aws" profile (prod and staging environments).
 
 spring:
+  cloud:
+    aws:
+      sqs:
+        enabled: true
   datasource:
     hikari:
       data-source-properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,6 +49,11 @@ spring:
       - org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration
       - org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreAutoConfiguration
 
+  cloud:
+    aws:
+      sqs:
+        enabled: false
+
   datasource:
     url: "${DATABASE_URL:jdbc:postgresql://localhost:5432/terraware}"
     username: "${DATABASE_USER:${USER:postgres}}"


### PR DESCRIPTION
If an environment isn't using the splatter integration, we don't need the SQS
integration, and the attempt to initialize it was causing the server to fail
to start if there weren't any AWS credentials configured. Disable SQS by
default, but enable it for AWS deployments.

To test the splatter integration, users will need to enable SQS in their
`application-dev.yaml` files or by setting `SPRING_CLOUD_AWS_SQS_ENABLED=true`.