### PR TITLE
SW-7491 Add facilityInventories multi sublist to species search table

### DIFF
--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -29,15 +29,15 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
     with(tables) {
       listOf(
           batches.asMultiValueSublist("batches", SPECIES.ID.eq(BATCHES.SPECIES_ID)),
+          facilityInventories.asMultiValueSublist(
+              "facilityInventories",
+              SPECIES.ID.eq(FACILITY_INVENTORIES.SPECIES_ID),
+          ),
           inventories.asSingleValueSublist(
               "inventory",
               SPECIES.ORGANIZATION_ID.eq(INVENTORIES.ORGANIZATION_ID)
                   .and(SPECIES.ID.eq(INVENTORIES.SPECIES_ID)),
               isRequired = false,
-          ),
-          facilityInventories.asMultiValueSublist(
-              "facilityInventories",
-              SPECIES.ID.eq(FACILITY_INVENTORIES.SPECIES_ID),
           ),
           nurserySpeciesProjects.asMultiValueSublist(
               "nurseryProjects",

--- a/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
+++ b/src/main/kotlin/com/terraformation/backend/search/table/SpeciesTable.kt
@@ -11,6 +11,7 @@ import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PL
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_PROBLEMS
 import com.terraformation.backend.db.default_schema.tables.references.SPECIES_SUCCESSIONAL_GROUPS
 import com.terraformation.backend.db.nursery.tables.references.BATCHES
+import com.terraformation.backend.db.nursery.tables.references.FACILITY_INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.INVENTORIES
 import com.terraformation.backend.db.nursery.tables.references.SPECIES_PROJECTS
 import com.terraformation.backend.search.SearchTable
@@ -33,6 +34,10 @@ class SpeciesTable(tables: SearchTables) : SearchTable() {
               SPECIES.ORGANIZATION_ID.eq(INVENTORIES.ORGANIZATION_ID)
                   .and(SPECIES.ID.eq(INVENTORIES.SPECIES_ID)),
               isRequired = false,
+          ),
+          facilityInventories.asMultiValueSublist(
+              "facilityInventories",
+              SPECIES.ID.eq(FACILITY_INVENTORIES.SPECIES_ID),
           ),
           nurserySpeciesProjects.asMultiValueSublist(
               "nurseryProjects",


### PR DESCRIPTION
When filtering by a specific nursery on the By Species table, we were changing the search prefix from `inventories` to `facilityInventories`, but we now want to use a prefix of `species` for both in order to show species that have had batches but no longer have inventory. Add `facililtyInventories` as a multi value sublist to the `species` search table to support this.