### PR TITLE
SW-7491 Update facility_inventory_totals to include empty nurseries

### DIFF
--- a/src/main/resources/db/migration/0400/V444__EmptyFacilityTotals.sql
+++ b/src/main/resources/db/migration/0400/V444__EmptyFacilityTotals.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW nursery.facility_inventory_totals AS
+SELECT batches.organization_id,
+       batches.facility_id,
+       sum(batches.ready_quantity)         AS ready_quantity,
+       sum(batches.active_growth_quantity) AS active_growth_quantity,
+       sum(batches.germinating_quantity)   AS germinating_quantity,
+       sum(batches.hardening_off_quantity) AS hardening_off_quantity,
+       sum(batches.ready_quantity + batches.active_growth_quantity +
+           batches.hardening_off_quantity) AS total_quantity,
+       count(distinct batches.species_id)  AS total_species
+FROM nursery.batches
+GROUP BY batches.organization_id, batches.facility_id
+;

--- a/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
+++ b/src/test/kotlin/com/terraformation/backend/nursery/NurserySearchTest.kt
@@ -242,8 +242,8 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
 
     @Test
     fun `facility inventory totals table returns correct totals`() {
-      // Empty batch shouldn't count toward total species.
-      insertBatch(facilityId = facilityId2, speciesId = speciesId2)
+      // Empty batch should be included in total species.
+      insertBatch(organizationId = organizationId, facilityId = facilityId2, speciesId = speciesId2)
 
       val prefix = SearchFieldPrefix(root = searchTables.facilityInventoryTotals)
       val results =
@@ -306,7 +306,7 @@ internal class NurserySearchTest : DatabaseTest(), RunsAsUser {
                               ),
                           ),
                       "totalQuantity" to number(128 + 256 + 512),
-                      "totalSpecies" to number(1),
+                      "totalSpecies" to number(2),
                   ),
               )
           ),


### PR DESCRIPTION
The IFO team is requesting that the species inventory table show "empty" species (i.e. species that had inventory at one point but now do not). Product expanded this request to the nursery inventory table as well, which is the only use case in the BE or FE of the `facility_inventory_totals` view.
Remove the `<foo>Quantity > 0` check in the `facililty_inventory_totals` view.

This has an unfortunate side effect of causing `total_species` to be incorrect if the use-case only cares about non-empty facilities, however this property is not used by the BE or FE right now outside of a BE unit test.