### PR TITLE
SW-8015 Support mobile app background video uploads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
   implementation("jakarta.inject:jakarta.inject-api:2.0.1")
   implementation("jakarta.ws.rs:jakarta.ws.rs-api:4.0.0")
   implementation("net.coobird:thumbnailator:0.4.21")
+  implementation("org.apache.commons:commons-fileupload2-jakarta-servlet6:2.0.0-M4")
   implementation("org.apache.tika:tika-core:3.2.3")
   implementation("org.bouncycastle:bcpkix-jdk18on:1.83")
   implementation("org.commonmark:commonmark:0.27.1")

--- a/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
+++ b/src/main/kotlin/com/terraformation/backend/api/Extensions.kt
@@ -97,10 +97,11 @@ fun FileItemInput.getPlainContentType(allowedTypes: Set<MediaType>): String {
  * the content type, if any.
  */
 fun MultipartFile.getFilename(defaultBaseName: String = "upload"): String {
-  return originalFilename
+  return originalFilename?.ifEmpty { null }
       ?: run {
         val contentType = getPlainContentType() ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
-        val extension = MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType) ?: ""
+        val extension =
+            MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension ?: ""
         defaultBaseName + extension
       }
 }
@@ -111,11 +112,12 @@ fun MultipartFile.getFilename(defaultBaseName: String = "upload"): String {
  * the content type, if any.
  */
 fun FileItemInput.getFilename(defaultBaseName: String = "upload"): String {
-  return name
+  return name?.ifEmpty { null }
       ?: run {
         val contentType =
             getPlainContentType(contentType) ?: MediaType.APPLICATION_OCTET_STREAM_VALUE
-        val extension = MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType) ?: ""
+        val extension =
+            MimeTypes.getDefaultMimeTypes().getRegisteredMimeType(contentType)?.extension ?: ""
         defaultBaseName + extension
       }
 }

