### PR TITLE
SW-7931 Add phase to Projects search table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/ProjectsTable.kt
@@ -88,6 +88,9 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
     }
   }
 
+  private val phaseField =
+      DSL.field(DSL.select(COHORTS.PHASE_ID).from(COHORTS).where(COHORTS.ID.eq(PROJECTS.COHORT_ID)))
+
   override val fields: List<SearchField> =
       listOf(
           timestampField("createdTime", PROJECTS.CREATED_TIME),
@@ -95,6 +98,7 @@ class ProjectsTable(tables: SearchTables) : SearchTable() {
           idWrapperField("id", PROJECTS.ID) { ProjectId(it) },
           timestampField("modifiedTime", PROJECTS.MODIFIED_TIME),
           textField("name", PROJECTS.NAME),
+          enumField("phase", phaseField),
       )
 
   override fun conditionForVisibility(): Condition {

--- a/src/main/resources/i18n/Messages_en.properties
+++ b/src/main/resources/i18n/Messages_en.properties
@@ -879,6 +879,7 @@ search.projects.description=Project description
 search.projects.id=Project ID
 search.projects.modifiedTime=Project modified time
 search.projects.name=Project name
+search.projects.phase=Phase
 search.recordedTrees.description=Description/Notes
 search.recordedTrees.diameterAtBreastHeight=DBH (cm)
 search.recordedTrees.growthForm=Growth form

--- a/src/main/resources/i18n/Messages_es.properties
+++ b/src/main/resources/i18n/Messages_es.properties
@@ -1523,6 +1523,8 @@ search.projects.id=ID del proyecto
 search.projects.modifiedTime=Hora de modificación del proyecto
 # 5ea778ab
 search.projects.name=Nombre del proyecto
+# f9d98417
+search.projects.phase=Fase
 # 7e9110f3
 search.projectVariables.id=ID de variable más reciente para ID estable y del proyecto
 # 9c2d6e71

--- a/src/main/resources/i18n/Messages_fr.properties
+++ b/src/main/resources/i18n/Messages_fr.properties
@@ -1523,6 +1523,8 @@ search.projects.id=ID du projet
 search.projects.modifiedTime=Heure de modification du projet
 # 5ea778ab
 search.projects.name=Nom du projet
+# f9d98417
+search.projects.phase=Phase
 # 7e9110f3
 search.projectVariables.id=Dernier identifiant de variable pour identifiant stable et projet
 # 9c2d6e71


### PR DESCRIPTION
To simplify some of the FE work, add a `phase` property to the `Projects` search table. For now it will continue to reference the cohort's phase until the rest of the data model work is implemented.