### PR TITLE
SW-7997 Fix NPE in prod around null survival rates

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
+++ b/src/main/kotlin/com/terraformation/backend/accelerator/db/ReportStore.kt
@@ -1579,7 +1579,7 @@ class ReportStore(
                     .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
                     .and(COLLECTED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
             )
-            .convertFrom { it.toInt() }
+            .convertFrom { it?.toInt() }
       }
 
   private val withdrawnSeedlingsField =
@@ -1613,7 +1613,7 @@ class ReportStore(
                     .where(PROJECT_ID.eq(REPORTS.PROJECT_ID))
                     .and(ADDED_DATE.between(REPORTS.START_DATE, REPORTS.END_DATE))
             )
-            .convertFrom { it.toInt() }
+            .convertFrom { it?.toInt() }
       }
 
   // For species, we total up the number of trees planted per species, and take only ones that are
@@ -1667,7 +1667,7 @@ class ReportStore(
                     .and(WITHDRAWAL_SUMMARIES.PURPOSE_ID.notEqual(WithdrawalPurpose.Undo))
                     .and(WITHDRAWAL_SUMMARIES.UNDONE_BY_WITHDRAWAL_ID.isNull)
             )
-            .convertFrom { it.toInt() }
+            .convertFrom { it?.toInt() }
       }
 
   private val systemTerrawareValueField =

--- a/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/accelerator/db/ReportStoreTest.kt
@@ -1169,6 +1169,15 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
           modifiedBy = user.userId,
       )
 
+      insertReportSystemMetric(
+          reportId = reportId,
+          metric = SystemMetric.SurvivalRate,
+          systemValue = null,
+          systemTime = Instant.ofEpochSecond(9000),
+          modifiedTime = Instant.ofEpochSecond(700),
+          modifiedBy = user.userId,
+      )
+
       // These are ordered by reference.
       val systemMetrics =
           listOf(
@@ -1222,7 +1231,13 @@ class ReportStoreTest : DatabaseTest(), RunsAsDatabaseUser {
               ),
               ReportSystemMetricModel(
                   metric = SystemMetric.SurvivalRate,
-                  entry = ReportSystemMetricEntryModel(systemValue = null),
+                  entry =
+                      ReportSystemMetricEntryModel(
+                          systemValue = null,
+                          systemTime = Instant.ofEpochSecond(9000),
+                          modifiedTime = Instant.ofEpochSecond(700),
+                          modifiedBy = user.userId,
+                      ),
               ),
           )
 


### PR DESCRIPTION
Commits [f6364eda](https://github.com/terraware/terraware-server/commit/f6364eda) and [1c8bfaf1](https://github.com/terraware/terraware-server/commit/1c8bfaf1) allowed for report system metrics to have a null `system_value` which was needed to accurately show survival rates in reports. It updated the check to use the `system_time` for null checking and if it needed to be calculated.
This was then tested with reports that didn't have a survival rate system metric, but was not tested for reports that had this system metric but had a null value and a non-null `system_time`.

Specifically, the issue is from the case statements for the various system metric types. When using a case statement, even if only one of the cases is nullable, jOOQ doesn’t understand this and requires that all of them be able to handle null. In this situation, the cases for non-survival rate system metrics required that their `convertFrom` handle null values, because survival rate could be null.

was:
`.convertFrom { it.toInt() }`
needed:
`.convertFrom { it?.toInt() }`

This only showed up when a  survival rate system metric had a null `system_value` and a non-null `system_time`.

Fix the `convertFrom`s in `ReportStore`.
Add tests for survival rate with a non-null `system_time` and null `system_value`.