--- a/src/test/kotlin/com/terraformation/backend/api/ApiExtensionsTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/api/ApiExtensionsTest.kt
@@ -1,0 +1,190 @@
+package com.terraformation.backend.api
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.NotSupportedException
+import org.apache.commons.fileupload2.core.FileItemInput
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.MediaType
+import org.springframework.mock.web.MockMultipartFile
+
+class ApiExtensionsTest {
+  @Nested
+  inner class MultipartFileGetPlainContentType {
+    @Test
+    fun `returns content type without extended information`() {
+      val file = mockMultipartFile(contentType = "text/plain;charset=UTF-8")
+      assertEquals("text/plain", file.getPlainContentType())
+    }
+
+    @Test
+    fun `returns null if content type is null`() {
+      val file = mockMultipartFile(contentType = null)
+      assertEquals(null, file.getPlainContentType())
+    }
+
+    @Test
+    fun `lowercases content type`() {
+      val file = mockMultipartFile(contentType = "TEXT/PLAIN")
+      assertEquals("text/plain", file.getPlainContentType())
+    }
+
+    @Test
+    fun `returns content type if it matches allowed types`() {
+      val file = mockMultipartFile(contentType = "text/plain;charset=UTF-8")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
+
+      assertEquals("text/plain", file.getPlainContentType(allowedTypes))
+    }
+
+    @Test
+    fun `returns content type if wildcard matches allowed types`() {
+      val file = mockMultipartFile(contentType = "image/jpeg")
+      val allowedTypes = setOf(MediaType.parseMediaType("image/*"))
+
+      assertEquals("image/jpeg", file.getPlainContentType(allowedTypes))
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type not in allowed types`() {
+      val file = mockMultipartFile(contentType = "application/octet-stream")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
+
+      assertThrows(NotSupportedException::class.java) { file.getPlainContentType(allowedTypes) }
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type is null`() {
+      val file = mockMultipartFile(contentType = null)
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
+
+      assertThrows<NotSupportedException> { file.getPlainContentType(allowedTypes) }
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type is invalid`() {
+      val file = mockMultipartFile(contentType = "invalid-content-type")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
+
+      assertThrows<NotSupportedException> { file.getPlainContentType(allowedTypes) }
+    }
+  }
+
+  @Nested
+  inner class MultipartFileGetFilename {
+    @Test
+    fun `returns original filename when present`() {
+      val file = mockMultipartFile(originalFilename = "document.pdf")
+      assertEquals("document.pdf", file.getFilename())
+    }
+
+    @Test
+    fun `constructs filename when original filename is missing`() {
+      val file = mockMultipartFile(originalFilename = null, contentType = "application/json")
+      assertEquals("data.json", file.getFilename("data"))
+    }
+
+    @Test
+    fun `constructs filename with no extension when content type is unknown`() {
+      val file = mockMultipartFile(originalFilename = null, contentType = "application/x-unknown")
+      assertEquals("upload", file.getFilename())
+    }
+
+    @Test
+    fun `constructs filename with octet-stream extension when content type is null`() {
+      val file = mockMultipartFile(originalFilename = null, contentType = null)
+      assertEquals("upload.bin", file.getFilename())
+    }
+  }
+
+  @Nested
+  inner class FileItemInputGetPlainContentType {
+    @Test
+    fun `returns content type if it matches allowed types`() {
+      val fileItem = mockFileItemInput(contentType = "text/plain;charset=UTF-8")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
+
+      assertEquals("text/plain", fileItem.getPlainContentType(allowedTypes))
+    }
+
+    @Test
+    fun `returns content type if wildcard matches allowed types`() {
+      val fileItem = mockFileItemInput(contentType = "image/png")
+      val allowedTypes = setOf(MediaType.parseMediaType("image/*"))
+
+      assertEquals("image/png", fileItem.getPlainContentType(allowedTypes))
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type not in allowed types`() {
+      val fileItem = mockFileItemInput(contentType = "application/octet-stream")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
+
+      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type is null`() {
+      val fileItem = mockFileItemInput(contentType = null)
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
+
+      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
+    }
+
+    @Test
+    fun `throws NotSupportedException if content type is invalid`() {
+      val fileItem = mockFileItemInput(contentType = "invalid-content-type")
+      val allowedTypes = setOf(MediaType.TEXT_PLAIN)
+
+      assertThrows<NotSupportedException> { fileItem.getPlainContentType(allowedTypes) }
+    }
+  }
+
+  @Nested
+  inner class FileItemInputGetFilename {
+    @Test
+    fun `returns name when present`() {
+      val fileItem = mockFileItemInput(originalFilename = "document.pdf")
+      assertEquals("document.pdf", fileItem.getFilename())
+    }
+
+    @Test
+    fun `constructs filename when name is missing`() {
+      val fileItem = mockFileItemInput(originalFilename = null, contentType = "application/json")
+      assertEquals("data.json", fileItem.getFilename("data"))
+    }
+
+    @Test
+    fun `constructs filename with no extension when content type is unknown`() {
+      val fileItem =
+          mockFileItemInput(originalFilename = null, contentType = "application/x-unknown")
+      assertEquals("upload", fileItem.getFilename())
+    }
+
+    @Test
+    fun `constructs filename with octet-stream when content type is null`() {
+      val fileItem = mockFileItemInput(originalFilename = null, contentType = null)
+      assertEquals("upload.bin", fileItem.getFilename())
+    }
+  }
+
+  fun mockFileItemInput(
+      originalFilename: String? = "test.bin",
+      contentType: String? = "image/png",
+  ): FileItemInput {
+    val item = mockk<FileItemInput>()
+    every { item.contentType } returns contentType
+    every { item.name } returns originalFilename
+    return item
+  }
+
+  fun mockMultipartFile(
+      name: String = "file",
+      originalFilename: String? = "test.bin",
+      contentType: String? = "image/jpeg",
+  ) = MockMultipartFile(name, originalFilename, contentType, "content".toByteArray())
+}


### PR DESCRIPTION
There is a limitation on background file uploads in the mobile app: they are
always submitted with a content type of `application/octet-stream` even though
their request bodies are multipart form data. This prevents the default request
handling logic from parsing the request body.

Add an alternate version of the observation media upload endpoint that accepts
these requests.