### PR TITLE
Add admin UI page for manual splat generation

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminController.kt
@@ -103,6 +103,7 @@ class AdminController(
     model.addAttribute("canUpdateGlobalRoles", currentUser().canUpdateGlobalRoles())
     model.addAttribute("organizations", organizations)
     model.addAttribute("roles", Role.entries.map { it to it.getDisplayName(Locale.ENGLISH) })
+    model.addAttribute("splatterEnabled", config.splatter.enabled)
 
     return "/admin/index"
   }

--- a/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
+++ b/src/main/kotlin/com/terraformation/backend/admin/AdminSplatsController.kt
@@ -1,0 +1,67 @@
+package com.terraformation.backend.admin
+
+import com.terraformation.backend.api.RequireGlobalRole
+import com.terraformation.backend.db.default_schema.FileId
+import com.terraformation.backend.db.default_schema.GlobalRole
+import com.terraformation.backend.db.tracking.ObservationId
+import com.terraformation.backend.splat.SplatService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Controller
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+@ConditionalOnProperty("terraware.splatter.enabled")
+@Controller
+@RequestMapping("/admin")
+@RequireGlobalRole([GlobalRole.SuperAdmin])
+@Validated
+class AdminSplatsController(
+    private val splatService: SplatService,
+) {
+  @GetMapping("/splats")
+  fun splatsHome(): String {
+    return "/admin/splats"
+  }
+
+  @PostMapping("/splats/process")
+  fun processSplat(
+      @RequestParam observationId: ObservationId,
+      @RequestParam fileId: FileId,
+      @RequestParam dataFactor: Int?,
+      @RequestParam fps: Int?,
+      @RequestParam keepPercent: Double?,
+      @RequestParam maxSize: Int?,
+      @RequestParam maxSteps: Int?,
+      @RequestParam ssimLambda: Double?,
+      @RequestParam otherArgs: String?,
+      redirectAttributes: RedirectAttributes,
+  ): String {
+    try {
+      val args =
+          listOfNotNull(
+                  dataFactor?.let { listOf("--data-factor", "$dataFactor") },
+                  fps?.let { listOf("--fps", "$fps") },
+                  keepPercent?.let { listOf("--keep-percent", "${keepPercent / 100.0}") },
+                  maxSize?.let { listOf("--max-size", "$maxSize") },
+                  maxSteps?.let { listOf("--max-steps", "$maxSteps") },
+                  ssimLambda?.let { listOf("--ssim-lambda", "$ssimLambda") },
+                  otherArgs?.ifEmpty { null }?.split(" "),
+              )
+              .flatten()
+              .ifEmpty { null }
+
+      splatService.generateObservationSplat(observationId, fileId, true, args)
+      redirectAttributes.successMessage = "Sent request to splatter service."
+    } catch (e: Exception) {
+      redirectAttributes.failureMessage = "Splat generation failed: ${e.message}"
+    }
+
+    return redirectToSplatsHome()
+  }
+
+  private fun redirectToSplatsHome() = "redirect:/admin/splats"
+}

--- a/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
+++ b/src/main/kotlin/com/terraformation/backend/splat/SplatService.kt
@@ -146,6 +146,16 @@ class SplatService(
                 .execute()
           }
 
+      if (rowsInserted == 0 && force) {
+        with(SPLATS) {
+          dslContext
+              .update(SPLATS)
+              .set(ASSET_STATUS_ID, AssetStatus.Preparing)
+              .where(FILE_ID.eq(fileId))
+              .execute()
+        }
+      }
+
       if (rowsInserted == 1 || force) {
         val requestMessage =
             SplatterRequestMessage(

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -116,6 +116,10 @@
     <p>
         <a href="/admin/eventLog">Event log</a>
     </p>
+
+    <p th:if="${splatterEnabled}">
+        <a href="/admin/splats">Splats</a>
+    </p>
 </details>
 
 <details id="organizationManagement" class="section">

--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -1,0 +1,107 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{/admin/header :: head}"/>
+<body>
+
+<span th:replace="~{/admin/header :: top}"/>
+
+<a href="/admin/">Home</a>
+
+<h2>Splats</h2>
+
+<p>
+    Here you can send a request to the splatter service to generate a 3D Gaussian splatting model
+    from an already-uploaded observation video. You can adjust various processing settings.
+</p>
+
+<form method="POST" action="/admin/splats/process">
+    <table>
+        <tr>
+            <th>Setting</th>
+            <th/>
+            <th>Default</th>
+            <th>Explanation</th>
+        </tr>
+        <tr>
+            <td>Observation&nbsp;ID</td>
+            <td><input type="text" size="8" name="observationId" required/></td>
+            <td colspan="2"/>
+        </tr>
+        <tr>
+            <td>File ID</td>
+            <td><input type="text" size="8" name="fileId" required/></td>
+            <td colspan="2"/>
+        </tr>
+        <tr>
+            <td>Data Factor</td>
+            <td><input type="text" size="8" name="dataFactor"/></td>
+            <td>1</td>
+            <td>
+                Downscale frames by this factor during model training. You will probably want
+                to adjust Max Size rather than this.
+            </td>
+        </tr>
+        <tr>
+            <td>FPS</td>
+            <td><input type="text" size="8" name="fps"/></td>
+            <td>3</td>
+            <td>
+                Frames per second to extract from the video.
+            </td>
+        </tr>
+        <tr>
+            <td>Keep %</td>
+            <td><input type="text" size="8" name="keepPercent"/></td>
+            <td>90</td>
+            <td>
+                Percentage of frames to keep after checking for blurriness. If this is 90, the
+                blurriest 10% of frames will be dropped.
+            </td>
+        </tr>
+        <tr>
+            <td>Max Size</td>
+            <td><input type="text" size="8" name="maxSize"/></td>
+            <td>1600</td>
+            <td>
+                Downscale video frames to fit within a square this many pixels tall and wide.
+            </td>
+        </tr>
+        <tr>
+            <td>Max Steps</td>
+            <td><input type="text" size="8" name="maxSteps"/></td>
+            <td>30000</td>
+            <td>
+                Number of training steps to run.
+            </td>
+        </tr>
+        <tr>
+            <td>SSIM Lambda</td>
+            <td><input type="text" size="8" name="maxSteps"/></td>
+            <td>0.1</td>
+            <td>
+                Controls how much the training loss emphasizes structural similarity (SSIM) versus
+                raw pixel accuracy. Higher values tend to produce smoother, more visually
+                consistent results, while lower values prioritize sharper pixel-level detail.
+                Higher values also tend to produce larger model files.
+            </td>
+        </tr>
+        <tr>
+            <td>Other Args</td>
+            <td><input type="text" name="otherArgs"/></td>
+            <td></td>
+            <td>
+                Additional space-delimited arguments to pass to processing script, in case the
+                script is updated to support more options but the new options haven't been added
+                to this form yet.
+            </td>
+        </tr>
+
+        <tr>
+            <td/>
+            <td><input type="submit" value="Process Video" /></td>
+            <td colspan="2"/>
+        </tr>
+    </table>
+</form>
+
+</body>

--- a/src/main/resources/templates/admin/splats.html
+++ b/src/main/resources/templates/admin/splats.html
@@ -76,7 +76,7 @@
         </tr>
         <tr>
             <td>SSIM Lambda</td>
-            <td><input type="text" size="8" name="maxSteps"/></td>
+            <td><input type="text" size="8" name="ssimLambda"/></td>
             <td>0.1</td>
             <td>
                 Controls how much the training loss emphasizes structural similarity (SSIM) versus


### PR DESCRIPTION
To make it easier for people to test different combinations of settings
when generating 3D Gaussian splatting models from videos, add an admin UI
page that exposes all the processing script's parameters and allows the
same video to be processed multiple times.